### PR TITLE
feat(interactions): extend task deletion and checkpoint pruning to interaction rows

### DIFF
--- a/src/xagent/web/api/admin_users.py
+++ b/src/xagent/web/api/admin_users.py
@@ -74,6 +74,14 @@ def _purge_user_task_rows(db: Session, *, user_id: int) -> None:
     ``ON DELETE SET NULL`` that a still-active row's CHECK forbids -- so
     they must go after the pointer NULL-first and before the
     ``trace_events`` delete.
+
+    This path holds no lease and takes no row fence, matching how it
+    already treats every other child table; the interaction rows inherit
+    that shape. If a concurrent writer turns a row active between the
+    interaction delete and the ``trace_events`` delete, the failure mode
+    is one loud ``IntegrityError`` (the active-anchor CHECK) rolling back
+    the whole purge transaction with no partial state -- retrying the
+    deletion is the complete remedy.
     """
 
     task_ids = select(Task.id).where(Task.user_id == user_id).scalar_subquery()

--- a/src/xagent/web/api/admin_users.py
+++ b/src/xagent/web/api/admin_users.py
@@ -20,10 +20,12 @@ from ..models.task import (
     TraceEvent,
     TraceMessageBlob,
 )
+from ..models.task_interaction import TaskInteractionRequest
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
 from ..schemas.user import UserListResponse, UserResponse
 from ..services.model_store import ModelStore
+from ..services.task_interaction_schema import interaction_requests_table_exists
 from ..services.task_runtime import (
     TaskRuntimeExtensionError,
     delete_task_extensions,
@@ -66,7 +68,12 @@ def _purge_user_task_rows(db: Session, *, user_id: int) -> None:
     carries ``ON DELETE`` clauses. ``tasks`` itself is also referenced --
     ``last_checkpoint_trace_event_id`` FKs to ``trace_events.id`` -- so the
     pointer columns are NULLed first, before the ``trace_events`` delete
-    below.
+    below. ``task_interaction_requests`` rows sit on both ordering
+    obligations at once: they reference ``tasks.id`` directly, and their
+    ``resume_trace_event_id`` references ``trace_events.id`` through an
+    ``ON DELETE SET NULL`` that a still-active row's CHECK forbids -- so
+    they must go after the pointer NULL-first and before the
+    ``trace_events`` delete.
     """
 
     task_ids = select(Task.id).where(Task.user_id == user_id).scalar_subquery()
@@ -85,6 +92,19 @@ def _purge_user_task_rows(db: Session, *, user_id: int) -> None:
         },
         synchronize_session=False,
     )
+
+    # Interaction rows go before the trace_events delete below, for the same
+    # reason and with the same consequence as in purge_task_rows: the
+    # resume anchor's ON DELETE SET NULL would otherwise violate
+    # ck_task_interaction_requests_active_anchor on every active row and
+    # fail the whole user deletion.
+    #
+    # A separate statement rather than an entry in the loop below: the loop
+    # is unconditional, and this delete is gated on the table existing.
+    if interaction_requests_table_exists(db):
+        db.query(TaskInteractionRequest).filter(
+            TaskInteractionRequest.task_id.in_(task_ids)
+        ).delete(synchronize_session=False)
 
     # Children without a DB-level ``ON DELETE`` clause -- these are the rows a
     # bare ``DELETE FROM tasks`` would strand or fail on under strict FKs.

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -915,6 +915,15 @@ class DatabaseTraceHandler(BaseTraceHandler):
             # delete would leave a steady state with nothing to prune unable
             # to clear the signal at all.
             clear_degradation(CHECKPOINT_PRUNE_FAILED)
+            if not stale_rows:
+                # Nothing ranks outside the window, so no protection set is
+                # needed to decide there is nothing to delete: skip the
+                # schema gate and the interaction-anchor query below.
+                # stale_ids is a filtered subset of stale_rows, so an empty
+                # stale_rows always reaches the same early return further
+                # down. Placed after the clear above so the healthy-attempt
+                # signal still fires on every write.
+                return
             # Protection set, second source: a trace row anchored by an
             # ACTIVE interaction row must survive retention, or answering
             # that interaction later would find no checkpoint to resume
@@ -992,7 +1001,8 @@ class DatabaseTraceHandler(BaseTraceHandler):
             # and cannot raise this -- that changes when the interaction
             # table's migration lands, whose rows enforce their CHECK on
             # upgraded SQLite too; a freshly created SQLite database
-            # (create_all, e.g. tests) has the FK and can. Under stricter isolation levels the same race can instead
+            # (create_all, e.g. tests) has the FK and can. Under stricter
+            # isolation levels the same race can instead
             # surface as psycopg2's SerializationFailure or DeadlockDetected,
             # both of which SQLAlchemy wraps in OperationalError, not
             # IntegrityError -- catch both so this retention path degrades

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -982,10 +982,17 @@ class DatabaseTraceHandler(BaseTraceHandler):
             # PostgreSQL enforces the anchor FK, so a race that lets a
             # candidate row become the active anchor between selection and
             # delete surfaces here as a restrict violation (IntegrityError).
-            # A database upgraded through Alembic on SQLite has no DB-level
-            # FK for this column and cannot raise this; a freshly created
-            # SQLite database (create_all, e.g. tests) does have the FK and
-            # can. Under stricter isolation levels the same race can instead
+            # Two anchors can do that: the task's checkpoint pointer, and an
+            # active interaction row whose resume_trace_event_id lands on a
+            # candidate -- the latter trips
+            # ck_task_interaction_requests_active_anchor on both backends
+            # (the ON DELETE SET NULL fires and the CHECK forbids the NULL
+            # on active rows). For the pointer FK, a database upgraded
+            # through Alembic on SQLite has no DB-level constraint today
+            # and cannot raise this -- that changes when the interaction
+            # table's migration lands, whose rows enforce their CHECK on
+            # upgraded SQLite too; a freshly created SQLite database
+            # (create_all, e.g. tests) has the FK and can. Under stricter isolation levels the same race can instead
             # surface as psycopg2's SerializationFailure or DeadlockDetected,
             # both of which SQLAlchemy wraps in OperationalError, not
             # IntegrityError -- catch both so this retention path degrades

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -28,6 +28,7 @@ from ...core.tools.adapters.vibe.connector_runtime import (
 from ...web.models.database import get_db
 from ...web.models.task import Task, TaskStatus
 from ...web.models.task import TraceEvent as DatabaseTraceEvent
+from ...web.models.task_interaction import TaskInteractionRequest
 from ...web.models.tool_config import ToolUsage
 from ...web.services.ops_signals import (
     CHECKPOINT_DECODE_FALLBACK,
@@ -37,6 +38,7 @@ from ...web.services.ops_signals import (
     clear_degradation,
     register_degradation,
 )
+from ...web.services.task_interaction_schema import interaction_requests_table_exists
 from ...web.services.task_lease_service import (
     TASK_RUN_ID_TRACE_FIELD,
     current_task_lease,
@@ -853,9 +855,12 @@ class DatabaseTraceHandler(BaseTraceHandler):
         would discard the caller's pending writes and turn a misuse bug into
         silent data loss.
 
-        Retention is exactly ``limit`` rows, with one exception: when the
-        task's exact-row pointer names a row that itself ranks outside the
-        window, protecting that row keeps ``limit + 1``.
+        Retention is exactly ``limit`` rows, with up to two exceptions:
+        protecting a row named by the task's exact-row pointer, or by an
+        active interaction request's resume anchor, when that row itself
+        ranks outside the window keeps up to ``limit + 2`` (one pointer per
+        task, and at most one active interaction row per task -- see
+        ``uq_task_interaction_active_slot``).
         """
         if db.new or db.dirty or db.deleted:
             raise RuntimeError(
@@ -910,17 +915,54 @@ class DatabaseTraceHandler(BaseTraceHandler):
             # delete would leave a steady state with nothing to prune unable
             # to clear the signal at all.
             clear_degradation(CHECKPOINT_PRUNE_FAILED)
+            # Protection set, second source: a trace row anchored by an
+            # ACTIVE interaction row must survive retention, or answering
+            # that interaction later would find no checkpoint to resume
+            # from. Only active_slot IS NOT NULL rows protect: terminal rows
+            # are not resumable. Deliberately no expires_at filter -- an
+            # expired request is still answerable, so its anchor must stay.
+            #
+            # Placed after clear_degradation above, not before: on a
+            # deployment upgraded to a revision before this table exists the
+            # query raises OperationalError on SQLite and ProgrammingError
+            # on PostgreSQL, which would land in two different handlers and
+            # -- on SQLite -- register a CHECKPOINT_PRUNE_FAILED signal on
+            # every checkpoint that no operator could ever clear. The
+            # has_table gate makes that unreachable; the placement keeps the
+            # blast radius small if the gate is ever removed.
+            interaction_anchor_ids: set[int] = set()
+            if interaction_requests_table_exists(db):
+                interaction_anchor_ids = {
+                    row_id
+                    for (row_id,) in db.query(
+                        TaskInteractionRequest.resume_trace_event_id
+                    ).filter(
+                        TaskInteractionRequest.task_id == self.task_id,
+                        TaskInteractionRequest.active_slot.isnot(None),
+                        TaskInteractionRequest.resume_trace_event_id.isnot(None),
+                    )
+                }
             # Rank first, protect after. The row this task's exact-row
-            # pointer references is never deleted, whatever its position in
-            # the retention ranking; excluding it from the candidate set
-            # instead would shift every remaining row's OFFSET rank by one
-            # and retain limit + 1 rows whenever the anchor sits inside the
-            # window. For the steady-state writer the protection is
-            # structurally unreachable -- the pointer always names the row
+            # pointer references, and any row an active interaction request
+            # anchors, are never deleted, whatever their position in the
+            # retention ranking; excluding them from the candidate set
+            # instead would shift every remaining row's OFFSET rank and turn
+            # the retained count into an unpredictable limit + k. The
+            # exact-row pointer's protection is structurally unreachable for
+            # the steady-state writer -- the pointer always names the row
             # just written, which ranks ahead of the offset -- but it guards
-            # the backfill-vs-prune window and future back-pointing anchors
-            # that may point at an older row.
-            stale_ids = [row_id for (row_id,) in stale_rows if row_id != anchor_id]
+            # the backfill-vs-prune window and back-pointing anchors that
+            # point at an older row. The interaction anchor is exactly that
+            # kind of back-pointing anchor, arrived: a task can keep writing
+            # checkpoints after an interaction is raised, so the row the
+            # interaction resumes from steadily sinks in the retention
+            # ranking while the interaction stays open.
+            protected_ids = interaction_anchor_ids | (
+                {anchor_id} if anchor_id is not None else set()
+            )
+            stale_ids = [
+                row_id for (row_id,) in stale_rows if row_id not in protected_ids
+            ]
             if not stale_ids:
                 return
             # Chunk the IN clause: a backlog from previously-disabled pruning

--- a/src/xagent/web/services/task_deletion.py
+++ b/src/xagent/web/services/task_deletion.py
@@ -9,6 +9,8 @@ from ..models.task import (
     TraceEvent,
     TraceMessageBlob,
 )
+from ..models.task_interaction import TaskInteractionRequest
+from .task_interaction_schema import interaction_requests_table_exists
 
 
 def purge_task_rows(
@@ -22,6 +24,11 @@ def purge_task_rows(
     relationship without a cascade, so the unit of work nulls
     ``UploadedFile.task_id`` before the task row is removed. The rows and their
     backing blobs therefore outlive the task and are not reclaimed here.
+
+    ``task_interaction_requests`` rows, unlike ``UploadedFile``, are deleted
+    outright: the CASCADE on ``task_id`` would remove them anyway, and the
+    delete must run before the ``trace_events`` delete below (see the
+    ordering comment at that call).
     """
 
     task = db.query(Task).filter(Task.id == task_id).first()
@@ -42,6 +49,29 @@ def purge_task_rows(
         },
         synchronize_session=False,
     )
+
+    # Delete this task's interaction rows before the trace_events delete
+    # below. task_interaction_requests.resume_trace_event_id FKs to
+    # trace_events.id with ON DELETE SET NULL, and
+    # ck_task_interaction_requests_active_anchor requires an active row to
+    # hold a non-NULL anchor -- so deleting the anchored trace row first
+    # makes the database NULL a column the CHECK forbids being NULL, and the
+    # whole purge fails with an IntegrityError. Terminal rows are unaffected
+    # (the CHECK's status <> 'active' branch already satisfies it); the
+    # asymmetry is by design, and the ordering here is what makes the active
+    # case work too.
+    #
+    # Plain delete, not terminate-then-delete: tasks.id cascades to these
+    # rows anyway, so terminating first would cost an extra write and imply
+    # -- falsely -- that an interaction row can outlive the purge of its
+    # task.
+    #
+    # Gated on table presence: a deployment upgraded to a revision before
+    # this table exists must still be able to delete tasks.
+    if interaction_requests_table_exists(db):
+        db.query(TaskInteractionRequest).filter(
+            TaskInteractionRequest.task_id == task_id
+        ).delete(synchronize_session=False)
 
     db.query(TraceCheckpointBlob).filter(TraceCheckpointBlob.task_id == task_id).delete(
         synchronize_session=False

--- a/src/xagent/web/services/task_interaction_schema.py
+++ b/src/xagent/web/services/task_interaction_schema.py
@@ -4,6 +4,21 @@ Deletion and retention paths run on deployments upgraded to a revision
 before task_interaction_requests exists. Absence is a normal deployment
 state, not a fault: the migration that creates the table has not been
 applied yet.
+
+The check is deliberately uncached. Measured on PostgreSQL it costs less
+than the trace INSERT plus commit the same checkpoint write already
+performs, and it fires once per checkpoint write, not per trace event.
+Caching False would be poisonous: the table's migration can be applied
+while processes are running, and a process that latched False before the
+migration would skip interaction rows in purge (reintroducing the
+IntegrityError this module exists to prevent) and stop protecting active
+resume anchors in prune, permanently, with no operator remedy short of a
+restart. If measurements ever justify caching, the only safe shape is a
+one-way latch: cache True alone -- the table is only ever added, never
+dropped, so a stale True cannot occur -- and let False re-query on every
+call. A cheaper no-cache option also exists: inspecting the session's own
+connection instead of the engine skips a pool checkout and roughly halves
+the cost.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/task_interaction_schema.py
+++ b/src/xagent/web/services/task_interaction_schema.py
@@ -1,0 +1,19 @@
+"""Schema-presence predicate for the interaction table.
+
+Deletion and retention paths run on deployments upgraded to a revision
+before task_interaction_requests exists. Absence is a normal deployment
+state, not a fault: the migration that creates the table has not been
+applied yet.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session
+
+from ..models.task_interaction import TaskInteractionRequest
+
+
+def interaction_requests_table_exists(db: Session) -> bool:
+    """True when this session's database has task_interaction_requests."""
+    return inspect(db.get_bind()).has_table(TaskInteractionRequest.__tablename__)

--- a/src/xagent/web/services/task_interaction_schema.py
+++ b/src/xagent/web/services/task_interaction_schema.py
@@ -16,9 +16,20 @@ resume anchors in prune, permanently, with no operator remedy short of a
 restart. If measurements ever justify caching, the only safe shape is a
 one-way latch: cache True alone -- the table is only ever added, never
 dropped, so a stale True cannot occur -- and let False re-query on every
-call. A cheaper no-cache option also exists: inspecting the session's own
-connection instead of the engine skips a pool checkout and roughly halves
-the cost.
+call.
+
+The check inspects the session's own connection, not the engine.
+Inspecting the engine checks out two connections per call: on SQLite's
+NullPool each is a new physical connection that re-runs the WAL,
+busy_timeout and foreign_keys connect pragmas (measured ~12x the cost),
+and on PostgreSQL each is a pooled checkout taken while the caller
+already holds one (~4.5x). Reusing the session's connection also keeps
+the gate's answer on the same snapshot as the query it guards. Under
+READ COMMITTED -- the isolation level this deployment runs -- the two
+forms are indistinguishable, including across a migration applied while
+the process is running; under REPEATABLE READ or SERIALIZABLE the
+session's snapshot can miss a table created after its transaction began,
+where the constraint layer still fails loudly rather than silently.
 """
 
 from __future__ import annotations
@@ -31,4 +42,4 @@ from ..models.task_interaction import TaskInteractionRequest
 
 def interaction_requests_table_exists(db: Session) -> bool:
     """True when this session's database has task_interaction_requests."""
-    return inspect(db.get_bind()).has_table(TaskInteractionRequest.__tablename__)
+    return inspect(db.connection()).has_table(TaskInteractionRequest.__tablename__)

--- a/tests/web/services/task_interaction_schema_shared.py
+++ b/tests/web/services/task_interaction_schema_shared.py
@@ -1,5 +1,10 @@
 """Shared fixtures for the TaskInteractionRequest constraint-behavior suite.
 
+Also serves test_task_interaction_schema_gate.py and
+test_task_deletion_checkpoint_pointer.py, which import
+tables_excluding_interaction_requests() below to build the same
+filtered-schema shape those suites need.
+
 Split across test_task_interaction_schema.py (SQLite, always runs) and
 test_task_interaction_schema_postgresql.py (PostgreSQL, skips without
 XAGENT_TEST_POSTGRES_URL), following the split used for
@@ -42,6 +47,7 @@ from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.models.user import User
@@ -61,6 +67,22 @@ _UNIQUE_CONSTRAINT_COLUMNS: dict[str, tuple[str, ...]] = {
         "request_idempotency_key",
     ),
 }
+
+
+def tables_excluding_interaction_requests() -> list:
+    """Every table this repo's models declare, except the interaction table.
+
+    Building a database from this filtered set reproduces the shape of a
+    deployment upgraded through every migration except the (unmerged) one
+    that creates task_interaction_requests -- the table has no inbound
+    foreign keys, so excluding it cannot break create order (verified in the
+    audit: 52 of 53 tables created, zero inbound FKs to the target).
+    """
+    return [
+        table
+        for table in Base.metadata.sorted_tables
+        if table.name != TaskInteractionRequest.__tablename__
+    ]
 
 
 def make_user(db: Session) -> int:

--- a/tests/web/services/test_task_deletion_checkpoint_pointer.py
+++ b/tests/web/services/test_task_deletion_checkpoint_pointer.py
@@ -51,6 +51,9 @@ from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.models.user import User
 from xagent.web.services.task_deletion import purge_task_rows
+from xagent.web.services.task_interaction_schema import (
+    interaction_requests_table_exists,
+)
 
 
 def _seed_task_with_anchored_checkpoint(session: Session, *, username: str) -> int:
@@ -175,6 +178,39 @@ def sqlite_fk_on_session(tmp_path):
     engine.dispose()
 
 
+def _tables_excluding_interaction_requests() -> list:
+    return [
+        table
+        for table in Base.metadata.sorted_tables
+        if table.name != TaskInteractionRequest.__tablename__
+    ]
+
+
+@pytest.fixture
+def sqlite_fk_on_session_without_interaction_table(tmp_path):
+    """Same shape as sqlite_fk_on_session, minus task_interaction_requests
+    -- reproduces a deployment upgraded to a revision before that table
+    exists (see test_task_interaction_schema_gate.py for the same filter
+    used against the presence predicate directly)."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'fk_on_no_interaction.db'}")
+
+    @event.listens_for(engine, "connect")
+    def _set_fk(dbapi_connection, _record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    reset_checkpoint_anchor_fk_create_rule()
+    Base.metadata.create_all(
+        bind=engine, tables=_tables_excluding_interaction_requests()
+    )
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = session_factory()
+    yield session
+    session.close()
+    engine.dispose()
+
+
 @pytest.fixture
 def sqlite_upgraded_session(tmp_path):
     """A SQLite database shaped like the migration's ADD COLUMN path for a
@@ -214,6 +250,30 @@ def postgres_session():
         conn.execute(text("CREATE SCHEMA public"))
     reset_checkpoint_anchor_fk_create_rule()
     Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = session_factory()
+    yield session
+    session.close()
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    engine.dispose()
+
+
+@pytest.fixture
+def postgres_session_without_interaction_table():
+    """Same shape as postgres_session, minus task_interaction_requests."""
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    reset_checkpoint_anchor_fk_create_rule()
+    Base.metadata.create_all(
+        bind=engine, tables=_tables_excluding_interaction_requests()
+    )
     session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = session_factory()
     yield session
@@ -670,3 +730,65 @@ def test_purge_user_task_rows_deletes_interaction_rows_before_trace_events_postg
         _purge_user_task_rows(session, user_id=user_id)
     _assert_interaction_delete_between_pointer_update_and_trace_events_delete(seen)
     session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Absent-table branch: both purge functions on a deployment upgraded to a
+# revision before task_interaction_requests exists (PR-C2b, P4).
+# ---------------------------------------------------------------------------
+
+
+def test_purge_task_rows_succeeds_without_the_interaction_table_sqlite(
+    sqlite_fk_on_session_without_interaction_table,
+) -> None:
+    session = sqlite_fk_on_session_without_interaction_table
+    assert interaction_requests_table_exists(session) is False
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u-no-table-single")
+
+    assert purge_task_rows(session, task_id=task_id) is True
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+
+
+@pytest.mark.postgresql
+def test_purge_task_rows_succeeds_without_the_interaction_table_postgres(
+    postgres_session_without_interaction_table,
+) -> None:
+    session = postgres_session_without_interaction_table
+    assert interaction_requests_table_exists(session) is False
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u-no-table-single")
+
+    assert purge_task_rows(session, task_id=task_id) is True
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+
+
+def test_purge_user_task_rows_succeeds_without_the_interaction_table_sqlite(
+    sqlite_fk_on_session_without_interaction_table,
+) -> None:
+    session = sqlite_fk_on_session_without_interaction_table
+    assert interaction_requests_table_exists(session) is False
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u-no-table-bulk")
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    _purge_user_task_rows(session, user_id=user_id)
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+
+
+@pytest.mark.postgresql
+def test_purge_user_task_rows_succeeds_without_the_interaction_table_postgres(
+    postgres_session_without_interaction_table,
+) -> None:
+    session = postgres_session_without_interaction_table
+    assert interaction_requests_table_exists(session) is False
+    task_id = _seed_task_with_anchored_checkpoint(session, username="u-no-table-bulk")
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    _purge_user_task_rows(session, user_id=user_id)
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0

--- a/tests/web/services/test_task_deletion_checkpoint_pointer.py
+++ b/tests/web/services/test_task_deletion_checkpoint_pointer.py
@@ -42,6 +42,7 @@ from tests.web.services.task_interaction_schema_shared import (
     make_task,
     make_trace_event,
     make_user,
+    tables_excluding_interaction_requests,
 )
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.web.api.admin_users import _purge_user_task_rows
@@ -178,14 +179,6 @@ def sqlite_fk_on_session(tmp_path):
     engine.dispose()
 
 
-def _tables_excluding_interaction_requests() -> list:
-    return [
-        table
-        for table in Base.metadata.sorted_tables
-        if table.name != TaskInteractionRequest.__tablename__
-    ]
-
-
 @pytest.fixture
 def sqlite_fk_on_session_without_interaction_table(tmp_path):
     """Same shape as sqlite_fk_on_session, minus task_interaction_requests
@@ -202,7 +195,7 @@ def sqlite_fk_on_session_without_interaction_table(tmp_path):
 
     reset_checkpoint_anchor_fk_create_rule()
     Base.metadata.create_all(
-        bind=engine, tables=_tables_excluding_interaction_requests()
+        bind=engine, tables=tables_excluding_interaction_requests()
     )
     session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = session_factory()
@@ -272,7 +265,7 @@ def postgres_session_without_interaction_table():
         conn.execute(text("CREATE SCHEMA public"))
     reset_checkpoint_anchor_fk_create_rule()
     Base.metadata.create_all(
-        bind=engine, tables=_tables_excluding_interaction_requests()
+        bind=engine, tables=tables_excluding_interaction_requests()
     )
     session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = session_factory()

--- a/tests/web/services/test_task_deletion_checkpoint_pointer.py
+++ b/tests/web/services/test_task_deletion_checkpoint_pointer.py
@@ -422,11 +422,13 @@ def test_purge_task_rows_deletes_an_active_interaction_row_postgres(
 def test_purge_task_rows_deletes_a_terminal_interaction_row_sqlite(
     sqlite_fk_on_session,
 ) -> None:
-    """Regression control for M4: without a direct row-count assertion, this
-    test could stay green even if the interaction delete statement were
-    removed entirely, because a terminal row's anchor is never SET NULL by
-    the trace_events delete and so purge_task_rows would still return True
-    and leave the task deleted."""
+    """Regression control: the row count is asserted directly so the test
+    is about the interaction row being gone, not about purge returning
+    True. It is deliberately not a discriminator for removing the delete
+    statement -- a terminal row's anchor is never SET NULL by the
+    trace_events delete, and the ``tasks.id`` ON DELETE CASCADE removes
+    the row at the task delete regardless, so this stays green either
+    way. The active-row tests are the discriminators."""
     session = sqlite_fk_on_session
     task_id, _row_id = _seed_task_with_interaction_row(
         session, username="u-terminal-single", status="terminated"

--- a/tests/web/services/test_task_deletion_checkpoint_pointer.py
+++ b/tests/web/services/test_task_deletion_checkpoint_pointer.py
@@ -35,11 +35,20 @@ from tests.web.services.checkpoint_anchor_shared import (
     build_upgraded_sqlite_engine,
     reset_checkpoint_anchor_fk_create_rule,
 )
+from tests.web.services.task_interaction_schema_shared import (
+    make_row as make_interaction_row,
+)
+from tests.web.services.task_interaction_schema_shared import (
+    make_task,
+    make_trace_event,
+    make_user,
+)
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.web.api.admin_users import _purge_user_task_rows
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
+from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.models.user import User
 from xagent.web.services.task_deletion import purge_task_rows
 
@@ -69,6 +78,30 @@ def _seed_task_with_anchored_checkpoint(session: Session, *, username: str) -> i
     task.last_checkpoint_trace_event_id = event_row.id
     session.commit()
     return int(task.id)
+
+
+def _seed_task_with_interaction_row(
+    session: Session, *, username: str, status: str = "active"
+) -> tuple[int, int]:
+    """A task with one interaction row anchored to a real trace_events row.
+
+    Independent of _seed_task_with_anchored_checkpoint above: these tests
+    are about task_interaction_requests.resume_trace_event_id, not
+    tasks.last_checkpoint_trace_event_id, so the task's own pointer is left
+    unset.
+    """
+    user_id = make_user(session)
+    task_id = make_task(session, user_id=user_id)
+    anchor_id = make_trace_event(session, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_interaction_row(
+            task_id=task_id, resume_trace_event_id=anchor_id, status=status
+        )
+    )
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return task_id, int(row.id)
 
 
 @contextmanager
@@ -283,6 +316,156 @@ def test_purge_task_rows_nulls_pointer_before_the_task_delete_flushes(
 
 
 # ---------------------------------------------------------------------------
+# purge_task_rows: task_interaction_requests deletion (PR-C2b).
+# ---------------------------------------------------------------------------
+
+
+def _interaction_row_count(session: Session, task_id: int) -> int:
+    return (
+        session.query(TaskInteractionRequest)
+        .filter(TaskInteractionRequest.task_id == task_id)
+        .count()
+    )
+
+
+def test_purge_task_rows_deletes_an_active_interaction_row_sqlite(
+    sqlite_fk_on_session,
+) -> None:
+    session = sqlite_fk_on_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-active-single", status="active"
+    )
+
+    assert purge_task_rows(session, task_id=task_id) is True
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert _interaction_row_count(session, task_id) == 0
+
+
+@pytest.mark.postgresql
+def test_purge_task_rows_deletes_an_active_interaction_row_postgres(
+    postgres_session,
+) -> None:
+    session = postgres_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-active-single", status="active"
+    )
+
+    assert purge_task_rows(session, task_id=task_id) is True
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert _interaction_row_count(session, task_id) == 0
+
+
+def test_purge_task_rows_deletes_a_terminal_interaction_row_sqlite(
+    sqlite_fk_on_session,
+) -> None:
+    """Regression control for M4: without a direct row-count assertion, this
+    test could stay green even if the interaction delete statement were
+    removed entirely, because a terminal row's anchor is never SET NULL by
+    the trace_events delete and so purge_task_rows would still return True
+    and leave the task deleted."""
+    session = sqlite_fk_on_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-terminal-single", status="terminated"
+    )
+
+    assert purge_task_rows(session, task_id=task_id) is True
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert _interaction_row_count(session, task_id) == 0
+
+
+@pytest.mark.postgresql
+def test_purge_task_rows_deletes_a_terminal_interaction_row_postgres(
+    postgres_session,
+) -> None:
+    session = postgres_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-terminal-single", status="terminated"
+    )
+
+    assert purge_task_rows(session, task_id=task_id) is True
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert _interaction_row_count(session, task_id) == 0
+
+
+def _assert_interaction_delete_between_pointer_update_and_trace_events_delete(
+    seen,
+) -> None:  # type: ignore[no-untyped-def]
+    pointer_update = _index_of(
+        seen,
+        lambda s: s.startswith("UPDATE tasks")
+        and "last_checkpoint_trace_event_id" in s,
+        "pointer NULL update",
+    )
+    interaction_delete = _index_of(
+        seen,
+        lambda s: s.startswith("DELETE FROM task_interaction_requests"),
+        "task_interaction_requests delete",
+    )
+    trace_delete = _index_of(
+        seen,
+        lambda s: s.startswith("DELETE FROM trace_events"),
+        "trace_events delete",
+    )
+    assert pointer_update < interaction_delete < trace_delete, seen
+
+
+def test_purge_task_rows_deletes_interaction_rows_before_trace_events_fk_on(
+    sqlite_fk_on_session,
+) -> None:
+    session = sqlite_fk_on_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-order-single-fk-on", status="active"
+    )
+
+    with _recorded_statements(session.get_bind()) as seen:
+        assert purge_task_rows(session, task_id=task_id) is True
+    _assert_interaction_delete_between_pointer_update_and_trace_events_delete(seen)
+    session.commit()
+
+
+def test_purge_task_rows_deletes_interaction_rows_before_trace_events_upgraded(
+    sqlite_upgraded_session,
+) -> None:
+    """The alembic-upgraded form is where this matters most: it has no
+    DB-level FK for the checkpoint pointer column and (SQLite FK
+    enforcement defaulting off for this engine) no enforced ON DELETE SET
+    NULL for the interaction anchor either, so a reversed ordering would
+    not fail loudly here. Statement order is the only direct evidence."""
+    session = sqlite_upgraded_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-order-single-upgraded", status="active"
+    )
+
+    with _recorded_statements(session.get_bind()) as seen:
+        assert purge_task_rows(session, task_id=task_id) is True
+    _assert_interaction_delete_between_pointer_update_and_trace_events_delete(seen)
+    session.commit()
+
+
+@pytest.mark.postgresql
+def test_purge_task_rows_deletes_interaction_rows_before_trace_events_postgres(
+    postgres_session,
+) -> None:
+    session = postgres_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-order-single-postgres", status="active"
+    )
+
+    with _recorded_statements(session.get_bind()) as seen:
+        assert purge_task_rows(session, task_id=task_id) is True
+    _assert_interaction_delete_between_pointer_update_and_trace_events_delete(seen)
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
 # _purge_user_task_rows (bulk, admin path).
 # ---------------------------------------------------------------------------
 
@@ -365,3 +548,125 @@ def test_purge_user_task_rows_nulls_pointer_before_trace_events_are_gone(
     ).scalar_one()
     assert remaining_events == 0
     session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# _purge_user_task_rows: task_interaction_requests deletion (PR-C2b).
+# ---------------------------------------------------------------------------
+
+
+def test_purge_user_task_rows_deletes_an_active_interaction_row_sqlite(
+    sqlite_fk_on_session,
+) -> None:
+    session = sqlite_fk_on_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-active-bulk", status="active"
+    )
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    _purge_user_task_rows(session, user_id=user_id)
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert _interaction_row_count(session, task_id) == 0
+
+
+@pytest.mark.postgresql
+def test_purge_user_task_rows_deletes_an_active_interaction_row_postgres(
+    postgres_session,
+) -> None:
+    session = postgres_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-active-bulk", status="active"
+    )
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    _purge_user_task_rows(session, user_id=user_id)
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert _interaction_row_count(session, task_id) == 0
+
+
+def test_purge_user_task_rows_deletes_a_terminal_interaction_row_sqlite(
+    sqlite_fk_on_session,
+) -> None:
+    """M4 regression control, bulk path: see the single-task terminal test
+    above for why the count must be asserted directly."""
+    session = sqlite_fk_on_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-terminal-bulk", status="terminated"
+    )
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    _purge_user_task_rows(session, user_id=user_id)
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert _interaction_row_count(session, task_id) == 0
+
+
+@pytest.mark.postgresql
+def test_purge_user_task_rows_deletes_a_terminal_interaction_row_postgres(
+    postgres_session,
+) -> None:
+    session = postgres_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-terminal-bulk", status="terminated"
+    )
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    _purge_user_task_rows(session, user_id=user_id)
+    session.commit()
+
+    assert session.query(Task).filter(Task.id == task_id).count() == 0
+    assert _interaction_row_count(session, task_id) == 0
+
+
+def test_purge_user_task_rows_deletes_interaction_rows_before_trace_events_fk_on(
+    sqlite_fk_on_session,
+) -> None:
+    session = sqlite_fk_on_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-order-bulk-fk-on", status="active"
+    )
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    with _recorded_statements(session.get_bind()) as seen:
+        _purge_user_task_rows(session, user_id=user_id)
+    _assert_interaction_delete_between_pointer_update_and_trace_events_delete(seen)
+    session.commit()
+
+
+def test_purge_user_task_rows_deletes_interaction_rows_before_trace_events_upgraded(
+    sqlite_upgraded_session,
+) -> None:
+    """Same rationale as the single-task upgraded-form test above: no
+    DB-level enforcement makes a reversed ordering fail loudly here, so
+    statement order is the only direct evidence."""
+    session = sqlite_upgraded_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-order-bulk-upgraded", status="active"
+    )
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    with _recorded_statements(session.get_bind()) as seen:
+        _purge_user_task_rows(session, user_id=user_id)
+    _assert_interaction_delete_between_pointer_update_and_trace_events_delete(seen)
+    session.commit()
+
+
+@pytest.mark.postgresql
+def test_purge_user_task_rows_deletes_interaction_rows_before_trace_events_postgres(
+    postgres_session,
+) -> None:
+    session = postgres_session
+    task_id, _row_id = _seed_task_with_interaction_row(
+        session, username="u-order-bulk-postgres", status="active"
+    )
+    user_id = session.query(Task).filter(Task.id == task_id).one().user_id
+
+    with _recorded_statements(session.get_bind()) as seen:
+        _purge_user_task_rows(session, user_id=user_id)
+    _assert_interaction_delete_between_pointer_update_and_trace_events_delete(seen)
+    session.commit()

--- a/tests/web/services/test_task_interaction_schema_gate.py
+++ b/tests/web/services/test_task_interaction_schema_gate.py
@@ -1,0 +1,114 @@
+"""Tests for ``interaction_requests_table_exists``, the schema-presence gate
+the two purge implementations and the checkpoint prune path use to stay safe
+on a deployment upgraded to a migration revision before
+``task_interaction_requests`` exists.
+
+Named ``_gate`` rather than ``test_task_interaction_schema.py`` to avoid
+colliding with that already-existing file (added by #1209): it pins the
+model's own CHECK/FK/shape inventory, an unrelated concern to the presence
+predicate tested here.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from xagent.web.models.database import Base
+from xagent.web.models.task_interaction import TaskInteractionRequest
+from xagent.web.services.task_interaction_schema import (
+    interaction_requests_table_exists,
+)
+
+
+def _tables_excluding_target() -> list:
+    """Every table this repo's models declare, except the interaction table.
+
+    Building a database from this filtered set reproduces the shape of a
+    deployment upgraded through every migration except the (unmerged) one
+    that creates task_interaction_requests -- the table has no inbound
+    foreign keys, so excluding it cannot break create order (verified in the
+    audit: 52 of 53 tables created, zero inbound FKs to the target).
+    """
+    return [
+        table
+        for table in Base.metadata.sorted_tables
+        if table.name != TaskInteractionRequest.__tablename__
+    ]
+
+
+def _postgres_url() -> str | None:
+    return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
+        "POSTGRES_TEST_DATABASE_URL"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SQLite
+# ---------------------------------------------------------------------------
+
+
+def test_sqlite_full_create_all_has_the_table(tmp_path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'full.db'}")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        assert interaction_requests_table_exists(session) is True
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_sqlite_filtered_create_all_lacks_the_table(tmp_path) -> None:
+    engine = create_engine(f"sqlite:///{tmp_path / 'filtered.db'}")
+    Base.metadata.create_all(bind=engine, tables=_tables_excluding_target())
+    session = sessionmaker(bind=engine)()
+    try:
+        assert interaction_requests_table_exists(session) is False
+    finally:
+        session.close()
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def postgres_engine():
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    yield engine
+    with engine.begin() as conn:
+        conn.execute(text("DROP SCHEMA public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+    engine.dispose()
+
+
+@pytest.mark.postgresql
+def test_postgres_full_create_all_has_the_table(postgres_engine) -> None:
+    Base.metadata.create_all(bind=postgres_engine)
+    session = sessionmaker(bind=postgres_engine)()
+    try:
+        assert interaction_requests_table_exists(session) is True
+    finally:
+        session.close()
+
+
+@pytest.mark.postgresql
+def test_postgres_filtered_create_all_lacks_the_table(postgres_engine) -> None:
+    Base.metadata.create_all(bind=postgres_engine, tables=_tables_excluding_target())
+    session = sessionmaker(bind=postgres_engine)()
+    try:
+        assert interaction_requests_table_exists(session) is False
+    finally:
+        session.close()

--- a/tests/web/services/test_task_interaction_schema_gate.py
+++ b/tests/web/services/test_task_interaction_schema_gate.py
@@ -17,27 +17,13 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
+from tests.web.services.task_interaction_schema_shared import (
+    tables_excluding_interaction_requests,
+)
 from xagent.web.models.database import Base
-from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services.task_interaction_schema import (
     interaction_requests_table_exists,
 )
-
-
-def _tables_excluding_target() -> list:
-    """Every table this repo's models declare, except the interaction table.
-
-    Building a database from this filtered set reproduces the shape of a
-    deployment upgraded through every migration except the (unmerged) one
-    that creates task_interaction_requests -- the table has no inbound
-    foreign keys, so excluding it cannot break create order (verified in the
-    audit: 52 of 53 tables created, zero inbound FKs to the target).
-    """
-    return [
-        table
-        for table in Base.metadata.sorted_tables
-        if table.name != TaskInteractionRequest.__tablename__
-    ]
 
 
 def _postgres_url() -> str | None:
@@ -64,7 +50,9 @@ def test_sqlite_full_create_all_has_the_table(tmp_path) -> None:
 
 def test_sqlite_filtered_create_all_lacks_the_table(tmp_path) -> None:
     engine = create_engine(f"sqlite:///{tmp_path / 'filtered.db'}")
-    Base.metadata.create_all(bind=engine, tables=_tables_excluding_target())
+    Base.metadata.create_all(
+        bind=engine, tables=tables_excluding_interaction_requests()
+    )
     session = sessionmaker(bind=engine)()
     try:
         assert interaction_requests_table_exists(session) is False
@@ -106,7 +94,9 @@ def test_postgres_full_create_all_has_the_table(postgres_engine) -> None:
 
 @pytest.mark.postgresql
 def test_postgres_filtered_create_all_lacks_the_table(postgres_engine) -> None:
-    Base.metadata.create_all(bind=postgres_engine, tables=_tables_excluding_target())
+    Base.metadata.create_all(
+        bind=postgres_engine, tables=tables_excluding_interaction_requests()
+    )
     session = sessionmaker(bind=postgres_engine)()
     try:
         assert interaction_requests_table_exists(session) is False

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -14,6 +14,9 @@ from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Query, Session, sessionmaker
 from sqlalchemy.pool import QueuePool, StaticPool
 
+from tests.web.services.task_interaction_schema_shared import (
+    make_row as make_interaction_row,
+)
 from xagent.core.agent.checkpoint import (
     CHECKPOINT_EVENT_TYPE,
     CHECKPOINT_TYPE,
@@ -47,6 +50,7 @@ from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
+from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.models.user import User
 from xagent.web.models.workforce import WorkforceRun
 from xagent.web.services.task_lease_service import (
@@ -414,6 +418,28 @@ def _checkpoint_trace_row(
         timestamp=timestamp,
         data=data,
     )
+
+
+def _seed_interaction_row(
+    db: Session,
+    *,
+    task_id: int,
+    resume_trace_event_id: int | None,
+    status: str = "active",
+    **overrides: object,
+) -> TaskInteractionRequest:
+    row = TaskInteractionRequest(
+        **make_interaction_row(
+            task_id=task_id,
+            resume_trace_event_id=resume_trace_event_id,
+            status=status,
+            **overrides,
+        )
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
 
 
 @pytest.mark.asyncio
@@ -1895,6 +1921,326 @@ def test_database_trace_handler_prune_excludes_the_anchored_row(
             row.event_id
             for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
         } == {"anchored-old", "run-a-new"}
+    finally:
+        db.close()
+
+
+def test_prune_protects_a_trace_row_anchored_by_an_active_interaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The second protection source (PR-C2b): an active interaction row's
+    resume_trace_event_id keeps its anchor alive even when the anchor ranks
+    outside the retention window, the same way the task's exact-row pointer
+    does in the test above -- but through task_interaction_requests instead
+    of tasks.last_checkpoint_trace_event_id."""
+    _, db, task = _create_trace_handler_test_task("interaction-anchor-protected")
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    old_row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="interaction-anchored-old",
+        execution_id="shared-execution",
+        label="interaction-anchored-old",
+        timestamp=now,
+        run_id="run-a",
+    )
+    db.add(old_row)
+    db.commit()
+    db.refresh(old_row)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="run-a-new",
+            execution_id="shared-execution",
+            label="run-a-new",
+            timestamp=now + timedelta(seconds=1),
+            run_id="run-a",
+        )
+    )
+    db.commit()
+    _seed_interaction_row(
+        db, task_id=task_id, resume_trace_event_id=old_row.id, status="active"
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "execution_id": "shared-execution",
+                TASK_RUN_ID_TRACE_FIELD: "run-a",
+            },
+        )
+
+        assert {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
+        } == {"interaction-anchored-old", "run-a-new"}
+    finally:
+        db.close()
+
+
+def test_prune_does_not_protect_a_terminal_interaction_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reverse control for the test above: a terminated interaction row's
+    resume_trace_event_id must not enter the protection set -- only
+    active_slot IS NOT NULL rows do -- or the protection set would keep
+    growing forever as interactions terminate instead of shrinking back to
+    just the exact-row pointer."""
+    _, db, task = _create_trace_handler_test_task("interaction-anchor-terminal")
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    old_row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="terminal-anchored-old",
+        execution_id="shared-execution",
+        label="terminal-anchored-old",
+        timestamp=now,
+        run_id="run-a",
+    )
+    db.add(old_row)
+    db.commit()
+    db.refresh(old_row)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="run-a-new",
+            execution_id="shared-execution",
+            label="run-a-new",
+            timestamp=now + timedelta(seconds=1),
+            run_id="run-a",
+        )
+    )
+    db.commit()
+    _seed_interaction_row(
+        db, task_id=task_id, resume_trace_event_id=old_row.id, status="terminated"
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "execution_id": "shared-execution",
+                TASK_RUN_ID_TRACE_FIELD: "run-a",
+            },
+        )
+
+        assert {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
+        } == {"run-a-new"}
+    finally:
+        db.close()
+
+
+def test_prune_protects_an_expired_but_active_interaction_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deliberately no expires_at filter on the protection-set query: an
+    expired-but-still-active request (nothing has terminated it yet) is
+    still answerable, so its anchor must stay protected."""
+    _, db, task = _create_trace_handler_test_task("interaction-anchor-expired")
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    old_row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="expired-anchored-old",
+        execution_id="shared-execution",
+        label="expired-anchored-old",
+        timestamp=now,
+        run_id="run-a",
+    )
+    db.add(old_row)
+    db.commit()
+    db.refresh(old_row)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="run-a-new",
+            execution_id="shared-execution",
+            label="run-a-new",
+            timestamp=now + timedelta(seconds=1),
+            run_id="run-a",
+        )
+    )
+    db.commit()
+    _seed_interaction_row(
+        db,
+        task_id=task_id,
+        resume_trace_event_id=old_row.id,
+        status="active",
+        created_at=now - timedelta(hours=2),
+        expires_at=now - timedelta(hours=1),
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "execution_id": "shared-execution",
+                TASK_RUN_ID_TRACE_FIELD: "run-a",
+            },
+        )
+
+        assert {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
+        } == {"expired-anchored-old", "run-a-new"}
+    finally:
+        db.close()
+
+
+def test_prune_retains_at_most_limit_plus_two(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both protection sources at once, anchoring two distinct rows: the
+    exact-row pointer and the active interaction anchor are the two
+    exceptions the docstring's limit + 2 bound accounts for."""
+    _, db, task = _create_trace_handler_test_task("limit-plus-two")
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    pointer_row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="pointer-anchored-oldest",
+        execution_id="shared-execution",
+        label="pointer-anchored-oldest",
+        timestamp=now,
+        run_id="run-a",
+    )
+    db.add(pointer_row)
+    db.commit()
+    db.refresh(pointer_row)
+    interaction_anchor_row = _checkpoint_trace_row(
+        task_id=task_id,
+        event_id="interaction-anchored-middle",
+        execution_id="shared-execution",
+        label="interaction-anchored-middle",
+        timestamp=now + timedelta(seconds=1),
+        run_id="run-a",
+    )
+    db.add(interaction_anchor_row)
+    db.commit()
+    db.refresh(interaction_anchor_row)
+    db.add(
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id="run-a-newest",
+            execution_id="shared-execution",
+            label="run-a-newest",
+            timestamp=now + timedelta(seconds=2),
+            run_id="run-a",
+        )
+    )
+    task.last_checkpoint_trace_event_id = pointer_row.id
+    db.commit()
+    _seed_interaction_row(
+        db,
+        task_id=task_id,
+        resume_trace_event_id=interaction_anchor_row.id,
+        status="active",
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "execution_id": "shared-execution",
+                TASK_RUN_ID_TRACE_FIELD: "run-a",
+            },
+        )
+
+        remaining = {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
+        }
+        assert remaining == {
+            "pointer-anchored-oldest",
+            "interaction-anchored-middle",
+            "run-a-newest",
+        }
+        assert len(remaining) == 3  # limit (1) + 2
+    finally:
+        db.close()
+
+
+def test_prune_retains_exactly_the_limit_when_the_interaction_anchor_is_in_range(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interaction-anchor analog of
+    test_database_trace_handler_prune_retains_exactly_the_limit_when_the_anchor_is_in_range:
+    when the protected row already ranks inside the retention window, its
+    protection is redundant with natural retention, and the retained count
+    must stay exactly ``limit``.
+
+    This is also the test that actually distinguishes "exclude protected
+    rows from the ranking query, then OFFSET" (M9's bug) from "OFFSET
+    first, then exclude protected rows from the stale set" (the correct
+    order): when every protected row ranks outside the window (as in
+    test_prune_retains_at_most_limit_plus_two above), both orderings
+    produce the identical final set -- removing a row that already sits
+    past the OFFSET boundary cannot change which rows are within it. The
+    divergence only appears when a protected row ranks inside the window,
+    which is exactly this scenario.
+    """
+    _, db, task = _create_trace_handler_test_task("interaction-anchor-in-range")
+    task_id = int(task.id)
+    now = datetime.now(timezone.utc)
+    rows = [
+        _checkpoint_trace_row(
+            task_id=task_id,
+            event_id=event_id,
+            execution_id="shared-execution",
+            label=event_id,
+            timestamp=now + timedelta(seconds=offset),
+            run_id="run-a",
+        )
+        for offset, event_id in enumerate(["oldest", "middle", "newest"])
+    ]
+    db.add_all(rows)
+    db.commit()
+    db.refresh(rows[-1])
+    _seed_interaction_row(
+        db, task_id=task_id, resume_trace_event_id=rows[-1].id, status="active"
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "execution_id": "shared-execution",
+                TASK_RUN_ID_TRACE_FIELD: "run-a",
+            },
+        )
+
+        assert {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
+        } == {"newest"}
     finally:
         db.close()
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -53,6 +53,14 @@ from xagent.web.models.task import TraceEvent as DatabaseTraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.models.user import User
 from xagent.web.models.workforce import WorkforceRun
+from xagent.web.services.ops_signals import (
+    CHECKPOINT_PRUNE_FAILED,
+    active_degradations,
+    clear_degradation,
+)
+from xagent.web.services.task_interaction_schema import (
+    interaction_requests_table_exists,
+)
 from xagent.web.services.task_lease_service import (
     TASK_RUN_ID_TRACE_FIELD,
     TaskLease,
@@ -418,6 +426,46 @@ def _checkpoint_trace_row(
         timestamp=timestamp,
         data=data,
     )
+
+
+def _create_trace_handler_test_task_without_interaction_table(
+    username: str,
+    *,
+    title: str = "Chat task",
+    description: str = "Task chat",
+):
+    """Same shape as _create_trace_handler_test_task, built with a filtered
+    create_all that excludes task_interaction_requests -- reproducing a
+    deployment upgraded to a revision before that table exists (the
+    migration that creates it is not merged). The table has no inbound
+    foreign keys, so excluding it cannot break create order (verified in
+    the audit: 52 of 53 tables created, tasks and trace_events both
+    present, has_table(target) False).
+    """
+    engine = _shared_memory_sqlite_engine()
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    tables = [
+        table
+        for table in Base.metadata.sorted_tables
+        if table.name != TaskInteractionRequest.__tablename__
+    ]
+    Base.metadata.create_all(bind=engine, tables=tables)
+    db = SessionLocal()
+
+    user = User(username=username, password_hash="hashed_password", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    task = Task(
+        user_id=int(user.id),
+        title=title,
+        description=description,
+        status=TaskStatus.PENDING,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return SessionLocal, db, task
 
 
 def _seed_interaction_row(
@@ -2242,6 +2290,69 @@ def test_prune_retains_exactly_the_limit_when_the_interaction_anchor_is_in_range
             for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
         } == {"newest"}
     finally:
+        db.close()
+
+
+def test_prune_runs_without_the_interaction_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The has_table gate's reason to exist: on a deployment upgraded to a
+    revision before task_interaction_requests exists, prune must still
+    complete, still reclaim stale rows, and must not register
+    CHECKPOINT_PRUNE_FAILED -- registering it here would be exactly the
+    failure mode measured in the audit (SQLite's OperationalError landing
+    in the (IntegrityError, OperationalError) handler on every checkpoint
+    write, with no way for an operator to ever clear it)."""
+    _, db, task = _create_trace_handler_test_task_without_interaction_table(
+        "prune-without-interaction-table"
+    )
+    task_id = int(task.id)
+    assert interaction_requests_table_exists(db) is False
+    now = datetime.now(timezone.utc)
+    db.add_all(
+        [
+            _checkpoint_trace_row(
+                task_id=task_id,
+                event_id="no-table-old",
+                execution_id="shared-execution",
+                label="no-table-old",
+                timestamp=now,
+                run_id="run-a",
+            ),
+            _checkpoint_trace_row(
+                task_id=task_id,
+                event_id="no-table-new",
+                execution_id="shared-execution",
+                label="no-table-new",
+                timestamp=now + timedelta(seconds=1),
+                run_id="run-a",
+            ),
+        ]
+    )
+    db.commit()
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_checkpoint_history_limit",
+        lambda: 1,
+    )
+
+    clear_degradation(CHECKPOINT_PRUNE_FAILED)
+    try:
+        DatabaseTraceHandler(task_id)._prune_checkpoint_history(
+            db,
+            {
+                "checkpoint_type": CHECKPOINT_TYPE,
+                "execution_id": "shared-execution",
+                TASK_RUN_ID_TRACE_FIELD: "run-a",
+            },
+        )
+
+        assert CHECKPOINT_PRUNE_FAILED not in active_degradations()
+        assert {
+            row.event_id
+            for row in db.query(DatabaseTraceEvent).filter_by(task_id=task_id).all()
+        } == {"no-table-new"}
+    finally:
+        clear_degradation(CHECKPOINT_PRUNE_FAILED)
         db.close()
 
 


### PR DESCRIPTION
## What

Extends the task deletion paths and checkpoint pruning to `task_interaction_requests`:

- **Both purge implementations** (single-task purge and bulk owner deletion) delete a task's interaction rows after the checkpoint-pointer columns are NULLed and before the `trace_events` delete. Without this ordering, purging a task that holds an active interaction row raises `IntegrityError`: deleting the anchored trace row fires the FK's `ON DELETE SET NULL`, and the active-anchor CHECK forbids that NULL on active rows. Terminal rows pass cleanly either way — that asymmetry is by design, and the tests pin both cells on both backends.
- **Checkpoint pruning protects active interaction anchors**: the exclusion set grows from the task's own checkpoint pointer to also cover `resume_trace_event_id` of active-slot rows, applied after the ranked retention query, so the retention bound moves from limit+1 to limit+2. Terminal and merely-expired-but-active rows are treated differently on purpose: expiry is only authoritative for reclaim, so an expired active row's anchor stays protected.
- **A schema-presence gate** on all three paths: a database upgraded to a revision before the interaction table exists must purge and prune exactly as before. Without the gate, the absent table is an uncaught error on both purge paths (a 500 on task deletion), and on SQLite it lands in prune's degradation handler and re-registers an unclearable failure signal on every checkpoint write. Measured gate cost on PostgreSQL: 0.647 ms median, 1.90 ms p95 (N=1000) per prune — no caching warranted at that size. (measured against the engine-inspect form; the gate now inspects the session's own connection, which removes both per-call pool checkouts and is ~4.5x cheaper on PostgreSQL and ~12x on SQLite — the no-caching conclusion only strengthens).

Rows are deleted, not terminated first: the `tasks.id` FK cascades, terminating first would cost an extra write, and it would falsely imply interaction rows can outlive a purge.

## Closes #1071

This is the last undelivered clause of that issue. Per-clause accounting:

| Acceptance clause | Delivered by |
|---|---|
| Exact-row anchor column, FK + delete restriction | merged checkpoint-anchor work (#1137) |
| Checkpoint read contract dependency | #1137 |
| Shared reader/alias reuse | #1137 |
| Backfill + dual-read/write, partition-scoped resolution | #1137 |
| Lease recovery + CAS fence on the PK locator | #1137 |
| Checkpoint staging joins a caller-owned transaction | #1207 |
| Deletion paths clear dependent pointers / **rows** | pointers: #1137 · **rows: this PR** |
| Deletion clears or terminates dependents before trace cleanup | #1137 + this PR |
| Coverage incl. online **and offline** migrations, prune, deletion ordering | #1137 · offline: #1204 · prune/ordering: this PR |

#1207's body names three-way joint closure and #1204 used `Refs`, so closure lands here by construction. Two non-homes, checked: #1084 cannot carry any of this (it lists #1071 as its own dependency), and this PR does not close #1074 — the existing-table field pairs and the datetime read-back half remain open there, as discussed on that issue.

## Deferred, registered

The row-level lock serializing the single-task purge against the interaction handoff's finalizer writes is not in this PR. With zero production handoff writers there is nothing to serialize against and no test can demonstrate the lock's value, while the lock itself is a real concurrency behavior change (and SQLAlchemy silently drops `with_for_update()` on SQLite). It lands with the handoff's first production writer. Until then, the bulk path's failure shape under a concurrent writer is one loud `IntegrityError` rolling back the whole purge with no partial state; retrying completes the deletion.

## Verification

- Both backends, full matrix: {single purge, bulk purge} × {active row, terminal row, no rows} × {table present, table absent} — active-row purge succeeds post-fix, terminal-row behavior byte-unchanged, absent-table paths no-op cleanly.
- Statement order pinned on three schema shapes (create_all SQLite with FK enforcement, Alembic-upgraded SQLite, PostgreSQL); reverting the ordering reproduces the `IntegrityError` on both backends.
- Nine mutations, each run bug-in → red → revert → green, including: ordering reverted, interaction delete removed (active cells red, terminal cells stay green), prune protection filters dropped or over-widened, gate forced on an absent table, and protection folded into the ranking query (caught by a dedicated in-window retention test).
- Pointer-pairing static guards green; zero production writers of interaction rows confirmed by grep.
- Prune coverage is SQLite-only: the protection delta is a presence gate already pinned on both backends plus Python-side set arithmetic, and the checkpoint-stream module has no PostgreSQL fixture layer today.
- Full regression: SQLite 4746 passed / 0 failed; PostgreSQL web suite 4725 passed / 0 failed on a disposable database.

