### PR TITLE
fix(auth): preserve infrastructure failures at authentication boundaries

### DIFF
--- a/src/xagent/web/api/progress_ws.py
+++ b/src/xagent/web/api/progress_ws.py
@@ -17,9 +17,12 @@ from ...core.tools.core.RAG_tools.progress import (
     get_progress_manager,
     progress_broadcaster,
 )
-from ..auth_dependencies import get_current_user, get_user_from_websocket_token
-from ..models.database import get_db
+from ..auth_dependencies import get_current_user
 from ..models.user import User
+from .websocket_auth import (
+    _WebSocketAuthenticationTerminated,
+    get_authenticated_user,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +43,10 @@ async def progress_websocket_endpoint(
     """WebSocket endpoint for real-time progress monitoring."""
     try:
         # Verify token and get user
-        db_gen = get_db()
-        db = next(db_gen)
         try:
-            user = get_user_from_websocket_token(token, db)
-        finally:
-            db.close()
+            user = await get_authenticated_user(websocket, token)
+        except _WebSocketAuthenticationTerminated:
+            return
 
         if not user:
             # Token validation failed but didn't raise exception

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -8,6 +8,7 @@ import secrets
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from enum import Enum, auto
 from typing import Any, Callable, Protocol, TypeGuard, TypeVar
 
 from fastapi import Depends, HTTPException, Query, UploadFile, WebSocket
@@ -155,6 +156,28 @@ def _is_strict_int(value: object) -> TypeGuard[int]:
 class _PublicTokenRejected(Exception):
     """An expected widget/share credential rejection."""
 
+    def __init__(self, reason: "_PublicTokenRejectionReason") -> None:
+        super().__init__()
+        self.reason = reason
+
+
+class _PublicTokenRejectionReason(Enum):
+    INVALID_TOKEN = auto()
+    INVALID_CLAIMS = auto()
+    INVALID_ENTITY = auto()
+
+
+def _project_public_token_failure(
+    exc: Exception, *, invalid_detail: str
+) -> HTTPException | None:
+    """Project expected public-token failures while preserving operations."""
+    if isinstance(exc, HTTPException):
+        return exc
+    if isinstance(exc, _PublicTokenRejected):
+        logger.info("Public chat credential rejected reason=%s", exc.reason.name)
+        return HTTPException(status_code=401, detail=invalid_detail)
+    return None
+
 
 def _decode_public_token(token: str) -> dict[str, Any]:
     """Verify one public token without folding decoder defects into credentials."""
@@ -162,21 +185,23 @@ def _decode_public_token(token: str) -> dict[str, Any]:
         token = token[7:]
     try:
         payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-    except JWTError as exc:
-        raise _PublicTokenRejected from exc
+    except JWTError:
+        raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_TOKEN) from None
     except (TypeError, OverflowError) as exc:
         if has_matching_temporal_claim_conversion_failure(token, exc):
-            raise _PublicTokenRejected from exc
+            raise _PublicTokenRejected(
+                _PublicTokenRejectionReason.INVALID_CLAIMS
+            ) from None
         raise
     if type(payload) is not dict:
-        raise _PublicTokenRejected
+        raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_TOKEN)
     return payload
 
 
 def _require_bindable_public_id(value: object, dialect_name: str) -> int:
     """Return an exact query id accepted by the supported database dialect."""
     if not is_exact_integer_bindable(value, dialect_name):
-        raise _PublicTokenRejected
+        raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_CLAIMS)
     return value
 
 
@@ -328,7 +353,7 @@ def get_public_chat_user(
     try:
         payload = _decode_public_token(token)
         if payload.get("type") != "widget":
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_TOKEN)
 
         user_id = payload.get("user_id")
         channel_id = payload.get("channel_id")
@@ -341,7 +366,7 @@ def get_public_chat_user(
             raise HTTPException(status_code=403, detail="Access denied")
 
         if auth_mode != "widget":
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_TOKEN)
 
         # Defense in depth (#992): the same guard get_share_chat_user applies.
         # Without it the two widget branches below disagreed about a string
@@ -349,10 +374,15 @@ def get_public_chat_user(
         # comparison, while the workforce branch coerced it and admitted the
         # request. Establishing the type here is what lets both branches pass
         # ``user_id`` straight to their ``ensure_widget_*_available`` helper.
-        if not _is_strict_int(user_id) or not user_id or not guest_id:
-            raise _PublicTokenRejected
+        if (
+            not _is_strict_int(user_id)
+            or not user_id
+            or not isinstance(guest_id, str)
+            or not guest_id
+        ):
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_CLAIMS)
         if channel_id is not None and not _is_strict_int(channel_id):
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_CLAIMS)
 
         if _is_strict_int(widget_workforce_id):
             selected_agent_id = None
@@ -361,7 +391,7 @@ def get_public_chat_user(
             selected_agent_id = widget_agent_id
             selected_workforce_id = None
         else:
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_ENTITY)
 
         dialect_name = str(db.get_bind().dialect.name)
         user_id = _require_bindable_public_id(user_id, dialect_name)
@@ -378,7 +408,7 @@ def get_public_chat_user(
 
         user = db.query(User).filter(User.id == user_id).first()
         if not user:
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_CLAIMS)
 
         if selected_workforce_id is not None:
             # Workforce widget: re-validate the deployment on every use so
@@ -406,7 +436,7 @@ def get_public_chat_user(
         # calls back through here, so live sessions drop on the next inbound
         # message too.
         if selected_agent_id is None:
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_ENTITY)
         ensure_widget_agent_available(
             db,
             selected_agent_id,
@@ -424,13 +454,11 @@ def get_public_chat_user(
             widget_agent_id=selected_agent_id,
         )
     except Exception as exc:
-        logger.error("Public chat token validation error: %s", exc)
-        if isinstance(exc, HTTPException):
-            raise exc
-        if isinstance(exc, _PublicTokenRejected):
-            raise HTTPException(
-                status_code=401, detail="Invalid widget token"
-            ) from None
+        projected = _project_public_token_failure(
+            exc, invalid_detail="Invalid widget token"
+        )
+        if projected is not None:
+            raise projected from None
         raise
 
 
@@ -439,7 +467,7 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
     try:
         payload = _decode_public_token(token)
         if payload.get("type") != "widget":
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_TOKEN)
 
         user_id = payload.get("user_id")
         auth_mode = payload.get("auth_mode")
@@ -449,18 +477,18 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
         guest_id = payload.get("guest_id")
 
         if auth_mode != "share":
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_TOKEN)
         if not _is_strict_int(user_id):
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_CLAIMS)
         if not isinstance(share_token, str) or not share_token:
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_CLAIMS)
         # Fail closed on tokens minted before per-guest isolation (#973): they
         # carry no guest_id, so they cannot be scoped to a single guest and are
         # rejected rather than silently granted the old no-isolation behavior.
         # A whitespace-only id is treated as absent (it could never match a
         # server-minted token_urlsafe value and must not pass as a real guest).
         if not isinstance(guest_id, str) or not guest_id.strip():
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_CLAIMS)
 
         if _is_strict_int(share_workforce_id):
             selected_agent_id = None
@@ -469,7 +497,7 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
             selected_agent_id = share_agent_id
             selected_workforce_id = None
         else:
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_ENTITY)
 
         dialect_name = str(db.get_bind().dialect.name)
         user_id = _require_bindable_public_id(user_id, dialect_name)
@@ -484,7 +512,7 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
 
         user = db.query(User).filter(User.id == user_id).first()
         if not user:
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_CLAIMS)
 
         if selected_workforce_id is not None:
             workforce = ensure_share_workforce_available(
@@ -501,7 +529,7 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
             )
 
         if selected_agent_id is None:
-            raise _PublicTokenRejected
+            raise _PublicTokenRejected(_PublicTokenRejectionReason.INVALID_ENTITY)
         agent = ensure_share_agent_available(
             db,
             selected_agent_id,
@@ -512,11 +540,11 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
             user=user, share_token=share_token, guest_id=guest_id, agent=agent
         )
     except Exception as exc:
-        logger.error("Share chat token validation error: %s", exc)
-        if isinstance(exc, HTTPException):
-            raise exc
-        if isinstance(exc, _PublicTokenRejected):
-            raise HTTPException(status_code=401, detail="Invalid share token") from None
+        projected = _project_public_token_failure(
+            exc, invalid_detail="Invalid share token"
+        )
+        if projected is not None:
+            raise projected from None
         raise
 
 
@@ -1391,9 +1419,7 @@ async def public_chat_websocket_endpoint(
         await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
         return
     except Exception as exc:
-        await send_websocket_authentication_infrastructure_failure(
-            websocket, exc, already_accepted=True
-        )
+        await send_websocket_authentication_infrastructure_failure(websocket, exc)
         return
 
     # Already accepted above; register the live socket without re-accepting.
@@ -1417,7 +1443,7 @@ async def public_chat_websocket_endpoint(
                 return
             except Exception as exc:
                 await send_websocket_authentication_infrastructure_failure(
-                    websocket, exc, already_accepted=True
+                    websocket, exc
                 )
                 return
 
@@ -1500,9 +1526,7 @@ async def share_chat_websocket_endpoint(
         await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
         return
     except Exception as exc:
-        await send_websocket_authentication_infrastructure_failure(
-            websocket, exc, already_accepted=True
-        )
+        await send_websocket_authentication_infrastructure_failure(websocket, exc)
         return
 
     # Already accepted above; register the live socket without re-accepting.
@@ -1525,7 +1549,7 @@ async def share_chat_websocket_endpoint(
                 return
             except Exception as exc:
                 await send_websocket_authentication_infrastructure_failure(
-                    websocket, exc, already_accepted=True
+                    websocket, exc
                 )
                 return
 

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -12,11 +12,15 @@ from typing import Any, Callable, Protocol, TypeGuard, TypeVar
 
 from fastapi import Depends, HTTPException, Query, UploadFile, WebSocket
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import jwt
+from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+from ..jwt_validation import (
+    has_matching_temporal_claim_conversion_failure,
+    is_exact_integer_bindable,
+)
 from ..models.agent import Agent, AgentStatus, is_workforce_generated_manager_agent
 from ..models.database import get_db, get_session_local, release_db_connection_if_clean
 from ..models.deployment import DeploymentOwnerType
@@ -50,6 +54,7 @@ from .websocket import (
     manager,
     send_message_delivery,
 )
+from .websocket_auth import send_websocket_authentication_infrastructure_failure
 
 logger = logging.getLogger(__name__)
 db_session_context = contextmanager(get_db)
@@ -145,6 +150,34 @@ def _is_strict_int(value: object) -> TypeGuard[int]:
     claim today; this keeps every id claim failing closed regardless.
     """
     return isinstance(value, int) and not isinstance(value, bool)
+
+
+class _PublicTokenRejected(Exception):
+    """An expected widget/share credential rejection."""
+
+
+def _decode_public_token(token: str) -> dict[str, Any]:
+    """Verify one public token without folding decoder defects into credentials."""
+    if token.startswith("Bearer "):
+        token = token[7:]
+    try:
+        payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+    except JWTError as exc:
+        raise _PublicTokenRejected from exc
+    except (TypeError, OverflowError) as exc:
+        if has_matching_temporal_claim_conversion_failure(token, exc):
+            raise _PublicTokenRejected from exc
+        raise
+    if type(payload) is not dict:
+        raise _PublicTokenRejected
+    return payload
+
+
+def _require_bindable_public_id(value: object, dialect_name: str) -> int:
+    """Return an exact query id accepted by the supported database dialect."""
+    if not is_exact_integer_bindable(value, dialect_name):
+        raise _PublicTokenRejected
+    return value
 
 
 def create_public_chat_access_token(data: dict[str, Any]) -> str:
@@ -293,12 +326,9 @@ def get_public_chat_user(
 ) -> PublicChatAccessContext:
     """Get public chat access context from a widget/share token."""
     try:
-        if token.startswith("Bearer "):
-            token = token[7:]
-
-        payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        payload = _decode_public_token(token)
         if payload.get("type") != "widget":
-            raise ValueError("Invalid token type")
+            raise _PublicTokenRejected
 
         user_id = payload.get("user_id")
         channel_id = payload.get("channel_id")
@@ -311,7 +341,7 @@ def get_public_chat_user(
             raise HTTPException(status_code=403, detail="Access denied")
 
         if auth_mode != "widget":
-            raise ValueError("Invalid token payload")
+            raise _PublicTokenRejected
 
         # Defense in depth (#992): the same guard get_share_chat_user applies.
         # Without it the two widget branches below disagreed about a string
@@ -320,19 +350,43 @@ def get_public_chat_user(
         # request. Establishing the type here is what lets both branches pass
         # ``user_id`` straight to their ``ensure_widget_*_available`` helper.
         if not _is_strict_int(user_id) or not user_id or not guest_id:
-            raise ValueError("Invalid token payload")
+            raise _PublicTokenRejected
+        if channel_id is not None and not _is_strict_int(channel_id):
+            raise _PublicTokenRejected
+
+        if _is_strict_int(widget_workforce_id):
+            selected_agent_id = None
+            selected_workforce_id = widget_workforce_id
+        elif _is_strict_int(widget_agent_id):
+            selected_agent_id = widget_agent_id
+            selected_workforce_id = None
+        else:
+            raise _PublicTokenRejected
+
+        dialect_name = str(db.get_bind().dialect.name)
+        user_id = _require_bindable_public_id(user_id, dialect_name)
+        if channel_id is not None:
+            channel_id = _require_bindable_public_id(channel_id, dialect_name)
+        if selected_workforce_id is not None:
+            selected_workforce_id = _require_bindable_public_id(
+                selected_workforce_id, dialect_name
+            )
+        else:
+            selected_agent_id = _require_bindable_public_id(
+                selected_agent_id, dialect_name
+            )
 
         user = db.query(User).filter(User.id == user_id).first()
         if not user:
-            raise ValueError("User not found")
+            raise _PublicTokenRejected
 
-        if _is_strict_int(widget_workforce_id):
+        if selected_workforce_id is not None:
             # Workforce widget: re-validate the deployment on every use so
             # disabling the widget or rotating its key cuts off live guests,
             # mirroring the workforce share path.
             ensure_widget_workforce_available(
                 db,
-                widget_workforce_id,
+                selected_workforce_id,
                 user_id,
                 expected_widget_key=widget_key
                 if isinstance(widget_key, str) and widget_key
@@ -343,7 +397,7 @@ def get_public_chat_user(
                 channel_id=channel_id,
                 guest_id=guest_id,
                 auth_mode=auth_mode,
-                widget_workforce_id=widget_workforce_id,
+                widget_workforce_id=selected_workforce_id,
             )
 
         # Agent widget: re-validate against the live agent every request so
@@ -351,11 +405,11 @@ def get_public_chat_user(
         # tokens (mirrors the share path). The per-message WS revalidation
         # calls back through here, so live sessions drop on the next inbound
         # message too.
-        if not _is_strict_int(widget_agent_id):
-            raise ValueError("Invalid widget token payload")
+        if selected_agent_id is None:
+            raise _PublicTokenRejected
         ensure_widget_agent_available(
             db,
-            widget_agent_id,
+            selected_agent_id,
             user_id,
             expected_widget_key=widget_key
             if isinstance(widget_key, str) and widget_key
@@ -367,24 +421,25 @@ def get_public_chat_user(
             channel_id=channel_id,
             guest_id=guest_id,
             auth_mode=auth_mode,
-            widget_agent_id=widget_agent_id,
+            widget_agent_id=selected_agent_id,
         )
     except Exception as exc:
         logger.error("Public chat token validation error: %s", exc)
         if isinstance(exc, HTTPException):
             raise exc
-        raise HTTPException(status_code=401, detail="Invalid widget token")
+        if isinstance(exc, _PublicTokenRejected):
+            raise HTTPException(
+                status_code=401, detail="Invalid widget token"
+            ) from None
+        raise
 
 
 def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
     """Get share chat access context from a share token."""
     try:
-        if token.startswith("Bearer "):
-            token = token[7:]
-
-        payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        payload = _decode_public_token(token)
         if payload.get("type") != "widget":
-            raise ValueError("Invalid token type")
+            raise _PublicTokenRejected
 
         user_id = payload.get("user_id")
         auth_mode = payload.get("auth_mode")
@@ -394,27 +449,47 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
         guest_id = payload.get("guest_id")
 
         if auth_mode != "share":
-            raise ValueError("Invalid token payload")
+            raise _PublicTokenRejected
         if not _is_strict_int(user_id):
-            raise ValueError("Invalid token payload")
+            raise _PublicTokenRejected
         if not isinstance(share_token, str) or not share_token:
-            raise ValueError("Invalid share token payload")
+            raise _PublicTokenRejected
         # Fail closed on tokens minted before per-guest isolation (#973): they
         # carry no guest_id, so they cannot be scoped to a single guest and are
         # rejected rather than silently granted the old no-isolation behavior.
         # A whitespace-only id is treated as absent (it could never match a
         # server-minted token_urlsafe value and must not pass as a real guest).
         if not isinstance(guest_id, str) or not guest_id.strip():
-            raise ValueError("Invalid share token payload")
+            raise _PublicTokenRejected
+
+        if _is_strict_int(share_workforce_id):
+            selected_agent_id = None
+            selected_workforce_id = share_workforce_id
+        elif _is_strict_int(share_agent_id):
+            selected_agent_id = share_agent_id
+            selected_workforce_id = None
+        else:
+            raise _PublicTokenRejected
+
+        dialect_name = str(db.get_bind().dialect.name)
+        user_id = _require_bindable_public_id(user_id, dialect_name)
+        if selected_workforce_id is not None:
+            selected_workforce_id = _require_bindable_public_id(
+                selected_workforce_id, dialect_name
+            )
+        else:
+            selected_agent_id = _require_bindable_public_id(
+                selected_agent_id, dialect_name
+            )
 
         user = db.query(User).filter(User.id == user_id).first()
         if not user:
-            raise ValueError("User not found")
+            raise _PublicTokenRejected
 
-        if _is_strict_int(share_workforce_id):
+        if selected_workforce_id is not None:
             workforce = ensure_share_workforce_available(
                 db,
-                share_workforce_id,
+                selected_workforce_id,
                 user_id,
                 expected_share_token=share_token,
             )
@@ -425,12 +500,11 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
                 workforce=workforce,
             )
 
-        if not _is_strict_int(share_agent_id):
-            raise ValueError("Invalid share token payload")
-
+        if selected_agent_id is None:
+            raise _PublicTokenRejected
         agent = ensure_share_agent_available(
             db,
-            share_agent_id,
+            selected_agent_id,
             user_id,
             expected_share_token=share_token,
         )
@@ -441,7 +515,9 @@ def get_share_chat_user(token: str, db: Session) -> ShareChatAccessContext:
         logger.error("Share chat token validation error: %s", exc)
         if isinstance(exc, HTTPException):
             raise exc
-        raise HTTPException(status_code=401, detail="Invalid share token")
+        if isinstance(exc, _PublicTokenRejected):
+            raise HTTPException(status_code=401, detail="Invalid share token") from None
+        raise
 
 
 security = HTTPBearer()
@@ -1314,8 +1390,10 @@ async def public_chat_websocket_endpoint(
     except HTTPException as exc:
         await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
         return
-    except Exception:
-        await websocket.close(code=4001, reason="Authentication required")
+    except Exception as exc:
+        await send_websocket_authentication_infrastructure_failure(
+            websocket, exc, already_accepted=True
+        )
         return
 
     # Already accepted above; register the live socket without re-accepting.
@@ -1336,6 +1414,11 @@ async def public_chat_websocket_endpoint(
                 )
             except HTTPException as exc:
                 await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
+                return
+            except Exception as exc:
+                await send_websocket_authentication_infrastructure_failure(
+                    websocket, exc, already_accepted=True
+                )
                 return
 
             message_data["user_id"] = current_principal.id
@@ -1416,8 +1499,10 @@ async def share_chat_websocket_endpoint(
     except HTTPException as exc:
         await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
         return
-    except Exception:
-        await websocket.close(code=4001, reason="Authentication required")
+    except Exception as exc:
+        await send_websocket_authentication_infrastructure_failure(
+            websocket, exc, already_accepted=True
+        )
         return
 
     # Already accepted above; register the live socket without re-accepting.
@@ -1437,6 +1522,11 @@ async def share_chat_websocket_endpoint(
                 )
             except HTTPException as exc:
                 await websocket.close(code=4003, reason=_ws_close_reason(exc.detail))
+                return
+            except Exception as exc:
+                await send_websocket_authentication_infrastructure_failure(
+                    websocket, exc, already_accepted=True
+                )
                 return
 
             message_data["user_id"] = current_principal.id

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -61,7 +61,6 @@ from ...core.execution_scope import (
     resolve_execution_scope_off_turn,
 )
 from ...core.file_ref import FILE_REF_MODEL_INSTRUCTIONS, build_file_ref
-from ..auth_dependencies import get_user_from_websocket_token
 from ..models.chat_message import TaskChatMessage
 from ..models.database import (
     get_db,
@@ -185,6 +184,11 @@ from .public_trace_events import (
     is_audit_only_trace_data,
     normalize_public_trace_event,
     public_task_trace_filter,
+)
+from .websocket_auth import (
+    WebSocketPrincipal,
+    _WebSocketAuthenticationTerminated,
+    get_authenticated_user,
 )
 
 logger = logging.getLogger(__name__)
@@ -4880,62 +4884,6 @@ def _register_uploaded_files_for_agent(
         )
 
 
-@dataclass(frozen=True)
-class WebSocketPrincipal:
-    """The complete authenticated identity needed by WebSocket transports."""
-
-    id: int
-    is_admin: bool
-    # Per-guest isolation credential for public widget/share transports
-    # (#973). ``None`` for owner-authenticated sockets, which have no guest.
-    guest_id: str | None = None
-    # Widget entity scope ("agent:<id>" / "workforce:<id>") for widget
-    # transports; ``None`` elsewhere. Carried as the turn rate-limit key
-    # (#1056): the widget ``guest_id`` above is client-supplied (rotatable at
-    # will), so widget throttles key on the entity + caller IP instead.
-    widget_entity_key: str | None = None
-
-
-def _load_websocket_principal_sync(token: str) -> WebSocketPrincipal | None:
-    """Authenticate one token inside a worker-owned short Session."""
-
-    SessionLocal = get_session_local()
-    with SessionLocal() as db:
-        user = get_user_from_websocket_token(token, db)
-        if user is None or user.id is None:
-            return None
-        return WebSocketPrincipal(
-            id=int(user.id),
-            is_admin=bool(user.is_admin),
-        )
-
-
-async def get_authenticated_user(
-    websocket: WebSocket, token: Optional[str] = None
-) -> Optional[WebSocketPrincipal]:
-    """
-    Get authenticated user from WebSocket connection
-
-    Args:
-        websocket: WebSocket connection
-        token: Optional authentication token
-
-    Returns:
-        Frozen WebSocket principal if authenticated, None otherwise
-    """
-    del websocket
-    if not token:
-        return None
-
-    try:
-        return await run_db_io_cancellation_safe(
-            lambda: _load_websocket_principal_sync(token)
-        )
-    except Exception as e:
-        logger.error(f"Error authenticating WebSocket user: {e}")
-        return None
-
-
 async def handle_chat_message(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
@@ -7221,7 +7169,10 @@ async def websocket_chat_endpoint(
 ) -> None:
     """WebSocket unified endpoint - handle chat, execution status, and DAG intervention"""
     # Verify user identity
-    user = await get_authenticated_user(websocket, token)
+    try:
+        user = await get_authenticated_user(websocket, token)
+    except _WebSocketAuthenticationTerminated:
+        return
     if not user:
         await websocket.close(code=4001, reason="Authentication required")
         return
@@ -8070,7 +8021,10 @@ async def websocket_builder_chat_endpoint(
     token: Optional[str] = Query(None, description="Authentication token"),
 ) -> None:
     """WebSocket endpoint for AI Agent Builder Assistant chat."""
-    user = await get_authenticated_user(websocket, token)
+    try:
+        user = await get_authenticated_user(websocket, token)
+    except _WebSocketAuthenticationTerminated:
+        return
     if not user:
         await websocket.close(code=4001, reason="Authentication required")
         return
@@ -8512,7 +8466,10 @@ async def websocket_build_preview_endpoint(
 ) -> None:
     """WebSocket endpoint for build page agent preview using normal task execution."""
     # Verify user identity
-    user = await get_authenticated_user(websocket, token)
+    try:
+        user = await get_authenticated_user(websocket, token)
+    except _WebSocketAuthenticationTerminated:
+        return
     if not user:
         await websocket.close(code=4001, reason="Authentication required")
         return

--- a/src/xagent/web/api/websocket_auth.py
+++ b/src/xagent/web/api/websocket_auth.py
@@ -29,6 +29,44 @@ class _WebSocketAuthenticationTerminated(Exception):
     """Authentication already sent a terminal transport response."""
 
 
+async def send_websocket_authentication_infrastructure_failure(
+    websocket: WebSocket,
+    original_error: Exception,
+    *,
+    already_accepted: bool,
+) -> None:
+    """Send the shared sanitized response for an authentication outage."""
+    route_template = getattr(websocket.scope.get("route"), "path", "<unresolved>")
+    logger.error(
+        "WebSocket authentication infrastructure failure transport=websocket route=%s",
+        route_template,
+        exc_info=(
+            type(original_error),
+            original_error,
+            original_error.__traceback__,
+        ),
+    )
+    try:
+        if already_accepted:
+            await websocket.close(code=1011, reason="Internal server error")
+        elif "websocket.http.response" in (websocket.scope.get("extensions") or {}):
+            await websocket.send_denial_response(
+                JSONResponse(
+                    status_code=503,
+                    content={"detail": "Service temporarily unavailable"},
+                )
+            )
+        else:
+            await websocket.accept()
+            await websocket.close(code=1011, reason="Internal server error")
+    except Exception:
+        logger.exception(
+            "WebSocket authentication terminal response failure "
+            "transport=websocket route=%s",
+            route_template,
+        )
+
+
 def _load_websocket_principal_sync(token: str) -> WebSocketPrincipal | None:
     """Authenticate one token inside a worker-owned short Session."""
 
@@ -57,27 +95,9 @@ async def get_authenticated_user(
             lambda: _load_websocket_principal_sync(token)
         )
     except Exception as exc:
-        route_template = getattr(websocket.scope.get("route"), "path", "<unresolved>")
-        logger.exception(
-            "WebSocket authentication infrastructure failure "
-            "transport=websocket route=%s",
-            route_template,
+        await send_websocket_authentication_infrastructure_failure(
+            websocket,
+            exc,
+            already_accepted=False,
         )
-        try:
-            if "websocket.http.response" in websocket.scope.get("extensions", {}):
-                await websocket.send_denial_response(
-                    JSONResponse(
-                        status_code=503,
-                        content={"detail": "Service temporarily unavailable"},
-                    )
-                )
-            else:
-                await websocket.accept()
-                await websocket.close(code=1011, reason="Internal server error")
-        except Exception:
-            logger.exception(
-                "WebSocket authentication terminal response failure "
-                "transport=websocket route=%s",
-                route_template,
-            )
         raise _WebSocketAuthenticationTerminated() from exc

--- a/src/xagent/web/api/websocket_auth.py
+++ b/src/xagent/web/api/websocket_auth.py
@@ -57,7 +57,12 @@ async def get_authenticated_user(
             lambda: _load_websocket_principal_sync(token)
         )
     except Exception as exc:
-        logger.exception("WebSocket authentication infrastructure failure")
+        route_template = getattr(websocket.scope.get("route"), "path", "<unresolved>")
+        logger.exception(
+            "WebSocket authentication infrastructure failure "
+            "transport=websocket route=%s",
+            route_template,
+        )
         try:
             if "websocket.http.response" in websocket.scope.get("extensions", {}):
                 await websocket.send_denial_response(
@@ -70,5 +75,9 @@ async def get_authenticated_user(
                 await websocket.accept()
                 await websocket.close(code=1011, reason="Internal server error")
         except Exception:
-            logger.exception("WebSocket authentication terminal response failure")
+            logger.exception(
+                "WebSocket authentication terminal response failure "
+                "transport=websocket route=%s",
+                route_template,
+            )
         raise _WebSocketAuthenticationTerminated() from exc

--- a/src/xagent/web/api/websocket_auth.py
+++ b/src/xagent/web/api/websocket_auth.py
@@ -1,0 +1,74 @@
+"""Shared authentication ownership for authenticated WebSocket transports."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from fastapi import WebSocket
+from fastapi.responses import JSONResponse
+
+from ..auth_dependencies import get_user_from_websocket_token
+from ..models.database import get_session_local
+from ..services.db_runtime import run_db_io_cancellation_safe
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WebSocketPrincipal:
+    """The complete authenticated identity needed by WebSocket transports."""
+
+    id: int
+    is_admin: bool
+    guest_id: str | None = None
+    widget_entity_key: str | None = None
+
+
+class _WebSocketAuthenticationTerminated(Exception):
+    """Authentication already sent a terminal transport response."""
+
+
+def _load_websocket_principal_sync(token: str) -> WebSocketPrincipal | None:
+    """Authenticate one token inside a worker-owned short Session."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        user = get_user_from_websocket_token(token, db)
+        if user is None or user.id is None:
+            return None
+        return WebSocketPrincipal(id=int(user.id), is_admin=bool(user.is_admin))
+
+
+async def get_authenticated_user(
+    websocket: WebSocket, token: str | None = None
+) -> WebSocketPrincipal | None:
+    """Load a detached principal or return ``None`` for rejected credentials.
+
+    Operational authentication failures are raised after this owner sends its
+    terminal transport response. Cancellation and other process-control signals
+    propagate unchanged.
+    """
+
+    if not token:
+        return None
+    try:
+        return await run_db_io_cancellation_safe(
+            lambda: _load_websocket_principal_sync(token)
+        )
+    except Exception as exc:
+        logger.exception("WebSocket authentication infrastructure failure")
+        try:
+            if "websocket.http.response" in websocket.scope.get("extensions", {}):
+                await websocket.send_denial_response(
+                    JSONResponse(
+                        status_code=503,
+                        content={"detail": "Service temporarily unavailable"},
+                    )
+                )
+            else:
+                await websocket.accept()
+                await websocket.close(code=1011, reason="Internal server error")
+        except Exception:
+            logger.exception("WebSocket authentication terminal response failure")
+        raise _WebSocketAuthenticationTerminated() from exc

--- a/src/xagent/web/api/websocket_auth.py
+++ b/src/xagent/web/api/websocket_auth.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from fastapi import WebSocket
 from fastapi.responses import JSONResponse
+from starlette.websockets import WebSocketState
 
 from ..auth_dependencies import get_user_from_websocket_token
 from ..models.database import get_session_local
@@ -32,8 +33,6 @@ class _WebSocketAuthenticationTerminated(Exception):
 async def send_websocket_authentication_infrastructure_failure(
     websocket: WebSocket,
     original_error: Exception,
-    *,
-    already_accepted: bool,
 ) -> None:
     """Send the shared sanitized response for an authentication outage."""
     route_template = getattr(websocket.scope.get("route"), "path", "<unresolved>")
@@ -47,7 +46,7 @@ async def send_websocket_authentication_infrastructure_failure(
         ),
     )
     try:
-        if already_accepted:
+        if websocket.application_state is WebSocketState.CONNECTED:
             await websocket.close(code=1011, reason="Internal server error")
         elif "websocket.http.response" in (websocket.scope.get("extensions") or {}):
             await websocket.send_denial_response(
@@ -98,6 +97,5 @@ async def get_authenticated_user(
         await send_websocket_authentication_infrastructure_failure(
             websocket,
             exc,
-            already_accepted=False,
         )
         raise _WebSocketAuthenticationTerminated() from exc

--- a/src/xagent/web/auth_dependencies.py
+++ b/src/xagent/web/auth_dependencies.py
@@ -53,6 +53,8 @@ def _has_matching_temporal_claim_conversion_failure(
             continue
         try:
             int(claims[claim_name])
+        except ValueError:
+            continue
         except (TypeError, OverflowError) as reproduced_error:
             if type(reproduced_error) is type(original_error):
                 return True

--- a/src/xagent/web/auth_dependencies.py
+++ b/src/xagent/web/auth_dependencies.py
@@ -1,21 +1,155 @@
-"""Authentication dependency for user segregation"""
+"""Authentication dependencies for user segregation."""
 
-import logging
-from typing import Optional
+from enum import Enum, auto
+from typing import NoReturn, Optional, assert_never
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
+from jose import ExpiredSignatureError, JWTError, jwt
 from sqlalchemy.orm import Session
 
 from .auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from .models.database import get_db
 from .models.user import User
 
-logger = logging.getLogger(__name__)
-
 # JWT Bearer token authentication
 security = HTTPBearer()
+
+_SQLITE_INTEGER_MIN = -(2**63)
+_SQLITE_INTEGER_MAX = 2**63 - 1
+_POSTGRESQL_INTEGER_MIN = -(2**31)
+_POSTGRESQL_INTEGER_MAX = 2**31 - 1
+
+
+class _AccessTokenRejectionReason(Enum):
+    """Credential rejection categories owned by access-token authentication."""
+
+    EXPIRED = auto()
+    INVALID = auto()
+    WRONG_TYPE = auto()
+    INVALID_CLAIMS = auto()
+    USER_NOT_FOUND = auto()
+
+
+class _AccessTokenRejected(Exception):
+    """Expected access-token rejection without implementation details."""
+
+    def __init__(self, reason: _AccessTokenRejectionReason) -> None:
+        super().__init__()
+        self.reason = reason
+
+
+def _has_matching_temporal_claim_conversion_failure(
+    token: str, original_error: TypeError | OverflowError
+) -> bool:
+    """Whether unverified temporal data proves the decoder's exact failure."""
+    try:
+        claims = jwt.get_unverified_claims(token)
+    except JWTError:
+        return False
+
+    for claim_name in ("exp", "nbf", "iat"):
+        if claim_name not in claims:
+            continue
+        try:
+            int(claims[claim_name])
+        except (TypeError, OverflowError) as reproduced_error:
+            return type(reproduced_error) is type(original_error)
+    return False
+
+
+def _validate_access_token_claim_bindability(
+    username: object, user_id: object, db: Session
+) -> tuple[str, int]:
+    """Validate claim values against the bound database dialect's parameters."""
+    if type(username) is not str or type(user_id) is not int:
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS)
+    try:
+        username.encode("utf-8", "strict")
+    except UnicodeEncodeError:
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS) from None
+
+    dialect_name = db.get_bind().dialect.name
+    if dialect_name == "sqlite":
+        if not _SQLITE_INTEGER_MIN <= user_id <= _SQLITE_INTEGER_MAX:
+            raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS)
+    elif dialect_name == "postgresql":
+        if "\x00" in username or not (
+            _POSTGRESQL_INTEGER_MIN <= user_id <= _POSTGRESQL_INTEGER_MAX
+        ):
+            raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS)
+
+    return username, user_id
+
+
+def _resolve_access_token_user(token: str, db: Session) -> User:
+    """Return the matching user or raise a typed credential rejection."""
+    try:
+        payload = jwt.decode(
+            token,
+            JWT_SECRET_KEY,
+            algorithms=[JWT_ALGORITHM],
+            options={"verify_sub": False},
+        )
+    except ExpiredSignatureError:
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.EXPIRED) from None
+    except JWTError:
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID) from None
+    except (TypeError, OverflowError) as error:
+        if _has_matching_temporal_claim_conversion_failure(token, error):
+            raise _AccessTokenRejected(
+                _AccessTokenRejectionReason.INVALID_CLAIMS
+            ) from None
+        raise
+
+    if payload.get("type") != "access":
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.WRONG_TYPE)
+
+    username, user_id = _validate_access_token_claim_bindability(
+        payload.get("sub"), payload.get("user_id"), db
+    )
+
+    user = db.query(User).filter(User.username == username, User.id == user_id).first()
+    if user is None:
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.USER_NOT_FOUND)
+    return user
+
+
+def _required_http_rejection(reason: _AccessTokenRejectionReason) -> NoReturn:
+    """Raise the established HTTP response for a typed credential rejection."""
+    match reason:
+        case _AccessTokenRejectionReason.EXPIRED:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token expired",
+                headers={"WWW-Authenticate": "Bearer", "Error-Type": "TokenExpired"},
+            )
+        case _AccessTokenRejectionReason.INVALID:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token",
+                headers={"WWW-Authenticate": "Bearer", "Error-Type": "InvalidToken"},
+            )
+        case _AccessTokenRejectionReason.WRONG_TYPE:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token type",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        case _AccessTokenRejectionReason.INVALID_CLAIMS:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token payload",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        case _AccessTokenRejectionReason.USER_NOT_FOUND:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="User not found",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        case _:
+            assert_never(reason)
 
 
 def get_current_user(
@@ -23,7 +157,7 @@ def get_current_user(
     db: Session = Depends(get_db),
 ) -> User:
     """
-    Get current authenticated user from JWT token
+    Get current authenticated user from a JWT token.
 
     Args:
         credentials: Bearer token credentials
@@ -33,72 +167,13 @@ def get_current_user(
         User: Current authenticated user
 
     Raises:
-        HTTPException: If authentication fails
+        HTTPException: If the token is rejected as invalid credentials.
+        Exception: Database and unexpected operational failures propagate unchanged.
     """
     try:
-        token = credentials.credentials
-
-        # Validate JWT token
-        payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-        token_type = payload.get("type")
-        if token_type != "access":
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token type",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-        username = payload.get("sub")
-        user_id = payload.get("user_id")
-
-        if username is None or user_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token payload",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-
-        # Type narrowing after null check
-
-        # Get user from database
-        user = (
-            db.query(User).filter(User.username == username, User.id == user_id).first()
-        )
-
-        if not user:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="User not found",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-
-        return user
-
-    except JWTError as e:
-        logger.error(f"JWT validation error: {e}")
-        # Check if it's an expired token specifically
-        error_message = str(e)
-        if (
-            "expired" in error_message.lower()
-            or "signature has expired" in error_message.lower()
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Token expired",
-                headers={"WWW-Authenticate": "Bearer", "Error-Type": "TokenExpired"},
-            )
-        else:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token",
-                headers={"WWW-Authenticate": "Bearer", "Error-Type": "InvalidToken"},
-            )
-    except Exception as e:
-        logger.error(f"Authentication error: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authentication credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        return _resolve_access_token_user(credentials.credentials, db)
+    except _AccessTokenRejected as rejected:
+        _required_http_rejection(rejected.reason)
 
 
 def get_current_user_optional(
@@ -106,61 +181,47 @@ def get_current_user_optional(
     db: Session = Depends(get_db),
 ) -> Optional[User]:
     """
-    Get current authenticated user if token is provided
+    Get current authenticated user if a token is provided.
 
     Args:
         credentials: Optional Bearer token credentials
         db: Database session
 
     Returns:
-        Optional[User]: Current authenticated user or None
+        Optional[User]: The matching user, or None for absent or rejected credentials.
+
+    Raises:
+        Exception: Database and unexpected operational failures propagate unchanged.
     """
     if not credentials:
         return None
 
     try:
-        return get_current_user(credentials, db)
-    except HTTPException:
+        return _resolve_access_token_user(credentials.credentials, db)
+    except _AccessTokenRejected:
         return None
 
 
 def get_user_from_token(token: str, db: Session) -> Optional[User]:
     """
-    Get user from authentication token
+    Get user from an authentication token.
 
     Args:
         token: Authentication token
         db: Database session
 
     Returns:
-        Optional[User]: User if token is valid, None otherwise
+        Optional[User]: User if credentials are valid, None if they are rejected.
+
+    Raises:
+        Exception: Database and unexpected operational failures propagate unchanged.
     """
+    if token.startswith("Bearer "):
+        token = token[7:]
+
     try:
-        # Remove "Bearer " prefix if present
-        if token.startswith("Bearer "):
-            token = token[7:]
-
-        # Validate JWT token
-        payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-        if payload.get("type") != "access":
-            return None
-        username = payload.get("sub")
-        user_id = payload.get("user_id")
-
-        if username is None or user_id is None:
-            return None
-
-        # Type narrowing after null check
-
-        return (
-            db.query(User).filter(User.username == username, User.id == user_id).first()
-        )
-
-    except JWTError as e:
-        logger.error(f"JWT validation error: {e}")
-        return None
-    except Exception as e:
-        logger.error(f"Token validation error: {e}")
+        return _resolve_access_token_user(token, db)
+    except _AccessTokenRejected:
         return None
 
 
@@ -188,13 +249,16 @@ def is_admin_user(user: User) -> bool:
 
 def get_user_from_websocket_token(token: str, db: Session) -> Optional[User]:
     """
-    Get user from WebSocket authentication token
+    Get user from a WebSocket authentication token.
 
     Args:
         token: Authentication token from WebSocket
         db: Database session
 
     Returns:
-        Optional[User]: User if token is valid, None otherwise
+        Optional[User]: User if credentials are valid, None if they are rejected.
+
+    Raises:
+        Exception: Database and unexpected operational failures propagate unchanged.
     """
     return get_user_from_token(token, db)

--- a/src/xagent/web/auth_dependencies.py
+++ b/src/xagent/web/auth_dependencies.py
@@ -54,7 +54,8 @@ def _has_matching_temporal_claim_conversion_failure(
         try:
             int(claims[claim_name])
         except (TypeError, OverflowError) as reproduced_error:
-            return type(reproduced_error) is type(original_error)
+            if type(reproduced_error) is type(original_error):
+                return True
     return False
 
 

--- a/src/xagent/web/auth_dependencies.py
+++ b/src/xagent/web/auth_dependencies.py
@@ -9,16 +9,16 @@ from jose import ExpiredSignatureError, JWTError, jwt
 from sqlalchemy.orm import Session
 
 from .auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+from .jwt_validation import (
+    has_matching_temporal_claim_conversion_failure,
+    is_exact_integer_bindable,
+)
 from .models.database import get_db
 from .models.user import User
 
 # JWT Bearer token authentication
 security = HTTPBearer()
-
-_SQLITE_INTEGER_MIN = -(2**63)
-_SQLITE_INTEGER_MAX = 2**63 - 1
-_POSTGRESQL_INTEGER_MIN = -(2**31)
-_POSTGRESQL_INTEGER_MAX = 2**31 - 1
+optional_security = HTTPBearer(auto_error=False)
 
 
 class _AccessTokenRejectionReason(Enum):
@@ -39,28 +39,6 @@ class _AccessTokenRejected(Exception):
         self.reason = reason
 
 
-def _has_matching_temporal_claim_conversion_failure(
-    token: str, original_error: TypeError | OverflowError
-) -> bool:
-    """Whether unverified temporal data proves the decoder's exact failure."""
-    try:
-        claims = jwt.get_unverified_claims(token)
-    except JWTError:
-        return False
-
-    for claim_name in ("exp", "nbf", "iat"):
-        if claim_name not in claims:
-            continue
-        try:
-            int(claims[claim_name])
-        except ValueError:
-            continue
-        except (TypeError, OverflowError) as reproduced_error:
-            if type(reproduced_error) is type(original_error):
-                return True
-    return False
-
-
 def _validate_access_token_claim_bindability(
     username: object, user_id: object, db: Session
 ) -> tuple[str, int]:
@@ -73,14 +51,10 @@ def _validate_access_token_claim_bindability(
         raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS) from None
 
     dialect_name = db.get_bind().dialect.name
-    if dialect_name == "sqlite":
-        if not _SQLITE_INTEGER_MIN <= user_id <= _SQLITE_INTEGER_MAX:
-            raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS)
-    elif dialect_name == "postgresql":
-        if "\x00" in username or not (
-            _POSTGRESQL_INTEGER_MIN <= user_id <= _POSTGRESQL_INTEGER_MAX
-        ):
-            raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS)
+    if not is_exact_integer_bindable(user_id, dialect_name):
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS)
+    if dialect_name == "postgresql" and "\x00" in username:
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID_CLAIMS)
 
     return username, user_id
 
@@ -99,11 +73,14 @@ def _resolve_access_token_user(token: str, db: Session) -> User:
     except JWTError:
         raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID) from None
     except (TypeError, OverflowError) as error:
-        if _has_matching_temporal_claim_conversion_failure(token, error):
+        if has_matching_temporal_claim_conversion_failure(token, error):
             raise _AccessTokenRejected(
                 _AccessTokenRejectionReason.INVALID_CLAIMS
             ) from None
         raise
+
+    if "sub" in payload and type(payload["sub"]) is not str:
+        raise _AccessTokenRejected(_AccessTokenRejectionReason.INVALID)
 
     if payload.get("type") != "access":
         raise _AccessTokenRejected(_AccessTokenRejectionReason.WRONG_TYPE)
@@ -180,7 +157,7 @@ def get_current_user(
 
 
 def get_current_user_optional(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(optional_security),
     db: Session = Depends(get_db),
 ) -> Optional[User]:
     """

--- a/src/xagent/web/jwt_validation.py
+++ b/src/xagent/web/jwt_validation.py
@@ -1,0 +1,43 @@
+"""Side-effect-free JWT claim predicates shared by authentication owners."""
+
+from typing import TypeGuard
+
+from jose import JWTError, jwt
+
+_SQLITE_INTEGER_MIN = -(2**63)
+_SQLITE_INTEGER_MAX = 2**63 - 1
+_POSTGRESQL_INTEGER_MIN = -(2**31)
+_POSTGRESQL_INTEGER_MAX = 2**31 - 1
+
+
+def has_matching_temporal_claim_conversion_failure(
+    token: str, original_error: TypeError | OverflowError
+) -> bool:
+    """Whether unverified temporal data proves the decoder's exact failure."""
+    try:
+        claims = jwt.get_unverified_claims(token)
+    except JWTError:
+        return False
+
+    for claim_name in ("exp", "nbf", "iat"):
+        if claim_name not in claims:
+            continue
+        try:
+            int(claims[claim_name])
+        except ValueError:
+            continue
+        except (TypeError, OverflowError) as reproduced_error:
+            if type(reproduced_error) is type(original_error):
+                return True
+    return False
+
+
+def is_exact_integer_bindable(value: object, dialect_name: str) -> TypeGuard[int]:
+    """Whether an exact integer fits a supported database parameter domain."""
+    if type(value) is not int:
+        return False
+    if dialect_name == "sqlite":
+        return _SQLITE_INTEGER_MIN <= value <= _SQLITE_INTEGER_MAX
+    if dialect_name == "postgresql":
+        return _POSTGRESQL_INTEGER_MIN <= value <= _POSTGRESQL_INTEGER_MAX
+    return True

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -25,6 +25,7 @@ from typing import (
     Mapping,
     Optional,
     TypeVar,
+    cast,
 )
 
 import httpx
@@ -1166,9 +1167,7 @@ class WebToolConfig(BaseToolConfig):
         self._db_factory = db_factory
         self._lazy_db = None
         self.request = request
-        self._user_id = (
-            user_id if user_id is not None else self._get_user_id_from_request(request)
-        )
+        self._user_id = user_id
         # Tri-state: an explicit ``is_admin`` (including ``False``) is
         # authoritative and is NOT OR-ed with the request's admin flag. This
         # is the privilege-isolation boundary: when the runtime builds a tool
@@ -1294,38 +1293,6 @@ class WebToolConfig(BaseToolConfig):
                 unique_dirs.append(dir_path)
                 seen.add(dir_path)
         return ",".join(unique_dirs)
-
-    def _get_user_id_from_request(self, request: Any) -> int:
-        """Extract user ID from request using JWT authentication."""
-        try:
-            from ..auth_dependencies import get_user_from_websocket_token
-
-            # Check if this is a FastAPI request with proper authentication
-            if hasattr(request, "headers") and hasattr(request, "query_params"):
-                # Try to extract user from Authorization header
-                auth_header = request.headers.get("authorization")
-                if auth_header:
-                    user = get_user_from_websocket_token(auth_header, self.db)
-                    if user is not None:
-                        user_id = self._coerce_user_id(getattr(user, "id", None))
-                        if user_id is not None:
-                            return user_id
-
-            # If request has a user attribute directly, use it
-            if hasattr(request, "user") and request.user:
-                user_id = self._coerce_user_id(getattr(request.user, "id", None))
-                if user_id is not None:
-                    return user_id
-
-            # If no authentication, this should raise an exception
-            raise ValueError("Authentication required")
-
-        except Exception as e:
-            logger = logging.getLogger(__name__)
-            logger.error(f"Failed to get user ID from request: {e}")
-            # Fallback to default user ID for backward compatibility
-            # In production, this should raise an exception instead
-            return 1
 
     def _get_is_admin_from_request(self, request: Any) -> bool:
         """Extract is_admin flag from the request user, defaulting to False.
@@ -2131,7 +2098,7 @@ class WebToolConfig(BaseToolConfig):
             policy_snapshot = await run_db_io_cancellation_safe(
                 lambda: _load_tool_runtime_policy_snapshot(
                     session_factory,
-                    int(self._user_id),
+                    int(cast(int, self._user_id)),
                 )
             )
 
@@ -3227,7 +3194,7 @@ class WebToolConfig(BaseToolConfig):
                     registration_generation=registration_generation,
                     resolved=remote_hook_token,
                     providers=remote_providers_to_resolve,
-                    user_id=int(self._user_id),
+                    user_id=int(cast(int, self._user_id)),
                     scope=self.get_execution_scope(),
                     resource=remote_configured_resource,
                     non_auth_connection=self._non_auth_mcp_connection(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1164,18 +1164,15 @@ class WebToolConfig(BaseToolConfig):
         self._lazy_db = None
         self.request = request
         self._user_id = user_id
-        # Tri-state: an explicit ``is_admin`` (including ``False``) is
-        # authoritative and is NOT OR-ed with the request's admin flag. This
-        # is the privilege-isolation boundary: when the runtime builds a tool
-        # config for a task owner (passing ``is_admin=bool(owner.is_admin)``),
-        # an admin *actor* on the request must not silently widen the config
-        # to admin scope. Only when ``is_admin`` is unset do we fall back to
-        # the request.
-        self._is_admin_value = (
-            bool(is_admin)
-            if is_admin is not None
-            else self._get_is_admin_from_request(request)
-        )
+        # No identity can carry administrative privilege. For identified
+        # configs, an explicit value remains authoritative; only an unset value
+        # may fall back to the authenticated request user.
+        if self._user_id is None:
+            self._is_admin_value = False
+        elif is_admin is not None:
+            self._is_admin_value = bool(is_admin)
+        else:
+            self._is_admin_value = self._get_is_admin_from_request(request)
         # Initialize workspace_config with base_dir and task_id if provided
         if workspace_config is None:
             workspace_config = {}
@@ -1433,6 +1430,9 @@ class WebToolConfig(BaseToolConfig):
 
     async def get_mcp_server_configs(self) -> List[Dict[str, Any]]:
         """Load MCP server configurations from database."""
+        if self._user_id is None:
+            return []
+
         if not self._include_mcp_tools:
             return []
 
@@ -1447,6 +1447,12 @@ class WebToolConfig(BaseToolConfig):
         configs = await self._load_mcp_server_configs()
         self._store_mcp_config_cache_if_cacheable(configs)
         return configs
+
+    def _serialize_mcp_user_id(self) -> str:
+        """Return the explicit identity used to isolate an MCP config."""
+        if self._user_id is None:
+            raise RuntimeError("MCP configs require a user identity")
+        return str(self._user_id)
 
     def _mcp_config_cache_is_valid(self) -> bool:
         # MCP config caching is aware of hook-supplied token expiry only. The
@@ -2813,13 +2819,14 @@ class WebToolConfig(BaseToolConfig):
         normalized_failure_code = normalize_tool_failure_code(failure_code)
         if normalized_failure_code is not None:
             inner_config["failure_code"] = normalized_failure_code
+        serialized_user_id = self._serialize_mcp_user_id()
         return {
             "name": getattr(server, "name", ""),
             "transport": "unavailable",
             "description": getattr(server, "description", None),
             "config": inner_config,
-            "user_id": str(self._user_id),
-            "allow_users": [str(self._user_id)],
+            "user_id": serialized_user_id,
+            "allow_users": [serialized_user_id],
         }
 
     def _build_oauth_mcp_stdio_transport_config(
@@ -3294,8 +3301,9 @@ class WebToolConfig(BaseToolConfig):
         config["config"] = transport_config
 
         # Add user context for MCP tool isolation
-        config["user_id"] = str(self._user_id)
-        config["allow_users"] = [str(self._user_id)]  # Only allow current user
+        serialized_user_id = self._serialize_mcp_user_id()
+        config["user_id"] = serialized_user_id
+        config["allow_users"] = [serialized_user_id]  # Only allow current user
 
         logger.debug(f"Loaded MCP server config: {server.name} ({server.transport})")
         return config

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1114,10 +1114,6 @@ def _load_tool_runtime_policy_snapshot(
 class WebToolConfig(BaseToolConfig):
     """Web-specific tool configuration that loads from database."""
 
-    @staticmethod
-    def _coerce_user_id(value: Any) -> Optional[int]:
-        return value if isinstance(value, int) else None
-
     def __init__(
         self,
         db: Any,

--- a/src/xagent/web/user_context.py
+++ b/src/xagent/web/user_context.py
@@ -8,7 +8,7 @@ ensuring proper user isolation and security.
 import logging
 import os
 from contextlib import contextmanager
-from typing import Any, Iterator, Optional
+from typing import Iterator, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -51,61 +51,6 @@ class UserContext:
     def get_current_user(self) -> Optional[str]:
         """Get current user ID from environment."""
         return os.environ.get("XAGENT_USER_ID")
-
-
-def get_user_context_from_request(request: Any) -> Optional[str]:
-    """Extract user context from FastAPI request.
-
-    Args:
-        request: FastAPI request object
-
-    Returns:
-        User ID string or None
-    """
-    try:
-        from .auth_dependencies import get_current_user_optional
-        from .models.database import get_db
-
-        # Try to get user from authentication
-        db = next(get_db())
-        user = get_current_user_optional(request, db)
-
-        if user:
-            return str(user.id)
-
-    except Exception as e:
-        logger.error(f"Failed to get user context from request: {e}")
-
-    return None
-
-
-def create_user_context(
-    user_id: Optional[str] = None, request: Optional[Any] = None
-) -> UserContext:
-    """Create user context from various sources.
-
-    Args:
-        user_id: Explicit user ID
-        request: FastAPI request object
-
-    Returns:
-        UserContext instance
-    """
-    if user_id:
-        return UserContext(user_id)
-
-    if request:
-        user_id = get_user_context_from_request(request)
-        if user_id:
-            return UserContext(user_id)
-
-    # Fallback to environment variable
-    env_user_id = os.environ.get("XAGENT_USER_ID")
-    if env_user_id:
-        return UserContext(env_user_id)
-
-    # No user context available
-    return UserContext()
 
 
 def validate_user_access(user_id: Optional[str], allowed_users: Optional[list]) -> bool:

--- a/tests/web/api/test_progress_ws.py
+++ b/tests/web/api/test_progress_ws.py
@@ -175,6 +175,9 @@ class TestProgressWebSocketAPI:
         mock_task.end_time = None
         mock_task.metadata = {"collection": "docs"}
 
+        mock_user = MagicMock(spec=User)
+        mock_user.id = 1
+
         with (
             patch(
                 "xagent.web.api.progress_ws.get_progress_manager"
@@ -182,20 +185,11 @@ class TestProgressWebSocketAPI:
             patch(
                 "xagent.web.api.progress_ws.progress_broadcaster", spec=True
             ) as mock_broadcaster,
-            patch("xagent.web.api.progress_ws.get_db") as mock_get_db,
             patch(
-                "xagent.web.api.progress_ws.get_user_from_websocket_token"
-            ) as mock_get_user,
+                "xagent.web.api.progress_ws.get_authenticated_user",
+                new=AsyncMock(return_value=mock_user),
+            ),
         ):
-            # Mock DB generator
-            mock_db = MagicMock()
-            mock_get_db.return_value = iter([mock_db])
-
-            # Mock user
-            mock_user = MagicMock(spec=User)
-            mock_user.id = 1
-            mock_get_user.return_value = mock_user
-
             mock_manager = MagicMock()
             mock_manager.get_task_progress.return_value = mock_task
 
@@ -227,20 +221,11 @@ class TestProgressWebSocketAPI:
                 "xagent.web.api.progress_ws.get_progress_manager"
             ) as mock_get_manager,
             patch("xagent.web.api.progress_ws.progress_broadcaster", spec=True),
-            patch("xagent.web.api.progress_ws.get_db") as mock_get_db,
             patch(
-                "xagent.web.api.progress_ws.get_user_from_websocket_token"
-            ) as mock_get_user,
+                "xagent.web.api.progress_ws.get_authenticated_user",
+                new=AsyncMock(return_value=None),
+            ),
         ):
-            # Mock DB generator
-            mock_db = MagicMock()
-            mock_get_db.return_value = iter([mock_db])
-
-            # Mock invalid token
-            mock_get_user.side_effect = Exception("Invalid token")
-
-            # Should still work (anonymous access for progress monitoring)
-            # Actually, my current implementation closes the connection on failure
             mock_manager = MagicMock()
             mock_manager.get_task_progress.return_value = None
             mock_get_manager.return_value = mock_manager

--- a/tests/web/api/test_public_chat_websocket_db_boundary.py
+++ b/tests/web/api/test_public_chat_websocket_db_boundary.py
@@ -21,6 +21,7 @@ class _SingleMessageWebSocket:
         # so a post-accept close preserves the code/reason on the wire.
         self.accept = AsyncMock()
         self.close = AsyncMock()
+        self.scope = {"extensions": {}, "route": SimpleNamespace(path="/public/ws")}
 
     async def receive_text(self) -> str:
         if self._received:
@@ -62,7 +63,6 @@ async def test_public_access_websocket_authorization_uses_worker_owned_session(
         public_chat_access,
         "get_session_local",
         lambda: TrackingSession,
-        raising=False,
     )
 
     def load_public_context(
@@ -339,27 +339,30 @@ async def test_public_access_websocket_initial_http_auth_failure_maps_to_4003(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("endpoint_kind", ["public", "share"])
-async def test_public_access_websocket_initial_non_http_failure_stays_4001(
+@pytest.mark.parametrize("phase", ["initial", "revalidation"])
+async def test_public_access_websocket_infrastructure_failure_closes_with_1011(
     monkeypatch: pytest.MonkeyPatch,
     endpoint_kind: str,
+    phase: str,
 ) -> None:
-    # A non-HTTP failure at connect-time auth (an infra error, not an access
-    # denial) carries no reason the recovery flow keys on, so both endpoints
-    # keep the generic 4001 rather than dressing it up as a 4003 access denial.
     websocket = _SingleMessageWebSocket({"type": "chat", "message": "hello"})
-    authorize = AsyncMock(side_effect=RuntimeError("database is down"))
+    principal = WebSocketPrincipal(id=7, is_admin=False)
+    failure = RuntimeError("database is down token=secret")
+    authorize = AsyncMock(
+        side_effect=failure if phase == "initial" else [principal, failure]
+    )
     connection_manager = MagicMock()
     connection_manager.connect = AsyncMock()
     connection_manager.register_connection = MagicMock()
     connection_manager.disconnect = MagicMock()
     monkeypatch.setattr(public_chat_access, "manager", connection_manager)
+    monkeypatch.setattr(public_chat_access, "handle_status_request", AsyncMock())
 
     if endpoint_kind == "public":
         monkeypatch.setattr(
             public_chat_access,
             "_authorize_public_chat_websocket",
             authorize,
-            raising=False,
         )
         await public_chat_access.public_chat_websocket_endpoint(
             websocket=websocket,
@@ -372,7 +375,6 @@ async def test_public_access_websocket_initial_non_http_failure_stays_4001(
             public_chat_access,
             "_authorize_share_chat_websocket",
             authorize,
-            raising=False,
         )
         await public_chat_access.share_chat_websocket_endpoint(
             websocket=websocket,
@@ -380,14 +382,130 @@ async def test_public_access_websocket_initial_non_http_failure_stays_4001(
             token="share-token",
         )
 
-    # accept() runs unconditionally before the try/except that yields both the
-    # 4003 and 4001 outcomes, so pin it here too: a regression moving accept into
-    # only the HTTPException branch would slip past a 4001-only assertion.
     websocket.accept.assert_awaited_once()
     websocket.close.assert_awaited_once_with(
-        code=4001,
-        reason="Authentication required",
+        code=1011,
+        reason="Internal server error",
     )
     connection_manager.connect.assert_not_awaited()
-    connection_manager.register_connection.assert_not_called()
-    connection_manager.disconnect.assert_not_called()
+    if phase == "initial":
+        connection_manager.register_connection.assert_not_called()
+        connection_manager.disconnect.assert_not_called()
+    else:
+        connection_manager.register_connection.assert_called_once_with(websocket, 42)
+        connection_manager.disconnect.assert_called_once_with(websocket)
+
+
+class _PublicResolverSession:
+    def __init__(self, query_error: Exception | None = None) -> None:
+        self._bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+        self.query_error = query_error
+        self.bind_count = 0
+        self.query_count = 0
+
+    def get_bind(self) -> object:
+        self.bind_count += 1
+        return self._bind
+
+    def query(self, _model: object) -> "_PublicResolverSession":
+        self.query_count += 1
+        if self.query_error is not None:
+            raise self.query_error
+        raise AssertionError("malformed public IDs must be rejected before a query")
+
+
+def _resolve_public_token(
+    resolver_kind: str, token: str, db: _PublicResolverSession
+) -> object:
+    if resolver_kind == "widget":
+        return public_chat_access.get_public_chat_user(
+            token, db, expected_auth_mode="widget"
+        )
+    return public_chat_access.get_share_chat_user(token, db)
+
+
+@pytest.mark.parametrize("resolver_kind", ["widget", "share"])
+def test_public_token_resolvers_propagate_database_failures_by_identity(
+    resolver_kind: str,
+) -> None:
+    failure = RuntimeError("database unavailable")
+    db = _PublicResolverSession(failure)
+    if resolver_kind == "widget":
+        token = public_chat_access.create_public_chat_access_token(
+            {
+                "user_id": 1,
+                "channel_id": 2,
+                "guest_id": "guest",
+                "auth_mode": "widget",
+                "widget_agent_id": 3,
+            }
+        )
+    else:
+        token = public_chat_access.create_public_chat_access_token(
+            {
+                "user_id": 1,
+                "guest_id": "guest",
+                "auth_mode": "share",
+                "share_agent_id": 3,
+                "share_token": "share",
+            }
+        )
+
+    with pytest.raises(RuntimeError) as raised:
+        _resolve_public_token(resolver_kind, token, db)
+
+    assert raised.value is failure
+    assert db.bind_count == 1
+    assert db.query_count == 1
+
+
+@pytest.mark.parametrize(
+    ("resolver_kind", "claim", "value", "expected_bind_count"),
+    (
+        ("widget", "user_id", "1", 0),
+        ("widget", "channel_id", "2", 0),
+        ("widget", "widget_agent_id", "3", 0),
+        ("widget", "widget_workforce_id", "3", 0),
+        ("share", "user_id", "1", 0),
+        ("share", "share_agent_id", "3", 0),
+        ("share", "share_workforce_id", "3", 0),
+        ("widget", "user_id", 2**63, 1),
+        ("widget", "channel_id", 2**63, 1),
+        ("widget", "widget_agent_id", 2**63, 1),
+        ("widget", "widget_workforce_id", 2**63, 1),
+        ("share", "user_id", 2**63, 1),
+        ("share", "share_agent_id", 2**63, 1),
+        ("share", "share_workforce_id", 2**63, 1),
+    ),
+)
+def test_public_token_resolvers_reject_invalid_ids_before_query(
+    resolver_kind: str, claim: str, value: object, expected_bind_count: int
+) -> None:
+    db = _PublicResolverSession()
+    if resolver_kind == "widget":
+        claims = {
+            "user_id": 1,
+            "channel_id": 2,
+            "guest_id": "guest",
+            "auth_mode": "widget",
+            "widget_agent_id": 3,
+        }
+    else:
+        claims = {
+            "user_id": 1,
+            "guest_id": "guest",
+            "auth_mode": "share",
+            "share_agent_id": 3,
+            "share_token": "share",
+        }
+    if "workforce" in claim:
+        claims.pop("widget_agent_id" if resolver_kind == "widget" else "share_agent_id")
+    claims[claim] = value
+    token = public_chat_access.create_public_chat_access_token(claims)
+
+    with pytest.raises(HTTPException) as raised:
+        _resolve_public_token(resolver_kind, token, db)
+
+    assert raised.value.status_code == 401
+    assert db.bind_count == expected_bind_count
+    assert db.query_count == 0

--- a/tests/web/api/test_public_chat_websocket_db_boundary.py
+++ b/tests/web/api/test_public_chat_websocket_db_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import threading
 from dataclasses import fields, is_dataclass
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException, WebSocketDisconnect
+from starlette.websockets import WebSocketState
 
 from xagent.web.api import public_chat_access
 from xagent.web.api.websocket import WebSocketPrincipal
@@ -21,6 +23,7 @@ class _SingleMessageWebSocket:
         # so a post-accept close preserves the code/reason on the wire.
         self.accept = AsyncMock()
         self.close = AsyncMock()
+        self.application_state = WebSocketState.CONNECTED
         self.scope = {"extensions": {}, "route": SimpleNamespace(path="/public/ws")}
 
     async def receive_text(self) -> str:
@@ -427,9 +430,11 @@ def _resolve_public_token(
 @pytest.mark.parametrize("resolver_kind", ["widget", "share"])
 def test_public_token_resolvers_propagate_database_failures_by_identity(
     resolver_kind: str,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     failure = RuntimeError("database unavailable")
     db = _PublicResolverSession(failure)
+    caplog.set_level(logging.ERROR, logger=public_chat_access.__name__)
     if resolver_kind == "widget":
         token = public_chat_access.create_public_chat_access_token(
             {
@@ -457,6 +462,71 @@ def test_public_token_resolvers_propagate_database_failures_by_identity(
     assert raised.value is failure
     assert db.bind_count == 1
     assert db.query_count == 1
+    assert "database unavailable" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("guest_id", "expected_status"),
+    (("", 401), (7, 401), ("   ", None)),
+    ids=("empty", "non-string", "whitespace"),
+)
+def test_public_widget_guest_id_requires_nonempty_string(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    guest_id: object,
+    expected_status: int | None,
+) -> None:
+    payload = {
+        "type": "widget",
+        "user_id": 1,
+        "channel_id": None,
+        "guest_id": guest_id,
+        "auth_mode": "widget",
+        "widget_agent_id": 3,
+    }
+    db = MagicMock()
+    db.get_bind.return_value = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+    db.query.return_value.filter.return_value.first.return_value = SimpleNamespace(
+        id=1,
+        is_admin=False,
+    )
+    monkeypatch.setattr(
+        public_chat_access, "_decode_public_token", lambda _token: payload
+    )
+    monkeypatch.setattr(
+        public_chat_access, "ensure_widget_agent_available", MagicMock()
+    )
+    caplog.set_level(logging.INFO, logger=public_chat_access.__name__)
+
+    if expected_status is None:
+        context = public_chat_access.get_public_chat_user(
+            "signed-token", db, expected_auth_mode="widget"
+        )
+
+        assert context.guest_id == guest_id
+        return
+
+    with pytest.raises(HTTPException) as raised:
+        public_chat_access.get_public_chat_user(
+            "signed-token", db, expected_auth_mode="widget"
+        )
+
+    assert raised.value.status_code == expected_status
+    db.get_bind.assert_not_called()
+    assert "reason=INVALID_CLAIMS" in caplog.text
+    assert "signed-token" not in caplog.text
+    assert "database unavailable" not in caplog.text
+
+
+def test_public_token_failure_projection_preserves_http_exception_identity() -> None:
+    expected = HTTPException(status_code=403, detail="Access denied")
+
+    assert (
+        public_chat_access._project_public_token_failure(
+            expected, invalid_detail="Invalid widget token"
+        )
+        is expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/web/api/test_websocket_auth.py
+++ b/tests/web/api/test_websocket_auth.py
@@ -114,6 +114,7 @@ def test_loader_rejects_every_credential_reason_inside_worker_session(
     assert websocket_auth._load_websocket_principal_sync(case.build_token()) is None
     assert session.enter_count == 1
     assert session.exit_count == 1
+    assert session.query_count == (1 if case.expected_detail == "User not found" else 0)
 
 
 @pytest.mark.asyncio
@@ -223,6 +224,7 @@ async def test_operational_auth_failure_without_extension_accepts_then_closes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     websocket, messages = _asgi_websocket(denial_extension=False)
+    websocket.scope["extensions"] = None
 
     async def timeout(_operation: object) -> None:
         raise TimeoutError("database pool token=secret")
@@ -433,9 +435,7 @@ async def test_progress_returns_after_shared_terminal_authentication(
     broadcaster = MagicMock()
     broadcaster.connect = AsyncMock()
     authenticated_user = AsyncMock(side_effect=_authentication_terminated)
-    monkeypatch.setattr(
-        progress_ws, "get_authenticated_user", authenticated_user, raising=False
-    )
+    monkeypatch.setattr(progress_ws, "get_authenticated_user", authenticated_user)
     monkeypatch.setattr(progress_ws, "progress_broadcaster", broadcaster)
 
     await progress_ws.progress_websocket_endpoint(websocket, "task", "signed-token")

--- a/tests/web/api/test_websocket_auth.py
+++ b/tests/web/api/test_websocket_auth.py
@@ -6,15 +6,87 @@ import asyncio
 import json
 import threading
 from dataclasses import is_dataclass
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import WebSocket
+from jose import jwt
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from xagent.web.api import progress_ws
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api import websocket_auth
+from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+
+
+def _access_token(**claims: object) -> str:
+    payload: dict[str, object] = {
+        "type": "access",
+        "sub": "existing-user",
+        "user_id": 1,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+    payload.update(claims)
+    return jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+
+REJECTED_WEBSOCKET_TOKEN_CASES = (
+    pytest.param(
+        _access_token(exp=datetime.now(timezone.utc) - timedelta(minutes=5)),
+        id="expired",
+    ),
+    pytest.param(
+        jwt.encode(
+            {
+                "type": "access",
+                "sub": "existing-user",
+                "user_id": 1,
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            "different-signing-secret",
+            algorithm=JWT_ALGORITHM,
+        ),
+        id="invalid-signature",
+    ),
+    pytest.param(_access_token(type="refresh"), id="wrong-type"),
+    pytest.param(_access_token(sub=[]), id="invalid-claims"),
+    pytest.param(_access_token(sub="missing-user"), id="user-not-found"),
+)
+
+
+class _BoundSQLiteSession:
+    """Small worker Session double for real access-token resolution."""
+
+    def __init__(self, query_exception: Exception | None = None) -> None:
+        self._bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+        self._query_exception = query_exception
+        self.enter_count = 0
+        self.exit_count = 0
+        self.query_count = 0
+
+    def __enter__(self) -> "_BoundSQLiteSession":
+        self.enter_count += 1
+        return self
+
+    def __exit__(self, *_exception: object) -> None:
+        self.exit_count += 1
+
+    def get_bind(self) -> SimpleNamespace:
+        return self._bind
+
+    def query(self, _model: object) -> "_BoundSQLiteSession":
+        self.query_count += 1
+        if self._query_exception is not None:
+            raise self._query_exception
+        return self
+
+    def filter(self, *_conditions: object) -> "_BoundSQLiteSession":
+        return self
+
+    def first(self) -> None:
+        return None
 
 
 def _asgi_websocket(
@@ -62,26 +134,17 @@ async def test_missing_token_returns_none_without_starting_database_work(
     run_db_io.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_invalid_token_returns_none_and_closes_worker_owned_session(
+@pytest.mark.parametrize("token", REJECTED_WEBSOCKET_TOKEN_CASES)
+def test_loader_rejects_every_credential_reason_inside_worker_session(
     monkeypatch: pytest.MonkeyPatch,
+    token: str,
 ) -> None:
-    closed: list[bool] = []
+    session = _BoundSQLiteSession()
+    monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
 
-    class TrackingSession:
-        def __enter__(self) -> "TrackingSession":
-            return self
-
-        def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
-            closed.append(True)
-
-    monkeypatch.setattr(websocket_auth, "get_session_local", lambda: TrackingSession)
-    monkeypatch.setattr(
-        websocket_auth, "get_user_from_websocket_token", lambda _token, _db: None
-    )
-
-    assert await websocket_auth.get_authenticated_user(MagicMock(), "invalid") is None
-    assert closed == [True]
+    assert websocket_auth._load_websocket_principal_sync(token) is None
+    assert session.enter_count == 1
+    assert session.exit_count == 1
 
 
 @pytest.mark.asyncio
@@ -134,15 +197,16 @@ async def test_operational_auth_failure_sends_sanitized_extension_denial(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     websocket, messages = _asgi_websocket(denial_extension=True)
+    timeout = SQLAlchemyTimeoutError("database pool token=secret", None, None)
+    session = _BoundSQLiteSession(query_exception=timeout)
+    monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
 
-    async def timeout(_operation: object) -> None:
-        raise TimeoutError("database pool token=secret")
+    with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated) as raised:
+        await websocket_auth.get_authenticated_user(websocket, _access_token())
 
-    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", timeout)
-
-    with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated):
-        await websocket_auth.get_authenticated_user(websocket, "signed-token")
-
+    assert raised.value.__cause__ is timeout
+    assert session.enter_count == 1
+    assert session.exit_count == 1
     assert messages == [
         {
             "type": "websocket.http.response.start",
@@ -158,7 +222,7 @@ async def test_operational_auth_failure_sends_sanitized_extension_denial(
         },
     ]
     serialized_messages = json.dumps(messages, default=lambda value: value.decode())
-    assert "signed-token" not in serialized_messages
+    assert "secret" not in serialized_messages
     assert "database pool" not in serialized_messages
 
 
@@ -406,15 +470,22 @@ async def test_main_endpoints_retain_invalid_credential_close_codes(
 ) -> None:
     websocket = endpoint_args[0]
     websocket.close = AsyncMock()
-    monkeypatch.setattr(
-        websocket_api, "get_authenticated_user", AsyncMock(return_value=None)
-    )
+    websocket.accept = AsyncMock(side_effect=AssertionError("auth bypass"))
+    manager = MagicMock()
+    manager.connect = AsyncMock(side_effect=AssertionError("auth bypass"))
+    session = _BoundSQLiteSession()
+    monkeypatch.setattr(websocket_api, "manager", manager)
+    monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
 
-    await endpoint(*endpoint_args)  # type: ignore[operator]
+    await endpoint(*endpoint_args[:-1], _access_token(type="refresh"))  # type: ignore[operator]
 
     websocket.close.assert_awaited_once_with(
         code=4001, reason="Authentication required"
     )
+    websocket.accept.assert_not_awaited()
+    manager.connect.assert_not_awaited()
+    assert session.enter_count == 1
+    assert session.exit_count == 1
 
 
 @pytest.mark.asyncio
@@ -423,12 +494,19 @@ async def test_progress_retains_invalid_credential_close_code(
 ) -> None:
     websocket = MagicMock()
     websocket.close = AsyncMock()
-    authenticated_user = AsyncMock(return_value=None)
-    monkeypatch.setattr(
-        progress_ws, "get_authenticated_user", authenticated_user, raising=False
+    websocket.accept = AsyncMock(side_effect=AssertionError("auth bypass"))
+    broadcaster = MagicMock()
+    broadcaster.connect = AsyncMock(side_effect=AssertionError("auth bypass"))
+    session = _BoundSQLiteSession()
+    monkeypatch.setattr(progress_ws, "progress_broadcaster", broadcaster)
+    monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
+
+    await progress_ws.progress_websocket_endpoint(
+        websocket, "task", _access_token(type="refresh")
     )
 
-    await progress_ws.progress_websocket_endpoint(websocket, "task", "invalid")
-
-    authenticated_user.assert_awaited_once_with(websocket, "invalid")
     websocket.close.assert_awaited_once_with(code=1008)
+    websocket.accept.assert_not_awaited()
+    broadcaster.connect.assert_not_awaited()
+    assert session.enter_count == 1
+    assert session.exit_count == 1

--- a/tests/web/api/test_websocket_auth.py
+++ b/tests/web/api/test_websocket_auth.py
@@ -6,54 +6,22 @@ import asyncio
 import json
 import threading
 from dataclasses import is_dataclass
-from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import WebSocket
-from jose import jwt
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
+from tests.web.auth_token_cases import (
+    REJECTED_ACCESS_TOKEN_CASES,
+    WRONG_TYPE_ACCESS_TOKEN_CASE,
+    RejectedAccessTokenCase,
+    build_access_token,
+)
 from xagent.web.api import progress_ws
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api import websocket_auth
-from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
-
-
-def _access_token(**claims: object) -> str:
-    payload: dict[str, object] = {
-        "type": "access",
-        "sub": "existing-user",
-        "user_id": 1,
-        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
-    }
-    payload.update(claims)
-    return jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
-
-
-REJECTED_WEBSOCKET_TOKEN_CASES = (
-    pytest.param(
-        _access_token(exp=datetime.now(timezone.utc) - timedelta(minutes=5)),
-        id="expired",
-    ),
-    pytest.param(
-        jwt.encode(
-            {
-                "type": "access",
-                "sub": "existing-user",
-                "user_id": 1,
-                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
-            },
-            "different-signing-secret",
-            algorithm=JWT_ALGORITHM,
-        ),
-        id="invalid-signature",
-    ),
-    pytest.param(_access_token(type="refresh"), id="wrong-type"),
-    pytest.param(_access_token(sub=[]), id="invalid-claims"),
-    pytest.param(_access_token(sub="missing-user"), id="user-not-found"),
-)
 
 
 class _BoundSQLiteSession:
@@ -134,15 +102,15 @@ async def test_missing_token_returns_none_without_starting_database_work(
     run_db_io.assert_not_called()
 
 
-@pytest.mark.parametrize("token", REJECTED_WEBSOCKET_TOKEN_CASES)
+@pytest.mark.parametrize("case", REJECTED_ACCESS_TOKEN_CASES, ids=lambda case: case.id)
 def test_loader_rejects_every_credential_reason_inside_worker_session(
     monkeypatch: pytest.MonkeyPatch,
-    token: str,
+    case: RejectedAccessTokenCase,
 ) -> None:
     session = _BoundSQLiteSession()
     monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
 
-    assert websocket_auth._load_websocket_principal_sync(token) is None
+    assert websocket_auth._load_websocket_principal_sync(case.build_token()) is None
     assert session.enter_count == 1
     assert session.exit_count == 1
 
@@ -202,7 +170,7 @@ async def test_operational_auth_failure_sends_sanitized_extension_denial(
     monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
 
     with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated) as raised:
-        await websocket_auth.get_authenticated_user(websocket, _access_token())
+        await websocket_auth.get_authenticated_user(websocket, build_access_token())
 
     assert raised.value.__cause__ is timeout
     assert session.enter_count == 1
@@ -477,7 +445,7 @@ async def test_main_endpoints_retain_invalid_credential_close_codes(
     monkeypatch.setattr(websocket_api, "manager", manager)
     monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
 
-    await endpoint(*endpoint_args[:-1], _access_token(type="refresh"))  # type: ignore[operator]
+    await endpoint(*endpoint_args[:-1], WRONG_TYPE_ACCESS_TOKEN_CASE.build_token())  # type: ignore[operator]
 
     websocket.close.assert_awaited_once_with(
         code=4001, reason="Authentication required"
@@ -502,7 +470,7 @@ async def test_progress_retains_invalid_credential_close_code(
     monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
 
     await progress_ws.progress_websocket_endpoint(
-        websocket, "task", _access_token(type="refresh")
+        websocket, "task", WRONG_TYPE_ACCESS_TOKEN_CASE.build_token()
     )
 
     websocket.close.assert_awaited_once_with(code=1008)

--- a/tests/web/api/test_websocket_auth.py
+++ b/tests/web/api/test_websocket_auth.py
@@ -1,0 +1,380 @@
+"""Tests for the shared authenticated WebSocket transport owner."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from dataclasses import is_dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import WebSocket
+
+from xagent.web.api import progress_ws
+from xagent.web.api import websocket as websocket_api
+from xagent.web.api import websocket_auth
+
+
+def _asgi_websocket(
+    *, denial_extension: bool
+) -> tuple[WebSocket, list[dict[str, object]]]:
+    """Create a pre-handshake WebSocket and collect its outgoing ASGI messages."""
+
+    messages: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "websocket.connect"}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    extensions = {"websocket.http.response": {}} if denial_extension else {}
+    websocket = WebSocket(
+        {
+            "type": "websocket",
+            "asgi": {"version": "3.0"},
+            "scheme": "ws",
+            "path": "/ws/chat/1",
+            "raw_path": b"/ws/chat/1",
+            "query_string": b"",
+            "headers": [],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "subprotocols": [],
+            "extensions": extensions,
+        },
+        receive,
+        send,
+    )
+    return websocket, messages
+
+
+@pytest.mark.asyncio
+async def test_missing_token_returns_none_without_starting_database_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_db_io = MagicMock()
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", run_db_io)
+
+    assert await websocket_auth.get_authenticated_user(MagicMock(), None) is None
+    run_db_io.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_returns_none_and_closes_worker_owned_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed: list[bool] = []
+
+    class TrackingSession:
+        def __enter__(self) -> "TrackingSession":
+            return self
+
+        def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr(websocket_auth, "get_session_local", lambda: TrackingSession)
+    monkeypatch.setattr(
+        websocket_auth, "get_user_from_websocket_token", lambda _token, _db: None
+    )
+
+    assert await websocket_auth.get_authenticated_user(MagicMock(), "invalid") is None
+    assert closed == [True]
+
+
+@pytest.mark.asyncio
+async def test_valid_token_returns_frozen_detached_principal_from_worker_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_loop_thread = threading.get_ident()
+    auth_threads: list[int] = []
+    closed: list[bool] = []
+
+    class TrackingSession:
+        def __enter__(self) -> "TrackingSession":
+            return self
+
+        def __exit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+            closed.append(True)
+
+    def authenticate(_token: str, _db: object) -> SimpleNamespace:
+        auth_threads.append(threading.get_ident())
+        return SimpleNamespace(id=73, is_admin=True)
+
+    monkeypatch.setattr(websocket_auth, "get_session_local", lambda: TrackingSession)
+    monkeypatch.setattr(websocket_auth, "get_user_from_websocket_token", authenticate)
+
+    principal = await websocket_auth.get_authenticated_user(MagicMock(), "signed")
+
+    assert principal == websocket_auth.WebSocketPrincipal(id=73, is_admin=True)
+    assert is_dataclass(principal)
+    assert principal.__dataclass_params__.frozen is True
+    assert auth_threads == [auth_threads[0]]
+    assert auth_threads[0] != event_loop_thread
+    assert closed == [True]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates_from_database_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def cancelled(_operation: object) -> None:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        await websocket_auth.get_authenticated_user(MagicMock(), "signed")
+
+
+@pytest.mark.asyncio
+async def test_operational_auth_failure_sends_sanitized_extension_denial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket, messages = _asgi_websocket(denial_extension=True)
+
+    async def timeout(_operation: object) -> None:
+        raise TimeoutError("database pool token=secret")
+
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", timeout)
+
+    with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated):
+        await websocket_auth.get_authenticated_user(websocket, "signed-token")
+
+    assert messages == [
+        {
+            "type": "websocket.http.response.start",
+            "status": 503,
+            "headers": [
+                (b"content-length", b"44"),
+                (b"content-type", b"application/json"),
+            ],
+        },
+        {
+            "type": "websocket.http.response.body",
+            "body": b'{"detail":"Service temporarily unavailable"}',
+        },
+    ]
+    serialized_messages = json.dumps(messages, default=lambda value: value.decode())
+    assert "signed-token" not in serialized_messages
+    assert "database pool" not in serialized_messages
+
+
+@pytest.mark.asyncio
+async def test_operational_auth_failure_without_extension_accepts_then_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket, messages = _asgi_websocket(denial_extension=False)
+
+    async def timeout(_operation: object) -> None:
+        raise TimeoutError("database pool token=secret")
+
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", timeout)
+
+    with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated):
+        await websocket_auth.get_authenticated_user(websocket, "signed-token")
+
+    assert messages == [
+        {"type": "websocket.accept", "subprotocol": None, "headers": []},
+        {
+            "type": "websocket.close",
+            "code": 1011,
+            "reason": "Internal server error",
+        },
+    ]
+    serialized_messages = json.dumps(messages, default=lambda value: value.decode())
+    assert "signed-token" not in serialized_messages
+    assert "database pool" not in serialized_messages
+
+
+@pytest.mark.asyncio
+async def test_denial_send_failure_is_terminal_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = MagicMock()
+    websocket.scope = {"extensions": {"websocket.http.response": {}}}
+    websocket.send_denial_response = AsyncMock(side_effect=ConnectionError("closed"))
+    websocket.accept = AsyncMock()
+    websocket.close = AsyncMock()
+
+    async def timeout(_operation: object) -> None:
+        raise TimeoutError("database pool")
+
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", timeout)
+
+    with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated):
+        await websocket_auth.get_authenticated_user(websocket, "signed-token")
+
+    websocket.send_denial_response.assert_awaited_once()
+    websocket.accept.assert_not_awaited()
+    websocket.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_extensionless_accept_failure_is_terminal_without_close_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = MagicMock()
+    websocket.scope = {"extensions": {}}
+    websocket.accept = AsyncMock(side_effect=ConnectionError("closed"))
+    websocket.close = AsyncMock()
+    websocket.send_denial_response = AsyncMock()
+
+    async def timeout(_operation: object) -> None:
+        raise TimeoutError("database pool")
+
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", timeout)
+
+    with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated):
+        await websocket_auth.get_authenticated_user(websocket, "signed-token")
+
+    websocket.accept.assert_awaited_once()
+    websocket.close.assert_not_awaited()
+    websocket.send_denial_response.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_extensionless_close_failure_is_terminal_without_second_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = MagicMock()
+    websocket.scope = {"extensions": {}}
+    websocket.accept = AsyncMock()
+    websocket.close = AsyncMock(side_effect=ConnectionError("closed"))
+    websocket.send_denial_response = AsyncMock()
+
+    async def timeout(_operation: object) -> None:
+        raise TimeoutError("database pool")
+
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", timeout)
+
+    with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated):
+        await websocket_auth.get_authenticated_user(websocket, "signed-token")
+
+    websocket.accept.assert_awaited_once()
+    websocket.close.assert_awaited_once_with(code=1011, reason="Internal server error")
+    websocket.send_denial_response.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("control_signal", [KeyboardInterrupt, SystemExit])
+async def test_process_control_signals_are_not_translated(
+    monkeypatch: pytest.MonkeyPatch,
+    control_signal: type[BaseException],
+) -> None:
+    websocket = MagicMock()
+    websocket.send_denial_response = AsyncMock()
+
+    async def interrupted(_operation: object) -> None:
+        raise control_signal()
+
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", interrupted)
+
+    with pytest.raises(control_signal):
+        await websocket_auth.get_authenticated_user(websocket, "signed-token")
+
+    websocket.send_denial_response.assert_not_awaited()
+
+
+async def _authentication_terminated(*_args: object, **_kwargs: object) -> None:
+    raise websocket_auth._WebSocketAuthenticationTerminated()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "endpoint_args"),
+    [
+        (websocket_api.websocket_chat_endpoint, (MagicMock(), 1, "signed-token")),
+        (websocket_api.websocket_builder_chat_endpoint, (MagicMock(), "signed-token")),
+        (websocket_api.websocket_build_preview_endpoint, (MagicMock(), "signed-token")),
+    ],
+)
+async def test_main_endpoints_return_after_shared_terminal_authentication(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: object,
+    endpoint_args: tuple[MagicMock, object, str],
+) -> None:
+    websocket = endpoint_args[0]
+    websocket.close = AsyncMock()
+    websocket.accept = AsyncMock()
+    manager = MagicMock()
+    manager.connect = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", manager)
+    monkeypatch.setattr(
+        websocket_api, "get_authenticated_user", _authentication_terminated
+    )
+
+    await endpoint(*endpoint_args)  # type: ignore[operator]
+
+    websocket.close.assert_not_awaited()
+    websocket.accept.assert_not_awaited()
+    manager.connect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_progress_returns_after_shared_terminal_authentication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = MagicMock()
+    websocket.close = AsyncMock()
+    websocket.accept = AsyncMock()
+    broadcaster = MagicMock()
+    broadcaster.connect = AsyncMock()
+    authenticated_user = AsyncMock(side_effect=_authentication_terminated)
+    monkeypatch.setattr(
+        progress_ws, "get_authenticated_user", authenticated_user, raising=False
+    )
+    monkeypatch.setattr(progress_ws, "progress_broadcaster", broadcaster)
+
+    await progress_ws.progress_websocket_endpoint(websocket, "task", "signed-token")
+
+    authenticated_user.assert_awaited_once_with(websocket, "signed-token")
+    websocket.close.assert_not_awaited()
+    websocket.accept.assert_not_awaited()
+    broadcaster.connect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "endpoint_args"),
+    [
+        (websocket_api.websocket_chat_endpoint, (MagicMock(), 1, "invalid")),
+        (websocket_api.websocket_builder_chat_endpoint, (MagicMock(), "invalid")),
+        (websocket_api.websocket_build_preview_endpoint, (MagicMock(), "invalid")),
+    ],
+)
+async def test_main_endpoints_retain_invalid_credential_close_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: object,
+    endpoint_args: tuple[MagicMock, object, str],
+) -> None:
+    websocket = endpoint_args[0]
+    websocket.close = AsyncMock()
+    monkeypatch.setattr(
+        websocket_api, "get_authenticated_user", AsyncMock(return_value=None)
+    )
+
+    await endpoint(*endpoint_args)  # type: ignore[operator]
+
+    websocket.close.assert_awaited_once_with(
+        code=4001, reason="Authentication required"
+    )
+
+
+@pytest.mark.asyncio
+async def test_progress_retains_invalid_credential_close_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    websocket = MagicMock()
+    websocket.close = AsyncMock()
+    authenticated_user = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        progress_ws, "get_authenticated_user", authenticated_user, raising=False
+    )
+
+    await progress_ws.progress_websocket_endpoint(websocket, "task", "invalid")
+
+    authenticated_user.assert_awaited_once_with(websocket, "invalid")
+    websocket.close.assert_awaited_once_with(code=1008)

--- a/tests/web/api/test_websocket_auth.py
+++ b/tests/web/api/test_websocket_auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import threading
 from dataclasses import is_dataclass
 from types import SimpleNamespace
@@ -163,14 +164,21 @@ async def test_cancellation_propagates_from_database_runner(
 @pytest.mark.asyncio
 async def test_operational_auth_failure_sends_sanitized_extension_denial(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     websocket, messages = _asgi_websocket(denial_extension=True)
+    route_template = "/ws/chat/{task_id}"
+    query_secret = "query-secret-value"
+    websocket.scope["route"] = SimpleNamespace(path=route_template)
+    websocket.scope["query_string"] = f"debug={query_secret}".encode()
     timeout = SQLAlchemyTimeoutError("database pool token=secret", None, None)
     session = _BoundSQLiteSession(query_exception=timeout)
     monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
+    token = build_access_token()
+    caplog.set_level(logging.ERROR, logger=websocket_auth.__name__)
 
     with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated) as raised:
-        await websocket_auth.get_authenticated_user(websocket, build_access_token())
+        await websocket_auth.get_authenticated_user(websocket, token)
 
     assert raised.value.__cause__ is timeout
     assert session.enter_count == 1
@@ -192,6 +200,19 @@ async def test_operational_auth_failure_sends_sanitized_extension_denial(
     serialized_messages = json.dumps(messages, default=lambda value: value.decode())
     assert "secret" not in serialized_messages
     assert "database pool" not in serialized_messages
+    infrastructure_records = [
+        record
+        for record in caplog.records
+        if record.name == websocket_auth.__name__
+        and "authentication infrastructure failure" in record.getMessage()
+    ]
+    assert len(infrastructure_records) == 1
+    log_record = infrastructure_records[0]
+    assert "transport=websocket" in log_record.getMessage()
+    assert f"route={route_template}" in log_record.getMessage()
+    rendered_log_data = f"{log_record.getMessage()} {log_record.args!r}"
+    assert token not in rendered_log_data
+    assert query_secret not in rendered_log_data
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_auth.py
+++ b/tests/web/api/test_websocket_auth.py
@@ -175,6 +175,9 @@ async def test_operational_auth_failure_sends_sanitized_extension_denial(
     session = _BoundSQLiteSession(query_exception=timeout)
     monkeypatch.setattr(websocket_auth, "get_session_local", lambda: lambda: session)
     token = build_access_token()
+    monkeypatch.setattr(logging.root.manager, "disable", logging.NOTSET)
+    monkeypatch.setattr(websocket_auth.logger, "disabled", False)
+    monkeypatch.setattr(websocket_auth.logger, "propagate", True)
     caplog.set_level(logging.ERROR, logger=websocket_auth.__name__)
 
     with pytest.raises(websocket_auth._WebSocketAuthenticationTerminated) as raised:

--- a/tests/web/api/test_websocket_auth.py
+++ b/tests/web/api/test_websocket_auth.py
@@ -259,6 +259,60 @@ async def test_extensionless_close_failure_is_terminal_without_second_response(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "control_signal", [asyncio.CancelledError, KeyboardInterrupt, SystemExit]
+)
+@pytest.mark.parametrize("terminal_operation", ["denial", "accept", "close"])
+async def test_terminal_send_process_control_propagates_without_marker_or_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    control_signal: type[BaseException],
+    terminal_operation: str,
+) -> None:
+    signal = control_signal()
+    websocket = MagicMock()
+    websocket.send_denial_response = AsyncMock()
+    websocket.accept = AsyncMock()
+    websocket.close = AsyncMock()
+
+    if terminal_operation == "denial":
+        websocket.scope = {"extensions": {"websocket.http.response": {}}}
+        websocket.send_denial_response.side_effect = signal
+    elif terminal_operation == "accept":
+        websocket.scope = {"extensions": {}}
+        websocket.accept.side_effect = signal
+    else:
+        websocket.scope = {"extensions": {}}
+        websocket.close.side_effect = signal
+
+    async def timeout(_operation: object) -> None:
+        raise TimeoutError("database pool")
+
+    monkeypatch.setattr(websocket_auth, "run_db_io_cancellation_safe", timeout)
+
+    with pytest.raises(control_signal) as raised:
+        await websocket_auth.get_authenticated_user(websocket, "signed-token")
+
+    assert raised.value is signal
+    assert not isinstance(
+        raised.value, websocket_auth._WebSocketAuthenticationTerminated
+    )
+    if terminal_operation == "denial":
+        websocket.send_denial_response.assert_awaited_once()
+        websocket.accept.assert_not_awaited()
+        websocket.close.assert_not_awaited()
+    elif terminal_operation == "accept":
+        websocket.send_denial_response.assert_not_awaited()
+        websocket.accept.assert_awaited_once()
+        websocket.close.assert_not_awaited()
+    else:
+        websocket.send_denial_response.assert_not_awaited()
+        websocket.accept.assert_awaited_once()
+        websocket.close.assert_awaited_once_with(
+            code=1011, reason="Internal server error"
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("control_signal", [KeyboardInterrupt, SystemExit])
 async def test_process_control_signals_are_not_translated(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/web/api/test_websocket_auth.py
+++ b/tests/web/api/test_websocket_auth.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi import WebSocket
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from starlette.websockets import WebSocketState
 
 from tests.web.auth_token_cases import (
     REJECTED_ACCESS_TOKEN_CASES,
@@ -245,6 +246,26 @@ async def test_operational_auth_failure_without_extension_accepts_then_closes(
     serialized_messages = json.dumps(messages, default=lambda value: value.decode())
     assert "signed-token" not in serialized_messages
     assert "database pool" not in serialized_messages
+
+
+@pytest.mark.asyncio
+async def test_connected_auth_failure_closes_from_websocket_application_state() -> None:
+    websocket = MagicMock()
+    websocket.application_state = WebSocketState.CONNECTED
+    websocket.scope = {"extensions": {"websocket.http.response": {}}}
+    websocket.close = AsyncMock()
+    websocket.accept = AsyncMock()
+    websocket.send_denial_response = AsyncMock()
+
+    await websocket_auth.send_websocket_authentication_infrastructure_failure(
+        websocket,
+        TimeoutError("database pool"),
+    )
+
+    websocket.close.assert_awaited_once_with(
+        code=1011,
+        reason="Internal server error",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import threading
 from collections.abc import Callable
-from dataclasses import is_dataclass
 from types import SimpleNamespace
 from typing import Any, TypeVar
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -43,7 +42,6 @@ from xagent.web.api.websocket import (
     _waiting_or_paused_event_fields,
     background_task_manager,
     execute_resume_background,
-    get_authenticated_user,
     handle_chat_message,
     handle_pause_task,
     handle_resume_task,
@@ -177,58 +175,6 @@ async def test_rejected_delivery_serializes_an_explicit_outcome() -> None:
             turn_id="missing-outcome-turn",
             accepted=False,
         )
-
-
-@pytest.mark.asyncio
-async def test_websocket_authentication_returns_frozen_principal_off_loop(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    event_loop_thread = threading.get_ident()
-    auth_threads: list[int] = []
-    closed_sessions: list[bool] = []
-
-    class TrackingSession:
-        def close(self) -> None:
-            closed_sessions.append(True)
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, _exc_type, _exc, _traceback) -> None:
-            self.close()
-
-    def session_factory():
-        return TrackingSession()
-
-    def get_test_db():
-        session = TrackingSession()
-        try:
-            yield session
-        finally:
-            session.close()
-
-    def authenticate(_token: str, _db: object):
-        auth_threads.append(threading.get_ident())
-        return SimpleNamespace(id=73, is_admin=True)
-
-    monkeypatch.setattr(websocket_api, "get_session_local", lambda: session_factory)
-    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
-    monkeypatch.setattr(
-        websocket_api,
-        "get_user_from_websocket_token",
-        authenticate,
-    )
-
-    principal = await get_authenticated_user(MagicMock(), "signed-token")
-
-    assert principal is not None
-    assert principal.id == 73
-    assert principal.is_admin is True
-    assert auth_threads == [auth_threads[0]]
-    assert auth_threads[0] != event_loop_thread
-    assert closed_sessions
-    assert is_dataclass(principal)
-    assert principal.__dataclass_params__.frozen is True
 
 
 def _register_current_resume(task_id: int) -> None:

--- a/tests/web/auth_token_cases.py
+++ b/tests/web/auth_token_cases.py
@@ -85,7 +85,7 @@ REJECTED_ACCESS_TOKEN_CASES = (
         "invalid-claims",
         "Invalid token payload",
         _BEARER_HEADERS,
-        (("sub", ()),),
+        (("user_id", "1"),),
     ),
     RejectedAccessTokenCase(
         "user-not-found",

--- a/tests/web/auth_token_cases.py
+++ b/tests/web/auth_token_cases.py
@@ -1,0 +1,93 @@
+"""Shared access-token rejection cases for authentication contract tests."""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from jose import jwt
+
+from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+
+_DEFAULT_LIFETIME = timedelta(minutes=5)
+
+
+def _build_access_token(
+    claims: dict[str, object],
+    *,
+    lifetime: timedelta = _DEFAULT_LIFETIME,
+    signing_secret: str = JWT_SECRET_KEY,
+) -> str:
+    payload: dict[str, object] = {
+        "type": "access",
+        "sub": "existing-user",
+        "user_id": 1,
+        "exp": datetime.now(timezone.utc) + lifetime,
+    }
+    payload.update(claims)
+    return jwt.encode(payload, signing_secret, algorithm=JWT_ALGORITHM)
+
+
+def build_access_token(**claims: object) -> str:
+    """Build an access token whose default expiry starts at call time."""
+    return _build_access_token(claims)
+
+
+@dataclass(frozen=True, slots=True)
+class RejectedAccessTokenCase:
+    """One stable credential-rejection reason and its public HTTP contract."""
+
+    id: str
+    expected_detail: str
+    expected_header_items: tuple[tuple[str, str], ...]
+    claim_items: tuple[tuple[str, object], ...] = ()
+    lifetime: timedelta = _DEFAULT_LIFETIME
+    signing_secret: str = JWT_SECRET_KEY
+
+    @property
+    def expected_headers(self) -> dict[str, str]:
+        return dict(self.expected_header_items)
+
+    def build_token(self) -> str:
+        """Build this rejection token with expiry relative to current time."""
+        return _build_access_token(
+            dict(self.claim_items),
+            lifetime=self.lifetime,
+            signing_secret=self.signing_secret,
+        )
+
+
+_BEARER_HEADERS = (("WWW-Authenticate", "Bearer"),)
+
+REJECTED_ACCESS_TOKEN_CASES = (
+    RejectedAccessTokenCase(
+        "expired",
+        "Token expired",
+        _BEARER_HEADERS + (("Error-Type", "TokenExpired"),),
+        lifetime=-_DEFAULT_LIFETIME,
+    ),
+    RejectedAccessTokenCase(
+        "invalid-signature",
+        "Invalid token",
+        _BEARER_HEADERS + (("Error-Type", "InvalidToken"),),
+        signing_secret="different-signing-secret",
+    ),
+    RejectedAccessTokenCase(
+        "wrong-type",
+        "Invalid token type",
+        _BEARER_HEADERS,
+        (("type", "refresh"),),
+    ),
+    RejectedAccessTokenCase(
+        "invalid-claims",
+        "Invalid token payload",
+        _BEARER_HEADERS,
+        (("sub", ()),),
+    ),
+    RejectedAccessTokenCase(
+        "user-not-found",
+        "User not found",
+        _BEARER_HEADERS,
+        (("sub", "missing-user"),),
+    ),
+)
+
+WRONG_TYPE_ACCESS_TOKEN_CASE = REJECTED_ACCESS_TOKEN_CASES[2]

--- a/tests/web/auth_token_cases.py
+++ b/tests/web/auth_token_cases.py
@@ -13,6 +13,7 @@ _DEFAULT_LIFETIME = timedelta(minutes=5)
 def _build_access_token(
     claims: dict[str, object],
     *,
+    remove_claims: tuple[str, ...] = (),
     lifetime: timedelta = _DEFAULT_LIFETIME,
     signing_secret: str = JWT_SECRET_KEY,
 ) -> str:
@@ -23,12 +24,14 @@ def _build_access_token(
         "exp": datetime.now(timezone.utc) + lifetime,
     }
     payload.update(claims)
+    for claim in remove_claims:
+        payload.pop(claim, None)
     return jwt.encode(payload, signing_secret, algorithm=JWT_ALGORITHM)
 
 
-def build_access_token(**claims: object) -> str:
+def build_access_token(*, remove_claims: tuple[str, ...] = (), **claims: object) -> str:
     """Build an access token whose default expiry starts at call time."""
-    return _build_access_token(claims)
+    return _build_access_token(claims, remove_claims=remove_claims)
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +42,7 @@ class RejectedAccessTokenCase:
     expected_detail: str
     expected_header_items: tuple[tuple[str, str], ...]
     claim_items: tuple[tuple[str, object], ...] = ()
+    remove_claims: tuple[str, ...] = ()
     lifetime: timedelta = _DEFAULT_LIFETIME
     signing_secret: str = JWT_SECRET_KEY
 
@@ -50,6 +54,7 @@ class RejectedAccessTokenCase:
         """Build this rejection token with expiry relative to current time."""
         return _build_access_token(
             dict(self.claim_items),
+            remove_claims=self.remove_claims,
             lifetime=self.lifetime,
             signing_secret=self.signing_secret,
         )

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -1,6 +1,7 @@
 """Authentication dependency contract tests."""
 
 import ast
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -520,23 +521,186 @@ def test_invalid_claims_read_the_bound_dialect_without_pool_checkout() -> None:
     assert raised.value.detail == "Invalid token payload"
 
 
-def test_auth_dependencies_have_no_broad_exception_handler() -> None:
-    """The shared authentication owner cannot collapse operational failures."""
-    source = Path(auth_dependencies.__file__).read_text(encoding="utf-8")
-    handlers = [
-        handler
-        for handler in ast.walk(ast.parse(source))
-        if isinstance(handler, ast.ExceptHandler)
-    ]
+def test_auth_consumer_topology_is_closed_across_source_tree() -> None:
+    """Authentication consumers stay within the reviewed ownership topology."""
+    tracked = {
+        "_resolve_access_token_user",
+        "get_current_user",
+        "get_current_user_optional",
+        "get_user_from_token",
+        "get_user_from_websocket_token",
+        "get_authenticated_user",
+    }
+    auth_file = "web/auth_dependencies.py"
+    websocket_file = "web/api/websocket.py"
+    rejected = ("_AccessTokenRejected",)
+    terminated = ("_WebSocketAuthenticationTerminated",)
+    expected = (
+        (auth_file, "get_current_user", "_resolve_access_token_user", rejected),
+        (
+            auth_file,
+            "get_current_user_optional",
+            "_resolve_access_token_user",
+            rejected,
+        ),
+        (auth_file, "get_user_from_token", "_resolve_access_token_user", rejected),
+        (auth_file, "get_user_from_websocket_token", "get_user_from_token", ()),
+        (
+            "web/api/websocket_auth.py",
+            "_load_websocket_principal_sync",
+            "get_user_from_websocket_token",
+            (),
+        ),
+        (
+            websocket_file,
+            "websocket_chat_endpoint",
+            "get_authenticated_user",
+            terminated,
+        ),
+        (
+            websocket_file,
+            "websocket_builder_chat_endpoint",
+            "get_authenticated_user",
+            terminated,
+        ),
+        (
+            websocket_file,
+            "websocket_build_preview_endpoint",
+            "get_authenticated_user",
+            terminated,
+        ),
+        (
+            "web/api/progress_ws.py",
+            "progress_websocket_endpoint",
+            "get_authenticated_user",
+            terminated,
+        ),
+    )
+    modules = {"xagent.web.auth_dependencies", "xagent.web.api.websocket_auth"}
+    source_root = Path(auth_dependencies.__file__).parents[1]
+    actual: Counter[tuple[str, str, str, tuple[str, ...]]] = Counter()
+    lines: dict[tuple[str, str, str, tuple[str, ...]], list[int]] = {}
+    escapes: list[tuple[tuple[str, str, str, tuple[str, ...]], int]] = []
 
-    def catches_exception(handler: ast.ExceptHandler) -> bool:
-        if isinstance(handler.type, ast.Name):
-            return handler.type.id == "Exception"
-        if isinstance(handler.type, ast.Tuple):
-            return any(
-                isinstance(element, ast.Name) and element.id == "Exception"
-                for element in handler.type.elts
+    def handler_names(node: ast.expr | None) -> tuple[str, ...]:
+        if node is None:
+            return ("<bare>",)
+        if isinstance(node, ast.Tuple):
+            return tuple(name for item in node.elts for name in handler_names(item))
+        return (node.id if isinstance(node, ast.Name) else node.attr,)
+
+    def module_path(node: ast.expr, bases: dict[str, str]) -> str | None:
+        if isinstance(node, ast.Name):
+            return bases.get(node.id)
+        if isinstance(node, ast.Attribute):
+            base = module_path(node.value, bases)
+            return f"{base}.{node.attr}" if base else None
+        return None
+
+    for source_path in source_root.rglob("*.py"):
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        parents = {
+            child: parent
+            for parent in ast.walk(tree)
+            for child in ast.iter_child_nodes(parent)
+        }
+        relative_path = source_path.relative_to(source_root).as_posix()
+        names = {
+            node.name
+            for node in tree.body
+            if relative_path == "web/auth_dependencies.py"
+            and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in tracked
+        }
+        bases: dict[str, str] = {}
+        for node in tree.body:
+            if isinstance(node, ast.ImportFrom):
+                leaf = (node.module or "").rsplit(".", 1)[-1]
+                for alias in node.names:
+                    if (
+                        leaf in {"auth_dependencies", "websocket_auth"}
+                        and alias.name in tracked
+                    ):
+                        if alias.asname:
+                            escapes.append(
+                                (
+                                    (relative_path, "<module>", alias.name, ()),
+                                    alias.lineno,
+                                )
+                            )
+                        else:
+                            names.add(alias.name)
+                    if node.module in {
+                        "xagent.web",
+                        "xagent.web.api",
+                    } and alias.name in {"auth_dependencies", "websocket_auth"}:
+                        bases[alias.asname or alias.name] = (
+                            f"{node.module}.{alias.name}"
+                        )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in modules:
+                        bases[alias.asname or alias.name.split(".")[0]] = (
+                            alias.name if alias.asname else alias.name.split(".")[0]
+                        )
+
+        for node in ast.walk(tree):
+            callee = (
+                node.id if isinstance(node, ast.Name) and node.id in names else None
             )
-        return False
+            if (
+                isinstance(node, ast.Attribute)
+                and module_path(node.value, bases) in modules
+                and node.attr in tracked
+            ):
+                callee = node.attr
+            if callee is None:
+                continue
+            chain = [node]
+            while parent := parents.get(chain[-1]):
+                chain.append(parent)
+            scope = (
+                ".".join(
+                    ancestor.name
+                    for ancestor in reversed(chain)
+                    if isinstance(
+                        ancestor, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                    )
+                )
+                or "<module>"
+            )
+            catch_policy = ()
+            for child, ancestor in zip(chain, chain[1:]):
+                if (
+                    isinstance(ancestor, (ast.Try, ast.TryStar))
+                    and child in ancestor.body
+                ):
+                    catch_policy = tuple(
+                        name
+                        for handler in ancestor.handlers
+                        for name in handler_names(handler.type)
+                    )
+                    break
+            fact = (relative_path, scope, callee, catch_policy)
+            parent = parents.get(node)
+            safe_depends = (
+                callee == "get_current_user"
+                and isinstance(parent, ast.Call)
+                and isinstance(parent.func, ast.Name)
+                and parent.func.id == "Depends"
+                and bool(parent.args)
+                and parent.args[0] is node
+            )
+            if safe_depends:
+                continue
+            if isinstance(parent, ast.Call) and parent.func is node:
+                actual[fact] += 1
+                lines.setdefault(fact, []).append(node.lineno)
+            else:
+                escapes.append((fact, node.lineno))
 
-    assert not any(catches_exception(handler) for handler in handlers)
+    assert not escapes, f"unreviewed first-class callable escapes: {escapes}"
+    assert actual == Counter(expected), (
+        "authentication consumer facts differ: "
+        f"actual={actual}; expected={Counter(expected)}; lines={lines}"
+    )

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -2,21 +2,24 @@
 
 import ast
 from collections import Counter
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
-from jose import jwt
 from sqlalchemy import create_engine, event
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.auth_token_cases import (
+    REJECTED_ACCESS_TOKEN_CASES,
+    RejectedAccessTokenCase,
+)
+from tests.web.auth_token_cases import build_access_token as _access_token
 from xagent.web import auth_dependencies
-from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from xagent.web.auth_dependencies import (
     get_current_user,
     get_current_user_optional,
@@ -57,133 +60,67 @@ def db_session() -> Session:
         engine.dispose()
 
 
-def _access_token(**claims: object) -> str:
-    payload: dict[str, object] = {
-        "type": "access",
-        "sub": "existing-user",
-        "user_id": 1,
-        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
-    }
-    payload.update(claims)
-    return jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
-
-
-@pytest.mark.parametrize(
-    ("token", "detail", "headers"),
-    [
-        (
-            _access_token(exp=datetime.now(timezone.utc) - timedelta(minutes=5)),
-            "Token expired",
-            {"WWW-Authenticate": "Bearer", "Error-Type": "TokenExpired"},
-        ),
-        (
-            jwt.encode(
-                {
-                    "type": "access",
-                    "sub": "existing-user",
-                    "user_id": 1,
-                    "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
-                },
-                "different-signing-secret",
-                algorithm=JWT_ALGORITHM,
-            ),
-            "Invalid token",
-            {"WWW-Authenticate": "Bearer", "Error-Type": "InvalidToken"},
-        ),
-        (
-            _access_token(type="refresh"),
-            "Invalid token type",
-            {"WWW-Authenticate": "Bearer"},
-        ),
-        (
-            _access_token(sub=None),
-            "Invalid token payload",
-            {"WWW-Authenticate": "Bearer"},
-        ),
-        (
-            _access_token(sub=123),
-            "Invalid token payload",
-            {"WWW-Authenticate": "Bearer"},
-        ),
-        (
-            _access_token(user_id=None),
-            "Invalid token payload",
-            {"WWW-Authenticate": "Bearer"},
-        ),
-        (
-            _access_token(user_id="1"),
-            "Invalid token payload",
-            {"WWW-Authenticate": "Bearer"},
-        ),
-        (
-            _access_token(user_id=True),
-            "Invalid token payload",
-            {"WWW-Authenticate": "Bearer"},
-        ),
-        (
-            _access_token(sub="missing-user"),
-            "User not found",
-            {"WWW-Authenticate": "Bearer"},
-        ),
-    ],
-    ids=(
-        "expired",
-        "invalid-signature",
-        "wrong-type",
-        "missing-sub",
-        "wrong-type-sub",
-        "missing-user-id",
-        "wrong-type-user-id",
-        "bool-user-id",
-        "missing-user",
-    ),
-)
+@pytest.mark.parametrize("case", REJECTED_ACCESS_TOKEN_CASES, ids=lambda case: case.id)
 def test_access_token_rejection_matrix_preserves_required_http_contract(
-    db_session: Session, token: str, detail: str, headers: dict[str, str]
+    db_session: Session, case: RejectedAccessTokenCase
 ) -> None:
     """Required HTTP auth exposes its established reason-specific rejection."""
-    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=case.build_token()
+    )
 
     with pytest.raises(HTTPException) as raised:
         get_current_user(credentials, db_session)
 
     assert raised.value.status_code == 401
-    assert raised.value.detail == detail
-    assert raised.value.headers == headers
+    assert raised.value.detail == case.expected_detail
+    assert raised.value.headers == case.expected_headers
 
 
-REJECTED_ACCESS_TOKEN_CASES = (
-    pytest.param(
-        _access_token(exp=datetime.now(timezone.utc) - timedelta(minutes=5)),
-        id="expired",
-    ),
-    pytest.param(
-        jwt.encode(
-            {
-                "type": "access",
-                "sub": "existing-user",
-                "user_id": 1,
-                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
-            },
-            "different-signing-secret",
-            algorithm=JWT_ALGORITHM,
-        ),
-        id="invalid-signature",
-    ),
-    pytest.param(_access_token(type="refresh"), id="wrong-type"),
-    pytest.param(_access_token(sub=[]), id="invalid-claims"),
-    pytest.param(_access_token(sub="missing-user"), id="user-not-found"),
-)
-
-
-@pytest.mark.parametrize("token", REJECTED_ACCESS_TOKEN_CASES)
+@pytest.mark.parametrize("case", REJECTED_ACCESS_TOKEN_CASES, ids=lambda case: case.id)
 def test_optional_auth_rejects_every_credential_reason(
-    db_session: Session, token: str
+    db_session: Session, case: RejectedAccessTokenCase
 ) -> None:
     """Optional authentication suppresses every typed credential rejection."""
-    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=case.build_token()
+    )
 
     assert get_current_user_optional(credentials, db_session) is None
+
+
+@pytest.mark.parametrize(
+    "claims",
+    (
+        {"sub": None},
+        {"sub": 123},
+        {"user_id": None},
+        {"user_id": "1"},
+        {"user_id": True},
+    ),
+    ids=(
+        "missing-sub",
+        "wrong-type-sub",
+        "missing-user-id",
+        "wrong-type-user-id",
+        "bool-user-id",
+    ),
+)
+def test_malformed_identity_claim_shapes_are_rejected_before_any_user_query(
+    db_session: Session, claims: dict[str, object]
+) -> None:
+    """Identity claims with non-bindable types stay credential rejections."""
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=_access_token(**claims)
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        get_current_user(credentials, db_session)
+
+    assert raised.value.status_code == 401
+    assert raised.value.detail == "Invalid token payload"
+    assert raised.value.headers == {"WWW-Authenticate": "Bearer"}
+    assert db_session.info["user_query_count"] == 0
 
 
 @pytest.mark.parametrize("claim", ("exp", "nbf", "iat"))

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -173,6 +173,30 @@ def test_malformed_temporal_claims_are_rejected_before_any_user_query(
     assert db_session.info["user_query_count"] == 0
 
 
+@pytest.mark.parametrize(
+    "claims",
+    (
+        {"iat": [], "exp": float("inf")},
+        {"iat": float("inf"), "exp": []},
+    ),
+    ids=("type-error-before-overflow-error", "overflow-error-before-type-error"),
+)
+def test_mixed_malformed_temporal_claims_are_rejected_before_any_user_query(
+    db_session: Session, claims: dict[str, object]
+) -> None:
+    """A later mixed temporal claim cannot defeat the original error proof."""
+    token = _access_token(**claims)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(HTTPException) as raised:
+        get_current_user(credentials, db_session)
+
+    assert raised.value.status_code == 401
+    assert raised.value.detail == "Invalid token payload"
+    assert raised.value.headers == {"WWW-Authenticate": "Bearer"}
+    assert db_session.info["user_query_count"] == 0
+
+
 @pytest.mark.parametrize("claim", ("exp", "nbf", "iat"))
 def test_numeric_temporal_claims_keep_the_library_accepted_behavior(
     db_session: Session, claim: str

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -651,7 +651,24 @@ def test_auth_consumer_topology_is_closed_across_source_tree() -> None:
                             )
                         else:
                             names.add(alias.name)
-                    if node.module in {
+                    if node.level > 0 and alias.name in {
+                        "auth_dependencies",
+                        "websocket_auth",
+                    }:
+                        if alias.asname:
+                            escapes.append(
+                                (
+                                    (relative_path, "<module>", alias.name, ()),
+                                    alias.lineno,
+                                )
+                            )
+                        else:
+                            bases[alias.name] = (
+                                "xagent.web.auth_dependencies"
+                                if alias.name == "auth_dependencies"
+                                else "xagent.web.api.websocket_auth"
+                            )
+                    elif node.module in {
                         "xagent.web",
                         "xagent.web.api",
                     } and alias.name in {"auth_dependencies", "websocket_auth"}:

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -7,8 +7,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, event
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session, sessionmaker
@@ -93,8 +94,6 @@ def test_optional_auth_rejects_every_credential_reason(
     ("claims", "remove_claims"),
     (
         ({}, ("sub",)),
-        ({"sub": None}, ()),
-        ({"sub": 123}, ()),
         ({}, ("user_id",)),
         ({"user_id": None}, ()),
         ({"user_id": "1"}, ()),
@@ -102,8 +101,6 @@ def test_optional_auth_rejects_every_credential_reason(
     ),
     ids=(
         "absent-sub",
-        "null-sub",
-        "wrong-type-sub",
         "absent-user-id",
         "null-user-id",
         "wrong-type-user-id",
@@ -127,6 +124,26 @@ def test_malformed_identity_claim_shapes_are_rejected_before_any_user_query(
     assert raised.value.status_code == 401
     assert raised.value.detail == "Invalid token payload"
     assert raised.value.headers == {"WWW-Authenticate": "Bearer"}
+    assert db_session.info["user_query_count"] == 0
+
+
+@pytest.mark.parametrize("sub", (None, 123, True), ids=("null", "integer", "boolean"))
+def test_present_non_string_subject_preserves_invalid_token_http_contract(
+    db_session: Session, sub: object
+) -> None:
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=_access_token(sub=sub)
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        get_current_user(credentials, db_session)
+
+    assert raised.value.status_code == 401
+    assert raised.value.detail == "Invalid token"
+    assert raised.value.headers == {
+        "WWW-Authenticate": "Bearer",
+        "Error-Type": "InvalidToken",
+    }
     assert db_session.info["user_query_count"] == 0
 
 
@@ -305,9 +322,11 @@ class _DialectSession:
     def __init__(self, dialect_name: str, user: User | None = None) -> None:
         self._bind = SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
         self._user = user
+        self.bind_count = 0
         self.query_count = 0
 
     def get_bind(self) -> SimpleNamespace:
+        self.bind_count += 1
         return self._bind
 
     def query(self, _model: type[User]) -> "_DialectSession":
@@ -319,6 +338,19 @@ class _DialectSession:
 
     def first(self) -> User | None:
         return self._user
+
+
+def test_wrong_type_user_id_is_rejected_before_reading_database_binding() -> None:
+    db = _DialectSession("sqlite")
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=_access_token(user_id="1")
+    )
+
+    with pytest.raises(HTTPException):
+        get_current_user(credentials, db)  # type: ignore[arg-type]
+
+    assert db.bind_count == 0
+    assert db.query_count == 0
 
 
 @pytest.mark.parametrize(
@@ -442,6 +474,42 @@ def test_token_adapter_propagates_real_queue_pool_checkout_timeout() -> None:
 def test_optional_direct_none_returns_none(db_session: Session) -> None:
     """The optional helper preserves its direct no-credential contract."""
     assert get_current_user_optional(None, db_session) is None
+
+
+@pytest.mark.parametrize(
+    "headers",
+    ({}, {"Authorization": "Bearer "}, {"Authorization": "Basic abc"}),
+    ids=("missing", "empty-bearer", "basic"),
+)
+def test_optional_dependency_treats_non_credentials_as_anonymous(
+    db_session: Session, headers: dict[str, str]
+) -> None:
+    app = FastAPI()
+
+    @app.get("/optional")
+    def optional_endpoint(
+        user: User | None = Depends(get_current_user_optional),
+    ) -> dict[str, int | None]:
+        return {"user_id": user.id if user is not None else None}
+
+    @app.get("/required")
+    def required_endpoint(user: User = Depends(get_current_user)) -> dict[str, int]:
+        return {"user_id": user.id}
+
+    app.dependency_overrides[auth_dependencies.get_db] = lambda: db_session
+
+    client = TestClient(app)
+    assert client.get("/optional", headers=headers).json() == {"user_id": None}
+    assert client.get("/required", headers=headers).status_code == 403
+
+
+@pytest.mark.parametrize("helper", (get_user_from_token, get_user_from_websocket_token))
+@pytest.mark.parametrize("token", ("", "not-a-jwt"), ids=("empty", "garbage"))
+def test_direct_token_helpers_reject_malformed_input_without_query(
+    db_session: Session, helper: object, token: str
+) -> None:
+    assert helper(token, db_session) is None  # type: ignore[operator]
+    assert db_session.info["user_query_count"] == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -90,28 +90,35 @@ def test_optional_auth_rejects_every_credential_reason(
 
 
 @pytest.mark.parametrize(
-    "claims",
+    ("claims", "remove_claims"),
     (
-        {"sub": None},
-        {"sub": 123},
-        {"user_id": None},
-        {"user_id": "1"},
-        {"user_id": True},
+        ({}, ("sub",)),
+        ({"sub": None}, ()),
+        ({"sub": 123}, ()),
+        ({}, ("user_id",)),
+        ({"user_id": None}, ()),
+        ({"user_id": "1"}, ()),
+        ({"user_id": True}, ()),
     ),
     ids=(
-        "missing-sub",
+        "absent-sub",
+        "null-sub",
         "wrong-type-sub",
-        "missing-user-id",
+        "absent-user-id",
+        "null-user-id",
         "wrong-type-user-id",
         "bool-user-id",
     ),
 )
 def test_malformed_identity_claim_shapes_are_rejected_before_any_user_query(
-    db_session: Session, claims: dict[str, object]
+    db_session: Session,
+    claims: dict[str, object],
+    remove_claims: tuple[str, ...],
 ) -> None:
     """Identity claims with non-bindable types stay credential rejections."""
     credentials = HTTPAuthorizationCredentials(
-        scheme="Bearer", credentials=_access_token(**claims)
+        scheme="Bearer",
+        credentials=_access_token(remove_claims=remove_claims, **claims),
     )
 
     with pytest.raises(HTTPException) as raised:
@@ -584,6 +591,49 @@ def test_auth_consumer_topology_is_closed_across_source_tree() -> None:
             and node.name in tracked
         }
         bases: dict[str, str] = {}
+        for node in ast.walk(tree):
+            if node in tree.body:
+                continue
+            if isinstance(node, ast.ImportFrom):
+                leaf = (node.module or "").rsplit(".", 1)[-1]
+                for alias in node.names:
+                    tracked_symbol = (
+                        leaf in {"auth_dependencies", "websocket_auth"}
+                        and alias.name in tracked
+                    )
+                    tracked_module = alias.name in {
+                        "auth_dependencies",
+                        "websocket_auth",
+                    } and (
+                        node.level > 0
+                        or node.module in {"xagent.web", "xagent.web.api"}
+                    )
+                    if tracked_symbol or tracked_module:
+                        escapes.append(
+                            (
+                                (
+                                    relative_path,
+                                    "<local import>",
+                                    alias.name,
+                                    (),
+                                ),
+                                alias.lineno,
+                            )
+                        )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in modules:
+                        escapes.append(
+                            (
+                                (
+                                    relative_path,
+                                    "<local import>",
+                                    alias.name,
+                                    (),
+                                ),
+                                alias.lineno,
+                            )
+                        )
         for node in tree.body:
             if isinstance(node, ast.ImportFrom):
                 leaf = (node.module or "").rsplit(".", 1)[-1]

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -1,0 +1,494 @@
+"""Authentication dependency contract tests."""
+
+import ast
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import jwt
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import QueuePool
+
+from xagent.web import auth_dependencies
+from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+from xagent.web.auth_dependencies import (
+    get_current_user,
+    get_current_user_optional,
+    get_user_from_token,
+    get_user_from_websocket_token,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.user import User
+
+
+@pytest.fixture
+def db_session() -> Session:
+    """Provide a SQLite session with one matching user."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    session.add(
+        User(
+            id=1,
+            username="existing-user",
+            email="existing@example.com",
+            password_hash="not-used-by-auth-dependencies",
+        )
+    )
+    session.commit()
+    session.info["user_query_count"] = 0
+
+    def count_user_queries(*_args: object) -> None:
+        session.info["user_query_count"] += 1
+
+    event.listen(engine, "before_cursor_execute", count_user_queries)
+    try:
+        yield session
+    finally:
+        event.remove(engine, "before_cursor_execute", count_user_queries)
+        session.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def _access_token(**claims: object) -> str:
+    payload: dict[str, object] = {
+        "type": "access",
+        "sub": "existing-user",
+        "user_id": 1,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+    payload.update(claims)
+    return jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+
+@pytest.mark.parametrize(
+    ("token", "detail", "headers"),
+    [
+        (
+            _access_token(exp=datetime.now(timezone.utc) - timedelta(minutes=5)),
+            "Token expired",
+            {"WWW-Authenticate": "Bearer", "Error-Type": "TokenExpired"},
+        ),
+        (
+            jwt.encode(
+                {
+                    "type": "access",
+                    "sub": "existing-user",
+                    "user_id": 1,
+                    "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+                },
+                "different-signing-secret",
+                algorithm=JWT_ALGORITHM,
+            ),
+            "Invalid token",
+            {"WWW-Authenticate": "Bearer", "Error-Type": "InvalidToken"},
+        ),
+        (
+            _access_token(type="refresh"),
+            "Invalid token type",
+            {"WWW-Authenticate": "Bearer"},
+        ),
+        (
+            _access_token(sub=None),
+            "Invalid token payload",
+            {"WWW-Authenticate": "Bearer"},
+        ),
+        (
+            _access_token(sub=123),
+            "Invalid token payload",
+            {"WWW-Authenticate": "Bearer"},
+        ),
+        (
+            _access_token(user_id=None),
+            "Invalid token payload",
+            {"WWW-Authenticate": "Bearer"},
+        ),
+        (
+            _access_token(user_id="1"),
+            "Invalid token payload",
+            {"WWW-Authenticate": "Bearer"},
+        ),
+        (
+            _access_token(user_id=True),
+            "Invalid token payload",
+            {"WWW-Authenticate": "Bearer"},
+        ),
+        (
+            _access_token(sub="missing-user"),
+            "User not found",
+            {"WWW-Authenticate": "Bearer"},
+        ),
+    ],
+    ids=(
+        "expired",
+        "invalid-signature",
+        "wrong-type",
+        "missing-sub",
+        "wrong-type-sub",
+        "missing-user-id",
+        "wrong-type-user-id",
+        "bool-user-id",
+        "missing-user",
+    ),
+)
+def test_access_token_rejection_matrix_preserves_required_http_contract(
+    db_session: Session, token: str, detail: str, headers: dict[str, str]
+) -> None:
+    """Required HTTP auth exposes its established reason-specific rejection."""
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(HTTPException) as raised:
+        get_current_user(credentials, db_session)
+
+    assert raised.value.status_code == 401
+    assert raised.value.detail == detail
+    assert raised.value.headers == headers
+
+
+@pytest.mark.parametrize("claim", ("exp", "nbf", "iat"))
+@pytest.mark.parametrize(
+    "value",
+    ([], {}, None, float("inf"), float("-inf")),
+    ids=("list", "dict", "null", "positive-infinity", "negative-infinity"),
+)
+def test_malformed_temporal_claims_are_rejected_before_any_user_query(
+    db_session: Session, claim: str, value: object
+) -> None:
+    """Dependency conversion failures in signed temporal claims are credentials."""
+    token = _access_token(**{claim: value})
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(HTTPException) as raised:
+        get_current_user(credentials, db_session)
+
+    assert raised.value.status_code == 401
+    assert raised.value.detail == "Invalid token payload"
+    assert raised.value.headers == {"WWW-Authenticate": "Bearer"}
+    assert db_session.info["user_query_count"] == 0
+
+
+@pytest.mark.parametrize("claim", ("exp", "nbf", "iat"))
+def test_numeric_temporal_claims_keep_the_library_accepted_behavior(
+    db_session: Session, claim: str
+) -> None:
+    """Integer NumericDate values continue through verified token validation."""
+    now = int(datetime.now(timezone.utc).timestamp())
+    value = now + 300 if claim == "exp" else now - 300
+    token = _access_token(**{claim: value})
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    user = get_current_user(credentials, db_session)
+
+    assert user.username == "existing-user"
+    assert db_session.info["user_query_count"] == 1
+
+
+@pytest.mark.parametrize("exception_type", (TypeError, OverflowError))
+def test_unrelated_decode_type_errors_propagate_by_identity(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_type: type[Exception],
+) -> None:
+    """Only proven temporal-claim conversion failures are credential rejections."""
+    original = exception_type("unrelated decode failure")
+
+    def raise_original(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise original
+
+    monkeypatch.setattr(auth_dependencies.jwt, "decode", raise_original)
+    monkeypatch.setattr(
+        auth_dependencies.jwt, "get_unverified_claims", lambda _token: {"aud": "x"}
+    )
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+
+    with pytest.raises(exception_type) as raised:
+        get_current_user(credentials, db_session)
+
+    assert raised.value is original
+    assert db_session.info["user_query_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("username", "user_id"),
+    (
+        ("", 0),
+        ("long-" * 20, -1),
+        ("sqlite\x00nul", 2**31),
+        ("中文-😀", 2**63 - 1),
+        ("signed-64-minimum", -(2**63)),
+    ),
+    ids=("empty", "long", "nul", "unicode-and-signed-64-max", "signed-64-min"),
+)
+def test_sqlite_bindable_claims_reach_matching_persisted_users(
+    db_session: Session, username: str, user_id: int
+) -> None:
+    """SQLite-compatible claims preserve real persisted user identities."""
+    db_session.add(
+        User(
+            id=user_id,
+            username=username,
+            email=f"sqlite-{user_id}@example.com",
+            password_hash="not-used-by-auth-dependencies",
+        )
+    )
+    db_session.commit()
+    db_session.info["user_query_count"] = 0
+    token = _access_token(sub=username, user_id=user_id)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    user = get_current_user(credentials, db_session)
+
+    assert user.id == user_id
+    assert user.username == username
+    assert db_session.info["user_query_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "claims",
+    (
+        {"user_id": 2**63},
+        {"user_id": -(2**63) - 1},
+        {"sub": "\ud800"},
+    ),
+    ids=("above-signed-64", "below-signed-64", "lone-surrogate"),
+)
+def test_sqlite_unbindable_claims_are_rejected_without_a_user_query(
+    db_session: Session, claims: dict[str, object]
+) -> None:
+    """SQLite claim values outside the driver's bindability contract are rejected."""
+    token = _access_token(**claims)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(HTTPException) as raised:
+        get_current_user(credentials, db_session)
+
+    assert raised.value.detail == "Invalid token payload"
+    assert db_session.info["user_query_count"] == 0
+
+
+class _DialectSession:
+    """A query-counting Session shape with an already-bound dialect."""
+
+    def __init__(self, dialect_name: str, user: User | None = None) -> None:
+        self._bind = SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
+        self._user = user
+        self.query_count = 0
+
+    def get_bind(self) -> SimpleNamespace:
+        return self._bind
+
+    def query(self, _model: type[User]) -> "_DialectSession":
+        self.query_count += 1
+        return self
+
+    def filter(self, *_conditions: object) -> "_DialectSession":
+        return self
+
+    def first(self) -> User | None:
+        return self._user
+
+
+@pytest.mark.parametrize(
+    "claims",
+    (
+        {"user_id": 2**31},
+        {"user_id": -(2**31) - 1},
+        {"sub": "postgresql\x00nul"},
+        {"sub": "\udfff"},
+    ),
+    ids=("above-signed-32", "below-signed-32", "nul", "lone-surrogate"),
+)
+def test_postgresql_unbindable_claims_are_rejected_without_a_user_query(
+    claims: dict[str, object],
+) -> None:
+    """PostgreSQL-specific unbindable claims do not enter the User query."""
+    db = _DialectSession("postgresql")
+    token = _access_token(**claims)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(HTTPException) as raised:
+        get_current_user(credentials, db)  # type: ignore[arg-type]
+
+    assert raised.value.detail == "Invalid token payload"
+    assert db.query_count == 0
+
+
+@pytest.mark.parametrize("username", ("", "long-" * 20))
+def test_postgresql_empty_and_long_claims_remain_queryable(username: str) -> None:
+    """PostgreSQL does not impose unsupported empty or length claim rules."""
+    expected = User(
+        id=2**31 - 1,
+        username=username,
+        email="postgresql@example.com",
+        password_hash="not-used-by-auth-dependencies",
+    )
+    db = _DialectSession("postgresql", expected)
+    token = _access_token(sub=username, user_id=2**31 - 1)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    assert get_current_user(credentials, db) is expected  # type: ignore[arg-type]
+    assert db.query_count == 1
+
+
+def test_unrecognized_dialect_runs_the_query_and_propagates_backend_failure() -> None:
+    """Unknown dialects retain operational behavior instead of invented limits."""
+    original = RuntimeError("backend-specific failure")
+
+    class FailingDialectSession(_DialectSession):
+        def query(self, _model: type[User]) -> "_DialectSession":
+            self.query_count += 1
+            raise original
+
+    db = FailingDialectSession("unrecognized")
+    token = _access_token(sub="\x00still-queryable", user_id=2**63)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(RuntimeError) as raised:
+        get_current_user(credentials, db)  # type: ignore[arg-type]
+
+    assert raised.value is original
+    assert db.query_count == 1
+
+
+@pytest.mark.parametrize(
+    "adapter",
+    (
+        lambda credentials, db: get_current_user(credentials, db),
+        lambda credentials, db: get_current_user_optional(credentials, db),
+        lambda credentials, db: get_user_from_token(credentials.credentials, db),
+        lambda credentials, db: get_user_from_websocket_token(
+            credentials.credentials, db
+        ),
+    ),
+    ids=("required", "optional", "token", "websocket-token-alias"),
+)
+def test_auth_adapters_propagate_database_pool_timeout_by_identity(
+    adapter: object,
+) -> None:
+    """Operational database failures never become an authentication absence."""
+    original = SQLAlchemyTimeoutError("auth pool timeout", None, None)
+
+    class TimeoutSession(_DialectSession):
+        def query(self, _model: type[User]) -> "_DialectSession":
+            self.query_count += 1
+            raise original
+
+    db = TimeoutSession("sqlite")
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=_access_token()
+    )
+
+    with pytest.raises(SQLAlchemyTimeoutError) as raised:
+        adapter(credentials, db)  # type: ignore[operator,arg-type]
+
+    assert raised.value is original
+    assert db.query_count == 1
+
+
+def test_token_adapter_propagates_real_queue_pool_checkout_timeout() -> None:
+    """A real exhausted pool stays on the operational exception channel."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.01,
+    )
+    held_connection = engine.connect()
+    session = sessionmaker(bind=engine)()
+    try:
+        with pytest.raises(SQLAlchemyTimeoutError):
+            get_user_from_token(_access_token(), session)
+    finally:
+        session.close()
+        held_connection.close()
+        engine.dispose()
+
+
+def test_optional_direct_none_returns_none(db_session: Session) -> None:
+    """The optional helper preserves its direct no-credential contract."""
+    assert get_current_user_optional(None, db_session) is None
+
+
+@pytest.mark.parametrize(
+    "adapter",
+    (
+        lambda credentials, db: get_current_user(credentials, db),
+        lambda credentials, db: get_current_user_optional(credentials, db),
+        lambda credentials, db: get_user_from_token(
+            f"Bearer {credentials.credentials}", db
+        ),
+        lambda credentials, db: get_user_from_websocket_token(
+            credentials.credentials, db
+        ),
+    ),
+    ids=("required", "optional", "token-bearer-prefix", "websocket-token-alias"),
+)
+def test_valid_access_token_returns_matching_user_across_adapters(
+    db_session: Session, adapter: object
+) -> None:
+    """All public access-token adapters share the same successful resolution."""
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=_access_token()
+    )
+
+    user = adapter(credentials, db_session)  # type: ignore[operator]
+
+    assert user is not None
+    assert user.id == 1
+    assert user.username == "existing-user"
+
+
+def test_invalid_claims_read_the_bound_dialect_without_pool_checkout() -> None:
+    """Pre-query rejection inspects Session binding without acquiring a connection."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=0.01,
+    )
+    held_connection = engine.connect()
+    session = sessionmaker(bind=engine)()
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials=_access_token(user_id=2**63)
+    )
+    try:
+        with pytest.raises(HTTPException) as raised:
+            get_current_user(credentials, session)
+    finally:
+        session.close()
+        held_connection.close()
+        engine.dispose()
+
+    assert raised.value.detail == "Invalid token payload"
+
+
+def test_auth_dependencies_have_no_broad_exception_handler() -> None:
+    """The shared authentication owner cannot collapse operational failures."""
+    source = Path(auth_dependencies.__file__).read_text(encoding="utf-8")
+    handlers = [
+        handler
+        for handler in ast.walk(ast.parse(source))
+        if isinstance(handler, ast.ExceptHandler)
+    ]
+
+    def catches_exception(handler: ast.ExceptHandler) -> bool:
+        if isinstance(handler.type, ast.Name):
+            return handler.type.id == "Exception"
+        if isinstance(handler.type, ast.Tuple):
+            return any(
+                isinstance(element, ast.Name) and element.id == "Exception"
+                for element in handler.type.elts
+            )
+        return False
+
+    assert not any(catches_exception(handler) for handler in handlers)

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -21,6 +21,7 @@ from tests.web.auth_token_cases import (
 )
 from tests.web.auth_token_cases import build_access_token as _access_token
 from xagent.web import auth_dependencies
+from xagent.web.app import global_exception_handler
 from xagent.web.auth_dependencies import (
     get_current_user,
     get_current_user_optional,
@@ -477,14 +478,32 @@ def test_optional_direct_none_returns_none(db_session: Session) -> None:
 
 
 @pytest.mark.parametrize(
-    "headers",
-    ({}, {"Authorization": "Bearer "}, {"Authorization": "Basic abc"}),
-    ids=("missing", "empty-bearer", "basic"),
+    ("dependency_kind", "credential_kind", "expected_status"),
+    (
+        ("required", "missing", (401, 403)),
+        ("required", "empty-bearer", (401, 403)),
+        ("required", "basic", (401, 403)),
+        ("optional", "missing", (200,)),
+        ("optional", "empty-bearer", (200,)),
+        ("optional", "basic", (200,)),
+        ("required", "valid", (500,)),
+        ("optional", "valid", (500,)),
+    ),
 )
-def test_optional_dependency_treats_non_credentials_as_anonymous(
-    db_session: Session, headers: dict[str, str]
+def test_fastapi_auth_dependencies_preserve_framework_rejection_and_safe_pool_failure(
+    dependency_kind: str,
+    credential_kind: str,
+    expected_status: tuple[int, ...],
 ) -> None:
+    driver_message = "database pool driver detail"
+
+    class TimeoutSession(_DialectSession):
+        def query(self, _model: type[User]) -> "_DialectSession":
+            self.query_count += 1
+            raise SQLAlchemyTimeoutError(driver_message, None, None)
+
     app = FastAPI()
+    app.add_exception_handler(Exception, global_exception_handler)
 
     @app.get("/optional")
     def optional_endpoint(
@@ -496,11 +515,25 @@ def test_optional_dependency_treats_non_credentials_as_anonymous(
     def required_endpoint(user: User = Depends(get_current_user)) -> dict[str, int]:
         return {"user_id": user.id}
 
-    app.dependency_overrides[auth_dependencies.get_db] = lambda: db_session
+    app.dependency_overrides[auth_dependencies.get_db] = lambda: TimeoutSession(
+        "sqlite"
+    )
 
-    client = TestClient(app)
-    assert client.get("/optional", headers=headers).json() == {"user_id": None}
-    assert client.get("/required", headers=headers).status_code == 403
+    headers = {
+        "missing": {},
+        "empty-bearer": {"Authorization": "Bearer "},
+        "basic": {"Authorization": "Basic abc"},
+        "valid": {"Authorization": f"Bearer {_access_token()}"},
+    }[credential_kind]
+    path = f"/{dependency_kind}"
+    response = TestClient(app, raise_server_exceptions=False).get(path, headers=headers)
+
+    assert response.status_code in expected_status
+    if dependency_kind == "optional" and credential_kind != "valid":
+        assert response.json() == {"user_id": None}
+    if credential_kind == "valid":
+        assert driver_message not in response.text
+        assert "Traceback" not in response.text
 
 
 @pytest.mark.parametrize("helper", (get_user_from_token, get_user_from_websocket_token))

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -152,6 +152,40 @@ def test_access_token_rejection_matrix_preserves_required_http_contract(
     assert raised.value.headers == headers
 
 
+REJECTED_ACCESS_TOKEN_CASES = (
+    pytest.param(
+        _access_token(exp=datetime.now(timezone.utc) - timedelta(minutes=5)),
+        id="expired",
+    ),
+    pytest.param(
+        jwt.encode(
+            {
+                "type": "access",
+                "sub": "existing-user",
+                "user_id": 1,
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            "different-signing-secret",
+            algorithm=JWT_ALGORITHM,
+        ),
+        id="invalid-signature",
+    ),
+    pytest.param(_access_token(type="refresh"), id="wrong-type"),
+    pytest.param(_access_token(sub=[]), id="invalid-claims"),
+    pytest.param(_access_token(sub="missing-user"), id="user-not-found"),
+)
+
+
+@pytest.mark.parametrize("token", REJECTED_ACCESS_TOKEN_CASES)
+def test_optional_auth_rejects_every_credential_reason(
+    db_session: Session, token: str
+) -> None:
+    """Optional authentication suppresses every typed credential rejection."""
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    assert get_current_user_optional(credentials, db_session) is None
+
+
 @pytest.mark.parametrize("claim", ("exp", "nbf", "iat"))
 @pytest.mark.parametrize(
     "value",

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -197,6 +197,30 @@ def test_mixed_malformed_temporal_claims_are_rejected_before_any_user_query(
     assert db_session.info["user_query_count"] == 0
 
 
+@pytest.mark.parametrize(
+    "claims",
+    (
+        {"iat": [], "exp": "not-a-number"},
+        {"iat": float("inf"), "exp": "not-a-number"},
+    ),
+    ids=("type-error-before-value-error", "overflow-error-before-value-error"),
+)
+def test_mixed_temporal_claims_preserve_original_error_proof_after_value_error(
+    db_session: Session, claims: dict[str, object]
+) -> None:
+    """A dependency-handled temporal ValueError cannot replace the original error."""
+    token = _access_token(**claims)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with pytest.raises(HTTPException) as raised:
+        get_current_user(credentials, db_session)
+
+    assert raised.value.status_code == 401
+    assert raised.value.detail == "Invalid token payload"
+    assert raised.value.headers == {"WWW-Authenticate": "Bearer"}
+    assert db_session.info["user_query_count"] == 0
+
+
 @pytest.mark.parametrize("claim", ("exp", "nbf", "iat"))
 def test_numeric_temporal_claims_keep_the_library_accepted_behavior(
     db_session: Session, claim: str

--- a/tests/web/test_user_context.py
+++ b/tests/web/test_user_context.py
@@ -1,0 +1,21 @@
+"""Structural and behavior pins for MCP user-context utilities."""
+
+from xagent.web import user_context
+
+
+def test_user_context_module_removes_request_auth_helpers_and_preserves_utilities(
+    monkeypatch,
+) -> None:
+    """Only explicit context and access utilities remain at this boundary."""
+    assert not hasattr(user_context, "get_user_context_from_request")
+    assert not hasattr(user_context, "create_user_context")
+
+    monkeypatch.setenv("XAGENT_USER_ID", "original-user")
+    context = user_context.UserContext("tool-user")
+    with context.set_context():
+        assert context.get_current_user() == "tool-user"
+    assert context.get_current_user() == "original-user"
+
+    assert user_context.validate_user_access(None, ["system"]) is True
+    assert user_context.validate_user_access("tool-user", None) is True
+    assert user_context.validate_user_access("tool-user", ["other-user"]) is False

--- a/tests/web/tools/test_webtoolconfig_identity.py
+++ b/tests/web/tools/test_webtoolconfig_identity.py
@@ -6,6 +6,9 @@ silently widened to admin scope by the request.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from xagent.web import auth_dependencies
 from xagent.web.tools.config import WebToolConfig
@@ -69,7 +72,61 @@ def test_identity_free_config_ignores_request_authentication(monkeypatch) -> Non
     cfg = WebToolConfig(db=database, request=request)
 
     assert cfg.get_user_id() is None
+    assert cfg.is_admin() is False
     assert token_helper_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("builder", ["unavailable", "executable"])
+async def test_mcp_config_builders_require_an_explicit_user_identity(
+    builder: str,
+) -> None:
+    cfg = WebToolConfig(db=None, request=None, user_id=None)
+    server = SimpleNamespace(
+        id=1,
+        name="Example",
+        description=None,
+        transport="unsupported-test-transport",
+        managed="external",
+        concurrency_safe=False,
+        concurrent_tools=[],
+    )
+
+    with pytest.raises(RuntimeError, match="require a user identity"):
+        if builder == "unavailable":
+            cfg._build_unavailable_mcp_config(
+                server=server, reason="config_load_failed"
+            )
+        else:
+            await cfg._build_mcp_server_config(
+                server=server,
+                user_env_by_id={},
+                shared_env_by_id={},
+                env_source_by_id={},
+            )
+
+
+@pytest.mark.asyncio
+async def test_identity_free_mcp_load_returns_before_cache_or_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = WebToolConfig(db=object(), request=None, user_id=None, include_mcp_tools=True)
+    include_mcp_tools = MagicMock()
+    include_mcp_tools.__bool__.side_effect = AssertionError(
+        "include flag must not be read"
+    )
+    cfg._include_mcp_tools = include_mcp_tools
+    cfg._cached_mcp_configs = [{"user_id": "stale"}]
+    load = AsyncMock()
+    monkeypatch.setattr(cfg, "_load_mcp_server_configs", load)
+    monkeypatch.setattr(
+        cfg,
+        "_mcp_config_cache_is_valid",
+        MagicMock(side_effect=AssertionError("cache must not be read")),
+    )
+
+    assert await cfg.get_mcp_server_configs() == []
+    load.assert_not_awaited()
 
 
 def test_skill_scope_context_does_not_retain_request_resources() -> None:

--- a/tests/web/tools/test_webtoolconfig_identity.py
+++ b/tests/web/tools/test_webtoolconfig_identity.py
@@ -7,6 +7,7 @@ silently widened to admin scope by the request.
 
 from types import SimpleNamespace
 
+from xagent.web import auth_dependencies
 from xagent.web.tools.config import WebToolConfig
 
 
@@ -45,6 +46,30 @@ def test_minimal_request_without_user_is_not_admin() -> None:
     non-admin without raising / logging a spurious warning."""
     cfg = WebToolConfig(db=None, request=SimpleNamespace(), user_id=5)
     assert cfg.is_admin() is False
+
+
+def test_identity_free_config_ignores_request_authentication(monkeypatch) -> None:
+    """Identity-free configuration must not derive a user from its request."""
+    token_helper_calls: list[tuple[object, object]] = []
+
+    def unexpected_token_helper(token: object, db: object) -> None:
+        token_helper_calls.append((token, db))
+        raise AssertionError("identity-free config must not authenticate a request")
+
+    request = SimpleNamespace(
+        headers={"authorization": "Bearer request-token"},
+        query_params={"token": "request-token"},
+        user=SimpleNamespace(id=77, is_admin=True),
+    )
+    database = object()
+    monkeypatch.setattr(
+        auth_dependencies, "get_user_from_websocket_token", unexpected_token_helper
+    )
+
+    cfg = WebToolConfig(db=database, request=request)
+
+    assert cfg.get_user_id() is None
+    assert token_helper_calls == []
 
 
 def test_skill_scope_context_does_not_retain_request_resources() -> None:


### PR DESCRIPTION
## Summary

- distinguish expected credential rejection from database and runtime failures at the shared authentication owners
- preserve infrastructure exceptions across required, optional, token, main WebSocket, and public Widget/Share authentication paths
- project authentication infrastructure failures through the existing sanitized HTTP 500 boundary, a pre-handshake WebSocket HTTP 503 denial, or an accepted-WebSocket 1011 close while retaining established credential and access-denial responses
- prevent identity-free tool configuration from inheriting admin privilege or emitting an MCP isolation identity

## Root cause

Broad exception handling collapsed database checkout, query, deployment, and runtime failures into invalid credentials, anonymous users, or WebSocket authentication rejection. Optional HTTP authentication also used the required bearer scheme, so requests without bearer credentials were rejected before the optional dependency ran. Tool configuration could derive privilege or serialize an isolation key without an explicit user identity.

## Behavior

- expired, invalid, wrong-type, malformed, missing-user, and missing credentials keep their established HTTP details and headers
- required, optional, and direct token helpers propagate infrastructure failures instead of converting them to 401 or `None`
- optional authentication treats missing, empty Bearer, and non-Bearer headers as anonymous; required authentication retains framework rejection
- main authenticated WebSockets use a sanitized pre-handshake 503 or extensionless 1011 response for infrastructure failures
- public Widget/Share WebSockets preserve credential and access denials as 4003, while initial and per-message infrastructure failures close accepted sockets with 1011
- all signed public IDs are exact integers before binding lookup and are range-checked for SQLite/PostgreSQL before query; workforce-first selection is unchanged
- identity-free `WebToolConfig` instances are non-admin and return no MCP configs before cache, database, or resolver work
- client responses and structured log context exclude credentials, query strings, database messages, and tracebacks; server logs retain the original traceback for diagnosis

## Verification

- 427 focused and adjacent authentication, WebSocket, public-chat, tool-identity, MCP, and auth-API tests passed
- mutation checks covered rejection taxonomy, optional FastAPI dependency behavior, public resolver exception identity, every query-bound public ID, initial/per-message 1011 projection, `extensions=None`, and no-identity tool configuration
- changed-file pre-commit hooks, Ruff, formatting, mypy, isort, codespell, and diff checks passed
- SQLite runtime and PostgreSQL dialect/driver bindability cases are covered; a live PostgreSQL service was not available locally

## Scope

The access-token classifier, public credential owners, WebSocket transport projection, and identity-isolation boundaries form one failure-semantics change and are intended to land atomically. No frontend, schema, migration, retry, or public API shape changes are included.

Closes #930
