### PR TITLE
fix: authorize task Agent identity before SSH resolution

### DIFF
--- a/frontend/src/components/build/agent-builder-preview.test.tsx
+++ b/frontend/src/components/build/agent-builder-preview.test.tsx
@@ -181,6 +181,43 @@ describe("AgentBuilder preview", () => {
       if (url.endsWith("/api/mcp/servers")) {
         return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
       }
+      if (url.endsWith("/api/agents/42/triggers")) {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+      }
+      if (url.endsWith("/api/agents/42")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: 42,
+              user_id: 1,
+              name: "Existing SSH agent",
+              description: "Saved description",
+              instructions: "Saved instructions",
+              execution_mode: "balanced",
+              suggested_prompts: [],
+              visibility: "team",
+              team_id: null,
+              knowledge_bases: [],
+              skills: [],
+              tool_categories: ["ssh"],
+              logo_url: null,
+              models: {
+                general: 7,
+                small_fast: null,
+                visual: null,
+                compact: null,
+              },
+              can_edit: true,
+              status: "draft",
+              origin: "user",
+              widget_enabled: false,
+              allowed_domains: [],
+              share_enabled: false,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
       if (url.endsWith("/api/chat/task/create")) {
         return Promise.resolve(
           new Response(
@@ -239,6 +276,31 @@ describe("AgentBuilder preview", () => {
       expect(sendMessageMock).toHaveBeenCalledWith("Preview this", expect.objectContaining({ force: true }), undefined)
     })
     expect(globalThis.WebSocket).not.toHaveBeenCalled()
+  })
+
+  it("keeps an edit-mode agent identity inside preview config only", async () => {
+    render(<AgentBuilder agentId="42" />)
+
+    await screen.findByDisplayValue("Existing SSH agent")
+    fireEvent.click(screen.getByText("send-preview-message"))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/chat/task/create",
+        expect.objectContaining({ method: "POST", body: expect.any(String) }),
+      )
+    })
+
+    const createCall = apiRequestMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/api/chat/task/create"),
+    )
+    const payload = JSON.parse(createCall?.[1]?.body as string)
+    expect(payload.agent_id).toBeUndefined()
+    expect(payload.agent_config).toMatchObject({
+      preview_agent_id: 42,
+      is_preview: true,
+      tool_categories: ["ssh"],
+    })
   })
 
   it("shows task file management in the embedded preview panel", async () => {

--- a/src/xagent/core/tools/adapters/vibe/ssh_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/ssh_tools.py
@@ -264,19 +264,6 @@ class SshDownloadTool(_SshTransferTool):
         return SshOpResult(ok=True, message="downloaded").model_dump()
 
 
-def _agent_id_from_task(task: Any) -> int | None:
-    """Resolve the agent id a task runs as. Normal tasks carry ``agent_id``;
-    build-preview tasks (#459) leave it NULL and carry the edited agent id in
-    ``agent_config["preview_agent_id"]``."""
-    if task is None:
-        return None
-    if task.agent_id is not None:
-        return int(task.agent_id)
-    cfg = task.agent_config or {}
-    pid = cfg.get("preview_agent_id") if isinstance(cfg, dict) else None
-    return int(pid) if pid is not None else None
-
-
 def _numeric_task_id(task_id: Any) -> int | None:
     """Extract the DB task id. The tool config hands us a workspace-scoped
     string like ``"web_task_30"`` (or a non-task id like ``"tools_list"``),
@@ -294,12 +281,25 @@ def _numeric_task_id(task_id: Any) -> int | None:
 def _agent_id_for_task(session_factory: Any, numeric_task_id: int | None) -> int | None:
     if numeric_task_id is None:
         return None
+    from .....web.models.agent import AgentStatus
     from .....web.models.task import Task
+    from .....web.services.agent_team_scope import resolve_authorized_agent
     from .db_session import tool_session_scope
 
     with tool_session_scope(session_factory) as db:
         task = db.query(Task).filter(Task.id == numeric_task_id).first()
-        return _agent_id_from_task(task)
+        if task is None:
+            return None
+        candidate_id = task.agent_id
+        if candidate_id is None:
+            config = task.agent_config
+            candidate_id = (
+                config.get("preview_agent_id") if isinstance(config, dict) else None
+            )
+        agent = resolve_authorized_agent(db, int(task.user_id), candidate_id)
+        if agent is None or agent.status == AgentStatus.ARCHIVED:
+            return None
+        return int(agent.id)
 
 
 def _make_ssh_sandbox_lease(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -68,7 +68,11 @@ from ..sandbox_keys import (
 )
 from ..schemas.chat import TaskCreateRequest, TaskCreateResponse
 from ..services.agent_access import list_accessible_published_agents
-from ..services.agent_team_scope import get_agent_team_scope, owned_agent_clause
+from ..services.agent_team_scope import (
+    get_agent_team_scope,
+    owned_agent_clause,
+    resolve_authorized_agent,
+)
 from ..services.chat_history_service import (
     get_latest_waiting_question,
     load_task_transcript,
@@ -1919,16 +1923,10 @@ class AgentServiceManager:
                 )
             elif agent_config and agent_config.get("preview_agent_id"):
                 preview_user_id = int(task.user_id)
-                current_agent = (
-                    db.query(Agent)
-                    .filter(
-                        Agent.id == agent_config["preview_agent_id"],
-                        owned_agent_clause(
-                            preview_user_id,
-                            get_agent_team_scope(db, preview_user_id),
-                        ),
-                    )
-                    .first()
+                current_agent = resolve_authorized_agent(
+                    db,
+                    preview_user_id,
+                    agent_config.get("preview_agent_id"),
                 )
                 if current_agent and current_agent.status == AgentStatus.PUBLISHED:
                     excluded_agent_id = int(current_agent.id)
@@ -2560,24 +2558,16 @@ class AgentServiceManager:
                     and agent_config
                     and agent_config.get("preview_agent_id")
                 ):
-                    from ..models.agent import AgentStatus
-
                     if task is None:
                         raise ValueError(
                             f"Task {task_id} missing while resolving preview agent"
                         )
                     preview_user_id = int(task.user_id)
                     assert db is not None
-                    current_agent = (
-                        db.query(Agent)
-                        .filter(
-                            Agent.id == agent_config["preview_agent_id"],
-                            owned_agent_clause(
-                                preview_user_id,
-                                get_agent_team_scope(db, preview_user_id),
-                            ),
-                        )
-                        .first()
+                    current_agent = resolve_authorized_agent(
+                        db,
+                        preview_user_id,
+                        agent_config.get("preview_agent_id"),
                     )
                     if current_agent and current_agent.status == AgentStatus.PUBLISHED:
                         excluded_agent_id = int(current_agent.id)

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2544,14 +2544,9 @@ class AgentServiceManager:
                         "will exclude from agent tools"
                     )
 
-                # Inline preview_agent_id case (#459 build-preview): the
-                # snapshot path doesn't cover this because it resolves
-                # excluded_agent_id only through ``task.agent_id``; the
-                # preview agent is referenced inside the inline
-                # ``agent_config`` dict on tasks with ``agent_id=None``.
-                # Run this in addition to (not instead of) the snapshot
-                # value above -- they're mutually exclusive by design
-                # (either task has an agent_id OR has inline preview).
+                # This inline preview_agent_id branch is only for the
+                # live-session path where ``snapshot is None``. The snapshot
+                # loader resolves the same inline config before this point.
                 if (
                     excluded_agent_id is None
                     and snapshot is None

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2544,32 +2544,6 @@ class AgentServiceManager:
                         "will exclude from agent tools"
                     )
 
-                # This inline preview_agent_id branch is only for the
-                # live-session path where ``snapshot is None``. The snapshot
-                # loader resolves the same inline config before this point.
-                if (
-                    excluded_agent_id is None
-                    and snapshot is None
-                    and agent_config
-                    and agent_config.get("preview_agent_id")
-                ):
-                    if task is None:
-                        raise ValueError(
-                            f"Task {task_id} missing while resolving preview agent"
-                        )
-                    preview_user_id = int(task.user_id)
-                    assert db is not None
-                    current_agent = resolve_authorized_agent(
-                        db,
-                        preview_user_id,
-                        agent_config.get("preview_agent_id"),
-                    )
-                    if current_agent and current_agent.status == AgentStatus.PUBLISHED:
-                        excluded_agent_id = int(current_agent.id)
-                        logger.info(
-                            f"Preview task {task_id} is for published agent {current_agent.id} ({current_agent.name}), will exclude from agent tools"
-                        )
-
                 workforce_runtime = (
                     snapshot.workforce_runtime
                     if snapshot is not None

--- a/src/xagent/web/services/agent_team_scope.py
+++ b/src/xagent/web/services/agent_team_scope.py
@@ -34,8 +34,8 @@ _team_agent_connector_validator = None
 _team_agent_knowledge_base_validator = None
 
 _MAX_POSTGRES_INTEGER = 2**31 - 1
-_MAX_POSTGRES_INTEGER_DECIMAL = str(_MAX_POSTGRES_INTEGER)
-_CANONICAL_AGENT_ID = re.compile(r"[1-9][0-9]*", re.ASCII)
+_MAX_POSTGRES_INTEGER_DECIMAL_DIGITS = len(str(_MAX_POSTGRES_INTEGER))
+_CANONICAL_AGENT_ID = re.compile(r"[1-9][0-9]*")
 
 
 def set_agent_team_hooks(
@@ -144,16 +144,18 @@ def resolve_authorized_agent(
     Persisted task config is untrusted at every read boundary. Reject malformed
     values before constructing the SQL predicate, then reuse the same owner/team
     clause as all normal Agent reads.
+
+    Lifecycle status is caller-owned; each use case must apply its required status policy after resolution.
     """
     if isinstance(candidate_id, bool):
         return None
     if isinstance(candidate_id, int):
         agent_id = candidate_id
-    elif isinstance(candidate_id, str) and _CANONICAL_AGENT_ID.fullmatch(candidate_id):
-        if len(candidate_id) > len(_MAX_POSTGRES_INTEGER_DECIMAL) or (
-            len(candidate_id) == len(_MAX_POSTGRES_INTEGER_DECIMAL)
-            and candidate_id > _MAX_POSTGRES_INTEGER_DECIMAL
-        ):
+    elif isinstance(candidate_id, str):
+        # Bound untrusted text before regex scanning or integer conversion.
+        if len(candidate_id) > _MAX_POSTGRES_INTEGER_DECIMAL_DIGITS:
+            return None
+        if not _CANONICAL_AGENT_ID.fullmatch(candidate_id):
             return None
         agent_id = int(candidate_id)
     else:

--- a/src/xagent/web/services/agent_team_scope.py
+++ b/src/xagent/web/services/agent_team_scope.py
@@ -8,6 +8,7 @@ and whether that user is a team admin.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any, Optional, cast
 
@@ -31,6 +32,9 @@ _team_agent_connector_validator = None
 
 # (db, user_id, team_id, knowledge_bases) -> list of unshared KB dicts.
 _team_agent_knowledge_base_validator = None
+
+_MAX_POSTGRES_INTEGER = 2**31 - 1
+_CANONICAL_AGENT_ID = re.compile(r"[1-9][0-9]*", re.ASCII)
 
 
 def set_agent_team_hooks(
@@ -128,4 +132,33 @@ def owned_agent_clause(
     return or_(
         and_(Agent.team_id.is_(None), Agent.user_id == user_id),
         team_clause,
+    )
+
+
+def resolve_authorized_agent(
+    db: Session, owner_user_id: int, candidate_id: Any
+) -> Agent | None:
+    """Resolve a canonical Agent id within the task owner's team scope.
+
+    Persisted task config is untrusted at every read boundary. Reject malformed
+    values before constructing the SQL predicate, then reuse the same owner/team
+    clause as all normal Agent reads.
+    """
+    if isinstance(candidate_id, bool):
+        return None
+    if isinstance(candidate_id, int):
+        agent_id = candidate_id
+    elif isinstance(candidate_id, str) and _CANONICAL_AGENT_ID.fullmatch(candidate_id):
+        agent_id = int(candidate_id)
+    else:
+        return None
+    if not 0 < agent_id <= _MAX_POSTGRES_INTEGER:
+        return None
+    return (
+        db.query(Agent)
+        .filter(
+            Agent.id == agent_id,
+            owned_agent_clause(owner_user_id, get_agent_team_scope(db, owner_user_id)),
+        )
+        .first()
     )

--- a/src/xagent/web/services/agent_team_scope.py
+++ b/src/xagent/web/services/agent_team_scope.py
@@ -34,6 +34,7 @@ _team_agent_connector_validator = None
 _team_agent_knowledge_base_validator = None
 
 _MAX_POSTGRES_INTEGER = 2**31 - 1
+_MAX_POSTGRES_INTEGER_DECIMAL = str(_MAX_POSTGRES_INTEGER)
 _CANONICAL_AGENT_ID = re.compile(r"[1-9][0-9]*", re.ASCII)
 
 
@@ -149,6 +150,11 @@ def resolve_authorized_agent(
     if isinstance(candidate_id, int):
         agent_id = candidate_id
     elif isinstance(candidate_id, str) and _CANONICAL_AGENT_ID.fullmatch(candidate_id):
+        if len(candidate_id) > len(_MAX_POSTGRES_INTEGER_DECIMAL) or (
+            len(candidate_id) == len(_MAX_POSTGRES_INTEGER_DECIMAL)
+            and candidate_id > _MAX_POSTGRES_INTEGER_DECIMAL
+        ):
+            return None
         agent_id = int(candidate_id)
     else:
         return None

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -107,10 +107,11 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # the re-layer never fires here. So reserving ``is_preview`` or
 # ``preview_agent_id`` would still silently strip them from this config with
 # nothing to restore them, breaking agent-builder preview. That it cannot be
-# reserved is not a statement that it is safe: three of its readers resolve it
-# through an ownership-scoped query, but the SSH tools' ``_agent_id_from_task``
-# reads it with no such check and uses it to pick which targets a task may
-# reach, so the answer for that key has to be reader-side (issue #1136).
+# reserved is not a statement that it is safe: every authorization-sensitive
+# reader must treat it as an untrusted persisted candidate and route it through
+# ``agent_team_scope.resolve_authorized_agent`` using the task owner. The SSH
+# reader also rejects archived agents before it constructs an execution
+# identity, so malformed or out-of-scope values cannot select SSH targets.
 #
 # Before adding a key here: (1) confirm no server writer reaches this column
 # *through* the sanitizer (the preview path above is the only known case);

--- a/src/xagent/web/services/task_setup_snapshot.py
+++ b/src/xagent/web/services/task_setup_snapshot.py
@@ -215,20 +215,14 @@ def _resolve_inline_preview_excluded_agent_id(
     if not agent_config or not agent_config.get("preview_agent_id"):
         return None
 
-    from ..models.agent import Agent, AgentStatus
-    from .agent_team_scope import get_agent_team_scope, owned_agent_clause
+    from ..models.agent import AgentStatus
+    from .agent_team_scope import resolve_authorized_agent
 
     owner_user_id = int(task_row.user_id)
-    preview_agent = (
-        session.query(Agent)
-        .filter(
-            Agent.id == agent_config["preview_agent_id"],
-            owned_agent_clause(
-                owner_user_id,
-                get_agent_team_scope(session, owner_user_id),
-            ),
-        )
-        .first()
+    preview_agent = resolve_authorized_agent(
+        session,
+        owner_user_id,
+        agent_config.get("preview_agent_id"),
     )
     if preview_agent is None or preview_agent.status != AgentStatus.PUBLISHED:
         return None

--- a/tests/core/tools/test_ssh_tools.py
+++ b/tests/core/tools/test_ssh_tools.py
@@ -501,6 +501,77 @@ async def test_create_ssh_tools_denies_cross_scope_preview_before_provider_targe
         set_ssh_target_provider_hook(None)
 
 
+@pytest.mark.parametrize(
+    ("case", "preview_candidate"),
+    [
+        ("cross-owner-direct", None),
+        ("malformed-preview", "abc"),
+        ("oversized-preview", "1" * 5000),
+        ("archived-direct", None),
+        ("denied-primary-no-preview-fallback", None),
+    ],
+)
+async def test_create_ssh_tools_denies_unresolved_task_agent_before_provider_targets(
+    task_db,
+    case,
+    preview_candidate,
+) -> None:
+    """Persisted task identity must be authorized before provider target access."""
+    from xagent.core.tools.adapters.vibe import ssh_tools
+    from xagent.web.services.ssh_runtime import set_ssh_target_provider_hook
+
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        if case == "cross-owner-direct":
+            other = _new_user(db, "other")
+            foreign = _new_agent(db, int(other.id), status=AgentStatus.PUBLISHED)
+            task = _new_task(db, int(owner.id), agent_id=int(foreign.id))
+        elif case in {"malformed-preview", "oversized-preview"}:
+            task = _new_task(
+                db,
+                int(owner.id),
+                agent_config={"preview_agent_id": preview_candidate},
+            )
+        elif case == "archived-direct":
+            archived = _new_agent(db, int(owner.id), status=AgentStatus.ARCHIVED)
+            task = _new_task(db, int(owner.id), agent_id=int(archived.id))
+        else:
+            other = _new_user(db, "other")
+            denied_primary = _new_agent(db, int(other.id), name="foreign")
+            owned_preview = _new_agent(db, int(owner.id), name="owned")
+            task = _new_task(
+                db,
+                int(owner.id),
+                agent_id=int(denied_primary.id),
+                agent_config={"preview_agent_id": int(owned_preview.id)},
+            )
+    finally:
+        db.close()
+
+    provider = _RecordingTargetProvider()
+    factory_calls: list[object] = []
+
+    def _factory(session_factory):
+        factory_calls.append(session_factory)
+        return provider
+
+    set_ssh_target_provider_hook(_factory)
+    config = SimpleNamespace(
+        get_session_factory=lambda: task_db,
+        get_user_id=lambda: int(owner.id),
+        get_task_id=lambda: f"web_task_{int(task.id)}",
+        get_workspace_config=lambda: None,
+    )
+    try:
+        assert await ssh_tools.create_ssh_tools(config) == []
+        assert factory_calls == [task_db]
+        assert provider.list_calls == 0
+        assert provider.resolve_calls == 0
+    finally:
+        set_ssh_target_provider_hook(None)
+
+
 async def test_create_ssh_tools_propagates_task_owner_scope_failure(task_db) -> None:
     from xagent.core.tools.adapters.vibe import ssh_tools
     from xagent.web.services.ssh_runtime import set_ssh_target_provider_hook

--- a/tests/core/tools/test_ssh_tools.py
+++ b/tests/core/tools/test_ssh_tools.py
@@ -9,12 +9,14 @@ from xagent.core.ssh import (
     BoundTargetInfo,
     PrincipalRef,
     ResolvedSshTarget,
+    SensitiveSshCredential,
     SshError,
     SshErrorCode,
     SshExecutionContext,
     SshSecretHandle,
 )
 from xagent.core.ssh.executor import SshExecuteOutcome
+from xagent.core.ssh.runner import SshRunResult
 from xagent.core.tools.adapters.vibe.ssh_tools import (
     SshDownloadTool,
     SshExecuteTool,
@@ -442,21 +444,153 @@ def test_agent_id_for_task_allows_team_admin_private_and_member_team_visible(
 
 
 class _RecordingTargetProvider(_Provider):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(
+        self,
+        *,
+        resolved=None,
+        targets=None,
+        credential=None,
+        events=None,
+    ) -> None:
+        super().__init__(resolved=resolved, targets=targets)
+        self._credential = credential
+        self._events = events
         self.list_calls = 0
         self.resolve_calls = 0
+        self.list_contexts = []
+        self.resolve_contexts = []
 
     async def resolve(self, context, target_alias):
         self.resolve_calls += 1
+        self.resolve_contexts.append(context)
+        if self._events is not None:
+            self._events.append(("resolve", context, target_alias))
         return await super().resolve(context, target_alias)
 
     async def list_bound_targets(self, context):
         self.list_calls += 1
-        return []
+        self.list_contexts.append(context)
+        if self._events is not None:
+            self._events.append(("list", context))
+        return await super().list_bound_targets(context)
 
     async def read_version(self, secret_handle):
-        raise NotImplementedError
+        if self._events is not None:
+            self._events.append(("read_version", secret_handle))
+        if self._credential is None:
+            raise NotImplementedError
+        return self._credential
+
+
+class _RecordingRunner:
+    def __init__(self, events) -> None:
+        self._events = events
+
+    async def execute(self, **kwargs) -> SshRunResult:
+        self._events.append(("run", kwargs["command"]))
+        return SshRunResult(exit_code=0, stdout="ok", stderr="", truncated=False)
+
+
+@pytest.mark.parametrize("status", [AgentStatus.DRAFT, AgentStatus.PUBLISHED])
+async def test_create_ssh_tools_propagates_authorized_preview_context_to_execute(
+    task_db,
+    monkeypatch,
+    status,
+) -> None:
+    from xagent.core.tools.adapters.vibe import ssh_tools
+    from xagent.web.services.ssh_runtime import set_ssh_target_provider_hook
+
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        _new_agent(db, int(owner.id), name="id-separator")
+        preview = _new_agent(db, int(owner.id), name="preview", status=status)
+        task = _new_task(
+            db,
+            int(owner.id),
+            agent_config={"preview_agent_id": int(preview.id)},
+        )
+        owner_id = int(owner.id)
+        preview_id = int(preview.id)
+        task_id = int(task.id)
+    finally:
+        db.close()
+    assert preview_id != owner_id
+
+    events: list[tuple] = []
+    provider = _RecordingTargetProvider(
+        resolved=_resolved(),
+        targets=[
+            BoundTargetInfo(
+                alias="prod",
+                display_name="Production",
+                capabilities=frozenset({"execute"}),
+            )
+        ],
+        credential=SensitiveSshCredential(b"KEY", "", "ssh-ed25519"),
+        events=events,
+    )
+
+    def _factory(session_factory):
+        events.append(("factory", session_factory))
+        return provider
+
+    runner = _RecordingRunner(events)
+    set_ssh_target_provider_hook(_factory)
+    monkeypatch.setattr(ssh_tools, "_make_ssh_sandbox_lease", lambda *_args: None)
+    monkeypatch.setattr(ssh_tools, "AsyncsshRunner", lambda: runner)
+    config = SimpleNamespace(
+        get_session_factory=lambda: task_db,
+        get_user_id=lambda: owner_id,
+        get_task_id=lambda: f"web_task_{task_id}",
+        get_workspace_config=lambda: None,
+    )
+    try:
+        tools = await ssh_tools.create_ssh_tools(config)
+        assert [tool.name for tool in tools] == [
+            "ssh_list_targets",
+            "ssh_execute",
+            "ssh_upload",
+            "ssh_download",
+        ]
+
+        expected_context = SshExecutionContext(
+            actor=ActorRef(actor_type="user", actor_id=str(owner_id)),
+            execution_principal=PrincipalRef(
+                principal_type="user", principal_id=str(owner_id)
+            ),
+            agent_id=preview_id,
+            task_id=task_id,
+            turn_id=None,
+            request_id=f"web_task_{task_id}",
+        )
+        assert provider.list_contexts == [expected_context]
+        assert events == [("factory", task_db), ("list", expected_context)]
+
+        execute_tool = next(tool for tool in tools if tool.name == "ssh_execute")
+        assert isinstance(execute_tool, SshExecuteTool)
+
+        async def _resolve_public(_hostname, _port):
+            return ["8.8.8.8"]
+
+        execute_tool._executor._resolver = _resolve_public
+        outcome = await execute_tool.run_json_async(
+            {"target": "prod", "command": "uptime"}
+        )
+
+        assert outcome["ok"] is True
+        assert outcome["stdout"] == "ok"
+        assert provider.resolve_contexts == [expected_context]
+        assert provider.resolve_contexts[0] is provider.list_contexts[0]
+        assert events == [
+            ("factory", task_db),
+            ("list", expected_context),
+            ("resolve", expected_context, "prod"),
+            ("read_version", _resolved().secret_handle),
+            ("run", "uptime"),
+        ]
+    finally:
+        set_ssh_target_provider_hook(None)
 
 
 async def test_create_ssh_tools_denies_cross_scope_preview_before_provider_targets(

--- a/tests/core/tools/test_ssh_tools.py
+++ b/tests/core/tools/test_ssh_tools.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from xagent.core.ssh import (
     ActorRef,
@@ -18,9 +20,17 @@ from xagent.core.tools.adapters.vibe.ssh_tools import (
     SshExecuteTool,
     SshListTargetsTool,
     SshUploadTool,
-    _agent_id_from_task,
+    _agent_id_for_task,
     _egress_from_env,
     _numeric_task_id,
+)
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.agent_team_scope import (
+    AgentTeamScope,
+    set_agent_team_scope_hook,
 )
 
 
@@ -232,23 +242,298 @@ def test_numeric_task_id_parses_workspace_prefixed_id() -> None:
     assert _numeric_task_id(None) is None
 
 
-def test_agent_id_from_task_normal() -> None:
-    task = SimpleNamespace(agent_id=5, agent_config=None)
-    assert _agent_id_from_task(task) == 5
+@pytest.fixture
+def task_db(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'ssh-tools.db'}")
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(autoflush=False, bind=engine, expire_on_commit=False)
+    try:
+        yield session_factory
+    finally:
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
 
 
-def test_agent_id_from_task_preview_fallback() -> None:
-    # Preview tasks (#459) carry agent_id=None; the edited agent id lives in
-    # agent_config["preview_agent_id"].
-    task = SimpleNamespace(agent_id=None, agent_config={"preview_agent_id": 7})
-    assert _agent_id_from_task(task) == 7
+def _new_user(db, name: str) -> User:
+    user = User(username=name, email=f"{name}@example.test", password_hash="x")
+    db.add(user)
+    db.flush()
+    return user
 
 
-def test_agent_id_from_task_none_when_unresolvable() -> None:
-    assert _agent_id_from_task(None) is None
-    assert (
-        _agent_id_from_task(SimpleNamespace(agent_id=None, agent_config=None)) is None
+def _new_agent(db, user_id: int, **overrides) -> Agent:
+    agent = Agent(
+        user_id=user_id,
+        name=overrides.pop("name", "ssh-agent"),
+        status=overrides.pop("status", AgentStatus.DRAFT),
+        **overrides,
     )
+    db.add(agent)
+    db.flush()
+    return agent
+
+
+def _new_task(db, user_id: int, **overrides) -> Task:
+    task = Task(
+        user_id=user_id,
+        title="SSH task",
+        description="SSH task",
+        status=TaskStatus.PENDING,
+        **overrides,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@pytest.mark.parametrize("status", [AgentStatus.DRAFT, AgentStatus.PUBLISHED])
+def test_agent_id_for_task_authorizes_owned_direct_agent(task_db, status) -> None:
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        agent = _new_agent(db, int(owner.id), status=status)
+        task = _new_task(db, int(owner.id), agent_id=int(agent.id))
+    finally:
+        db.close()
+
+    assert _agent_id_for_task(task_db, int(task.id)) == int(agent.id)
+
+
+@pytest.mark.parametrize("status", [AgentStatus.DRAFT, AgentStatus.PUBLISHED])
+def test_agent_id_for_task_authorizes_owned_preview_agent(task_db, status) -> None:
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        agent = _new_agent(db, int(owner.id), status=status)
+        task = _new_task(
+            db,
+            int(owner.id),
+            agent_config={"preview_agent_id": int(agent.id)},
+        )
+    finally:
+        db.close()
+
+    assert _agent_id_for_task(task_db, int(task.id)) == int(agent.id)
+
+
+def test_agent_id_for_task_rejects_cross_owner_published_direct_agent(task_db) -> None:
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        other = _new_user(db, "other")
+        published = _new_agent(db, int(other.id), status=AgentStatus.PUBLISHED)
+        task = _new_task(db, int(owner.id), agent_id=int(published.id))
+    finally:
+        db.close()
+
+    assert _agent_id_for_task(task_db, int(task.id)) is None
+
+
+@pytest.mark.parametrize("candidate", ["01", "abc", True, 2**31, str(2**31)])
+def test_agent_id_for_task_rejects_malformed_preview_candidate(
+    task_db, candidate
+) -> None:
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        task = _new_task(
+            db,
+            int(owner.id),
+            agent_config={"preview_agent_id": candidate},
+        )
+    finally:
+        db.close()
+
+    assert _agent_id_for_task(task_db, int(task.id)) is None
+
+
+def test_agent_id_for_task_rejects_cross_scope_preview_agent(task_db) -> None:
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        other = _new_user(db, "other")
+        foreign = _new_agent(db, int(other.id))
+        task = _new_task(
+            db,
+            int(owner.id),
+            agent_config={"preview_agent_id": int(foreign.id)},
+        )
+    finally:
+        db.close()
+
+    assert _agent_id_for_task(task_db, int(task.id)) is None
+
+
+def test_agent_id_for_task_rejects_archived_agent(task_db) -> None:
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        archived = _new_agent(db, int(owner.id), status=AgentStatus.ARCHIVED)
+        task = _new_task(
+            db,
+            int(owner.id),
+            agent_config={"preview_agent_id": int(archived.id)},
+        )
+    finally:
+        db.close()
+
+    assert _agent_id_for_task(task_db, int(task.id)) is None
+
+
+def test_agent_id_for_task_does_not_fallback_after_denied_primary_agent(
+    task_db,
+) -> None:
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        other = _new_user(db, "other")
+        denied_primary = _new_agent(db, int(other.id), name="foreign")
+        owned_preview = _new_agent(db, int(owner.id), name="owned")
+        task = _new_task(
+            db,
+            int(owner.id),
+            agent_id=int(denied_primary.id),
+            agent_config={"preview_agent_id": int(owned_preview.id)},
+        )
+    finally:
+        db.close()
+
+    assert _agent_id_for_task(task_db, int(task.id)) is None
+
+
+def test_agent_id_for_task_allows_team_admin_private_and_member_team_visible(
+    task_db,
+) -> None:
+    db = task_db()
+    try:
+        admin = _new_user(db, "admin")
+        member = _new_user(db, "member")
+        private = _new_agent(
+            db, int(member.id), team_id=77, visibility="admins", name="private"
+        )
+        shared = _new_agent(
+            db, int(admin.id), team_id=77, visibility="team", name="shared"
+        )
+        legacy = _new_agent(db, int(member.id), team_id=None, name="legacy")
+        admin_task = _new_task(
+            db, int(admin.id), agent_config={"preview_agent_id": int(private.id)}
+        )
+        member_task = _new_task(
+            db, int(member.id), agent_config={"preview_agent_id": int(shared.id)}
+        )
+        legacy_task = _new_task(
+            db, int(member.id), agent_config={"preview_agent_id": int(legacy.id)}
+        )
+    finally:
+        db.close()
+
+    set_agent_team_scope_hook(
+        lambda _db, user_id: AgentTeamScope(
+            team_id=77, is_team_admin=user_id == int(admin.id)
+        )
+    )
+    try:
+        assert _agent_id_for_task(task_db, int(admin_task.id)) == int(private.id)
+        assert _agent_id_for_task(task_db, int(member_task.id)) == int(shared.id)
+        assert _agent_id_for_task(task_db, int(legacy_task.id)) == int(legacy.id)
+    finally:
+        set_agent_team_scope_hook(None)
+
+
+class _RecordingTargetProvider(_Provider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.list_calls = 0
+        self.resolve_calls = 0
+
+    async def resolve(self, context, target_alias):
+        self.resolve_calls += 1
+        return await super().resolve(context, target_alias)
+
+    async def list_bound_targets(self, context):
+        self.list_calls += 1
+        return []
+
+    async def read_version(self, secret_handle):
+        raise NotImplementedError
+
+
+async def test_create_ssh_tools_denies_cross_scope_preview_before_provider_targets(
+    task_db,
+) -> None:
+    from xagent.core.tools.adapters.vibe import ssh_tools
+    from xagent.web.services.ssh_runtime import set_ssh_target_provider_hook
+
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        other = _new_user(db, "other")
+        foreign = _new_agent(db, int(other.id))
+        task = _new_task(
+            db,
+            int(owner.id),
+            agent_config={"preview_agent_id": int(foreign.id)},
+        )
+    finally:
+        db.close()
+
+    provider = _RecordingTargetProvider()
+    factory_calls: list[object] = []
+
+    def _factory(session_factory):
+        factory_calls.append(session_factory)
+        return provider
+
+    set_ssh_target_provider_hook(_factory)
+    config = SimpleNamespace(
+        get_session_factory=lambda: task_db,
+        get_user_id=lambda: int(owner.id),
+        get_task_id=lambda: f"web_task_{int(task.id)}",
+        get_workspace_config=lambda: None,
+    )
+    try:
+        assert await ssh_tools.create_ssh_tools(config) == []
+        assert factory_calls == [task_db]
+        assert provider.list_calls == 0
+        assert provider.resolve_calls == 0
+    finally:
+        set_ssh_target_provider_hook(None)
+
+
+async def test_create_ssh_tools_propagates_task_owner_scope_failure(task_db) -> None:
+    from xagent.core.tools.adapters.vibe import ssh_tools
+    from xagent.web.services.ssh_runtime import set_ssh_target_provider_hook
+
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        agent = _new_agent(db, int(owner.id))
+        task = _new_task(db, int(owner.id), agent_id=int(agent.id))
+    finally:
+        db.close()
+
+    provider = _RecordingTargetProvider()
+    set_ssh_target_provider_hook(lambda _session_factory: provider)
+
+    def _raise_scope_failure(*_args):
+        raise RuntimeError("team scope unavailable")
+
+    set_agent_team_scope_hook(_raise_scope_failure)
+    config = SimpleNamespace(
+        get_session_factory=lambda: task_db,
+        get_user_id=lambda: int(owner.id),
+        get_task_id=lambda: f"web_task_{int(task.id)}",
+        get_workspace_config=lambda: None,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="team scope unavailable"):
+            await ssh_tools.create_ssh_tools(config)
+        assert provider.list_calls == 0
+        assert provider.resolve_calls == 0
+    finally:
+        set_agent_team_scope_hook(None)
+        set_ssh_target_provider_hook(None)
 
 
 class _FakeLease:

--- a/tests/core/tools/test_ssh_tools.py
+++ b/tests/core/tools/test_ssh_tools.py
@@ -507,6 +507,7 @@ async def test_create_ssh_tools_denies_cross_scope_preview_before_provider_targe
         ("cross-owner-direct", None),
         ("malformed-preview", "abc"),
         ("oversized-preview", "1" * 5000),
+        ("nonexistent-preview", "2147483647"),
         ("archived-direct", None),
         ("denied-primary-no-preview-fallback", None),
     ],
@@ -527,7 +528,7 @@ async def test_create_ssh_tools_denies_unresolved_task_agent_before_provider_tar
             other = _new_user(db, "other")
             foreign = _new_agent(db, int(other.id), status=AgentStatus.PUBLISHED)
             task = _new_task(db, int(owner.id), agent_id=int(foreign.id))
-        elif case in {"malformed-preview", "oversized-preview"}:
+        elif case in {"malformed-preview", "oversized-preview", "nonexistent-preview"}:
             task = _new_task(
                 db,
                 int(owner.id),

--- a/tests/web/api/test_get_agent_for_task_snapshot_threaded.py
+++ b/tests/web/api/test_get_agent_for_task_snapshot_threaded.py
@@ -43,6 +43,7 @@ from xagent.web.api import chat as chat_module
 from xagent.web.api.chat import AgentServiceManager
 from xagent.web.models import Base, Task
 from xagent.web.models import database as database_module
+from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.task import TaskStatus
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
@@ -570,6 +571,110 @@ async def test_loop_consumes_snapshot_after_session_close() -> None:
     # before reaching this point.
     assert constructed.get("pattern") == "single_call"
     assert constructed.get("task_id") == "42"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "expected_excluded"),
+    [
+        (AgentStatus.PUBLISHED, True),
+        (AgentStatus.DRAFT, False),
+    ],
+)
+async def test_get_agent_for_task_snapshot_reader_uses_persisted_task_owner(
+    tmp_path,
+    monkeypatch,
+    status,
+    expected_excluded,
+) -> None:
+    """The reachable get-agent path delegates preview exclusion to its snapshot."""
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'preview-owner.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False)
+    monkeypatch.setattr(database_module, "_SessionLocal", session_factory)
+
+    with session_factory() as setup_db:
+        owner = User(username="preview-owner", password_hash="hash", is_admin=False)
+        actor = User(username="preview-actor", password_hash="hash", is_admin=False)
+        setup_db.add_all([owner, actor])
+        setup_db.flush()
+        preview_agent = Agent(
+            user_id=int(owner.id),
+            name="preview-agent",
+            status=status,
+            instructions="preview instructions",
+            execution_mode="flash",
+            models={},
+            knowledge_bases=[],
+            skills=[],
+            tool_categories=[],
+        )
+        setup_db.add(preview_agent)
+        setup_db.flush()
+        task = Task(
+            user_id=int(owner.id),
+            title="preview task",
+            description="preview",
+            status=TaskStatus.PENDING,
+            execution_mode="flash",
+            agent_config={
+                "instructions": "preview instructions",
+                "skills": [],
+                "knowledge_bases": [],
+                "tool_categories": [],
+                "preview_agent_id": str(int(preview_agent.id)),
+            },
+        )
+        setup_db.add(task)
+        setup_db.commit()
+        owner_id = int(owner.id)
+        actor_id = int(actor.id)
+        preview_agent_id = int(preview_agent.id)
+        task_id = int(task.id)
+
+    resolved_owner_ids: list[int] = []
+    from xagent.web.services import agent_team_scope
+
+    real_resolver = agent_team_scope.resolve_authorized_agent
+
+    def observe_resolver(session, owner_user_id, candidate_id):
+        resolved_owner_ids.append(owner_user_id)
+        return real_resolver(session, owner_user_id, candidate_id)
+
+    observed_excluded_ids: list[int | None] = []
+
+    async def capture_tools(*_args: Any, **kwargs: Any):
+        observed_excluded_ids.append(kwargs["excluded_agent_id"])
+        return [], MagicMock()
+
+    manager = AgentServiceManager()
+    agent_service = MagicMock()
+    agent_service.workspace = None
+    request_db = session_factory()
+    actor_user = request_db.get(User, actor_id)
+    assert actor_user is not None
+    monkeypatch.setattr(agent_team_scope, "resolve_authorized_agent", observe_resolver)
+    try:
+        with (
+            patch.object(manager, "_load_persisted_conversation_history"),
+            patch.object(manager, "_load_persisted_execution_context", new=AsyncMock()),
+            patch("xagent.web.api.chat.create_task_tracer", return_value=MagicMock()),
+            patch("xagent.web.api.chat.create_default_tools", new=capture_tools),
+            patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None),
+            patch("xagent.web.api.chat.AgentService", return_value=agent_service),
+        ):
+            await manager.get_agent_for_task(task_id, request_db, user=actor_user)
+    finally:
+        request_db.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+    assert actor_id != owner_id
+    assert resolved_owner_ids == [owner_id]
+    assert observed_excluded_ids == [preview_agent_id if expected_excluded else None]
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_task_runtime_delete_bindings.py
+++ b/tests/web/api/test_task_runtime_delete_bindings.py
@@ -71,6 +71,43 @@ def _register(name: str, provider: _Provider, registered: list[str]) -> _Provide
     return provider
 
 
+@pytest.mark.asyncio
+async def test_task_create_persists_inline_preview_agent_without_top_level_agent_id() -> (
+    None
+):
+    _admin_headers()
+    _register_second_user("preview-owner", "previewpass1")
+    db = _direct_db_session()
+    try:
+        owner = db.query(User).filter(User.username == "preview-owner").one()
+        created = await create_task(
+            TaskCreateRequest(
+                title="inline preview",
+                description="inline preview",
+                agent_id=None,
+                agent_config={
+                    "instructions": "preview",
+                    "knowledge_bases": [],
+                    "skills": [],
+                    "tool_categories": ["ssh"],
+                    "is_preview": True,
+                    "preview_agent_id": 41,
+                },
+                is_visible=False,
+            ),
+            db=db,
+            user=owner,
+        )
+
+        db.expire_all()
+        task = db.query(Task).filter(Task.id == int(created.task_id)).one()
+        assert task.agent_id is None
+        assert task.agent_config["preview_agent_id"] == 41
+        assert task.agent_config["tool_categories"] == ["ssh"]
+    finally:
+        db.close()
+
+
 # ===== reserved agent_config keys are server-owned, never client-supplied =====
 
 

--- a/tests/web/api/test_websocket_preview.py
+++ b/tests/web/api/test_websocket_preview.py
@@ -87,6 +87,7 @@ async def test_handle_build_preview_execution_uses_normal_task_flow():
     mock_user.is_admin = False
 
     message_data = {
+        "agent_id": 41,
         "instructions": "test instructions",
         "execution_mode": "graph",
         "models": {
@@ -127,6 +128,7 @@ async def test_handle_build_preview_execution_uses_normal_task_flow():
     assert create_request.is_visible is False
     assert create_request.agent_id is None
     assert create_request.agent_config["instructions"] == "test instructions"
+    assert create_request.agent_config["preview_agent_id"] == 41
     assert create_request.llm_ids == ["1", None, None, None]
     assert create_request.files is None
     mock_register_connection.assert_called_once_with(mock_websocket, 123)

--- a/tests/web/services/test_task_setup_snapshot.py
+++ b/tests/web/services/test_task_setup_snapshot.py
@@ -499,6 +499,77 @@ def test_inline_preview_agent_with_noncanonical_id_is_not_excluded_in_snapshot(
     assert snapshot.excluded_agent_id is None
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "expected_excluded"),
+    [
+        (AgentStatus.PUBLISHED, True),
+        (AgentStatus.DRAFT, False),
+    ],
+)
+async def test_build_tools_inline_preview_uses_persisted_task_owner(
+    db_session,
+    monkeypatch,
+    status,
+    expected_excluded,
+) -> None:
+    """The live DB reader authorizes preview IDs as the persisted task owner."""
+    from xagent.web.api import chat as chat_module
+    from xagent.web.api.chat import AgentServiceManager
+
+    owner = _create_user(db_session)
+    actor = User(username="preview-actor", password_hash="hash", is_admin=False)
+    db_session.add(actor)
+    db_session.commit()
+    db_session.refresh(actor)
+    preview_agent = _create_agent(db_session, int(owner.id), status=status)
+    task = _create_task(
+        db_session,
+        user_id=int(owner.id),
+        agent_config={
+            "instructions": "preview instructions",
+            "skills": [],
+            "knowledge_bases": [],
+            "tool_categories": [],
+            "preview_agent_id": str(int(preview_agent.id)),
+        },
+    )
+
+    resolved_owner_ids: list[int] = []
+    real_resolver = chat_module.resolve_authorized_agent
+
+    def observe_resolver(session, owner_user_id, candidate_id):
+        resolved_owner_ids.append(owner_user_id)
+        return real_resolver(session, owner_user_id, candidate_id)
+
+    observed_excluded_ids: list[int | None] = []
+
+    async def capture_tools(*_args, **kwargs):
+        observed_excluded_ids.append(kwargs["excluded_agent_id"])
+        return [], object()
+
+    monkeypatch.setattr(chat_module, "resolve_authorized_agent", observe_resolver)
+    monkeypatch.setattr(chat_module, "create_default_tools", capture_tools)
+    monkeypatch.setattr("xagent.web.sandbox_manager.get_sandbox_manager", lambda: None)
+
+    manager = AgentServiceManager()
+    await manager._build_tools_for_task(
+        task_id=int(task.id),
+        task=task,
+        db=db_session,
+        user=actor,
+        agent_config=task.agent_config,
+        task_llm=None,
+        task_vision_llm=None,
+    )
+
+    assert resolved_owner_ids == [int(owner.id)]
+    assert int(actor.id) != int(owner.id)
+    assert observed_excluded_ids == [
+        int(preview_agent.id) if expected_excluded else None
+    ]
+
+
 def test_agent_builder_published_sets_excluded_agent_id(db_session) -> None:
     """Task pointing at a PUBLISHED agent: excluded_agent_id matches
     agent.id, agent_config is populated, agent.status flows through."""

--- a/tests/web/services/test_task_setup_snapshot.py
+++ b/tests/web/services/test_task_setup_snapshot.py
@@ -474,6 +474,31 @@ def test_inline_published_preview_agent_is_excluded_in_snapshot(db_session) -> N
     assert snapshot.excluded_agent_id == int(preview_agent.id)
 
 
+def test_inline_preview_agent_with_noncanonical_id_is_not_excluded_in_snapshot(
+    db_session,
+) -> None:
+    user = _create_user(db_session)
+    preview_agent = _create_agent(db_session, user_id=int(user.id))
+    task = _create_task(
+        db_session,
+        user_id=int(user.id),
+        agent_config={
+            "instructions": "preview instructions",
+            "skills": [],
+            "knowledge_bases": [],
+            "tool_categories": [],
+            "preview_agent_id": f"0{int(preview_agent.id)}",
+        },
+    )
+
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
+
+    assert snapshot is not None
+    assert snapshot.excluded_agent_id is None
+
+
 def test_agent_builder_published_sets_excluded_agent_id(db_session) -> None:
     """Task pointing at a PUBLISHED agent: excluded_agent_id matches
     agent.id, agent_config is populated, agent.status flows through."""

--- a/tests/web/test_agent_team_scope.py
+++ b/tests/web/test_agent_team_scope.py
@@ -115,7 +115,6 @@ class _RecordingSession:
         "\N{ARABIC-INDIC DIGIT ONE}",
         2**31,
         str(2**31),
-        "1" * 5000,
     ],
 )
 def test_resolve_authorized_agent_rejects_noncanonical_or_out_of_range_ids_before_query(
@@ -125,6 +124,23 @@ def test_resolve_authorized_agent_rejects_noncanonical_or_out_of_range_ids_befor
 
     assert (
         ats.resolve_authorized_agent(session, owner_user_id=7, candidate_id=candidate)
+        is None
+    )
+    assert session.query_calls == []
+
+
+def test_resolve_authorized_agent_rejects_overlong_string_before_regex_or_query(
+    monkeypatch,
+):
+    class _RegexSentinel:
+        def fullmatch(self, _candidate):
+            raise AssertionError("regex must not scan overlong candidate ids")
+
+    session = _RecordingSession()
+    monkeypatch.setattr(ats, "_CANONICAL_AGENT_ID", _RegexSentinel())
+
+    assert (
+        ats.resolve_authorized_agent(session, owner_user_id=7, candidate_id="1" * 5000)
         is None
     )
     assert session.query_calls == []

--- a/tests/web/test_agent_team_scope.py
+++ b/tests/web/test_agent_team_scope.py
@@ -1,5 +1,6 @@
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import operators
 from sqlalchemy.sql.elements import BinaryExpression, BooleanClauseList
@@ -70,6 +71,108 @@ def test_scope_uses_hook_when_installed():
         assert ats.get_agent_team_scope(None, None) is None  # None user -> no scope
     finally:
         ats.set_agent_team_scope_hook(None)
+
+
+class _QueryRecorder:
+    def __init__(self) -> None:
+        self.filters: tuple[object, ...] = ()
+
+    def filter(self, *_clauses):
+        self.filters = _clauses
+        return self
+
+    def first(self):
+        return None
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.query_calls: list[object] = []
+        self.query_recorder = _QueryRecorder()
+
+    def query(self, model):
+        self.query_calls.append(model)
+        return self.query_recorder
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        None,
+        False,
+        True,
+        1.0,
+        0,
+        -1,
+        "",
+        "0",
+        "01",
+        "+1",
+        " 1",
+        "1 ",
+        "1.0",
+        "1x",
+        "\N{ARABIC-INDIC DIGIT ONE}",
+        2**31,
+        str(2**31),
+    ],
+)
+def test_resolve_authorized_agent_rejects_noncanonical_or_out_of_range_ids_before_query(
+    candidate,
+):
+    session = _RecordingSession()
+
+    assert (
+        ats.resolve_authorized_agent(session, owner_user_id=7, candidate_id=candidate)
+        is None
+    )
+    assert session.query_calls == []
+
+
+@pytest.mark.parametrize("candidate", [1, "1", 2**31 - 1, str(2**31 - 1)])
+def test_resolve_authorized_agent_queries_canonical_postgres_integer_ids(candidate):
+    session = _RecordingSession()
+
+    assert (
+        ats.resolve_authorized_agent(session, owner_user_id=7, candidate_id=candidate)
+        is None
+    )
+    assert session.query_calls == [Agent]
+
+
+def test_resolve_authorized_agent_binds_postgres_integer_maximum_as_an_integer():
+    session = _RecordingSession()
+
+    assert (
+        ats.resolve_authorized_agent(
+            session, owner_user_id=7, candidate_id=str(2**31 - 1)
+        )
+        is None
+    )
+    compiled = session.query_recorder.filters[0].compile(dialect=postgresql.dialect())
+    assert 2**31 - 1 in compiled.params.values()
+
+
+def test_resolve_authorized_agent_applies_existing_owner_team_scope(db):
+    owner = _make_user(db, "owner@scope.test")
+    outsider = _make_user(db, "outsider@scope.test")
+    owned = Agent(user_id=int(owner.id), name="owned")
+    foreign = Agent(user_id=int(outsider.id), name="foreign")
+    db.add_all([owned, foreign])
+    db.commit()
+
+    assert (
+        ats.resolve_authorized_agent(
+            db, owner_user_id=int(owner.id), candidate_id=owned.id
+        )
+        == owned
+    )
+    assert (
+        ats.resolve_authorized_agent(
+            db, owner_user_id=int(owner.id), candidate_id=foreign.id
+        )
+        is None
+    )
 
 
 def test_owned_clause_shape():

--- a/tests/web/test_agent_team_scope.py
+++ b/tests/web/test_agent_team_scope.py
@@ -115,6 +115,7 @@ class _RecordingSession:
         "\N{ARABIC-INDIC DIGIT ONE}",
         2**31,
         str(2**31),
+        "1" * 5000,
     ],
 )
 def test_resolve_authorized_agent_rejects_noncanonical_or_out_of_range_ids_before_query(


### PR DESCRIPTION
## Summary

- authorize persisted SSH task Agent identifiers against the task owner before target discovery
- reuse the same owner/team authorization rule for preview Agent readers
- reject malformed or out-of-range Agent identifiers before database conversion
- preserve direct-Agent precedence, DRAFT/PUBLISHED compatibility, and ARCHIVED denial

## Root cause

SSH task construction accepted a persisted direct Agent ID or preview Agent ID as execution context without revalidating that the persisted task owner could still access that Agent. A stale, cross-owner, or otherwise invalid identifier could therefore reach a downstream SSH provider's target-resolution boundary.

## Security and compatibility

- denied Agent candidates return no SSH tools and call no provider target method
- the provider factory remains the feature-availability gate and retains its existing ordering
- task owner identity remains distinct from the authorized Agent identity
- no schema, protocol, producer payload, or public error-code change

## Verification

- focused Core authorization, SSH, runtime, and snapshot suites passed
- Agent Builder preview suite: 5 passed
- Ruff, formatting, pre-commit, and diff checks passed
- negative-path and positive production-path regressions were mutation-checked

Closes #1136
