### PR TITLE
feat: add local browser runtime

### DIFF
--- a/example.env
+++ b/example.env
@@ -409,6 +409,22 @@ XAGENT_WEB_SEARCH_PROVIDER="auto"
 # XAGENT_TASK_RUNTIME_HOOK_MAX_WORKERS="8"
 # XAGENT_TASK_RUNTIME_HOOK_QUEUE_TIMEOUT_SECONDS="30"
 
+# ===========================================
+# Local browser use
+# ===========================================
+# Controls one visible window of the configured browser on the same host as
+# the Xagent backend through `cua-driver mcp`. Tasks bind to an exact browser
+# window and never switch silently. Keep disabled on shared/cloud hosts.
+# XAGENT_NATIVE_BROWSER_ENABLED="false"
+# XAGENT_NATIVE_BROWSER_APP_NAME="Google Chrome"
+# XAGENT_BROWSER_CUA_DRIVER_COMMAND="cua-driver"
+# XAGENT_BROWSER_CUA_DRIVER_SOCKET=""
+# XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS="30"
+# Number of AX nodes scanned before Xagent prioritizes at most 100 visible,
+# actionable elements for model context. A larger scan preserves transient
+# menus without sending the full accessibility tree to the model.
+# XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS="2000"
+
 # Context compaction: the conversation is compacted when the estimated context
 # size reaches (model context window * ratio). Set a model's context window in
 # the model config; models without one fall back to the default below.

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -117,6 +117,71 @@ describe("ChatInput", () => {
     expect(onSend).not.toHaveBeenCalled()
   })
 
+  it("binds a new task to a selected local browser window", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/computer/local-browser/readiness") {
+        return Promise.resolve(
+          new Response(JSON.stringify({
+            ready: true,
+            connected: true,
+            attached: true,
+            application: "Google Chrome",
+            title: "GitHub",
+            windows: [
+              {
+                pid: 100,
+                window_id: 20,
+                application: "Google Chrome",
+                title: "GitHub",
+              },
+            ],
+            permissions: {},
+            issues: [],
+            message: "",
+          }), { status: 200, headers: { "Content-Type": "application/json" } })
+        )
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+    const onSend = vi.fn()
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect this page"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+        taskConfig={{ model: "model-1" }}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"))
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"))
+    fireEvent.click(await screen.findByText("GitHub"))
+
+    expect(screen.queryByText("chatPage.input.localBrowser.chipLabel")).not.toBeInTheDocument()
+    expect(screen.getByRole("status", { name: "Google Chrome · GitHub" })).toBeInTheDocument()
+    const form = container.querySelector("form") as HTMLFormElement
+    expect(form).toHaveClass("rounded-2xl")
+    expect(form).not.toHaveClass("rounded-tl-none")
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        "inspect this page",
+        expect.objectContaining({
+          runtimeExtensions: {
+            local_browser: {
+              pid: 100,
+              window_id: 20,
+              application: "Google Chrome",
+              title: "GitHub",
+            },
+          },
+        }),
+      )
+    })
+  })
+
   it("suppresses preseeded files and restored file previews when files are disabled", () => {
     const onSend = vi.fn()
     const onFilesChange = vi.fn()

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -167,7 +167,7 @@ describe("ChatInput", () => {
     fireEvent.click(await screen.findByText("GitHub"))
 
     expect(screen.queryByText("chatPage.input.localBrowser.chipLabel")).not.toBeInTheDocument()
-    expect(screen.getByRole("status", { name: "Google Chrome · GitHub" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Google Chrome · GitHub")).toBeInTheDocument()
     const form = container.querySelector("form") as HTMLFormElement
     expect(form).toHaveClass("rounded-2xl")
     expect(form).not.toHaveClass("rounded-tl-none")
@@ -188,6 +188,54 @@ describe("ChatInput", () => {
         }),
       )
     })
+  })
+
+  it("disambiguates browser windows with the same application and title", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/computer/local-browser/readiness") {
+        return Promise.resolve(
+          new Response(JSON.stringify({
+            ready: true,
+            application: "Google Chrome",
+            windows: [
+              {
+                pid: 100,
+                window_id: 20,
+                application: "Google Chrome",
+                title: "GitHub",
+              },
+              {
+                pid: 100,
+                window_id: 21,
+                application: "Google Chrome",
+                title: "GitHub",
+              },
+            ],
+            issues: [],
+            message: "",
+          }), { status: 200, headers: { "Content-Type": "application/json" } }),
+        )
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+
+    render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect"
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+        taskConfig={{ model: "model-1" }}
+      />,
+    )
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"))
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"))
+
+    expect(await screen.findAllByText("GitHub")).toHaveLength(2)
+    expect(
+      screen.getAllByText("chatPage.input.localBrowser.windowIdentifier"),
+    ).toHaveLength(2)
   })
 
   it("does not advertise local browser to a non-admin", () => {

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -8,6 +8,9 @@ const openFilePreviewMock = vi.hoisted(() => vi.fn())
 const routerPushMock = vi.hoisted(() => vi.fn())
 const resetMentionMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
+const authUserMock = vi.hoisted(() => ({
+  current: { id: "1", is_admin: true } as { id: string; is_admin: boolean },
+}))
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -40,6 +43,10 @@ vi.mock("@/contexts/app-context-chat", () => ({
   useApp: () => ({
     openFilePreview: openFilePreviewMock,
   }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ user: authUserMock.current }),
 }))
 
 vi.mock("@/components/config-dialog", () => ({
@@ -84,6 +91,7 @@ const emptyJsonResponse = () =>
 
 describe("ChatInput", () => {
   beforeEach(() => {
+    authUserMock.current = { id: "1", is_admin: true }
     apiRequestMock.mockReset()
     apiRequestMock.mockImplementation(() => Promise.resolve(emptyJsonResponse()))
     openFilePreviewMock.mockReset()
@@ -180,6 +188,54 @@ describe("ChatInput", () => {
         }),
       )
     })
+  })
+
+  it("does not advertise local browser to a non-admin", () => {
+    authUserMock.current = { id: "2", is_admin: false }
+
+    render(
+      <ChatInput
+        hideFileUpload
+        inputValue="hello"
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+        taskConfig={{ model: "model-1" }}
+      />
+    )
+
+    expect(screen.queryByLabelText("chatPage.input.actions.add")).not.toBeInTheDocument()
+    expect(apiRequestMock).not.toHaveBeenCalledWith(
+      "http://api.local/api/computer/local-browser/readiness",
+      expect.anything(),
+    )
+  })
+
+  it("aborts an in-flight readiness request when the picker unmounts", async () => {
+    let readinessSignal: AbortSignal | undefined
+    apiRequestMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "http://api.local/api/computer/local-browser/readiness") {
+        readinessSignal = init?.signal ?? undefined
+        return new Promise<Response>(() => {})
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+    const { unmount } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect"
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+        taskConfig={{ model: "model-1" }}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"))
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"))
+    await waitFor(() => expect(readinessSignal).toBeDefined())
+
+    unmount()
+
+    expect(readinessSignal?.aborted).toBe(true)
   })
 
   it("suppresses preseeded files and restored file previews when files are disabled", () => {

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -190,6 +190,49 @@ describe("ChatInput", () => {
     })
   })
 
+  it("does not submit a stale local browser target after the feature is hidden", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/computer/local-browser/readiness") {
+        return Promise.resolve(
+          new Response(JSON.stringify({
+            ready: true,
+            application: "Google Chrome",
+            windows: [{
+              pid: 100,
+              window_id: 20,
+              application: "Google Chrome",
+              title: "GitHub",
+            }],
+            issues: [],
+            message: "",
+          }), { status: 200, headers: { "Content-Type": "application/json" } }),
+        )
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+    const onSend = vi.fn()
+    const commonProps = {
+      hideFileUpload: true,
+      inputValue: "inspect this page",
+      onInputChange: vi.fn(),
+      onSend,
+      taskConfig: { model: "model-1" },
+    }
+    const { container, rerender } = render(<ChatInput {...commonProps} />)
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"))
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"))
+    fireEvent.click(await screen.findByText("GitHub"))
+    expect(screen.getByLabelText("Google Chrome · GitHub")).toBeInTheDocument()
+
+    rerender(<ChatInput {...commonProps} readOnlyConfig />)
+    expect(screen.queryByLabelText("Google Chrome · GitHub")).not.toBeInTheDocument()
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1))
+    expect(onSend.mock.calls[0][1]).not.toHaveProperty("runtimeExtensions")
+  })
+
   it("disambiguates browser windows with the same application and title", async () => {
     apiRequestMock.mockImplementation((url: string) => {
       if (url === "http://api.local/api/computer/local-browser/readiness") {

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -233,6 +233,58 @@ describe("ChatInput", () => {
     expect(onSend.mock.calls[0][1]).not.toHaveProperty("runtimeExtensions")
   })
 
+  it("clears a selected target that disappears from refreshed readiness", async () => {
+    let readinessCalls = 0
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/computer/local-browser/readiness") {
+        readinessCalls += 1
+        return Promise.resolve(
+          new Response(JSON.stringify({
+            ready: true,
+            application: "Google Chrome",
+            windows: readinessCalls === 1 ? [{
+              pid: 100,
+              window_id: 20,
+              application: "Google Chrome",
+              title: "GitHub",
+            }] : [{
+              pid: 100,
+              window_id: 21,
+              application: "Google Chrome",
+              title: "Xagent",
+            }],
+            issues: [],
+            message: "",
+          }), { status: 200, headers: { "Content-Type": "application/json" } }),
+        )
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+    render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect this page"
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+        taskConfig={{ model: "model-1" }}
+      />,
+    )
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"))
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"))
+    fireEvent.click(await screen.findByText("GitHub"))
+    expect(screen.getByLabelText("Google Chrome · GitHub")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"))
+    fireEvent.click(
+      screen.getAllByText("chatPage.input.localBrowser.label").at(-1) as HTMLElement,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Google Chrome · GitHub")).not.toBeInTheDocument()
+    })
+  })
+
   it("disambiguates browser windows with the same application and title", async () => {
     apiRequestMock.mockImplementation((url: string) => {
       if (url === "http://api.local/api/computer/local-browser/readiness") {

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -582,6 +582,10 @@ export function ChatInput({
     !allowsLiveGuidanceInput &&
     !isStoppedTaskStatus(normalizedTaskStatus);
   const showLocalBrowser = Boolean(user?.is_admin) && !readOnlyConfig && !hideConfig;
+  const activeLocalBrowserTarget = showLocalBrowser ? localBrowserTarget : null;
+  useEffect(() => {
+    if (!showLocalBrowser) setLocalBrowserTarget(null);
+  }, [showLocalBrowser]);
   const voiceInputLabel =
     voiceInput.status === "recording"
       ? t("voiceInput.stop")
@@ -683,7 +687,7 @@ export function ChatInput({
       const executionMode = taskConfig?.executionMode;
       const deliveryKey = JSON.stringify([
         messageToSend,
-        localBrowserTarget,
+        activeLocalBrowserTarget,
         enabledFiles.map((file) => [
           file.name,
           file.size,
@@ -699,11 +703,11 @@ export function ChatInput({
       const configToSend = {
         ...agentConfig,
         clientMessageId,
-        ...(localBrowserTarget
+        ...(activeLocalBrowserTarget
           ? {
               runtimeExtensions: {
                 ...(agentConfig.runtimeExtensions || {}),
-                local_browser: { ...localBrowserTarget },
+                local_browser: { ...activeLocalBrowserTarget },
               },
             }
           : {}),

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -14,6 +14,7 @@ import { useFileMention, FileItem } from "@/hooks/use-file-mention";
 import { FileMentionDropdown } from "./FileMentionDropdown";
 import { toast } from "@/components/ui/sonner";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
+import { LocalBrowserMenu, type LocalBrowserTarget } from "./LocalBrowserMenu";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -111,6 +112,7 @@ interface AgentConfig {
   memorySimilarityThreshold?: number;
   executionMode?: ExecutionModeConfig;
   clientMessageId?: string;
+  runtimeExtensions?: Record<string, Record<string, unknown>>;
 }
 
 interface ModelRecord {
@@ -158,6 +160,8 @@ export function ChatInput({
   const [isFocused, setIsFocused] = useState(false);
   const [showNoModelAlert, setShowNoModelAlert] = useState(false);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  const [localBrowserTarget, setLocalBrowserTarget] =
+    useState<LocalBrowserTarget | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<HTMLDivElement>(null);
@@ -676,6 +680,7 @@ export function ChatInput({
       const executionMode = taskConfig?.executionMode;
       const deliveryKey = JSON.stringify([
         messageToSend,
+        localBrowserTarget,
         enabledFiles.map((file) => [
           file.name,
           file.size,
@@ -691,6 +696,14 @@ export function ChatInput({
       const configToSend = {
         ...agentConfig,
         clientMessageId,
+        ...(localBrowserTarget
+          ? {
+              runtimeExtensions: {
+                ...(agentConfig.runtimeExtensions || {}),
+                local_browser: { ...localBrowserTarget },
+              },
+            }
+          : {}),
         ...(executionMode
           ? {
               executionMode:
@@ -703,6 +716,7 @@ export function ChatInput({
 
       await onSend(messageToSend, configToSend);
       deliveryAttemptRef.current = null;
+      setLocalBrowserTarget(null);
       fileMention.resetMention();
 
       if (isControlled) {
@@ -1098,30 +1112,32 @@ export function ChatInput({
                     )}
                   </>
                 )}
-                {/* Upload button - adjacent to bottom toolbar */}
-                {!hideFileUpload && !filesDisabled && (
+                {/* Add files or bind this new task to a local host window. */}
+                {(!hideFileUpload && !filesDisabled) || (!readOnlyConfig && !hideConfig) ? (
                   <>
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      multiple
-                      onChange={handleFileSelect}
-                      className="hidden"
-                      accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls,.ppt,.pptx,.png,.jpg,.jpeg,.gif,.webp"
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-9 w-9 p-0 text-muted-foreground hover:text-foreground hover:bg-secondary/80 rounded-full"
-                      onClick={() => fileInputRef.current?.click()}
+                    {!hideFileUpload && !filesDisabled && (
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        onChange={handleFileSelect}
+                        className="hidden"
+                        accept=".pdf,.doc,.docx,.txt,.md,.csv,.json,.xlsx,.xls,.ppt,.pptx,.png,.jpg,.jpeg,.gif,.webp"
+                      />
+                    )}
+                    <LocalBrowserMenu
                       disabled={isInputBusy}
-                      title={t("chatPage.input.actions.upload")}
-                    >
-                      <Paperclip className="h-4 w-4" />
-                    </Button>
+                      selectedTarget={localBrowserTarget}
+                      onTargetChange={setLocalBrowserTarget}
+                      onAddFiles={
+                        !hideFileUpload && !filesDisabled
+                          ? () => fileInputRef.current?.click()
+                          : undefined
+                      }
+                      showLocalBrowser={!readOnlyConfig && !hideConfig}
+                    />
                   </>
-                )}
+                ) : null}
               </div>
 
               <div className="flex items-center gap-2">

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { cn, generateClientMessageId, getApiUrl, getUploadApiUrl } from "@/lib/utils";
 import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
+import { useAuth } from "@/contexts/auth-context";
 import { ConfigDialog } from "@/components/config-dialog";
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper";
 import { sanitizeFilesDisabledPresentationText } from "@/lib/files-disabled-presentation";
@@ -170,6 +171,7 @@ export function ChatInput({
   const deliveryAttemptRef = useRef<{ key: string; clientMessageId: string } | null>(null);
   const dragDepthRef = useRef(0);
   const { t } = useI18n();
+  const { user } = useAuth();
   const { openFilePreview } = useApp();
   const voiceInput = useVoiceInputControls({ enabled: voiceInputEnabled });
 
@@ -579,6 +581,7 @@ export function ChatInput({
     !!isLoading &&
     !allowsLiveGuidanceInput &&
     !isStoppedTaskStatus(normalizedTaskStatus);
+  const showLocalBrowser = Boolean(user?.is_admin) && !readOnlyConfig && !hideConfig;
   const voiceInputLabel =
     voiceInput.status === "recording"
       ? t("voiceInput.stop")
@@ -1113,7 +1116,7 @@ export function ChatInput({
                   </>
                 )}
                 {/* Add files or bind this new task to a local host window. */}
-                {(!hideFileUpload && !filesDisabled) || (!readOnlyConfig && !hideConfig) ? (
+                {(!hideFileUpload && !filesDisabled) || showLocalBrowser ? (
                   <>
                     {!hideFileUpload && !filesDisabled && (
                       <input
@@ -1134,7 +1137,7 @@ export function ChatInput({
                           ? () => fileInputRef.current?.click()
                           : undefined
                       }
-                      showLocalBrowser={!readOnlyConfig && !hideConfig}
+                      showLocalBrowser={showLocalBrowser}
                     />
                   </>
                 ) : null}

--- a/frontend/src/components/chat/ChatMessage.test.tsx
+++ b/frontend/src/components/chat/ChatMessage.test.tsx
@@ -142,7 +142,7 @@ describe("ChatMessage Session file capability", () => {
     )
 
     expect(
-      screen.getByLabelText("Computer use · Local browser"),
+      screen.getByRole("note", { name: "Computer use · Local browser" }),
     ).toBeInTheDocument()
   })
 

--- a/frontend/src/components/chat/ChatMessage.test.tsx
+++ b/frontend/src/components/chat/ChatMessage.test.tsx
@@ -128,6 +128,24 @@ describe("ChatMessage Session file capability", () => {
     )
   })
 
+  it("renders Computer use context on a user message", () => {
+    render(
+      <ChatMessage
+        role="user"
+        content="Open the selected page"
+        contextBadges={[{
+          kind: "computer_use",
+          label: "Computer use",
+          detail: "Local browser",
+        }]}
+      />,
+    )
+
+    expect(
+      screen.getByLabelText("Computer use · Local browser"),
+    ).toBeInTheDocument()
+  })
+
   it("uses the same safe projection for normal assistant DOM and copied content", () => {
     appContextMock.filesDisabled = true
     const { container } = render(

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { Bot, ChevronDown, ChevronUp, Copy, Check } from "lucide-react";
+import { Bot, ChevronDown, ChevronUp, Copy, Check, Laptop } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { TraceEventRenderer, type AgentExecutionSummary } from "./TraceEventRenderer";
@@ -83,6 +83,11 @@ export interface ChatMessageProps {
   onOpenExecutionPlan?: () => void;
   onAgentExecutionClick?: (execution: AgentExecutionSummary) => void;
   onSendInteraction?: (message: string, files?: File[], metadata?: any) => Promise<void> | void;
+  contextBadges?: Array<{
+    kind: "computer_use";
+    label: string;
+    detail: string;
+  }>;
 }
 
 function GeneratingIndicator({ latestTitle, taskStatus }: { latestTitle?: string, taskStatus?: string }) {
@@ -303,6 +308,7 @@ export function ChatMessage({
   onOpenExecutionPlan,
   onAgentExecutionClick,
   onSendInteraction,
+  contextBadges,
 }: ChatMessageProps) {
   const { t, tDynamic } = useI18n();
   const { filesDisabled, openFilePreview } = useApp();
@@ -503,6 +509,22 @@ export function ChatMessage({
                 !isUser && (showEmptyStatus || (!showProcessView && isStoppedWithoutAnswer)) && (
                   <GeneratingIndicator latestTitle={statusTitle} taskStatus={resolvedProcessStatus} />
                 )
+              )}
+              {isUser && contextBadges && contextBadges.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {contextBadges.map((badge) => (
+                    <div
+                      key={`${badge.kind}:${badge.label}:${badge.detail}`}
+                      className="inline-flex h-7 min-w-0 items-center gap-1.5 rounded-lg border border-border/80 bg-background/55 px-2 text-xs text-muted-foreground"
+                      aria-label={`${badge.label} · ${badge.detail}`}
+                    >
+                      <Laptop className="h-3.5 w-3.5 shrink-0" />
+                      <span className="truncate">{badge.label}</span>
+                      <span aria-hidden="true">·</span>
+                      <span className="truncate">{badge.detail}</span>
+                    </div>
+                  ))}
+                </div>
               )}
               {!isUser && interactions && interactions.length > 0 && (
                 <div className="mt-4 border-t pt-4">

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -515,6 +515,7 @@ export function ChatMessage({
                   {contextBadges.map((badge) => (
                     <div
                       key={`${badge.kind}:${badge.label}:${badge.detail}`}
+                      role="note"
                       className="inline-flex h-7 min-w-0 items-center gap-1.5 rounded-lg border border-border/80 bg-background/55 px-2 text-xs text-muted-foreground"
                       aria-label={`${badge.label} · ${badge.detail}`}
                     >

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Check,
   ChevronRight,
@@ -64,6 +64,7 @@ export function LocalBrowserMenu({
     readinessRequestRef.current = null;
     request?.abort();
     setLoading(false);
+    setReadiness(null);
   }, []);
 
   useEffect(() => () => {
@@ -108,6 +109,18 @@ export function LocalBrowserMenu({
 
   const localBrowserDisabled = disabled || loading || readiness?.ready !== true;
   const selected = selectedTarget !== null;
+  const duplicateWindowLabels = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const browserWindow of readiness?.windows || []) {
+      const key = `${browserWindow.application}\u0000${browserWindow.title || ""}`;
+      counts.set(key, (counts.get(key) || 0) + 1);
+    }
+    return new Set(
+      [...counts.entries()]
+        .filter(([, count]) => count > 1)
+        .map(([key]) => key),
+    );
+  }, [readiness?.windows]);
   const status = loading
     ? t("chatPage.input.localBrowser.checking")
     : readiness?.ready
@@ -200,16 +213,17 @@ export function LocalBrowserMenu({
                       <span>{t("chatPage.input.localBrowser.checking")}</span>
                     </div>
                   ) : readiness?.ready && readiness.windows.length > 0 ? (
-                    readiness.windows.map((window) => {
-                      const isSelected = selectedTarget?.pid === window.pid
-                        && selectedTarget?.window_id === window.window_id;
+                    readiness.windows.map((browserWindow) => {
+                      const labelKey = `${browserWindow.application}\u0000${browserWindow.title || ""}`;
+                      const isSelected = selectedTarget?.pid === browserWindow.pid
+                        && selectedTarget?.window_id === browserWindow.window_id;
                       return (
                         <button
                           type="button"
-                          key={`${window.pid}:${window.window_id}`}
+                          key={`${browserWindow.pid}:${browserWindow.window_id}`}
                           disabled={localBrowserDisabled}
                           onClick={() => {
-                            onTargetChange(window);
+                            onTargetChange(browserWindow);
                             setShowWindowPicker(false);
                             setOpen(false);
                           }}
@@ -219,10 +233,17 @@ export function LocalBrowserMenu({
                           )}
                         >
                           <span className="min-w-0 flex-1">
-                            <span className="block truncate text-sm">{window.application}</span>
-                            {window.title && (
+                            <span className="block truncate text-sm">{browserWindow.application}</span>
+                            {browserWindow.title && (
                               <span className="block truncate text-xs text-muted-foreground">
-                                {window.title}
+                                {browserWindow.title}
+                              </span>
+                            )}
+                            {duplicateWindowLabels.has(labelKey) && (
+                              <span className="block truncate text-xs text-muted-foreground">
+                                {t("chatPage.input.localBrowser.windowIdentifier", {
+                                  id: browserWindow.window_id,
+                                })}
                               </span>
                             )}
                           </span>
@@ -246,12 +267,12 @@ export function LocalBrowserMenu({
         <div
           className="inline-flex h-8 min-w-0 max-w-[180px] items-center gap-1.5 rounded-lg border border-border bg-secondary/70 px-2.5 text-xs text-foreground"
           title={status}
+          aria-label={status}
         >
           <Laptop className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">{t("chatPage.input.localBrowser.label")}</span>
           <span
-            role="status"
-            aria-label={status}
+            aria-hidden="true"
             className={cn(
               "h-2 w-2 shrink-0 rounded-full",
               readiness?.ready

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -90,6 +90,16 @@ export function LocalBrowserMenu({
       const nextReadiness = await response.json();
       if (readinessRequestRef.current === request) {
         setReadiness(nextReadiness);
+        if (selectedTarget && (
+          nextReadiness.ready !== true
+          || !Array.isArray(nextReadiness.windows)
+          || !nextReadiness.windows.some((browserWindow: LocalBrowserTarget) => (
+            browserWindow.pid === selectedTarget.pid
+            && browserWindow.window_id === selectedTarget.window_id
+          ))
+        )) {
+          onTargetChange(null);
+        }
       }
     } catch {
       if (!request.signal.aborted && readinessRequestRef.current === request) {
@@ -107,7 +117,7 @@ export function LocalBrowserMenu({
         setLoading(false);
       }
     }
-  }, [showLocalBrowser, t]);
+  }, [onTargetChange, selectedTarget, showLocalBrowser, t]);
 
   const localBrowserDisabled = disabled || loading || readiness?.ready !== true;
   const selected = selectedTarget !== null;

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import React, { useCallback, useState } from "react";
+import {
+  Check,
+  ChevronRight,
+  Laptop,
+  Loader2,
+  Paperclip,
+  Plus,
+  X,
+} from "lucide-react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useI18n } from "@/contexts/i18n-context";
+import { apiRequest } from "@/lib/api-wrapper";
+import { cn, getApiUrl } from "@/lib/utils";
+
+interface ReadinessIssue {
+  code: string;
+  message: string;
+}
+
+export interface LocalBrowserTarget {
+  pid: number;
+  window_id: number;
+  application: string;
+  title?: string | null;
+}
+
+interface LocalBrowserReadiness {
+  ready: boolean;
+  application: string;
+  title?: string | null;
+  windows: LocalBrowserTarget[];
+  issues: ReadinessIssue[];
+  message: string;
+}
+
+interface LocalBrowserMenuProps {
+  disabled: boolean;
+  selectedTarget: LocalBrowserTarget | null;
+  onTargetChange: (target: LocalBrowserTarget | null) => void;
+  onAddFiles?: () => void;
+  showLocalBrowser: boolean;
+}
+
+export function LocalBrowserMenu({
+  disabled,
+  selectedTarget,
+  onTargetChange,
+  onAddFiles,
+  showLocalBrowser,
+}: LocalBrowserMenuProps) {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const [showWindowPicker, setShowWindowPicker] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [readiness, setReadiness] = useState<LocalBrowserReadiness | null>(null);
+
+  const refreshReadiness = useCallback(async () => {
+    if (!showLocalBrowser) return;
+    setLoading(true);
+    try {
+      const response = await apiRequest(
+        `${getApiUrl()}/api/computer/local-browser/readiness`,
+        { cache: "no-store" },
+      );
+      if (!response.ok) throw new Error("readiness request failed");
+      setReadiness(await response.json());
+    } catch {
+      setReadiness({
+        ready: false,
+        application: "Local browser",
+        windows: [],
+        issues: [],
+        message: t("chatPage.input.localBrowser.unavailable"),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [showLocalBrowser, t]);
+
+  const localBrowserDisabled = disabled || loading || readiness?.ready !== true;
+  const selected = selectedTarget !== null;
+  const status = loading
+    ? t("chatPage.input.localBrowser.checking")
+    : readiness?.ready
+      ? selectedTarget
+        ? [selectedTarget.application, selectedTarget.title].filter(Boolean).join(" · ")
+        : t("chatPage.input.localBrowser.chooseWindow")
+      : readiness?.message || t("chatPage.input.localBrowser.unavailable");
+
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      <Popover
+        open={open}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          if (!nextOpen) setShowWindowPicker(false);
+        }}
+      >
+        <PopoverTrigger
+          type="button"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full p-0 text-muted-foreground hover:bg-secondary/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+          disabled={disabled}
+          title={t("chatPage.input.actions.add")}
+          aria-label={t("chatPage.input.actions.add")}
+        >
+          <Plus className="h-4 w-4" />
+        </PopoverTrigger>
+        <PopoverContent align="start" side="top" className="w-80 space-y-1 p-1.5">
+          {onAddFiles && (
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                onAddFiles();
+              }}
+              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-muted"
+            >
+              <Paperclip className="h-4 w-4 shrink-0" />
+              <span>{t("chatPage.input.actions.upload")}</span>
+            </button>
+          )}
+          {showLocalBrowser && (
+            <Popover
+              open={showWindowPicker}
+              onOpenChange={(nextOpen) => {
+                setShowWindowPicker(nextOpen);
+                if (nextOpen) void refreshReadiness();
+              }}
+            >
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted"
+                >
+                  <Laptop className="h-4 w-4 shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-medium">
+                      {t("chatPage.input.localBrowser.label")}
+                    </span>
+                    {selectedTarget && (
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {[selectedTarget.application, selectedTarget.title]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </span>
+                    )}
+                  </span>
+                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                side="right"
+                sideOffset={8}
+                className="w-80 space-y-1 p-1.5"
+              >
+                <p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                  {t("chatPage.input.localBrowser.chooseWindow")}
+                </p>
+                <p className="px-2 pb-1 text-xs leading-relaxed text-muted-foreground">
+                  {t("chatPage.input.localBrowser.controlScope")}
+                </p>
+                <div className="max-h-64 space-y-0.5 overflow-y-auto px-1 pb-1">
+                  {loading ? (
+                    <div className="flex items-center gap-3 px-2 py-2 text-sm text-muted-foreground">
+                      <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                      <span>{t("chatPage.input.localBrowser.checking")}</span>
+                    </div>
+                  ) : readiness?.ready && readiness.windows.length > 0 ? (
+                    readiness.windows.map((window) => {
+                      const isSelected = selectedTarget?.pid === window.pid
+                        && selectedTarget?.window_id === window.window_id;
+                      return (
+                        <button
+                          type="button"
+                          key={`${window.pid}:${window.window_id}`}
+                          disabled={localBrowserDisabled}
+                          onClick={() => {
+                            onTargetChange(window);
+                            setShowWindowPicker(false);
+                            setOpen(false);
+                          }}
+                          className={cn(
+                            "flex w-full items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted",
+                            isSelected && "bg-primary/5",
+                          )}
+                        >
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-sm">{window.application}</span>
+                            {window.title && (
+                              <span className="block truncate text-xs text-muted-foreground">
+                                {window.title}
+                              </span>
+                            )}
+                          </span>
+                          {isSelected && <Check className="h-4 w-4 shrink-0 text-primary" />}
+                        </button>
+                      );
+                    })
+                  ) : (
+                    <p className="px-2 py-2 text-sm text-muted-foreground">
+                      {readiness?.message || t("chatPage.input.localBrowser.unavailable")}
+                    </p>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {selected && (
+        <div
+          className="inline-flex h-8 min-w-0 max-w-[180px] items-center gap-1.5 rounded-lg border border-border bg-secondary/70 px-2.5 text-xs text-foreground"
+          title={status}
+        >
+          <Laptop className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{t("chatPage.input.localBrowser.label")}</span>
+          <span
+            role="status"
+            aria-label={status}
+            className={cn(
+              "h-2 w-2 shrink-0 rounded-full",
+              readiness?.ready
+                ? "bg-emerald-500"
+                : readiness
+                  ? "bg-amber-500"
+                  : "bg-muted-foreground/35",
+            )}
+          />
+          <button
+            type="button"
+            aria-label={t("common.remove")}
+            title={t("common.remove")}
+            className="ml-0.5 rounded-sm p-0.5 hover:bg-foreground/10"
+            onClick={() => onTargetChange(null)}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   Check,
   ChevronRight,
@@ -57,27 +57,52 @@ export function LocalBrowserMenu({
   const [showWindowPicker, setShowWindowPicker] = useState(false);
   const [loading, setLoading] = useState(false);
   const [readiness, setReadiness] = useState<LocalBrowserReadiness | null>(null);
+  const readinessRequestRef = useRef<AbortController | null>(null);
+
+  const cancelReadiness = useCallback(() => {
+    const request = readinessRequestRef.current;
+    readinessRequestRef.current = null;
+    request?.abort();
+    setLoading(false);
+  }, []);
+
+  useEffect(() => () => {
+    const request = readinessRequestRef.current;
+    readinessRequestRef.current = null;
+    request?.abort();
+  }, []);
 
   const refreshReadiness = useCallback(async () => {
     if (!showLocalBrowser) return;
+    readinessRequestRef.current?.abort();
+    const request = new AbortController();
+    readinessRequestRef.current = request;
     setLoading(true);
     try {
       const response = await apiRequest(
         `${getApiUrl()}/api/computer/local-browser/readiness`,
-        { cache: "no-store" },
+        { cache: "no-store", signal: request.signal },
       );
       if (!response.ok) throw new Error("readiness request failed");
-      setReadiness(await response.json());
+      const nextReadiness = await response.json();
+      if (readinessRequestRef.current === request) {
+        setReadiness(nextReadiness);
+      }
     } catch {
-      setReadiness({
-        ready: false,
-        application: "Local browser",
-        windows: [],
-        issues: [],
-        message: t("chatPage.input.localBrowser.unavailable"),
-      });
+      if (!request.signal.aborted && readinessRequestRef.current === request) {
+        setReadiness({
+          ready: false,
+          application: "Local browser",
+          windows: [],
+          issues: [],
+          message: t("chatPage.input.localBrowser.unavailable"),
+        });
+      }
     } finally {
-      setLoading(false);
+      if (readinessRequestRef.current === request) {
+        readinessRequestRef.current = null;
+        setLoading(false);
+      }
     }
   }, [showLocalBrowser, t]);
 
@@ -97,7 +122,10 @@ export function LocalBrowserMenu({
         open={open}
         onOpenChange={(nextOpen) => {
           setOpen(nextOpen);
-          if (!nextOpen) setShowWindowPicker(false);
+          if (!nextOpen) {
+            setShowWindowPicker(false);
+            cancelReadiness();
+          }
         }}
       >
         <PopoverTrigger
@@ -129,6 +157,7 @@ export function LocalBrowserMenu({
               onOpenChange={(nextOpen) => {
                 setShowWindowPicker(nextOpen);
                 if (nextOpen) void refreshReadiness();
+                else cancelReadiness();
               }}
             >
               <PopoverTrigger asChild>

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -64,7 +64,9 @@ export function LocalBrowserMenu({
     readinessRequestRef.current = null;
     request?.abort();
     setLoading(false);
-    setReadiness(null);
+    // Window choices are short-lived, but the last readiness result remains
+    // useful for the already selected target's status chip.
+    setReadiness((current) => current ? { ...current, windows: [] } : null);
   }, []);
 
   useEffect(() => () => {
@@ -121,13 +123,13 @@ export function LocalBrowserMenu({
         .map(([key]) => key),
     );
   }, [readiness?.windows]);
-  const status = loading
-    ? t("chatPage.input.localBrowser.checking")
-    : readiness?.ready
-      ? selectedTarget
-        ? [selectedTarget.application, selectedTarget.title].filter(Boolean).join(" · ")
-        : t("chatPage.input.localBrowser.chooseWindow")
-      : readiness?.message || t("chatPage.input.localBrowser.unavailable");
+  const status = selectedTarget
+    ? [selectedTarget.application, selectedTarget.title].filter(Boolean).join(" · ")
+    : loading
+      ? t("chatPage.input.localBrowser.checking")
+      : readiness?.ready
+        ? t("chatPage.input.localBrowser.chooseWindow")
+        : readiness?.message || t("chatPage.input.localBrowser.unavailable");
 
   return (
     <div className="flex min-w-0 items-center gap-1.5">

--- a/frontend/src/components/chat/chat-input-public-file-access.test.tsx
+++ b/frontend/src/components/chat/chat-input-public-file-access.test.tsx
@@ -15,6 +15,10 @@ vi.mock("@/contexts/app-context-chat", () => ({
   useApp: () => ({ openFilePreview: vi.fn() }),
 }))
 
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ user: { id: "guest", is_admin: false } }),
+}))
+
 vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({ t: (key: string) => key }),
 }))

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -249,6 +249,7 @@ describe("TaskConversationPanel", () => {
     appState.traceEvents = []
     appState.currentTask = null
     appState.taskRuntimeExtensions = {}
+    appState.taskId = 42
     appState.isProcessing = false
     appState.isHistoryLoading = false
     appState.filePreview = { isOpen: false, fileId: "", fileName: "", viewMode: "preview" }
@@ -293,6 +294,7 @@ describe("TaskConversationPanel", () => {
       updatedAt: "2026-08-07T07:01:00Z",
       runtimeExtensionBindings: ["local_browser"],
     }
+    appState.taskId = 823
 
     render(<TaskConversationPanel mode="page" />)
 
@@ -303,6 +305,32 @@ describe("TaskConversationPanel", () => {
         label: "chatPage.input.localBrowser.chipLabel",
         detail: "chatPage.input.localBrowser.label",
       }]),
+    )
+  })
+
+  it("does not reuse the previous task's Computer use badge", () => {
+    appState.messages = [{
+      id: "user-1",
+      role: "user",
+      content: "Inspect this window",
+      timestamp: "2026-08-07T07:00:00Z",
+    }]
+    appState.taskId = 824
+    appState.currentTask = {
+      id: "823",
+      title: "Previous local browser task",
+      description: "Inspect another window",
+      status: "completed",
+      createdAt: "2026-08-07T07:00:00Z",
+      updatedAt: "2026-08-07T07:01:00Z",
+      runtimeExtensionBindings: ["local_browser"],
+    }
+
+    render(<TaskConversationPanel mode="page" />)
+
+    expect(screen.getByTestId("chat-message")).toHaveAttribute(
+      "data-context-badges",
+      JSON.stringify([]),
     )
   })
 

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -3,9 +3,10 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const appState = vi.hoisted(() => ({
-  messages: [],
+  messages: [] as Array<Record<string, unknown>>,
   traceEvents: [],
-  currentTask: null,
+  currentTask: null as null | Record<string, unknown>,
+  taskRuntimeExtensions: {} as Record<string, Record<string, unknown>>,
   isProcessing: false,
   isHistoryLoading: false,
   taskId: 42,
@@ -108,6 +109,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     showEmptyStatus,
     showProcessView,
     onOpenExecutionPlan,
+    contextBadges,
   }: {
     content?: string | null
     interactionsActive?: boolean
@@ -117,6 +119,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     showEmptyStatus?: boolean
     showProcessView?: boolean
     onOpenExecutionPlan?: () => void
+    contextBadges?: Array<{ kind: string; label: string; detail: string }>
   }) => (
     <div
       data-testid="chat-message"
@@ -126,6 +129,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
       data-process-status={processStatus || ""}
       data-show-empty-status={showEmptyStatus ? "true" : "false"}
       data-show-process-view={showProcessView ? "true" : "false"}
+      data-context-badges={JSON.stringify(contextBadges || [])}
     >
       {content}
       {onOpenExecutionPlan && traceEvents?.some((event) => {
@@ -244,9 +248,62 @@ describe("TaskConversationPanel", () => {
     appState.messages = []
     appState.traceEvents = []
     appState.currentTask = null
+    appState.taskRuntimeExtensions = {}
     appState.isProcessing = false
     appState.isHistoryLoading = false
     appState.filePreview = { isOpen: false, fileId: "", fileName: "", viewMode: "preview" }
+  })
+
+  it("marks user turns with the task's Local browser context", () => {
+    appState.messages = [{
+      id: "user-1",
+      role: "user",
+      content: "Inspect this window",
+      timestamp: "2026-08-07T07:00:00Z",
+    }]
+    appState.taskRuntimeExtensions = {
+      local_browser: { kind: "local_browser" },
+    }
+
+    render(<TaskConversationPanel mode="page" />)
+
+    expect(screen.getByTestId("chat-message")).toHaveAttribute(
+      "data-context-badges",
+      JSON.stringify([{
+        kind: "computer_use",
+        label: "chatPage.input.localBrowser.chipLabel",
+        detail: "chatPage.input.localBrowser.label",
+      }]),
+    )
+  })
+
+  it("restores the Computer use badge from the task's persisted binding", () => {
+    appState.messages = [{
+      id: "user-1",
+      role: "user",
+      content: "Inspect this window",
+      timestamp: "2026-08-07T07:00:00Z",
+    }]
+    appState.currentTask = {
+      id: "823",
+      title: "Local browser task",
+      description: "Inspect this window",
+      status: "completed",
+      createdAt: "2026-08-07T07:00:00Z",
+      updatedAt: "2026-08-07T07:01:00Z",
+      runtimeExtensionBindings: ["local_browser"],
+    }
+
+    render(<TaskConversationPanel mode="page" />)
+
+    expect(screen.getByTestId("chat-message")).toHaveAttribute(
+      "data-context-badges",
+      JSON.stringify([{
+        kind: "computer_use",
+        label: "chatPage.input.localBrowser.chipLabel",
+        detail: "chatPage.input.localBrowser.label",
+      }]),
+    )
   })
 
   it("disables every file surface and drops staged files when the capability is disabled", async () => {

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -223,7 +223,10 @@ export function TaskConversationPanel({
   const containerRef = useRef<HTMLDivElement>(null)
   const userMessageContextBadges = useMemo(() => {
     const hasBoundLocalBrowser = (
-      state.currentTask?.runtimeExtensionBindings?.includes("local_browser")
+      (
+        state.currentTask?.id === String(state.taskId)
+        && state.currentTask.runtimeExtensionBindings?.includes("local_browser")
+      )
       || Object.values(state.taskRuntimeExtensions || {}).some(
         (metadata) => metadata.kind === "local_browser",
       )
@@ -236,7 +239,9 @@ export function TaskConversationPanel({
         }]
       : []
   }, [
+    state.currentTask?.id,
     state.currentTask?.runtimeExtensionBindings,
+    state.taskId,
     state.taskRuntimeExtensions,
     t,
   ])

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -221,6 +221,25 @@ export function TaskConversationPanel({
   const [isDragging, setIsDragging] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const userMessageContextBadges = useMemo(() => {
+    const hasBoundLocalBrowser = (
+      state.currentTask?.runtimeExtensionBindings?.includes("local_browser")
+      || Object.values(state.taskRuntimeExtensions || {}).some(
+        (metadata) => metadata.kind === "local_browser",
+      )
+    )
+    return hasBoundLocalBrowser
+      ? [{
+          kind: "computer_use" as const,
+          label: t("chatPage.input.localBrowser.chipLabel"),
+          detail: t("chatPage.input.localBrowser.label"),
+        }]
+      : []
+  }, [
+    state.currentTask?.runtimeExtensionBindings,
+    state.taskRuntimeExtensions,
+    t,
+  ])
   const isFilePreviewOpen = !filesDisabled && state.filePreview.isOpen
   const anyPreviewOpen = mode === "page" && (isFilePreviewOpen || dagPreviewOpen)
   const hideDelegatedChildTraces = Boolean(onAgentExecutionClick)
@@ -746,6 +765,7 @@ export function TaskConversationPanel({
                         interactions={item.interactions}
                         interactionsActive={item.id === activeWaitingMessageId}
                         showEmptyStatus={item.showEmptyStatus}
+                        contextBadges={item.role === "user" ? userMessageContextBadges : undefined}
                         onOpenExecutionPlan={showDagPreview ? openDagPreview : undefined}
                         onAgentExecutionClick={onAgentExecutionClick}
                       />

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -212,9 +212,23 @@ function MessageContentProbe() {
 }
 
 function TaskRuntimeMetadataProbe() {
-  const { setTaskId } = useApp()
+  const { dispatch, setTaskId } = useApp()
   return (
-    <button type="button" onClick={() => setTaskId(823, { navigate: false })}>
+    <button type="button" onClick={() => {
+      dispatch({
+        type: "SET_CURRENT_TASK",
+        payload: {
+          id: "823",
+          title: "Local browser task",
+          status: "completed",
+          description: "Inspect the selected window",
+          createdAt: "2026-08-07T07:00:00Z",
+          updatedAt: "2026-08-07T07:01:00Z",
+          runtimeExtensionBindings: ["local_browser"],
+        },
+      })
+      setTaskId(823, { navigate: false })
+    }}>
       select task
     </button>
   )

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -178,6 +178,12 @@ function StateProbe() {
       <div data-testid="task-status">{state.currentTask?.status || ""}</div>
       <div data-testid="task-title">{state.currentTask?.title || ""}</div>
       <div data-testid="task-id">{state.taskId ?? ""}</div>
+      <div data-testid="task-runtime-extensions">
+        {JSON.stringify(state.taskRuntimeExtensions)}
+      </div>
+      <div data-testid="task-runtime-extension-bindings">
+        {JSON.stringify(state.currentTask?.runtimeExtensionBindings || [])}
+      </div>
       <div data-testid="steps-count">{state.steps.length}</div>
       <div data-testid="steps">{JSON.stringify(state.steps.map((step) => ({
         id: step.id,
@@ -202,6 +208,15 @@ function MessageContentProbe() {
         <React.Fragment key={message.id}>{message.content}</React.Fragment>
       ))}
     </div>
+  )
+}
+
+function TaskRuntimeMetadataProbe() {
+  const { setTaskId } = useApp()
+  return (
+    <button type="button" onClick={() => setTaskId(823, { navigate: false })}>
+      select task
+    </button>
   )
 }
 
@@ -965,6 +980,97 @@ describe("AppProvider websocket message routing", () => {
     ])
   })
 
+  it("sends selected task runtime extensions in the create request", async () => {
+    let createBody: Record<string, unknown> | undefined
+    apiRequestMock.mockImplementation(
+      async (url: string, options?: RequestInit) => {
+        if (url.endsWith("/api/chat/task/create")) {
+          createBody = JSON.parse(String(options?.body || "{}"))
+          return {
+            ok: true,
+            json: async () => ({
+              task_id: 8,
+              title: "inspect browser",
+              description: "inspect browser",
+              status: "pending",
+            }),
+          }
+        }
+        return { ok: true, json: async () => ({}) }
+      },
+    )
+
+    let send: (() => Promise<void>) | undefined
+    function RuntimeExtensionProbe() {
+      const { sendMessage } = useApp()
+      send = () => sendMessage("inspect browser", {
+        clientMessageId: "turn-local-browser",
+        runtimeExtensions: { local_browser: {} },
+      })
+      return null
+    }
+
+    wsHarness.isConnected = false
+    render(
+      <AppProvider token="token">
+        <RuntimeExtensionProbe />
+      </AppProvider>
+    )
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = send?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(createBody).toEqual(
+      expect.objectContaining({
+        runtime_extensions: { local_browser: {} },
+      })
+    )
+
+    await act(async () => {
+      wsHarness.isConnected = true
+      webSocketOptions.current?.onConnect?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    await act(async () => {
+      await delivery
+    })
+  })
+
+  it("loads task runtime metadata for history replay", async () => {
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("/api/chat/task/823/runtime-extensions")) {
+        return {
+          ok: true,
+          json: async () => ({
+            task_id: 823,
+            runtime_extensions: {
+              local_browser: { kind: "local_browser" },
+            },
+          }),
+        }
+      }
+      return { ok: true, json: async () => ({}) }
+    })
+
+    render(
+      <AppProvider token="token">
+        <TaskRuntimeMetadataProbe />
+        <StateProbe />
+      </AppProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "select task" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-runtime-extensions")).toHaveTextContent(
+        JSON.stringify({ local_browser: { kind: "local_browser" } }),
+      )
+    })
+  })
+
   it("does not crash on a trace event without data", () => {
     render(
       <AppProvider token="token">
@@ -1334,6 +1440,41 @@ describe("AppProvider websocket message routing", () => {
     await waitFor(() => {
       expect(screen.getByTestId("task-status").textContent).toBe("failed")
       expect(screen.getByTestId("processing").textContent).toBe("false")
+    })
+  })
+
+  it("retains persisted runtime-extension bindings from task info", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        data: {
+          event_id: "task-info-runtime-1",
+          event_type: "task_info",
+          data: {
+            id: 1,
+            title: "Test task",
+            description: "Test task",
+            status: "COMPLETED",
+            created_at: "2026-05-27T05:00:00Z",
+            updated_at: "2026-05-27T05:00:02Z",
+            runtime_extension_bindings: ["local_browser"],
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("task-runtime-extension-bindings"),
+      ).toHaveTextContent(JSON.stringify(["local_browser"]))
     })
   })
 

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1880,7 +1880,11 @@ export function AppProvider({
 
   useEffect(() => {
     const taskId = state.taskId
-    if (taskId === null || sessionTransport) return
+    const hasRuntimeExtensionBinding = (
+      state.currentTask?.id === String(taskId)
+      && (state.currentTask.runtimeExtensionBindings?.length || 0) > 0
+    )
+    if (taskId === null || sessionTransport || !hasRuntimeExtensionBinding) return
 
     let cancelled = false
     const loadRuntimeExtensions = async () => {
@@ -1910,7 +1914,13 @@ export function AppProvider({
     return () => {
       cancelled = true
     }
-  }, [dispatch, sessionTransport, state.taskId])
+  }, [
+    dispatch,
+    sessionTransport,
+    state.currentTask?.id,
+    state.currentTask?.runtimeExtensionBindings,
+    state.taskId,
+  ])
 
   useEffect(() => {
     const previousIdentity = previousSessionConnectionIdentityRef.current
@@ -2344,16 +2354,6 @@ export function AppProvider({
               type: "SET_CURRENT_TASK",
               payload: task,
             })
-            if (isJsonRecord(taskData.runtime_extensions)) {
-              dispatch({
-                type: "SET_TASK_RUNTIME_EXTENSIONS",
-                payload: {
-                  taskId,
-                  extensions: normalizeTaskRuntimeExtensions(taskData.runtime_extensions),
-                },
-              })
-            }
-
             // Check if this is a new task (created within last 5 seconds)
             // If so, we don't expect historical messages, so stop loading
             // We do NOT stop loading here for new tasks anymore.

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -598,6 +598,17 @@ interface Message {
   isOptimistic?: boolean
 }
 
+export type TaskRuntimeExtensions = Record<string, Record<string, unknown>>
+
+const normalizeTaskRuntimeExtensions = (value: unknown): TaskRuntimeExtensions => {
+  if (!isJsonRecord(value)) return {}
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, Record<string, unknown>] => (
+      isJsonRecord(entry[1])
+    )),
+  )
+}
+
 export interface Task {
   id: string
   title: string
@@ -619,6 +630,7 @@ export interface Task {
   agentId?: number
   agentName?: string
   agentLogoUrl?: string
+  runtimeExtensionBindings?: string[]
   waitingQuestion?: string
   waitingInteractions?: Interaction[]
   runId?: string | null
@@ -737,6 +749,7 @@ const taskFromTaskInfoData = (
   agentId: taskData.agent_id as number | undefined,
   agentName: taskData.agent_name as string | undefined,
   agentLogoUrl: taskData.agent_logo_url as string | undefined,
+  runtimeExtensionBindings: getStringArray(taskData.runtime_extension_bindings),
   waitingQuestion: taskData.waiting_question as string | undefined,
   waitingInteractions: normalizeInteractions(taskData.waiting_interactions),
   runId: taskData.run_id as string | null | undefined,
@@ -806,6 +819,7 @@ interface DAGExecution {
 interface AppState {
   messages: Message[]
   currentTask: Task | null
+  taskRuntimeExtensions: TaskRuntimeExtensions
   dagExecution: DAGExecution | null
   steps: StepExecution[]
   traceEvents: TraceEvent[]
@@ -857,6 +871,7 @@ type AppAction =
   | { type: "ADD_MESSAGE"; payload: Message }
   | { type: "UPSERT_STREAMING_FINAL_ANSWER"; payload: { messageId: string; delta?: string; content?: string; status?: Message["status"]; timestamp: string } }
   | { type: "SET_CURRENT_TASK"; payload: Task | null }
+  | { type: "SET_TASK_RUNTIME_EXTENSIONS"; payload: { taskId: number; extensions: TaskRuntimeExtensions } }
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; runId?: string | null; stateVersion?: number; controlState?: TaskControlState } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
@@ -899,6 +914,7 @@ type AppAction =
 const createInitialState = (): AppState => ({
   messages: [],
   currentTask: null,
+  taskRuntimeExtensions: {},
   dagExecution: null,
   steps: [],
   traceEvents: [],
@@ -964,7 +980,14 @@ function projectAppState(state: AppState, action: AppAction): AppState {
       const taskChanged = state.taskId !== action.payload
       const messages = taskChanged ? [] : state.messages
       const contextUsage = taskChanged ? null : state.contextUsage
-      const newState = { ...state, taskId: action.payload, messages, contextUsage }
+      const taskRuntimeExtensions = taskChanged ? {} : state.taskRuntimeExtensions
+      const newState = {
+        ...state,
+        taskId: action.payload,
+        messages,
+        contextUsage,
+        taskRuntimeExtensions,
+      }
       console.log('🔄 Reducer returning new state:', newState)
       return newState
 
@@ -973,6 +996,7 @@ function projectAppState(state: AppState, action: AppAction): AppState {
         ...state,
         taskId: action.payload.taskId,
         currentTask: action.payload.task,
+        taskRuntimeExtensions: {},
       }
 
     case "RESET_SESSION_CONVERSATION":
@@ -1134,6 +1158,13 @@ function projectAppState(state: AppState, action: AppAction): AppState {
           : state.isProcessing,
       }
     }
+
+    case "SET_TASK_RUNTIME_EXTENSIONS":
+      if (state.taskId !== action.payload.taskId) return state
+      return {
+        ...state,
+        taskRuntimeExtensions: action.payload.extensions,
+      }
 
     case "UPDATE_TASK_STATUS": {
       if (!state.currentTask) {
@@ -1848,6 +1879,40 @@ export function AppProvider({
   }, [discardSessionPreAdoptionBuffer, rejectSessionResetFlight])
 
   useEffect(() => {
+    const taskId = state.taskId
+    if (taskId === null || sessionTransport) return
+
+    let cancelled = false
+    const loadRuntimeExtensions = async () => {
+      try {
+        const response = await apiRequest(
+          `${getApiUrl()}/api/chat/task/${taskId}/runtime-extensions`,
+          { cache: "no-store" },
+        )
+        if (!response || !response.ok) return
+        const payload = await response.json()
+        if (cancelled) return
+        dispatch({
+          type: "SET_TASK_RUNTIME_EXTENSIONS",
+          payload: {
+            taskId,
+            extensions: normalizeTaskRuntimeExtensions(payload?.runtime_extensions),
+          },
+        })
+      } catch (error) {
+        // Runtime metadata only decorates the transcript. A temporary metadata
+        // failure must not block loading or running the task itself.
+        console.warn("Failed to load task runtime metadata", error)
+      }
+    }
+    void loadRuntimeExtensions()
+
+    return () => {
+      cancelled = true
+    }
+  }, [dispatch, sessionTransport, state.taskId])
+
+  useEffect(() => {
     const previousIdentity = previousSessionConnectionIdentityRef.current
     previousSessionConnectionIdentityRef.current = sessionConnectionIdentity
     if (previousIdentity === sessionConnectionIdentity) return
@@ -2279,6 +2344,15 @@ export function AppProvider({
               type: "SET_CURRENT_TASK",
               payload: task,
             })
+            if (isJsonRecord(taskData.runtime_extensions)) {
+              dispatch({
+                type: "SET_TASK_RUNTIME_EXTENSIONS",
+                payload: {
+                  taskId,
+                  extensions: normalizeTaskRuntimeExtensions(taskData.runtime_extensions),
+                },
+              })
+            }
 
             // Check if this is a new task (created within last 5 seconds)
             // If so, we don't expect historical messages, so stop loading
@@ -5597,6 +5671,9 @@ export function AppProvider({
         if (config?.agentConfig) {
           requestBody.agent_config = config.agentConfig
         }
+        if (config?.runtimeExtensions) {
+          requestBody.runtime_extensions = config.runtimeExtensions
+        }
 
         const response = await apiRequest(`${apiUrl}/api/chat/task/create`, {
           method: 'POST',
@@ -5618,6 +5695,14 @@ export function AppProvider({
           console.log('🎯 About to call setTaskId with payload:', newTaskId)
           setTaskId(newTaskId)
           console.log('🎯 setTaskId completed')
+
+          dispatch({
+            type: "SET_TASK_RUNTIME_EXTENSIONS",
+            payload: {
+              taskId: newTaskId,
+              extensions: normalizeTaskRuntimeExtensions(taskData.runtime_extensions),
+            },
+          })
 
           // Create a new task from response
           const newTask: Task = {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -243,6 +243,7 @@ const en = {
         chipLabel: "Computer use",
         checking: "Checking the Xagent host...",
         chooseWindow: "Choose a browser window",
+        windowIdentifier: "Window {id}",
         controlScope: "Controls only this browser window through native accessibility. It does not connect Chrome debugging.",
         unavailable: "Not available on this Xagent host",
       },

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -234,8 +234,17 @@ const en = {
       processing: "Processing",
       usingAgentLabel: "Using",
       actions: {
+        add: "Add",
         config: "Configure Model",
         upload: "Upload",
+      },
+      localBrowser: {
+        label: "Local browser",
+        chipLabel: "Computer use",
+        checking: "Checking the Xagent host...",
+        chooseWindow: "Choose a browser window",
+        controlScope: "Controls only this browser window through native accessibility. It does not connect Chrome debugging.",
+        unavailable: "Not available on this Xagent host",
       },
       noModel: "No Model",
       noModelAlert: "No model configured. Please configure a model first.",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -234,8 +234,17 @@ const zh = {
       processing: "处理中",
       usingAgentLabel: "使用",
       actions: {
+        add: "添加",
         config: "配置模型",
         upload: "上传文件",
+      },
+      localBrowser: {
+        label: "本机浏览器",
+        chipLabel: "操作浏览器",
+        checking: "正在检查 Xagent 主机...",
+        chooseWindow: "选择一个浏览器窗口",
+        controlScope: "仅通过系统辅助功能控制这个浏览器窗口，不会连接 Chrome 调试。",
+        unavailable: "此 Xagent 主机不可用",
       },
       noModel: "暂无模型",
       noModelAlert: "暂无模型，请先配置模型",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -243,6 +243,7 @@ const zh = {
         chipLabel: "操作浏览器",
         checking: "正在检查 Xagent 主机...",
         chooseWindow: "选择一个浏览器窗口",
+        windowIdentifier: "窗口 {id}",
         controlScope: "仅通过系统辅助功能控制这个浏览器窗口，不会连接 Chrome 调试。",
         unavailable: "此 Xagent 主机不可用",
       },

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -54,6 +54,19 @@ BROWSER_CUA_DRIVER_COMMAND = "XAGENT_BROWSER_CUA_DRIVER_COMMAND"
 BROWSER_CUA_DRIVER_SOCKET = "XAGENT_BROWSER_CUA_DRIVER_SOCKET"
 BROWSER_CUA_DRIVER_TIMEOUT_SECONDS = "XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS"
 BROWSER_CUA_DRIVER_MAX_ELEMENTS = "XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS"
+SUPPORTED_NATIVE_BROWSER_APP_NAMES = frozenset(
+    {
+        "Brave Browser",
+        "Google Chrome",
+        "Google Chrome Canary",
+        "Chromium",
+        "Microsoft Edge",
+        "Vivaldi",
+    }
+)
+_NATIVE_BROWSER_APP_NAMES_BY_CASEFOLD = {
+    name.casefold(): name for name in SUPPORTED_NATIVE_BROWSER_APP_NAMES
+}
 MAX_UPLOAD_SIZE = "XAGENT_MAX_UPLOAD_SIZE"
 FILE_STORAGE_URI = "XAGENT_FILE_STORAGE_URI"
 FILE_STORAGE_OPTIONS = "XAGENT_FILE_STORAGE_OPTIONS"
@@ -618,9 +631,16 @@ def get_native_browser_enabled() -> bool:
 def get_native_browser_app_name() -> str:
     """Browser application exposed by the Local browser runtime."""
 
-    return (
+    configured = (
         os.getenv(NATIVE_BROWSER_APP_NAME, "Google Chrome").strip() or "Google Chrome"
     )
+    canonical = _NATIVE_BROWSER_APP_NAMES_BY_CASEFOLD.get(configured.casefold())
+    if canonical is None:
+        supported = ", ".join(sorted(SUPPORTED_NATIVE_BROWSER_APP_NAMES))
+        raise ValueError(
+            f"{NATIVE_BROWSER_APP_NAME} must name a supported browser: {supported}"
+        )
+    return canonical
 
 
 def get_browser_cua_driver_command() -> str:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -48,6 +48,12 @@ UPLOADED_FILE_RECOVERY_INTERVAL_SECONDS = (
 UPLOADED_FILE_RECOVERY_STALE_SECONDS = "XAGENT_UPLOADED_FILE_RECOVERY_STALE_SECONDS"
 UPLOADED_FILE_RECOVERY_BATCH_SIZE = "XAGENT_UPLOADED_FILE_RECOVERY_BATCH_SIZE"
 STORAGE_ROOT = "XAGENT_STORAGE_ROOT"
+NATIVE_BROWSER_ENABLED = "XAGENT_NATIVE_BROWSER_ENABLED"
+NATIVE_BROWSER_APP_NAME = "XAGENT_NATIVE_BROWSER_APP_NAME"
+BROWSER_CUA_DRIVER_COMMAND = "XAGENT_BROWSER_CUA_DRIVER_COMMAND"
+BROWSER_CUA_DRIVER_SOCKET = "XAGENT_BROWSER_CUA_DRIVER_SOCKET"
+BROWSER_CUA_DRIVER_TIMEOUT_SECONDS = "XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS"
+BROWSER_CUA_DRIVER_MAX_ELEMENTS = "XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS"
 MAX_UPLOAD_SIZE = "XAGENT_MAX_UPLOAD_SIZE"
 FILE_STORAGE_URI = "XAGENT_FILE_STORAGE_URI"
 FILE_STORAGE_OPTIONS = "XAGENT_FILE_STORAGE_OPTIONS"
@@ -601,6 +607,57 @@ def get_task_runtime_hook_queue_timeout_seconds() -> int:
     """Seconds a provider hook may wait for a runtime worker before starting."""
 
     return _get_positive_int_env(TASK_RUNTIME_HOOK_QUEUE_TIMEOUT_SECONDS, 30)
+
+
+def get_native_browser_enabled() -> bool:
+    """Whether tasks may control a browser on the interactive Xagent host."""
+
+    return _get_bool_env(NATIVE_BROWSER_ENABLED, False)
+
+
+def get_native_browser_app_name() -> str:
+    """Browser application exposed by the Local browser runtime."""
+
+    return (
+        os.getenv(NATIVE_BROWSER_APP_NAME, "Google Chrome").strip() or "Google Chrome"
+    )
+
+
+def get_browser_cua_driver_command() -> str:
+    """Executable used to start the Local browser cua-driver MCP server."""
+
+    return os.getenv(BROWSER_CUA_DRIVER_COMMAND, "cua-driver").strip() or "cua-driver"
+
+
+def get_browser_cua_driver_socket() -> str | None:
+    """Optional cua-driver daemon socket endpoint for Local browser."""
+
+    value = os.getenv(BROWSER_CUA_DRIVER_SOCKET, "").strip()
+    return value or None
+
+
+def get_browser_cua_driver_timeout_seconds() -> float:
+    """Per-call timeout for the Local browser driver."""
+
+    raw_value = os.getenv(BROWSER_CUA_DRIVER_TIMEOUT_SECONDS, "30").strip()
+    try:
+        value = float(raw_value)
+    except ValueError:
+        value = 30.0
+    if value > 0:
+        return value
+    logger.warning(
+        "Invalid %s=%r; falling back to 30 seconds",
+        BROWSER_CUA_DRIVER_TIMEOUT_SECONDS,
+        raw_value,
+    )
+    return 30.0
+
+
+def get_browser_cua_driver_max_elements() -> int:
+    """Maximum AX elements requested for one Local browser observation."""
+
+    return _get_positive_int_env(BROWSER_CUA_DRIVER_MAX_ELEMENTS, 2_000)
 
 
 def get_checkpoint_encoding_v2_enabled() -> bool:

--- a/src/xagent/core/computer/cua_driver.py
+++ b/src/xagent/core/computer/cua_driver.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Protocol
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.types import CallToolResult, ImageContent, TextContent
+
+from ...config import (
+    get_browser_cua_driver_command,
+    get_browser_cua_driver_socket,
+    get_browser_cua_driver_timeout_seconds,
+)
+
+
+class CuaDriverError(RuntimeError):
+    """Raised when the local cua-driver process cannot satisfy a tool call."""
+
+
+@dataclass(frozen=True)
+class CuaDriverResult:
+    """Provider-neutral subset of one cua-driver MCP tool response."""
+
+    structured: dict[str, Any] = field(default_factory=dict)
+    text: str = ""
+    image_bytes: bytes | None = None
+    image_mime_type: str | None = None
+
+
+class CuaDriverClientProtocol(Protocol):
+    async def call_tool(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+    ) -> CuaDriverResult: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class _ToolCallRequest:
+    name: str
+    arguments: dict[str, Any]
+    future: asyncio.Future[CallToolResult]
+
+
+class CuaDriverMCPClient:
+    """Lazy, task-scoped stdio MCP client for the native cua-driver runtime."""
+
+    def __init__(
+        self,
+        *,
+        command: str | None = None,
+        socket: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self.command = command or get_browser_cua_driver_command()
+        self.socket = (
+            get_browser_cua_driver_socket()
+            if socket is None
+            else socket.strip() or None
+        )
+        self.timeout_seconds = (
+            get_browser_cua_driver_timeout_seconds()
+            if timeout_seconds is None
+            else timeout_seconds
+        )
+        if not self.command.strip():
+            raise ValueError("cua-driver command must not be empty")
+        if self.timeout_seconds <= 0:
+            raise ValueError("cua-driver timeout must be positive")
+        self._worker: asyncio.Task[None] | None = None
+        self._queue: asyncio.Queue[_ToolCallRequest | None] | None = None
+        self._ready: asyncio.Future[None] | None = None
+        self._lifecycle_lock = asyncio.Lock()
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+    ) -> CuaDriverResult:
+        if not name.strip():
+            raise ValueError("cua-driver tool name must not be empty")
+        queue = await self._ensure_worker()
+        future: asyncio.Future[CallToolResult] = (
+            asyncio.get_running_loop().create_future()
+        )
+        await queue.put(
+            _ToolCallRequest(
+                name=name,
+                arguments=dict(arguments or {}),
+                future=future,
+            )
+        )
+        try:
+            response = await asyncio.wait_for(
+                asyncio.shield(future),
+                timeout=self.timeout_seconds,
+            )
+        except TimeoutError as exc:
+            raise CuaDriverError(
+                f"cua-driver tool {name!r} timed out after "
+                f"{self.timeout_seconds:g} seconds"
+            ) from exc
+        except Exception as exc:
+            raise CuaDriverError(f"cua-driver tool {name!r} failed: {exc}") from exc
+        finally:
+            if not future.done():
+                future.cancel()
+
+        text_parts = [
+            item.text for item in response.content if isinstance(item, TextContent)
+        ]
+        image_parts = [
+            item for item in response.content if isinstance(item, ImageContent)
+        ]
+        message = "\n".join(text_parts).strip()
+        if response.isError:
+            raise CuaDriverError(message or f"cua-driver tool {name!r} failed")
+
+        image_bytes: bytes | None = None
+        image_mime_type: str | None = None
+        if image_parts:
+            image = image_parts[0]
+            try:
+                image_bytes = base64.b64decode(image.data, validate=True)
+            except (binascii.Error, ValueError) as exc:
+                raise CuaDriverError(
+                    f"cua-driver tool {name!r} returned invalid image data"
+                ) from exc
+            image_mime_type = image.mimeType
+
+        structured = response.structuredContent
+        return CuaDriverResult(
+            structured=dict(structured) if isinstance(structured, dict) else {},
+            text=message,
+            image_bytes=image_bytes,
+            image_mime_type=image_mime_type,
+        )
+
+    async def close(self) -> None:
+        async with self._lifecycle_lock:
+            worker = self._worker
+            queue = self._queue
+            self._worker = None
+            self._queue = None
+            self._ready = None
+        if worker is None:
+            return
+        if queue is not None and not worker.done():
+            await queue.put(None)
+        try:
+            await asyncio.wait_for(worker, timeout=self.timeout_seconds)
+        except TimeoutError:
+            worker.cancel()
+            await asyncio.gather(worker, return_exceptions=True)
+        except Exception:
+            # Callers already receive the specific transport failure from their
+            # request future. Teardown remains best-effort and idempotent.
+            pass
+
+    async def _ensure_worker(
+        self,
+    ) -> asyncio.Queue[_ToolCallRequest | None]:
+        async with self._lifecycle_lock:
+            if self._worker is None or self._worker.done():
+                loop = asyncio.get_running_loop()
+                self._queue = asyncio.Queue()
+                self._ready = loop.create_future()
+                self._worker = asyncio.create_task(
+                    self._run_worker(self._queue, self._ready),
+                    name="xagent-cua-driver-mcp",
+                )
+            queue = self._queue
+            ready = self._ready
+        assert queue is not None and ready is not None
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(ready),
+                timeout=self.timeout_seconds,
+            )
+        except TimeoutError as exc:
+            raise CuaDriverError(
+                "cua-driver MCP initialization timed out after "
+                f"{self.timeout_seconds:g} seconds"
+            ) from exc
+        except Exception as exc:
+            if isinstance(exc, CuaDriverError):
+                raise
+            raise CuaDriverError(f"could not initialize cua-driver MCP: {exc}") from exc
+        return queue
+
+    async def _run_worker(
+        self,
+        queue: asyncio.Queue[_ToolCallRequest | None],
+        ready: asyncio.Future[None],
+    ) -> None:
+        args = ["mcp"]
+        if self.socket is not None:
+            args.extend(["--socket", self.socket])
+        parameters = StdioServerParameters(
+            command=self.command,
+            args=args,
+            env={
+                # The MCP SDK inherits only a safe environment allowlist. Keep
+                # driver telemetry disabled unless the host explicitly opted in.
+                "CUA_DRIVER_RS_TELEMETRY_ENABLED": os.getenv(
+                    "CUA_DRIVER_RS_TELEMETRY_ENABLED",
+                    "0",
+                ),
+            },
+        )
+        failure: BaseException | None = None
+        try:
+            with open(os.devnull, "w", encoding="utf-8") as errlog:
+                async with (
+                    stdio_client(parameters, errlog=errlog) as (
+                        read_stream,
+                        write_stream,
+                    ),
+                    ClientSession(
+                        read_stream,
+                        write_stream,
+                        read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
+                    ) as session,
+                ):
+                    await session.initialize()
+                    if not ready.done():
+                        ready.set_result(None)
+                    while True:
+                        request = await queue.get()
+                        if request is None:
+                            break
+                        if request.future.done():
+                            continue
+                        try:
+                            response = await session.call_tool(
+                                request.name,
+                                request.arguments,
+                            )
+                        except Exception as exc:
+                            if not request.future.done():
+                                request.future.set_exception(exc)
+                        else:
+                            if not request.future.done():
+                                request.future.set_result(response)
+        except FileNotFoundError as exc:
+            failure = CuaDriverError(
+                f"cua-driver executable was not found: {self.command!r}"
+            )
+            failure.__cause__ = exc
+        except asyncio.CancelledError:
+            failure = CuaDriverError("cua-driver MCP worker was cancelled")
+            raise
+        except Exception as exc:
+            failure = CuaDriverError(f"could not initialize cua-driver MCP: {exc}")
+            failure.__cause__ = exc
+        finally:
+            if failure is not None and not ready.done():
+                ready.set_exception(failure)
+            while not queue.empty():
+                request = queue.get_nowait()
+                if request is not None and not request.future.done():
+                    request.future.set_exception(
+                        failure or CuaDriverError("cua-driver MCP worker stopped")
+                    )

--- a/src/xagent/core/computer/cua_driver.py
+++ b/src/xagent/core/computer/cua_driver.py
@@ -186,15 +186,21 @@ class CuaDriverMCPClient:
                 asyncio.shield(ready),
                 timeout=self.timeout_seconds,
             )
-        except TimeoutError as exc:
-            raise CuaDriverError(
-                "cua-driver MCP initialization timed out after "
-                f"{self.timeout_seconds:g} seconds"
-            ) from exc
-        except Exception as exc:
-            if isinstance(exc, CuaDriverError):
-                raise
-            raise CuaDriverError(f"could not initialize cua-driver MCP: {exc}") from exc
+        except BaseException as exc:
+            # Initialization owns a partially started worker/subprocess. Reset
+            # it before propagating timeouts, transport failures, or caller
+            # cancellation so a later call can create a fresh worker.
+            await self.close()
+            if isinstance(exc, TimeoutError):
+                raise CuaDriverError(
+                    "cua-driver MCP initialization timed out after "
+                    f"{self.timeout_seconds:g} seconds"
+                ) from exc
+            if isinstance(exc, Exception) and not isinstance(exc, CuaDriverError):
+                raise CuaDriverError(
+                    f"could not initialize cua-driver MCP: {exc}"
+                ) from exc
+            raise
         return queue
 
     async def _run_worker(

--- a/src/xagent/core/computer/cua_driver.py
+++ b/src/xagent/core/computer/cua_driver.py
@@ -80,6 +80,10 @@ class CuaDriverMCPClient:
         self._queue: asyncio.Queue[_ToolCallRequest | None] | None = None
         self._ready: asyncio.Future[None] | None = None
         self._lifecycle_lock = asyncio.Lock()
+        # Sessions are process-local inside cua-driver. Keep only successfully
+        # established registrations so a replacement worker can restore their
+        # capture scope before it accepts another tool call.
+        self._active_sessions: dict[str, dict[str, Any]] = {}
 
     async def call_tool(
         self,
@@ -125,6 +129,8 @@ class CuaDriverMCPClient:
         if response.isError:
             raise CuaDriverError(message or f"cua-driver tool {name!r} failed")
 
+        await self._record_session_call(name, dict(arguments or {}))
+
         image_bytes: bytes | None = None
         image_mime_type: str | None = None
         if image_parts:
@@ -146,12 +152,17 @@ class CuaDriverMCPClient:
         )
 
     async def close(self) -> None:
+        await self._stop_worker(clear_sessions=True)
+
+    async def _stop_worker(self, *, clear_sessions: bool) -> None:
         async with self._lifecycle_lock:
             worker = self._worker
             queue = self._queue
             self._worker = None
             self._queue = None
             self._ready = None
+            if clear_sessions:
+                self._active_sessions.clear()
         if worker is None:
             return
         if queue is not None and not worker.done():
@@ -190,7 +201,10 @@ class CuaDriverMCPClient:
             # Initialization owns a partially started worker/subprocess. Reset
             # it before propagating timeouts, transport failures, or caller
             # cancellation so a later call can create a fresh worker.
-            await self.close()
+            # Keep registrations across an initialization failure. A later
+            # replacement must either restore every session or fail closed;
+            # silently forgetting the window-scoped session is unsafe.
+            await self._stop_worker(clear_sessions=False)
             if isinstance(exc, TimeoutError):
                 raise CuaDriverError(
                     "cua-driver MCP initialization timed out after "
@@ -238,6 +252,7 @@ class CuaDriverMCPClient:
                     ) as session,
                 ):
                     await session.initialize()
+                    await self._restore_active_sessions(session)
                     if not ready.done():
                         ready.set_result(None)
                     while True:
@@ -277,3 +292,32 @@ class CuaDriverMCPClient:
                     request.future.set_exception(
                         failure or CuaDriverError("cua-driver MCP worker stopped")
                     )
+
+    async def _record_session_call(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> None:
+        session_id = arguments.get("session")
+        if not isinstance(session_id, str) or not session_id:
+            return
+        async with self._lifecycle_lock:
+            if name == "start_session":
+                self._active_sessions[session_id] = arguments
+            elif name == "end_session":
+                self._active_sessions.pop(session_id, None)
+
+    async def _restore_active_sessions(self, session: ClientSession) -> None:
+        async with self._lifecycle_lock:
+            registrations = tuple(self._active_sessions.values())
+        for arguments in registrations:
+            response = await session.call_tool("start_session", arguments)
+            if response.isError:
+                message = "\n".join(
+                    item.text
+                    for item in response.content
+                    if isinstance(item, TextContent)
+                ).strip()
+                raise CuaDriverError(
+                    message or "cua-driver could not restore an active session"
+                )

--- a/src/xagent/core/computer/input_platform.py
+++ b/src/xagent/core/computer/input_platform.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from typing import Any
+
+
+class ComputerInputPlatform(str, Enum):
+    MACOS = "macos"
+    WINDOWS = "windows"
+    LINUX = "linux"
+    CHROMEOS = "chromeos"
+    ANDROID = "android"
+    UNKNOWN = "unknown"
+
+
+class ComputerPrimaryModifier(str, Enum):
+    META = "META"
+    CTRL = "CTRL"
+
+
+def normalize_computer_input_platform(value: str | None) -> ComputerInputPlatform:
+    normalized = str(value or "").strip().lower()
+    aliases = {
+        "darwin": ComputerInputPlatform.MACOS,
+        "mac": ComputerInputPlatform.MACOS,
+        "macos": ComputerInputPlatform.MACOS,
+        "win": ComputerInputPlatform.WINDOWS,
+        "win32": ComputerInputPlatform.WINDOWS,
+        "windows": ComputerInputPlatform.WINDOWS,
+        "linux": ComputerInputPlatform.LINUX,
+        "openbsd": ComputerInputPlatform.LINUX,
+        "chromeos": ComputerInputPlatform.CHROMEOS,
+        "android": ComputerInputPlatform.ANDROID,
+    }
+    return aliases.get(normalized, ComputerInputPlatform.UNKNOWN)
+
+
+def host_computer_input_platform() -> ComputerInputPlatform:
+    return normalize_computer_input_platform(sys.platform)
+
+
+def primary_modifier_for_platform(
+    platform: ComputerInputPlatform | str,
+) -> ComputerPrimaryModifier:
+    normalized = (
+        platform
+        if isinstance(platform, ComputerInputPlatform)
+        else normalize_computer_input_platform(platform)
+    )
+    if normalized is ComputerInputPlatform.MACOS:
+        return ComputerPrimaryModifier.META
+    return ComputerPrimaryModifier.CTRL
+
+
+def computer_input_metadata(
+    platform: ComputerInputPlatform | str,
+) -> dict[str, Any]:
+    normalized = (
+        platform
+        if isinstance(platform, ComputerInputPlatform)
+        else normalize_computer_input_platform(platform)
+    )
+    return {
+        "platform": normalized.value,
+        "primary_modifier": primary_modifier_for_platform(normalized).value,
+    }

--- a/src/xagent/core/computer/native_browser.py
+++ b/src/xagent/core/computer/native_browser.py
@@ -1,0 +1,1636 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import struct
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from ...config import (
+    get_browser_cua_driver_max_elements,
+    get_native_browser_app_name,
+    get_native_browser_enabled,
+)
+from .cua_driver import (
+    CuaDriverClientProtocol,
+    CuaDriverError,
+    CuaDriverMCPClient,
+    CuaDriverResult,
+)
+from .environment import (
+    ComputerEnvironment,
+    ComputerFrameMismatchError,
+    ComputerTargetNotFoundError,
+)
+from .input_platform import (
+    ComputerInputPlatform,
+    computer_input_metadata,
+    host_computer_input_platform,
+)
+from .native_navigation import (
+    NativeBrowserNavigator,
+    default_native_browser_navigator,
+)
+from .schema import (
+    COMPUTER_CONTROL_METADATA_KEY,
+    COMPUTER_FRAME_ID_METADATA_KEY,
+    COMPUTER_PERCEPTION_METADATA_KEY,
+    COMPUTER_SESSION_ID_METADATA_KEY,
+    ELEMENT_EXTRACTION_FAILED_KEY,
+    ELEMENT_EXTRACTION_INCOMPLETE_KEY,
+    ELEMENTS_TRUNCATED_KEY,
+    MAX_OBSERVATION_ELEMENTS,
+    ComputerAction,
+    ComputerActionBatch,
+    ComputerActionType,
+    ComputerControlTransport,
+    ComputerElement,
+    ComputerElementSource,
+    ComputerElementSurface,
+    ComputerEnvironmentType,
+    ComputerObservation,
+    ComputerPerceptionMode,
+    NormalizedPoint,
+    NormalizedRect,
+    Viewport,
+)
+from .store import ObservationStore
+
+_BASE_SUPPORTED_ACTIONS = tuple(
+    action
+    for action in ComputerActionType
+    if action not in {ComputerActionType.MOVE, ComputerActionType.NAVIGATE}
+)
+_PID_KEYBOARD_ACTIONS = frozenset(
+    {
+        ComputerActionType.TYPE,
+        ComputerActionType.REPLACE_TEXT,
+        ComputerActionType.KEYPRESS,
+    }
+)
+_ACTION_RESULT_FIELDS = (
+    "path",
+    "effect",
+    "verified",
+    "escalation",
+    "status",
+    "code",
+)
+_BROWSER_APP_MARKERS = (
+    "arc",
+    "brave",
+    "chrome",
+    "chromium",
+    "edge",
+    "firefox",
+    "safari",
+    "vivaldi",
+)
+_AX_DOCUMENT_ROOT_ROLES = frozenset({"axwebarea", "webarea"})
+_AX_OVERLAY_ROLES = frozenset(
+    {
+        "axdialog",
+        "axdrawer",
+        "axmenu",
+        "axpopover",
+        "axsheet",
+        "dialog",
+        "drawer",
+        "menu",
+        "popover",
+        "sheet",
+    }
+)
+_AX_WINDOW_ROLES = frozenset({"axwindow", "window"})
+_ACTIONABLE_ROLE_MARKERS = (
+    "button",
+    "checkbox",
+    "combobox",
+    "field",
+    "link",
+    "menuitem",
+    "popup",
+    "radio",
+    "row",
+    "slider",
+    "switch",
+    "tab",
+)
+_PIXEL_FRAME_ERROR_MARKERS = (
+    "not one coherent 1x/2x frame",
+    "lies outside window",
+    "px_frame_mismatch",
+)
+_POST_ACTION_SETTLE_SECONDS = 0.25
+_POST_ACTION_SETTLE_RETRIES = 3
+_SEMANTIC_SETTLE_RADIUS = 0.06
+
+CuaDriverClientFactory = Callable[[], CuaDriverClientProtocol]
+LOCAL_BROWSER_TASK_EXTENSION = "local_browser"
+
+
+@dataclass(frozen=True)
+class NativeBrowserWindow:
+    pid: int
+    window_id: int
+    app_name: str
+    title: str | None
+    x: float
+    y: float
+    width: float
+    height: float
+    z_index: int
+    is_on_screen: bool
+    on_current_space: bool | None
+
+
+class NativeBrowserEnvironment(ComputerEnvironment):
+    """Control one configured browser window through cua-driver's native tools.
+
+    A caller may provide one exact ``(pid, window_id)`` selected by the user.
+    Otherwise the first observation chooses the frontmost visible window of the
+    configured browser. The resulting binding is sticky: if the window closes,
+    the environment fails instead of silently taking over another window.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        workspace: Any,
+        driver: CuaDriverClientProtocol | None = None,
+        driver_factory: CuaDriverClientFactory | None = None,
+        observation_store: ObservationStore | None = None,
+        target_pid: int | None = None,
+        target_window_id: int | None = None,
+        browser_app_name: str | None = None,
+        perception_mode: ComputerPerceptionMode | str = ComputerPerceptionMode.AUTO,
+        max_elements: int | None = None,
+        headless: bool = False,
+        native_browser_navigator: NativeBrowserNavigator | None = None,
+    ) -> None:
+        del headless
+        super().__init__(session_id)
+        if driver is not None and driver_factory is not None:
+            raise ValueError("provide either driver or driver_factory, not both")
+        if driver is None and not get_native_browser_enabled():
+            raise RuntimeError(
+                "Local browser access is disabled. Set "
+                "XAGENT_NATIVE_BROWSER_ENABLED=true only on a trusted "
+                "interactive Xagent host."
+            )
+        self.workspace = workspace
+        self.observation_store = observation_store or ObservationStore(workspace)
+        if (target_pid is None) != (target_window_id is None):
+            raise ValueError(
+                "target_pid and target_window_id must be provided together"
+            )
+        self.target_pid = target_pid
+        self.target_window_id = target_window_id
+        self.browser_app_name = (
+            browser_app_name or get_native_browser_app_name()
+        ).strip()
+        if not self.browser_app_name:
+            raise ValueError("local browser app name must not be empty")
+        self.perception_mode = ComputerPerceptionMode(perception_mode)
+        self.max_elements = (
+            get_browser_cua_driver_max_elements()
+            if max_elements is None
+            else max_elements
+        )
+        if self.max_elements <= 0:
+            raise ValueError("local browser max_elements must be positive")
+        self._driver = driver
+        self._driver_factory = driver_factory or CuaDriverMCPClient
+        self._target: NativeBrowserWindow | None = None
+        self._visible_windows: list[NativeBrowserWindow] = []
+        self._session_started = False
+        self._last_action_result: dict[str, Any] | None = None
+        self._unsupported_action_reasons: dict[str, str] = {}
+        self._known_element_signatures: set[tuple[Any, ...]] = set()
+        self._native_browser_navigator = (
+            native_browser_navigator or default_native_browser_navigator()
+        )
+
+    async def _close(self) -> None:
+        driver = self._driver
+        self._driver = None
+        if driver is None:
+            return
+        if self._session_started:
+            try:
+                await driver.call_tool("end_session", {"session": self.session_id})
+            except Exception:
+                # Closing stdin still tears down process-owned driver state.
+                pass
+        await driver.close()
+        self._session_started = False
+
+    async def health_report(self) -> dict[str, Any]:
+        """Return cua-driver's stable structured diagnostics contract."""
+
+        result = await self._get_driver().call_tool("health_report", {})
+        return result.structured
+
+    async def _observe(self) -> ComputerObservation:
+        await self._ensure_session()
+        if self._target is None:
+            self._target = await self._select_target()
+        else:
+            await self._refresh_bound_target()
+        return await self._capture_observation()
+
+    async def _execute(self, batch: ComputerActionBatch) -> ComputerObservation:
+        if len(batch.actions) != 1:
+            raise ValueError("local browser executes exactly one action per frame")
+        action = batch.actions[0]
+        supported_actions = (
+            self.current_observation.metadata.get("supported_actions")
+            if self.current_observation is not None
+            else None
+        )
+        if self.current_observation is not None and (
+            not isinstance(supported_actions, list)
+            or action.type.value not in supported_actions
+        ):
+            reason = self._unsupported_action_reasons.get(action.type.value)
+            detail = f": {reason}" if reason else ""
+            raise ValueError(
+                f"{action.type.value} is not supported by the local browser runtime"
+                f"{detail}"
+            )
+        await self._refresh_bound_target()
+        self._validate_pixel_frame(action)
+        try:
+            await self._execute_action(action)
+        except CuaDriverError as exc:
+            if any(marker in str(exc) for marker in _PIXEL_FRAME_ERROR_MARKERS):
+                raise ComputerFrameMismatchError(
+                    "The selected window's pixel geometry changed after this "
+                    "frame was captured. Request a fresh observation and plan "
+                    "from its new frame_id; do not retry coordinates from the "
+                    "invalidated frame."
+                ) from exc
+            raise
+        if action.type not in {
+            ComputerActionType.OBSERVE,
+            ComputerActionType.SCREENSHOT,
+            ComputerActionType.WAIT,
+        }:
+            await asyncio.sleep(_POST_ACTION_SETTLE_SECONDS)
+        await self._refresh_bound_target()
+        observation = await self._capture_observation()
+        return await self._settle_unverified_action(
+            action=action,
+            previous=self.current_observation,
+            observation=observation,
+        )
+
+    async def _settle_unverified_action(
+        self,
+        *,
+        action: ComputerAction,
+        previous: ComputerObservation | None,
+        observation: ComputerObservation,
+    ) -> ComputerObservation:
+        """Wait briefly for asynchronous native UI state to become observable."""
+
+        if previous is None or action.type in {
+            ComputerActionType.OBSERVE,
+            ComputerActionType.SCREENSHOT,
+            ComputerActionType.WAIT,
+        }:
+            return observation
+        action_result = observation.metadata.get("last_action_result")
+        semantic_target_point = self._semantic_target_point(action, previous)
+        include_screenshot = semantic_target_point is None
+        previous_signature = self._observation_state_signature(
+            previous,
+            include_screenshot=include_screenshot,
+            target_point=semantic_target_point,
+        )
+        state_changed = self._post_action_state_changed(
+            action=action,
+            previous=previous,
+            observation=observation,
+            previous_signature=previous_signature,
+            include_screenshot=include_screenshot,
+            semantic_target_point=semantic_target_point,
+        )
+        if (
+            not isinstance(action_result, Mapping)
+            or (
+                action.type is not ComputerActionType.NAVIGATE
+                and action_result.get("effect") != "unverifiable"
+            )
+            or state_changed
+        ):
+            return observation
+
+        for _attempt in range(_POST_ACTION_SETTLE_RETRIES):
+            await asyncio.sleep(_POST_ACTION_SETTLE_SECONDS)
+            await self._refresh_bound_target()
+            refreshed = await self._capture_observation()
+            refreshed = refreshed.model_copy(
+                update={
+                    "metadata": {
+                        **refreshed.metadata,
+                        "last_action_result": dict(action_result),
+                    }
+                }
+            )
+            observation = refreshed
+            state_changed = self._post_action_state_changed(
+                action=action,
+                previous=previous,
+                observation=observation,
+                previous_signature=previous_signature,
+                include_screenshot=include_screenshot,
+                semantic_target_point=semantic_target_point,
+            )
+            if state_changed:
+                break
+        if (
+            action.type is not ComputerActionType.NAVIGATE
+            and str(action.metadata.get("delivery_mode") or "").strip().lower()
+            != "foreground"
+            and not state_changed
+        ):
+            updated_result = {
+                **dict(action_result),
+                "verified": False,
+                "escalation": {
+                    "recommended": "foreground",
+                    "reason": "no_observable_state_change_after_background_delivery",
+                },
+            }
+            observation = observation.model_copy(
+                update={
+                    "metadata": {
+                        **observation.metadata,
+                        "last_action_result": updated_result,
+                    }
+                }
+            )
+        return observation
+
+    @classmethod
+    def _post_action_state_changed(
+        cls,
+        *,
+        action: ComputerAction,
+        previous: ComputerObservation,
+        observation: ComputerObservation,
+        previous_signature: tuple[Any, ...],
+        include_screenshot: bool,
+        semantic_target_point: NormalizedPoint | None,
+    ) -> bool:
+        if observation.title != previous.title:
+            return True
+        if action.type is ComputerActionType.NAVIGATE:
+            return False
+        current_signature = cls._observation_state_signature(
+            observation,
+            include_screenshot=include_screenshot,
+            target_point=semantic_target_point,
+        )
+        if semantic_target_point is None:
+            return current_signature != previous_signature
+        current_local_elements = current_signature[2]
+        return bool(current_local_elements) and current_signature != previous_signature
+
+    @staticmethod
+    def _observation_state_signature(
+        observation: ComputerObservation,
+        *,
+        include_screenshot: bool,
+        target_point: NormalizedPoint | None,
+    ) -> tuple[Any, ...]:
+        elements = observation.elements
+        if target_point is not None:
+            elements = [
+                element
+                for element in elements
+                if (
+                    element.metadata.get("enabled") is not False
+                    and any(
+                        marker in (element.role or "").casefold()
+                        for marker in _ACTIONABLE_ROLE_MARKERS
+                    )
+                    and (
+                        element.surface is ComputerElementSurface.OVERLAY
+                        or (
+                            (
+                                element.bounds.x
+                                + element.bounds.width / 2
+                                - target_point.x
+                            )
+                            ** 2
+                            + (
+                                element.bounds.y
+                                + element.bounds.height / 2
+                                - target_point.y
+                            )
+                            ** 2
+                            <= _SEMANTIC_SETTLE_RADIUS**2
+                        )
+                    )
+                )
+            ]
+        return (
+            observation.title,
+            (
+                observation.screenshot.metadata.get("sha256")
+                if include_screenshot
+                else None
+            ),
+            tuple(
+                sorted(
+                    (
+                        element.source.value,
+                        (element.surface.value if element.surface is not None else ""),
+                        element.role or "",
+                        element.label or "",
+                        element.text or "",
+                        str(element.metadata.get("selected")),
+                        str(element.metadata.get("enabled")),
+                        round(element.bounds.x, 4),
+                        round(element.bounds.y, 4),
+                        round(element.bounds.width, 4),
+                        round(element.bounds.height, 4),
+                    )
+                    for element in elements
+                )
+            ),
+        )
+
+    @staticmethod
+    def _semantic_target_point(
+        action: ComputerAction,
+        observation: ComputerObservation,
+    ) -> NormalizedPoint | None:
+        target = action.target
+        if target is None or target.element_id is None:
+            return None
+        element = next(
+            (
+                candidate
+                for candidate in observation.elements
+                if candidate.element_id == target.element_id
+            ),
+            None,
+        )
+        if element is None:
+            return None
+        return NormalizedPoint(
+            x=element.bounds.x + element.bounds.width / 2,
+            y=element.bounds.y + element.bounds.height / 2,
+        )
+
+    async def _ensure_session(self) -> None:
+        if self._session_started:
+            return
+        await self._get_driver().call_tool(
+            "start_session",
+            {
+                "session": self.session_id,
+                "capture_scope": "window",
+            },
+        )
+        self._session_started = True
+
+    def _get_driver(self) -> CuaDriverClientProtocol:
+        if self._driver is None:
+            self._driver = self._driver_factory()
+        return self._driver
+
+    async def _select_target(self) -> NativeBrowserWindow:
+        result = await self._get_driver().call_tool(
+            "list_windows",
+            {"on_screen_only": True},
+        )
+        raw_windows = result.structured.get("windows")
+        if not isinstance(raw_windows, list):
+            raise CuaDriverError("cua-driver list_windows returned no window list")
+        windows = [
+            parsed
+            for raw in raw_windows
+            if isinstance(raw, Mapping)
+            and (parsed := self._parse_window(raw)) is not None
+        ]
+        visible = [
+            window
+            for window in windows
+            if window.is_on_screen and window.on_current_space is not False
+        ]
+        browser_windows = [
+            window
+            for window in visible
+            if window.app_name.casefold() == self.browser_app_name.casefold()
+        ]
+        self._visible_windows = browser_windows
+        if self.target_pid is not None and self.target_window_id is not None:
+            exact = next(
+                (
+                    window
+                    for window in browser_windows
+                    if window.pid == self.target_pid
+                    and window.window_id == self.target_window_id
+                ),
+                None,
+            )
+            if exact is None:
+                raise ComputerTargetNotFoundError(
+                    f"The selected {self.browser_app_name} window is no longer "
+                    "visible. Choose the browser window again before starting "
+                    "a new task."
+                )
+            return exact
+        if not browser_windows:
+            raise ComputerTargetNotFoundError(
+                f"No visible {self.browser_app_name} window is available on the "
+                "Xagent host."
+            )
+        return max(browser_windows, key=lambda window: window.z_index)
+
+    async def _refresh_bound_target(self) -> NativeBrowserWindow:
+        target = self._require_target()
+        result = await self._get_driver().call_tool(
+            "list_windows",
+            {"on_screen_only": True},
+        )
+        raw_windows = result.structured.get("windows")
+        if not isinstance(raw_windows, list):
+            raise CuaDriverError("cua-driver list_windows returned no window list")
+        visible = [
+            parsed
+            for raw in raw_windows
+            if isinstance(raw, Mapping)
+            and (parsed := self._parse_window(raw)) is not None
+            and parsed.is_on_screen
+            and parsed.on_current_space is not False
+        ]
+        browser_windows = [
+            window
+            for window in visible
+            if window.app_name.casefold() == self.browser_app_name.casefold()
+        ]
+        self._visible_windows = browser_windows
+        refreshed = next(
+            (
+                window
+                for window in browser_windows
+                if window.pid == target.pid and window.window_id == target.window_id
+            ),
+            None,
+        )
+        if refreshed is None:
+            raise ComputerTargetNotFoundError(
+                f"The selected {self.browser_app_name} window disappeared during "
+                "navigation."
+            )
+        self._target = refreshed
+        return refreshed
+
+    @staticmethod
+    def _parse_window(raw: Mapping[str, Any]) -> NativeBrowserWindow | None:
+        bounds = raw.get("bounds")
+        if not isinstance(bounds, Mapping):
+            return None
+        try:
+            width = float(bounds["width"])
+            height = float(bounds["height"])
+            if width <= 0 or height <= 0:
+                return None
+            return NativeBrowserWindow(
+                pid=int(raw["pid"]),
+                window_id=int(raw["window_id"]),
+                app_name=str(raw["app_name"]),
+                title=(
+                    str(raw["title"]).strip()
+                    if raw.get("title") is not None and str(raw["title"]).strip()
+                    else None
+                ),
+                x=float(bounds["x"]),
+                y=float(bounds["y"]),
+                width=width,
+                height=height,
+                z_index=int(raw.get("z_index") or 0),
+                is_on_screen=raw.get("is_on_screen") is True,
+                on_current_space=(
+                    raw.get("on_current_space")
+                    if isinstance(raw.get("on_current_space"), bool)
+                    else None
+                ),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    async def _capture_observation(self) -> ComputerObservation:
+        target = self._require_target()
+        requested_max_elements = self.max_elements
+        result = await self._get_driver().call_tool(
+            "get_window_state",
+            {
+                "session": self.session_id,
+                "pid": target.pid,
+                "window_id": target.window_id,
+                "include_screenshot": True,
+                "max_elements": requested_max_elements,
+            },
+        )
+        raw_elements = result.structured.get("elements")
+        raw_element_list = raw_elements if isinstance(raw_elements, list) else []
+        frame_id = f"frame-{uuid4().hex}"
+        image_bytes = result.image_bytes
+        screenshot_fresh = bool(image_bytes)
+        if not screenshot_fresh and (
+            self.current_observation is None
+            or not raw_element_list
+            or self.perception_mode is ComputerPerceptionMode.VISION
+        ):
+            raise CuaDriverError(
+                "cua-driver could not capture the bound browser window. Check "
+                "Screen Recording permission with `cua-driver health_report`."
+            )
+        if image_bytes:
+            mime_type = result.image_mime_type or str(
+                result.structured.get("screenshot_mime_type") or "image/png"
+            )
+            if mime_type not in {"image/png", "image/jpeg", "image/webp"}:
+                raise CuaDriverError(
+                    f"cua-driver returned unsupported screenshot type {mime_type!r}"
+                )
+            width, height = self._screenshot_size(result)
+            viewport = Viewport(width=width, height=height, device_pixel_ratio=1.0)
+            screenshot = await self.observation_store.save_screenshot(
+                session_id=self.session_id,
+                frame_id=frame_id,
+                image_bytes=image_bytes,
+                mime_type=mime_type,
+                viewport=viewport,
+                text_fallback=(f"Current local {target.app_name} window screenshot."),
+                metadata={
+                    "computer_runtime_kind": "local_browser",
+                    "pid": target.pid,
+                    "window_id": target.window_id,
+                },
+            )
+        else:
+            previous = self.current_observation
+            assert previous is not None
+            viewport = previous.viewport
+            width = viewport.width
+            height = viewport.height
+            screenshot = previous.screenshot.model_copy(
+                update={
+                    "text_fallback": (
+                        "Previous exact-window screenshot reused because the "
+                        "current transient UI could only be observed through "
+                        "fresh accessibility elements."
+                    ),
+                    "metadata": {
+                        **previous.screenshot.metadata,
+                        COMPUTER_SESSION_ID_METADATA_KEY: self.session_id,
+                        COMPUTER_FRAME_ID_METADATA_KEY: frame_id,
+                        "screenshot_fresh": False,
+                        "reused_from_frame_id": previous.frame_id,
+                    },
+                }
+            )
+        semantic_elements, semantic_candidate_count = self._build_elements(
+            raw_element_list,
+            target=target,
+        )
+        elements = (
+            []
+            if self.perception_mode is ComputerPerceptionMode.VISION
+            else semantic_elements
+        )
+        raw_element_count = self._optional_int(result.structured.get("element_count"))
+        metadata: dict[str, Any] = {
+            "computer_runtime_kind": "local_browser",
+            "native_driver": "cua-driver",
+            "application": target.app_name,
+            "pid": target.pid,
+            "window_id": target.window_id,
+            "screenshot_fresh": screenshot_fresh,
+            "coordinate_frame": {
+                "screenshot_width": width,
+                "screenshot_height": height,
+                "screenshot_fresh": screenshot_fresh,
+                "window_bounds": self._window_bounds(target),
+            },
+            "user_takeover_available": True,
+            "delivery_mode": "background",
+            COMPUTER_PERCEPTION_METADATA_KEY: {
+                "mode": self.perception_mode.value,
+                "available": [
+                    *(["vision"] if screenshot_fresh else []),
+                    *(["semantic"] if semantic_elements else []),
+                ],
+                "semantic_source": "accessibility" if semantic_elements else None,
+            },
+            COMPUTER_CONTROL_METADATA_KEY: {
+                "transport": ComputerControlTransport.NATIVE_ACCESSIBILITY.value,
+                "scope": "window",
+                "browser_debugging": False,
+            },
+            **computer_input_metadata(host_computer_input_platform()),
+            "available_windows": [
+                {
+                    "pid": window.pid,
+                    "window_id": window.window_id,
+                    "application": window.app_name,
+                    "title": window.title,
+                }
+                for window in self._visible_windows[:20]
+            ],
+        }
+        if result.structured.get("degraded") is True:
+            metadata[ELEMENT_EXTRACTION_FAILED_KEY] = True
+            metadata["driver_degraded_reason"] = str(
+                result.structured.get("degraded_reason") or ""
+            )
+        if (
+            self.perception_mode is not ComputerPerceptionMode.VISION
+            and raw_element_count is not None
+            and raw_element_count > len(elements)
+        ):
+            metadata[ELEMENT_EXTRACTION_INCOMPLETE_KEY] = True
+        if (
+            self.perception_mode is not ComputerPerceptionMode.VISION
+            and isinstance(raw_elements, list)
+            and len(elements) < len(raw_elements)
+        ):
+            metadata[ELEMENT_EXTRACTION_INCOMPLETE_KEY] = True
+        if (
+            semantic_candidate_count > MAX_OBSERVATION_ELEMENTS
+            or (
+                raw_element_count is not None
+                and raw_element_count > requested_max_elements
+            )
+            or (
+                isinstance(raw_elements, list)
+                and len(raw_elements) >= requested_max_elements
+            )
+        ):
+            metadata[ELEMENT_EXTRACTION_INCOMPLETE_KEY] = True
+            metadata[ELEMENTS_TRUNCATED_KEY] = True
+        escalation = result.structured.get("escalation")
+        if isinstance(escalation, Mapping):
+            metadata["driver_escalation"] = dict(escalation)
+        background_input = result.structured.get("background_input")
+        if isinstance(background_input, Mapping):
+            metadata["background_input"] = dict(background_input)
+        supported_actions, unsupported_reasons = self._supported_actions(
+            background_input,
+            elements=semantic_elements,
+            target=target,
+        )
+        self._unsupported_action_reasons = unsupported_reasons
+        metadata["supported_actions"] = supported_actions
+        if unsupported_reasons:
+            metadata["unsupported_actions"] = dict(unsupported_reasons)
+        last_action_result = self._last_action_result
+        if last_action_result is not None:
+            metadata["last_action_result"] = last_action_result
+            self._last_action_result = None
+        return ComputerObservation(
+            session_id=self.session_id,
+            frame_id=frame_id,
+            environment=ComputerEnvironmentType.DESKTOP,
+            viewport=viewport,
+            screenshot=screenshot,
+            elements=elements,
+            active_url=(
+                _optional_active_url(result.structured)
+                or _optional_active_url(last_action_result or {})
+            ),
+            title=target.title,
+            metadata=metadata,
+        )
+
+    def _supported_actions(
+        self,
+        background_input: Any,
+        *,
+        elements: list[ComputerElement],
+        target: NativeBrowserWindow,
+    ) -> tuple[list[str], dict[str, str]]:
+        keyboard_reason = self._pid_keyboard_refusal_reason(background_input)
+        if keyboard_reason is None and not isinstance(background_input, Mapping):
+            same_pid_windows = [
+                window
+                for window in self._visible_windows
+                if self._target is not None and window.pid == self._target.pid
+            ]
+            if len(same_pid_windows) > 1:
+                keyboard_reason = "same_pid_keyboard_ambiguity"
+
+        unsupported_reasons: dict[str, str] = {}
+        supported: list[str] = []
+        for action in _BASE_SUPPORTED_ACTIONS:
+            if keyboard_reason is not None and action in _PID_KEYBOARD_ACTIONS:
+                unsupported_reasons[action.value] = keyboard_reason
+            else:
+                supported.append(action.value)
+        address_available = (
+            self._browser_address_element(elements, target=target) is not None
+        )
+        native_navigation_available = (
+            self._native_browser_navigator is not None
+            and self._native_browser_navigator.supports(target)
+        )
+        if native_navigation_available or (
+            address_available and keyboard_reason is None
+        ):
+            supported.append(ComputerActionType.NAVIGATE.value)
+        elif address_available and keyboard_reason is not None:
+            unsupported_reasons[ComputerActionType.NAVIGATE.value] = keyboard_reason
+        return supported, unsupported_reasons
+
+    @staticmethod
+    def _pid_keyboard_refusal_reason(background_input: Any) -> str | None:
+        if not isinstance(background_input, Mapping):
+            return None
+        routes = background_input.get("routes")
+        if not isinstance(routes, list):
+            return "pid_keyboard_capability_unknown"
+        for route in routes:
+            if not isinstance(route, Mapping) or route.get("route") != "pid_keyboard":
+                continue
+            if str(route.get("status") or "").strip().lower() == "available":
+                return None
+            reason = str(route.get("reason") or "").strip()
+            return reason or "pid_keyboard_unavailable"
+        return "pid_keyboard_capability_unknown"
+
+    def _screenshot_size(self, result: CuaDriverResult) -> tuple[int, int]:
+        width = self._optional_int(result.structured.get("screenshot_width"))
+        height = self._optional_int(result.structured.get("screenshot_height"))
+        if width and height:
+            return width, height
+        image = result.image_bytes or b""
+        if image.startswith(b"\x89PNG\r\n\x1a\n") and len(image) >= 24:
+            parsed_width, parsed_height = struct.unpack(">II", image[16:24])
+            if parsed_width > 0 and parsed_height > 0:
+                return parsed_width, parsed_height
+        raise CuaDriverError("cua-driver screenshot dimensions are missing")
+
+    def _build_elements(
+        self,
+        raw_elements: list[Any],
+        *,
+        target: NativeBrowserWindow,
+    ) -> tuple[list[ComputerElement], int]:
+        hierarchy = self._element_hierarchy(raw_elements)
+        is_browser = any(
+            marker in target.app_name.casefold() for marker in _BROWSER_APP_MARKERS
+        )
+        elements: list[ComputerElement] = []
+        for raw in raw_elements:
+            if not isinstance(raw, Mapping):
+                continue
+            frame = raw.get("frame")
+            if not isinstance(frame, Mapping):
+                continue
+            bounds = self._normalize_element_bounds(frame, target=target)
+            if bounds is None:
+                continue
+            token = str(raw.get("element_token") or "").strip()
+            index = self._optional_int(raw.get("element_index"))
+            if not token and index is None:
+                continue
+            element_id = token or f"cua-index:{index}"
+            role = str(raw.get("role") or "").strip() or None
+            label = str(raw.get("label") or "").strip() or None
+            sensitive = self._is_sensitive_element(
+                raw,
+                role=role,
+                label=label,
+            )
+            value = str(raw.get("value") or "").strip() or None
+            surface, surface_root_index = self._element_surface(
+                raw,
+                hierarchy=hierarchy,
+                is_browser=is_browser,
+            )
+            metadata = {
+                "element_index": index,
+                "element_token": token or None,
+                "depth": self._optional_int(raw.get("depth")),
+                "parent_index": self._optional_int(raw.get("parent_index")),
+                "enabled": raw.get("enabled"),
+                "selected": raw.get("selected"),
+                "sensitive": sensitive,
+                "surface": surface.value,
+                "surface_root_index": surface_root_index,
+            }
+            return_metadata = {
+                key: value for key, value in metadata.items() if value is not None
+            }
+            elements.append(
+                ComputerElement(
+                    element_id=element_id,
+                    source=ComputerElementSource.ACCESSIBILITY,
+                    bounds=bounds,
+                    surface=surface,
+                    label="Sensitive input" if sensitive else label,
+                    role=role,
+                    text=None if sensitive else value,
+                    metadata=return_metadata,
+                )
+            )
+        prioritized = sorted(
+            enumerate(elements),
+            key=lambda item: self._element_priority(item[1], item[0]),
+        )
+        selected = [
+            element for _index, element in prioritized[:MAX_OBSERVATION_ELEMENTS]
+        ]
+        self._known_element_signatures = {
+            self._element_signature(element) for element in elements
+        }
+        return selected, len(elements)
+
+    def _element_priority(
+        self,
+        element: ComputerElement,
+        original_index: int,
+    ) -> tuple[int, int, int]:
+        role = (element.role or "").casefold()
+        actionable = element.metadata.get("enabled") is not False and any(
+            marker in role for marker in _ACTIONABLE_ROLE_MARKERS
+        )
+        is_new = self._element_signature(element) not in self._known_element_signatures
+        if element.surface is ComputerElementSurface.OVERLAY:
+            group = 0
+        elif is_new and actionable:
+            group = 1
+        elif actionable and bool(element.label):
+            group = 2
+        elif element.label or element.text:
+            group = 3
+        else:
+            group = 4
+        return (
+            group,
+            0 if element.metadata.get("selected") is True else 1,
+            original_index,
+        )
+
+    @staticmethod
+    def _element_signature(element: ComputerElement) -> tuple[Any, ...]:
+        return (
+            (element.role or "").casefold(),
+            element.label or "",
+            element.text or "",
+            element.surface.value if element.surface is not None else "",
+            round(element.bounds.x, 3),
+            round(element.bounds.y, 3),
+            round(element.bounds.width, 3),
+            round(element.bounds.height, 3),
+        )
+
+    @classmethod
+    def _element_hierarchy(
+        cls,
+        raw_elements: list[Any],
+    ) -> dict[int, tuple[int | None, int | None, str]]:
+        hierarchy: dict[int, tuple[int | None, int | None, str]] = {}
+        for raw in raw_elements:
+            if not isinstance(raw, Mapping):
+                continue
+            index = cls._optional_int(raw.get("element_index"))
+            if index is None:
+                continue
+            hierarchy[index] = (
+                cls._optional_int(raw.get("parent_index")),
+                cls._optional_int(raw.get("depth")),
+                str(raw.get("role") or "").strip().casefold(),
+            )
+        return hierarchy
+
+    @classmethod
+    def _element_surface(
+        cls,
+        raw: Mapping[str, Any],
+        *,
+        hierarchy: Mapping[int, tuple[int | None, int | None, str]],
+        is_browser: bool,
+    ) -> tuple[ComputerElementSurface, int | None]:
+        index = cls._optional_int(raw.get("element_index"))
+        if index is None or index not in hierarchy:
+            return ComputerElementSurface.UNKNOWN, None
+
+        path: list[tuple[int, int | None, str]] = []
+        visited: set[int] = set()
+        current_index: int | None = index
+        complete = False
+        while current_index is not None:
+            if current_index in visited:
+                return ComputerElementSurface.UNKNOWN, None
+            visited.add(current_index)
+            node = hierarchy.get(current_index)
+            if node is None:
+                return ComputerElementSurface.UNKNOWN, None
+            parent_index, depth, role = node
+            path.append((current_index, depth, role))
+            if parent_index is None:
+                complete = depth == 0 or role in _AX_WINDOW_ROLES
+                break
+            current_index = parent_index
+
+        document_root = next(
+            (
+                node_index
+                for node_index, _depth, role in path
+                if role in _AX_DOCUMENT_ROOT_ROLES
+            ),
+            None,
+        )
+        if document_root is not None:
+            return ComputerElementSurface.DOCUMENT, document_root
+
+        overlay_root = next(
+            (
+                node_index
+                for node_index, _depth, role in path
+                if role in _AX_OVERLAY_ROLES
+            ),
+            None,
+        )
+        if overlay_root is not None:
+            return ComputerElementSurface.OVERLAY, overlay_root
+
+        if not complete:
+            return ComputerElementSurface.UNKNOWN, None
+        root_index = path[-1][0]
+        if is_browser:
+            return ComputerElementSurface.APPLICATION_CHROME, root_index
+        return ComputerElementSurface.NATIVE_APP, root_index
+
+    @staticmethod
+    def _is_sensitive_element(
+        raw: Mapping[str, Any],
+        *,
+        role: str | None,
+        label: str | None,
+    ) -> bool:
+        role_text = " ".join(
+            str(value or "").casefold()
+            for value in (role, raw.get("subrole"), raw.get("input_type"))
+        )
+        if any(marker in role_text for marker in ("secure", "password")):
+            return True
+        if any(
+            raw.get(flag) is True for flag in ("sensitive", "protected", "is_password")
+        ):
+            return True
+        is_text_input = any(
+            marker in role_text for marker in ("text", "input", "field", "edit")
+        )
+        label_text = (label or "").casefold()
+        return is_text_input and any(
+            marker in label_text
+            for marker in ("password", "passcode", "security code", "verification code")
+        )
+
+    @staticmethod
+    def _normalize_element_bounds(
+        raw: Mapping[str, Any],
+        *,
+        target: NativeBrowserWindow,
+    ) -> NormalizedRect | None:
+        try:
+            x = float(raw["x"])
+            y = float(raw["y"])
+            width = float(raw["w"])
+            height = float(raw["h"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if width <= 0 or height <= 0:
+            return None
+
+        # AX frames are normally screen-relative. Some platform backends emit
+        # window-local frames, so accept that shape when subtracting the native
+        # window origin would put the entire element outside the screenshot.
+        local_x = x - target.x
+        local_y = y - target.y
+        if (
+            (
+                local_x + width <= 0
+                or local_y + height <= 0
+                or local_x >= target.width
+                or local_y >= target.height
+            )
+            and 0 <= x < target.width
+            and 0 <= y < target.height
+        ):
+            local_x = x
+            local_y = y
+
+        left = max(0.0, local_x)
+        top = max(0.0, local_y)
+        right = min(target.width, local_x + width)
+        bottom = min(target.height, local_y + height)
+        if right <= left or bottom <= top:
+            return None
+        return NormalizedRect(
+            x=left / target.width,
+            y=top / target.height,
+            width=(right - left) / target.width,
+            height=(bottom - top) / target.height,
+        )
+
+    async def _execute_action(self, action: ComputerAction) -> None:
+        if action.type in {
+            ComputerActionType.OBSERVE,
+            ComputerActionType.SCREENSHOT,
+        }:
+            return
+        if action.type is ComputerActionType.WAIT:
+            duration_ms = action.duration_ms or 1_000
+            await asyncio.sleep(duration_ms / 1_000)
+            self._last_action_result = {
+                "effect": "confirmed",
+                "verified": True,
+            }
+            return
+        target = self._require_target()
+        common: dict[str, Any] = {
+            "session": self.session_id,
+            "pid": target.pid,
+            "window_id": target.window_id,
+            "delivery_mode": self._delivery_mode(action),
+        }
+        if action.type is ComputerActionType.NAVIGATE:
+            await self._navigate_to_url(target, str(action.url or ""), common=common)
+            return
+        if action.type in {
+            ComputerActionType.CLICK,
+            ComputerActionType.DOUBLE_CLICK,
+        }:
+            arguments = {**common, **self._action_target_arguments(action)}
+            tool_name = (
+                "double_click"
+                if action.type is ComputerActionType.DOUBLE_CLICK
+                else "click"
+            )
+            # A rejected accessibility target must fail closed. In particular,
+            # element_outside_target_window means the driver could not prove
+            # that the element belongs to the user-selected window. Silently
+            # converting its center to a CGEvent pixel click can cross the
+            # authorization boundary on mixed-display coordinate systems.
+            await self._call_action(tool_name, arguments)
+            return
+        if action.type is ComputerActionType.TYPE:
+            arguments = {**common, "text": action.text or ""}
+            await self._call_action("type_text", arguments)
+            return
+        if action.type is ComputerActionType.REPLACE_TEXT:
+            x, y = self._action_point_pixels(action)
+            modifier = self._primary_driver_modifier()
+            await self._call_action(
+                "hotkey",
+                {
+                    **common,
+                    "keys": [modifier, "a"],
+                    "x": x,
+                    "y": y,
+                },
+                remember=False,
+            )
+            await self._call_action(
+                "type_text",
+                {
+                    **common,
+                    "text": action.text or "",
+                },
+            )
+            return
+        if action.type is ComputerActionType.KEYPRESS:
+            keys = [self._driver_key(key) for key in action.keys]
+            if len(keys) == 1:
+                arguments = {**common, "key": keys[0]}
+                tool_name = "press_key"
+            else:
+                arguments = {**common, "keys": keys}
+                tool_name = "hotkey"
+            await self._call_action(tool_name, arguments)
+            return
+        if action.type is ComputerActionType.SCROLL:
+            horizontal = abs(action.delta_x) > abs(action.delta_y)
+            delta = action.delta_x if horizontal else action.delta_y
+            direction = (
+                ("right" if delta > 0 else "left")
+                if horizontal
+                else ("down" if delta > 0 else "up")
+            )
+            arguments = {
+                **common,
+                "direction": direction,
+                "amount": max(1, min(20, math.ceil(abs(delta) * 10))),
+                "by": "line",
+            }
+            if action.target is not None:
+                arguments.update(self._action_target_arguments(action))
+            await self._call_action("scroll", arguments)
+            return
+        if action.type is ComputerActionType.DRAG:
+            if action.start is None or action.end is None:
+                raise ValueError("drag requires start and end points")
+            from_x, from_y = self._point_pixels(action.start)
+            to_x, to_y = self._point_pixels(action.end)
+            await self._call_action(
+                "drag",
+                {
+                    **common,
+                    "from_x": from_x,
+                    "from_y": from_y,
+                    "to_x": to_x,
+                    "to_y": to_y,
+                    "duration_ms": action.duration_ms or 500,
+                    "steps": max(
+                        1,
+                        min(50, (action.duration_ms or 500) // 25),
+                    ),
+                },
+            )
+            return
+        raise ValueError(f"unsupported local browser action: {action.type.value}")
+
+    async def _call_action(
+        self,
+        name: str,
+        arguments: Mapping[str, Any],
+        *,
+        remember: bool = True,
+    ) -> CuaDriverResult:
+        result = await self._get_driver().call_tool(name, arguments)
+        status = str(result.structured.get("status") or "").strip().lower()
+        if status in {"refused", "failed", "error"}:
+            refusal = result.structured.get("refusal")
+            detail = (
+                refusal.get("message")
+                if isinstance(refusal, Mapping)
+                else result.structured.get("message")
+            )
+            raise CuaDriverError(
+                str(detail or result.text or f"cua-driver {name} was {status}")
+            )
+        if remember:
+            metadata = {
+                field: result.structured[field]
+                for field in _ACTION_RESULT_FIELDS
+                if field in result.structured
+            }
+            if result.text:
+                metadata["summary"] = result.text[:500]
+            self._last_action_result = metadata or {
+                "effect": "unverifiable",
+                "verified": False,
+            }
+        return result
+
+    def _action_target_arguments(self, action: ComputerAction) -> dict[str, Any]:
+        target = action.target
+        if target is None:
+            return {}
+        if target.element_id is not None:
+            element = self._find_element(target.element_id)
+            arguments = self._element_arguments(element)
+            if arguments:
+                return arguments
+        x, y = self._action_point_pixels(action)
+        return {"x": x, "y": y}
+
+    async def _navigate_to_url(
+        self,
+        target: NativeBrowserWindow,
+        url: str,
+        *,
+        common: Mapping[str, Any],
+    ) -> None:
+        navigator = self._native_browser_navigator
+        if navigator is not None and navigator.supports(target):
+            result = await navigator.navigate(target, url)
+            self._last_action_result = {
+                "path": result.route,
+                "effect": "confirmed",
+                "verified": True,
+                "browser_window_id": result.browser_window_id,
+                "actual_url": result.actual_url,
+            }
+            return
+        observation = self.current_observation
+        address = self._browser_address_element(
+            observation.elements if observation is not None else [],
+            target=target,
+        )
+        if address is None:
+            raise ValueError("navigate requires a native browser address field")
+        await self._call_action(
+            "set_value",
+            {
+                "session": self.session_id,
+                "pid": target.pid,
+                "window_id": target.window_id,
+                **self._element_arguments(address),
+                "value": url,
+            },
+            remember=False,
+        )
+
+        # set_value may refresh the driver's element-token generation. Obtain a
+        # fresh exact-window snapshot before directing Return to the address bar.
+        refreshed = await self._get_driver().call_tool(
+            "get_window_state",
+            {
+                "session": self.session_id,
+                "pid": target.pid,
+                "window_id": target.window_id,
+                "include_screenshot": False,
+                "max_elements": min(self.max_elements, MAX_OBSERVATION_ELEMENTS),
+            },
+        )
+        raw_elements = refreshed.structured.get("elements")
+        elements, _candidate_count = self._build_elements(
+            raw_elements if isinstance(raw_elements, list) else [],
+            target=target,
+        )
+        address = self._browser_address_element(elements, target=target)
+        if address is None:
+            raise ValueError("browser address field disappeared before navigation")
+        await self._call_action(
+            "press_key",
+            {
+                **common,
+                **self._element_arguments(address),
+                "key": "return",
+            },
+        )
+
+    @staticmethod
+    def _element_arguments(element: ComputerElement) -> dict[str, Any]:
+        token = str(element.metadata.get("element_token") or "").strip()
+        if token:
+            return {"element_token": token}
+        index = element.metadata.get("element_index")
+        if isinstance(index, int):
+            return {"element_index": index}
+        return {}
+
+    @staticmethod
+    def _browser_address_element(
+        elements: list[ComputerElement],
+        *,
+        target: NativeBrowserWindow,
+    ) -> ComputerElement | None:
+        if not any(
+            marker in target.app_name.casefold() for marker in _BROWSER_APP_MARKERS
+        ):
+            return None
+        candidates = [
+            element
+            for element in elements
+            if (element.role or "").casefold() in {"axtextfield", "textfield"}
+            and element.bounds.y < 0.15
+            and element.bounds.width >= 0.25
+            and element.metadata.get("sensitive") is not True
+            and bool(NativeBrowserEnvironment._element_arguments(element))
+        ]
+        return max(candidates, key=lambda element: element.bounds.width, default=None)
+
+    def _action_point_pixels(self, action: ComputerAction) -> tuple[float, float]:
+        target = action.target
+        if target is None:
+            raise ValueError(f"{action.type.value} requires a target")
+        if target.point is not None:
+            return self._point_pixels(target.point)
+        element = self._find_element(target.element_id or "")
+        return self._point_pixels(
+            NormalizedPoint(
+                x=element.bounds.x + element.bounds.width / 2,
+                y=element.bounds.y + element.bounds.height / 2,
+            )
+        )
+
+    def _point_pixels(self, point: NormalizedPoint) -> tuple[float, float]:
+        observation = self.current_observation
+        if observation is None:
+            raise RuntimeError("local browser action requires a current observation")
+        return (
+            point.x * observation.viewport.width,
+            point.y * observation.viewport.height,
+        )
+
+    def _validate_pixel_frame(self, action: ComputerAction) -> None:
+        target = action.target
+        uses_pixels = action.type in {
+            ComputerActionType.DRAG,
+            ComputerActionType.REPLACE_TEXT,
+        } or (
+            action.type
+            in {
+                ComputerActionType.CLICK,
+                ComputerActionType.DOUBLE_CLICK,
+            }
+            and target is not None
+            and target.point is not None
+        )
+        if uses_pixels:
+            self._validate_current_coordinate_frame()
+            self._validate_unambiguous_pixel_target(action)
+
+    def _validate_unambiguous_pixel_target(self, action: ComputerAction) -> None:
+        target_window = self._require_target()
+        points = self._pixel_action_points(action)
+        siblings = [
+            window
+            for window in self._visible_windows
+            if window.pid == target_window.pid
+            and window.window_id != target_window.window_id
+        ]
+        for point in points:
+            screen_x = target_window.x + point.x * target_window.width
+            screen_y = target_window.y + point.y * target_window.height
+            if any(
+                sibling.x <= screen_x <= sibling.x + sibling.width
+                and sibling.y <= screen_y <= sibling.y + sibling.height
+                for sibling in siblings
+            ):
+                raise ComputerTargetNotFoundError(
+                    "Pixel action is ambiguous because another window from "
+                    "the same application overlaps the selected window at "
+                    "that point. Use an accessibility element target or "
+                    "select a non-overlapping window; do not retry the pixel "
+                    "coordinate."
+                )
+
+    def _pixel_action_points(self, action: ComputerAction) -> list[NormalizedPoint]:
+        if action.type is ComputerActionType.DRAG:
+            return [point for point in (action.start, action.end) if point is not None]
+        target = action.target
+        if target is None:
+            return []
+        if target.point is not None:
+            return [target.point]
+        if action.type is ComputerActionType.REPLACE_TEXT:
+            element = self._find_element(target.element_id or "")
+            return [
+                NormalizedPoint(
+                    x=element.bounds.x + element.bounds.width / 2,
+                    y=element.bounds.y + element.bounds.height / 2,
+                )
+            ]
+        return []
+
+    def _validate_current_coordinate_frame(self) -> None:
+        observation = self.current_observation
+        target = self._require_target()
+        if observation is None:
+            raise ComputerFrameMismatchError(
+                "pixel action requires a current computer observation"
+            )
+        coordinate_frame = observation.metadata.get("coordinate_frame")
+        if not isinstance(coordinate_frame, Mapping):
+            raise ComputerFrameMismatchError(
+                "the current observation has no verified pixel coordinate frame; "
+                "request a fresh observation"
+            )
+        captured_bounds = coordinate_frame.get("window_bounds")
+        if not isinstance(captured_bounds, Mapping):
+            raise ComputerFrameMismatchError(
+                "the current observation has no verified pixel coordinate frame; "
+                "request a fresh observation"
+            )
+        if coordinate_frame.get("screenshot_fresh") is not True:
+            raise ComputerFrameMismatchError(
+                "the current observation contains fresh semantic elements but "
+                "no fresh exact-window screenshot. Use an accessibility element "
+                "target or request a later observation; do not use pixel "
+                "coordinates from the reused image."
+            )
+        current_bounds = self._window_bounds(target)
+        for field, current_value in current_bounds.items():
+            captured_value = captured_bounds.get(field)
+            if isinstance(captured_value, bool) or not isinstance(
+                captured_value,
+                (str, int, float),
+            ):
+                unchanged = False
+                captured_value = None
+            try:
+                if captured_value is not None:
+                    unchanged = math.isclose(
+                        float(captured_value),
+                        current_value,
+                        rel_tol=0.0,
+                        abs_tol=0.5,
+                    )
+            except (TypeError, ValueError):
+                unchanged = False
+            if not unchanged:
+                raise ComputerFrameMismatchError(
+                    "The selected window moved or resized after frame "
+                    f"{observation.frame_id!r} was captured. Request a fresh "
+                    "observation before using pixel coordinates."
+                )
+
+    @staticmethod
+    def _window_bounds(target: NativeBrowserWindow) -> dict[str, float]:
+        return {
+            "x": target.x,
+            "y": target.y,
+            "width": target.width,
+            "height": target.height,
+        }
+
+    def _find_element(self, element_id: str) -> ComputerElement:
+        observation = self.current_observation
+        if observation is None:
+            raise RuntimeError("element target requires a current observation")
+        element = next(
+            (item for item in observation.elements if item.element_id == element_id),
+            None,
+        )
+        if element is None:
+            raise ComputerTargetNotFoundError(
+                f"element {element_id!r} is not present in frame "
+                f"{observation.frame_id!r}"
+            )
+        return element
+
+    def _require_target(self) -> NativeBrowserWindow:
+        if self._target is None:
+            raise RuntimeError("local browser window has not been selected")
+        return self._target
+
+    def _delivery_mode(self, action: ComputerAction) -> str:
+        requested = str(action.metadata.get("delivery_mode") or "").strip().lower()
+        if requested != "foreground":
+            return "background"
+        observation = self.current_observation
+        metadata = observation.metadata if observation is not None else {}
+        last_result = metadata.get("last_action_result")
+        escalations = [
+            last_result.get("escalation") if isinstance(last_result, Mapping) else None,
+            metadata.get("driver_escalation"),
+        ]
+        for escalation in escalations:
+            if (
+                isinstance(escalation, Mapping)
+                and str(escalation.get("recommended") or "").strip().lower()
+                == "foreground"
+            ):
+                return "foreground"
+        raise ValueError(
+            "foreground delivery requires a cua-driver escalation recommendation "
+            "from the current observation"
+        )
+
+    @staticmethod
+    def _driver_key(key: str) -> str:
+        normalized = key.strip().lower()
+        aliases = {
+            "meta": "cmd",
+            "command": "cmd",
+            "alt": "option",
+            "enter": "return",
+            "esc": "escape",
+            "arrowup": "up",
+            "arrowdown": "down",
+            "arrowleft": "left",
+            "arrowright": "right",
+            "page_up": "pageup",
+            "page_down": "pagedown",
+        }
+        return aliases.get(normalized, normalized)
+
+    @staticmethod
+    def _primary_driver_modifier() -> str:
+        if host_computer_input_platform() is ComputerInputPlatform.MACOS:
+            return "cmd"
+        return "ctrl"
+
+    @staticmethod
+    def _optional_int(value: Any) -> int | None:
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+
+def _optional_active_url(structured: Mapping[str, Any]) -> str | None:
+    for key in ("active_url", "url", "actual_url"):
+        value = structured.get(key)
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip()
+        if normalized.startswith(("http://", "https://", "about:")):
+            return normalized
+    return None

--- a/src/xagent/core/computer/native_browser.py
+++ b/src/xagent/core/computer/native_browser.py
@@ -70,6 +70,13 @@ _PID_KEYBOARD_ACTIONS = frozenset(
         ComputerActionType.KEYPRESS,
     }
 )
+_UNSCOPED_KEYBOARD_ACTIONS = frozenset(
+    {
+        ComputerActionType.TYPE,
+        ComputerActionType.KEYPRESS,
+    }
+)
+_UNSCOPED_KEYBOARD_REFUSAL_REASON = "unscoped_keyboard_input_disabled"
 _ACTION_RESULT_FIELDS = (
     "path",
     "effect",
@@ -141,7 +148,7 @@ class NativeBrowserWindow:
     y: float
     width: float
     height: float
-    z_index: int
+    z_index: int | None
     is_on_screen: bool
     on_current_space: bool | None
 
@@ -552,7 +559,13 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 f"No visible {self.browser_app_name} window is available on the "
                 "Xagent host."
             )
-        return max(browser_windows, key=lambda window: window.z_index)
+        return max(
+            browser_windows,
+            key=lambda window: (
+                window.z_index is not None,
+                window.z_index if window.z_index is not None else 0,
+            ),
+        )
 
     async def _refresh_bound_target(self) -> NativeBrowserWindow:
         target = self._require_target()
@@ -617,7 +630,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 y=float(bounds["y"]),
                 width=width,
                 height=height,
-                z_index=int(raw.get("z_index") or 0),
+                z_index=NativeBrowserEnvironment._optional_z_index(raw.get("z_index")),
                 is_on_screen=raw.get("is_on_screen") is True,
                 on_current_space=(
                     raw.get("on_current_space")
@@ -816,7 +829,9 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         unsupported_reasons: dict[str, str] = {}
         supported: list[str] = []
         for action in _BASE_SUPPORTED_ACTIONS:
-            if keyboard_reason is not None and action in _PID_KEYBOARD_ACTIONS:
+            if action in _UNSCOPED_KEYBOARD_ACTIONS:
+                unsupported_reasons[action.value] = _UNSCOPED_KEYBOARD_REFUSAL_REASON
+            elif keyboard_reason is not None and action in _PID_KEYBOARD_ACTIONS:
                 unsupported_reasons[action.value] = keyboard_reason
             else:
                 supported.append(action.value)
@@ -1153,6 +1168,12 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         if action.type is ComputerActionType.NAVIGATE:
             await self._navigate_to_url(target, str(action.url or ""), common=common)
             return
+        if action.type in _UNSCOPED_KEYBOARD_ACTIONS:
+            raise ValueError(
+                "Free type and keypress actions are disabled in the local browser. "
+                "Use replace_text on an exact document element, or the atomic "
+                "navigate action for an http/https URL."
+            )
         if action.type in {
             ComputerActionType.CLICK,
             ComputerActionType.DOUBLE_CLICK,
@@ -1170,11 +1191,8 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             # authorization boundary on mixed-display coordinate systems.
             await self._call_action(tool_name, arguments)
             return
-        if action.type is ComputerActionType.TYPE:
-            arguments = {**common, "text": action.text or ""}
-            await self._call_action("type_text", arguments)
-            return
         if action.type is ComputerActionType.REPLACE_TEXT:
+            self._document_text_target(action)
             x, y = self._action_point_pixels(action)
             modifier = self._primary_driver_modifier()
             await self._call_action(
@@ -1194,16 +1212,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                     "text": action.text or "",
                 },
             )
-            return
-        if action.type is ComputerActionType.KEYPRESS:
-            keys = [self._driver_key(key) for key in action.keys]
-            if len(keys) == 1:
-                arguments = {**common, "key": keys[0]}
-                tool_name = "press_key"
-            else:
-                arguments = {**common, "keys": keys}
-                tool_name = "hotkey"
-            await self._call_action(tool_name, arguments)
             return
         if action.type is ComputerActionType.SCROLL:
             horizontal = abs(action.delta_x) > abs(action.delta_y)
@@ -1432,12 +1440,11 @@ class NativeBrowserEnvironment(ComputerEnvironment):
     def _validate_unambiguous_pixel_target(self, action: ComputerAction) -> None:
         target_window = self._require_target()
         points = self._pixel_action_points(action)
-        occluding_windows = [
+        other_windows = [
             window
             for window in self._on_screen_windows
             if (window.pid, window.window_id)
             != (target_window.pid, target_window.window_id)
-            and window.z_index > target_window.z_index
         ]
         for point in points:
             screen_x = target_window.x + point.x * target_window.width
@@ -1445,7 +1452,12 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             if any(
                 window.x <= screen_x <= window.x + window.width
                 and window.y <= screen_y <= window.y + window.height
-                for window in occluding_windows
+                and (
+                    target_window.z_index is None
+                    or window.z_index is None
+                    or window.z_index > target_window.z_index
+                )
+                for window in other_windows
             ):
                 raise ComputerTargetNotFoundError(
                     "Pixel action is ambiguous because another on-screen window "
@@ -1454,6 +1466,32 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                     "select a non-overlapping window; do not retry the pixel "
                     "coordinate."
                 )
+
+    def _document_text_target(self, action: ComputerAction) -> ComputerElement:
+        target = action.target
+        if target is None or target.element_id is None:
+            raise ValueError(
+                "replace_text in the local browser requires an exact semantic "
+                "document element target; coordinate and implicit keyboard input "
+                "are disabled"
+            )
+        element = self._find_element(target.element_id)
+        if element.surface is not ComputerElementSurface.DOCUMENT:
+            raise ValueError(
+                "replace_text is limited to document elements in the selected "
+                "browser window; browser chrome and unknown surfaces are not "
+                "authorized"
+            )
+        return element
+
+    @staticmethod
+    def _optional_z_index(value: Any) -> int | None:
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     def _pixel_action_points(self, action: ComputerAction) -> list[NormalizedPoint]:
         if action.type is ComputerActionType.DRAG:
@@ -1576,24 +1614,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             "foreground delivery requires a cua-driver escalation recommendation "
             "from the current observation"
         )
-
-    @staticmethod
-    def _driver_key(key: str) -> str:
-        normalized = key.strip().lower()
-        aliases = {
-            "meta": "cmd",
-            "command": "cmd",
-            "alt": "option",
-            "enter": "return",
-            "esc": "escape",
-            "arrowup": "up",
-            "arrowdown": "down",
-            "arrowleft": "left",
-            "arrowright": "right",
-            "page_up": "pageup",
-            "page_down": "pagedown",
-        }
-        return aliases.get(normalized, normalized)
 
     @staticmethod
     def _primary_driver_modifier() -> str:

--- a/src/xagent/core/computer/native_browser.py
+++ b/src/xagent/core/computer/native_browser.py
@@ -9,6 +9,7 @@ from typing import Any
 from uuid import uuid4
 
 from ...config import (
+    SUPPORTED_NATIVE_BROWSER_APP_NAMES,
     get_browser_cua_driver_max_elements,
     get_native_browser_app_name,
     get_native_browser_enabled,
@@ -85,15 +86,8 @@ _ACTION_RESULT_FIELDS = (
     "status",
     "code",
 )
-_BROWSER_APP_MARKERS = (
-    "arc",
-    "brave",
-    "chrome",
-    "chromium",
-    "edge",
-    "firefox",
-    "safari",
-    "vivaldi",
+_SUPPORTED_BROWSER_APP_NAMES = frozenset(
+    name.casefold() for name in SUPPORTED_NATIVE_BROWSER_APP_NAMES
 )
 _AX_DOCUMENT_ROOT_ROLES = frozenset({"axwebarea", "webarea"})
 _AX_OVERLAY_ROLES = frozenset(
@@ -213,7 +207,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         self._driver_factory = driver_factory or CuaDriverMCPClient
         self._target: NativeBrowserWindow | None = None
         self._on_screen_windows: list[NativeBrowserWindow] = []
-        self._visible_windows: list[NativeBrowserWindow] = []
         self._session_started = False
         self._last_action_result: dict[str, Any] | None = None
         self._unsupported_action_reasons: dict[str, str] = {}
@@ -235,12 +228,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         await driver.close()
         self._driver = None
         self._session_started = False
-
-    async def health_report(self) -> dict[str, Any]:
-        """Return cua-driver's stable structured diagnostics contract."""
-
-        result = await self._get_driver().call_tool("health_report", {})
-        return result.structured
 
     async def _observe(self) -> ComputerObservation:
         await self._ensure_session()
@@ -536,7 +523,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             for window in visible
             if window.app_name.casefold() == self.browser_app_name.casefold()
         ]
-        self._visible_windows = browser_windows
         if self.target_pid is not None and self.target_window_id is not None:
             exact = next(
                 (
@@ -590,7 +576,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             for window in visible
             if window.app_name.casefold() == self.browser_app_name.casefold()
         ]
-        self._visible_windows = browser_windows
         refreshed = next(
             (
                 window
@@ -693,7 +678,10 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             )
         else:
             previous = self.current_observation
-            assert previous is not None
+            if previous is None:
+                raise CuaDriverError(
+                    "cua-driver returned no screenshot before an observation existed"
+                )
             viewport = previous.viewport
             width = viewport.width
             height = viewport.height
@@ -885,9 +873,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         target: NativeBrowserWindow,
     ) -> tuple[list[ComputerElement], int]:
         hierarchy = self._element_hierarchy(raw_elements)
-        is_browser = any(
-            marker in target.app_name.casefold() for marker in _BROWSER_APP_MARKERS
-        )
+        is_browser = target.app_name.casefold() in _SUPPORTED_BROWSER_APP_NAMES
         elements: list[ComputerElement] = []
         for raw in raw_elements:
             if not isinstance(raw, Mapping):
@@ -1214,6 +1200,10 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             )
             return
         if action.type is ComputerActionType.SCROLL:
+            if action.target is not None:
+                raise ValueError(
+                    "targeted scroll is not supported by the local browser runtime"
+                )
             horizontal = abs(action.delta_x) > abs(action.delta_y)
             delta = action.delta_x if horizontal else action.delta_y
             direction = (
@@ -1227,8 +1217,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 "amount": max(1, min(20, math.ceil(abs(delta) * 10))),
                 "by": "line",
             }
-            if action.target is not None:
-                arguments.update(self._action_target_arguments(action))
             await self._call_action("scroll", arguments)
             return
         if action.type is ComputerActionType.DRAG:
@@ -1296,6 +1284,9 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             arguments = self._element_arguments(element)
             if arguments:
                 return arguments
+            raise ValueError(
+                "local browser semantic target has no driver element identity"
+            )
         x, y = self._action_point_pixels(action)
         return {"x": x, "y": y}
 
@@ -1381,9 +1372,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         *,
         target: NativeBrowserWindow,
     ) -> ComputerElement | None:
-        if not any(
-            marker in target.app_name.casefold() for marker in _BROWSER_APP_MARKERS
-        ):
+        if target.app_name.casefold() not in _SUPPORTED_BROWSER_APP_NAMES:
             return None
         candidates = [
             element

--- a/src/xagent/core/computer/native_browser.py
+++ b/src/xagent/core/computer/native_browser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import re
 import struct
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -26,7 +27,6 @@ from .environment import (
     ComputerTargetNotFoundError,
 )
 from .input_platform import (
-    ComputerInputPlatform,
     computer_input_metadata,
     host_computer_input_platform,
 )
@@ -63,13 +63,6 @@ _BASE_SUPPORTED_ACTIONS = tuple(
     action
     for action in ComputerActionType
     if action not in {ComputerActionType.MOVE, ComputerActionType.NAVIGATE}
-)
-_PID_KEYBOARD_ACTIONS = frozenset(
-    {
-        ComputerActionType.TYPE,
-        ComputerActionType.REPLACE_TEXT,
-        ComputerActionType.KEYPRESS,
-    }
 )
 _UNSCOPED_KEYBOARD_ACTIONS = frozenset(
     {
@@ -127,6 +120,29 @@ _PIXEL_FRAME_ERROR_MARKERS = (
 _POST_ACTION_SETTLE_SECONDS = 0.25
 _POST_ACTION_SETTLE_RETRIES = 3
 _SEMANTIC_SETTLE_RADIUS = 0.06
+_SENSITIVE_AUTOCOMPLETE_VALUES = frozenset(
+    {
+        "cc-csc",
+        "current-password",
+        "new-password",
+        "one-time-code",
+    }
+)
+_SENSITIVE_LABEL_MARKERS = (
+    "password",
+    "passcode",
+    "security code",
+    "verification code",
+    "one-time code",
+    "密码",
+    "口令",
+    "验证码",
+    "安全码",
+    "动态码",
+)
+_SENSITIVE_LABEL_TOKEN_RE = re.compile(
+    r"(?:^|[^a-z0-9])(?:otp|2fa|mfa|cvv|cvc|pin|ssn)(?:$|[^a-z0-9])"
+)
 
 CuaDriverClientFactory = Callable[[], CuaDriverClientProtocol]
 LOCAL_BROWSER_TASK_EXTENSION = "local_browser"
@@ -353,10 +369,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             updated_result = {
                 **dict(action_result),
                 "verified": False,
-                "escalation": {
-                    "recommended": "foreground",
-                    "reason": "no_observable_state_change_after_background_delivery",
-                },
+                "code": "no_observable_state_change_after_background_delivery",
             }
             observation = observation.model_copy(
                 update={
@@ -819,8 +832,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         for action in _BASE_SUPPORTED_ACTIONS:
             if action in _UNSCOPED_KEYBOARD_ACTIONS:
                 unsupported_reasons[action.value] = _UNSCOPED_KEYBOARD_REFUSAL_REASON
-            elif keyboard_reason is not None and action in _PID_KEYBOARD_ACTIONS:
-                unsupported_reasons[action.value] = keyboard_reason
             else:
                 supported.append(action.value)
         address_available = (
@@ -886,9 +897,12 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 continue
             token = str(raw.get("element_token") or "").strip()
             index = self._optional_int(raw.get("element_index"))
-            if not token and index is None:
+            # element_index is scoped to one driver snapshot and can be reused
+            # for a different element after a worker restart. Only expose the
+            # opaque token that cua-driver can validate against its snapshot.
+            if not token:
                 continue
-            element_id = token or f"cua-index:{index}"
+            element_id = token
             role = str(raw.get("role") or "").strip() or None
             label = str(raw.get("label") or "").strip() or None
             sensitive = self._is_sensitive_element(
@@ -1074,13 +1088,23 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             raw.get(flag) is True for flag in ("sensitive", "protected", "is_password")
         ):
             return True
+        autocomplete = str(raw.get("autocomplete") or "").strip().casefold()
+        if autocomplete in _SENSITIVE_AUTOCOMPLETE_VALUES:
+            return True
         is_text_input = any(
             marker in role_text for marker in ("text", "input", "field", "edit")
         )
-        label_text = (label or "").casefold()
-        return is_text_input and any(
-            marker in label_text
-            for marker in ("password", "passcode", "security code", "verification code")
+        label_text = " ".join(
+            str(value or "").casefold()
+            for value in (
+                label,
+                raw.get("placeholder"),
+                raw.get("description"),
+            )
+        )
+        return is_text_input and (
+            any(marker in label_text for marker in _SENSITIVE_LABEL_MARKERS)
+            or _SENSITIVE_LABEL_TOKEN_RE.search(label_text) is not None
         )
 
     @staticmethod
@@ -1178,24 +1202,15 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             await self._call_action(tool_name, arguments)
             return
         if action.type is ComputerActionType.REPLACE_TEXT:
-            self._document_text_target(action)
-            x, y = self._action_point_pixels(action)
-            modifier = self._primary_driver_modifier()
+            element = self._document_text_target(action)
             await self._call_action(
-                "hotkey",
+                "set_value",
                 {
-                    **common,
-                    "keys": [modifier, "a"],
-                    "x": x,
-                    "y": y,
-                },
-                remember=False,
-            )
-            await self._call_action(
-                "type_text",
-                {
-                    **common,
-                    "text": action.text or "",
+                    "session": self.session_id,
+                    "pid": target.pid,
+                    "window_id": target.window_id,
+                    **self._element_arguments(element),
+                    "value": action.text or "",
                 },
             )
             return
@@ -1361,9 +1376,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         token = str(element.metadata.get("element_token") or "").strip()
         if token:
             return {"element_token": token}
-        index = element.metadata.get("element_index")
-        if isinstance(index, int):
-            return {"element_index": index}
         return {}
 
     @staticmethod
@@ -1470,6 +1482,11 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 "replace_text is limited to document elements in the selected "
                 "browser window; browser chrome and unknown surfaces are not "
                 "authorized"
+            )
+        if element.metadata.get("sensitive") is True:
+            raise ValueError(
+                "replace_text is disabled for sensitive input elements in the "
+                "local browser"
             )
         return element
 
@@ -1587,28 +1604,16 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             return "background"
         observation = self.current_observation
         metadata = observation.metadata if observation is not None else {}
-        last_result = metadata.get("last_action_result")
-        escalations = [
-            last_result.get("escalation") if isinstance(last_result, Mapping) else None,
-            metadata.get("driver_escalation"),
-        ]
-        for escalation in escalations:
-            if (
-                isinstance(escalation, Mapping)
-                and str(escalation.get("recommended") or "").strip().lower()
-                == "foreground"
-            ):
-                return "foreground"
+        escalation = metadata.get("driver_escalation")
+        if (
+            isinstance(escalation, Mapping)
+            and str(escalation.get("recommended") or "").strip().lower() == "foreground"
+        ):
+            return "foreground"
         raise ValueError(
-            "foreground delivery requires a cua-driver escalation recommendation "
+            "foreground delivery requires a current cua-driver escalation recommendation "
             "from the current observation"
         )
-
-    @staticmethod
-    def _primary_driver_modifier() -> str:
-        if host_computer_input_platform() is ComputerInputPlatform.MACOS:
-            return "cmd"
-        return "ctrl"
 
     @staticmethod
     def _optional_int(value: Any) -> int | None:

--- a/src/xagent/core/computer/native_browser.py
+++ b/src/xagent/core/computer/native_browser.py
@@ -1424,7 +1424,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         target = action.target
         uses_pixels = action.type in {
             ComputerActionType.DRAG,
-            ComputerActionType.REPLACE_TEXT,
         } or (
             action.type
             in {
@@ -1507,14 +1506,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             return []
         if target.point is not None:
             return [target.point]
-        if action.type is ComputerActionType.REPLACE_TEXT:
-            element = self._find_element(target.element_id or "")
-            return [
-                NormalizedPoint(
-                    x=element.bounds.x + element.bounds.width / 2,
-                    y=element.bounds.y + element.bounds.height / 2,
-                )
-            ]
         return []
 
     def _validate_current_coordinate_frame(self) -> None:

--- a/src/xagent/core/computer/native_browser.py
+++ b/src/xagent/core/computer/native_browser.py
@@ -205,6 +205,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         self._driver = driver
         self._driver_factory = driver_factory or CuaDriverMCPClient
         self._target: NativeBrowserWindow | None = None
+        self._on_screen_windows: list[NativeBrowserWindow] = []
         self._visible_windows: list[NativeBrowserWindow] = []
         self._session_started = False
         self._last_action_result: dict[str, Any] | None = None
@@ -216,7 +217,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
 
     async def _close(self) -> None:
         driver = self._driver
-        self._driver = None
         if driver is None:
             return
         if self._session_started:
@@ -226,6 +226,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 # Closing stdin still tears down process-owned driver state.
                 pass
         await driver.close()
+        self._driver = None
         self._session_started = False
 
     async def health_report(self) -> dict[str, Any]:
@@ -321,10 +322,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         )
         if (
             not isinstance(action_result, Mapping)
-            or (
-                action.type is not ComputerActionType.NAVIGATE
-                and action_result.get("effect") != "unverifiable"
-            )
+            or action_result.get("effect") != "unverifiable"
             or state_changed
         ):
             return observation
@@ -525,6 +523,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             for window in windows
             if window.is_on_screen and window.on_current_space is not False
         ]
+        self._on_screen_windows = visible
         browser_windows = [
             window
             for window in visible
@@ -572,6 +571,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
             and parsed.is_on_screen
             and parsed.on_current_space is not False
         ]
+        self._on_screen_windows = visible
         browser_windows = [
             window
             for window in visible
@@ -739,15 +739,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
                 "browser_debugging": False,
             },
             **computer_input_metadata(host_computer_input_platform()),
-            "available_windows": [
-                {
-                    "pid": window.pid,
-                    "window_id": window.window_id,
-                    "application": window.app_name,
-                    "title": window.title,
-                }
-                for window in self._visible_windows[:20]
-            ],
         }
         if result.structured.get("degraded") is True:
             metadata[ELEMENT_EXTRACTION_FAILED_KEY] = True
@@ -821,14 +812,6 @@ class NativeBrowserEnvironment(ComputerEnvironment):
         target: NativeBrowserWindow,
     ) -> tuple[list[str], dict[str, str]]:
         keyboard_reason = self._pid_keyboard_refusal_reason(background_input)
-        if keyboard_reason is None and not isinstance(background_input, Mapping):
-            same_pid_windows = [
-                window
-                for window in self._visible_windows
-                if self._target is not None and window.pid == self._target.pid
-            ]
-            if len(same_pid_windows) > 1:
-                keyboard_reason = "same_pid_keyboard_ambiguity"
 
         unsupported_reasons: dict[str, str] = {}
         supported: list[str] = []
@@ -855,7 +838,7 @@ class NativeBrowserEnvironment(ComputerEnvironment):
     @staticmethod
     def _pid_keyboard_refusal_reason(background_input: Any) -> str | None:
         if not isinstance(background_input, Mapping):
-            return None
+            return "pid_keyboard_capability_unknown"
         routes = background_input.get("routes")
         if not isinstance(routes, list):
             return "pid_keyboard_capability_unknown"
@@ -1449,24 +1432,25 @@ class NativeBrowserEnvironment(ComputerEnvironment):
     def _validate_unambiguous_pixel_target(self, action: ComputerAction) -> None:
         target_window = self._require_target()
         points = self._pixel_action_points(action)
-        siblings = [
+        occluding_windows = [
             window
-            for window in self._visible_windows
-            if window.pid == target_window.pid
-            and window.window_id != target_window.window_id
+            for window in self._on_screen_windows
+            if (window.pid, window.window_id)
+            != (target_window.pid, target_window.window_id)
+            and window.z_index > target_window.z_index
         ]
         for point in points:
             screen_x = target_window.x + point.x * target_window.width
             screen_y = target_window.y + point.y * target_window.height
             if any(
-                sibling.x <= screen_x <= sibling.x + sibling.width
-                and sibling.y <= screen_y <= sibling.y + sibling.height
-                for sibling in siblings
+                window.x <= screen_x <= window.x + window.width
+                and window.y <= screen_y <= window.y + window.height
+                for window in occluding_windows
             ):
                 raise ComputerTargetNotFoundError(
-                    "Pixel action is ambiguous because another window from "
-                    "the same application overlaps the selected window at "
-                    "that point. Use an accessibility element target or "
+                    "Pixel action is ambiguous because another on-screen window "
+                    "occludes the selected window at that point. Use an "
+                    "accessibility element target or "
                     "select a non-overlapping window; do not retry the pixel "
                     "coordinate."
                 )

--- a/src/xagent/core/computer/native_browser_readiness.py
+++ b/src/xagent/core/computer/native_browser_readiness.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ...config import get_native_browser_app_name
+from .cua_driver import CuaDriverError, CuaDriverMCPClient
+
+_READINESS_CACHE_SECONDS = 10.0
+
+
+class LocalBrowserReadinessIssue(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    code: str
+    message: str
+
+
+class LocalBrowserWindowSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    pid: int
+    window_id: int
+    application: str
+    title: str | None = None
+
+
+class LocalBrowserReadiness(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    ready: bool
+    connected: bool
+    attached: bool
+    application: str = ""
+    title: str | None = None
+    windows: list[LocalBrowserWindowSummary] = Field(default_factory=list)
+    permissions: dict[str, bool] = Field(default_factory=dict)
+    issues: list[LocalBrowserReadinessIssue] = Field(default_factory=list)
+    message: str = ""
+
+
+@dataclass
+class _ReadinessCache:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    expires_at: float = 0
+    value: LocalBrowserReadiness | None = None
+
+
+_cache = _ReadinessCache()
+
+
+async def get_local_browser_readiness() -> LocalBrowserReadiness:
+    """Probe cua-driver and configured-browser windows with a short cache."""
+
+    now = time.monotonic()
+    if _cache.value is not None and _cache.expires_at > now:
+        return _cache.value.model_copy(deep=True)
+    async with _cache.lock:
+        now = time.monotonic()
+        if _cache.value is not None and _cache.expires_at > now:
+            return _cache.value.model_copy(deep=True)
+        value = await _probe_local_browser_readiness()
+        _cache.value = value
+        _cache.expires_at = time.monotonic() + _READINESS_CACHE_SECONDS
+        return value.model_copy(deep=True)
+
+
+def reset_local_browser_readiness_cache() -> None:
+    _cache.value = None
+    _cache.expires_at = 0
+
+
+async def _probe_local_browser_readiness() -> LocalBrowserReadiness:
+    browser_app_name = get_native_browser_app_name()
+    client = CuaDriverMCPClient()
+    try:
+        health, windows_result = await asyncio.gather(
+            client.call_tool("health_report", {}),
+            client.call_tool("list_windows", {"on_screen_only": True}),
+        )
+    except (CuaDriverError, FileNotFoundError, OSError) as exc:
+        issue = LocalBrowserReadinessIssue(
+            code="driver_unavailable",
+            message=f"cua-driver is unavailable on this Xagent host: {exc}",
+        )
+        return LocalBrowserReadiness(
+            ready=False,
+            connected=False,
+            attached=False,
+            application=browser_app_name,
+            issues=[issue],
+            message=issue.message,
+        )
+    finally:
+        await client.close()
+
+    report = health.structured
+    overall = str(report.get("overall") or "").strip().lower()
+    connected = overall in {"ok", "degraded"}
+    permissions = _health_permissions(report)
+    windows = _visible_windows(
+        windows_result.structured.get("windows"),
+        app_name=browser_app_name,
+    )
+    window = windows[0] if windows else None
+    issues: list[LocalBrowserReadinessIssue] = []
+    if not connected:
+        issues.append(
+            LocalBrowserReadinessIssue(
+                code="driver_unhealthy",
+                message=_health_failure_message(report),
+            )
+        )
+    if permissions.get("screen_recording") is False:
+        issues.append(
+            LocalBrowserReadinessIssue(
+                code="screen_recording_permission_missing",
+                message="cua-driver needs Screen Recording permission.",
+            )
+        )
+    if permissions.get("accessibility") is False:
+        issues.append(
+            LocalBrowserReadinessIssue(
+                code="accessibility_permission_missing",
+                message="cua-driver needs Accessibility permission.",
+            )
+        )
+    if window is None:
+        issues.append(
+            LocalBrowserReadinessIssue(
+                code="browser_not_found",
+                message=(
+                    f"No visible {browser_app_name} window is available on the "
+                    "Xagent host."
+                ),
+            )
+        )
+
+    title = _optional_string(window.get("title")) if window is not None else None
+    return LocalBrowserReadiness(
+        ready=not issues,
+        connected=connected,
+        attached=window is not None,
+        application=browser_app_name,
+        title=title,
+        windows=[_window_summary(item) for item in windows],
+        permissions=permissions,
+        issues=issues,
+        message=" ".join(issue.message for issue in issues),
+    )
+
+
+def _health_permissions(report: Mapping[str, Any]) -> dict[str, bool]:
+    permissions: dict[str, bool] = {}
+    checks = report.get("checks")
+    if not isinstance(checks, list):
+        return permissions
+    names = {
+        "tcc_accessibility": "accessibility",
+        "ax_capability": "accessibility",
+        "tcc_screen_recording": "screen_recording",
+        "screen_capture_capability": "screen_recording",
+    }
+    for check in checks:
+        if not isinstance(check, Mapping):
+            continue
+        permission = names.get(str(check.get("name") or ""))
+        status = str(check.get("status") or "").strip().lower()
+        if permission is None or status not in {"pass", "fail"}:
+            continue
+        passed = status == "pass"
+        current = permissions.get(permission)
+        permissions[permission] = passed if current is None else current and passed
+    return permissions
+
+
+def _health_failure_message(report: Mapping[str, Any]) -> str:
+    checks = report.get("checks")
+    if isinstance(checks, list):
+        for check in checks:
+            if not isinstance(check, Mapping):
+                continue
+            if str(check.get("status") or "").lower() != "fail":
+                continue
+            message = _optional_string(check.get("message"))
+            hint = _optional_string(check.get("hint"))
+            if message and hint:
+                return f"cua-driver is unhealthy: {message} {hint}"
+            if message:
+                return f"cua-driver is unhealthy: {message}"
+    return "cua-driver health checks failed on the Xagent host."
+
+
+def _visible_windows(
+    raw_windows: Any,
+    *,
+    app_name: str,
+) -> list[Mapping[str, Any]]:
+    if not isinstance(raw_windows, list):
+        return []
+    matches = [
+        item
+        for item in raw_windows
+        if isinstance(item, Mapping)
+        and item.get("on_current_space") is not False
+        and item.get("is_on_screen") is True
+        and _safe_int(item.get("pid")) > 0
+        and _safe_int(item.get("window_id")) > 0
+        and (_optional_string(item.get("app_name")) or "").casefold()
+        == app_name.casefold()
+    ]
+    return sorted(
+        matches,
+        key=lambda item: _safe_int(item.get("z_index")),
+        reverse=True,
+    )[:50]
+
+
+def _window_summary(window: Mapping[str, Any]) -> LocalBrowserWindowSummary:
+    return LocalBrowserWindowSummary(
+        pid=_safe_int(window.get("pid")),
+        window_id=_safe_int(window.get("window_id")),
+        application=_optional_string(window.get("app_name")) or "Application",
+        title=_optional_string(window.get("title")),
+    )
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _optional_string(value: Any) -> str | None:
+    text = str(value).strip() if value is not None else ""
+    return text or None

--- a/src/xagent/core/computer/native_navigation.py
+++ b/src/xagent/core/computer/native_navigation.py
@@ -7,6 +7,8 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from ...config import SUPPORTED_NATIVE_BROWSER_APP_NAMES
+
 
 class NativeBrowserWindowTarget(Protocol):
     @property
@@ -58,14 +60,7 @@ class NativeBrowserNavigator(Protocol):
 JXARunner = Callable[[str, list[str]], Awaitable[Mapping[str, Any]]]
 
 _CHROMIUM_APP_NAMES = frozenset(
-    {
-        "brave browser",
-        "google chrome",
-        "google chrome canary",
-        "chromium",
-        "microsoft edge",
-        "vivaldi",
-    }
+    name.casefold() for name in SUPPORTED_NATIVE_BROWSER_APP_NAMES
 )
 _CHROMIUM_BUNDLE_IDS = frozenset(
     {

--- a/src/xagent/core/computer/native_navigation.py
+++ b/src/xagent/core/computer/native_navigation.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+class NativeBrowserWindowTarget(Protocol):
+    @property
+    def pid(self) -> int: ...
+
+    @property
+    def window_id(self) -> int: ...
+
+    @property
+    def app_name(self) -> str: ...
+
+    @property
+    def title(self) -> str | None: ...
+
+    @property
+    def x(self) -> float: ...
+
+    @property
+    def y(self) -> float: ...
+
+    @property
+    def width(self) -> float: ...
+
+    @property
+    def height(self) -> float: ...
+
+
+class NativeBrowserNavigationError(RuntimeError):
+    """Raised when an exact native browser window cannot be navigated safely."""
+
+
+@dataclass(frozen=True)
+class NativeBrowserNavigationResult:
+    route: str
+    browser_window_id: int
+    actual_url: str
+
+
+class NativeBrowserNavigator(Protocol):
+    def supports(self, target: NativeBrowserWindowTarget) -> bool: ...
+
+    async def navigate(
+        self,
+        target: NativeBrowserWindowTarget,
+        url: str,
+    ) -> NativeBrowserNavigationResult: ...
+
+
+JXARunner = Callable[[str, list[str]], Awaitable[Mapping[str, Any]]]
+
+_CHROMIUM_APP_NAMES = frozenset(
+    {
+        "brave browser",
+        "google chrome",
+        "google chrome canary",
+        "chromium",
+        "microsoft edge",
+        "vivaldi",
+    }
+)
+_CHROMIUM_BUNDLE_IDS = frozenset(
+    {
+        "com.brave.Browser",
+        "com.google.Chrome",
+        "com.google.Chrome.canary",
+        "com.microsoft.edgemac",
+        "com.vivaldi.Vivaldi",
+        "org.chromium.Chromium",
+    }
+)
+_WINDOW_ENUMERATION_SCRIPT = r"""
+function normalizedBounds(browserWindow) {
+  const bounds = browserWindow.bounds();
+  return [
+    Number(bounds.x),
+    Number(bounds.y),
+    Number(bounds.x) + Number(bounds.width),
+    Number(bounds.y) + Number(bounds.height),
+  ];
+}
+
+function run(argv) {
+  ObjC.import("AppKit");
+  const pid = Number(argv[0]);
+  const running = $.NSRunningApplication.runningApplicationWithProcessIdentifier(pid);
+  if (!running) {
+    throw new Error("authorized browser process is no longer running");
+  }
+  const bundleId = String(ObjC.unwrap(running.bundleIdentifier));
+  const app = Application(bundleId);
+  const windows = app.windows();
+  const result = [];
+  for (let index = 0; index < windows.length; index += 1) {
+    const browserWindow = windows[index];
+    result.push({
+      id: Number(browserWindow.id()),
+      title: String(browserWindow.name() || ""),
+      bounds: normalizedBounds(browserWindow),
+    });
+  }
+  return JSON.stringify({bundle_id: bundleId, windows: result});
+}
+"""
+_WINDOW_NAVIGATION_SCRIPT = r"""
+function normalizedBounds(browserWindow) {
+  const bounds = browserWindow.bounds();
+  return [
+    Number(bounds.x),
+    Number(bounds.y),
+    Number(bounds.x) + Number(bounds.width),
+    Number(bounds.y) + Number(bounds.height),
+  ];
+}
+
+function sameBounds(actual, expected) {
+  if (!Array.isArray(actual) || actual.length !== 4) return false;
+  for (let index = 0; index < 4; index += 1) {
+    if (Math.abs(Number(actual[index]) - Number(expected[index])) > 2) return false;
+  }
+  return true;
+}
+
+function run(argv) {
+  ObjC.import("AppKit");
+  const pid = Number(argv[0]);
+  const browserWindowId = Number(argv[1]);
+  const expectedTitle = argv[2];
+  const expectedBounds = JSON.parse(argv[3]);
+  const requestedUrl = argv[4];
+  const running = $.NSRunningApplication.runningApplicationWithProcessIdentifier(pid);
+  if (!running) {
+    throw new Error("authorized browser process is no longer running");
+  }
+  const bundleId = String(ObjC.unwrap(running.bundleIdentifier));
+  const app = Application(bundleId);
+  const windows = app.windows();
+  let matched = null;
+  for (let index = 0; index < windows.length; index += 1) {
+    const candidate = windows[index];
+    if (Number(candidate.id()) === browserWindowId) {
+      matched = candidate;
+      break;
+    }
+  }
+  if (matched === null) {
+    throw new Error("authorized browser window disappeared before navigation");
+  }
+  const currentTitle = String(matched.name() || "");
+  const currentBounds = normalizedBounds(matched);
+  if (currentTitle !== expectedTitle || !sameBounds(currentBounds, expectedBounds)) {
+    throw new Error("authorized browser window changed before navigation");
+  }
+  const tab = matched.activeTab();
+  tab.url = requestedUrl;
+  const loadingDeadline = Date.now() + 5000;
+  delay(0.1);
+  while (Boolean(tab.loading()) && Date.now() < loadingDeadline) {
+    delay(0.1);
+  }
+  return JSON.stringify({
+    bundle_id: bundleId,
+    browser_window_id: browserWindowId,
+    actual_url: String(tab.url() || ""),
+    loading: Boolean(tab.loading()),
+  });
+}
+"""
+
+
+@dataclass(frozen=True)
+class _ScriptBrowserWindow:
+    window_id: int
+    title: str
+    bounds: tuple[float, float, float, float]
+
+
+class MacOSChromiumNavigator:
+    """Navigate one authorized Chromium window without keyboard or CDP.
+
+    Chrome's scriptable window ids are not CGWindowIDs. The adapter therefore
+    resolves the authorized CG window to exactly one scriptable browser window
+    using its fresh title and bounds, and rechecks that fingerprint immediately
+    before changing the active tab URL. Ambiguous mappings fail before mutation.
+    """
+
+    def __init__(
+        self,
+        *,
+        runner: JXARunner | None = None,
+        platform: str | None = None,
+    ) -> None:
+        self._runner = runner or _run_jxa
+        self._platform = platform or sys.platform
+
+    def supports(self, target: NativeBrowserWindowTarget) -> bool:
+        return (
+            self._platform == "darwin"
+            and target.app_name.strip().casefold() in _CHROMIUM_APP_NAMES
+        )
+
+    async def navigate(
+        self,
+        target: NativeBrowserWindowTarget,
+        url: str,
+    ) -> NativeBrowserNavigationResult:
+        if not self.supports(target):
+            raise NativeBrowserNavigationError(
+                f"native navigation is unavailable for {target.app_name}"
+            )
+        inventory = await self._runner(
+            _WINDOW_ENUMERATION_SCRIPT,
+            [str(target.pid)],
+        )
+        bundle_id = str(inventory.get("bundle_id") or "")
+        if bundle_id not in _CHROMIUM_BUNDLE_IDS:
+            raise NativeBrowserNavigationError(
+                "authorized process is not a supported Chromium browser"
+            )
+        windows = self._parse_windows(inventory.get("windows"))
+        matched = self._match_window(target, windows)
+        expected_bounds = self._target_bounds(target)
+        result = await self._runner(
+            _WINDOW_NAVIGATION_SCRIPT,
+            [
+                str(target.pid),
+                str(matched.window_id),
+                matched.title,
+                json.dumps(expected_bounds, separators=(",", ":")),
+                url,
+            ],
+        )
+        if str(result.get("bundle_id") or "") != bundle_id:
+            raise NativeBrowserNavigationError(
+                "authorized browser process changed during navigation"
+            )
+        if int(result.get("browser_window_id") or -1) != matched.window_id:
+            raise NativeBrowserNavigationError(
+                "browser reported a different window after navigation"
+            )
+        actual_url = str(result.get("actual_url") or "").strip()
+        if not actual_url.startswith(("http://", "https://")):
+            raise NativeBrowserNavigationError(
+                "browser did not report an HTTP URL after navigation"
+            )
+        return NativeBrowserNavigationResult(
+            route="macos_chromium_apple_events",
+            browser_window_id=matched.window_id,
+            actual_url=actual_url,
+        )
+
+    @staticmethod
+    def _parse_windows(raw_windows: Any) -> list[_ScriptBrowserWindow]:
+        if not isinstance(raw_windows, list):
+            raise NativeBrowserNavigationError(
+                "browser did not return a scriptable window inventory"
+            )
+        parsed: list[_ScriptBrowserWindow] = []
+        for raw in raw_windows:
+            if not isinstance(raw, Mapping):
+                continue
+            bounds = raw.get("bounds")
+            if not isinstance(bounds, list) or len(bounds) != 4:
+                continue
+            try:
+                parsed.append(
+                    _ScriptBrowserWindow(
+                        window_id=int(raw["id"]),
+                        title=str(raw.get("title") or ""),
+                        bounds=tuple(float(value) for value in bounds),  # type: ignore[arg-type]
+                    )
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+        return parsed
+
+    @classmethod
+    def _match_window(
+        cls,
+        target: NativeBrowserWindowTarget,
+        windows: list[_ScriptBrowserWindow],
+    ) -> _ScriptBrowserWindow:
+        expected_title = target.title or ""
+        expected_bounds = cls._target_bounds(target)
+        matches = [
+            window
+            for window in windows
+            if window.title == expected_title
+            and all(
+                abs(actual - expected) <= 2
+                for actual, expected in zip(window.bounds, expected_bounds, strict=True)
+            )
+        ]
+        if len(matches) != 1:
+            detail = "ambiguous" if len(matches) > 1 else "not found"
+            raise NativeBrowserNavigationError(
+                "authorized browser window mapping is "
+                f"{detail}; navigation was not attempted"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _target_bounds(
+        target: NativeBrowserWindowTarget,
+    ) -> tuple[float, float, float, float]:
+        return (
+            target.x,
+            target.y,
+            target.x + target.width,
+            target.y + target.height,
+        )
+
+
+async def _run_jxa(script: str, arguments: list[str]) -> Mapping[str, Any]:
+    process = await asyncio.create_subprocess_exec(
+        "/usr/bin/osascript",
+        "-l",
+        "JavaScript",
+        "-e",
+        script,
+        "--",
+        *arguments,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=8)
+    except TimeoutError as exc:
+        process.kill()
+        await process.wait()
+        raise NativeBrowserNavigationError(
+            "native browser navigation timed out"
+        ) from exc
+    if process.returncode != 0:
+        detail = stderr.decode("utf-8", errors="replace").strip()
+        raise NativeBrowserNavigationError(
+            detail[:500] or "native browser navigation failed"
+        )
+    try:
+        payload = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise NativeBrowserNavigationError(
+            "native browser navigation returned invalid output"
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise NativeBrowserNavigationError(
+            "native browser navigation returned an invalid result"
+        )
+    return payload
+
+
+def default_native_browser_navigator() -> NativeBrowserNavigator | None:
+    navigator = MacOSChromiumNavigator()
+    return navigator if sys.platform == "darwin" else None

--- a/src/xagent/core/computer/native_navigation.py
+++ b/src/xagent/core/computer/native_navigation.py
@@ -339,6 +339,13 @@ async def _run_jxa(script: str, arguments: list[str]) -> Mapping[str, Any]:
         raise NativeBrowserNavigationError(
             "native browser navigation timed out"
         ) from exc
+    except BaseException:
+        # The subprocess outlives a cancelled coroutine unless it is explicitly
+        # terminated and reaped. Always clean up, then preserve cancellation or
+        # another process-control exception unchanged.
+        process.kill()
+        await process.wait()
+        raise
     if process.returncode != 0:
         detail = stderr.decode("utf-8", errors="replace").strip()
         raise NativeBrowserNavigationError(

--- a/src/xagent/core/computer/schema.py
+++ b/src/xagent/core/computer/schema.py
@@ -119,7 +119,6 @@ class ComputerControlTransport(str, Enum):
     """Transport used to deliver actions to a selected computer target."""
 
     NATIVE_ACCESSIBILITY = "native_accessibility"
-    BROWSER_AUTOMATION = "browser_automation"
 
 
 class ComputerActionType(str, Enum):

--- a/src/xagent/core/computer/schema.py
+++ b/src/xagent/core/computer/schema.py
@@ -20,6 +20,8 @@ from ..context_ref import ContextReference
 
 COMPUTER_FRAME_ID_METADATA_KEY = "computer_frame_id"
 COMPUTER_SESSION_ID_METADATA_KEY = "computer_session_id"
+COMPUTER_PERCEPTION_METADATA_KEY = "computer_perception"
+COMPUTER_CONTROL_METADATA_KEY = "computer_control"
 
 # Observation metadata flags set by adapters when their structural view is
 # incomplete. Missing structure is diagnostic context, not proof of risk.
@@ -111,6 +113,13 @@ class ComputerPerceptionMode(str, Enum):
     AUTO = "auto"
     VISION = "vision"
     SEMANTIC = "semantic"
+
+
+class ComputerControlTransport(str, Enum):
+    """Transport used to deliver actions to a selected computer target."""
+
+    NATIVE_ACCESSIBILITY = "native_accessibility"
+    BROWSER_AUTOMATION = "browser_automation"
 
 
 class ComputerActionType(str, Enum):

--- a/src/xagent/core/tools/adapters/vibe/browser_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_tools.py
@@ -11,10 +11,42 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _has_local_browser_runtime(contribution: Any) -> bool:
+    from ....computer.native_browser import (
+        LOCAL_BROWSER_TASK_EXTENSION,
+    )
+    from ....task_runtime import (
+        TaskRuntimeContribution,
+        full_task_runtime_contribution,
+    )
+
+    if not isinstance(contribution, TaskRuntimeContribution):
+        return False
+    full_contribution = full_task_runtime_contribution(contribution)
+    return any(
+        provider_name == LOCAL_BROWSER_TASK_EXTENSION
+        and any(
+            getattr(tool, "name", None) == "computer"
+            for tool in provider_contribution.tools
+        )
+        for provider_name, provider_contribution in (
+            full_contribution.provider_contributions
+        )
+    )
+
+
 @register_tool(categories={"browser"})
 async def create_browser_tools(config: "BaseToolConfig") -> List[Any]:
     """Create browser automation tools."""
     if not config.get_browser_tools_enabled():
+        return []
+
+    # A bound Local browser task contributes its own ``computer`` instance.
+    # Suppress the Playwright browser family as one unit so the runtime tool
+    # does not collide with the core tool or accidentally expose a second,
+    # unrelated browser to the model.
+    contribution = config.get_task_runtime_contribution()
+    if _has_local_browser_runtime(contribution):
         return []
 
     task_id = config.get_task_id()

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -201,7 +201,10 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         environment_label: str = "browser",
         perception_mode: ComputerPerceptionMode | str = ComputerPerceptionMode.AUTO,
         headless: bool = True,
+        environment_scope: Literal["step", "task"] = "step",
     ) -> None:
+        if environment_scope not in {"step", "task"}:
+            raise ValueError("environment_scope must be 'step' or 'task'")
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
         self._workspace = workspace
@@ -218,6 +221,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
             )
         )
         self._headless = headless
+        self._environment_scope = environment_scope
         self._environments: dict[str, ComputerEnvironment] = {}
 
     @property
@@ -305,7 +309,9 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         # The session is an execution-scoped resource. Never let model output
         # select another task's browser, even if it invents a session_id field.
         raw_args.pop("session_id", None)
-        session_id = self._default_session_id(step_id)
+        session_id = self._default_session_id(
+            step_id if self._environment_scope == "step" else None
+        )
         if not session_id:
             return self._error_result(
                 session_id="",

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -328,20 +328,19 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
                 error=f"Invalid computer action: {exc}",
             )
 
-        environment = self._environments.get(session_id)
-        if environment is None:
-            environment = self._environment_factory(
-                session_id=session_id,
-                workspace=self._workspace,
-                headless=self._headless,
-            )
-            self._environments[session_id] = environment
-
         observation_only = action.type in {
             ComputerActionType.OBSERVE,
             ComputerActionType.SCREENSHOT,
         }
+        environment = self._environments.get(session_id)
         try:
+            if environment is None:
+                environment = self._environment_factory(
+                    session_id=session_id,
+                    workspace=self._workspace,
+                    headless=self._headless,
+                )
+                self._environments[session_id] = environment
             current = environment.current_observation
             if current is None:
                 if not observation_only:
@@ -399,14 +398,14 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
             RuntimeError,
             ValueError,
         ) as exc:
-            current = environment.current_observation
+            current = environment.current_observation if environment else None
             return self._error_result(
                 session_id=session_id,
                 frame_id=current.frame_id if current else None,
                 error=str(exc),
             )
         except Exception as exc:  # noqa: BLE001 - provider failures become tool results.
-            current = environment.current_observation
+            current = environment.current_observation if environment else None
             return self._error_result(
                 session_id=session_id,
                 frame_id=current.frame_id if current else None,

--- a/src/xagent/web/api/computer.py
+++ b/src/xagent/web/api/computer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response
+
+from ...config import get_native_browser_app_name, get_native_browser_enabled
+from ...core.computer.native_browser_readiness import (
+    LocalBrowserReadiness,
+    LocalBrowserReadinessIssue,
+)
+from ...core.computer.native_browser_readiness import (
+    get_local_browser_readiness as probe_local_browser_readiness,
+)
+from ..models.user import User
+from .auth import get_current_user
+
+computer_router = APIRouter(prefix="/api/computer", tags=["computer"])
+
+
+@computer_router.get(
+    "/local-browser/readiness",
+    response_model=LocalBrowserReadiness,
+)
+async def get_local_browser_readiness_endpoint(
+    response: Response,
+    user: User = Depends(get_current_user),
+) -> LocalBrowserReadiness:
+    """Return whether this administrator can control the configured browser."""
+
+    response.headers["Cache-Control"] = "no-store"
+    browser_app_name = get_native_browser_app_name()
+    if not get_native_browser_enabled():
+        issue = LocalBrowserReadinessIssue(
+            code="disabled",
+            message="Local browser is disabled on this Xagent host.",
+        )
+        return LocalBrowserReadiness(
+            ready=False,
+            connected=False,
+            attached=False,
+            application=browser_app_name,
+            issues=[issue],
+            message=issue.message,
+        )
+    if not bool(user.is_admin):
+        issue = LocalBrowserReadinessIssue(
+            code="not_authorized",
+            message=(
+                "Local browser is restricted to Xagent administrators because "
+                "it controls a signed-in browser on the backend host."
+            ),
+        )
+        return LocalBrowserReadiness(
+            ready=False,
+            connected=False,
+            attached=False,
+            application=browser_app_name,
+            issues=[issue],
+            message=issue.message,
+        )
+    return await probe_local_browser_readiness()

--- a/src/xagent/web/api/computer.py
+++ b/src/xagent/web/api/computer.py
@@ -27,7 +27,6 @@ async def get_local_browser_readiness_endpoint(
     """Return whether this administrator can control the configured browser."""
 
     response.headers["Cache-Control"] = "no-store"
-    browser_app_name = get_native_browser_app_name()
     if not get_native_browser_enabled():
         issue = LocalBrowserReadinessIssue(
             code="disabled",
@@ -37,7 +36,7 @@ async def get_local_browser_readiness_endpoint(
             ready=False,
             connected=False,
             attached=False,
-            application=browser_app_name,
+            application="Local browser",
             issues=[issue],
             message=issue.message,
         )
@@ -53,7 +52,22 @@ async def get_local_browser_readiness_endpoint(
             ready=False,
             connected=False,
             attached=False,
-            application=browser_app_name,
+            application="Local browser",
+            issues=[issue],
+            message=issue.message,
+        )
+    try:
+        get_native_browser_app_name()
+    except ValueError as exc:
+        issue = LocalBrowserReadinessIssue(
+            code="invalid_configuration",
+            message=str(exc),
+        )
+        return LocalBrowserReadiness(
+            ready=False,
+            connected=False,
+            attached=False,
+            application="Local browser",
             issues=[issue],
             message=issue.message,
         )

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -163,7 +163,10 @@ from ..services.task_lease_service import (
     run_while_task_lease_owned,
     stop_task_lease_heartbeat,
 )
-from ..services.task_runtime import SELECTED_FILE_IDS_AGENT_CONFIG_KEY
+from ..services.task_runtime import (
+    SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
+    task_extension_bindings_from_agent_config,
+)
 from ..services.uploaded_file_store import (
     StagedUploadedFile,
     SupersededObjectCleanupClaim,
@@ -5238,6 +5241,9 @@ def _load_websocket_task_routing_snapshot(
                 "agent_id": task.agent_id,
                 "agent_name": agent_name,
                 "agent_logo_url": agent_logo_url,
+                "runtime_extension_bindings": list(
+                    task_extension_bindings_from_agent_config(task.agent_config)
+                ),
                 "is_dag": (
                     agent_execution_mode == "think"
                     if agent_execution_mode is not None
@@ -6467,6 +6473,9 @@ def _load_legacy_execute_task_request_sync(
                 "agent_id": task.agent_id,
                 "agent_name": agent_name,
                 "agent_logo_url": agent_logo_url,
+                "runtime_extension_bindings": list(
+                    task_extension_bindings_from_agent_config(task.agent_config)
+                ),
                 "created_at": safe_timestamp_to_unix(task.created_at)
                 if task.created_at
                 else None,

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -47,6 +47,7 @@ from .api.auth import auth_router
 from .api.channel import router as channel_router
 from .api.chat import chat_router
 from .api.cloud_storage import cloud_router
+from .api.computer import computer_router
 from .api.conversation_logs import router as conversation_logs_router
 from .api.custom_api import custom_api_router
 from .api.deployment_config import router as deployment_config_router
@@ -76,6 +77,10 @@ from .dynamic_memory_store import get_memory_store
 from .logging_config import setup_logging
 from .models.database import init_db
 from .services.a2a_protocol import A2AApiError, a2a_api_error_handler, a2a_error
+from .services.local_browser_runtime import (
+    register_local_browser_runtime,
+    unregister_local_browser_runtime,
+)
 from .services.orphan_upload_gc import run_orphan_upload_gc_loop
 from .services.skill_runtime import (
     SkillRuntimeSessionBoundaryError,
@@ -90,7 +95,6 @@ from .services.uploaded_file_recovery import (
 setup_logging()  # Uses XAGENT_LOG_LEVEL env var or defaults to INFO
 
 logger = logging.getLogger(__name__)
-
 
 __all__ = ["app"]
 
@@ -973,6 +977,7 @@ memory_router = MemoryManagementRouter(get_memory_store).get_router()
 app.include_router(auth_router)
 app.include_router(chat_router)
 app.include_router(cloud_router)
+app.include_router(computer_router)
 app.include_router(conversation_logs_router)
 app.include_router(file_router)
 app.include_router(jobs_router)
@@ -1015,6 +1020,11 @@ async def startup_event() -> None:
     logger.info("Initializing database...")
     init_db()
     logger.info("Database initialized successfully")
+
+    # Keep built-in task-runtime providers scoped to the application lifespan.
+    # Register even when disabled so task creation receives a precise 403
+    # instead of an ambiguous "unknown extension" error.
+    register_local_browser_runtime()
 
     # Reopen process-local task admission before any trigger, command, or
     # channel ingress can create background execution work for this lifespan.
@@ -1615,6 +1625,7 @@ async def shutdown_event() -> None:
     from .services.task_runtime import shutdown_task_runtime_hook_executor
 
     shutdown_task_runtime_hook_executor()
+    unregister_local_browser_runtime()
 
     # Shutdown all sandboxes
     from .sandbox_manager import get_sandbox_manager

--- a/src/xagent/web/services/local_browser_runtime.py
+++ b/src/xagent/web/services/local_browser_runtime.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from functools import partial
+from typing import Any
+
+from ...config import get_native_browser_app_name, get_native_browser_enabled
+from ...core.computer.native_browser import (
+    LOCAL_BROWSER_TASK_EXTENSION,
+    NativeBrowserEnvironment,
+)
+from ...core.computer.schema import ComputerPerceptionMode
+from ...core.task_runtime import (
+    TaskRuntimeClientError,
+    TaskRuntimeContext,
+    TaskRuntimeContribution,
+)
+from ...core.tools.adapters.vibe.computer import ComputerTool
+from ..models.task import Task
+from ..models.user import User
+from .task_runtime import (
+    register_task_extension,
+    registered_task_extensions,
+    task_extension_bindings_from_agent_config,
+    unregister_task_extension,
+)
+
+_TARGET_AGENT_CONFIG_KEY = "local_browser_target"
+
+
+class LocalBrowserTaskRuntimeProvider:
+    """Bind one task to a configured browser window on the backend host."""
+
+    def __init__(self, extension_name: str = LOCAL_BROWSER_TASK_EXTENSION) -> None:
+        self.extension_name = extension_name
+
+    def on_task_created(
+        self,
+        context: TaskRuntimeContext,
+        configuration: Mapping[str, Any],
+    ) -> None:
+        if not get_native_browser_enabled():
+            raise TaskRuntimeClientError(
+                "Local browser is disabled on this Xagent host.",
+                status_code=403,
+            )
+        if not _task_owner_is_admin(context):
+            raise TaskRuntimeClientError(
+                "Local browser is restricted to Xagent administrators because "
+                "it controls a signed-in browser on the backend host.",
+                status_code=403,
+            )
+        target = _validate_target_configuration(configuration)
+        _store_task_target(context, target)
+
+    def build_runtime(
+        self,
+        context: TaskRuntimeContext,
+    ) -> TaskRuntimeContribution | None:
+        if not _task_is_bound(context, self.extension_name):
+            return None
+        if context.workspace is None:
+            raise RuntimeError("Local browser requires a task workspace")
+
+        target = _task_target(context)
+        if target is None:
+            raise RuntimeError("Local browser task has no selected browser window")
+        perception_mode = target.get(
+            "perception_mode", ComputerPerceptionMode.AUTO.value
+        )
+        environment_factory = partial(
+            NativeBrowserEnvironment,
+            target_pid=target["pid"],
+            target_window_id=target["window_id"],
+            browser_app_name=get_native_browser_app_name(),
+            perception_mode=perception_mode,
+        )
+        tool = ComputerTool(
+            task_id=str(context.task_id),
+            workspace=context.workspace,
+            environment_factory=environment_factory,
+            environment_label="the selected local browser window",
+            perception_mode=perception_mode,
+            headless=False,
+            environment_instructions=(
+                "This task controls one configured browser window on the same "
+                "host as Xagent through cua-driver. The window may contain the "
+                "user's existing signed-in state. The first screenshot locks "
+                "the task to that exact window; never switch windows silently. "
+                "Control is delivered through native OS automation. It never "
+                "opens a Chrome debugging connection. "
+                "For browser URL changes, use the atomic navigate action when the "
+                "observation explicitly lists it as supported. Never simulate "
+                "navigation with address-bar clicks, typing, or key presses. "
+                "Treat each observation's supported_actions as authoritative. If "
+                "an action is unavailable, do not retry or work around that "
+                "capability through another tool. "
+                "Actions use background delivery unless the observation explicitly "
+                "recommends foreground delivery. Never ask for credentials."
+            ),
+        )
+        return TaskRuntimeContribution(
+            tools=(tool,),
+            environment=(
+                "Local browser is enabled for this task. Operate the selected "
+                "browser window with the computer tool. This is the Xagent "
+                "backend host, not a browser extension or remote relay."
+            ),
+            preferred_input_modalities=("image",),
+        )
+
+    def public_metadata(
+        self,
+        context: TaskRuntimeContext,
+    ) -> Mapping[str, Any] | None:
+        if not _task_is_bound(context, self.extension_name):
+            return None
+        target = _task_target(context)
+        metadata: dict[str, Any] = {
+            "kind": "local_browser",
+            "enabled": get_native_browser_enabled(),
+            "perception_mode": (
+                target.get("perception_mode", ComputerPerceptionMode.AUTO.value)
+                if target
+                else ComputerPerceptionMode.AUTO.value
+            ),
+            "control_transport": "native_accessibility",
+        }
+        if target:
+            metadata["target"] = target
+        return metadata
+
+    def on_task_deleted(self, context: TaskRuntimeContext) -> None:
+        # The task-scoped ComputerTool owns cua-driver and closes it through
+        # normal AgentService teardown. The binding itself has no durable state.
+        del context
+
+
+def register_local_browser_runtime() -> None:
+    """Register the built-in provider once for this web process."""
+
+    if LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions():
+        register_task_extension(
+            LOCAL_BROWSER_TASK_EXTENSION,
+            LocalBrowserTaskRuntimeProvider(),
+        )
+
+
+def unregister_local_browser_runtime() -> None:
+    """Remove the built-in provider at the end of the web-app lifespan."""
+
+    unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+
+
+def _task_is_bound(context: TaskRuntimeContext, extension_name: str) -> bool:
+    session = context.session_factory()
+    try:
+        task = session.query(Task).filter(Task.id == context.task_id).first()
+        if task is None or int(task.user_id) != context.user_id:
+            return False
+        return extension_name in task_extension_bindings_from_agent_config(
+            task.agent_config
+        )
+    finally:
+        session.close()
+
+
+def _task_owner_is_admin(context: TaskRuntimeContext) -> bool:
+    session = context.session_factory()
+    try:
+        user = session.query(User).filter(User.id == context.user_id).first()
+        return bool(user is not None and user.is_admin)
+    finally:
+        session.close()
+
+
+def _validate_target_configuration(
+    configuration: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not configuration:
+        raise TaskRuntimeClientError(
+            "Local browser requires an explicitly selected browser window."
+        )
+    allowed = {"pid", "window_id", "application", "title", "perception_mode"}
+    unexpected = set(configuration) - allowed
+    if unexpected:
+        raise TaskRuntimeClientError(
+            "Local browser configuration contains unsupported fields: "
+            + ", ".join(sorted(unexpected))
+        )
+    try:
+        pid = int(configuration["pid"])
+        window_id = int(configuration["window_id"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise TaskRuntimeClientError(
+            "Local browser requires integer pid and window_id values."
+        ) from exc
+    if pid <= 0 or window_id <= 0:
+        raise TaskRuntimeClientError(
+            "Local browser pid and window_id must be positive."
+        )
+    application = str(configuration.get("application") or "").strip()
+    browser_app_name = get_native_browser_app_name()
+    if application.casefold() != browser_app_name.casefold():
+        raise TaskRuntimeClientError(
+            f"Local browser only accepts {browser_app_name} windows."
+        )
+    target: dict[str, Any] = {
+        "pid": pid,
+        "window_id": window_id,
+        "application": browser_app_name,
+    }
+    title = str(configuration.get("title") or "").strip()
+    if title:
+        target["title"] = title[:512]
+    try:
+        target["perception_mode"] = ComputerPerceptionMode(
+            configuration.get("perception_mode", ComputerPerceptionMode.AUTO.value)
+        ).value
+    except ValueError as exc:
+        raise TaskRuntimeClientError(
+            "Local browser perception_mode must be auto, vision, or semantic."
+        ) from exc
+    return target
+
+
+def _store_task_target(
+    context: TaskRuntimeContext,
+    target: Mapping[str, Any],
+) -> None:
+    session = context.session_factory()
+    try:
+        task = session.query(Task).filter(Task.id == context.task_id).first()
+        if task is None or int(task.user_id) != context.user_id:
+            raise TaskRuntimeClientError("Local browser task was not found.")
+        agent_config = dict(task.agent_config or {})
+        agent_config[_TARGET_AGENT_CONFIG_KEY] = dict(target)
+        task.agent_config = agent_config
+        session.commit()
+    finally:
+        session.close()
+
+
+def _task_target(context: TaskRuntimeContext) -> dict[str, Any] | None:
+    session = context.session_factory()
+    try:
+        task = session.query(Task).filter(Task.id == context.task_id).first()
+        if task is None or int(task.user_id) != context.user_id:
+            return None
+        raw = (task.agent_config or {}).get(_TARGET_AGENT_CONFIG_KEY)
+        return dict(raw) if isinstance(raw, Mapping) else None
+    finally:
+        session.close()

--- a/src/xagent/web/services/local_browser_runtime.py
+++ b/src/xagent/web/services/local_browser_runtime.py
@@ -60,19 +60,41 @@ class LocalBrowserTaskRuntimeProvider:
         if not _task_is_bound(context, self.extension_name):
             return None
         if context.workspace is None:
-            raise RuntimeError("Local browser requires a task workspace")
+            return _unavailable_runtime(
+                context,
+                "Local browser requires a task workspace.",
+            )
+        if not get_native_browser_enabled():
+            return _unavailable_runtime(
+                context,
+                "Local browser is disabled on this Xagent host.",
+            )
+        if not _task_owner_is_admin(context):
+            return _unavailable_runtime(
+                context,
+                "Local browser authorization was revoked because the task owner "
+                "is no longer an Xagent administrator.",
+            )
 
         target = _task_target(context)
         if target is None:
-            raise RuntimeError("Local browser task has no selected browser window")
+            return _unavailable_runtime(
+                context,
+                "Local browser task has no selected browser window.",
+            )
         perception_mode = target.get(
             "perception_mode", ComputerPerceptionMode.AUTO.value
         )
+        try:
+            browser_app_name = get_native_browser_app_name()
+        except ValueError as exc:
+            return _unavailable_runtime(context, str(exc))
         environment_factory = partial(
-            NativeBrowserEnvironment,
+            _authorized_native_browser_environment,
+            context,
             target_pid=target["pid"],
             target_window_id=target["window_id"],
-            browser_app_name=get_native_browser_app_name(),
+            browser_app_name=browser_app_name,
             perception_mode=perception_mode,
         )
         tool = ComputerTool(
@@ -115,10 +137,20 @@ class LocalBrowserTaskRuntimeProvider:
     ) -> Mapping[str, Any] | None:
         if not _task_is_bound(context, self.extension_name):
             return None
+        enabled = get_native_browser_enabled()
+        authorized = enabled and _task_owner_is_admin(context)
+        if not authorized:
+            return {
+                "kind": "local_browser",
+                "enabled": False,
+                "reason": "disabled" if not enabled else "authorization_revoked",
+                "perception_mode": ComputerPerceptionMode.AUTO.value,
+                "control_transport": "native_accessibility",
+            }
         target = _task_target(context)
         metadata: dict[str, Any] = {
             "kind": "local_browser",
-            "enabled": get_native_browser_enabled(),
+            "enabled": True,
             "perception_mode": (
                 target.get("perception_mode", ComputerPerceptionMode.AUTO.value)
                 if target
@@ -150,6 +182,51 @@ def unregister_local_browser_runtime() -> None:
     """Remove the built-in provider at the end of the web-app lifespan."""
 
     unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+
+
+def _authorized_native_browser_environment(
+    context: TaskRuntimeContext,
+    **kwargs: Any,
+) -> NativeBrowserEnvironment:
+    """Re-check host enablement and owner privilege at environment use time."""
+
+    if not get_native_browser_enabled():
+        raise RuntimeError("Local browser is disabled on this Xagent host.")
+    if not _task_owner_is_admin(context):
+        raise RuntimeError(
+            "Local browser authorization was revoked because the task owner is "
+            "no longer an Xagent administrator."
+        )
+    return NativeBrowserEnvironment(**kwargs)
+
+
+def _unavailable_runtime(
+    context: TaskRuntimeContext,
+    reason: str,
+) -> TaskRuntimeContribution:
+    """Keep a bound task fail-closed without falling back to Playwright."""
+
+    def unavailable_environment(**_kwargs: Any) -> NativeBrowserEnvironment:
+        raise RuntimeError(reason)
+
+    tool = ComputerTool(
+        task_id=str(context.task_id),
+        workspace=context.workspace,
+        environment_factory=unavailable_environment,
+        environment_label="the selected local browser window",
+        headless=False,
+        environment_instructions=(
+            f"Local browser is unavailable for this task: {reason} "
+            "Do not use another browser runtime as a substitute."
+        ),
+    )
+    return TaskRuntimeContribution(
+        tools=(tool,),
+        environment=(
+            f"Local browser is bound to this task but unavailable: {reason} "
+            "Do not substitute a different browser runtime."
+        ),
+    )
 
 
 def _task_is_bound(context: TaskRuntimeContext, extension_name: str) -> bool:
@@ -206,7 +283,10 @@ def _validate_target_configuration(
             "Local browser pid and window_id must be positive."
         )
     application = str(configuration.get("application") or "").strip()
-    browser_app_name = get_native_browser_app_name()
+    try:
+        browser_app_name = get_native_browser_app_name()
+    except ValueError as exc:
+        raise TaskRuntimeClientError(str(exc), status_code=403) from exc
     if application.casefold() != browser_app_name.casefold():
         raise TaskRuntimeClientError(
             f"Local browser only accepts {browser_app_name} windows."

--- a/src/xagent/web/services/local_browser_runtime.py
+++ b/src/xagent/web/services/local_browser_runtime.py
@@ -19,7 +19,7 @@ from ...core.tools.adapters.vibe.computer import ComputerTool
 from ..models.task import Task
 from ..models.user import User
 from .task_runtime import (
-    register_task_extension,
+    _register_task_extension_idempotently,
     task_extension_bindings_from_agent_config,
     unregister_task_extension,
 )
@@ -170,12 +170,18 @@ class LocalBrowserTaskRuntimeProvider:
         del context
 
 
+_LOCAL_BROWSER_RUNTIME_PROVIDER = LocalBrowserTaskRuntimeProvider()
+
+
 def register_local_browser_runtime() -> None:
     """Register the built-in provider for this application lifespan."""
 
-    register_task_extension(
+    # Embedded apps and tests can enter the same FastAPI lifespan more than
+    # once in one process. Re-entering our own stateless provider is safe; a
+    # different provider using the same name remains a hard collision.
+    _register_task_extension_idempotently(
         LOCAL_BROWSER_TASK_EXTENSION,
-        LocalBrowserTaskRuntimeProvider(),
+        _LOCAL_BROWSER_RUNTIME_PROVIDER,
     )
 
 

--- a/src/xagent/web/services/local_browser_runtime.py
+++ b/src/xagent/web/services/local_browser_runtime.py
@@ -20,7 +20,6 @@ from ..models.task import Task
 from ..models.user import User
 from .task_runtime import (
     register_task_extension,
-    registered_task_extensions,
     task_extension_bindings_from_agent_config,
     unregister_task_extension,
 )
@@ -172,13 +171,12 @@ class LocalBrowserTaskRuntimeProvider:
 
 
 def register_local_browser_runtime() -> None:
-    """Register the built-in provider once for this web process."""
+    """Register the built-in provider for this application lifespan."""
 
-    if LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions():
-        register_task_extension(
-            LOCAL_BROWSER_TASK_EXTENSION,
-            LocalBrowserTaskRuntimeProvider(),
-        )
+    register_task_extension(
+        LOCAL_BROWSER_TASK_EXTENSION,
+        LocalBrowserTaskRuntimeProvider(),
+    )
 
 
 def unregister_local_browser_runtime() -> None:

--- a/src/xagent/web/services/local_browser_runtime.py
+++ b/src/xagent/web/services/local_browser_runtime.py
@@ -188,13 +188,19 @@ def _validate_target_configuration(
             "Local browser configuration contains unsupported fields: "
             + ", ".join(sorted(unexpected))
         )
-    try:
-        pid = int(configuration["pid"])
-        window_id = int(configuration["window_id"])
-    except (KeyError, TypeError, ValueError) as exc:
+    pid = configuration.get("pid")
+    window_id = configuration.get("window_id")
+    if pid is None or window_id is None:
+        raise TaskRuntimeClientError("Local browser requires pid and window_id values.")
+    if (
+        not isinstance(pid, int)
+        or isinstance(pid, bool)
+        or not isinstance(window_id, int)
+        or isinstance(window_id, bool)
+    ):
         raise TaskRuntimeClientError(
-            "Local browser requires integer pid and window_id values."
-        ) from exc
+            "Local browser pid and window_id must be integers."
+        )
     if pid <= 0 or window_id <= 0:
         raise TaskRuntimeClientError(
             "Local browser pid and window_id must be positive."

--- a/src/xagent/web/services/local_browser_runtime.py
+++ b/src/xagent/web/services/local_browser_runtime.py
@@ -104,6 +104,7 @@ class LocalBrowserTaskRuntimeProvider:
             environment_label="the selected local browser window",
             perception_mode=perception_mode,
             headless=False,
+            environment_scope="task",
             environment_instructions=(
                 "This task controls one configured browser window on the same "
                 "host as Xagent through cua-driver. The window may contain the "
@@ -112,8 +113,10 @@ class LocalBrowserTaskRuntimeProvider:
                 "Control is delivered through native OS automation. It never "
                 "opens a Chrome debugging connection. "
                 "For browser URL changes, use the atomic navigate action when the "
-                "observation explicitly lists it as supported. Never simulate "
-                "navigation with address-bar clicks, typing, or key presses. "
+                "observation explicitly lists it as supported. Free type and "
+                "keypress actions are disabled; use replace_text only on an exact "
+                "document element. Never simulate navigation with address-bar "
+                "clicks, typing, or key presses. "
                 "Treat each observation's supported_actions as authoritative. If "
                 "an action is unavailable, do not retry or work around that "
                 "capability through another tool. "

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -262,17 +262,10 @@ def _get_task_runtime_hook_executor() -> ThreadPoolExecutor:
         return _task_runtime_hook_executor
 
 
-def register_task_extension(
+def _validate_task_extension_provider(
     name: str,
     provider: TaskRuntimeExtensionProvider,
-) -> None:
-    """Register one process-wide task runtime provider.
-
-    Registration is deliberately not idempotent: re-registering a name raises
-    so a second provider cannot silently shadow the first. Replacing a live
-    provider is an ``unregister_task_extension`` followed by a fresh register.
-    """
-
+) -> str:
     normalized = _normalize_extension_name(name)
     missing = [
         method
@@ -284,8 +277,41 @@ def register_task_extension(
             "Task runtime extension provider is missing callable method(s): "
             + ", ".join(missing)
         )
+    return normalized
+
+
+def register_task_extension(
+    name: str,
+    provider: TaskRuntimeExtensionProvider,
+) -> None:
+    """Register one process-wide task runtime provider.
+
+    Registration is deliberately not idempotent: re-registering a name raises
+    so a second provider cannot silently shadow the first. Replacing a live
+    provider is an ``unregister_task_extension`` followed by a fresh register.
+    """
+
+    normalized = _validate_task_extension_provider(name, provider)
     with _task_runtime_extensions_lock:
         if normalized in _task_runtime_extensions:
+            raise ValueError(
+                f"Task runtime extension '{normalized}' is already registered"
+            )
+        _task_runtime_extensions[normalized] = provider
+
+
+def _register_task_extension_idempotently(
+    name: str,
+    provider: TaskRuntimeExtensionProvider,
+) -> None:
+    """Register ``provider`` once while rejecting a different owner."""
+
+    normalized = _validate_task_extension_provider(name, provider)
+    with _task_runtime_extensions_lock:
+        existing = _task_runtime_extensions.get(normalized)
+        if existing is provider:
+            return
+        if existing is not None:
             raise ValueError(
                 f"Task runtime extension '{normalized}' is already registered"
             )

--- a/tests/core/computer/test_computer_tool.py
+++ b/tests/core/computer/test_computer_tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -476,6 +477,53 @@ async def test_computer_tool_derives_session_from_task_and_step() -> None:
 
     assert result["session_id"] == "task-1:inspect_page"
     assert factory.calls[0]["session_id"] == "task-1:inspect_page"
+
+
+@pytest.mark.asyncio
+async def test_task_scoped_computer_tool_shares_one_environment_across_steps() -> None:
+    factory = EnvironmentFactory()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=factory,
+        environment_scope="task",
+    )
+
+    first = await tool.run_json_async({"_xagent_step_id": "inspect"})
+    second = await tool.run_json_async({"_xagent_step_id": "act"})
+
+    assert first["session_id"] == "task-1"
+    assert second["session_id"] == "task-1"
+    assert len(factory.environments) == 1
+    assert factory.environments[0].observe_count == 2
+
+
+@pytest.mark.asyncio
+async def test_task_scoped_computer_tool_serializes_competing_step_actions() -> None:
+    factory = EnvironmentFactory()
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=factory,
+        environment_scope="task",
+    )
+    initial = await tool.run_json_async({"_xagent_step_id": "inspect"})
+    action = {
+        "expected_frame_id": initial["frame_id"],
+        "action": "click",
+        "target": {"point": {"x": 0.5, "y": 0.5}},
+    }
+
+    first, second = await asyncio.gather(
+        tool.run_json_async({**action, "_xagent_step_id": "first"}),
+        tool.run_json_async({**action, "_xagent_step_id": "second"}),
+    )
+
+    assert sorted((first["success"], second["success"])) == [False, True]
+    assert len(factory.environments) == 1
+    assert len(factory.environments[0].executed) == 1
+    failure = first if first["success"] is False else second
+    assert "current frame" in failure["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/computer/test_computer_tool.py
+++ b/tests/core/computer/test_computer_tool.py
@@ -227,6 +227,25 @@ async def test_computer_tool_executes_normalized_bare_element_id_target() -> Non
     assert target.element_id == "button-1"
 
 
+@pytest.mark.asyncio
+async def test_computer_tool_returns_environment_factory_failure() -> None:
+    def failing_factory(**_kwargs: Any) -> ComputerEnvironment:
+        raise RuntimeError("local browser authorization was revoked")
+
+    tool = ComputerTool(
+        task_id="task-1",
+        workspace=object(),  # type: ignore[arg-type]
+        environment_factory=failing_factory,
+    )
+
+    result = await tool.run_json_async({})
+
+    assert result["success"] is False
+    assert result["session_id"] == "task-1"
+    assert "authorization was revoked" in result["error"]
+    assert tool._environments == {}
+
+
 @pytest.mark.parametrize(
     ("serialized_target", "element_id", "point"),
     [

--- a/tests/core/computer/test_cua_driver_client.py
+++ b/tests/core/computer/test_cua_driver_client.py
@@ -72,6 +72,16 @@ class BlockingSession(FakeSession):
         )
 
 
+class BlockingInitializeSession(FakeSession):
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        super().__init__(*_args, **_kwargs)
+        self.initialize_started = asyncio.Event()
+
+    async def initialize(self) -> None:
+        self.initialize_started.set()
+        await asyncio.Event().wait()
+
+
 @pytest.mark.asyncio
 async def test_cua_driver_client_serializes_calls_on_owned_worker(
     monkeypatch: pytest.MonkeyPatch,
@@ -126,6 +136,56 @@ async def test_cua_driver_client_surfaces_mcp_tool_error(
         await client.call_tool("failure")
 
     await client.close()
+
+
+@pytest.mark.asyncio
+async def test_cua_driver_client_cleans_up_timed_out_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = BlockingInitializeSession()
+
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **_kwargs: Any):
+        yield object(), object()
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", lambda *_args, **_kwargs: session)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=0.01)
+
+    with pytest.raises(CuaDriverError, match="initialization timed out"):
+        await client.call_tool("one")
+
+    assert session.initialize_started.is_set()
+    assert session.closed is True
+    assert client._worker is None
+    assert client._queue is None
+    assert client._ready is None
+
+
+@pytest.mark.asyncio
+async def test_cua_driver_client_cleans_up_cancelled_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = BlockingInitializeSession()
+
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **_kwargs: Any):
+        yield object(), object()
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", lambda *_args, **_kwargs: session)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=0.01)
+    call = asyncio.create_task(client.call_tool("one"))
+    await session.initialize_started.wait()
+
+    call.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await call
+
+    assert session.closed is True
+    assert client._worker is None
+    assert client._queue is None
+    assert client._ready is None
 
 
 @pytest.mark.asyncio

--- a/tests/core/computer/test_cua_driver_client.py
+++ b/tests/core/computer/test_cua_driver_client.py
@@ -139,6 +139,47 @@ async def test_cua_driver_client_surfaces_mcp_tool_error(
 
 
 @pytest.mark.asyncio
+async def test_cua_driver_client_restores_sessions_before_using_restarted_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sessions: list[FakeSession] = []
+
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **_kwargs: Any):
+        yield object(), object()
+
+    def fake_session(*args: Any, **kwargs: Any) -> FakeSession:
+        session = FakeSession(*args, **kwargs)
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", fake_session)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=1)
+
+    await client.call_tool(
+        "start_session",
+        {"session": "task-1", "capture_scope": "window"},
+    )
+    assert client._queue is not None
+    assert client._worker is not None
+    await client._queue.put(None)
+    await client._worker
+
+    await client.call_tool("capture", {"session": "task-1"})
+    await client.close()
+
+    assert len(sessions) == 2
+    assert sessions[1].calls == [
+        (
+            "start_session",
+            {"session": "task-1", "capture_scope": "window"},
+        ),
+        ("capture", {"session": "task-1"}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_cua_driver_client_cleans_up_timed_out_initialization(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/core/computer/test_cua_driver_client.py
+++ b/tests/core/computer/test_cua_driver_client.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult, ImageContent, TextContent
+
+from xagent.core.computer import cua_driver
+from xagent.core.computer.cua_driver import CuaDriverError, CuaDriverMCPClient
+
+
+class FakeSession:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.initialized = False
+        self.closed = False
+
+    async def __aenter__(self) -> "FakeSession":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        self.closed = True
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if name == "failure":
+            return CallToolResult(
+                isError=True,
+                content=[TextContent(type="text", text="permission denied")],
+            )
+        return CallToolResult(
+            content=[
+                TextContent(type="text", text=f"{name} done"),
+                ImageContent(
+                    type="image",
+                    data=base64.b64encode(b"png").decode(),
+                    mimeType="image/png",
+                ),
+            ],
+            structuredContent={"name": name},
+        )
+
+
+class BlockingSession(FakeSession):
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        super().__init__(*_args, **_kwargs)
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if name == "blocking":
+            self.started.set()
+            await self.release.wait()
+        return CallToolResult(
+            content=[TextContent(type="text", text=f"{name} done")],
+            structuredContent={"name": name},
+        )
+
+
+@pytest.mark.asyncio
+async def test_cua_driver_client_serializes_calls_on_owned_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sessions: list[FakeSession] = []
+
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **kwargs: Any):
+        assert kwargs["errlog"].fileno() >= 0
+        yield object(), object()
+
+    def fake_session(*args: Any, **kwargs: Any) -> FakeSession:
+        session = FakeSession(*args, **kwargs)
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", fake_session)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=1)
+
+    first, second = await asyncio.gather(
+        client.call_tool("one", {"value": 1}),
+        client.call_tool("two", {"value": 2}),
+    )
+    await client.close()
+
+    assert first.structured == {"name": "one"}
+    assert first.image_bytes == b"png"
+    assert second.text == "two done"
+    assert len(sessions) == 1
+    assert sessions[0].initialized is True
+    assert sessions[0].calls == [
+        ("one", {"value": 1}),
+        ("two", {"value": 2}),
+    ]
+    assert sessions[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_cua_driver_client_surfaces_mcp_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **_kwargs: Any):
+        yield object(), object()
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", FakeSession)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=1)
+
+    with pytest.raises(CuaDriverError, match="permission denied"):
+        await client.call_tool("failure")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_cua_driver_client_skips_cancelled_queued_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = BlockingSession()
+
+    @asynccontextmanager
+    async def fake_stdio(*_args: Any, **_kwargs: Any):
+        yield object(), object()
+
+    monkeypatch.setattr(cua_driver, "stdio_client", fake_stdio)
+    monkeypatch.setattr(cua_driver, "ClientSession", lambda *_args, **_kwargs: session)
+    client = CuaDriverMCPClient(command="fake-driver", timeout_seconds=1)
+
+    blocking = asyncio.create_task(client.call_tool("blocking"))
+    await session.started.wait()
+    stale = asyncio.create_task(client.call_tool("stale"))
+    while client._queue is None or client._queue.qsize() < 1:
+        await asyncio.sleep(0)
+
+    stale.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await stale
+    session.release.set()
+
+    assert (await blocking).structured == {"name": "blocking"}
+    await client.close()
+    assert session.calls == [("blocking", {})]

--- a/tests/core/computer/test_native_browser_environment.py
+++ b/tests/core/computer/test_native_browser_environment.py
@@ -1,0 +1,1023 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.computer.cua_driver import CuaDriverError, CuaDriverResult
+from xagent.core.computer.environment import (
+    ComputerFrameMismatchError,
+    ComputerTargetNotFoundError,
+)
+from xagent.core.computer.native_browser import NativeBrowserEnvironment
+from xagent.core.computer.native_navigation import NativeBrowserNavigationResult
+from xagent.core.computer.schema import (
+    COMPUTER_CONTROL_METADATA_KEY,
+    COMPUTER_FRAME_ID_METADATA_KEY,
+    COMPUTER_PERCEPTION_METADATA_KEY,
+    COMPUTER_SESSION_ID_METADATA_KEY,
+    ELEMENT_EXTRACTION_INCOMPLETE_KEY,
+    ComputerAction,
+    ComputerActionBatch,
+    ComputerActionType,
+    ComputerPerceptionMode,
+    ComputerTarget,
+    NormalizedPoint,
+)
+from xagent.core.context_ref import ContextReference
+
+
+class FakeObservationStore:
+    async def save_screenshot(self, **kwargs: Any) -> ContextReference:
+        return ContextReference(
+            file_ref={
+                "file_id": "native-shot",
+                "filename": "native.png",
+                "mime_type": kwargs["mime_type"],
+            },
+            metadata={
+                COMPUTER_SESSION_ID_METADATA_KEY: kwargs["session_id"],
+                COMPUTER_FRAME_ID_METADATA_KEY: kwargs["frame_id"],
+            },
+        )
+
+
+class FakeCuaDriver:
+    def __init__(
+        self,
+        *,
+        windows: list[dict[str, Any]] | None = None,
+        elements: list[dict[str, Any]] | None = None,
+        escalation: dict[str, Any] | None = None,
+        background_input: dict[str, Any] | None = None,
+    ) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.closed = False
+        self.windows = windows if windows is not None else self._default_windows()
+        self.elements = elements if elements is not None else self._default_elements()
+        self.escalation = escalation
+        self.background_input = background_input
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> CuaDriverResult:
+        payload = dict(arguments or {})
+        self.calls.append((name, payload))
+        if name == "list_windows":
+            return CuaDriverResult(structured={"windows": self.windows})
+        if name == "get_window_state":
+            structured: dict[str, Any] = {
+                "window_id": payload["window_id"],
+                "pid": payload["pid"],
+                "url": "https://example.com/inbox",
+                "element_count": 2,
+                "screenshot_width": 1200,
+                "screenshot_height": 800,
+                "elements": self.elements,
+            }
+            if self.escalation is not None:
+                structured["escalation"] = self.escalation
+            if self.background_input is not None:
+                structured["background_input"] = self.background_input
+            return CuaDriverResult(
+                structured=structured,
+                image_bytes=b"native-png",
+                image_mime_type="image/png",
+            )
+        if name == "health_report":
+            return CuaDriverResult(structured={"schema_version": "1", "overall": "ok"})
+        return CuaDriverResult(
+            structured={"effect": "confirmed", "verified": True},
+            text=f"{name} completed",
+        )
+
+    async def close(self) -> None:
+        self.closed = True
+
+    @staticmethod
+    def _default_elements() -> list[dict[str, Any]]:
+        return [
+            {
+                "element_index": 4,
+                "element_token": "snapshot-1:4",
+                "role": "AXButton",
+                "label": "Continue",
+                "frame": {"x": 200, "y": 300, "w": 200, "h": 80},
+            },
+            {
+                "element_index": 5,
+                "element_token": "snapshot-1:5",
+                "role": "AXSecureTextField",
+                "label": "Password",
+                "value": "do-not-leak",
+                "frame": {"x": 300, "y": 450, "w": 300, "h": 50},
+            },
+            {
+                "element_index": 6,
+                "element_token": "snapshot-1:6",
+                "role": "AXTextField",
+                "label": "Address and search bar",
+                "value": "https://example.com/inbox",
+                "frame": {"x": 180, "y": 220, "w": 760, "h": 40},
+            },
+        ]
+
+    @staticmethod
+    def _default_windows() -> list[dict[str, Any]]:
+        return [
+            {
+                "window_id": 10,
+                "pid": 100,
+                "app_name": "Google Chrome",
+                "title": "Background",
+                "bounds": {"x": 10, "y": 10, "width": 900, "height": 700},
+                "z_index": 1,
+                "is_on_screen": True,
+                "on_current_space": False,
+            },
+            {
+                "window_id": 20,
+                "pid": 200,
+                "app_name": "Google Chrome",
+                "title": "Inbox",
+                "bounds": {"x": 100, "y": 200, "width": 1000, "height": 800},
+                "z_index": 9,
+                "is_on_screen": True,
+                "on_current_space": True,
+            },
+        ]
+
+
+class FakeNativeBrowserNavigator:
+    def __init__(self, *, supported: bool) -> None:
+        self.supported = supported
+        self.calls: list[tuple[Any, str]] = []
+
+    def supports(self, target: Any) -> bool:
+        return self.supported
+
+    async def navigate(
+        self,
+        target: Any,
+        url: str,
+    ) -> NativeBrowserNavigationResult:
+        self.calls.append((target, url))
+        return NativeBrowserNavigationResult(
+            route="fake_native_navigation",
+            browser_window_id=777,
+            actual_url=url,
+        )
+
+
+def make_environment(
+    driver: FakeCuaDriver,
+    *,
+    perception_mode: ComputerPerceptionMode | str = ComputerPerceptionMode.AUTO,
+    native_navigator: FakeNativeBrowserNavigator | None = None,
+) -> NativeBrowserEnvironment:
+    return NativeBrowserEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        perception_mode=perception_mode,
+        native_browser_navigator=(
+            native_navigator or FakeNativeBrowserNavigator(supported=False)
+        ),
+    )
+
+
+def batch(frame_id: str, action: ComputerAction) -> ComputerActionBatch:
+    return ComputerActionBatch(
+        session_id="task-1",
+        expected_frame_id=frame_id,
+        actions=[action],
+    )
+
+
+def test_local_browser_requires_explicit_enablement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+
+    with pytest.raises(RuntimeError, match="Local browser access is disabled"):
+        NativeBrowserEnvironment(session_id="task-1", workspace=object())
+
+
+@pytest.mark.asyncio
+async def test_local_browser_binds_frontmost_window_and_redacts_password() -> None:
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+
+    observation = await environment.observe()
+
+    assert observation.title == "Inbox"
+    assert observation.active_url == "https://example.com/inbox"
+    assert observation.viewport.width == 1200
+    assert observation.metadata["pid"] == 200
+    assert observation.metadata["window_id"] == 20
+    assert observation.environment.value == "desktop"
+    assert observation.metadata["computer_runtime_kind"] == "local_browser"
+    assert observation.metadata[COMPUTER_PERCEPTION_METADATA_KEY] == {
+        "mode": "auto",
+        "available": ["vision", "semantic"],
+        "semantic_source": "accessibility",
+    }
+    assert observation.metadata[COMPUTER_CONTROL_METADATA_KEY] == {
+        "transport": "native_accessibility",
+        "scope": "window",
+        "browser_debugging": False,
+    }
+    assert (
+        observation.metadata["available_windows"][0]["application"] == "Google Chrome"
+    )
+    assert "move" not in observation.metadata["supported_actions"]
+    assert "navigate" in observation.metadata["supported_actions"]
+    assert observation.elements[0].element_id == "snapshot-1:4"
+    assert observation.elements[1].label == "Sensitive input"
+    assert observation.elements[1].text is None
+    assert "do-not-leak" not in observation.model_dump_json()
+    assert [name for name, _payload in driver.calls[:3]] == [
+        "start_session",
+        "list_windows",
+        "get_window_state",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_local_browser_vision_mode_does_not_expose_semantic_targets() -> None:
+    driver = FakeCuaDriver()
+    environment = make_environment(
+        driver,
+        perception_mode=ComputerPerceptionMode.VISION,
+    )
+
+    observation = await environment.observe()
+
+    assert observation.elements == []
+    assert observation.metadata[COMPUTER_PERCEPTION_METADATA_KEY] == {
+        "mode": "vision",
+        "available": ["vision", "semantic"],
+        "semantic_source": "accessibility",
+    }
+    assert ELEMENT_EXTRACTION_INCOMPLETE_KEY not in observation.metadata
+    assert all(not name.startswith("browser_") for name, _ in driver.calls)
+
+
+@pytest.mark.asyncio
+async def test_local_browser_marks_ax_surfaces_from_parent_chain() -> None:
+    elements = [
+        {
+            "element_index": 0,
+            "element_token": "snapshot-1:0",
+            "role": "AXWindow",
+            "depth": 0,
+            "frame": {"x": 100, "y": 200, "w": 1000, "h": 800},
+        },
+        {
+            "element_index": 13,
+            "element_token": "snapshot-1:13",
+            "role": "AXButton",
+            "label": "Xuye",
+            "depth": 1,
+            "parent_index": 0,
+            "frame": {"x": 1060, "y": 220, "w": 20, "h": 20},
+        },
+        {
+            "element_index": 15,
+            "element_token": "snapshot-1:15",
+            "role": "AXWebArea",
+            "label": "Zhihu",
+            "depth": 1,
+            "parent_index": 0,
+            "frame": {"x": 100, "y": 260, "w": 1000, "h": 740},
+        },
+        {
+            "element_index": 16,
+            "element_token": "snapshot-1:16",
+            "role": "AXLink",
+            "label": "Qin Xuye",
+            "depth": 2,
+            "parent_index": 15,
+            "frame": {"x": 900, "y": 300, "w": 80, "h": 30},
+        },
+        {
+            "element_index": 20,
+            "element_token": "snapshot-1:20",
+            "role": "AXSheet",
+            "depth": 1,
+            "parent_index": 0,
+            "frame": {"x": 400, "y": 300, "w": 400, "h": 300},
+        },
+        {
+            "element_index": 21,
+            "element_token": "snapshot-1:21",
+            "role": "AXButton",
+            "label": "Confirm",
+            "depth": 2,
+            "parent_index": 20,
+            "frame": {"x": 650, "y": 520, "w": 100, "h": 40},
+        },
+        {
+            "element_index": 30,
+            "element_token": "snapshot-1:30",
+            "role": "AXButton",
+            "label": "Incomplete",
+            "depth": 2,
+            "parent_index": 999,
+            "frame": {"x": 200, "y": 300, "w": 100, "h": 40},
+        },
+    ]
+    environment = make_environment(FakeCuaDriver(elements=elements))
+
+    observation = await environment.observe()
+    by_index = {
+        element.metadata["element_index"]: element for element in observation.elements
+    }
+
+    assert by_index[13].surface is not None
+    assert by_index[13].surface.value == "application_chrome"
+    assert by_index[13].metadata["surface"] == "application_chrome"
+    assert by_index[13].metadata["surface_root_index"] == 0
+    assert by_index[15].surface is not None
+    assert by_index[15].surface.value == "document"
+    assert by_index[15].metadata["surface"] == "document"
+    assert by_index[15].metadata["surface_root_index"] == 15
+    assert by_index[16].metadata["surface"] == "document"
+    assert by_index[16].metadata["surface_root_index"] == 15
+    assert by_index[20].metadata["surface"] == "overlay"
+    assert by_index[20].metadata["surface_root_index"] == 20
+    assert by_index[21].metadata["surface"] == "overlay"
+    assert by_index[21].metadata["surface_root_index"] == 20
+    assert by_index[30].metadata["surface"] == "unknown"
+    assert "surface_root_index" not in by_index[30].metadata
+
+
+@pytest.mark.asyncio
+async def test_native_browser_click_uses_bound_window_and_element_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("xagent.core.computer.native_browser.asyncio.sleep", no_sleep)
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    second = await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.CLICK,
+                target=ComputerTarget(element_id="snapshot-1:4"),
+            ),
+        )
+    )
+
+    name, payload = next(
+        (name, payload) for name, payload in driver.calls if name == "click"
+    )
+    assert name == "click"
+    assert payload["pid"] == 200
+    assert payload["window_id"] == 20
+    assert payload["element_token"] == "snapshot-1:4"
+    assert payload["delivery_mode"] == "background"
+    assert second.metadata["last_action_result"]["effect"] == "confirmed"
+    assert [name for name, _payload in driver.calls].count("list_windows") == 3
+
+
+@pytest.mark.asyncio
+async def test_local_browser_refuses_ambiguous_pid_keyboard_actions() -> None:
+    driver = FakeCuaDriver(
+        background_input={
+            "exact_window": {"pid": 200, "window_id": 20, "status": "matched"},
+            "routes": [
+                {"route": "accessibility", "status": "available"},
+                {"route": "window_pointer", "status": "available"},
+                {
+                    "route": "pid_keyboard",
+                    "status": "refused",
+                    "reason": "same_pid_keyboard_ambiguity",
+                },
+            ],
+        }
+    )
+    environment = make_environment(
+        driver,
+        native_navigator=FakeNativeBrowserNavigator(supported=True),
+    )
+    observation = await environment.observe()
+
+    assert observation.metadata["background_input"] == driver.background_input
+    assert "click" in observation.metadata["supported_actions"]
+    assert "type" not in observation.metadata["supported_actions"]
+    assert "replace_text" not in observation.metadata["supported_actions"]
+    assert "keypress" not in observation.metadata["supported_actions"]
+    assert "navigate" in observation.metadata["supported_actions"]
+    assert observation.metadata["unsupported_actions"] == {
+        "type": "same_pid_keyboard_ambiguity",
+        "replace_text": "same_pid_keyboard_ambiguity",
+        "keypress": "same_pid_keyboard_ambiguity",
+    }
+
+    with pytest.raises(ValueError, match="same_pid_keyboard_ambiguity"):
+        await environment.execute(
+            batch(
+                observation.frame_id,
+                ComputerAction(type=ComputerActionType.TYPE, text="unsafe"),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_browser_requires_driver_proof_for_foreground_delivery() -> None:
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    with pytest.raises(ValueError, match="escalation recommendation"):
+        await environment.execute(
+            batch(
+                first.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(element_id="snapshot-1:4"),
+                    metadata={"delivery_mode": "foreground"},
+                ),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_native_browser_allows_driver_recommended_foreground_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("xagent.core.computer.native_browser.asyncio.sleep", no_sleep)
+    driver = FakeCuaDriver(
+        escalation={"recommended": "foreground", "reason": "background did not land"}
+    )
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.CLICK,
+                target=ComputerTarget(element_id="snapshot-1:4"),
+                metadata={"delivery_mode": "foreground"},
+            ),
+        )
+    )
+
+    click = next(payload for name, payload in driver.calls if name == "click")
+    assert click["delivery_mode"] == "foreground"
+
+
+@pytest.mark.asyncio
+async def test_local_browser_rejects_pixel_action_after_window_geometry_changes() -> (
+    None
+):
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+    assert first.metadata["coordinate_frame"] == {
+        "screenshot_width": 1200,
+        "screenshot_height": 800,
+        "screenshot_fresh": True,
+        "window_bounds": {
+            "x": 100.0,
+            "y": 200.0,
+            "width": 1000.0,
+            "height": 800.0,
+        },
+    }
+    driver.windows[1]["bounds"]["width"] = 900
+
+    with pytest.raises(ComputerFrameMismatchError, match="moved or resized"):
+        await environment.execute(
+            batch(
+                first.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(
+                        point=NormalizedPoint(x=0.5, y=0.5),
+                    ),
+                ),
+            )
+        )
+
+    assert all(name != "click" for name, _payload in driver.calls)
+
+
+@pytest.mark.asyncio
+async def test_local_browser_rejects_pixel_action_under_overlapping_same_pid_window() -> (
+    None
+):
+    driver = FakeCuaDriver()
+    driver.windows.append(
+        {
+            "window_id": 21,
+            "pid": 200,
+            "app_name": "Google Chrome",
+            "title": "Another tab window",
+            "bounds": {"x": 100, "y": 200, "width": 1000, "height": 800},
+            "z_index": 8,
+            "is_on_screen": True,
+            "on_current_space": True,
+        }
+    )
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    with pytest.raises(ComputerTargetNotFoundError, match="Pixel action is ambiguous"):
+        await environment.execute(
+            batch(
+                first.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(
+                        point=NormalizedPoint(x=0.5, y=0.5),
+                    ),
+                ),
+            )
+        )
+
+    assert all(name != "click" for name, _payload in driver.calls)
+
+
+@pytest.mark.asyncio
+async def test_local_browser_prioritizes_overlay_elements_beyond_context_limit() -> (
+    None
+):
+    elements: list[dict[str, Any]] = [
+        {
+            "element_index": 0,
+            "element_token": "snapshot-1:0",
+            "role": "AXWindow",
+            "depth": 0,
+            "frame": {"x": 100, "y": 200, "w": 1000, "h": 800},
+        }
+    ]
+    elements.extend(
+        {
+            "element_index": index,
+            "element_token": f"snapshot-1:{index}",
+            "role": "AXButton",
+            "label": f"Action {index}",
+            "depth": 1,
+            "parent_index": 0,
+            "enabled": True,
+            "frame": {
+                "x": 120 + (index % 20) * 30,
+                "y": 260 + (index % 15) * 25,
+                "w": 24,
+                "h": 20,
+            },
+        }
+        for index in range(1, 131)
+    )
+    elements.extend(
+        [
+            {
+                "element_index": 200,
+                "element_token": "snapshot-1:200",
+                "role": "AXMenu",
+                "depth": 1,
+                "parent_index": 0,
+                "frame": {"x": 800, "y": 260, "w": 200, "h": 180},
+            },
+            {
+                "element_index": 201,
+                "element_token": "snapshot-1:201",
+                "role": "AXMenuItem",
+                "label": "My profile",
+                "depth": 2,
+                "parent_index": 200,
+                "enabled": True,
+                "frame": {"x": 820, "y": 280, "w": 160, "h": 30},
+            },
+        ]
+    )
+    driver = FakeCuaDriver(elements=elements)
+    environment = make_environment(driver)
+
+    observation = await environment.observe()
+
+    assert len(observation.elements) == 100
+    profile = next(
+        element for element in observation.elements if element.label == "My profile"
+    )
+    assert profile.surface is not None
+    assert profile.surface.value == "overlay"
+    state_call = next(
+        payload for name, payload in driver.calls if name == "get_window_state"
+    )
+    assert state_call["max_elements"] == 2_000
+
+
+@pytest.mark.asyncio
+async def test_local_browser_refuses_pixel_fallback_when_ax_owner_is_unprovable() -> (
+    None
+):
+    class RefusingElementDriver(FakeCuaDriver):
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any] | None = None,
+        ) -> CuaDriverResult:
+            payload = dict(arguments or {})
+            if name == "click" and "element_token" in payload:
+                self.calls.append((name, payload))
+                raise CuaDriverError(
+                    "Background input refused (element_outside_target_window)"
+                )
+            return await super().call_tool(name, arguments)
+
+    driver = RefusingElementDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    with pytest.raises(CuaDriverError, match="element_outside_target_window"):
+        await environment.execute(
+            batch(
+                first.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(element_id="snapshot-1:4"),
+                ),
+            )
+        )
+
+    clicks = [payload for name, payload in driver.calls if name == "click"]
+    assert len(clicks) == 1
+    assert clicks[0]["element_token"] == "snapshot-1:4"
+    assert "x" not in clicks[0]
+    assert "y" not in clicks[0]
+
+
+@pytest.mark.asyncio
+async def test_local_browser_keeps_fresh_semantics_when_transient_capture_is_unavailable() -> (
+    None
+):
+    class TransientCaptureDriver(FakeCuaDriver):
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any] | None = None,
+        ) -> CuaDriverResult:
+            if name == "get_window_state" and any(
+                called_name == "click" for called_name, _payload in self.calls
+            ):
+                payload = dict(arguments or {})
+                self.calls.append((name, payload))
+                return CuaDriverResult(
+                    structured={
+                        "window_id": payload["window_id"],
+                        "pid": payload["pid"],
+                        "element_count": 1,
+                        "elements": [
+                            {
+                                "element_index": 20,
+                                "element_token": "snapshot-2:20",
+                                "role": "AXLink",
+                                "label": "My profile",
+                                "frame": {
+                                    "x": 800,
+                                    "y": 260,
+                                    "w": 120,
+                                    "h": 30,
+                                },
+                            }
+                        ],
+                        "background_input": {
+                            "observation": {"one_shot_capture": "unavailable"}
+                        },
+                    }
+                )
+            return await super().call_tool(name, arguments)
+
+    driver = TransientCaptureDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    second = await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.CLICK,
+                target=ComputerTarget(element_id="snapshot-1:4"),
+            ),
+        )
+    )
+
+    assert second.frame_id != first.frame_id
+    assert second.screenshot.file_id == first.screenshot.file_id
+    assert second.screenshot.metadata["reused_from_frame_id"] == first.frame_id
+    assert second.metadata["screenshot_fresh"] is False
+    assert second.metadata["computer_perception"]["available"] == ["semantic"]
+    assert [element.label for element in second.elements] == ["My profile"]
+
+    with pytest.raises(ComputerFrameMismatchError, match="fresh semantic elements"):
+        await environment.execute(
+            batch(
+                second.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(
+                        point=NormalizedPoint(x=0.5, y=0.5),
+                    ),
+                ),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_local_browser_waits_for_unverified_semantic_state_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("xagent.core.computer.native_browser.asyncio.sleep", no_sleep)
+
+    class DelayedSemanticDriver(FakeCuaDriver):
+        state_reads = 0
+
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any] | None = None,
+        ) -> CuaDriverResult:
+            if name == "click":
+                payload = dict(arguments or {})
+                self.calls.append((name, payload))
+                return CuaDriverResult(
+                    structured={"effect": "unverifiable"},
+                    text="AXPress posted",
+                )
+            if name == "get_window_state":
+                self.state_reads += 1
+                if self.state_reads >= 3:
+                    self.elements = [
+                        {
+                            "element_index": 20,
+                            "element_token": "snapshot-2:20",
+                            "role": "AXLink",
+                            "label": "My profile",
+                            "frame": {"x": 250, "y": 360, "w": 120, "h": 30},
+                        }
+                    ]
+            return await super().call_tool(name, arguments)
+
+    driver = DelayedSemanticDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+
+    second = await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.CLICK,
+                target=ComputerTarget(element_id="snapshot-1:4"),
+            ),
+        )
+    )
+
+    assert driver.state_reads == 3
+    assert [element.label for element in second.elements] == ["My profile"]
+    assert second.metadata["last_action_result"]["effect"] == "unverifiable"
+
+
+@pytest.mark.asyncio
+async def test_local_browser_recommends_foreground_only_after_background_stalls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("xagent.core.computer.native_browser.asyncio.sleep", no_sleep)
+
+    class UnchangedSemanticDriver(FakeCuaDriver):
+        async def call_tool(
+            self,
+            name: str,
+            arguments: dict[str, Any] | None = None,
+        ) -> CuaDriverResult:
+            if name == "click":
+                payload = dict(arguments or {})
+                self.calls.append((name, payload))
+                return CuaDriverResult(
+                    structured={"effect": "unverifiable"},
+                    text="AXPress posted",
+                )
+            return await super().call_tool(name, arguments)
+
+    driver = UnchangedSemanticDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+    stalled = await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.CLICK,
+                target=ComputerTarget(element_id="snapshot-1:4"),
+            ),
+        )
+    )
+
+    assert stalled.metadata["last_action_result"]["escalation"] == {
+        "recommended": "foreground",
+        "reason": "no_observable_state_change_after_background_delivery",
+    }
+
+    await environment.execute(
+        batch(
+            stalled.frame_id,
+            ComputerAction(
+                type=ComputerActionType.CLICK,
+                target=ComputerTarget(element_id="snapshot-1:4"),
+                metadata={"delivery_mode": "foreground"},
+            ),
+        )
+    )
+    clicks = [payload for name, payload in driver.calls if name == "click"]
+    assert clicks[-1]["delivery_mode"] == "foreground"
+
+
+@pytest.mark.asyncio
+async def test_native_browser_defensively_rejects_incomplete_drag() -> None:
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+    invalid_drag = ComputerAction.model_construct(
+        type=ComputerActionType.DRAG,
+        target=None,
+        url=None,
+        text=None,
+        keys=[],
+        delta_x=0,
+        delta_y=0,
+        start=None,
+        end=None,
+        duration_ms=0,
+        metadata={},
+    )
+
+    with pytest.raises(ValueError, match="drag requires start and end points"):
+        await environment.execute(batch(first.frame_id, invalid_drag))
+
+
+@pytest.mark.asyncio
+async def test_local_browser_navigates_with_native_browser_adapter() -> None:
+    driver = FakeCuaDriver()
+    navigator = FakeNativeBrowserNavigator(supported=True)
+    environment = NativeBrowserEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        native_browser_navigator=navigator,
+    )
+    first = await environment.observe()
+
+    await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.NAVIGATE,
+                url="https://example.com/account",
+            ),
+        )
+    )
+
+    assert len(navigator.calls) == 1
+    navigated_target, navigated_url = navigator.calls[0]
+    assert navigated_target.pid == 200
+    assert navigated_target.window_id == 20
+    assert navigated_url == "https://example.com/account"
+    assert environment.current_observation is not None
+    assert (
+        environment.current_observation.metadata["last_action_result"]["actual_url"]
+        == "https://example.com/account"
+    )
+    assert all(name not in {"set_value", "press_key"} for name, _ in driver.calls)
+    await environment.close()
+    assert ("end_session", {"session": "task-1"}) in driver.calls
+    assert driver.closed is True
+    assert environment.closed is True
+
+
+@pytest.mark.asyncio
+async def test_local_browser_falls_back_to_address_field_when_keyboard_is_safe() -> (
+    None
+):
+    driver = FakeCuaDriver()
+    environment = NativeBrowserEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        native_browser_navigator=FakeNativeBrowserNavigator(supported=False),
+    )
+    first = await environment.observe()
+
+    await environment.execute(
+        batch(
+            first.frame_id,
+            ComputerAction(
+                type=ComputerActionType.NAVIGATE,
+                url="https://example.com/account",
+            ),
+        )
+    )
+
+    set_value = next(payload for name, payload in driver.calls if name == "set_value")
+    assert set_value["element_token"] == "snapshot-1:6"
+    assert set_value["value"] == "https://example.com/account"
+    press_key = next(payload for name, payload in driver.calls if name == "press_key")
+    assert press_key["element_token"] == "snapshot-1:6"
+    assert press_key["key"] == "return"
+    assert press_key["delivery_mode"] == "background"
+
+
+@pytest.mark.asyncio
+async def test_local_browser_refuses_missing_or_hidden_window() -> None:
+    driver = FakeCuaDriver(windows=[])
+    with pytest.raises(RuntimeError, match="No visible Google Chrome window"):
+        await make_environment(driver).observe()
+
+    hidden = FakeCuaDriver(
+        windows=[
+            {
+                "window_id": 10,
+                "pid": 100,
+                "app_name": "Google Chrome",
+                "title": "Hidden",
+                "bounds": {"x": 10, "y": 10, "width": 900, "height": 700},
+                "z_index": 1,
+                "is_on_screen": False,
+                "on_current_space": False,
+            }
+        ]
+    )
+    with pytest.raises(RuntimeError, match="No visible Google Chrome window"):
+        await make_environment(hidden).observe()
+
+
+@pytest.mark.asyncio
+async def test_local_browser_never_selects_a_non_browser_window() -> None:
+    driver = FakeCuaDriver(
+        windows=[
+            {
+                "window_id": 30,
+                "pid": 300,
+                "app_name": "Music",
+                "title": "Songs",
+                "bounds": {"x": 10, "y": 10, "width": 900, "height": 700},
+                "z_index": 20,
+                "is_on_screen": True,
+                "on_current_space": True,
+            }
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="No visible Google Chrome window"):
+        await make_environment(driver).observe()
+
+
+@pytest.mark.asyncio
+async def test_local_browser_honors_exact_user_selected_window() -> None:
+    driver = FakeCuaDriver()
+    environment = NativeBrowserEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        target_pid=100,
+        target_window_id=10,
+    )
+
+    # Window 10 is on another Space and is therefore not a valid selected target.
+    with pytest.raises(RuntimeError, match="no longer visible"):
+        await environment.observe()
+
+    visible_driver = FakeCuaDriver()
+    visible_driver.windows[0]["on_current_space"] = True
+    selected = NativeBrowserEnvironment(
+        session_id="task-2",
+        workspace=object(),
+        driver=visible_driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        target_pid=100,
+        target_window_id=10,
+    )
+    observation = await selected.observe()
+    assert observation.metadata["pid"] == 100
+    assert observation.metadata["window_id"] == 10

--- a/tests/core/computer/test_native_browser_environment.py
+++ b/tests/core/computer/test_native_browser_environment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -230,11 +231,13 @@ async def test_local_browser_binds_frontmost_window_and_redacts_password() -> No
         "scope": "window",
         "browser_debugging": False,
     }
-    assert (
-        observation.metadata["available_windows"][0]["application"] == "Google Chrome"
-    )
+    assert "available_windows" not in observation.metadata
+    assert "Background" not in observation.model_dump_json()
     assert "move" not in observation.metadata["supported_actions"]
-    assert "navigate" in observation.metadata["supported_actions"]
+    assert "navigate" not in observation.metadata["supported_actions"]
+    assert observation.metadata["unsupported_actions"]["navigate"] == (
+        "pid_keyboard_capability_unknown"
+    )
     assert observation.elements[0].element_id == "snapshot-1:4"
     assert observation.elements[1].label == "Sensitive input"
     assert observation.elements[1].text is None
@@ -433,6 +436,18 @@ async def test_local_browser_refuses_ambiguous_pid_keyboard_actions() -> None:
 
 
 @pytest.mark.asyncio
+async def test_local_browser_refuses_keyboard_when_driver_capability_is_absent() -> (
+    None
+):
+    observation = await make_environment(FakeCuaDriver()).observe()
+
+    assert "type" not in observation.metadata["supported_actions"]
+    assert observation.metadata["unsupported_actions"]["type"] == (
+        "pid_keyboard_capability_unknown"
+    )
+
+
+@pytest.mark.asyncio
 async def test_native_browser_requires_driver_proof_for_foreground_delivery() -> None:
     driver = FakeCuaDriver()
     environment = make_environment(driver)
@@ -517,23 +532,52 @@ async def test_local_browser_rejects_pixel_action_after_window_geometry_changes(
 
 
 @pytest.mark.asyncio
-async def test_local_browser_rejects_pixel_action_under_overlapping_same_pid_window() -> (
+async def test_local_browser_rejects_actions_after_bound_window_disappears() -> None:
+    driver = FakeCuaDriver()
+    environment = make_environment(driver)
+    first = await environment.observe()
+    driver.windows = [window for window in driver.windows if window["window_id"] != 20]
+
+    with pytest.raises(ComputerTargetNotFoundError, match="disappeared"):
+        await environment.execute(
+            batch(
+                first.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(element_id="snapshot-1:4"),
+                ),
+            )
+        )
+
+    assert all(name != "click" for name, _payload in driver.calls)
+
+
+@pytest.mark.asyncio
+async def test_local_browser_rejects_pixel_action_under_cross_app_occluding_window() -> (
     None
 ):
     driver = FakeCuaDriver()
     driver.windows.append(
         {
-            "window_id": 21,
-            "pid": 200,
-            "app_name": "Google Chrome",
-            "title": "Another tab window",
+            "window_id": 31,
+            "pid": 300,
+            "app_name": "Terminal",
+            "title": "Unrelated foreground window",
             "bounds": {"x": 100, "y": 200, "width": 1000, "height": 800},
-            "z_index": 8,
+            "z_index": 10,
             "is_on_screen": True,
             "on_current_space": True,
         }
     )
-    environment = make_environment(driver)
+    environment = NativeBrowserEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        target_pid=200,
+        target_window_id=20,
+        native_browser_navigator=FakeNativeBrowserNavigator(supported=False),
+    )
     first = await environment.observe()
 
     with pytest.raises(ComputerTargetNotFoundError, match="Pixel action is ambiguous"):
@@ -908,6 +952,7 @@ async def test_local_browser_navigates_with_native_browser_adapter() -> None:
         == "https://example.com/account"
     )
     assert all(name not in {"set_value", "press_key"} for name, _ in driver.calls)
+    assert [name for name, _payload in driver.calls].count("get_window_state") == 2
     await environment.close()
     assert ("end_session", {"session": "task-1"}) in driver.calls
     assert driver.closed is True
@@ -915,10 +960,37 @@ async def test_local_browser_navigates_with_native_browser_adapter() -> None:
 
 
 @pytest.mark.asyncio
+async def test_local_browser_close_can_retry_after_cancellation() -> None:
+    class CancelOnceDriver(FakeCuaDriver):
+        close_calls = 0
+
+        async def close(self) -> None:
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise asyncio.CancelledError
+            self.closed = True
+
+    driver = CancelOnceDriver()
+    environment = make_environment(driver)
+    await environment.observe()
+
+    with pytest.raises(asyncio.CancelledError):
+        await environment.close()
+    await environment.close()
+
+    assert driver.close_calls == 2
+    assert driver.closed is True
+
+
+@pytest.mark.asyncio
 async def test_local_browser_falls_back_to_address_field_when_keyboard_is_safe() -> (
     None
 ):
-    driver = FakeCuaDriver()
+    driver = FakeCuaDriver(
+        background_input={
+            "routes": [{"route": "pid_keyboard", "status": "available"}],
+        }
+    )
     environment = NativeBrowserEnvironment(
         session_id="task-1",
         workspace=object(),

--- a/tests/core/computer/test_native_browser_environment.py
+++ b/tests/core/computer/test_native_browser_environment.py
@@ -417,12 +417,11 @@ async def test_local_browser_refuses_ambiguous_pid_keyboard_actions() -> None:
     assert observation.metadata["background_input"] == driver.background_input
     assert "click" in observation.metadata["supported_actions"]
     assert "type" not in observation.metadata["supported_actions"]
-    assert "replace_text" not in observation.metadata["supported_actions"]
+    assert "replace_text" in observation.metadata["supported_actions"]
     assert "keypress" not in observation.metadata["supported_actions"]
     assert "navigate" in observation.metadata["supported_actions"]
     assert observation.metadata["unsupported_actions"] == {
         "type": "unscoped_keyboard_input_disabled",
-        "replace_text": "same_pid_keyboard_ambiguity",
         "keypress": "unscoped_keyboard_input_disabled",
     }
 
@@ -524,9 +523,91 @@ async def test_local_browser_limits_keyboard_input_to_document_text_targets() ->
             )
         )
 
-    assert any(name == "hotkey" for name, _ in driver.calls[:action_call_count])
-    assert any(name == "type_text" for name, _ in driver.calls[:action_call_count])
+    set_value = next(
+        payload
+        for name, payload in driver.calls[:action_call_count]
+        if name == "set_value"
+    )
+    assert set_value["element_token"] == "snapshot-1:3"
+    assert set_value["value"] == "safe site search"
+    assert all(
+        name not in {"hotkey", "type_text"}
+        for name, _ in driver.calls[:action_call_count]
+    )
     assert len(driver.calls) == action_call_count + 1  # Bound-window revalidation only.
+
+
+@pytest.mark.asyncio
+async def test_local_browser_rejects_sensitive_document_text_targets() -> None:
+    elements = [
+        {
+            "element_index": 0,
+            "element_token": "snapshot-1:0",
+            "role": "AXWindow",
+            "depth": 0,
+            "frame": {"x": 100, "y": 200, "w": 1000, "h": 800},
+        },
+        {
+            "element_index": 1,
+            "element_token": "snapshot-1:1",
+            "role": "AXWebArea",
+            "depth": 1,
+            "parent_index": 0,
+            "frame": {"x": 100, "y": 280, "w": 1000, "h": 720},
+        },
+        {
+            "element_index": 2,
+            "element_token": "snapshot-1:2",
+            "role": "AXTextField",
+            "label": "一次性验证码 (OTP)",
+            "depth": 2,
+            "parent_index": 1,
+            "frame": {"x": 300, "y": 350, "w": 400, "h": 40},
+        },
+    ]
+    driver = FakeCuaDriver(elements=elements)
+    environment = make_environment(driver)
+    observation = await environment.observe()
+
+    sensitive = next(
+        element
+        for element in observation.elements
+        if element.element_id == "snapshot-1:2"
+    )
+    assert sensitive.label == "Sensitive input"
+    assert sensitive.metadata["sensitive"] is True
+
+    with pytest.raises(ValueError, match="sensitive input"):
+        await environment.execute(
+            batch(
+                observation.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.REPLACE_TEXT,
+                    target=ComputerTarget(element_id="snapshot-1:2"),
+                    text="123456",
+                ),
+            )
+        )
+
+    assert all(name != "set_value" for name, _ in driver.calls)
+
+
+@pytest.mark.asyncio
+async def test_local_browser_does_not_expose_snapshot_indices_without_tokens() -> None:
+    driver = FakeCuaDriver(
+        elements=[
+            {
+                "element_index": 4,
+                "role": "AXButton",
+                "label": "Stale target",
+                "frame": {"x": 200, "y": 300, "w": 200, "h": 80},
+            }
+        ]
+    )
+
+    observation = await make_environment(driver).observe()
+
+    assert observation.elements == []
 
 
 @pytest.mark.asyncio
@@ -961,7 +1042,7 @@ async def test_local_browser_waits_for_unverified_semantic_state_change(
 
 
 @pytest.mark.asyncio
-async def test_local_browser_recommends_foreground_only_after_background_stalls(
+async def test_local_browser_records_stall_without_authorizing_foreground(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def no_sleep(_seconds: float) -> None:
@@ -997,23 +1078,22 @@ async def test_local_browser_recommends_foreground_only_after_background_stalls(
         )
     )
 
-    assert stalled.metadata["last_action_result"]["escalation"] == {
-        "recommended": "foreground",
-        "reason": "no_observable_state_change_after_background_delivery",
-    }
-
-    await environment.execute(
-        batch(
-            stalled.frame_id,
-            ComputerAction(
-                type=ComputerActionType.CLICK,
-                target=ComputerTarget(element_id="snapshot-1:4"),
-                metadata={"delivery_mode": "foreground"},
-            ),
-        )
+    assert stalled.metadata["last_action_result"]["code"] == (
+        "no_observable_state_change_after_background_delivery"
     )
-    clicks = [payload for name, payload in driver.calls if name == "click"]
-    assert clicks[-1]["delivery_mode"] == "foreground"
+    assert "escalation" not in stalled.metadata["last_action_result"]
+
+    with pytest.raises(ValueError, match="current cua-driver escalation"):
+        await environment.execute(
+            batch(
+                stalled.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(element_id="snapshot-1:4"),
+                    metadata={"delivery_mode": "foreground"},
+                ),
+            )
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/core/computer/test_native_browser_environment.py
+++ b/tests/core/computer/test_native_browser_environment.py
@@ -421,12 +421,12 @@ async def test_local_browser_refuses_ambiguous_pid_keyboard_actions() -> None:
     assert "keypress" not in observation.metadata["supported_actions"]
     assert "navigate" in observation.metadata["supported_actions"]
     assert observation.metadata["unsupported_actions"] == {
-        "type": "same_pid_keyboard_ambiguity",
+        "type": "unscoped_keyboard_input_disabled",
         "replace_text": "same_pid_keyboard_ambiguity",
-        "keypress": "same_pid_keyboard_ambiguity",
+        "keypress": "unscoped_keyboard_input_disabled",
     }
 
-    with pytest.raises(ValueError, match="same_pid_keyboard_ambiguity"):
+    with pytest.raises(ValueError, match="unscoped_keyboard_input_disabled"):
         await environment.execute(
             batch(
                 observation.frame_id,
@@ -443,8 +443,90 @@ async def test_local_browser_refuses_keyboard_when_driver_capability_is_absent()
 
     assert "type" not in observation.metadata["supported_actions"]
     assert observation.metadata["unsupported_actions"]["type"] == (
-        "pid_keyboard_capability_unknown"
+        "unscoped_keyboard_input_disabled"
     )
+
+
+@pytest.mark.asyncio
+async def test_local_browser_limits_keyboard_input_to_document_text_targets() -> None:
+    elements = [
+        {
+            "element_index": 0,
+            "element_token": "snapshot-1:0",
+            "role": "AXWindow",
+            "depth": 0,
+            "frame": {"x": 100, "y": 200, "w": 1000, "h": 800},
+        },
+        {
+            "element_index": 1,
+            "element_token": "snapshot-1:1",
+            "role": "AXTextField",
+            "label": "Address and search bar",
+            "depth": 1,
+            "parent_index": 0,
+            "frame": {"x": 180, "y": 220, "w": 760, "h": 40},
+        },
+        {
+            "element_index": 2,
+            "element_token": "snapshot-1:2",
+            "role": "AXWebArea",
+            "depth": 1,
+            "parent_index": 0,
+            "frame": {"x": 100, "y": 280, "w": 1000, "h": 720},
+        },
+        {
+            "element_index": 3,
+            "element_token": "snapshot-1:3",
+            "role": "AXTextField",
+            "label": "Search",
+            "depth": 2,
+            "parent_index": 2,
+            "frame": {"x": 300, "y": 350, "w": 400, "h": 40},
+        },
+    ]
+    driver = FakeCuaDriver(
+        elements=elements,
+        background_input={
+            "routes": [{"route": "pid_keyboard", "status": "available"}],
+        },
+    )
+    environment = make_environment(driver)
+    observation = await environment.observe()
+
+    assert "replace_text" in observation.metadata["supported_actions"]
+    assert "type" not in observation.metadata["supported_actions"]
+    assert "keypress" not in observation.metadata["supported_actions"]
+    assert observation.metadata["unsupported_actions"]["type"] == (
+        "unscoped_keyboard_input_disabled"
+    )
+
+    after_document_edit = await environment.execute(
+        batch(
+            observation.frame_id,
+            ComputerAction(
+                type=ComputerActionType.REPLACE_TEXT,
+                target=ComputerTarget(element_id="snapshot-1:3"),
+                text="safe site search",
+            ),
+        )
+    )
+    action_call_count = len(driver.calls)
+
+    with pytest.raises(ValueError, match="limited to document elements"):
+        await environment.execute(
+            batch(
+                after_document_edit.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.REPLACE_TEXT,
+                    target=ComputerTarget(element_id="snapshot-1:1"),
+                    text="file:///Users/admin/.ssh/id_rsa",
+                ),
+            )
+        )
+
+    assert any(name == "hotkey" for name, _ in driver.calls[:action_call_count])
+    assert any(name == "type_text" for name, _ in driver.calls[:action_call_count])
+    assert len(driver.calls) == action_call_count + 1  # Bound-window revalidation only.
 
 
 @pytest.mark.asyncio
@@ -589,6 +671,45 @@ async def test_local_browser_rejects_pixel_action_under_cross_app_occluding_wind
                     target=ComputerTarget(
                         point=NormalizedPoint(x=0.5, y=0.5),
                     ),
+                ),
+            )
+        )
+
+    assert all(name != "click" for name, _payload in driver.calls)
+
+
+@pytest.mark.asyncio
+async def test_local_browser_treats_unknown_overlapping_z_index_as_occluding() -> None:
+    driver = FakeCuaDriver()
+    driver.windows.append(
+        {
+            "window_id": 31,
+            "pid": 300,
+            "app_name": "Terminal",
+            "title": "Unknown stacking order",
+            "bounds": {"x": 100, "y": 200, "width": 1000, "height": 800},
+            "is_on_screen": True,
+            "on_current_space": True,
+        }
+    )
+    environment = NativeBrowserEnvironment(
+        session_id="task-1",
+        workspace=object(),
+        driver=driver,
+        observation_store=FakeObservationStore(),  # type: ignore[arg-type]
+        target_pid=200,
+        target_window_id=20,
+        native_browser_navigator=FakeNativeBrowserNavigator(supported=False),
+    )
+    first = await environment.observe()
+
+    with pytest.raises(ComputerTargetNotFoundError, match="Pixel action is ambiguous"):
+        await environment.execute(
+            batch(
+                first.frame_id,
+                ComputerAction(
+                    type=ComputerActionType.CLICK,
+                    target=ComputerTarget(point=NormalizedPoint(x=0.5, y=0.5)),
                 ),
             )
         )

--- a/tests/core/computer/test_native_browser_environment.py
+++ b/tests/core/computer/test_native_browser_environment.py
@@ -538,6 +538,66 @@ async def test_local_browser_limits_keyboard_input_to_document_text_targets() ->
 
 
 @pytest.mark.asyncio
+async def test_local_browser_replace_text_does_not_use_pixel_occlusion() -> None:
+    elements = [
+        {
+            "element_index": 0,
+            "element_token": "snapshot-1:0",
+            "role": "AXWindow",
+            "depth": 0,
+            "frame": {"x": 100, "y": 200, "w": 1000, "h": 800},
+        },
+        {
+            "element_index": 1,
+            "element_token": "snapshot-1:1",
+            "role": "AXWebArea",
+            "depth": 1,
+            "parent_index": 0,
+            "frame": {"x": 100, "y": 280, "w": 1000, "h": 720},
+        },
+        {
+            "element_index": 2,
+            "element_token": "snapshot-1:2",
+            "role": "AXTextField",
+            "label": "Search",
+            "depth": 2,
+            "parent_index": 1,
+            "frame": {"x": 300, "y": 350, "w": 400, "h": 40},
+        },
+    ]
+    driver = FakeCuaDriver(elements=elements)
+    driver.windows.append(
+        {
+            "window_id": 31,
+            "pid": 300,
+            "app_name": "Terminal",
+            "title": "Overlapping window",
+            "bounds": {"x": 100, "y": 200, "width": 1000, "height": 800},
+            "z_index": 10,
+            "is_on_screen": True,
+            "on_current_space": True,
+        }
+    )
+    environment = make_environment(driver)
+    observation = await environment.observe()
+
+    await environment.execute(
+        batch(
+            observation.frame_id,
+            ComputerAction(
+                type=ComputerActionType.REPLACE_TEXT,
+                target=ComputerTarget(element_id="snapshot-1:2"),
+                text="semantic input",
+            ),
+        )
+    )
+
+    set_value = next(payload for name, payload in driver.calls if name == "set_value")
+    assert set_value["element_token"] == "snapshot-1:2"
+    assert set_value["value"] == "semantic input"
+
+
+@pytest.mark.asyncio
 async def test_local_browser_rejects_sensitive_document_text_targets() -> None:
     elements = [
         {

--- a/tests/core/computer/test_native_browser_readiness.py
+++ b/tests/core/computer/test_native_browser_readiness.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.computer import native_browser_readiness as readiness
+from xagent.core.computer.cua_driver import CuaDriverError, CuaDriverResult
+
+
+class FakeClient:
+    def __init__(self, responses: dict[str, CuaDriverResult | Exception]) -> None:
+        self.responses = responses
+        self.closed = False
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> CuaDriverResult:
+        self.calls.append((name, arguments))
+        response = self.responses[name]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def reset_cache() -> None:
+    readiness.reset_local_browser_readiness_cache()
+
+
+@pytest.mark.asyncio
+async def test_native_browser_readiness_combines_health_and_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient(
+        {
+            "health_report": CuaDriverResult(
+                structured={
+                    "overall": "ok",
+                    "checks": [
+                        {"name": "tcc_accessibility", "status": "pass"},
+                        {"name": "tcc_screen_recording", "status": "pass"},
+                    ],
+                }
+            ),
+            "list_windows": CuaDriverResult(
+                structured={
+                    "windows": [
+                        {
+                            "pid": 200,
+                            "window_id": 20,
+                            "app_name": "Music",
+                            "title": "Songs",
+                            "on_current_space": True,
+                            "is_on_screen": True,
+                            "z_index": 20,
+                        },
+                        {
+                            "pid": 100,
+                            "window_id": 10,
+                            "app_name": "Google Chrome",
+                            "title": "Inbox",
+                            # cua-driver 0.16 may omit Space metadata after
+                            # honoring on_screen_only at the transport layer.
+                            "on_current_space": None,
+                            "is_on_screen": True,
+                            "z_index": 4,
+                        },
+                    ]
+                }
+            ),
+        }
+    )
+    monkeypatch.setattr(readiness, "CuaDriverMCPClient", lambda: client)
+
+    result = await readiness.get_local_browser_readiness()
+
+    assert result.ready is True
+    assert result.connected is True
+    assert result.attached is True
+    assert result.title == "Inbox"
+    assert result.windows[0].pid == 100
+    assert [window.application for window in result.windows] == ["Google Chrome"]
+    assert result.permissions == {
+        "accessibility": True,
+        "screen_recording": True,
+    }
+    assert ("list_windows", {"on_screen_only": True}) in client.calls
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_native_browser_readiness_reports_driver_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient(
+        {
+            "health_report": CuaDriverError("not installed"),
+            "list_windows": CuaDriverResult(structured={"windows": []}),
+        }
+    )
+    monkeypatch.setattr(readiness, "CuaDriverMCPClient", lambda: client)
+
+    result = await readiness.get_local_browser_readiness()
+
+    assert result.ready is False
+    assert result.connected is False
+    assert [issue.code for issue in result.issues] == ["driver_unavailable"]
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_local_browser_readiness_reports_permissions_and_missing_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient(
+        {
+            "health_report": CuaDriverResult(
+                structured={
+                    "overall": "degraded",
+                    "checks": [
+                        {"name": "tcc_accessibility", "status": "fail"},
+                        {"name": "tcc_screen_recording", "status": "fail"},
+                    ],
+                }
+            ),
+            "list_windows": CuaDriverResult(structured={"windows": []}),
+        }
+    )
+    monkeypatch.setattr(readiness, "CuaDriverMCPClient", lambda: client)
+
+    result = await readiness.get_local_browser_readiness()
+
+    assert result.connected is True
+    assert result.attached is False
+    assert [issue.code for issue in result.issues] == [
+        "screen_recording_permission_missing",
+        "accessibility_permission_missing",
+        "browser_not_found",
+    ]

--- a/tests/core/computer/test_native_navigation.py
+++ b/tests/core/computer/test_native_navigation.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 from typing import Any
 
 import pytest
 
+from xagent.core.computer import native_navigation
 from xagent.core.computer.native_browser import NativeBrowserWindow
 from xagent.core.computer.native_navigation import (
     MacOSChromiumNavigator,
@@ -119,3 +121,48 @@ def test_macos_chromium_navigate_rejects_other_platforms_and_apps() -> None:
     )
     macos = MacOSChromiumNavigator(platform="darwin")
     assert macos.supports(non_browser) is False
+
+
+@pytest.mark.asyncio
+async def test_run_jxa_kills_and_reaps_subprocess_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.returncode: int | None = None
+            self.communicate_started = asyncio.Event()
+            self.killed = False
+            self.waited = False
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            self.communicate_started.set()
+            await asyncio.Event().wait()
+            return b"", b""
+
+        def kill(self) -> None:
+            self.killed = True
+            self.returncode = -9
+
+        async def wait(self) -> int:
+            self.waited = True
+            return self.returncode or 0
+
+    process = FakeProcess()
+
+    async def create_subprocess(*_args: Any, **_kwargs: Any) -> FakeProcess:
+        return process
+
+    monkeypatch.setattr(
+        native_navigation.asyncio,
+        "create_subprocess_exec",
+        create_subprocess,
+    )
+    task = asyncio.create_task(native_navigation._run_jxa("script", []))
+    await process.communicate_started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.killed is True
+    assert process.waited is True

--- a/tests/core/computer/test_native_navigation.py
+++ b/tests/core/computer/test_native_navigation.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from xagent.core.computer.native_browser import NativeBrowserWindow
+from xagent.core.computer.native_navigation import (
+    MacOSChromiumNavigator,
+    NativeBrowserNavigationError,
+)
+
+
+def target() -> NativeBrowserWindow:
+    return NativeBrowserWindow(
+        pid=83366,
+        window_id=46049,
+        app_name="Google Chrome",
+        title="New Tab",
+        x=1512,
+        y=30,
+        width=2560,
+        height=1410,
+        z_index=10,
+        is_on_screen=True,
+        on_current_space=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_macos_chromium_navigate_maps_and_rechecks_exact_window() -> None:
+    calls: list[list[str]] = []
+    scripts: list[str] = []
+
+    async def runner(script: str, arguments: list[str]) -> Mapping[str, Any]:
+        scripts.append(script)
+        calls.append(arguments)
+        if len(calls) == 1:
+            return {
+                "bundle_id": "com.google.Chrome",
+                "windows": [
+                    {
+                        "id": 101,
+                        "title": "Another Window",
+                        "bounds": [1512, 30, 4072, 1440],
+                    },
+                    {
+                        "id": 202,
+                        "title": "New Tab",
+                        "bounds": [1512, 30, 4072, 1440],
+                    },
+                ],
+            }
+        return {
+            "bundle_id": "com.google.Chrome",
+            "browser_window_id": 202,
+            "actual_url": "https://www.zhihu.com/people/qin-xu-ye",
+        }
+
+    navigator = MacOSChromiumNavigator(runner=runner, platform="darwin")
+    result = await navigator.navigate(
+        target(),
+        "https://www.zhihu.com/people/qin-xu-ye",
+    )
+
+    assert result.route == "macos_chromium_apple_events"
+    assert result.browser_window_id == 202
+    assert calls == [
+        ["83366"],
+        [
+            "83366",
+            "202",
+            "New Tab",
+            "[1512,30,4072,1440]",
+            "https://www.zhihu.com/people/qin-xu-ye",
+        ],
+    ]
+    assert "while (Boolean(tab.loading())" in scripts[1]
+
+
+@pytest.mark.asyncio
+async def test_macos_chromium_navigate_refuses_ambiguous_mapping() -> None:
+    call_count = 0
+
+    async def runner(script: str, arguments: list[str]) -> Mapping[str, Any]:
+        nonlocal call_count
+        del script, arguments
+        call_count += 1
+        return {
+            "bundle_id": "com.google.Chrome",
+            "windows": [
+                {
+                    "id": 101,
+                    "title": "New Tab",
+                    "bounds": [1512, 30, 4072, 1440],
+                },
+                {
+                    "id": 202,
+                    "title": "New Tab",
+                    "bounds": [1512, 30, 4072, 1440],
+                },
+            ],
+        }
+
+    navigator = MacOSChromiumNavigator(runner=runner, platform="darwin")
+    with pytest.raises(NativeBrowserNavigationError, match="mapping is ambiguous"):
+        await navigator.navigate(target(), "https://www.zhihu.com")
+
+    assert call_count == 1
+
+
+def test_macos_chromium_navigate_rejects_other_platforms_and_apps() -> None:
+    linux = MacOSChromiumNavigator(platform="linux")
+    assert linux.supports(target()) is False
+
+    non_browser = NativeBrowserWindow(
+        **{**target().__dict__, "app_name": "Music"},
+    )
+    macos = MacOSChromiumNavigator(platform="darwin")
+    assert macos.supports(non_browser) is False

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -15,6 +15,10 @@ from xagent.config import (
     BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS,
     BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS,
     BOXLITE_HOME_DIR,
+    BROWSER_CUA_DRIVER_COMMAND,
+    BROWSER_CUA_DRIVER_MAX_ELEMENTS,
+    BROWSER_CUA_DRIVER_SOCKET,
+    BROWSER_CUA_DRIVER_TIMEOUT_SECONDS,
     CELERY_BROKER_URL,
     CELERY_ENABLED,
     CELERY_RESULT_BACKEND,
@@ -49,6 +53,8 @@ from xagent.config import (
     MCP_OAUTH_ALLOW_PRIVATE_HOSTS,
     MCP_OAUTH_PROXY_URL,
     MCP_TOOL_INIT_TIMEOUT_SECONDS,
+    NATIVE_BROWSER_APP_NAME,
+    NATIVE_BROWSER_ENABLED,
     OPENROUTER_OFFICIAL_PROVIDERS_ONLY,
     PASSWORD_RESET_EXPIRE_MINUTES,
     PREVIEW_TMP_DIR,
@@ -105,6 +111,10 @@ from xagent.config import (
     get_background_job_sweep_interval_seconds,
     get_background_job_visibility_timeout_seconds,
     get_boxlite_home_dir,
+    get_browser_cua_driver_command,
+    get_browser_cua_driver_max_elements,
+    get_browser_cua_driver_socket,
+    get_browser_cua_driver_timeout_seconds,
     get_celery_broker_url,
     get_celery_enabled,
     get_celery_result_backend,
@@ -141,6 +151,8 @@ from xagent.config import (
     get_mcp_oauth_allow_private_hosts,
     get_mcp_oauth_proxy_url,
     get_mcp_tool_init_timeout_seconds,
+    get_native_browser_app_name,
+    get_native_browser_enabled,
     get_openrouter_official_providers_only,
     get_password_reset_expire_minutes,
     get_preview_tmp_dir,
@@ -214,6 +226,19 @@ class TestEnvironmentVariableConstants:
 
     def test_storage_root_constant(self):
         assert STORAGE_ROOT == "XAGENT_STORAGE_ROOT"
+
+    def test_local_browser_constants(self):
+        assert NATIVE_BROWSER_ENABLED == "XAGENT_NATIVE_BROWSER_ENABLED"
+        assert NATIVE_BROWSER_APP_NAME == "XAGENT_NATIVE_BROWSER_APP_NAME"
+        assert BROWSER_CUA_DRIVER_COMMAND == "XAGENT_BROWSER_CUA_DRIVER_COMMAND"
+        assert BROWSER_CUA_DRIVER_SOCKET == "XAGENT_BROWSER_CUA_DRIVER_SOCKET"
+        assert (
+            BROWSER_CUA_DRIVER_TIMEOUT_SECONDS
+            == "XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS"
+        )
+        assert (
+            BROWSER_CUA_DRIVER_MAX_ELEMENTS == "XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS"
+        )
 
     def test_sandbox_image_constant(self):
         assert SANDBOX_IMAGE == "SANDBOX_IMAGE"
@@ -1674,6 +1699,48 @@ class TestTaskRuntimeHookConfig:
 
         assert get_task_runtime_hook_max_workers() == 8
         assert get_task_runtime_hook_queue_timeout_seconds() == 30
+
+
+class TestLocalBrowserConfig:
+    def test_defaults(self, monkeypatch):
+        for name in (
+            NATIVE_BROWSER_ENABLED,
+            NATIVE_BROWSER_APP_NAME,
+            BROWSER_CUA_DRIVER_COMMAND,
+            BROWSER_CUA_DRIVER_SOCKET,
+            BROWSER_CUA_DRIVER_TIMEOUT_SECONDS,
+            BROWSER_CUA_DRIVER_MAX_ELEMENTS,
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        assert get_native_browser_enabled() is False
+        assert get_native_browser_app_name() == "Google Chrome"
+        assert get_browser_cua_driver_command() == "cua-driver"
+        assert get_browser_cua_driver_socket() is None
+        assert get_browser_cua_driver_timeout_seconds() == 30
+        assert get_browser_cua_driver_max_elements() == 2_000
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv(NATIVE_BROWSER_ENABLED, "true")
+        monkeypatch.setenv(NATIVE_BROWSER_APP_NAME, "Chromium")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_COMMAND, "/opt/bin/cua-driver")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_SOCKET, "/tmp/cua.sock")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_TIMEOUT_SECONDS, "12.5")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_MAX_ELEMENTS, "250")
+
+        assert get_native_browser_enabled() is True
+        assert get_native_browser_app_name() == "Chromium"
+        assert get_browser_cua_driver_command() == "/opt/bin/cua-driver"
+        assert get_browser_cua_driver_socket() == "/tmp/cua.sock"
+        assert get_browser_cua_driver_timeout_seconds() == 12.5
+        assert get_browser_cua_driver_max_elements() == 250
+
+    def test_invalid_values_fall_back(self, monkeypatch):
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_TIMEOUT_SECONDS, "0")
+        monkeypatch.setenv(BROWSER_CUA_DRIVER_MAX_ELEMENTS, "invalid")
+
+        assert get_browser_cua_driver_timeout_seconds() == 30
+        assert get_browser_cua_driver_max_elements() == 2_000
 
 
 class TestCheckpointStorageConfig:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1742,6 +1742,12 @@ class TestLocalBrowserConfig:
         assert get_browser_cua_driver_timeout_seconds() == 30
         assert get_browser_cua_driver_max_elements() == 2_000
 
+    def test_rejects_non_browser_native_application(self, monkeypatch):
+        monkeypatch.setenv(NATIVE_BROWSER_APP_NAME, "Terminal")
+
+        with pytest.raises(ValueError, match="must name a supported browser"):
+            get_native_browser_app_name()
+
 
 class TestCheckpointStorageConfig:
     """Config for checkpoint trace-event storage encoding and retention."""

--- a/tests/web/api/test_computer_readiness.py
+++ b/tests/web/api/test_computer_readiness.py
@@ -74,3 +74,20 @@ async def test_local_browser_readiness_probes_for_enabled_admin(
     )
 
     assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_local_browser_readiness_rejects_non_browser_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_APP_NAME", "Terminal")
+
+    result = await computer.get_local_browser_readiness_endpoint(
+        Response(),
+        user=SimpleNamespace(is_admin=True),  # type: ignore[arg-type]
+    )
+
+    assert result.ready is False
+    assert [issue.code for issue in result.issues] == ["invalid_configuration"]
+    assert "supported browser" in result.message

--- a/tests/web/api/test_computer_readiness.py
+++ b/tests/web/api/test_computer_readiness.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.responses import Response
+
+from xagent.core.computer.native_browser_readiness import LocalBrowserReadiness
+from xagent.web.api import computer
+
+
+@pytest.mark.asyncio
+async def test_local_browser_readiness_is_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+    response = Response()
+
+    result = await computer.get_local_browser_readiness_endpoint(
+        response,
+        user=SimpleNamespace(is_admin=True),  # type: ignore[arg-type]
+    )
+
+    assert result.ready is False
+    assert [issue.code for issue in result.issues] == ["disabled"]
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_local_browser_readiness_does_not_probe_for_non_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+
+    async def unexpected_probe() -> LocalBrowserReadiness:
+        raise AssertionError("driver probe must not run")
+
+    monkeypatch.setattr(
+        computer,
+        "probe_local_browser_readiness",
+        unexpected_probe,
+    )
+
+    result = await computer.get_local_browser_readiness_endpoint(
+        Response(),
+        user=SimpleNamespace(is_admin=False),  # type: ignore[arg-type]
+    )
+
+    assert result.ready is False
+    assert [issue.code for issue in result.issues] == ["not_authorized"]
+
+
+@pytest.mark.asyncio
+async def test_local_browser_readiness_probes_for_enabled_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    expected = LocalBrowserReadiness(
+        ready=True,
+        connected=True,
+        attached=True,
+        application="Google Chrome",
+        title="Inbox",
+    )
+
+    async def probe() -> LocalBrowserReadiness:
+        return expected
+
+    monkeypatch.setattr(computer, "probe_local_browser_readiness", probe)
+
+    result = await computer.get_local_browser_readiness_endpoint(
+        Response(),
+        user=SimpleNamespace(is_admin=True),  # type: ignore[arg-type]
+    )
+
+    assert result == expected

--- a/tests/web/api/test_websocket_execute_task_db_boundary.py
+++ b/tests/web/api/test_websocket_execute_task_db_boundary.py
@@ -44,6 +44,7 @@ async def test_legacy_execute_uses_worker_snapshot_and_primitive_scheduler_bound
             process_description="Follow the saved process",
             examples=[{"input": "a", "output": "b"}],
             source="internal",
+            agent_config={"runtime_extension_bindings": ["local_browser"]},
         )
         db.add(task)
         db.commit()
@@ -147,6 +148,34 @@ async def test_legacy_execute_uses_worker_snapshot_and_primitive_scheduler_bound
     assert task_info["event_type"] == "task_info"
     assert task_info["data"]["id"] == task_id
     assert task_info["data"]["status"] == TaskStatus.PENDING.value
+    assert task_info["data"]["runtime_extension_bindings"] == ["local_browser"]
+
+
+def test_websocket_task_info_exposes_persisted_runtime_extension_bindings(
+    _test_db: None,
+) -> None:
+    db = _direct_db_session()
+    try:
+        user = User(username="runtime-binding-owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+        task = Task(
+            user_id=int(user.id),
+            title="Runtime-bound task",
+            description="Use the selected computer",
+            status=TaskStatus.COMPLETED,
+            source="internal",
+            agent_config={"runtime_extension_bindings": ["local_browser"]},
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+
+        routing, _ = websocket_api._load_websocket_task_routing_snapshot(db, task)
+
+        assert routing.task_info["runtime_extension_bindings"] == ["local_browser"]
+    finally:
+        db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -293,6 +293,31 @@ async def test_bound_local_browser_fails_closed_after_admin_demotion(
 
 
 @pytest.mark.asyncio
+async def test_local_browser_rechecks_admin_before_environment_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    provider = LocalBrowserTaskRuntimeProvider()
+    context, sessions = make_context(bound=True, admin=True)
+    provider.on_task_created(
+        context,
+        {
+            "pid": 100,
+            "window_id": 20,
+            "application": "Google Chrome",
+        },
+    )
+    contribution = provider.build_runtime(context)
+    assert isinstance(contribution, TaskRuntimeContribution)
+
+    sessions[-1].user.is_admin = False
+    result = await contribution.tools[0].run_json_async({})
+
+    assert result["success"] is False
+    assert "no longer an Xagent administrator" in result["error"]
+
+
+@pytest.mark.asyncio
 async def test_local_browser_binding_suppresses_colliding_playwright_family() -> None:
     contribution = merge_task_runtime_contributions(
         {

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -96,7 +96,8 @@ def test_local_browser_registration_is_explicit_and_lifespan_scoped() -> None:
     unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
     try:
         register_local_browser_runtime()
-        register_local_browser_runtime()
+        with pytest.raises(ValueError, match="already registered"):
+            register_local_browser_runtime()
         assert registered_task_extensions().count(LOCAL_BROWSER_TASK_EXTENSION) == 1
 
         unregister_local_browser_runtime()

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -27,6 +27,7 @@ from xagent.web.services.local_browser_runtime import (
 )
 from xagent.web.services.task_runtime import (
     agent_config_with_task_extension_bindings,
+    register_task_extension,
     registered_task_extensions,
     unregister_task_extension,
 )
@@ -96,12 +97,25 @@ def test_local_browser_registration_is_explicit_and_lifespan_scoped() -> None:
     unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
     try:
         register_local_browser_runtime()
-        with pytest.raises(ValueError, match="already registered"):
-            register_local_browser_runtime()
+        register_local_browser_runtime()
         assert registered_task_extensions().count(LOCAL_BROWSER_TASK_EXTENSION) == 1
 
         unregister_local_browser_runtime()
         assert LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions()
+    finally:
+        unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+
+
+def test_local_browser_registration_rejects_a_foreign_provider_collision() -> None:
+    unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+    try:
+        register_task_extension(
+            LOCAL_BROWSER_TASK_EXTENSION,
+            LocalBrowserTaskRuntimeProvider(),
+        )
+
+        with pytest.raises(ValueError, match="already registered"):
+            register_local_browser_runtime()
     finally:
         unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
 

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -157,6 +157,45 @@ def test_local_browser_create_requires_enablement_admin_and_valid_target(
         )
 
 
+@pytest.mark.parametrize(
+    ("configuration", "message"),
+    [
+        ({"window_id": 20, "application": "Google Chrome"}, "requires pid"),
+        (
+            {"pid": None, "window_id": 20, "application": "Google Chrome"},
+            "requires pid and window_id",
+        ),
+        (
+            {"pid": 100, "application": "Google Chrome"},
+            "requires pid and window_id",
+        ),
+        (
+            {"pid": True, "window_id": 20, "application": "Google Chrome"},
+            "must be integers",
+        ),
+        (
+            {"pid": "100", "window_id": 20, "application": "Google Chrome"},
+            "must be integers",
+        ),
+        (
+            {"pid": 100, "window_id": 20.0, "application": "Google Chrome"},
+            "must be integers",
+        ),
+    ],
+)
+def test_local_browser_rejects_missing_or_non_integer_window_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    configuration: dict[str, Any],
+    message: str,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    provider = LocalBrowserTaskRuntimeProvider()
+    context, _ = make_context(bound=True, admin=True)
+
+    with pytest.raises(TaskRuntimeClientError, match=message):
+        provider.on_task_created(context, configuration)
+
+
 def test_local_browser_contributes_standard_computer_tool_only_when_bound(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -156,6 +156,17 @@ def test_local_browser_create_requires_enablement_admin_and_valid_target(
             },
         )
 
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_APP_NAME", "Terminal")
+    with pytest.raises(TaskRuntimeClientError, match="supported browser"):
+        provider.on_task_created(
+            context,
+            {
+                "pid": 100,
+                "window_id": 20,
+                "application": "Terminal",
+            },
+        )
+
 
 @pytest.mark.parametrize(
     ("configuration", "message"),
@@ -220,6 +231,50 @@ def test_local_browser_contributes_standard_computer_tool_only_when_bound(
     assert contribution.preferred_input_modalities == ("image",)
     assert "not a browser extension or remote relay" in (contribution.environment or "")
     assert sessions[-1].closed is True
+
+
+@pytest.mark.asyncio
+async def test_bound_local_browser_fails_closed_after_admin_demotion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    provider = LocalBrowserTaskRuntimeProvider()
+    context, sessions = make_context(bound=True, admin=True)
+    provider.on_task_created(
+        context,
+        {
+            "pid": 100,
+            "window_id": 20,
+            "application": "Google Chrome",
+        },
+    )
+    sessions[-1].user.is_admin = False
+
+    contribution = provider.build_runtime(context)
+
+    assert isinstance(contribution, TaskRuntimeContribution)
+    assert [tool.name for tool in contribution.tools] == ["computer"]
+    assert (
+        await create_browser_tools(
+            SimpleNamespace(
+                get_browser_tools_enabled=lambda: True,
+                get_task_runtime_contribution=lambda: merge_task_runtime_contributions(
+                    {LOCAL_BROWSER_TASK_EXTENSION: contribution}
+                ),
+            )
+        )
+        == []
+    )
+    result = await contribution.tools[0].run_json_async({})
+    assert result["success"] is False
+    assert "authorization was revoked" in result["error"]
+    assert provider.public_metadata(context) == {
+        "kind": "local_browser",
+        "enabled": False,
+        "reason": "authorization_revoked",
+        "perception_mode": "auto",
+        "control_transport": "native_accessibility",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from xagent.core.computer.native_browser import (
+    LOCAL_BROWSER_TASK_EXTENSION,
+)
+from xagent.core.task_runtime import (
+    TaskRuntimeClientError,
+    TaskRuntimeContext,
+    TaskRuntimeContribution,
+    merge_task_runtime_contributions,
+)
+from xagent.core.tools.adapters.vibe.browser_tools import (
+    _has_local_browser_runtime,
+    create_browser_tools,
+)
+from xagent.web.models.task import Task
+from xagent.web.models.user import User
+from xagent.web.services.local_browser_runtime import (
+    LocalBrowserTaskRuntimeProvider,
+    register_local_browser_runtime,
+    unregister_local_browser_runtime,
+)
+from xagent.web.services.task_runtime import (
+    agent_config_with_task_extension_bindings,
+    registered_task_extensions,
+    unregister_task_extension,
+)
+
+
+class FakeSession:
+    def __init__(self, *, task: Any, user: Any) -> None:
+        self.task = task
+        self.user = user
+        self.model: Any = None
+        self.closed = False
+        self.committed = False
+
+    def query(self, model: Any) -> "FakeSession":
+        self.model = model
+        return self
+
+    def filter(self, *_args: Any) -> "FakeSession":
+        return self
+
+    def first(self) -> Any:
+        if self.model is Task:
+            return self.task
+        if self.model is User:
+            return self.user
+        raise AssertionError(f"unexpected query model: {self.model}")
+
+    def close(self) -> None:
+        self.closed = True
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def make_context(
+    *,
+    bound: bool,
+    admin: bool,
+    workspace: Any = object(),
+    extension: str = LOCAL_BROWSER_TASK_EXTENSION,
+):
+    agent_config = (
+        agent_config_with_task_extension_bindings({}, [extension]) if bound else {}
+    )
+    sessions: list[FakeSession] = []
+    task = SimpleNamespace(id=7, user_id=3, agent_config=agent_config)
+    user = SimpleNamespace(id=3, is_admin=admin)
+
+    def session_factory() -> FakeSession:
+        session = FakeSession(task=task, user=user)
+        sessions.append(session)
+        return session
+
+    return (
+        TaskRuntimeContext(
+            task_id=7,
+            user_id=3,
+            source="internal",
+            session_factory=session_factory,
+            workspace=workspace,
+        ),
+        sessions,
+    )
+
+
+def test_local_browser_registration_is_explicit_and_lifespan_scoped() -> None:
+    unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+    try:
+        register_local_browser_runtime()
+        register_local_browser_runtime()
+        assert registered_task_extensions().count(LOCAL_BROWSER_TASK_EXTENSION) == 1
+
+        unregister_local_browser_runtime()
+        assert LOCAL_BROWSER_TASK_EXTENSION not in registered_task_extensions()
+    finally:
+        unregister_task_extension(LOCAL_BROWSER_TASK_EXTENSION)
+
+
+def test_local_browser_create_requires_enablement_admin_and_valid_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LocalBrowserTaskRuntimeProvider()
+    context, sessions = make_context(bound=True, admin=True)
+    monkeypatch.delenv("XAGENT_NATIVE_BROWSER_ENABLED", raising=False)
+
+    with pytest.raises(TaskRuntimeClientError, match="disabled") as disabled:
+        provider.on_task_created(context, {})
+    assert disabled.value.status_code == 403
+
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    non_admin, _ = make_context(bound=True, admin=False)
+    with pytest.raises(TaskRuntimeClientError, match="administrators"):
+        provider.on_task_created(non_admin, {})
+
+    with pytest.raises(TaskRuntimeClientError, match="explicitly selected"):
+        provider.on_task_created(context, {})
+
+    provider.on_task_created(
+        context,
+        {
+            "pid": 100,
+            "window_id": 20,
+            "application": "Google Chrome",
+            "title": "Inbox",
+        },
+    )
+    assert sessions[-1].committed is True
+
+    with pytest.raises(TaskRuntimeClientError, match="perception_mode"):
+        provider.on_task_created(
+            context,
+            {
+                "pid": 100,
+                "window_id": 20,
+                "application": "Google Chrome",
+                "perception_mode": "hidden_dom_fallback",
+            },
+        )
+
+    with pytest.raises(TaskRuntimeClientError, match="only accepts Google Chrome"):
+        provider.on_task_created(
+            context,
+            {
+                "pid": 100,
+                "window_id": 20,
+                "application": "Music",
+            },
+        )
+
+
+def test_local_browser_contributes_standard_computer_tool_only_when_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    provider = LocalBrowserTaskRuntimeProvider()
+    unbound, _ = make_context(bound=False, admin=True)
+    assert provider.build_runtime(unbound) is None
+
+    bound, sessions = make_context(bound=True, admin=True)
+    provider.on_task_created(
+        bound,
+        {
+            "pid": 100,
+            "window_id": 20,
+            "application": "Google Chrome",
+        },
+    )
+    contribution = provider.build_runtime(bound)
+
+    assert isinstance(contribution, TaskRuntimeContribution)
+    assert [tool.name for tool in contribution.tools] == ["computer"]
+    assert contribution.preferred_input_modalities == ("image",)
+    assert "not a browser extension or remote relay" in (contribution.environment or "")
+    assert sessions[-1].closed is True
+
+
+@pytest.mark.asyncio
+async def test_local_browser_binding_suppresses_colliding_playwright_family() -> None:
+    contribution = merge_task_runtime_contributions(
+        {
+            LOCAL_BROWSER_TASK_EXTENSION: TaskRuntimeContribution(
+                tools=(SimpleNamespace(name="computer"),)
+            )
+        }
+    )
+    config = SimpleNamespace(
+        get_browser_tools_enabled=lambda: True,
+        get_task_runtime_contribution=lambda: contribution,
+    )
+
+    assert await create_browser_tools(config) == []
+
+
+def test_unbound_local_browser_provider_does_not_suppress_playwright() -> None:
+    contribution = merge_task_runtime_contributions(
+        {LOCAL_BROWSER_TASK_EXTENSION: None}
+    )
+
+    assert _has_local_browser_runtime(contribution) is False
+
+
+def test_local_browser_public_metadata_is_bound_task_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAGENT_NATIVE_BROWSER_ENABLED", "true")
+    provider = LocalBrowserTaskRuntimeProvider()
+    unbound, _ = make_context(bound=False, admin=True)
+    bound, _ = make_context(bound=True, admin=True)
+
+    assert provider.public_metadata(unbound) is None
+    assert provider.public_metadata(bound) == {
+        "kind": "local_browser",
+        "enabled": True,
+        "perception_mode": "auto",
+        "control_transport": "native_accessibility",
+    }


### PR DESCRIPTION
## Summary

- add a task-scoped cua-driver MCP client and a browser-only ComputerEnvironment for a configured browser on the Xagent host
- require an administrator to explicitly bind each task to one exact visible browser window; keep the binding sticky and reject other applications
- add readiness/configuration, native accessibility and screenshot observations, exact-window navigation, and collision suppression for the Playwright browser tool family
- add the two-level Local browser picker, persisted task context metadata, and Computer use badges on user messages

## Scope and security boundary

This PR is intentionally limited to a browser running on the same machine as the Xagent backend. The feature is disabled by default, administrator-only, restricted to XAGENT_NATIVE_BROWSER_APP_NAME, and bound to an exact pid/window_id chosen before task creation.

In scope:
- same-host browser windows and an existing signed-in browser profile
- cua-driver native accessibility and exact-window screenshot/action delivery
- explicit vision/semantic perception modes already defined by the Computer Use foundation
- local readiness, configuration, UI selection, and task context display

Out of scope:
- Chrome extension takeover of a users existing tab
- WebSocket/Redis distributed browser relay, pairing, or cloud-to-laptop control
- arbitrary desktop applications, whole-machine control, or the macOS desktop companion
- provider-native OpenAI, Claude, or Gemini computer-use APIs
- CDP/remote-debugging attachment or hidden DOM fallback

Those capabilities require separate implementations and must not be inferred from this local browser runtime.

## Validation

- 594 focused Python tests covering the complete computer module plus Local browser API/service/WebSocket boundaries
- 140 focused frontend tests covering task creation, picker behavior, message badges, and history restoration
- frontend TypeScript type-check
- staged pre-commit hooks: ruff, format, mypy, isort, codespell, frontend lint, and frontend type-check