### PR TITLE
feat(interactions): add the interaction staging primitive and handoff context manager

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -22,6 +22,8 @@ on:
       - 'tests/web/services/test_task_status_storage_postgresql.py'
       - 'src/xagent/web/api/monitor.py'
       - 'tests/web/api/test_monitor_postgresql.py'
+      - 'src/xagent/web/services/task_interaction_staging.py'
+      - 'tests/web/services/test_interaction_staging_postgresql.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -75,6 +77,8 @@ jobs:
             tests/web/services/test_task_status_storage_postgresql.py
             src/xagent/web/api/monitor.py
             tests/web/api/test_monitor_postgresql.py
+            src/xagent/web/services/task_interaction_staging.py
+            tests/web/services/test_interaction_staging_postgresql.py
           )
 
           case "$EVENT_NAME" in
@@ -267,6 +271,13 @@ jobs:
         run: |
           pip install pytest-asyncio
           pytest tests/web/api/test_monitor_postgresql.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test interaction staging primitives (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/services/test_interaction_staging_postgresql.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/web/models/task_interaction.py
+++ b/src/xagent/web/models/task_interaction.py
@@ -44,12 +44,17 @@ from .database import Base
 # lowercased there. Do not unify the two -- each rule is pinned by its own
 # tests and guards a different kind of input.
 # ---------------------------------------------------------------------------
-# The one literal list. Ordered: the ``ck_task_interaction_requests_origin``
-# CHECK below renders its IN-list from this tuple, and offline SQL must be
-# byte-deterministic, so order is part of the contract. Every other surface
-# -- the two frozenset views below and the staging primitive's Python-side
-# validation -- derives from this tuple, so no second hand-written copy can
-# drift.
+INTERACTION_ORIGIN_VOCABULARY = frozenset(
+    {"internal", "sdk", "a2a", "trigger", "widget", "shared_link"}
+)
+INTERACTION_PROTOCOL_VERSION = 1
+
+# Ordering overlay for the ``ck_task_interaction_requests_origin`` CHECK
+# below: offline SQL must be byte-deterministic and the already-frozen
+# migration rendered the IN-list in exactly this order, so the order cannot
+# be derived by sorting. Membership is owned by
+# ``INTERACTION_ORIGIN_VOCABULARY`` above -- this tuple only fixes the
+# rendering order, and the assert keeps the pair from ever diverging.
 ORIGIN_VALUES: tuple[str, ...] = (
     "internal",
     "sdk",
@@ -58,8 +63,10 @@ ORIGIN_VALUES: tuple[str, ...] = (
     "widget",
     "shared_link",
 )
-INTERACTION_ORIGIN_VOCABULARY = frozenset(ORIGIN_VALUES)
-INTERACTION_PROTOCOL_VERSION = 1
+assert frozenset(ORIGIN_VALUES) == INTERACTION_ORIGIN_VOCABULARY, (
+    "ORIGIN_VALUES is an ordering overlay over INTERACTION_ORIGIN_VOCABULARY; "
+    "change membership there, then mirror it here"
+)
 
 # ``Task.source`` literals actually written by producers today -- a proper
 # subset of INTERACTION_ORIGIN_VOCABULARY, never an alias for it. The
@@ -95,12 +102,6 @@ def normalize_interaction_origin(source: str | None) -> str | None:
     if source in INTERACTION_ORIGIN_VOCABULARY:
         return source
     return None
-
-
-# Alias imported by the staging primitive's Python-side validation
-# (``_ORIGIN_VOCABULARY`` in task_interaction_staging.py). A view over
-# ``ORIGIN_VALUES`` above, same object as INTERACTION_ORIGIN_VOCABULARY.
-ORIGIN_VOCABULARY = INTERACTION_ORIGIN_VOCABULARY
 
 
 class TaskInteractionRequest(Base):  # type: ignore

--- a/src/xagent/web/models/task_interaction.py
+++ b/src/xagent/web/models/task_interaction.py
@@ -166,30 +166,32 @@ class TaskInteractionRequest(Base):  # type: ignore
     validation.
 
     Clock source for ``ck_task_interaction_requests_expiry_after_creation``:
-    ``created_at`` is bound by ``server_default=func.now()`` and never from
-    Python, matching every other ``created_at`` in this package. That is
-    PostgreSQL's transaction-start clock and SQLite's per-statement
-    ``CURRENT_TIMESTAMP``; both can only place ``created_at`` at or before
-    the row's real insert instant, never after, so the CHECK never rejects
-    a legitimately positive TTL. The price of that direction-safety is that
-    this CHECK only pins the *sign* of the TTL -- it is not a guarantee
-    that a stored row is unexpired, and each backend leaves a measured
-    slack. PostgreSQL compares real ``timestamptz(6)`` values, but
-    ``now()`` does not advance inside an open transaction, so an inversion
-    smaller than the writing transaction's age is admitted. SQLite stores
-    ``DateTime`` as text: ``CURRENT_TIMESTAMP`` writes
-    ``"YYYY-MM-DD HH:MM:SS"`` with no fractional part while a Python-bound
-    ``expires_at`` writes ``"YYYY-MM-DD HH:MM:SS.ffffff"``, and the
-    lexicographic comparison makes the shorter string a prefix of the
-    longer one -- exactly as if ``created_at`` were truncated down to the
-    second, so any ``expires_at`` inside the insert's own wall-clock second
-    is admitted, including a zero or negative TTL of up to one second.
-    Neither slack is reachable at the minute-scale TTLs this table exists
-    for: a 15-minute inversion is rejected on both backends. The writing
-    primitive must still reject a non-positive TTL in plain Python before
-    it reaches SQL -- the same division of labour as the deleted
-    run-partition CHECK below -- and that obligation must be settled
-    before any sub-second TTL ships.
+    both operands now come from the caller's ``now`` -- the staging
+    primitive (``stage_interaction_request`` in ``task_interaction_staging.py``)
+    binds ``created_at`` explicitly to the same ``now`` it already validates
+    and uses for the reclaim UPDATE, rather than leaving it to
+    ``server_default=func.now()``. ``server_default`` stays on the column
+    for every other writer this table may eventually get; it is simply not
+    what this table's one production writer today relies on. That retires
+    the earlier single-operand analysis and the per-backend slack it
+    documented here (PostgreSQL's non-advancing in-transaction ``now()``;
+    SQLite's second-truncated ``CURRENT_TIMESTAMP`` text comparison): with
+    both operands bound from the same Python value, the CHECK is exactly
+    the Python predicate the primitive already enforces
+    (``expires_at > now``) at microsecond granularity, verified directly
+    against both backends.
+
+    The price of that precision is caller-clock skew inheritance: a stored
+    row's ``created_at`` is only as accurate as the caller's own clock, the
+    same exposure ``terminated_at`` and ``updated_at`` already carry on this
+    table (both are also bound from caller-supplied values, never a server
+    clock). A caller running fast can make a row's ``created_at`` land after
+    its own server-defaulted ``updated_at`` from the same INSERT -- no
+    constraint on this table pairs the two columns, and nothing in this
+    module reads ``updated_at``, so that skew is inert here. What the CHECK
+    actually asserts is that the row is internally consistent under one
+    clock -- the caller's -- not that any column agrees with wall-clock
+    time on the server.
 
     ``expires_at`` must always be bound as an aware **UTC** datetime by the
     caller -- that obligation is portable, not SQLite-specific. Neither

--- a/src/xagent/web/models/task_interaction.py
+++ b/src/xagent/web/models/task_interaction.py
@@ -44,9 +44,21 @@ from .database import Base
 # lowercased there. Do not unify the two -- each rule is pinned by its own
 # tests and guards a different kind of input.
 # ---------------------------------------------------------------------------
-INTERACTION_ORIGIN_VOCABULARY = frozenset(
-    {"internal", "sdk", "a2a", "trigger", "widget", "shared_link"}
+# The one literal list. Ordered: the ``ck_task_interaction_requests_origin``
+# CHECK below renders its IN-list from this tuple, and offline SQL must be
+# byte-deterministic, so order is part of the contract. Every other surface
+# -- the two frozenset views below and the staging primitive's Python-side
+# validation -- derives from this tuple, so no second hand-written copy can
+# drift.
+ORIGIN_VALUES: tuple[str, ...] = (
+    "internal",
+    "sdk",
+    "a2a",
+    "trigger",
+    "widget",
+    "shared_link",
 )
+INTERACTION_ORIGIN_VOCABULARY = frozenset(ORIGIN_VALUES)
 INTERACTION_PROTOCOL_VERSION = 1
 
 # ``Task.source`` literals actually written by producers today -- a proper
@@ -85,22 +97,10 @@ def normalize_interaction_origin(source: str | None) -> str | None:
     return None
 
 
-# The single source of truth for the origin vocabulary: both the CHECK
-# constraint's IN-list below and the staging primitive's own Python-side
-# validation (``_ORIGIN_VOCABULARY`` in task_interaction_staging.py) derive
-# from this tuple, so the two can never drift apart the way two
-# independently hand-written copies could. Order is preserved in
-# ORIGIN_VALUES for the CHECK's rendered SQL; ORIGIN_VOCABULARY is the
-# frozenset membership tests actually want.
-ORIGIN_VALUES: tuple[str, ...] = (
-    "internal",
-    "sdk",
-    "a2a",
-    "trigger",
-    "widget",
-    "shared_link",
-)
-ORIGIN_VOCABULARY = frozenset(ORIGIN_VALUES)
+# Alias imported by the staging primitive's Python-side validation
+# (``_ORIGIN_VOCABULARY`` in task_interaction_staging.py). A view over
+# ``ORIGIN_VALUES`` above, same object as INTERACTION_ORIGIN_VOCABULARY.
+ORIGIN_VOCABULARY = INTERACTION_ORIGIN_VOCABULARY
 
 
 class TaskInteractionRequest(Base):  # type: ignore

--- a/src/xagent/web/models/task_interaction.py
+++ b/src/xagent/web/models/task_interaction.py
@@ -85,6 +85,24 @@ def normalize_interaction_origin(source: str | None) -> str | None:
     return None
 
 
+# The single source of truth for the origin vocabulary: both the CHECK
+# constraint's IN-list below and the staging primitive's own Python-side
+# validation (``_ORIGIN_VOCABULARY`` in task_interaction_staging.py) derive
+# from this tuple, so the two can never drift apart the way two
+# independently hand-written copies could. Order is preserved in
+# ORIGIN_VALUES for the CHECK's rendered SQL; ORIGIN_VOCABULARY is the
+# frozenset membership tests actually want.
+ORIGIN_VALUES: tuple[str, ...] = (
+    "internal",
+    "sdk",
+    "a2a",
+    "trigger",
+    "widget",
+    "shared_link",
+)
+ORIGIN_VOCABULARY = frozenset(ORIGIN_VALUES)
+
+
 class TaskInteractionRequest(Base):  # type: ignore
     """One blocking interaction request raised by a task and its lifecycle to answer or expiry.
 
@@ -256,7 +274,7 @@ class TaskInteractionRequest(Base):  # type: ignore
             name="ck_task_interaction_requests_kind",
         ),
         CheckConstraint(
-            "origin IN ('internal','sdk','a2a','trigger','widget','shared_link')",
+            "origin IN (" + ",".join(f"'{v}'" for v in ORIGIN_VALUES) + ")",
             name="ck_task_interaction_requests_origin",
         ),
         CheckConstraint(

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -36,13 +36,13 @@ INTERACTION_ROLLOUT_SCHEMA_ABSENT = "interaction_rollout_schema_absent"
 # evidence for it.
 INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE = "interaction_rollout_unknown_task_source"
 # interaction_handoff (task_interaction_staging.py) degrades instead of
-# losing a caller's turn on four expected failures, sharing this signal.
+# losing a caller's turn on five expected failures, sharing this signal.
 INTERACTION_HANDOFF_DEGRADED = "interaction_handoff_degraded"
-# A fifth, separately addressable signal for InteractionRunPartitionMismatch
-# specifically: PR-C2a's degrade-instead-of-propagate policy for that one
-# exception is an override with zero production reachability data behind it
-# (see interaction_handoff's docstring), so it stays distinguishable on
-# /health from the other four rather than folded into the signal above.
+# A sixth, separately addressable signal for InteractionRunPartitionMismatch
+# specifically: degrading rather than propagating that one exception is an
+# override with no production reachability data behind it (see
+# interaction_handoff's docstring), so it stays distinguishable on /health
+# from the other five.
 INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED = (
     "interaction_run_partition_mismatch_degraded"
 )

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -35,6 +35,17 @@ INTERACTION_ROLLOUT_SCHEMA_ABSENT = "interaction_rollout_schema_absent"
 # data being fixed. Auto-clearing would assert "the data got fixed" without
 # evidence for it.
 INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE = "interaction_rollout_unknown_task_source"
+# interaction_handoff (task_interaction_staging.py) degrades instead of
+# losing a caller's turn on four expected failures, sharing this signal.
+INTERACTION_HANDOFF_DEGRADED = "interaction_handoff_degraded"
+# A fifth, separately addressable signal for InteractionRunPartitionMismatch
+# specifically: PR-C2a's degrade-instead-of-propagate policy for that one
+# exception is an override with zero production reachability data behind it
+# (see interaction_handoff's docstring), so it stays distinguishable on
+# /health from the other four rather than folded into the signal above.
+INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED = (
+    "interaction_run_partition_mismatch_degraded"
+)
 
 _signals: dict[str, str] = {}
 _lock = threading.Lock()

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -59,7 +59,7 @@ test's docstring for the removal condition.
 Every rejection the database's 23 CHECK constraints could raise on the
 INSERT is rejected in plain Python first, inside
 ``stage_interaction_request``'s validation block, because the post-conflict
-re-check (step 7 below) classifies any ``IntegrityError`` for which no row
+re-check (step 6 below) classifies any ``IntegrityError`` for which no row
 exists at the caller's own identity as a slot conflict --
 ``InteractionSlotTaken`` (a re-check hit that does exist there, but is
 already ``answered`` or ``terminated``, raises ``InteractionRequestClosed``
@@ -102,7 +102,7 @@ being deleted concurrently, some time between whatever read gave the
 caller its ``task_id`` / the anchor's ``trace_event_id`` and this call's
 own INSERT. Neither has a Python precondition here -- nothing in this
 function's own arguments could detect a row disappearing out from under
-it -- and both surface as a foreign-key ``IntegrityError`` that step 7's
+it -- and both surface as a foreign-key ``IntegrityError`` that step 6's
 re-check, finding no matching identity row, classifies as
 ``InteractionSlotTaken`` along with everything else in the
 misclassification funnel above. Closing that gap is not this validation
@@ -189,7 +189,7 @@ class InteractionHandoffError(RuntimeError):
 class InteractionSlotTaken(InteractionHandoffError):
     """The active-row INSERT collided with another request's active slot.
 
-    Raised only when the post-conflict re-check (step 7) finds no row at all
+    Raised only when the post-conflict re-check (step 6) finds no row at all
     at the caller's own ``(task_id, run_id, request_idempotency_key)`` after
     an ``IntegrityError`` -- there is no identity row to explain the
     conflict, so it must have been the active-slot unique. A re-check hit
@@ -209,9 +209,9 @@ class InteractionRequestClosed(InteractionHandoffError):
 
     Raised when ``(task_id, run_id, request_idempotency_key)`` names a row
     whose ``status`` is ``answered`` or ``terminated`` rather than
-    ``active`` -- both by the idempotency pre-read (step 4, before this
+    ``active`` -- both by the idempotency pre-read (step 3, before this
     call's own INSERT is ever attempted) and by the post-conflict re-check
-    (step 7, when this call's own INSERT collided with a row that turns out
+    (step 6, when this call's own INSERT collided with a row that turns out
     to already be closed rather than merely active elsewhere). Both reads
     share ``_identity_lookup_stmt``, so the two call sites classify the same
     row state identically. Identity is scoped by ``run_id``: a key that was
@@ -305,15 +305,18 @@ class InteractionHandoffMisuse(InteractionHandoffError):
       call's row while reporting success.
     * The caller committed or rolled back the session from inside the
       ``with`` block -- violating ``interaction_handoff``'s "no I/O in
-      between" obligation -- after ``stage()`` had already succeeded. Both
-      operations end the whole transaction, deactivating this context
-      manager's own outer savepoint along with it; by the time the block
-      exits normally, that savepoint no longer exists to commit. Raising
-      here instead of silently skipping the now-impossible commit matters
-      because skipping would report success for a row whose containment is
-      gone -- the caller's own commit already decided that row's fate one
-      way or the other, and this context manager has no way left to tell
-      which.
+      between" obligation -- whether or not ``stage()`` had already
+      succeeded (zero calls is otherwise legal on its own -- see
+      ``_InteractionHandoff``'s own docstring). Both operations end the
+      whole transaction, deactivating this context manager's own outer
+      savepoint along with it; by the time the block exits normally, that
+      savepoint no longer exists to commit. Raising here instead of
+      silently skipping the now-impossible commit matters because skipping
+      would report success for a row whose containment is gone -- the
+      caller's own commit already decided that row's fate one way or the
+      other, and this context manager has no way left to tell which. The
+      message differs by whether ``stage()`` was actually called; the
+      exception type does not.
 
     Deliberately absent from ``_SWALLOWED`` in both cases: these are caller
     bugs, classified the same way ``InteractionOwnerStateError`` is --
@@ -442,13 +445,13 @@ class StagedInteractionRequest:
 
     ``created`` is ``True`` only on the clean-INSERT path. It is ``False``
     on every replay path: a pre-existing ``active`` row hit by the
-    idempotency pre-read (step 4, before any reclaim or INSERT was even
+    idempotency pre-read (step 3, before any reclaim or INSERT was even
     attempted) and a pre-existing ``active`` row hit by the post-conflict
-    re-check (step 7, after this call's own INSERT lost a race). Both
+    re-check (step 6, after this call's own INSERT lost a race). Both
     replay paths return the *other* request's row, not a new one --
     ``status`` and ``active_slot`` describe that row as it stood at the
-    moment this call read it, which on the step-4 path may already be
-    expired (see ``stage_interaction_request``'s docstring on why step 4
+    moment this call read it, which on the step-3 path may already be
+    expired (see ``stage_interaction_request``'s docstring on why step 3
     does not consult ``expires_at``).
     """
 
@@ -535,10 +538,11 @@ def _validate_request_fields(
     caught by a CHECK constraint on the INSERT. See the module docstring's
     misclassification-funnel paragraph for why this list must stay complete.
 
-    Row 13 of that list: ``now`` must be validated as an aware UTC datetime
-    the same way ``expires_at`` is (row 6) -- not normalized, only rejected
-    if it fails. ``now`` has no CHECK constraint of its own to back this up
-    (unlike every other row here), but it is not a free pass: the reclaim
+    ``now`` must be validated as an aware UTC datetime the same way
+    ``expires_at`` is, immediately above it in this same function -- not
+    normalized, only rejected if it fails. ``now`` has no CHECK constraint
+    of its own to back this up (unlike every other value this function
+    checks), but it is not a free pass: the reclaim
     UPDATE (``_reclaim_stale_slot_stmt``) persists this exact value into
     ``terminated_at`` and ``updated_at`` on every row it reclaims, so a
     naive or non-UTC ``now`` would otherwise reach SQL and get silently
@@ -668,7 +672,7 @@ def _identity_lookup_stmt(
     *, task_id: int, run_id: str, request_idempotency_key: str
 ) -> sa.Select[Any]:
     """The identical Core SELECT used by both the idempotency pre-read (step
-    4) and the post-conflict re-check (step 7). Written once so the two
+    3) and the post-conflict re-check (step 6). Written once so the two
     statements cannot drift apart at the edges of what they match."""
 
     return sa.select(
@@ -683,7 +687,7 @@ def _identity_lookup_stmt(
 
 
 def _reclaim_stale_slot_stmt(*, task_id: int, run_id: str, now: datetime) -> sa.Update:
-    """The reclaim UPDATE (step 5). Stays in the caller's outer transaction,
+    """The reclaim UPDATE (step 4). Stays in the caller's outer transaction,
     not this function's inner savepoint -- it dies with the whole handoff on
     rollback, and the post-conflict re-check must not have undone it.
 
@@ -1169,12 +1173,17 @@ def interaction_handoff(
     six swallowed exceptions below is swallowed because it is a named,
     expected outcome with its own degradation signal, never because the
     underlying data (the task, the anchor, the request row) turned out to
-    be missing or unreadable. A caller with a missing task or a broken
-    anchor gets an exception here -- ``InteractionAnchorCorrupt`` or a
-    database error, not a quiet no-op -- because a blocking interaction
-    request that is silently never staged strands the caller's turn
-    exactly the way this module's degrade-instead-of-losing-the-turn design
-    exists to prevent.
+    be missing or unreadable. A broken anchor is itself one of those six:
+    ``InteractionAnchorCorrupt`` degrades the same way the other five do --
+    it registers ``INTERACTION_HANDOFF_DEGRADED``, with a message naming the
+    specific corrupt field, and the ``with`` block exits without staging a
+    row, not by raising. A caller with a missing task still gets an
+    exception here -- ``ObjectDeletedError`` from the first stale
+    ``task.<attr>`` access, or another database error, not a quiet no-op --
+    because neither is one of the six named outcomes this module degrades
+    on, and a blocking interaction request that is silently never staged
+    would otherwise strand the caller's turn exactly the way this module's
+    degrade-instead-of-losing-the-turn design exists to prevent.
 
     Nesting, exactly:
 
@@ -1439,9 +1448,24 @@ def interaction_handoff(
         raise
     else:
         if not savepoint.is_active:
+            # handoff._staged tells the two ways this misuse can happen
+            # apart: a caller can violate the no-I/O-in-between obligation
+            # either after a successful stage() (there is a real staged row
+            # whose containment just vanished) or without ever calling
+            # stage() at all (zero calls is otherwise legal -- see
+            # _InteractionHandoff's own docstring -- so nothing was staged,
+            # but the caller's own commit/rollback still deactivated this
+            # savepoint the same way). Same exception type either way; only
+            # the message should claim a staged row exists when one does.
+            if handoff._staged:
+                raise InteractionHandoffMisuse(
+                    "the caller committed or rolled back inside the "
+                    "interaction_handoff block; the savepoint that contains "
+                    "the staged interaction row no longer exists"
+                )
             raise InteractionHandoffMisuse(
                 "the caller committed or rolled back inside the "
-                "interaction_handoff block; the savepoint that contains the "
-                "staged interaction row no longer exists"
+                "interaction_handoff block; no interaction row was staged, "
+                "but the handoff's savepoint no longer exists"
             )
         savepoint.commit()

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -294,14 +294,29 @@ class InteractionOwnerStateError(InteractionHandoffError):
 
 
 class InteractionHandoffMisuse(InteractionHandoffError):
-    """``stage()`` was called more than once inside one handoff.
+    """Raised for either of two ways a caller can misuse the ``with``
+    block, both caught only once the block's body has finished running:
 
-    Deliberately absent from ``_SWALLOWED``: the schema allows exactly one
-    active interaction row per task, so a second ``stage()`` in the same
-    handoff can only fail -- and the handler that would swallow it rolls
-    back the outer savepoint, discarding the first call's row while
-    reporting success. This is a caller bug, classified the same way
-    ``InteractionOwnerStateError`` is: propagate, do not degrade.
+    * ``stage()`` was called more than once inside one handoff. The schema
+      allows exactly one active interaction row per task, so a second
+      ``stage()`` in the same handoff can only fail -- and the handler that
+      would swallow it rolls back the outer savepoint, discarding the first
+      call's row while reporting success.
+    * The caller committed or rolled back the session from inside the
+      ``with`` block -- violating ``interaction_handoff``'s "no I/O in
+      between" obligation -- after ``stage()`` had already succeeded. Both
+      operations end the whole transaction, deactivating this context
+      manager's own outer savepoint along with it; by the time the block
+      exits normally, that savepoint no longer exists to commit. Raising
+      here instead of silently skipping the now-impossible commit matters
+      because skipping would report success for a row whose containment is
+      gone -- the caller's own commit already decided that row's fate one
+      way or the other, and this context manager has no way left to tell
+      which.
+
+    Deliberately absent from ``_SWALLOWED`` in both cases: these are caller
+    bugs, classified the same way ``InteractionOwnerStateError`` is --
+    propagate, do not degrade.
     """
 
 
@@ -1322,4 +1337,10 @@ def interaction_handoff(
             savepoint.rollback()
         raise
     else:
+        if not savepoint.is_active:
+            raise InteractionHandoffMisuse(
+                "the caller committed or rolled back inside the "
+                "interaction_handoff block; the savepoint that contains the "
+                "staged interaction row no longer exists"
+            )
         savepoint.commit()

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -789,6 +789,7 @@ def stage_interaction_request(
 
     row = {
         "task_id": resolved_task_id,
+        "created_at": now,
         "run_id": run_id,
         "kind": kind,
         "protocol_version": protocol_version,

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -454,32 +454,24 @@ def _validate_anchor_fields(anchor: InteractionAnchor) -> None:
     reaches SQL.
     """
 
-    if not anchor.resume_event_id:
-        raise InteractionAnchorCorrupt("anchor.resume_event_id must not be empty")
-    if len(anchor.resume_event_id) > _MAX_LENGTHS["resume_event_id"]:
+    if not isinstance(anchor, InteractionAnchor):
         raise InteractionAnchorCorrupt(
-            "resume_event_id exceeds the column limit "
-            f"{_MAX_LENGTHS['resume_event_id']} (got {len(anchor.resume_event_id)}): "
-            "a locator this long cannot have come from a valid trace row"
+            f"anchor must be an InteractionAnchor, got {type(anchor).__name__}"
         )
-    if not anchor.resume_execution_id:
-        raise InteractionAnchorCorrupt("anchor.resume_execution_id must not be empty")
-    if len(anchor.resume_execution_id) > _MAX_LENGTHS["resume_execution_id"]:
-        raise InteractionAnchorCorrupt(
-            "resume_execution_id exceeds the column limit "
-            f"{_MAX_LENGTHS['resume_execution_id']} (got "
-            f"{len(anchor.resume_execution_id)}): a locator this long cannot "
-            "have come from a valid trace row"
-        )
-    if not anchor.resume_run_partition:
-        raise InteractionAnchorCorrupt("anchor.resume_run_partition must not be empty")
-    if len(anchor.resume_run_partition) > _MAX_LENGTHS["resume_run_partition"]:
-        raise InteractionAnchorCorrupt(
-            "resume_run_partition exceeds the column limit "
-            f"{_MAX_LENGTHS['resume_run_partition']} (got "
-            f"{len(anchor.resume_run_partition)}): a locator this long cannot "
-            "have come from a valid trace row"
-        )
+    for field_name in (
+        "resume_event_id",
+        "resume_execution_id",
+        "resume_run_partition",
+    ):
+        value = getattr(anchor, field_name)
+        if not value:
+            raise InteractionAnchorCorrupt(f"anchor.{field_name} must not be empty")
+        if len(value) > _MAX_LENGTHS[field_name]:
+            raise InteractionAnchorCorrupt(
+                f"{field_name} exceeds the column limit "
+                f"{_MAX_LENGTHS[field_name]} (got {len(value)}): a locator "
+                "this long cannot have come from a valid trace row"
+            )
     if anchor.resume_locator_format != _RESUME_LOCATOR_FORMAT:
         raise InteractionAnchorCorrupt(
             f"anchor.resume_locator_format must be {_RESUME_LOCATOR_FORMAT!r}, "
@@ -542,7 +534,11 @@ def _validate_request_fields(
         raise ValueError(
             f"kind must be one of {sorted(_KIND_VOCABULARY)}, got {kind!r}"
         )
-    if isinstance(protocol_version, bool) or protocol_version != _PROTOCOL_VERSION:
+    if (
+        not isinstance(protocol_version, int)
+        or isinstance(protocol_version, bool)
+        or protocol_version != _PROTOCOL_VERSION
+    ):
         raise ValueError(
             f"protocol_version must be {_PROTOCOL_VERSION}, got {protocol_version!r}"
         )
@@ -603,11 +599,17 @@ def _validate_request_fields(
         json.dumps(request_payload, allow_nan=False)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"request_payload is not JSON-serializable: {exc}") from exc
+    if not isinstance(expires_at, datetime):
+        raise ValueError(
+            f"expires_at must be a datetime, got {type(expires_at).__name__}"
+        )
     utc_offset = expires_at.utcoffset()
     if expires_at.tzinfo is None or utc_offset is None:
         raise ValueError("expires_at must be an aware UTC datetime")
     if utc_offset.total_seconds() != 0:
         raise ValueError("expires_at must be UTC (utcoffset must be zero)")
+    if not isinstance(now, datetime):
+        raise ValueError(f"now must be a datetime, got {type(now).__name__}")
     now_utc_offset = now.utcoffset()
     if now.tzinfo is None or now_utc_offset is None:
         raise ValueError("now must be an aware UTC datetime")
@@ -1049,6 +1051,11 @@ class _InteractionHandoff:
                 "attempted a second"
             )
         self._staged = True
+        if self.lease.task_id != int(self.task.id):
+            raise ValueError(
+                f"lease names task {self.lease.task_id} but this handoff was "
+                f"given task {int(self.task.id)}"
+            )
         self._assert_current_attempt()
         self._assert_anchor_consistent()
         if self.lease.run_id is None:

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -183,6 +183,9 @@ _MAX_LENGTHS: dict[str, int] = {
         "resume_run_partition",
     )
 }
+assert all(v is not None for v in _MAX_LENGTHS.values()), (
+    "a locator column widened to Text reports length None; re-derive these caps"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +234,15 @@ class InteractionRequestClosed(InteractionHandoffError):
     reclaimed to ``terminated`` earlier in the *same* run still raises this
     on reuse (there is no cross-run leakage to guard against, because a
     different run never shares this row at all).
+
+    This exception deliberately covers both terminal outcomes alike --
+    ``answered`` and ``terminated`` both raise it, with no separate type or
+    argument telling the two apart. For staging purposes they are the same
+    fact: the identity row is closed and cannot be staged over, regardless
+    of which of the two ways it got there. The caller-visible distinction
+    between "a human answered this" and "this was reclaimed/expired" belongs
+    to whatever reads the row back afterward, not to this staging-time
+    check.
     """
 
 
@@ -596,6 +608,17 @@ def _validate_request_fields(
         raise ValueError("request_idempotency_key must be 1-64 URL-safe characters")
     if request_payload is None:
         raise ValueError("request_payload must not be None")
+    # request_payload's *shape* -- what keys it has, what its values look
+    # like -- is deliberately never inspected anywhere in this function,
+    # beyond the two checks below (not None, and JSON-serializable). It is
+    # an opaque caller-supplied blob as far as this primitive is concerned:
+    # the protocol layer that eventually renders it to a human or another
+    # system is what owns and enforces its shape, not the staging layer
+    # that merely persists it. Widening this function to also validate
+    # shape would duplicate a contract that belongs one layer up and would
+    # make this primitive reject payloads its own protocol layer might
+    # still consider valid.
+    #
     # A value that cannot be JSON-serialized at all never reaches this
     # block's other checks -- it would sail through every one of them (it is
     # not None, and nothing else here inspects its shape) and fail instead
@@ -671,6 +694,27 @@ def _validate_request_fields(
             f"got {len(run_id)}"
         )
 
+    # This length check on run_id, and _validate_anchor_fields's own length
+    # check on anchor.resume_run_partition right below, guard the same
+    # _MAX_LENGTHS["run_id"] cap on what is structurally the same value --
+    # both are compared against each other a few lines down -- but they
+    # raise different exception types on purpose, and this function's
+    # ordering is what decides which one fires when both are over-length at
+    # once. run_id comes from the service's own lease, not from persisted
+    # data; an over-length run_id is a programming error in this module's
+    # own caller, so it raises ValueError here and propagates uncaught, the
+    # same as every other row-13-and-earlier violation in this function.
+    # anchor.resume_run_partition, by contrast, comes from a database read
+    # of whatever a trace_events row happens to hold; an over-length value
+    # there is data corruption this module is built to degrade on, not a
+    # caller bug, so _validate_anchor_fields raises InteractionAnchorCorrupt
+    # for it instead -- swallowed by interaction_handoff. Because this
+    # run_id check runs first, before _validate_anchor_fields is ever
+    # called, a caller that supplies both an over-length run_id and an
+    # over-length anchor.resume_run_partition at once always sees the
+    # run_id's ValueError, never the anchor's InteractionAnchorCorrupt: the
+    # programming-error classification wins over the data-corruption one,
+    # deliberately.
     _validate_anchor_fields(anchor)
 
     if run_id != anchor.resume_run_partition:

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -136,7 +136,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..models.task import Task
-from ..models.task_interaction import TaskInteractionRequest
+from ..models.task_interaction import ORIGIN_VOCABULARY, TaskInteractionRequest
 from .ops_signals import (
     INTERACTION_HANDOFF_DEGRADED,
     INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED,
@@ -148,9 +148,10 @@ from .task_lease_service import TaskLease
 logger = logging.getLogger(__name__)
 
 _KIND_VOCABULARY = frozenset({"clarification"})
-_ORIGIN_VOCABULARY = frozenset(
-    {"internal", "sdk", "a2a", "trigger", "widget", "shared_link"}
-)
+# Derived from the model's own ORIGIN_VOCABULARY, not a second hand-written
+# frozenset -- see that module's comment for why the two must share one
+# source instead of two copies that could drift apart.
+_ORIGIN_VOCABULARY = ORIGIN_VOCABULARY
 _RESUME_LOCATOR_FORMAT = "trace_event_pk_v1"
 _RESUME_CHECKPOINT_TYPE = "agent_execution_checkpoint"
 _PROTOCOL_VERSION = 1

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -145,7 +145,11 @@ from sqlalchemy.exc import DataError, IntegrityError, ResourceClosedError
 from sqlalchemy.orm import Session
 
 from ..models.task import Task
-from ..models.task_interaction import ORIGIN_VOCABULARY, TaskInteractionRequest
+from ..models.task_interaction import (
+    INTERACTION_ORIGIN_VOCABULARY,
+    INTERACTION_PROTOCOL_VERSION,
+    TaskInteractionRequest,
+)
 from .ops_signals import (
     INTERACTION_HANDOFF_DEGRADED,
     INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED,
@@ -157,13 +161,17 @@ from .task_lease_service import TaskLease
 logger = logging.getLogger(__name__)
 
 _KIND_VOCABULARY = frozenset({"clarification"})
-# Derived from the model's own ORIGIN_VOCABULARY, not a second hand-written
-# frozenset -- see that module's comment for why the two must share one
-# source instead of two copies that could drift apart.
-_ORIGIN_VOCABULARY = ORIGIN_VOCABULARY
+# Derived from the model's own INTERACTION_ORIGIN_VOCABULARY (the merged
+# rollout-controls change owns the vocabulary now), not a second
+# hand-written frozenset -- see that module's comment for why every surface
+# must share one source instead of copies that could drift apart. NOT the
+# rollout gate's INTERACTION_GATING_SOURCES, which is a strict superset
+# carrying the synthetic gating-only "channel" key that must never pass
+# this module's validation.
+_ORIGIN_VOCABULARY = INTERACTION_ORIGIN_VOCABULARY
 _RESUME_LOCATOR_FORMAT = "trace_event_pk_v1"
 _RESUME_CHECKPOINT_TYPE = "agent_execution_checkpoint"
-_PROTOCOL_VERSION = 1
+_PROTOCOL_VERSION = INTERACTION_PROTOCOL_VERSION
 
 _MAX_LENGTHS: dict[str, int] = {
     # Derived from the model so they cannot drift from the schema. These

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -258,6 +258,18 @@ class InteractionOwnerStateError(InteractionHandoffError):
     """
 
 
+class InteractionHandoffMisuse(InteractionHandoffError):
+    """``stage()`` was called more than once inside one handoff.
+
+    Deliberately absent from ``_SWALLOWED``: the schema allows exactly one
+    active interaction row per task, so a second ``stage()`` in the same
+    handoff can only fail -- and the handler that would swallow it rolls
+    back the outer savepoint, discarding the first call's row while
+    reporting success. This is a caller bug, classified the same way
+    ``InteractionOwnerStateError`` is: propagate, do not degrade.
+    """
+
+
 # Explicit tuple, not `isinstance(exc, InteractionHandoffError)`: dispatching
 # off the common base class would make any *future* subclass of it
 # automatically swallowed the moment it is defined -- a fail-open default.
@@ -755,7 +767,8 @@ def stage_interaction_request(
 
 class _InteractionHandoff:
     """The object ``interaction_handoff`` yields. Constructed once per
-    ``with`` block; ``stage`` may be called zero or more times inside it.
+    ``with`` block; ``stage`` may be called exactly once (zero calls is
+    legal: a caller may decide not to ask).
     """
 
     def __init__(
@@ -772,6 +785,7 @@ class _InteractionHandoff:
         self.task = task
         self.anchor = anchor
         self.now = now
+        self._staged = False
 
     def _assert_current_attempt(self) -> None:
         """``lease.attempt_id is None`` is a fail-open sentinel (a
@@ -846,6 +860,13 @@ class _InteractionHandoff:
         docstring for why they live here rather than in ``__enter__``.
         """
 
+        if self._staged:
+            raise InteractionHandoffMisuse(
+                "interaction_handoff supports exactly one stage() call per "
+                f"handoff; task {self.task.id} run {self.lease.run_id} "
+                "attempted a second"
+            )
+        self._staged = True
         self._assert_current_attempt()
         self._assert_anchor_consistent()
         if self.lease.run_id is None:
@@ -916,11 +937,11 @@ def interaction_handoff(
 
         savepoint = db.begin_nested()        # this function's own
         yield handoff                        # caller calls handoff.stage()
-                                              # zero or more times; each
-                                              # call asserts attempt and
-                                              # anchor validity first, then
-                                              # opens and closes its *own*
-                                              # inner savepoint (see
+                                              # exactly once; that call
+                                              # asserts attempt and anchor
+                                              # validity first, then opens
+                                              # and closes its *own* inner
+                                              # savepoint (see
                                               # stage_interaction_request)
         normal exit         -> savepoint.commit()
         one of five expected failures

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -138,7 +138,7 @@ from datetime import datetime
 from typing import Any, Iterator
 
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, ResourceClosedError
 from sqlalchemy.orm import Session
 
 from ..models.task import Task
@@ -972,19 +972,18 @@ def stage_interaction_request(
             active_slot=1,
         )
     finally:
-        # A no-op on both handled paths above (the except branch's own
-        # inner.rollback() and the else branch's inner.commit() have already
-        # deactivated the savepoint by the time this runs). What it actually
-        # guards is any exception this try block does not otherwise catch --
-        # IntegrityError is the only one classified above, so anything else
-        # db.flush() or the constructor could raise (a StatementError from a
-        # bind-time serialization failure, for instance) would previously
-        # propagate straight out with this savepoint still open, leaking it
-        # into whatever the caller does next. Closing it here regardless of
-        # which path was taken keeps this function's own savepoint scoped to
-        # this function on every exit, not just the two it names explicitly.
-        if inner.is_active:
+        # Three states are possible here. Active: roll back normally.
+        # Flush-deactivated -- a bind-time failure inside flush marks
+        # the savepoint inactive BEFORE the exception surfaces
+        # (measured) -- is_active is already False, but rollback() is
+        # exactly what unwinds it; an is_active guard would skip it and
+        # leak the savepoint. Closed -- the caller committed or rolled
+        # back the whole transaction -- rollback() raises
+        # ResourceClosedError, absorbed: nothing is left to unwind.
+        try:
             inner.rollback()
+        except ResourceClosedError:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -1465,18 +1464,32 @@ def interaction_handoff(
             # lives in finally so it still runs even if logger.error itself
             # raises (a misconfigured handler, for instance) -- otherwise
             # that would leak this savepoint open on top of replacing the
-            # swallowed exception. The rollback stays guarded: a caller that
+            # swallowed exception. Three states are possible here. Active:
+            # roll back normally. Flush-deactivated -- a bind-time failure
+            # inside some statement issued during the with-block already
+            # marked the savepoint inactive before the swallowed exception
+            # ever surfaced (measured) -- is_active is already False, but
+            # rollback() is exactly what unwinds it; an is_active guard
+            # would skip it and leak the savepoint. Closed -- a caller that
             # violated the never-commit-or-rollback-inside-this-block
-            # contract has already deactivated this savepoint, and an
-            # unguarded rollback would raise ResourceClosedError, replacing
-            # whatever exception is already in flight and skipping the
-            # degradation signal entirely.
-            if savepoint.is_active:
+            # contract has already deactivated this savepoint by committing
+            # or rolling back the whole transaction -- rollback() raises
+            # ResourceClosedError, absorbed: nothing is left to unwind.
+            try:
                 savepoint.rollback()
+            except ResourceClosedError:
+                pass
         return
     except BaseException:
-        if savepoint.is_active:
+        # Same three-state reasoning as the swallowed-exception handler's
+        # own finally above: active or flush-deactivated, rollback()
+        # unwinds it; closed (absorbed ResourceClosedError) because a
+        # caller-misuse commit/rollback inside the block already ended the
+        # transaction and left nothing to unwind.
+        try:
             savepoint.rollback()
+        except ResourceClosedError:
+            pass
         raise
     else:
         if not savepoint.is_active:

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -227,7 +227,7 @@ class InteractionRunPartitionMismatch(InteractionHandoffError):
     at all, which the post-conflict re-check would then misclassify as a
     slot conflict instead of surfacing as the corruption it actually is.
 
-    PR-C2a deliberately swallows this exception -- see ``_SWALLOWED`` and
+    The handoff layer deliberately swallows this exception -- see ``_SWALLOWED`` and
     ``interaction_handoff``'s docstring for the reasoning and for why that
     is a scoped override of this primitive's own default, not this
     primitive's design intent.
@@ -265,7 +265,7 @@ class InteractionOwnerStateError(InteractionHandoffError):
 # purpose, in the same line reviewers already read, before it starts being
 # swallowed.
 #
-# PR-C2a note: InteractionRunPartitionMismatch's presence in this tuple is a
+# Note: InteractionRunPartitionMismatch's presence in this tuple is a
 # deliberate override of this primitive's literal design default (which
 # called for propagating it unchanged, the same as InteractionOwnerStateError
 # below it). See interaction_handoff's docstring for the reasoning and the
@@ -304,11 +304,10 @@ _DEGRADATION_SIGNALS: dict[type[BaseException], str] = {
 class InteractionAnchor:
     """The resume anchor a caller is staging an interaction request against.
 
-    This is not ``trace_event_staging.StagedCheckpointAnchor``. That type is
-    PR-A's return value for the shell's pointer UPDATE and carries only
-    ``checkpoint_event_id`` / ``trace_event_id``; PR-A's own review already
-    confirmed this module does not consume it, and it is not reused or
-    subclassed here.
+    This is not ``trace_event_staging.StagedCheckpointAnchor``. That type
+    exists for the trace shell's pointer UPDATE and carries only
+    ``checkpoint_event_id`` / ``trace_event_id``; this module does not
+    consume it, and it is not reused or subclassed here.
 
     Represents only half of anchor resolution. The other half -- a database
     read against ``trace_events`` by primary key, layered into
@@ -395,6 +394,18 @@ def _validate_anchor_fields(anchor: InteractionAnchor) -> None:
         )
     if anchor.trace_event_id is None:
         raise InteractionAnchorCorrupt("anchor.trace_event_id must not be None")
+    if isinstance(anchor.trace_event_id, bool) or not isinstance(
+        anchor.trace_event_id, int
+    ):
+        raise InteractionAnchorCorrupt(
+            "anchor.trace_event_id must be an integer row id, got "
+            f"{anchor.trace_event_id!r}"
+        )
+    if anchor.trace_event_id <= 0:
+        raise InteractionAnchorCorrupt(
+            "anchor.trace_event_id must be a positive row id, got "
+            f"{anchor.trace_event_id!r}"
+        )
 
 
 def _validate_request_fields(
@@ -431,7 +442,7 @@ def _validate_request_fields(
         raise ValueError(
             f"kind must be one of {sorted(_KIND_VOCABULARY)}, got {kind!r}"
         )
-    if protocol_version != _PROTOCOL_VERSION:
+    if isinstance(protocol_version, bool) or protocol_version != _PROTOCOL_VERSION:
         raise ValueError(
             f"protocol_version must be {_PROTOCOL_VERSION}, got {protocol_version!r}"
         )
@@ -954,7 +965,7 @@ def interaction_handoff(
     unchanged, the same as ``InteractionOwnerStateError`` -- on the
     reasoning that a confirmed identity mismatch between a run and its own
     resume anchor is closer to "something is structurally wrong" than to an
-    ordinary race. PR-C2a overrides that default and swallows it here
+    ordinary race. The handoff overrides that default and swallows it here
     instead, registering its own dedicated signal
     (``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED``, kept separate from the
     other four's shared ``INTERACTION_HANDOFF_DEGRADED`` so it stays

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -59,18 +59,22 @@ test's docstring for the removal condition.
 Every rejection the database's 23 CHECK constraints could raise on the
 INSERT is rejected in plain Python first, inside
 ``stage_interaction_request``'s validation block, because the post-conflict
-re-check (step 7 below) classifies any ``IntegrityError`` that does not
-match the caller's own identity key as a slot conflict --
-``InteractionSlotTaken``. That re-check cannot tell a real slot conflict
-apart from a programming error (an out-of-vocabulary ``origin``, a
-non-positive TTL, a ``None`` payload past ``JSON(none_as_null=True))``) that
-also violates a CHECK: both land on the same ``else`` branch. The backstop
-is the database's constraint set, not the primary defense; the primary
-defense is this validation block, and it must reject everything the INSERT
-could reject except the two concurrent-parent-deletion cells documented
-below, before the INSERT is ever issued. Adding a column CHECK to
-``TaskInteractionRequest`` without adding the matching Python check here
-reopens that misclassification funnel by one more case.
+re-check (step 7 below) classifies any ``IntegrityError`` for which no row
+exists at the caller's own identity as a slot conflict --
+``InteractionSlotTaken`` (a re-check hit that does exist there, but is
+already ``answered`` or ``terminated``, raises ``InteractionRequestClosed``
+instead -- see that exception's docstring -- because the identity row itself
+explains the conflict). A CHECK-violating programming error (an
+out-of-vocabulary ``origin``, a non-positive TTL, a ``None`` payload past
+``JSON(none_as_null=True))``) never inserted a row in the first place, so it
+always lands on the no-identity-row branch, indistinguishable from a real
+slot conflict. The backstop is the database's constraint set, not the
+primary defense; the primary defense is this validation block, and it must
+reject everything the INSERT could reject except the two
+concurrent-parent-deletion cells documented below, before the INSERT is
+ever issued. Adding a column CHECK to ``TaskInteractionRequest`` without
+adding the matching Python check here reopens that misclassification
+funnel by one more case.
 
 Two cells this validation block cannot close, by construction: the parent
 ``tasks`` row (``fk_task_interaction_requests_task_id``) or the anchor's
@@ -149,25 +153,35 @@ class InteractionHandoffError(RuntimeError):
 class InteractionSlotTaken(InteractionHandoffError):
     """The active-row INSERT collided with another request's active slot.
 
-    Raised only when the post-conflict re-check (step 7) does not find the
-    caller's own ``(task_id, run_id, request_idempotency_key)`` among the
-    surviving rows after an ``IntegrityError``. Because that re-check cannot
-    distinguish a real slot conflict from any other ``IntegrityError`` the
-    INSERT could have raised, this exception is also what a programming
-    error that skipped the plain-Python validation block would surface as.
-    See the module docstring's misclassification-funnel paragraph.
+    Raised only when the post-conflict re-check (step 7) finds no row at all
+    at the caller's own ``(task_id, run_id, request_idempotency_key)`` after
+    an ``IntegrityError`` -- there is no identity row to explain the
+    conflict, so it must have been the active-slot unique. A re-check hit
+    whose ``status`` is ``answered`` or ``terminated`` raises
+    ``InteractionRequestClosed`` instead (see that exception's docstring):
+    it is the same identity key, just already closed, not a slot race.
+    Because a no-hit re-check still cannot distinguish a real slot conflict
+    from any other ``IntegrityError`` the INSERT could have raised, this
+    exception is also what a programming error that skipped the
+    plain-Python validation block would surface as. See the module
+    docstring's misclassification-funnel paragraph.
     """
 
 
 class InteractionRequestClosed(InteractionHandoffError):
-    """The idempotency pre-read found this identity key already terminal.
+    """This identity key already names a terminal row.
 
     Raised when ``(task_id, run_id, request_idempotency_key)`` names a row
     whose ``status`` is ``answered`` or ``terminated`` rather than
-    ``active``. Identity is scoped by ``run_id``: a key that was reclaimed
-    to ``terminated`` earlier in the *same* run still raises this on reuse
-    (there is no cross-run leakage to guard against, because a different
-    run never shares this row at all).
+    ``active`` -- both by the idempotency pre-read (step 4, before this
+    call's own INSERT is ever attempted) and by the post-conflict re-check
+    (step 7, when this call's own INSERT collided with a row that turns out
+    to already be closed rather than merely active elsewhere). Both reads
+    share ``_identity_lookup_stmt``, so the two call sites classify the same
+    row state identically. Identity is scoped by ``run_id``: a key that was
+    reclaimed to ``terminated`` earlier in the *same* run still raises this
+    on reuse (there is no cross-run leakage to guard against, because a
+    different run never shares this row at all).
     """
 
 
@@ -399,6 +413,17 @@ def _validate_request_fields(
     caught by a CHECK constraint on the INSERT. See the module docstring's
     misclassification-funnel paragraph for why this list must stay complete.
 
+    Row 13 of that list: ``now`` must be validated as an aware UTC datetime
+    the same way ``expires_at`` is (row 6) -- not normalized, only rejected
+    if it fails. ``now`` has no CHECK constraint of its own to back this up
+    (unlike every other row here), but it is not a free pass: the reclaim
+    UPDATE (``_reclaim_stale_slot_stmt``) persists this exact value into
+    ``terminated_at`` and ``updated_at`` on every row it reclaims, so a
+    naive or non-UTC ``now`` would otherwise reach SQL and get silently
+    mis-stored the same way an unvalidated ``expires_at`` would (see
+    ``TaskInteractionRequest``'s own docstring on the aware-UTC obligation
+    for that column).
+
     Returns the normalized (stripped) idempotency key.
     """
 
@@ -424,6 +449,11 @@ def _validate_request_fields(
         raise ValueError("expires_at must be an aware UTC datetime")
     if utc_offset.total_seconds() != 0:
         raise ValueError("expires_at must be UTC (utcoffset must be zero)")
+    now_utc_offset = now.utcoffset()
+    if now.tzinfo is None or now_utc_offset is None:
+        raise ValueError("now must be an aware UTC datetime")
+    if now_utc_offset.total_seconds() != 0:
+        raise ValueError("now must be UTC (utcoffset must be zero)")
     if expires_at <= now:
         raise ValueError("expires_at must be after now")
     if not run_id:
@@ -472,12 +502,14 @@ def _reclaim_stale_slot_stmt(*, task_id: int, run_id: str, now: datetime) -> sa.
     plain expiry when a row is both (``run_id <> :reclaim_run_id`` is
     checked before falling through to ``deadline_elapsed``).
 
-    One of two ``sa.text`` usages in this module -- the other is
-    ``interaction_handoff``'s SQLite-only savepoint guard, which needs no
-    parameter because its predicate is a hardcoded constant, not caller
-    input. This one carries caller input (``run_id``) and must stay
-    parameterized via ``.bindparams`` -- see the module docstring's
-    statement-discipline note.
+    ``terminal_reason`` is built with ``sa.case``, not ``sa.text`` -- Core
+    compiles and parameterizes ``run_id`` on both backends without any raw
+    SQL fragment, verified equivalent to the earlier hand-written ``CASE
+    WHEN run_id <> :reclaim_run_id THEN 'run_superseded' ELSE
+    'deadline_elapsed' END``. The only remaining ``sa.text`` usage in this
+    module is ``interaction_handoff``'s SQLite-only savepoint guard, which
+    needs no parameter because its predicate is a hardcoded constant, not
+    caller input.
 
     This UPDATE is also the shape the next status-writing statement on this
     table needs to follow: it writes ``status`` and ``terminated_at``
@@ -503,10 +535,10 @@ def _reclaim_stale_slot_stmt(*, task_id: int, run_id: str, now: datetime) -> sa.
         )
         .values(
             status="terminated",
-            terminal_reason=sa.text(
-                "CASE WHEN run_id <> :reclaim_run_id THEN 'run_superseded' "
-                "ELSE 'deadline_elapsed' END"
-            ).bindparams(reclaim_run_id=run_id),
+            terminal_reason=sa.case(
+                (TaskInteractionRequest.run_id != run_id, "run_superseded"),
+                else_="deadline_elapsed",
+            ),
             active_slot=None,
             terminated_at=now,
             updated_at=now,
@@ -573,9 +605,16 @@ def stage_interaction_request(
        re-check identity with the same SELECT step 3 used. A hit whose
        ``status`` is ``active`` is a REPLAY-after-conflict: another session
        won the race between this call's step-3 read and its own INSERT, so
-       the row this call now owns is that winner's row, not a fresh one.
-       No hit (or a non-active hit) raises ``InteractionSlotTaken`` --
-       which, because this re-check cannot distinguish a genuine slot
+       the row this call now owns is that winner's row, not a fresh one. A
+       hit whose ``status`` is ``answered`` or ``terminated`` raises
+       ``InteractionRequestClosed`` -- the same classification step 3 gives
+       that state, since both reads share ``_identity_lookup_stmt``: the
+       identity row this call collided with had already closed by the time
+       the INSERT fired, which is a fact about that row's own lifecycle, not
+       an active-slot race. No hit at all raises ``InteractionSlotTaken`` --
+       the INSERT collided with some other row's active slot instead, and
+       there is no identity row here to explain the conflict any other way
+       -- which, because this re-check cannot distinguish a genuine slot
        conflict from a programming error that also violates some other
        CHECK, is why step 1's validation list must be complete.
 
@@ -584,7 +623,11 @@ def stage_interaction_request(
     directly lets a dead run silently displace a live run's question.
     """
 
-    resolved_task_id = int(task_id)
+    if isinstance(task_id, bool) or not isinstance(task_id, int):
+        raise ValueError(f"task_id must be a positive int, got {task_id!r}")
+    if task_id <= 0:
+        raise ValueError(f"task_id must be a positive int, got {task_id!r}")
+    resolved_task_id = task_id
     normalized_key = _validate_request_fields(
         run_id=run_id,
         anchor=anchor,
@@ -667,12 +710,17 @@ def stage_interaction_request(
                 request_idempotency_key=normalized_key,
             )
         ).first()
-        if again is not None and again.status == "active":
-            return StagedInteractionRequest(
-                staged_db_id=int(again.id),
-                created=False,
-                status=again.status,
-                active_slot=again.active_slot,
+        if again is not None:
+            if again.status == "active":
+                return StagedInteractionRequest(
+                    staged_db_id=int(again.id),
+                    created=False,
+                    status=again.status,
+                    active_slot=again.active_slot,
+                )
+            raise InteractionRequestClosed(
+                f"request {normalized_key!r} on task {resolved_task_id} run "
+                f"{run_id!r} is already {again.status}"
             )
         raise InteractionSlotTaken(
             f"task {resolved_task_id} already has an active interaction "

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -168,6 +168,13 @@ _MAX_LENGTHS: dict[str, int] = {
     # silently stored on SQLite and raises DataError -- not IntegrityError
     # -- on PostgreSQL, so it never enters the conflict classifier and
     # never reaches the swallowed set.
+    #
+    # This derivation assumes every one of these columns is a String(N).
+    # A Text column has no length cap at all -- .type.length reports None
+    # for one -- which would make the length check built from this dict a
+    # silent no-op for that field instead of raising at construction time.
+    # Re-derive this dict's shape if any of these locator columns ever
+    # widens from String(N) to Text.
     name: TaskInteractionRequest.__table__.c[name].type.length
     for name in (
         "run_id",
@@ -648,6 +655,12 @@ def _validate_request_fields(
         raise ValueError("now must be UTC (utcoffset must be zero)")
     if expires_at <= now:
         raise ValueError("expires_at must be after now")
+    # Unlike request_idempotency_key just above (normalized with .strip()),
+    # run_id is never stripped. It arrives from the service's own lease --
+    # not from caller-shaped input -- and is compared verbatim, below,
+    # against anchor.resume_run_partition. Normalizing either side of that
+    # comparison would risk masking a real mismatch between the two instead
+    # of surfacing it as InteractionRunPartitionMismatch.
     if not isinstance(run_id, str):
         raise ValueError(f"run_id must be a str, got {type(run_id).__name__}")
     if not run_id:

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -294,6 +294,20 @@ class InteractionHandoffMisuse(InteractionHandoffError):
     """
 
 
+class InteractionOriginUnknown(InteractionHandoffError):
+    """``task.source`` names a value outside the frozen origin vocabulary.
+
+    ``origin`` is a frozen copy of ``task.source`` and an audit column: it
+    records which source surface an interaction was raised on behalf of.
+    Substituting ``"internal"`` for an unrecognised value would write a
+    false provenance into that column, so this degrades instead -- the row
+    is not written, and the drift is reported. Unlike the ``ValueError``
+    ``stage_interaction_request`` raises for a caller-supplied ``origin``,
+    this names a value read out of a persisted row: data drift, not a
+    programming error.
+    """
+
+
 # Explicit tuple, not `isinstance(exc, InteractionHandoffError)`: dispatching
 # off the common base class would make any *future* subclass of it
 # automatically swallowed the moment it is defined -- a fail-open default.
@@ -312,6 +326,7 @@ _SWALLOWED: tuple[type[BaseException], ...] = (
     InteractionAnchorCorrupt,
     InteractionAttemptMismatch,
     InteractionRunPartitionMismatch,
+    InteractionOriginUnknown,
 )
 
 # Which ops_signals name a given swallowed exception type registers.
@@ -328,6 +343,7 @@ _DEGRADATION_SIGNALS: dict[type[BaseException], str] = {
     InteractionAnchorCorrupt: INTERACTION_HANDOFF_DEGRADED,
     InteractionAttemptMismatch: INTERACTION_HANDOFF_DEGRADED,
     InteractionRunPartitionMismatch: INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED,
+    InteractionOriginUnknown: INTERACTION_HANDOFF_DEGRADED,
 }
 
 
@@ -922,6 +938,12 @@ class _InteractionHandoff:
             raise ValueError(
                 "lease has no run_id; cannot stage an interaction request without one"
             )
+        origin = str(self.task.source) if self.task.source else "internal"
+        if origin not in _ORIGIN_VOCABULARY:
+            raise InteractionOriginUnknown(
+                f"task {self.task.id}'s source {origin!r} is outside the "
+                f"origin vocabulary {sorted(_ORIGIN_VOCABULARY)}"
+            )
         return stage_interaction_request(
             self.db,
             task_id=int(self.task.id),
@@ -929,7 +951,7 @@ class _InteractionHandoff:
             anchor=self.anchor,
             kind=kind,
             protocol_version=protocol_version,
-            origin=(str(self.task.source) if self.task.source else "internal"),
+            origin=origin,
             request_payload=request_payload,
             request_idempotency_key=request_idempotency_key,
             expires_at=expires_at,

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -510,6 +510,8 @@ def _validate_request_fields(
     Returns the normalized (stripped) idempotency key.
     """
 
+    if not isinstance(kind, str):
+        raise ValueError(f"kind must be a str, got {type(kind).__name__}")
     if kind not in _KIND_VOCABULARY:
         raise ValueError(
             f"kind must be one of {sorted(_KIND_VOCABULARY)}, got {kind!r}"
@@ -518,9 +520,16 @@ def _validate_request_fields(
         raise ValueError(
             f"protocol_version must be {_PROTOCOL_VERSION}, got {protocol_version!r}"
         )
+    if not isinstance(origin, str):
+        raise ValueError(f"origin must be a str, got {type(origin).__name__}")
     if origin not in _ORIGIN_VOCABULARY:
         raise ValueError(
             f"origin must be one of {sorted(_ORIGIN_VOCABULARY)}, got {origin!r}"
+        )
+    if not isinstance(request_idempotency_key, str):
+        raise ValueError(
+            "request_idempotency_key must be a str, got "
+            f"{type(request_idempotency_key).__name__}"
         )
     normalized_key = request_idempotency_key.strip()
     if COMMAND_ID_PATTERN.fullmatch(normalized_key) is None:
@@ -539,6 +548,8 @@ def _validate_request_fields(
         raise ValueError("now must be UTC (utcoffset must be zero)")
     if expires_at <= now:
         raise ValueError("expires_at must be after now")
+    if not isinstance(run_id, str):
+        raise ValueError(f"run_id must be a str, got {type(run_id).__name__}")
     if not run_id:
         raise ValueError("run_id must not be empty")
     if len(run_id) > _MAX_LENGTHS["run_id"]:
@@ -1175,8 +1186,8 @@ def interaction_handoff(
     # clause never growing back to include a real data column -- do not
     # replace this with sa.update(Task) in any form without re-verifying
     # what it compiles to.
-    if db.get_bind().dialect.name == "sqlite":
-        db.execute(sa.text("UPDATE tasks SET id = id WHERE id = -1"))
+    if db.get_bind(Task).dialect.name == "sqlite":
+        db.execute(sa.text(f"UPDATE {Task.__tablename__} SET id = id WHERE id = -1"))
 
     # Session.begin_nested() always flushes first (it has to, in order to
     # establish the SAVEPOINT after whatever is already pending): a doomed

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -347,6 +347,26 @@ class InteractionOriginUnknown(InteractionHandoffError):
 # called for propagating it unchanged, the same as InteractionOwnerStateError
 # below it). See interaction_handoff's docstring for the reasoning and the
 # re-adjudication obligation this override carries forward.
+#
+# A second trigger for auditing this tuple, beyond a new exception type
+# being defined here: any new way a statement inside the with-block can
+# fail at all, whether or not it introduces a new named exception. The
+# JSON-serialization probe in _validate_request_fields is one instance of
+# this already in this module -- before it existed, a non-serializable
+# request_payload failed at bind time as StatementError, a genuinely new
+# failure mode this tuple had never been asked to classify, escaping
+# _SWALLOWED silently rather than being named here on purpose. Probing for
+# it earlier and converting it to ValueError was a deliberate choice to
+# keep it out of this tuple, propagating like every other programming-error
+# ValueError in this module -- not a decision this tuple's own contents
+# would ever surface on inspection, since the exception type it now raises
+# already existed. Every future change that makes some new class of
+# failure reachable from inside the with-block -- a new column CHECK, a new
+# I/O call, a new library the underlying INSERT might route through --
+# carries the same obligation this tuple's own definition asks of a new
+# exception type: decide, on purpose, whether it belongs on this list or
+# off it, and leave that decision visible in the diff a reviewer actually
+# reads.
 _SWALLOWED: tuple[type[BaseException], ...] = (
     InteractionSlotTaken,
     InteractionRequestClosed,
@@ -806,6 +826,13 @@ def stage_interaction_request(
     live run's own next staging attempt then surfaces as
     ``InteractionSlotTaken`` or ``InteractionRequestClosed``, not as the
     precondition violation that actually caused it.
+
+    ``now`` is a trusted service-internal clock, taken as a parameter so
+    reclaim and expiry are testable without sleeping. It is validated for
+    timezone-awareness but deliberately not bounded against wall-clock
+    time: an absurd value retires live, unexpired rows as
+    ``deadline_elapsed`` indistinguishably from a real expiry, and nothing
+    in this function can tell the two apart afterwards.
     """
 
     if isinstance(task_id, bool) or not isinstance(task_id, int):
@@ -1196,12 +1223,32 @@ def interaction_handoff(
     AST gate -- must re-adjudicate this policy once a real reachability
     picture exists**, not carry it forward unexamined.
 
-    Every degradation signal this module registers is sticky: nothing
-    clears it once set (``ops_signals.py`` has no automatic-clear path, by
-    design -- see that module's docstring). ``/health`` reports a
-    degradation from an hour-old, already-recovered handoff exactly the
-    same as one from a second ago. This module inherits that behavior; it
-    does not introduce it.
+    Every degradation signal this module registers is sticky in a way none
+    of ``ops_signals.py``'s other six signals are.
+    ``CHECKPOINT_LOAD_UNAVAILABLE``, ``CHECKPOINT_DECODE_FALLBACK``,
+    ``CHECKPOINT_PK_ANCHOR_DANGLING``, ``CHECKPOINT_PRUNE_FAILED``,
+    ``CHECKPOINT_LEGACY_POINTER_AMBIGUOUS``, and
+    ``GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED`` each have a producer-side
+    ``clear_degradation()`` call somewhere in this codebase
+    (``trace_handlers.py``, ``task_lease_recovery.py``,
+    ``trigger_providers/gmail.py``) that runs once the condition that set
+    them resolves. ``INTERACTION_HANDOFF_DEGRADED`` and
+    ``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED`` are the only two
+    entries in the registry with no ``clear_degradation()`` call anywhere
+    -- not because ``ops_signals.py`` forbids clearing (it does not;
+    ``clear_degradation`` exists and every other signal uses it), but
+    because nothing in this module, or any future caller of it, has been
+    written to call it. ``/health`` therefore reports a degradation from an
+    hour-old, already-recovered handoff exactly the same as one from a
+    second ago -- at the same security-relevant-misconfiguration severity
+    ``ops_signals.py``'s own docstring describes for every entry, with
+    nothing to distinguish stale from fresh. This is a property this
+    module introduces, not one it inherits from ``ops_signals.py``'s
+    design: the change that wires the first production caller must decide
+    who owns clearing these two signals, alongside the run-partition
+    override's own re-adjudication obligation above -- both are open
+    questions the zero-production-caller state of this module has left
+    unexamined, not settled defaults to carry forward unchanged.
 
     A SQLite-only correctness gap, found and fixed while building this
     module: a session whose first write-adjacent statement is a bare
@@ -1318,6 +1365,11 @@ def interaction_handoff(
             "caller's pending writes failed to flush while opening the "
             "interaction handoff's savepoint"
         ) from exc
+    # Must not raise: this sits outside the try that owns `savepoint`, so a
+    # raise here would leak it un-rolled-back and, because this whole
+    # function is a @contextmanager generator, would fire from __enter__ --
+    # before `with` ever runs its body, and before this savepoint could be
+    # unwound the way every other exit path below unwinds it.
     handoff = _InteractionHandoff(db, lease, task=task, anchor=anchor, now=now)
     try:
         yield handoff

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -1,0 +1,583 @@
+"""Stage one interaction request row into a session the caller already owns.
+
+``stage_interaction_request`` does the plain-Python validation, the
+caller's own flush, a keyed idempotency pre-read, the reclaim UPDATE that
+retires a stale or superseded active row, and the active-row INSERT under a
+savepoint this function owns.
+
+Caller obligations, because none of them happen here:
+
+* This function joins the ``Session`` passed in; it never calls
+  ``db.commit()`` or the outer ``db.rollback()``. It manages only its own
+  inner savepoint (see below) -- the caller owns the transaction and
+  decides when to commit or roll it back.
+* It never notifies, prunes, or writes any column of ``tasks``.
+* If this function raises ``InteractionOwnerStateError``, the session is
+  left mid-transaction with no savepoint of its own to roll back to (the
+  failure happened before this function opened one) -- the caller must
+  roll back the whole transaction before issuing another statement on it.
+  Every other exception this function raises is contained by its own inner
+  savepoint.
+
+Zero production callers as of this module's introduction: a static test
+(``tests/web/services/test_interaction_staging_production_gate.py``) asserts
+that no production module calls this function. See that test's docstring
+for the removal condition.
+
+Every rejection the database's 23 CHECK constraints could raise on the
+INSERT is rejected in plain Python first, inside this function's own
+validation block, because the post-conflict re-check (step 7 below)
+classifies any ``IntegrityError`` that does not match the caller's own
+identity key as a slot conflict -- ``InteractionSlotTaken``. That re-check
+cannot tell a real slot conflict apart from a programming error (an
+out-of-vocabulary ``origin``, a non-positive TTL, a ``None`` payload past
+``JSON(none_as_null=True))``) that also violates a CHECK: both land on the
+same ``else`` branch. The backstop is the database's constraint set, not
+the primary defense; the primary defense is this validation block, and it
+must reject everything the INSERT could reject before the INSERT is ever
+issued. Adding a column CHECK to ``TaskInteractionRequest`` without adding
+the matching Python check here reopens that misclassification funnel by
+one more case.
+
+Concurrency note (inherited, not introduced here): on PostgreSQL, an
+``IntegrityError`` poisons the rest of the transaction
+(``InFailedSqlTransaction``) until something rolls back at least to the
+savepoint that was open when it fired; SQLite instead lets the session keep
+issuing statements. This function's own inner ``db.begin_nested()`` around
+the INSERT is what makes the post-conflict re-check possible on both
+backends -- see the function's docstring for why a savepoint shared with
+the caller does not work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..models.task_interaction import TaskInteractionRequest
+from .task_command_transport import COMMAND_ID_PATTERN
+
+_KIND_VOCABULARY = frozenset({"clarification"})
+_ORIGIN_VOCABULARY = frozenset(
+    {"internal", "sdk", "a2a", "trigger", "widget", "shared_link"}
+)
+_RESUME_LOCATOR_FORMAT = "trace_event_pk_v1"
+_RESUME_CHECKPOINT_TYPE = "agent_execution_checkpoint"
+_PROTOCOL_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class InteractionHandoffError(RuntimeError):
+    """Common base for every exception this module raises.
+
+    Deliberately not the dispatch key ``interaction_handoff`` uses to decide
+    what to swallow -- see ``_SWALLOWED`` below for why an explicit tuple is
+    used instead of ``isinstance(exc, InteractionHandoffError)``.
+    """
+
+
+class InteractionSlotTaken(InteractionHandoffError):
+    """The active-row INSERT collided with another request's active slot.
+
+    Raised only when the post-conflict re-check (step 7) does not find the
+    caller's own ``(task_id, run_id, request_idempotency_key)`` among the
+    surviving rows after an ``IntegrityError``. Because that re-check cannot
+    distinguish a real slot conflict from any other ``IntegrityError`` the
+    INSERT could have raised, this exception is also what a programming
+    error that skipped the plain-Python validation block would surface as.
+    See the module docstring's misclassification-funnel paragraph.
+    """
+
+
+class InteractionRequestClosed(InteractionHandoffError):
+    """The idempotency pre-read found this identity key already terminal.
+
+    Raised when ``(task_id, run_id, request_idempotency_key)`` names a row
+    whose ``status`` is ``answered`` or ``terminated`` rather than
+    ``active``. Identity is scoped by ``run_id``: a key that was reclaimed
+    to ``terminated`` earlier in the *same* run still raises this on reuse
+    (there is no cross-run leakage to guard against, because a different
+    run never shares this row at all).
+    """
+
+
+class InteractionAnchorCorrupt(InteractionHandoffError):
+    """The resume anchor handed to this call is not self-consistent.
+
+    Raised by the shared field-validation helper both
+    ``stage_interaction_request`` and ``interaction_handoff`` call: an empty
+    or wrong-vocabulary anchor field, or a missing ``trace_event_id``. This
+    is the plain-Python half of anchor validation -- see
+    ``InteractionAnchor``'s docstring for what the other half (a database
+    read resolving absence/unavailable/corrupt against the live
+    ``trace_events`` row) is and why it is not this module's job.
+    """
+
+
+class InteractionAttemptMismatch(InteractionHandoffError):
+    """The caller's lease no longer names the task's current attempt.
+
+    Raised by ``interaction_handoff.__enter__`` when
+    ``lease.attempt_id is not None`` and it disagrees with
+    ``task.lease_attempt_id``. See ``TaskLease.attempt_id``'s docstring
+    (``task_lease_service.py``) for the ``is not None`` gate: a permanent
+    ``None`` lease (the ambient snapshot ``_task_lease_snapshot`` builds)
+    must read as "cannot prove attempt identity", never as "matches" or "does
+    not match".
+    """
+
+
+class InteractionRunPartitionMismatch(InteractionHandoffError):
+    """The interaction's run identity does not match its resume anchor's.
+
+    Raised by ``stage_interaction_request``'s validation block when
+    ``run_id != anchor.resume_run_partition``. There is deliberately no
+    database CHECK for this comparison
+    (``ck_task_interaction_requests_run_partition_matches`` was written and
+    then deleted from the model -- see ``task_interaction.py``'s
+    ``__table_args__`` comment): forcing it into a CHECK would turn the kind
+    of corruption #1071 exists to detect into a row that cannot be written
+    at all, which the post-conflict re-check would then misclassify as a
+    slot conflict instead of surfacing as the corruption it actually is.
+
+    PR-C2a deliberately swallows this exception -- see ``_SWALLOWED`` and
+    ``interaction_handoff``'s docstring for the reasoning and for why that
+    is a scoped override of this primitive's own default, not this
+    primitive's design intent.
+    """
+
+
+class InteractionOwnerStateError(InteractionHandoffError):
+    """The caller's own pending writes failed to flush before staging began.
+
+    Raised by ``stage_interaction_request``'s first ``db.flush()`` when
+    called directly, mirroring ``TaskCommandOwnerStateError``
+    (``task_command_transport.py``) for the identical reason: the wrapper's
+    ``except IntegrityError`` around the INSERT must classify conflicts on
+    that INSERT, and must not also catch a failure that has nothing to do
+    with it. Called through ``interaction_handoff`` instead, it can also
+    fire one statement earlier, from that context manager's own
+    ``db.begin_nested()`` -- ``Session.begin_nested()`` always flushes
+    pending state first, to establish the SAVEPOINT after whatever is
+    already pending, so the same caller-write failure can surface there
+    before ``stage_interaction_request`` is ever reached. After this is
+    raised the session is unusable until the caller rolls back -- and,
+    because it fires before any savepoint in this module has been opened,
+    there is no savepoint of this module's own to roll back to. This
+    exception is never swallowed:
+    the caller's own write failed, not the interaction's, and on PostgreSQL
+    the transaction is already poisoned by the time this fires, so
+    degrading in place is not physically possible.
+    """
+
+
+# Explicit tuple, not `isinstance(exc, InteractionHandoffError)`: dispatching
+# off the common base class would make any *future* subclass of it
+# automatically swallowed the moment it is defined -- a fail-open default.
+# Naming each swallowed type here means a new one has to be added on
+# purpose, in the same line reviewers already read, before it starts being
+# swallowed.
+#
+# PR-C2a note: InteractionRunPartitionMismatch's presence in this tuple is a
+# deliberate override of this primitive's literal design default (which
+# called for propagating it unchanged, the same as InteractionOwnerStateError
+# below it). See interaction_handoff's docstring for the reasoning and the
+# re-adjudication obligation this override carries forward.
+# ---------------------------------------------------------------------------
+# Data carriers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InteractionAnchor:
+    """The resume anchor a caller is staging an interaction request against.
+
+    This is not ``trace_event_staging.StagedCheckpointAnchor``. That type is
+    PR-A's return value for the shell's pointer UPDATE and carries only
+    ``checkpoint_event_id`` / ``trace_event_id``; PR-A's own review already
+    confirmed this module does not consume it, and it is not reused or
+    subclassed here.
+
+    Represents only half of anchor resolution. The other half -- a database
+    read against ``trace_events`` by primary key, layered into
+    absence/unavailable/corrupt outcomes with a legacy-column fallback -- is
+    a caller obligation that belongs to the batch that wires a production
+    reader, because it is a DB read that must happen outside any savepoint
+    this module opens. What this dataclass carries is the *result* of that
+    read once the caller already has one in hand: the fields both
+    ``stage_interaction_request`` and ``interaction_handoff`` validate for
+    self-consistency (non-empty strings, the two closed vocabularies, and a
+    real primary key) before ever building SQL from them. A caller that
+    passes an anchor whose fields fail that validation gets
+    ``InteractionAnchorCorrupt``, not a database round-trip.
+    """
+
+    trace_event_id: int
+    resume_event_id: str
+    resume_execution_id: str
+    resume_run_partition: str
+    resume_locator_format: str = _RESUME_LOCATOR_FORMAT
+    resume_checkpoint_type: str = _RESUME_CHECKPOINT_TYPE
+
+
+@dataclass(frozen=True)
+class StagedInteractionRequest:
+    """One interaction request row added to a caller-owned session.
+
+    Meaningful only once the caller commits the transaction this row was
+    staged into -- ``staged_db_id`` is the primary key SQLAlchemy assigned
+    during this call's flush (whether from a fresh INSERT or from an
+    existing row this call replayed), but it names a real, durable row only
+    after that commit succeeds.
+
+    ``created`` is ``True`` only on the clean-INSERT path. It is ``False``
+    on every replay path: a pre-existing ``active`` row hit by the
+    idempotency pre-read (step 4, before any reclaim or INSERT was even
+    attempted) and a pre-existing ``active`` row hit by the post-conflict
+    re-check (step 7, after this call's own INSERT lost a race). Both
+    replay paths return the *other* request's row, not a new one --
+    ``status`` and ``active_slot`` describe that row as it stood at the
+    moment this call read it, which on the step-4 path may already be
+    expired (see ``stage_interaction_request``'s docstring on why step 4
+    does not consult ``expires_at``).
+    """
+
+    staged_db_id: int
+    created: bool
+    status: str
+    active_slot: int | None
+
+
+# ---------------------------------------------------------------------------
+# Shared validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_anchor_fields(anchor: InteractionAnchor) -> None:
+    """The plain-Python half of anchor validation, shared by
+    ``stage_interaction_request``'s own pre-INSERT check and
+    ``interaction_handoff``'s ``__enter__`` precondition, so the two never
+    drift into checking different things for the same dataclass.
+
+    Every field checked here backs a real CHECK constraint on
+    ``task_interaction_requests`` (see the audit in this PR's design
+    record); a corrupt anchor caught here never reaches SQL.
+    """
+
+    if not anchor.resume_event_id:
+        raise InteractionAnchorCorrupt("anchor.resume_event_id must not be empty")
+    if not anchor.resume_execution_id:
+        raise InteractionAnchorCorrupt("anchor.resume_execution_id must not be empty")
+    if not anchor.resume_run_partition:
+        raise InteractionAnchorCorrupt("anchor.resume_run_partition must not be empty")
+    if anchor.resume_locator_format != _RESUME_LOCATOR_FORMAT:
+        raise InteractionAnchorCorrupt(
+            f"anchor.resume_locator_format must be {_RESUME_LOCATOR_FORMAT!r}, "
+            f"got {anchor.resume_locator_format!r}"
+        )
+    if anchor.resume_checkpoint_type != _RESUME_CHECKPOINT_TYPE:
+        raise InteractionAnchorCorrupt(
+            f"anchor.resume_checkpoint_type must be {_RESUME_CHECKPOINT_TYPE!r}, "
+            f"got {anchor.resume_checkpoint_type!r}"
+        )
+    if anchor.trace_event_id is None:
+        raise InteractionAnchorCorrupt("anchor.trace_event_id must not be None")
+
+
+def _validate_request_fields(
+    *,
+    run_id: str,
+    anchor: InteractionAnchor,
+    kind: str,
+    protocol_version: int,
+    origin: str,
+    request_payload: Any,
+    request_idempotency_key: str,
+    expires_at: datetime,
+    now: datetime,
+) -> str:
+    """Reject, in plain Python, every condition that could otherwise only be
+    caught by a CHECK constraint on the INSERT. See the module docstring's
+    misclassification-funnel paragraph for why this list must stay complete.
+
+    Returns the normalized (stripped) idempotency key.
+    """
+
+    if kind not in _KIND_VOCABULARY:
+        raise ValueError(
+            f"kind must be one of {sorted(_KIND_VOCABULARY)}, got {kind!r}"
+        )
+    if protocol_version != _PROTOCOL_VERSION:
+        raise ValueError(
+            f"protocol_version must be {_PROTOCOL_VERSION}, got {protocol_version!r}"
+        )
+    if origin not in _ORIGIN_VOCABULARY:
+        raise ValueError(
+            f"origin must be one of {sorted(_ORIGIN_VOCABULARY)}, got {origin!r}"
+        )
+    normalized_key = request_idempotency_key.strip()
+    if COMMAND_ID_PATTERN.fullmatch(normalized_key) is None:
+        raise ValueError("request_idempotency_key must be 1-64 URL-safe characters")
+    if request_payload is None:
+        raise ValueError("request_payload must not be None")
+    utc_offset = expires_at.utcoffset()
+    if expires_at.tzinfo is None or utc_offset is None:
+        raise ValueError("expires_at must be an aware UTC datetime")
+    if utc_offset.total_seconds() != 0:
+        raise ValueError("expires_at must be UTC (utcoffset must be zero)")
+    if expires_at <= now:
+        raise ValueError("expires_at must be after now")
+    if not run_id:
+        raise ValueError("run_id must not be empty")
+
+    _validate_anchor_fields(anchor)
+
+    if run_id != anchor.resume_run_partition:
+        raise InteractionRunPartitionMismatch(
+            f"run_id {run_id!r} does not match anchor.resume_run_partition "
+            f"{anchor.resume_run_partition!r}"
+        )
+
+    return normalized_key
+
+
+# ---------------------------------------------------------------------------
+# Statement helpers
+# ---------------------------------------------------------------------------
+
+
+def _identity_lookup_stmt(
+    *, task_id: int, run_id: str, request_idempotency_key: str
+) -> sa.Select[Any]:
+    """The identical Core SELECT used by both the idempotency pre-read (step
+    4) and the post-conflict re-check (step 7). Written once so the two
+    statements cannot drift apart at the edges of what they match."""
+
+    return sa.select(
+        TaskInteractionRequest.id,
+        TaskInteractionRequest.status,
+        TaskInteractionRequest.active_slot,
+    ).where(
+        TaskInteractionRequest.task_id == task_id,
+        TaskInteractionRequest.run_id == run_id,
+        TaskInteractionRequest.request_idempotency_key == request_idempotency_key,
+    )
+
+
+def _reclaim_stale_slot_stmt(*, task_id: int, run_id: str, now: datetime) -> sa.Update:
+    """The reclaim UPDATE (step 5). Stays in the caller's outer transaction,
+    not this function's inner savepoint -- it dies with the whole handoff on
+    rollback, and the post-conflict re-check must not have undone it.
+
+    Branch order is load-bearing: cross-run supersession takes priority over
+    plain expiry when a row is both (``run_id <> :reclaim_run_id`` is
+    checked before falling through to ``deadline_elapsed``).
+
+    The one ``sa.text`` in this module, and it must stay parameterized via
+    ``.bindparams`` -- see the module docstring's statement-discipline note.
+    """
+
+    return (
+        sa.update(TaskInteractionRequest)
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.active_slot.isnot(None),
+            sa.or_(
+                TaskInteractionRequest.expires_at <= now,
+                TaskInteractionRequest.run_id != run_id,
+            ),
+        )
+        .values(
+            status="terminated",
+            terminal_reason=sa.text(
+                "CASE WHEN run_id <> :reclaim_run_id THEN 'run_superseded' "
+                "ELSE 'deadline_elapsed' END"
+            ).bindparams(reclaim_run_id=run_id),
+            active_slot=None,
+            terminated_at=now,
+            updated_at=now,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# The staging primitive
+# ---------------------------------------------------------------------------
+
+
+def stage_interaction_request(
+    db: Session,
+    *,
+    task_id: int,
+    run_id: str,
+    anchor: InteractionAnchor,
+    kind: str,
+    protocol_version: int,
+    origin: str,
+    request_payload: Any,
+    request_idempotency_key: str,
+    expires_at: datetime,
+    now: datetime,
+) -> StagedInteractionRequest:
+    """Add one active interaction request row to ``db``, without ending its
+    transaction. See the module docstring for what the caller still owns.
+
+    Statement order is load-bearing:
+
+    1. Reject, in plain Python, everything the INSERT could otherwise only
+       be rejected for by a CHECK constraint (see the module docstring).
+       Nothing below this point issues SQL until this block has returned
+       cleanly.
+    2. Flush the caller's own pending writes first, so a conflict there is
+       reported as ``InteractionOwnerStateError`` rather than folded into
+       the ``IntegrityError`` this function raises for a slot conflict on
+       its own INSERT below.
+    3. Read for an existing row at this identity -- ``(task_id, run_id,
+       request_idempotency_key)`` -- before touching anything else. A hit
+       whose ``status`` is ``active`` is replayed as-is (``created=False``);
+       this branch does not consult ``expires_at``, so a replayed row may
+       already be expired -- callers must not assume otherwise (see
+       ``StagedInteractionRequest``'s docstring). A hit whose ``status`` is
+       ``answered`` or ``terminated`` raises ``InteractionRequestClosed``:
+       identity is scoped by ``run_id``, so a key reclaimed to
+       ``terminated`` earlier in *this same run* still raises here on reuse.
+    4. Reclaim: retire this task's stale or run-superseded active row, if
+       any, in the same outer transaction as everything else -- not inside
+       the inner savepoint opened next, so a post-conflict re-check below
+       cannot undo it.
+    5. Insert the new active row inside a savepoint this function opens and
+       owns (``db.begin_nested()``), then flush. A savepoint shared with a
+       caller (or with ``interaction_handoff``'s own savepoint) does not
+       work here: ``ResourceClosedError: This transaction is closed`` fires
+       on both backends, on both the exception exit path and the successful
+       REPLAY-after-conflict exit path, because a savepoint that something
+       else already rolled back cannot be committed or rolled back again.
+       Measured directly against this tree; see this PR's mutation test for
+       the primitive's own savepoint (M-1), which reproduces the same
+       failure by making that same mistake on purpose.
+    6. On ``IntegrityError``, roll back only this inner savepoint and
+       re-check identity with the same SELECT step 3 used. A hit whose
+       ``status`` is ``active`` is a REPLAY-after-conflict: another session
+       won the race between this call's step-3 read and its own INSERT, so
+       the row this call now owns is that winner's row, not a fresh one.
+       No hit (or a non-active hit) raises ``InteractionSlotTaken`` --
+       which, because this re-check cannot distinguish a genuine slot
+       conflict from a programming error that also violates some other
+       CHECK, is why step 1's validation list must be complete.
+
+    This function's reclaim UPDATE assumes the caller has already proven it
+    holds the task's current attempt; bypassing that precondition to call it
+    directly lets a dead run silently displace a live run's question.
+    """
+
+    resolved_task_id = int(task_id)
+    normalized_key = _validate_request_fields(
+        run_id=run_id,
+        anchor=anchor,
+        kind=kind,
+        protocol_version=protocol_version,
+        origin=origin,
+        request_payload=request_payload,
+        request_idempotency_key=request_idempotency_key,
+        expires_at=expires_at,
+        now=now,
+    )
+
+    try:
+        db.flush()
+    except IntegrityError as exc:
+        raise InteractionOwnerStateError(
+            "caller's pending writes failed to flush before interaction staging"
+        ) from exc
+
+    existing = db.execute(
+        _identity_lookup_stmt(
+            task_id=resolved_task_id,
+            run_id=run_id,
+            request_idempotency_key=normalized_key,
+        )
+    ).first()
+    if existing is not None:
+        if existing.status == "active":
+            return StagedInteractionRequest(
+                staged_db_id=int(existing.id),
+                created=False,
+                status=existing.status,
+                active_slot=existing.active_slot,
+            )
+        raise InteractionRequestClosed(
+            f"request {normalized_key!r} on task {resolved_task_id} run "
+            f"{run_id!r} is already {existing.status}"
+        )
+
+    db.execute(
+        _reclaim_stale_slot_stmt(task_id=resolved_task_id, run_id=run_id, now=now)
+    )
+
+    row = {
+        "task_id": resolved_task_id,
+        "run_id": run_id,
+        "kind": kind,
+        "protocol_version": protocol_version,
+        "status": "active",
+        "active_slot": 1,
+        "origin": origin,
+        "request_payload": request_payload,
+        "response_payload": None,
+        "request_idempotency_key": normalized_key,
+        "resume_trace_event_id": anchor.trace_event_id,
+        "resume_event_id": anchor.resume_event_id,
+        "resume_execution_id": anchor.resume_execution_id,
+        "resume_locator_format": anchor.resume_locator_format,
+        "resume_checkpoint_type": anchor.resume_checkpoint_type,
+        "resume_run_partition": anchor.resume_run_partition,
+        "responder_user_id": None,
+        "responder_identity": None,
+        "terminal_reason": None,
+        "expires_at": expires_at,
+        "responded_at": None,
+        "terminated_at": None,
+    }
+
+    inner = db.begin_nested()
+    try:
+        new_row = TaskInteractionRequest(**row)
+        db.add(new_row)
+        db.flush()
+    except IntegrityError:
+        inner.rollback()
+        again = db.execute(
+            _identity_lookup_stmt(
+                task_id=resolved_task_id,
+                run_id=run_id,
+                request_idempotency_key=normalized_key,
+            )
+        ).first()
+        if again is not None and again.status == "active":
+            return StagedInteractionRequest(
+                staged_db_id=int(again.id),
+                created=False,
+                status=again.status,
+                active_slot=again.active_slot,
+            )
+        raise InteractionSlotTaken(
+            f"task {resolved_task_id} already has an active interaction "
+            "request in a different slot"
+        )
+    else:
+        inner.commit()
+        return StagedInteractionRequest(
+            staged_db_id=int(new_row.id),
+            created=True,
+            status="active",
+            active_slot=1,
+        )

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -76,14 +76,24 @@ ever issued. Adding a column CHECK to ``TaskInteractionRequest`` without
 adding the matching Python check here reopens that misclassification
 funnel by one more case.
 
-Two mechanisms, not one: a CHECK violation surfaces as an ``IntegrityError``
-and lands in the misclassification funnel above; a column-length violation
-surfaces as a ``DataError`` on PostgreSQL -- not an ``IntegrityError``, so
-the conflict classifier never sees it, and not in ``_SWALLOWED``, so it
-would escape the handoff entirely -- and is silently accepted on SQLite,
-which does not enforce ``VARCHAR`` length. That asymmetry is why the length
-caps are derived from the model's own column types rather than written as
-literals.
+Three mechanisms, not one. A CHECK violation surfaces as an
+``IntegrityError`` and lands in the misclassification funnel above. A
+column-length violation surfaces as a ``DataError`` on PostgreSQL -- not an
+``IntegrityError``, so the conflict classifier never sees it, and not in
+``_SWALLOWED``, so it would escape the handoff entirely -- and is silently
+accepted on SQLite, which does not enforce ``VARCHAR`` length. That
+asymmetry is why the length caps are derived from the model's own column
+types rather than written as literals. A value ``request_payload`` cannot
+serialize at all is the third: SQLAlchemy's JSON type serializes at bind
+time, inside the INSERT, well past this validation block, and a value that
+fails there raises ``StatementError`` on both backends -- not
+``IntegrityError``, so it would also escape the conflict classifier and
+``_SWALLOWED`` the same way a length violation does. ``request_payload`` is
+probed with ``json.dumps(..., allow_nan=False)`` in this validation block
+for exactly this reason, before the INSERT is ever issued (see that check's
+own comment for why ``allow_nan=False`` is load-bearing: the two backends
+diverge on ``NaN``/``Infinity`` in a way plain ``json.dumps`` would not
+catch).
 
 Two cells this validation block cannot close, by construction: the parent
 ``tasks`` row (``fk_task_interaction_requests_task_id``) or the anchor's
@@ -114,6 +124,7 @@ savepoint) does not work.
 
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -536,6 +547,47 @@ def _validate_request_fields(
         raise ValueError("request_idempotency_key must be 1-64 URL-safe characters")
     if request_payload is None:
         raise ValueError("request_payload must not be None")
+    # A value that cannot be JSON-serialized at all never reaches this
+    # block's other checks -- it would sail through every one of them (it is
+    # not None, and nothing else here inspects its shape) and fail instead
+    # at bind time, inside the INSERT, as a StatementError on both backends.
+    # StatementError is not IntegrityError, so the post-conflict re-check
+    # would never see it, and it is not in _SWALLOWED either, so it would
+    # escape interaction_handoff entirely instead of degrading like every
+    # other expected failure this module knows how to name. Probing here,
+    # before the INSERT is ever issued, turns that crash into the same
+    # ValueError every other row-13-and-earlier violation raises.
+    #
+    # allow_nan=False is load-bearing, not a strictness knob: the default
+    # json.dumps happily renders float('nan') / float('inf') as the bare
+    # (non-JSON) tokens NaN / Infinity, which round-trips through Python's
+    # own json.loads but is not valid JSON text. The two backends then
+    # diverge on what a real INSERT does with it -- SQLite has no native
+    # JSON type and stores the column as TEXT, so it stores that invalid
+    # JSON verbatim with no complaint at all; PostgreSQL's jsonb parser
+    # rejects it, raising DataError, not StatementError. Passing
+    # allow_nan=False makes this probe raise ValueError for NaN/Infinity
+    # before either of those divergent, backend-specific outcomes is ever
+    # reached, so this validation block rejects the payload the same way
+    # regardless of which backend the caller happens to be running against.
+    #
+    # A payload that is valid JSON but serializes twice (e.g. a dict whose
+    # value is itself already a JSON string) is accepted here: this probe
+    # only checks that request_payload itself is JSON-serializable, not that
+    # its values are not already-serialized JSON text -- double-serialization
+    # is a caller-shape question this primitive does not adjudicate, and it
+    # is well within the size this table's clarification payloads are
+    # expected to carry.
+    #
+    # If this engine is ever configured with a custom json_serializer (it is
+    # not, today -- see xagent/db/sqlite.py and the engine construction this
+    # module's callers use), this probe must derive from that serializer
+    # rather than calling json.dumps directly, or the two could accept
+    # different payloads.
+    try:
+        json.dumps(request_payload, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"request_payload is not JSON-serializable: {exc}") from exc
     utc_offset = expires_at.utcoffset()
     if expires_at.tzinfo is None or utc_offset is None:
         raise ValueError("expires_at must be an aware UTC datetime")

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -1104,7 +1104,13 @@ def interaction_handoff(
         yield handoff
     except _SWALLOWED as exc:
         savepoint.rollback()
-        signal = _DEGRADATION_SIGNALS[type(exc)]
+        # The except clause matches subclasses (isinstance semantics), so the
+        # signal lookup must too: an exact type(exc) key lookup would raise
+        # KeyError for a future subclass of a swallowed type, and KeyError is
+        # not swallowed -- the degradation path would become a crash path.
+        signal = next(
+            sig for cls, sig in _DEGRADATION_SIGNALS.items() if isinstance(exc, cls)
+        )
         register_degradation(
             signal,
             f"task {task.id} run {lease.run_id}: {type(exc).__name__}: {exc}",

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -918,6 +918,20 @@ def stage_interaction_request(
             status="active",
             active_slot=1,
         )
+    finally:
+        # A no-op on both handled paths above (the except branch's own
+        # inner.rollback() and the else branch's inner.commit() have already
+        # deactivated the savepoint by the time this runs). What it actually
+        # guards is any exception this try block does not otherwise catch --
+        # IntegrityError is the only one classified above, so anything else
+        # db.flush() or the constructor could raise (a StatementError from a
+        # bind-time serialization failure, for instance) would previously
+        # propagate straight out with this savepoint still open, leaking it
+        # into whatever the caller does next. Closing it here regardless of
+        # which path was taken keeps this function's own savepoint scoped to
+        # this function on every exit, not just the two it names explicitly.
+        if inner.is_active:
+            inner.rollback()
 
 
 # ---------------------------------------------------------------------------
@@ -1308,29 +1322,35 @@ def interaction_handoff(
             (sig for cls, sig in _DEGRADATION_SIGNALS.items() if isinstance(exc, cls)),
             INTERACTION_HANDOFF_DEGRADED,
         )
-        register_degradation(
-            signal,
-            f"task {task.id} run {lease.run_id}: {type(exc).__name__}: {exc}",
-        )
-        logger.error(
-            "interaction handoff degraded",
-            extra={
-                "task_id": task.id,
-                "lease_run_id": lease.run_id,
-                "lease_attempt_id": lease.attempt_id,
-                "anchor_run_partition": anchor.resume_run_partition,
-                "exception_type": type(exc).__name__,
-                "degradation_signal": signal,
-            },
-        )
-        # Registration and logging run first, and the rollback is
-        # guarded: a caller that violated the never-commit-or-rollback-
-        # inside-this-block contract has already deactivated this
-        # savepoint, and an unguarded rollback would raise
-        # ResourceClosedError -- replacing the swallowed exception and
-        # skipping the degradation signal entirely.
-        if savepoint.is_active:
-            savepoint.rollback()
+        try:
+            register_degradation(
+                signal,
+                f"task {task.id} run {lease.run_id}: {type(exc).__name__}: {exc}",
+            )
+            logger.error(
+                "interaction handoff degraded",
+                extra={
+                    "task_id": task.id,
+                    "lease_run_id": lease.run_id,
+                    "lease_attempt_id": lease.attempt_id,
+                    "anchor_run_partition": anchor.resume_run_partition,
+                    "exception_type": type(exc).__name__,
+                    "degradation_signal": signal,
+                },
+            )
+        finally:
+            # Registration and logging run first, in the try; the rollback
+            # lives in finally so it still runs even if logger.error itself
+            # raises (a misconfigured handler, for instance) -- otherwise
+            # that would leak this savepoint open on top of replacing the
+            # swallowed exception. The rollback stays guarded: a caller that
+            # violated the never-commit-or-rollback-inside-this-block
+            # contract has already deactivated this savepoint, and an
+            # unguarded rollback would raise ResourceClosedError, replacing
+            # whatever exception is already in flight and skipping the
+            # degradation signal entirely.
+            if savepoint.is_active:
+                savepoint.rollback()
         return
     except BaseException:
         if savepoint.is_active:

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -1174,7 +1174,6 @@ def interaction_handoff(
     try:
         yield handoff
     except _SWALLOWED as exc:
-        savepoint.rollback()
         # The except clause matches subclasses (isinstance semantics), so the
         # signal lookup must too: an exact type(exc) key lookup would raise
         # KeyError for a future subclass of a swallowed type, and KeyError is
@@ -1198,9 +1197,18 @@ def interaction_handoff(
                 "degradation_signal": signal,
             },
         )
+        # Registration and logging run first, and the rollback is
+        # guarded: a caller that violated the never-commit-or-rollback-
+        # inside-this-block contract has already deactivated this
+        # savepoint, and an unguarded rollback would raise
+        # ResourceClosedError -- replacing the swallowed exception and
+        # skipping the degradation signal entirely.
+        if savepoint.is_active:
+            savepoint.rollback()
         return
     except BaseException:
-        savepoint.rollback()
+        if savepoint.is_active:
+            savepoint.rollback()
         raise
     else:
         savepoint.commit()

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -22,12 +22,27 @@ Caller obligations, because none of them happen here:
   manages only its own inner savepoint (see below); ``interaction_handoff``
   manages only the outer savepoint it opens in ``__enter__``. The caller
   owns the transaction and decides when to commit or roll it back.
-* Neither one notifies, prunes, or writes any column of ``tasks``. A
-  degraded handoff still leaves whatever the caller was about to persist
-  for its own reasons (a stale attempt continuing to write its own task
-  row, for instance) untouched -- that is a fact the three eventual
-  finalizer call sites must each account for, not something this module
-  can prevent.
+* Neither one writes any *data* column of ``tasks``, and neither notifies
+  or prunes anything. The one exception is structural, not data: on
+  SQLite, ``interaction_handoff`` issues a single self-assigning,
+  zero-row ``UPDATE tasks SET id = id WHERE id = -1`` immediately before
+  opening its own outer savepoint (see that function's docstring for why).
+  ``id = -1`` can never match a row an autoincrement primary key minted,
+  so this can never touch a real row's data, and it is skipped entirely
+  on PostgreSQL, which does not need it. A degraded handoff still leaves
+  whatever the caller was about to persist for its own reasons (a stale
+  attempt continuing to write its own task row, for instance) untouched --
+  that is a fact the three eventual finalizer call sites must each account
+  for, not something this module can prevent. Those three finalizers are
+  the complete writer set this module assumes: a fourth, legacy release
+  path (``AgentServiceManager.execute_task`` in ``web/api/chat.py``) also
+  formally writes ``TaskStatus.WAITING_FOR_USER`` on a task row when
+  ``manage_task_lease`` is true, but every production call site
+  (``websocket.py``, and the Feishu/Slack/Telegram bot channels) passes
+  ``manage_task_lease=False`` -- that write path is confirmed unreachable
+  today, not merely unlikely. A caller added later that reaches it with
+  ``manage_task_lease=True`` would make it a fourth writer this module's
+  finalizer accounting does not yet account for.
 * If ``stage_interaction_request`` raises ``InteractionOwnerStateError``,
   the session is left mid-transaction with no savepoint of its own to roll
   back to (the failure happened before this function opened one) -- the
@@ -52,9 +67,26 @@ non-positive TTL, a ``None`` payload past ``JSON(none_as_null=True))``) that
 also violates a CHECK: both land on the same ``else`` branch. The backstop
 is the database's constraint set, not the primary defense; the primary
 defense is this validation block, and it must reject everything the INSERT
-could reject before the INSERT is ever issued. Adding a column CHECK to
+could reject except the two concurrent-parent-deletion cells documented
+below, before the INSERT is ever issued. Adding a column CHECK to
 ``TaskInteractionRequest`` without adding the matching Python check here
 reopens that misclassification funnel by one more case.
+
+Two cells this validation block cannot close, by construction: the parent
+``tasks`` row (``fk_task_interaction_requests_task_id``) or the anchor's
+``trace_events`` row (``fk_task_interaction_requests_resume_trace_event_id``)
+being deleted concurrently, some time between whatever read gave the
+caller its ``task_id`` / the anchor's ``trace_event_id`` and this call's
+own INSERT. Neither has a Python precondition here -- nothing in this
+function's own arguments could detect a row disappearing out from under
+it -- and both surface as a foreign-key ``IntegrityError`` that step 7's
+re-check, finding no matching identity row, classifies as
+``InteractionSlotTaken`` along with everything else in the
+misclassification funnel above. Closing that gap is not this validation
+block's job: it belongs to whatever serializes deletion against staging
+(the task-deletion path's own locking, and the trace-event pruning job's
+own protection set for rows a live anchor could still name), not to a
+plain-Python check inside this primitive.
 
 Concurrency note (inherited, not introduced here): on PostgreSQL, an
 ``IntegrityError`` poisons the rest of the transaction
@@ -155,7 +187,10 @@ class InteractionAnchorCorrupt(InteractionHandoffError):
 class InteractionAttemptMismatch(InteractionHandoffError):
     """The caller's lease no longer names the task's current attempt.
 
-    Raised by ``interaction_handoff.__enter__`` when
+    Raised by ``_InteractionHandoff.stage()``, at the start of the call,
+    before any staging SQL is issued -- not by ``interaction_handoff``'s
+    ``__enter__`` (see ``stage()``'s own docstring for why this
+    precondition has to live there). Raised when
     ``lease.attempt_id is not None`` and it disagrees with
     ``task.lease_attempt_id``. See ``TaskLease.attempt_id``'s docstring
     (``task_lease_service.py``) for the ``is not None`` gate: a permanent
@@ -319,8 +354,9 @@ class StagedInteractionRequest:
 def _validate_anchor_fields(anchor: InteractionAnchor) -> None:
     """The plain-Python half of anchor validation, shared by
     ``stage_interaction_request``'s own pre-INSERT check and
-    ``interaction_handoff``'s ``__enter__`` precondition, so the two never
-    drift into checking different things for the same dataclass.
+    ``_InteractionHandoff.stage()``'s own precondition check -- both now run
+    at the start of their respective calls, not in ``__enter__`` -- so the
+    two never drift into checking different things for the same dataclass.
 
     Every field checked here backs a real CHECK constraint on
     ``task_interaction_requests`` (see the audit in this PR's design
@@ -436,8 +472,23 @@ def _reclaim_stale_slot_stmt(*, task_id: int, run_id: str, now: datetime) -> sa.
     plain expiry when a row is both (``run_id <> :reclaim_run_id`` is
     checked before falling through to ``deadline_elapsed``).
 
-    The one ``sa.text`` in this module, and it must stay parameterized via
-    ``.bindparams`` -- see the module docstring's statement-discipline note.
+    One of two ``sa.text`` usages in this module -- the other is
+    ``interaction_handoff``'s SQLite-only savepoint guard, which needs no
+    parameter because its predicate is a hardcoded constant, not caller
+    input. This one carries caller input (``run_id``) and must stay
+    parameterized via ``.bindparams`` -- see the module docstring's
+    statement-discipline note.
+
+    This UPDATE is also the shape the next status-writing statement on this
+    table needs to follow: it writes ``status`` and ``terminated_at``
+    together, because
+    ``ck_task_interaction_requests_terminated_at_pairs_status`` enforces
+    ``(status = 'terminated') = (terminated_at IS NOT NULL)`` on every row
+    -- setting one without the other fails at the database, not just in
+    review. A future answering statement (writing ``status='answered'``) is
+    bound by the same discipline in the other direction: it must write
+    neither ``terminated_at`` nor ``terminal_reason``, since neither column
+    pairs with ``answered`` in any CHECK on this table.
     """
 
     return (
@@ -674,6 +725,25 @@ class _InteractionHandoff:
         This is a plain Python object comparison, not a SQL expression: the
         `` == None`` -> ``IS NULL`` folding that affects a SQLAlchemy
         column comparison compiled to SQL does not apply here.
+
+        This reads ``self.task.lease_attempt_id`` from whatever snapshot of
+        the task row the caller already loaded -- it is not itself a SQL
+        read, and it does not take a lock. Whether the comparison is safe
+        against a concurrent attempt change depends on the backend, not on
+        this line: on PostgreSQL, a caller that loaded ``task`` with its own
+        ``SELECT ... FOR UPDATE`` genuinely blocks a concurrent writer for
+        as long as that lock is held. On SQLite, SQLAlchemy silently drops
+        ``with_for_update()`` -- the dialect does not support it -- so no
+        row lock is ever actually taken there (the same fact
+        ``get_next_expired_task_lease_candidate_for_update`` in
+        ``task_lease_service.py`` documents for its own row-lock read).
+        What keeps this comparison's window closed on SQLite instead is
+        single-writer semantics: SQLite's database-wide writer lock
+        serializes every write regardless of which row it targets. That
+        makes this a TOCTOU (time-of-check-to-time-of-use) gap that happens
+        to stay closed because nothing else can be writing concurrently,
+        not a genuine row-level lock -- a caller that assumes real row
+        locking here is assuming something SQLite does not provide.
         """
 
         if (
@@ -764,6 +834,24 @@ def interaction_handoff(
     SQLite's database-wide writer lock (or, on PostgreSQL, ordinary row
     locks) for the whole span, not just an instant.
 
+    This handoff fails closed, on purpose, and does not inherit the
+    silent-discard shape a sibling primitive in this package uses.
+    ``trace_event_staging.stage_trace_event_row`` / its caller
+    ``DatabaseTraceHandler._save_trace_event`` (``web/api/trace_handlers.py``)
+    has a branch that discovers the parent task row is gone and, for a
+    non-required event, logs at debug and returns without raising -- a
+    deliberate silent discard, scoped to that primitive's best-effort trace
+    events. This module has no equivalent branch anywhere: every one of the
+    five swallowed exceptions below is swallowed because it is a named,
+    expected outcome with its own degradation signal, never because the
+    underlying data (the task, the anchor, the request row) turned out to
+    be missing or unreadable. A caller with a missing task or a broken
+    anchor gets an exception here -- ``InteractionAnchorCorrupt`` or a
+    database error, not a quiet no-op -- because a blocking interaction
+    request that is silently never staged strands the caller's turn
+    exactly the way this module's degrade-instead-of-losing-the-turn design
+    exists to prevent.
+
     Nesting, exactly:
 
         savepoint = db.begin_nested()        # this function's own
@@ -847,11 +935,12 @@ def interaction_handoff(
     no DML of its own before entering this context manager, which would
     make every one of the five swallowed exceptions' rollback silently do
     nothing -- the half-written garbage this context manager exists to
-    prevent. The zero-row UPDATE issued immediately below, before the
-    savepoint opens, is the fix: see the comment there for the reproduction,
-    the SQLAlchemy-documented pysqlite recipe that was considered and
-    rejected instead, and why. PostgreSQL was checked directly and does not
-    share this behavior at all.
+    prevent. The zero-row, single-column, SQLite-only ``UPDATE`` issued
+    immediately below, before the savepoint opens, is the fix: see the
+    comment there for the reproduction, the SQLAlchemy-documented pysqlite
+    recipe that was considered and rejected instead, and why. It is gated
+    on the session's own dialect and skipped entirely on PostgreSQL, which
+    was checked directly and does not share this behavior at all.
 
     In the wiring-window while ``lease.attempt_id is None`` is still
     possible (see ``_assert_current_attempt``'s docstring), this handoff's
@@ -863,13 +952,14 @@ def interaction_handoff(
     rolling-restart window at once.
     """
 
-    # A zero-row UPDATE, issued deliberately before this function's own
-    # savepoint opens. This statement's only purpose is to be a real DML
-    # statement: it touches no row (task.id == -1 can never match one) and
-    # its rowcount is never read. Removing it silently breaks the
-    # swallow-and-rollback contract this function exists to provide,
-    # whenever a caller enters this context manager without a prior write
-    # of its own on the same session -- exactly this file's own
+    # A zero-row, SQLite-only, single-column UPDATE, issued deliberately
+    # before this function's own savepoint opens. This statement's only
+    # purpose is to be a real DML statement: it touches no row (id = -1 can
+    # never match one an autoincrement primary key minted) and its rowcount
+    # is never read. Removing it silently breaks the swallow-and-rollback
+    # contract this function exists to provide, whenever a caller enters
+    # this context manager without a prior write of its own on the same
+    # session -- exactly this file's own
     # test_cm4_with_exit_does_not_commit_outer_transaction shape.
     #
     # Reproduction: on SQLite, a session whose first write-adjacent
@@ -881,7 +971,9 @@ def interaction_handoff(
     # stage_interaction_request's own inner savepoint, whose reclaim UPDATE
     # -- a real DML -- always runs first); this function's outer savepoint
     # has no such statement ahead of it otherwise. PostgreSQL does not
-    # share this behavior at all.
+    # share this behavior at all, so this guard is gated to SQLite; issuing
+    # it unconditionally on PostgreSQL would do nothing useful there while
+    # adding a statement to every handoff.
     #
     # The standard fix, and why it was not used: SQLAlchemy's documented
     # pysqlite recipe (disable pysqlite's own isolation_level, issue an
@@ -910,7 +1002,29 @@ def interaction_handoff(
     # batch, once real caller topology and deployment concurrency
     # assumptions exist, should revisit whether the engine-level recipe
     # becomes worth its cost at that point.
-    db.execute(sa.update(Task).where(Task.id == -1))
+    #
+    # Written as raw SQL via sa.text(), not sa.update(Task), specifically to
+    # keep its SET clause to exactly the one column named ("id = id", a
+    # self-assignment): sa.update(Task).where(Task.id == -1), with no
+    # .values() at all, compiles to a SET clause naming every column
+    # SQLAlchemy maps on Task -- all 44 of them, including runner_id and
+    # lease_attempt_id -- because Core has nothing to narrow the SET clause
+    # to without an explicit .values(). Even sa.update(Task).where(...)
+    # .values(id=-1) does not get down to one column: Task.updated_at
+    # carries onupdate=func.now(), which SQLAlchemy Core appends to any
+    # UPDATE on this table whenever the column is not given an explicit
+    # value, so that form still compiles to two SET columns (id,
+    # updated_at) on both backends -- confirmed directly. Raw text is the
+    # only way to name exactly one column and nothing else; the same
+    # bypass-the-onupdate-handler technique is already used for the same
+    # reason by acquire_runtime_key_transition_fence in
+    # services/api_keys.py. This module's own module-docstring invariant
+    # ("neither one writes any data column of tasks") depends on the SET
+    # clause never growing back to include a real data column -- do not
+    # replace this with sa.update(Task) in any form without re-verifying
+    # what it compiles to.
+    if db.get_bind().dialect.name == "sqlite":
+        db.execute(sa.text("UPDATE tasks SET id = id WHERE id = -1"))
 
     # Session.begin_nested() always flushes first (it has to, in order to
     # establish the SAVEPOINT after whatever is already pending): a doomed

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -331,12 +331,12 @@ _SWALLOWED: tuple[type[BaseException], ...] = (
 
 # Which ops_signals name a given swallowed exception type registers.
 # InteractionRunPartitionMismatch gets its own signal, distinct from the
-# other four's shared INTERACTION_HANDOFF_DEGRADED, precisely because it is
-# the one override the reachability-free state of this PR cannot validate --
-# see interaction_handoff's docstring. Keeping it separately addressable in
-# /health lets the first wiring PR tell "a run-partition anchor went stale"
-# apart from every other reason a handoff degraded, without having to
-# reparse log lines to do it.
+# other five's shared INTERACTION_HANDOFF_DEGRADED, precisely because it is
+# the one override that cannot be validated at this layer -- see
+# interaction_handoff's docstring. Keeping it separately addressable in
+# /health lets the change that wires the first production caller tell "a
+# run-partition anchor went stale" apart from every other reason a handoff
+# degraded, without having to reparse log lines to do it.
 _DEGRADATION_SIGNALS: dict[type[BaseException], str] = {
     InteractionSlotTaken: INTERACTION_HANDOFF_DEGRADED,
     InteractionRequestClosed: INTERACTION_HANDOFF_DEGRADED,
@@ -364,7 +364,7 @@ class InteractionAnchor:
     Represents only half of anchor resolution. The other half -- a database
     read against ``trace_events`` by primary key, layered into
     absence/unavailable/corrupt outcomes with a legacy-column fallback -- is
-    a caller obligation that belongs to the batch that wires a production
+    a caller obligation that belongs to the change that wires a production
     reader, because it is a DB read that must happen outside any savepoint
     this module opens. What this dataclass carries is the *result* of that
     read once the caller already has one in hand: the fields both
@@ -424,8 +424,8 @@ def _validate_anchor_fields(anchor: InteractionAnchor) -> None:
     two never drift into checking different things for the same dataclass.
 
     Every field checked here backs a real CHECK constraint on
-    ``task_interaction_requests`` (see the audit in this PR's design
-    record); a corrupt anchor caught here never reaches SQL.
+    ``task_interaction_requests``; a corrupt anchor caught here never
+    reaches SQL.
     """
 
     if not anchor.resume_event_id:
@@ -697,9 +697,9 @@ def stage_interaction_request(
        on both backends, on both the exception exit path and the successful
        REPLAY-after-conflict exit path, because a savepoint that something
        else already rolled back cannot be committed or rolled back again.
-       Measured directly against this tree; see this PR's mutation test for
-       the primitive's own savepoint (M-1), which reproduces the same
-       failure by making that same mistake on purpose.
+       Measured directly against this tree; pinned by the primitive's
+       savepoint mutation test, which reproduces the same failure by making
+       that same mistake on purpose.
     6. On ``IntegrityError``, roll back only this inner savepoint and
        re-check identity with the same SELECT step 3 used. A hit whose
        ``status`` is ``active`` is a REPLAY-after-conflict: another session
@@ -717,9 +717,25 @@ def stage_interaction_request(
        conflict from a programming error that also violates some other
        CHECK, is why step 1's validation list must be complete.
 
+    The post-conflict re-check assumes READ COMMITTED. It re-reads the
+    identity key after rolling back the inner savepoint, and needs a fresh
+    snapshot to see the row the winning session committed between this
+    call's pre-read and its own INSERT. Under REPEATABLE READ or
+    SERIALIZABLE the re-read reuses this transaction's original snapshot,
+    does not see that row, and classifies a legitimate replay as
+    ``InteractionSlotTaken`` -- measured on PostgreSQL 16 at both levels.
+    That is a degradation, not a corruption: ``InteractionSlotTaken`` is
+    swallowed, so the caller's turn survives and the question is lost.
+    READ COMMITTED is PostgreSQL's default and this codebase sets no
+    ``isolation_level`` on its engine; the change that wires the first
+    production caller should assert that rather than continue to assume it.
+
     This function's reclaim UPDATE assumes the caller has already proven it
     holds the task's current attempt; bypassing that precondition to call it
-    directly lets a dead run silently displace a live run's question.
+    directly lets a dead run silently displace a live run's question -- the
+    live run's own next staging attempt then surfaces as
+    ``InteractionSlotTaken`` or ``InteractionRequestClosed``, not as the
+    precondition violation that actually caused it.
     """
 
     if isinstance(task_id, bool) or not isinstance(task_id, int):
@@ -877,8 +893,16 @@ class _InteractionHandoff:
         column comparison compiled to SQL does not apply here.
 
         This reads ``self.task.lease_attempt_id`` from whatever snapshot of
-        the task row the caller already loaded -- it is not itself a SQL
-        read, and it does not take a lock. Whether the comparison is safe
+        the task row the caller already loaded. Whether that attribute
+        access itself touches the database is conditional on the object's
+        own session-bound state, not a fixed property of this line: if
+        SQLAlchemy has expired ``task`` (its default behavior after every
+        commit) the access issues its own lazy-load ``SELECT`` before
+        returning a value; if ``task`` is detached from any session
+        entirely it raises ``DetachedInstanceError`` instead -- neither is
+        swallowed here. When the attribute is already loaded and unexpired,
+        this line takes no lock and issues no SQL of its own. Whether the
+        comparison is safe
         against a concurrent attempt change depends on the backend, not on
         this line: on PostgreSQL, a caller that loaded ``task`` with its own
         ``SELECT ... FOR UPDATE`` genuinely blocks a concurrent writer for
@@ -1005,7 +1029,7 @@ def interaction_handoff(
     non-required event, logs at debug and returns without raising -- a
     deliberate silent discard, scoped to that primitive's best-effort trace
     events. This module has no equivalent branch anywhere: every one of the
-    five swallowed exceptions below is swallowed because it is a named,
+    six swallowed exceptions below is swallowed because it is a named,
     expected outcome with its own degradation signal, never because the
     underlying data (the task, the anchor, the request row) turned out to
     be missing or unreadable. A caller with a missing task or a broken
@@ -1026,7 +1050,7 @@ def interaction_handoff(
                                               # savepoint (see
                                               # stage_interaction_request)
         normal exit         -> savepoint.commit()
-        one of five expected failures
+        one of six expected failures
                              -> savepoint.rollback(), register a
                                 degradation signal, log, and swallow
         anything else        -> savepoint.rollback(), re-raise unchanged
@@ -1044,7 +1068,7 @@ def interaction_handoff(
     without yielding -- but a generator that returns instead of yielding
     makes ``next()`` raise ``StopIteration``, and ``contextlib`` turns that
     into ``RuntimeError("generator didn't yield")`` from ``__enter__``. That
-    error is not one of the five swallowed types, so it would propagate to
+    error is not one of the six swallowed types, so it would propagate to
     the caller anyway, defeating the whole point of swallowing it in the
     first place -- and because it fires from ``__enter__``, the caller's own
     code after the ``with`` block (its commit, most importantly) never
@@ -1054,13 +1078,14 @@ def interaction_handoff(
     the generator's normal exception-resumption path, so ``with`` completes
     normally and everything after it, including the caller's commit, still
     executes. Both assertions run first, before any statement ``stage``
-    could otherwise issue -- this PR's mutation tests pin that ordering.
+    could otherwise issue -- mutation tests pin that ordering.
 
-    Five expected failures are swallowed:
+    Six expected failures are swallowed:
     ``InteractionSlotTaken``, ``InteractionRequestClosed``,
-    ``InteractionAnchorCorrupt``, ``InteractionAttemptMismatch``, and
-    ``InteractionRunPartitionMismatch``. Every other exception -- including
-    ``InteractionOwnerStateError`` -- propagates unchanged, after this
+    ``InteractionAnchorCorrupt``, ``InteractionAttemptMismatch``,
+    ``InteractionRunPartitionMismatch``, and ``InteractionOriginUnknown``.
+    Every other exception -- including ``InteractionOwnerStateError`` and
+    ``InteractionHandoffMisuse`` -- propagates unchanged, after this
     savepoint is rolled back.
 
     ``InteractionRunPartitionMismatch`` is a deliberate, scoped override of
@@ -1072,14 +1097,14 @@ def interaction_handoff(
     ordinary race. The handoff overrides that default and swallows it here
     instead, registering its own dedicated signal
     (``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED``, kept separate from the
-    other four's shared ``INTERACTION_HANDOFF_DEGRADED`` so it stays
+    other five's shared ``INTERACTION_HANDOFF_DEGRADED`` so it stays
     individually addressable on ``/health``) and a structured log line
     naming the task, the lease's run, and the anchor's run partition. This
     override ships with zero production callers and therefore zero
-    real-world reachability data for it: **the first wiring PR -- the one
-    that removes the zero-production-caller AST gate -- must re-adjudicate
-    this policy once a real reachability picture exists**, not carry it
-    forward unexamined.
+    real-world reachability data for it: **the change that wires the first
+    production caller -- the one that removes the zero-production-caller
+    AST gate -- must re-adjudicate this policy once a real reachability
+    picture exists**, not carry it forward unexamined.
 
     Every degradation signal this module registers is sticky: nothing
     clears it once set (``ops_signals.py`` has no automatic-clear path, by
@@ -1096,7 +1121,7 @@ def interaction_handoff(
     from that same session's own point of view). This function's own outer
     savepoint is exactly that first statement whenever a caller has issued
     no DML of its own before entering this context manager, which would
-    make every one of the five swallowed exceptions' rollback silently do
+    make every one of the six swallowed exceptions' rollback silently do
     nothing -- the half-written garbage this context manager exists to
     prevent. The zero-row, single-column, SQLite-only ``UPDATE`` issued
     immediately below, before the savepoint opens, is the fix: see the
@@ -1142,9 +1167,9 @@ def interaction_handoff(
     # pysqlite recipe (disable pysqlite's own isolation_level, issue an
     # explicit BEGIN on the engine's "begin" event -- see
     # https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#serializable-isolation-savepoints-transactional-ddl)
-    # does fix this, confirmed directly. It also breaks a scenario this PR's
-    # own tests require: two sessions racing on the same identity key
-    # (REPLAY-after-conflict, T-P-9/T-SP-2), where the first session reads
+    # does fix this, confirmed directly. It also breaks a scenario this
+    # module's own tests require: two sessions racing on the same identity
+    # key (REPLAY-after-conflict, T-P-9/T-SP-2), where the first session reads
     # before the second commits and then tries to write afterward, fails
     # with sqlite3.OperationalError ("database is locked", sqlite_errorcode
     # 517 / SQLITE_BUSY_SNAPSHOT) instead of the IntegrityError this

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -1111,6 +1111,26 @@ class _InteractionHandoff:
         )
 
 
+def _safe(obj: Any, name: str) -> Any:
+    """Best-effort attribute read for the swallow handler's own logging.
+
+    By definition, the objects logged there (``task``, ``lease``, ``anchor``)
+    may already be invalid or stale -- that is often exactly what the
+    exception that brought us here proves (a corrupt anchor may not even be
+    an ``InteractionAnchor`` at all; see ``_validate_anchor_fields``'s own
+    ``isinstance`` check). Catches all exceptions, not just
+    ``AttributeError``: a detached ``task`` row raises
+    ``DetachedInstanceError``, a ``SQLAlchemyError`` subclass, not an
+    ``AttributeError``, so a bare ``getattr(obj, name, None)`` would not
+    catch it and would crash the logging it was meant to protect.
+    """
+
+    try:
+        return getattr(obj, name, None)
+    except Exception:
+        return None
+
+
 @contextmanager
 def interaction_handoff(
     db: Session,
@@ -1385,15 +1405,16 @@ def interaction_handoff(
         try:
             register_degradation(
                 signal,
-                f"task {task.id} run {lease.run_id}: {type(exc).__name__}: {exc}",
+                f"task {_safe(task, 'id')} run {_safe(lease, 'run_id')}: "
+                f"{type(exc).__name__}: {exc}",
             )
             logger.error(
                 "interaction handoff degraded",
                 extra={
-                    "task_id": task.id,
-                    "lease_run_id": lease.run_id,
-                    "lease_attempt_id": lease.attempt_id,
-                    "anchor_run_partition": anchor.resume_run_partition,
+                    "task_id": _safe(task, "id"),
+                    "lease_run_id": _safe(lease, "run_id"),
+                    "lease_attempt_id": _safe(lease, "attempt_id"),
+                    "anchor_run_partition": _safe(anchor, "resume_run_partition"),
                     "exception_type": type(exc).__name__,
                     "degradation_signal": signal,
                 },

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -76,6 +76,15 @@ ever issued. Adding a column CHECK to ``TaskInteractionRequest`` without
 adding the matching Python check here reopens that misclassification
 funnel by one more case.
 
+Two mechanisms, not one: a CHECK violation surfaces as an ``IntegrityError``
+and lands in the misclassification funnel above; a column-length violation
+surfaces as a ``DataError`` on PostgreSQL -- not an ``IntegrityError``, so
+the conflict classifier never sees it, and not in ``_SWALLOWED``, so it
+would escape the handoff entirely -- and is silently accepted on SQLite,
+which does not enforce ``VARCHAR`` length. That asymmetry is why the length
+caps are derived from the model's own column types rather than written as
+literals.
+
 Two cells this validation block cannot close, by construction: the parent
 ``tasks`` row (``fk_task_interaction_requests_task_id``) or the anchor's
 ``trace_events`` row (``fk_task_interaction_requests_resume_trace_event_id``)
@@ -134,6 +143,21 @@ _ORIGIN_VOCABULARY = frozenset(
 _RESUME_LOCATOR_FORMAT = "trace_event_pk_v1"
 _RESUME_CHECKPOINT_TYPE = "agent_execution_checkpoint"
 _PROTOCOL_VERSION = 1
+
+_MAX_LENGTHS: dict[str, int] = {
+    # Derived from the model so they cannot drift from the schema. These
+    # are column types, not CHECK constraints: an over-length value is
+    # silently stored on SQLite and raises DataError -- not IntegrityError
+    # -- on PostgreSQL, so it never enters the conflict classifier and
+    # never reaches the swallowed set.
+    name: TaskInteractionRequest.__table__.c[name].type.length
+    for name in (
+        "run_id",
+        "resume_event_id",
+        "resume_execution_id",
+        "resume_run_partition",
+    )
+}
 
 
 # ---------------------------------------------------------------------------
@@ -390,10 +414,30 @@ def _validate_anchor_fields(anchor: InteractionAnchor) -> None:
 
     if not anchor.resume_event_id:
         raise InteractionAnchorCorrupt("anchor.resume_event_id must not be empty")
+    if len(anchor.resume_event_id) > _MAX_LENGTHS["resume_event_id"]:
+        raise InteractionAnchorCorrupt(
+            "resume_event_id exceeds the column limit "
+            f"{_MAX_LENGTHS['resume_event_id']} (got {len(anchor.resume_event_id)}): "
+            "a locator this long cannot have come from a valid trace row"
+        )
     if not anchor.resume_execution_id:
         raise InteractionAnchorCorrupt("anchor.resume_execution_id must not be empty")
+    if len(anchor.resume_execution_id) > _MAX_LENGTHS["resume_execution_id"]:
+        raise InteractionAnchorCorrupt(
+            "resume_execution_id exceeds the column limit "
+            f"{_MAX_LENGTHS['resume_execution_id']} (got "
+            f"{len(anchor.resume_execution_id)}): a locator this long cannot "
+            "have come from a valid trace row"
+        )
     if not anchor.resume_run_partition:
         raise InteractionAnchorCorrupt("anchor.resume_run_partition must not be empty")
+    if len(anchor.resume_run_partition) > _MAX_LENGTHS["resume_run_partition"]:
+        raise InteractionAnchorCorrupt(
+            "resume_run_partition exceeds the column limit "
+            f"{_MAX_LENGTHS['resume_run_partition']} (got "
+            f"{len(anchor.resume_run_partition)}): a locator this long cannot "
+            "have come from a valid trace row"
+        )
     if anchor.resume_locator_format != _RESUME_LOCATOR_FORMAT:
         raise InteractionAnchorCorrupt(
             f"anchor.resume_locator_format must be {_RESUME_LOCATOR_FORMAT!r}, "
@@ -481,6 +525,11 @@ def _validate_request_fields(
         raise ValueError("expires_at must be after now")
     if not run_id:
         raise ValueError("run_id must not be empty")
+    if len(run_id) > _MAX_LENGTHS["run_id"]:
+        raise ValueError(
+            f"run_id must be at most {_MAX_LENGTHS['run_id']} characters, "
+            f"got {len(run_id)}"
+        )
 
     _validate_anchor_fields(anchor)
 

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -679,7 +679,8 @@ def stage_interaction_request(
         )
 
     db.execute(
-        _reclaim_stale_slot_stmt(task_id=resolved_task_id, run_id=run_id, now=now)
+        _reclaim_stale_slot_stmt(task_id=resolved_task_id, run_id=run_id, now=now),
+        execution_options={"synchronize_session": False},
     )
 
     row = {
@@ -1109,7 +1110,8 @@ def interaction_handoff(
         # KeyError for a future subclass of a swallowed type, and KeyError is
         # not swallowed -- the degradation path would become a crash path.
         signal = next(
-            sig for cls, sig in _DEGRADATION_SIGNALS.items() if isinstance(exc, cls)
+            (sig for cls, sig in _DEGRADATION_SIGNALS.items() if isinstance(exc, cls)),
+            INTERACTION_HANDOFF_DEGRADED,
         )
         register_degradation(
             signal,

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -1,66 +1,95 @@
-"""Stage one interaction request row into a session the caller already owns.
+"""Stage one blocking task interaction request into a session the caller
+already owns, and hand it off under a savepoint this module controls.
 
-``stage_interaction_request`` does the plain-Python validation, the
-caller's own flush, a keyed idempotency pre-read, the reclaim UPDATE that
-retires a stale or superseded active row, and the active-row INSERT under a
-savepoint this function owns.
+Two production entry points, sharing one module because they share every
+exception type and one nesting invariant that must never be split across a
+file boundary:
+
+* ``stage_interaction_request`` -- plain-Python validation, the caller's own
+  flush, a keyed idempotency pre-read, the reclaim UPDATE that retires a
+  stale or superseded active row, and the active-row INSERT under a
+  savepoint this function owns.
+* ``interaction_handoff`` -- a context manager that opens the outer
+  savepoint the whole handoff lives in, asserts the caller's lease still
+  owns the task row and that the anchor it was given is self-consistent,
+  and degrades on a closed set of expected failures instead of losing the
+  caller's turn.
 
 Caller obligations, because none of them happen here:
 
-* This function joins the ``Session`` passed in; it never calls
-  ``db.commit()`` or the outer ``db.rollback()``. It manages only its own
-  inner savepoint (see below) -- the caller owns the transaction and
-  decides when to commit or roll it back.
-* It never notifies, prunes, or writes any column of ``tasks``.
-* If this function raises ``InteractionOwnerStateError``, the session is
-  left mid-transaction with no savepoint of its own to roll back to (the
-  failure happened before this function opened one) -- the caller must
-  roll back the whole transaction before issuing another statement on it.
-  Every other exception this function raises is contained by its own inner
-  savepoint.
+* Both entry points join the ``Session`` passed in; neither ever calls
+  ``db.commit()`` or the outer ``db.rollback()``. ``stage_interaction_request``
+  manages only its own inner savepoint (see below); ``interaction_handoff``
+  manages only the outer savepoint it opens in ``__enter__``. The caller
+  owns the transaction and decides when to commit or roll it back.
+* Neither one notifies, prunes, or writes any column of ``tasks``. A
+  degraded handoff still leaves whatever the caller was about to persist
+  for its own reasons (a stale attempt continuing to write its own task
+  row, for instance) untouched -- that is a fact the three eventual
+  finalizer call sites must each account for, not something this module
+  can prevent.
+* If ``stage_interaction_request`` raises ``InteractionOwnerStateError``,
+  the session is left mid-transaction with no savepoint of its own to roll
+  back to (the failure happened before this function opened one) -- the
+  caller must roll back the whole transaction before issuing another
+  statement on it. Every other exception this module raises during a call
+  wrapped by ``interaction_handoff`` is contained by that context manager's
+  own savepoint; called outside it, the same rollback obligation applies.
 
 Zero production callers as of this module's introduction: a static test
 (``tests/web/services/test_interaction_staging_production_gate.py``) asserts
-that no production module calls this function. See that test's docstring
-for the removal condition.
+that no production module imports or calls either entry point. See that
+test's docstring for the removal condition.
 
 Every rejection the database's 23 CHECK constraints could raise on the
-INSERT is rejected in plain Python first, inside this function's own
-validation block, because the post-conflict re-check (step 7 below)
-classifies any ``IntegrityError`` that does not match the caller's own
-identity key as a slot conflict -- ``InteractionSlotTaken``. That re-check
-cannot tell a real slot conflict apart from a programming error (an
-out-of-vocabulary ``origin``, a non-positive TTL, a ``None`` payload past
-``JSON(none_as_null=True))``) that also violates a CHECK: both land on the
-same ``else`` branch. The backstop is the database's constraint set, not
-the primary defense; the primary defense is this validation block, and it
-must reject everything the INSERT could reject before the INSERT is ever
-issued. Adding a column CHECK to ``TaskInteractionRequest`` without adding
-the matching Python check here reopens that misclassification funnel by
-one more case.
+INSERT is rejected in plain Python first, inside
+``stage_interaction_request``'s validation block, because the post-conflict
+re-check (step 7 below) classifies any ``IntegrityError`` that does not
+match the caller's own identity key as a slot conflict --
+``InteractionSlotTaken``. That re-check cannot tell a real slot conflict
+apart from a programming error (an out-of-vocabulary ``origin``, a
+non-positive TTL, a ``None`` payload past ``JSON(none_as_null=True))``) that
+also violates a CHECK: both land on the same ``else`` branch. The backstop
+is the database's constraint set, not the primary defense; the primary
+defense is this validation block, and it must reject everything the INSERT
+could reject before the INSERT is ever issued. Adding a column CHECK to
+``TaskInteractionRequest`` without adding the matching Python check here
+reopens that misclassification funnel by one more case.
 
 Concurrency note (inherited, not introduced here): on PostgreSQL, an
 ``IntegrityError`` poisons the rest of the transaction
 (``InFailedSqlTransaction``) until something rolls back at least to the
 savepoint that was open when it fired; SQLite instead lets the session keep
-issuing statements. This function's own inner ``db.begin_nested()`` around
-the INSERT is what makes the post-conflict re-check possible on both
-backends -- see the function's docstring for why a savepoint shared with
-the caller does not work.
+issuing statements. ``stage_interaction_request``'s own inner
+``db.begin_nested()`` around the INSERT is what makes the post-conflict
+re-check possible on both backends -- see the function's docstring for why
+a savepoint shared with the caller (or with ``interaction_handoff``'s own
+savepoint) does not work.
 """
 
 from __future__ import annotations
 
+import logging
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, Iterator
 
 import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from ..models.task import Task
 from ..models.task_interaction import TaskInteractionRequest
+from .ops_signals import (
+    INTERACTION_HANDOFF_DEGRADED,
+    INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED,
+    register_degradation,
+)
 from .task_command_transport import COMMAND_ID_PATTERN
+from .task_lease_service import TaskLease
+
+logger = logging.getLogger(__name__)
 
 _KIND_VOCABULARY = frozenset({"clarification"})
 _ORIGIN_VOCABULARY = frozenset(
@@ -192,6 +221,31 @@ class InteractionOwnerStateError(InteractionHandoffError):
 # called for propagating it unchanged, the same as InteractionOwnerStateError
 # below it). See interaction_handoff's docstring for the reasoning and the
 # re-adjudication obligation this override carries forward.
+_SWALLOWED: tuple[type[BaseException], ...] = (
+    InteractionSlotTaken,
+    InteractionRequestClosed,
+    InteractionAnchorCorrupt,
+    InteractionAttemptMismatch,
+    InteractionRunPartitionMismatch,
+)
+
+# Which ops_signals name a given swallowed exception type registers.
+# InteractionRunPartitionMismatch gets its own signal, distinct from the
+# other four's shared INTERACTION_HANDOFF_DEGRADED, precisely because it is
+# the one override the reachability-free state of this PR cannot validate --
+# see interaction_handoff's docstring. Keeping it separately addressable in
+# /health lets the first wiring PR tell "a run-partition anchor went stale"
+# apart from every other reason a handoff degraded, without having to
+# reparse log lines to do it.
+_DEGRADATION_SIGNALS: dict[type[BaseException], str] = {
+    InteractionSlotTaken: INTERACTION_HANDOFF_DEGRADED,
+    InteractionRequestClosed: INTERACTION_HANDOFF_DEGRADED,
+    InteractionAnchorCorrupt: INTERACTION_HANDOFF_DEGRADED,
+    InteractionAttemptMismatch: INTERACTION_HANDOFF_DEGRADED,
+    InteractionRunPartitionMismatch: INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED,
+}
+
+
 # ---------------------------------------------------------------------------
 # Data carriers
 # ---------------------------------------------------------------------------
@@ -581,3 +635,321 @@ def stage_interaction_request(
             status="active",
             active_slot=1,
         )
+
+
+# ---------------------------------------------------------------------------
+# The handoff context manager
+# ---------------------------------------------------------------------------
+
+
+class _InteractionHandoff:
+    """The object ``interaction_handoff`` yields. Constructed once per
+    ``with`` block; ``stage`` may be called zero or more times inside it.
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        lease: TaskLease,
+        *,
+        task: Task,
+        anchor: InteractionAnchor,
+        now: datetime,
+    ) -> None:
+        self.db = db
+        self.lease = lease
+        self.task = task
+        self.anchor = anchor
+        self.now = now
+
+    def _assert_current_attempt(self) -> None:
+        """``lease.attempt_id is None`` is a fail-open sentinel (a
+        pre-attempt-column lease, or the permanent-``None`` ambient snapshot
+        ``_task_lease_snapshot`` builds in ``websocket.py``) and must be
+        treated as "cannot prove attempt identity", not as "matches" --
+        skipping this assertion, never failing it. See
+        ``TaskLease.attempt_id``'s docstring (``task_lease_service.py``) for
+        the two distinct sources of that ``None``.
+
+        This is a plain Python object comparison, not a SQL expression: the
+        `` == None`` -> ``IS NULL`` folding that affects a SQLAlchemy
+        column comparison compiled to SQL does not apply here.
+        """
+
+        if (
+            self.lease.attempt_id is not None
+            and self.task.lease_attempt_id != self.lease.attempt_id
+        ):
+            raise InteractionAttemptMismatch(
+                f"task {self.task.id}'s current attempt "
+                f"({self.task.lease_attempt_id!r}) does not match this "
+                f"lease's attempt ({self.lease.attempt_id!r})"
+            )
+
+    def _assert_anchor_consistent(self) -> None:
+        """Re-validates the same structural rules
+        ``stage_interaction_request`` validates before its own INSERT (see
+        ``_validate_anchor_fields``), so a corrupt anchor is caught before
+        any staging SQL is issued, even on the very first ``stage`` call."""
+
+        _validate_anchor_fields(self.anchor)
+
+    def stage(
+        self,
+        *,
+        kind: str,
+        protocol_version: int,
+        request_payload: Any,
+        request_idempotency_key: str,
+        expires_at: datetime,
+    ) -> StagedInteractionRequest:
+        """Stage one interaction request for this handoff's task, run, and
+        anchor. ``run_id`` is always this handoff's ``lease.run_id`` --
+        callers cannot stage a request under a different run through this
+        method, which is what keeps the reclaim UPDATE's cross-run
+        supersession branch meaningful. ``origin`` is always
+        ``task.source or "internal"``, computed here rather than left to the
+        caller (see ``TaskInteractionRequest.origin``'s column comment).
+
+        The attempt and anchor assertions run first, in that order, before
+        any statement this call could issue -- see ``interaction_handoff``'s
+        docstring for why they live here rather than in ``__enter__``.
+        """
+
+        self._assert_current_attempt()
+        self._assert_anchor_consistent()
+        if self.lease.run_id is None:
+            raise ValueError(
+                "lease has no run_id; cannot stage an interaction request without one"
+            )
+        return stage_interaction_request(
+            self.db,
+            task_id=int(self.task.id),
+            run_id=self.lease.run_id,
+            anchor=self.anchor,
+            kind=kind,
+            protocol_version=protocol_version,
+            origin=(str(self.task.source) if self.task.source else "internal"),
+            request_payload=request_payload,
+            request_idempotency_key=request_idempotency_key,
+            expires_at=expires_at,
+            now=self.now,
+        )
+
+
+@contextmanager
+def interaction_handoff(
+    db: Session,
+    lease: TaskLease,
+    *,
+    task: Task,
+    anchor: InteractionAnchor,
+    now: datetime,
+) -> Iterator[_InteractionHandoff]:
+    """Open the savepoint one interaction handoff lives in and degrade --
+    instead of losing the caller's turn -- on a closed set of expected
+    failures, including the caller's lease no longer owning the task's
+    current attempt and the resume anchor it was given being inconsistent.
+
+    Caller obligations: none. Unlike ``stage_interaction_request``, this
+    context manager leaves nothing for its caller to do beyond the
+    surrounding transaction's own commit/rollback -- the anchor's database
+    read (the other half described in ``InteractionAnchor``'s docstring)
+    has already happened before this is ever called, and the attempt and
+    anchor assertions that used to be caller obligations are now checked by
+    ``handoff.stage()`` itself, on every call. The one obligation that
+    remains is structural, not sequential: the ``with`` block must be the
+    transaction's last word before the caller commits -- no I/O in between
+    -- because every write inside it, including the reclaim UPDATE, holds
+    SQLite's database-wide writer lock (or, on PostgreSQL, ordinary row
+    locks) for the whole span, not just an instant.
+
+    Nesting, exactly:
+
+        savepoint = db.begin_nested()        # this function's own
+        yield handoff                        # caller calls handoff.stage()
+                                              # zero or more times; each
+                                              # call asserts attempt and
+                                              # anchor validity first, then
+                                              # opens and closes its *own*
+                                              # inner savepoint (see
+                                              # stage_interaction_request)
+        normal exit         -> savepoint.commit()
+        one of five expected failures
+                             -> savepoint.rollback(), register a
+                                degradation signal, log, and swallow
+        anything else        -> savepoint.rollback(), re-raise unchanged
+
+    The attempt and anchor assertions live inside ``handoff.stage()``,
+    called from the caller's ``with``-body, not in this function before
+    ``yield``. That placement is forced by what a ``@contextmanager``
+    generator can and cannot do, not a style preference: a ``with``
+    statement always runs its body once ``__enter__`` succeeds -- there is
+    no way for ``__enter__`` to succeed and have the body silently skipped.
+    ``__enter__`` succeeding, for a generator-based context manager, means
+    the generator reached its ``yield``. If an assertion raised and was
+    caught *before* ``yield``, the only way to make ``with`` proceed as if
+    nothing happened would be to swallow it and fall out of the generator
+    without yielding -- but a generator that returns instead of yielding
+    makes ``next()`` raise ``StopIteration``, and ``contextlib`` turns that
+    into ``RuntimeError("generator didn't yield")`` from ``__enter__``. That
+    error is not one of the five swallowed types, so it would propagate to
+    the caller anyway, defeating the whole point of swallowing it in the
+    first place -- and because it fires from ``__enter__``, the caller's own
+    code after the ``with`` block (its commit, most importantly) never
+    runs. Checking both preconditions inside ``stage()`` instead means a
+    failure surfaces from *inside* the ``with``-body, at a point the
+    surrounding ``try``/``except`` here is actually able to intercept via
+    the generator's normal exception-resumption path, so ``with`` completes
+    normally and everything after it, including the caller's commit, still
+    executes. Both assertions run first, before any statement ``stage``
+    could otherwise issue -- this PR's mutation tests pin that ordering.
+
+    Five expected failures are swallowed:
+    ``InteractionSlotTaken``, ``InteractionRequestClosed``,
+    ``InteractionAnchorCorrupt``, ``InteractionAttemptMismatch``, and
+    ``InteractionRunPartitionMismatch``. Every other exception -- including
+    ``InteractionOwnerStateError`` -- propagates unchanged, after this
+    savepoint is rolled back.
+
+    ``InteractionRunPartitionMismatch`` is a deliberate, scoped override of
+    this primitive's own default. Read literally, the design that produced
+    ``stage_interaction_request`` calls for this exception to propagate
+    unchanged, the same as ``InteractionOwnerStateError`` -- on the
+    reasoning that a confirmed identity mismatch between a run and its own
+    resume anchor is closer to "something is structurally wrong" than to an
+    ordinary race. PR-C2a overrides that default and swallows it here
+    instead, registering its own dedicated signal
+    (``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED``, kept separate from the
+    other four's shared ``INTERACTION_HANDOFF_DEGRADED`` so it stays
+    individually addressable on ``/health``) and a structured log line
+    naming the task, the lease's run, and the anchor's run partition. This
+    override ships with zero production callers and therefore zero
+    real-world reachability data for it: **the first wiring PR -- the one
+    that removes the zero-production-caller AST gate -- must re-adjudicate
+    this policy once a real reachability picture exists**, not carry it
+    forward unexamined.
+
+    Every degradation signal this module registers is sticky: nothing
+    clears it once set (``ops_signals.py`` has no automatic-clear path, by
+    design -- see that module's docstring). ``/health`` reports a
+    degradation from an hour-old, already-recovered handoff exactly the
+    same as one from a second ago. This module inherits that behavior; it
+    does not introduce it.
+
+    A SQLite-only correctness gap, found and fixed while building this
+    module: a session whose first write-adjacent statement is a bare
+    SAVEPOINT breaks pysqlite's transaction tracking badly enough that the
+    savepoint's later release becomes a permanent commit and a subsequent
+    ``Session.rollback()`` does not undo it, confirmed directly (not even
+    from that same session's own point of view). This function's own outer
+    savepoint is exactly that first statement whenever a caller has issued
+    no DML of its own before entering this context manager, which would
+    make every one of the five swallowed exceptions' rollback silently do
+    nothing -- the half-written garbage this context manager exists to
+    prevent. The zero-row UPDATE issued immediately below, before the
+    savepoint opens, is the fix: see the comment there for the reproduction,
+    the SQLAlchemy-documented pysqlite recipe that was considered and
+    rejected instead, and why. PostgreSQL was checked directly and does not
+    share this behavior at all.
+
+    In the wiring-window while ``lease.attempt_id is None`` is still
+    possible (see ``_assert_current_attempt``'s docstring), this handoff's
+    identity key is already run-scoped (``uq_task_interaction_request_identity``
+    covers ``task_id, run_id, request_idempotency_key``), which is weaker
+    protection against a stale worker than the task-scoped identity an
+    earlier design considered: both the attempt fence and the stale-worker
+    protection a task-scoped key would have given are absent for the same
+    rolling-restart window at once.
+    """
+
+    # A zero-row UPDATE, issued deliberately before this function's own
+    # savepoint opens. This statement's only purpose is to be a real DML
+    # statement: it touches no row (task.id == -1 can never match one) and
+    # its rowcount is never read. Removing it silently breaks the
+    # swallow-and-rollback contract this function exists to provide,
+    # whenever a caller enters this context manager without a prior write
+    # of its own on the same session -- exactly this file's own
+    # test_cm4_with_exit_does_not_commit_outer_transaction shape.
+    #
+    # Reproduction: on SQLite, a session whose first write-adjacent
+    # statement is a bare SAVEPOINT breaks pysqlite's transaction tracking.
+    # The savepoint's later release becomes a permanent commit at the
+    # engine level, and a subsequent Session.rollback() does not undo it --
+    # confirmed directly, including from that same session's own point of
+    # view. A caller's own prior write avoids this (and so does
+    # stage_interaction_request's own inner savepoint, whose reclaim UPDATE
+    # -- a real DML -- always runs first); this function's outer savepoint
+    # has no such statement ahead of it otherwise. PostgreSQL does not
+    # share this behavior at all.
+    #
+    # The standard fix, and why it was not used: SQLAlchemy's documented
+    # pysqlite recipe (disable pysqlite's own isolation_level, issue an
+    # explicit BEGIN on the engine's "begin" event -- see
+    # https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#serializable-isolation-savepoints-transactional-ddl)
+    # does fix this, confirmed directly. It also breaks a scenario this PR's
+    # own tests require: two sessions racing on the same identity key
+    # (REPLAY-after-conflict, T-P-9/T-SP-2), where the first session reads
+    # before the second commits and then tries to write afterward, fails
+    # with sqlite3.OperationalError ("database is locked", sqlite_errorcode
+    # 517 / SQLITE_BUSY_SNAPSHOT) instead of the IntegrityError this
+    # primitive is built to classify -- a WAL snapshot conflict, not
+    # ordinary lock contention, so busy_timeout cannot wait it out. That
+    # recipe is also not present in this codebase's actual SQLite engine
+    # configuration (apply_sqlite_concurrency_pragmas, xagent/db/sqlite.py),
+    # and applying it there instead -- the only way to make it available
+    # without every caller opting in individually -- would change
+    # transaction behavior for every other user of db.begin_nested() in
+    # this codebase, a blast radius well beyond one staging primitive, and
+    # would need its own resolution for the busy_timeout/snapshot-conflict
+    # tradeoff for genuine concurrent callers before it could ship anywhere.
+    # That is a SQLite concurrency-model decision, not a staging-primitive
+    # one. The dummy-DML fix below is the scoped alternative: local to this
+    # function, changes nothing about how any other caller's session
+    # behaves, and does not touch engine configuration at all. The wiring
+    # batch, once real caller topology and deployment concurrency
+    # assumptions exist, should revisit whether the engine-level recipe
+    # becomes worth its cost at that point.
+    db.execute(sa.update(Task).where(Task.id == -1))
+
+    # Session.begin_nested() always flushes first (it has to, in order to
+    # establish the SAVEPOINT after whatever is already pending): a doomed
+    # caller write that stage_interaction_request's own flush would
+    # otherwise catch and turn into InteractionOwnerStateError can just as
+    # well surface right here, before this function's own savepoint even
+    # exists to roll back. Same exception, same reasoning, only fired one
+    # statement earlier than the primitive's own docstring describes.
+    try:
+        savepoint = db.begin_nested()
+    except IntegrityError as exc:
+        raise InteractionOwnerStateError(
+            "caller's pending writes failed to flush while opening the "
+            "interaction handoff's savepoint"
+        ) from exc
+    handoff = _InteractionHandoff(db, lease, task=task, anchor=anchor, now=now)
+    try:
+        yield handoff
+    except _SWALLOWED as exc:
+        savepoint.rollback()
+        signal = _DEGRADATION_SIGNALS[type(exc)]
+        register_degradation(
+            signal,
+            f"task {task.id} run {lease.run_id}: {type(exc).__name__}: {exc}",
+        )
+        logger.error(
+            "interaction handoff degraded",
+            extra={
+                "task_id": task.id,
+                "lease_run_id": lease.run_id,
+                "lease_attempt_id": lease.attempt_id,
+                "anchor_run_partition": anchor.resume_run_partition,
+                "exception_type": type(exc).__name__,
+                "degradation_signal": signal,
+            },
+        )
+        return
+    except BaseException:
+        savepoint.rollback()
+        raise
+    else:
+        savepoint.commit()

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -29,20 +29,26 @@ Caller obligations, because none of them happen here:
   opening its own outer savepoint (see that function's docstring for why).
   ``id = -1`` can never match a row an autoincrement primary key minted,
   so this can never touch a real row's data, and it is skipped entirely
-  on PostgreSQL, which does not need it. A degraded handoff still leaves
-  whatever the caller was about to persist for its own reasons (a stale
-  attempt continuing to write its own task row, for instance) untouched --
-  that is a fact the three eventual finalizer call sites must each account
-  for, not something this module can prevent. Those three finalizers are
-  the complete writer set this module assumes: a fourth, legacy release
-  path (``AgentServiceManager.execute_task`` in ``web/api/chat.py``) also
-  formally writes ``TaskStatus.WAITING_FOR_USER`` on a task row when
-  ``manage_task_lease`` is true, but every production call site
-  (``websocket.py``, and the Feishu/Slack/Telegram bot channels) passes
-  ``manage_task_lease=False`` -- that write path is confirmed unreachable
-  today, not merely unlikely. A caller added later that reaches it with
-  ``manage_task_lease=True`` would make it a fourth writer this module's
-  finalizer accounting does not yet account for.
+  on PostgreSQL, which does not need it. A degraded handoff's own rollback
+  reaches only as far as the savepoint this function opens at
+  ``with``-entry: a write the caller flushed *before* entering the block
+  is already durable in the caller's outer transaction and survives a
+  degrade untouched. A write the caller issues *inside* the block instead
+  shares this function's own savepoint with the interaction row itself, so
+  a degrade's ``ROLLBACK TO SAVEPOINT`` discards both together,
+  indistinguishably -- which is why the caller contract restricts the
+  ``with`` body to handoff operations alone, nothing else. Getting that
+  boundary right is a fact the three eventual finalizer call sites must
+  each account for, not something this module can prevent. Those three
+  finalizers are the complete writer set this module assumes: a fourth,
+  legacy release path (``AgentServiceManager.execute_task`` in
+  ``web/api/chat.py``) also formally writes ``TaskStatus.WAITING_FOR_USER``
+  on a task row when ``manage_task_lease`` is true, but every production
+  call site (``websocket.py``, and the Feishu/Slack/Telegram bot channels)
+  passes ``manage_task_lease=False`` -- that write path is confirmed
+  unreachable today, not merely unlikely. A caller added later that
+  reaches it with ``manage_task_lease=True`` would make it a fourth writer
+  this module's finalizer accounting does not yet account for.
 * If ``stage_interaction_request`` raises ``InteractionOwnerStateError``,
   the session is left mid-transaction with no savepoint of its own to roll
   back to (the failure happened before this function opened one) -- the
@@ -994,6 +1000,13 @@ class _InteractionHandoff:
         self.anchor = anchor
         self.now = now
         self._staged = False
+        # Whether a call to stage() actually returned a staged row, as
+        # opposed to _staged, which only counts that stage() was called at
+        # all (the one-call-per-handoff reentry rule) regardless of whether
+        # that call raised before ever staging anything. See stage()'s own
+        # assignment of this flag, and the misuse handler below that reads
+        # it, for why the two must not be conflated.
+        self._staged_row = False
 
     def _assert_current_attempt(self) -> None:
         """``lease.attempt_id is None`` is a fail-open sentinel (a
@@ -1100,7 +1113,7 @@ class _InteractionHandoff:
                 f"task {self.task.id}'s source {origin!r} is outside the "
                 f"origin vocabulary {sorted(_ORIGIN_VOCABULARY)}"
             )
-        return stage_interaction_request(
+        result = stage_interaction_request(
             self.db,
             task_id=int(self.task.id),
             run_id=self.lease.run_id,
@@ -1113,6 +1126,12 @@ class _InteractionHandoff:
             expires_at=expires_at,
             now=self.now,
         )
+        # Only set once stage_interaction_request has actually returned a
+        # row -- an exception from any of it (the misclassification funnel,
+        # a DataError, ...) leaves this False, which is what the misuse
+        # handler below relies on to keep its message accurate.
+        self._staged_row = True
+        return result
 
 
 def _safe(obj: Any, name: str) -> Any:
@@ -1448,16 +1467,23 @@ def interaction_handoff(
         raise
     else:
         if not savepoint.is_active:
-            # handoff._staged tells the two ways this misuse can happen
+            # handoff._staged_row tells the two ways this misuse can happen
             # apart: a caller can violate the no-I/O-in-between obligation
             # either after a successful stage() (there is a real staged row
             # whose containment just vanished) or without ever calling
-            # stage() at all (zero calls is otherwise legal -- see
-            # _InteractionHandoff's own docstring -- so nothing was staged,
-            # but the caller's own commit/rollback still deactivated this
-            # savepoint the same way). Same exception type either way; only
+            # stage() at all, or calling it but never reaching a staged row
+            # (zero calls is otherwise legal -- see _InteractionHandoff's
+            # own docstring -- and a stage() call that raised before
+            # returning also leaves nothing staged), so the caller's own
+            # commit/rollback still deactivated this savepoint the same way
+            # with no row behind it. Same exception type either way; only
             # the message should claim a staged row exists when one does.
-            if handoff._staged:
+            # _staged (call count, for the one-call-per-handoff reentry
+            # rule) is deliberately not used here: it is True the instant
+            # stage() is entered, before it is known whether a row was ever
+            # staged, which would make this message claim a row exists even
+            # when stage() raised before staging anything.
+            if handoff._staged_row:
                 raise InteractionHandoffMisuse(
                     "the caller committed or rolled back inside the "
                     "interaction_handoff block; the savepoint that contains "

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -10,10 +10,10 @@ file boundary:
   stale or superseded active row, and the active-row INSERT under a
   savepoint this function owns.
 * ``interaction_handoff`` -- a context manager that opens the outer
-  savepoint the whole handoff lives in, asserts the caller's lease still
-  owns the task row and that the anchor it was given is self-consistent,
-  and degrades on a closed set of expected failures instead of losing the
-  caller's turn.
+  savepoint the whole handoff lives in, and -- when ``stage()`` is called --
+  asserts the caller's lease still owns the task row and that the anchor it
+  was given is self-consistent, degrading on a closed set of expected
+  failures instead of losing the caller's turn.
 
 Caller obligations, because none of them happen here:
 
@@ -55,7 +55,10 @@ Caller obligations, because none of them happen here:
   caller must roll back the whole transaction before issuing another
   statement on it. Every other exception this module raises during a call
   wrapped by ``interaction_handoff`` is contained by that context manager's
-  own savepoint; called outside it, the same rollback obligation applies.
+  own savepoint; called outside it, the same rollback obligation applies --
+  including for ``InteractionSlotTaken`` and ``InteractionRequestClosed``,
+  the two a direct caller can still see after the reclaim UPDATE has
+  already committed in this transaction.
 
 Zero production callers as of this module's introduction: a static test
 (``tests/web/services/test_interaction_staging_production_gate.py``) asserts
@@ -138,7 +141,7 @@ from datetime import datetime
 from typing import Any, Iterator
 
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError, ResourceClosedError
+from sqlalchemy.exc import DataError, IntegrityError, ResourceClosedError
 from sqlalchemy.orm import Session
 
 from ..models.task import Task
@@ -171,10 +174,10 @@ _MAX_LENGTHS: dict[str, int] = {
     #
     # This derivation assumes every one of these columns is a String(N).
     # A Text column has no length cap at all -- .type.length reports None
-    # for one -- which would make the length check built from this dict a
-    # silent no-op for that field instead of raising at construction time.
-    # Re-derive this dict's shape if any of these locator columns ever
-    # widens from String(N) to Text.
+    # for one -- and the import-time assert immediately below this dict
+    # fails at module import when that happens, so schema drift here is
+    # loud, not silent. Re-derive this dict's shape if any of these locator
+    # columns ever widens from String(N) to Text.
     name: TaskInteractionRequest.__table__.c[name].type.length
     for name in (
         "run_id",
@@ -477,7 +480,11 @@ class StagedInteractionRequest:
     ``status`` and ``active_slot`` describe that row as it stood at the
     moment this call read it, which on the step-3 path may already be
     expired (see ``stage_interaction_request``'s docstring on why step 3
-    does not consult ``expires_at``).
+    does not consult ``expires_at``). Both replay paths match on the
+    identity key alone -- they never compare payload, anchor, or
+    ``expires_at`` against the row they return -- and the key's own
+    derivation contract belongs to the first production writer (see
+    ``request_idempotency_key``'s column comment, ``models/task_interaction.py``).
     """
 
     staged_db_id: int
@@ -628,7 +635,7 @@ def _validate_request_fields(
     # escape interaction_handoff entirely instead of degrading like every
     # other expected failure this module knows how to name. Probing here,
     # before the INSERT is ever issued, turns that crash into the same
-    # ValueError every other row-13-and-earlier violation raises.
+    # ValueError every other pure-Python precondition violation raises.
     #
     # allow_nan=False is load-bearing, not a strictness knob: the default
     # json.dumps happily renders float('nan') / float('inf') as the bare
@@ -703,7 +710,7 @@ def _validate_request_fields(
     # once. run_id comes from the service's own lease, not from persisted
     # data; an over-length run_id is a programming error in this module's
     # own caller, so it raises ValueError here and propagates uncaught, the
-    # same as every other row-13-and-earlier violation in this function.
+    # same as every other pure-Python precondition violation in this function.
     # anchor.resume_run_partition, by contrast, comes from a database read
     # of whatever a trace_events row happens to hold; an over-length value
     # there is data corruption this module is built to degrade on, not a
@@ -802,6 +809,38 @@ def _reclaim_stale_slot_stmt(*, task_id: int, run_id: str, now: datetime) -> sa.
     )
 
 
+def _replay_or_raise_closed(
+    row: Any,
+    *,
+    task_id: int,
+    run_id: str,
+    key: str,
+) -> StagedInteractionRequest | None:
+    """The dispatch both the idempotency pre-read (step 3) and the
+    post-conflict re-check (step 6) apply to a hit on
+    ``_identity_lookup_stmt``: replay an ``active`` row as-is, or raise
+    ``InteractionRequestClosed`` for a terminal one. Returns ``None`` when
+    ``row`` is ``None`` -- what "no hit" means differs at each call site (step
+    3 proceeds to reclaim and INSERT; step 6 raises ``InteractionSlotTaken``),
+    so that decision stays with the caller. Extracted so the two sites cannot
+    classify the same row state differently; behavior-preserving, including
+    the exact exception message text.
+    """
+
+    if row is None:
+        return None
+    if row.status == "active":
+        return StagedInteractionRequest(
+            staged_db_id=int(row.id),
+            created=False,
+            status=row.status,
+            active_slot=row.active_slot,
+        )
+    raise InteractionRequestClosed(
+        f"request {key!r} on task {task_id} run {run_id!r} is already {row.status}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # The staging primitive
 # ---------------------------------------------------------------------------
@@ -887,6 +926,16 @@ def stage_interaction_request(
     ``isolation_level`` on its engine; the change that wires the first
     production caller should assert that rather than continue to assume it.
 
+    ``SELECT ... FOR UPDATE`` on the task row was considered, as an
+    alternative to the savepoint-plus-re-check design above, and rejected:
+    it would close only the slot-race cell, not the two FK-race cells
+    (concurrent task deletion, concurrent trace-event pruning) documented
+    above, which belong to a different serialization boundary than this
+    function's own; SQLAlchemy silently drops ``with_for_update()`` on
+    SQLite, so the savepoint fallback would still be required for that
+    backend regardless; and it would hold a row lock across the whole
+    validation-plus-insert span, increasing contention with lease renewal.
+
     This function's reclaim UPDATE assumes the caller has already proven it
     holds the task's current attempt; bypassing that precondition to call it
     directly lets a dead run silently displace a live run's question -- the
@@ -921,7 +970,7 @@ def stage_interaction_request(
 
     try:
         db.flush()
-    except IntegrityError as exc:
+    except (IntegrityError, DataError) as exc:
         raise InteractionOwnerStateError(
             "caller's pending writes failed to flush before interaction staging"
         ) from exc
@@ -933,18 +982,11 @@ def stage_interaction_request(
             request_idempotency_key=normalized_key,
         )
     ).first()
-    if existing is not None:
-        if existing.status == "active":
-            return StagedInteractionRequest(
-                staged_db_id=int(existing.id),
-                created=False,
-                status=existing.status,
-                active_slot=existing.active_slot,
-            )
-        raise InteractionRequestClosed(
-            f"request {normalized_key!r} on task {resolved_task_id} run "
-            f"{run_id!r} is already {existing.status}"
-        )
+    replay = _replay_or_raise_closed(
+        existing, task_id=resolved_task_id, run_id=run_id, key=normalized_key
+    )
+    if replay is not None:
+        return replay
 
     db.execute(
         _reclaim_stale_slot_stmt(task_id=resolved_task_id, run_id=run_id, now=now),
@@ -991,18 +1033,11 @@ def stage_interaction_request(
                 request_idempotency_key=normalized_key,
             )
         ).first()
-        if again is not None:
-            if again.status == "active":
-                return StagedInteractionRequest(
-                    staged_db_id=int(again.id),
-                    created=False,
-                    status=again.status,
-                    active_slot=again.active_slot,
-                )
-            raise InteractionRequestClosed(
-                f"request {normalized_key!r} on task {resolved_task_id} run "
-                f"{run_id!r} is already {again.status}"
-            )
+        replay = _replay_or_raise_closed(
+            again, task_id=resolved_task_id, run_id=run_id, key=normalized_key
+        )
+        if replay is not None:
+            return replay
         raise InteractionSlotTaken(
             f"task {resolved_task_id} already has an active interaction "
             "request in a different slot"
@@ -1163,6 +1198,10 @@ class _InteractionHandoff:
             raise ValueError(
                 "lease has no run_id; cannot stage an interaction request without one"
             )
+        # An out-of-vocabulary task.source is currently unreachable because
+        # every production write site hardcodes a literal from
+        # ORIGIN_VALUES (or takes the "internal" default) -- the safety is
+        # a property of the callers, not of any normalization function here.
         origin = str(self.task.source) if self.task.source else "internal"
         if origin not in _ORIGIN_VOCABULARY:
             raise InteractionOriginUnknown(
@@ -1464,7 +1503,7 @@ def interaction_handoff(
     # statement earlier than the primitive's own docstring describes.
     try:
         savepoint = db.begin_nested()
-    except IntegrityError as exc:
+    except (IntegrityError, DataError) as exc:
         raise InteractionOwnerStateError(
             "caller's pending writes failed to flush while opening the "
             "interaction handoff's savepoint"

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -226,12 +226,15 @@ def _reset_ops_signals():
 
 _T_P_1_CASES = [
     pytest.param({"kind": "approval"}, ValueError, id="illegal-kind"),
+    pytest.param({"kind": 123}, ValueError, id="kind-not-str"),
     pytest.param({"protocol_version": 2}, ValueError, id="protocol-not-1"),
     pytest.param({"origin": "email"}, ValueError, id="illegal-origin"),
+    pytest.param({"origin": 123}, ValueError, id="origin-not-str"),
     pytest.param(
         {"request_idempotency_key": "has a space"}, ValueError, id="key-bad-pattern"
     ),
     pytest.param({"request_idempotency_key": ""}, ValueError, id="key-empty"),
+    pytest.param({"request_idempotency_key": 123}, ValueError, id="key-not-str"),
     pytest.param(
         {"expires_at": _now() - timedelta(minutes=1)}, ValueError, id="ttl-non-positive"
     ),
@@ -247,6 +250,13 @@ _T_P_1_CASES = [
     pytest.param({"request_payload": None}, ValueError, id="payload-none"),
     pytest.param({"run_id": ""}, ValueError, id="run-id-empty"),
     pytest.param({"run_id": "x" * 65}, ValueError, id="run-id-too-long"),
+    # A list, not any non-str: it has a __len__ (so it would have survived
+    # the length check added for run_id above without crashing there) and
+    # will never == anchor.resume_run_partition (a str), so before the
+    # isinstance guard this misclassified as InteractionRunPartitionMismatch
+    # instead of failing loudly on the real problem -- a caller passing the
+    # wrong type.
+    pytest.param({"run_id": ["not", "a", "string"]}, ValueError, id="run-id-not-str"),
     pytest.param({"now": datetime.now()}, ValueError, id="now-naive"),
     pytest.param(
         {"now": _now().replace(tzinfo=timezone(timedelta(hours=8)))},

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1784,3 +1784,43 @@ def test_step_one_rejects_boolean_protocol_version_without_sql(
         stage_interaction_request(db, task_id=task_id, **kwargs)
     assert statements[before:] == []
     db.close()
+
+
+def test_cm_swallows_subclasses_of_swallowed_types(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The except clause matches subclasses, so the signal lookup must too:
+    a subclass of a swallowed type must degrade with its parent's signal
+    rather than escaping as a KeyError from inside the handler."""
+
+    from xagent.web.services import task_interaction_staging as _module
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    task = db.get(Task, task_id)
+    lease = _lease(task)
+
+    class _SubSlotTaken(InteractionSlotTaken):
+        pass
+
+    def _raise_subclass(*args: Any, **kwargs: Any) -> None:
+        raise _SubSlotTaken("subclassed slot conflict")
+
+    monkeypatch.setattr(_module, "stage_interaction_request", _raise_subclass)
+
+    with interaction_handoff(
+        db, lease, task=task, anchor=_anchor(anchor_id), now=_now()
+    ) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    caller_ran_after_with = True
+    assert caller_ran_after_with
+    assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
+    db.close()

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -538,16 +538,21 @@ def test_p2_run_partition_mismatch_is_not_a_slot_taken_subclass(
     """T-P-2: run_id != resume_run_partition raises
     InteractionRunPartitionMismatch, and that type is not a subclass of
     InteractionSlotTaken -- the two must stay distinguishable so a
-    corruption is never observably confused with an ordinary slot race."""
+    corruption is never observably confused with an ordinary slot race.
+    Also, like every other step-1 rejection, this must be raised in plain
+    Python before any SQL is issued."""
 
     engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
     session_factory = _session_factory(engine)
     task_id, anchor_id = _seed(session_factory)
     db = session_factory()
     anchor = _anchor(anchor_id, run_partition="run-b")
     kwargs = _stage_kwargs(anchor, run_id="run-a")
+    before = len(statements)
     with pytest.raises(InteractionRunPartitionMismatch) as excinfo:
         stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
     assert not isinstance(excinfo.value, InteractionSlotTaken)
     db.close()
 
@@ -1406,6 +1411,16 @@ def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
     without a second connection: what matters for this mutation is only
     where the reclaim statement sits relative to the inner savepoint
     boundary, not why the INSERT failed.
+
+    The dirty-view read right after the raise (below) only proves this
+    session's own uncommitted state -- it cannot tell a real, durable
+    reclaim apart from one this session merely staged in memory and would
+    lose on rollback; a mutation that dropped the reclaim from the outer
+    transaction entirely, but happened to leave this session's own
+    in-memory identity map looking reclaimed, could still pass that read.
+    Committing and re-reading from a fresh session afterward is what
+    actually proves the reclaim survived: durable on disk, not just visible
+    to the session that wrote it.
     """
 
     engine = _engine(tmp_path)
@@ -1456,7 +1471,13 @@ def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
     row = _row_state(db, victim.staged_db_id)
     assert row.status == "terminated"
     assert row.terminal_reason == "run_superseded"
-    db.rollback()
+
+    db.commit()
+    other = session_factory()
+    durable_row = _row_state(other, victim.staged_db_id)
+    assert durable_row.status == "terminated"
+    assert durable_row.terminal_reason == "run_superseded"
+    other.close()
     db.close()
 
 
@@ -2264,7 +2285,6 @@ def test_v_n4_degrade_still_lets_caller_commit_run(tmp_path: Path, case: str) ->
         anchor = _anchor(anchor_id, resume_event_id="")
         lease = _lease(task_id)
 
-    ran_after_with = False
     with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
         h.stage(
             kind="clarification",
@@ -2273,15 +2293,15 @@ def test_v_n4_degrade_still_lets_caller_commit_run(tmp_path: Path, case: str) ->
             request_idempotency_key=_next_key(),
             expires_at=_now() + timedelta(minutes=15),
         )
-    # This line standing in for "the caller's own commit" -- reaching it at
-    # all is the assertion.
-    ran_after_with = True
+    # Code placed here, standing in for "the caller's own commit" -- the
+    # real assertion is that it runs at all and its write is durable,
+    # checked below via a fresh session, not via a boolean flag that would
+    # only prove this line was reached, not that its effect persisted.
     db.execute(
         sa.update(Task).where(Task.id == task_id).values(title="post-with-write")
     )
     db.commit()
 
-    assert ran_after_with is True
     db2 = session_factory()
     assert (
         db2.execute(sa.select(Task.title).where(Task.id == task_id)).scalar_one()
@@ -2416,6 +2436,14 @@ def test_sp1_slot_taken_rolls_back_cleanly(tmp_path: Path) -> None:
         )
     db.commit()
     assert _caller_write_survived(db, task_id, "sp1-write")
+    # Exact-set, not `in`, scoped to this module's own signal names -- same
+    # idiom as T-CM-1 (test_cm1_seven_cell_exit_matrix): the module-global
+    # registry can carry residue from other tests sharing the same process,
+    # and a bare `in` check would not catch a second, unexpected signal
+    # firing alongside the expected one.
+    signals = ops_signals.active_degradations()
+    interaction_signals = {name for name in signals if name.startswith("interaction_")}
+    assert interaction_signals == {ops_signals.INTERACTION_HANDOFF_DEGRADED}
     db.close()
 
 
@@ -2550,6 +2578,7 @@ def test_cm_swallows_subclasses_of_swallowed_types(
     db = session_factory()
     task = db.get(Task, task_id)
     lease = _lease(task_id)
+    _mark_caller_write(db, task_id, "cm-subclass-write")
 
     class _SubSlotTaken(InteractionSlotTaken):
         pass
@@ -2569,8 +2598,13 @@ def test_cm_swallows_subclasses_of_swallowed_types(
             request_idempotency_key=_next_key(),
             expires_at=_now() + timedelta(minutes=15),
         )
-    caller_ran_after_with = True
-    assert caller_ran_after_with
+    db.commit()
+    # A real durability assertion, not a boolean flag: the with-block must
+    # actually exit and let the caller's own commit run, and that commit's
+    # effect (the caller write marked above) must survive it -- the same
+    # caller-write-survival pattern every other T-CM cell in this suite
+    # uses to prove the same thing.
+    assert _caller_write_survived(db, task_id, "cm-subclass-write")
     assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
     db.close()
 
@@ -2624,8 +2658,6 @@ def test_cm11_swallow_handler_survives_a_non_object_anchor(tmp_path: Path) -> No
             request_idempotency_key=_next_key(),
             expires_at=_now() + timedelta(minutes=15),
         )
-    caller_ran_after_with = True
-    assert caller_ran_after_with
     db.commit()
 
     assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
@@ -2635,6 +2667,35 @@ def test_cm11_swallow_handler_survives_a_non_object_anchor(tmp_path: Path) -> No
         .where(TaskInteractionRequest.task_id == task_id)
     ).scalar_one()
     assert row_count == 0
+    db.close()
+
+
+def test_safe_returns_none_for_detached_expired_instance(tmp_path: Path) -> None:
+    """``_safe()``'s own docstring names ``DetachedInstanceError``
+    specifically, not just ``AttributeError``, as a case it must swallow --
+    ``test_cm11_swallow_handler_survives_a_non_object_anchor`` above only
+    exercises the ``AttributeError`` path (a dict has no such attribute at
+    all). This pins the other named path directly: an ORM instance that is
+    both expired (its column values must be reloaded from the database
+    before a read can return) and detached (there is no session left to do
+    that reload with) raises ``DetachedInstanceError`` -- a
+    ``SQLAlchemyError`` subclass, not ``AttributeError`` -- from the
+    attribute access itself, so a bare ``getattr(obj, name, None)`` would
+    not catch it and would crash the logging ``_safe()`` exists to
+    protect."""
+
+    from xagent.web.services.task_interaction_staging import _safe
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, _anchor_id = _seed(session_factory)
+    db = session_factory()
+    task = db.get(Task, task_id)
+    db.commit()
+    db.expire_all()
+    db.expunge(task)
+
+    assert _safe(task, "title") is None
     db.close()
 
 

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -159,15 +159,23 @@ def _force_next_identity_select_to_miss(
     matter what is actually committed, then let every later statement on
     ``db`` -- including any later ``SELECT`` -- run for real.
 
-    Exists because two sessions racing naturally (the winner commits, then
-    the loser's own pre-read runs) does not reach step 7's post-conflict
-    re-check on either backend this suite runs against: by the time the
-    loser's own step-3 pre-read fires, the winner's row is already
-    committed and visible to it (SQLite: a bare, non-transactional SELECT
-    sees the latest commit; PostgreSQL READ COMMITTED takes a fresh
-    per-statement snapshot), so the loser's call returns straight from
-    step 3 and never reaches its own INSERT at all. Forcing that one read
-    to lie is what actually drives the interleaving step 7 exists for: the
+    Exists because two sessions racing the way this suite constructs a race
+    (the winner commits and closes *before* the loser's own call even
+    starts) does not reach step 7's post-conflict re-check on either
+    backend: by the time the loser's own step-3 pre-read fires, the
+    winner's row is already committed and visible to it (SQLite: a bare,
+    non-transactional SELECT sees the latest commit; PostgreSQL READ
+    COMMITTED takes a fresh per-statement snapshot), so the loser's call
+    returns straight from step 3 and never reaches its own INSERT at all.
+    That is a fact about this suite's sequential, same-process
+    construction, not a general claim that step 7 is unreachable by
+    natural interleaving: on PostgreSQL specifically, a genuinely
+    concurrent INSERT that blocks on another session's still-uncommitted
+    duplicate row -- true overlap, not this suite's commit-then-run
+    ordering -- reaches step 7 naturally once the blocking transaction
+    commits and the waiting session's own INSERT then fails with a real
+    IntegrityError. Forcing one read to lie is what drives the same
+    interleaving inside this suite's own sequential constructions: the
     call proceeds to the reclaim UPDATE and its own INSERT, collides with
     the winner's real, already-committed row on the database's own unique
     constraints, rolls back its own inner savepoint, and only then does
@@ -237,6 +245,12 @@ _T_P_1_CASES = [
     ),
     pytest.param({"request_payload": None}, ValueError, id="payload-none"),
     pytest.param({"run_id": ""}, ValueError, id="run-id-empty"),
+    pytest.param({"now": datetime.now()}, ValueError, id="now-naive"),
+    pytest.param(
+        {"now": _now().replace(tzinfo=timezone(timedelta(hours=8)))},
+        ValueError,
+        id="now-non-utc",
+    ),
 ]
 
 _T_P_1_ANCHOR_CASES = [
@@ -350,6 +364,41 @@ def test_step_one_rejects_anchor_field_variants_without_sql(
     before = len(statements)
     with pytest.raises(expected_exc):
         stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
+    db.close()
+
+
+_T_P_TASK_ID_CASES = [
+    pytest.param(True, id="bool-true"),
+    pytest.param("7", id="string-digit"),
+    pytest.param(5.9, id="float"),
+    pytest.param(0, id="zero"),
+    pytest.param(-1, id="negative"),
+]
+
+
+@pytest.mark.parametrize("bad_task_id", _T_P_TASK_ID_CASES)
+def test_step_one_rejects_invalid_task_id_without_sql(
+    tmp_path: Path, bad_task_id: Any
+) -> None:
+    """``task_id`` gets a proper identity guard, not a silent ``int()``
+    coercion: ``bool`` is a subclass of ``int`` in Python and must be
+    rejected explicitly (``isinstance(x, bool)`` before ``isinstance(x,
+    int)``), a numeric string or a float must be rejected rather than
+    coerced, and zero/negative values must be rejected outright. All five
+    cases raise before any SQL is issued, the same as every other step-1
+    rejection."""
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    kwargs = _stage_kwargs(anchor)
+    before = len(statements)
+    with pytest.raises(ValueError):
+        stage_interaction_request(db, task_id=bad_task_id, **kwargs)
     assert statements[before:] == []
     db.close()
 
@@ -890,6 +939,95 @@ def test_p9b_replay_after_conflict_via_insert_collision(
     verify.close()
     assert row_count == 1, "A's own losing INSERT must not leave a second row"
     a.close()
+
+
+def test_p9c_post_conflict_recheck_reclassifies_terminal_identity_as_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """F-4 regression: when step 7's post-conflict re-check finds the
+    identity row it collided with in a *terminal* state, it must raise
+    ``InteractionRequestClosed`` -- the same classification step 3's own
+    pre-read gives that state -- not ``InteractionSlotTaken``. This is the
+    cell ``test_p9b_replay_after_conflict_via_insert_collision`` above does
+    not cover: that test's collision lands on a still-*active* identity row
+    (a REPLAY); this one lands on an already-*closed* one, which is a fact
+    about that row's own lifecycle, not an active-slot race.
+
+    B stages and commits a row at ``(task_id, run-a, key)``, then that row
+    is terminated directly, in one statement that respects
+    ``ck_..._terminated_at_pairs_status``'s paired-column shape (``status``,
+    ``terminated_at``, ``terminal_reason`` set together with
+    ``active_slot=NULL``) -- the same shape the module's own reclaim UPDATE
+    uses. The identity row still exists, just closed, so
+    ``uq_task_interaction_request_identity`` still blocks a second INSERT
+    at the same ``(task_id, run_id, key)`` -- unlike
+    ``uq_task_interaction_active_slot``, which B's terminated row no longer
+    holds. A's own pre-read is then forced to miss (the same
+    ``_force_next_identity_select_to_miss`` machinery ``test_p9b`` uses), so
+    A's call proceeds into the reclaim UPDATE and its own INSERT, which
+    collides for real -- on the identity unique, not the active-slot one.
+    That collision rolls back A's own inner savepoint, and step 7's own
+    re-check -- an unpatched, real SELECT by the time it runs -- finds B's
+    now-terminal row and reclassifies the conflict accordingly."""
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    anchor = _anchor(anchor_id)
+    key = _next_key()
+
+    b = session_factory()
+    b_result = stage_interaction_request(
+        b, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+    )
+    b.commit()
+    assert b_result.created is True
+
+    b.execute(
+        sa.update(TaskInteractionRequest)
+        .where(TaskInteractionRequest.id == b_result.staged_db_id)
+        .values(
+            status="terminated",
+            active_slot=None,
+            terminal_reason="deadline_elapsed",
+            terminated_at=_now(),
+        )
+    )
+    b.commit()
+    b.close()
+
+    a = session_factory()
+    _force_next_identity_select_to_miss(monkeypatch, a)
+    before = len(statements)
+    with pytest.raises(InteractionRequestClosed) as excinfo:
+        stage_interaction_request(
+            a, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+        )
+    issued = statements[before:]
+    assert not isinstance(excinfo.value, InteractionSlotTaken)
+
+    # The INSERT was genuinely attempted and genuinely collided -- on the
+    # identity unique, since B's row holds no active slot to collide on.
+    insert_count = sum(1 for s in issued if s.strip().upper().startswith("INSERT"))
+    assert insert_count == 1, issued
+    assert any("ROLLBACK TO SAVEPOINT" in s.upper() for s in issued), issued
+    assert not any("RELEASE SAVEPOINT" in s.upper() for s in issued), issued
+
+    a.rollback()
+    a.close()
+
+    verify = session_factory()
+    row_count = verify.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.request_idempotency_key == key,
+        )
+    ).scalar_one()
+    verify.close()
+    assert row_count == 1, "A's own losing INSERT must not leave a second row"
 
 
 def test_p10_slot_taken_does_not_retry(tmp_path: Path) -> None:

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1,15 +1,15 @@
-"""Contract tests for ``stage_interaction_request`` (the T-P group).
-
-The context manager (``interaction_handoff``) and its own tests (T-CM,
-T-SP) land in a follow-up commit -- this file's own docstring will grow to
-describe both once they do.
+"""Contract tests for ``stage_interaction_request`` and ``interaction_handoff``
+(SQLite half; always runs). The PostgreSQL half
+(``test_interaction_staging_postgresql.py``) re-runs only the savepoint
+containment group -- see that file's module docstring for why the rest is
+not duplicated there.
 
 Each test builds its own file-backed sqlite database under ``tmp_path``
 rather than the process-wide singleton, for the same reason
-``test_trace_event_staging.py`` does: T-P-9 needs two independent sessions
-with genuine transaction isolation between them (REPLAY-after-conflict),
-which an in-memory database shared over one pooled connection does not
-give.
+``test_trace_event_staging.py`` does: several tests here need two
+independent sessions with genuine transaction isolation between them
+(REPLAY-after-conflict), which an in-memory database shared over one pooled
+connection does not give.
 """
 
 from __future__ import annotations
@@ -42,8 +42,10 @@ from xagent.web.services.task_interaction_staging import (
     InteractionRequestClosed,
     InteractionRunPartitionMismatch,
     InteractionSlotTaken,
+    interaction_handoff,
     stage_interaction_request,
 )
+from xagent.web.services.task_lease_service import TaskLease
 
 _key_counter = count()
 
@@ -819,4 +821,511 @@ def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
     assert row.status == "terminated"
     assert row.terminal_reason == "run_superseded"
     db.rollback()
+    db.close()
+
+
+# --------------------------------------------------------------------------
+# T-CM group -- the context manager
+# --------------------------------------------------------------------------
+
+
+def _lease(
+    task_id: int, *, run_id: str = "run-a", attempt_id: str | None = None
+) -> TaskLease:
+    return TaskLease(
+        task_id=task_id, runner_id="runner-1", run_id=run_id, attempt_id=attempt_id
+    )
+
+
+def _mark_caller_write(db: Session, task_id: int, title: str) -> None:
+    db.execute(sa.update(Task).where(Task.id == task_id).values(title=title))
+
+
+def _caller_write_survived(db: Session, task_id: int, title: str) -> bool:
+    return (
+        db.execute(sa.select(Task.title).where(Task.id == task_id)).scalar_one()
+        == title
+    )
+
+
+def _force_attempt_mismatch(db: Session, task_id: int) -> TaskLease:
+    db.execute(
+        sa.update(Task)
+        .where(Task.id == task_id)
+        .values(lease_attempt_id="attempt-current")
+    )
+    return _lease(task_id, attempt_id="attempt-stale")
+
+
+_T_CM_1_CASES = [
+    "slot-taken",
+    "request-closed",
+    "anchor-corrupt",
+    "attempt-mismatch",
+    "run-partition-mismatch",
+    "replay-after-conflict",
+]
+
+
+@pytest.mark.parametrize("case", _T_CM_1_CASES)
+def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
+    """T-CM-1, widened to six cells: the four exceptions the book's design
+    names, plus InteractionRunPartitionMismatch (swallowed under PR-C2a's
+    F-3 override, see the CM's docstring), plus REPLAY-after-conflict as
+    the successful-return control. Every cell: (a) the with-block exits
+    without the exception escaping; (b) exactly the swallowed exceptions
+    register a degradation and log; (c) the caller's own pre-with pending
+    write survives and commits alongside the caller."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+
+    stage_key = _next_key()
+
+    if case == "slot-taken":
+        stage_interaction_request(
+            db,
+            task_id=task_id,
+            **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
+        )
+        db.commit()
+        expect_signal = ops_signals.INTERACTION_HANDOFF_DEGRADED
+    elif case == "request-closed":
+        r = stage_interaction_request(
+            db,
+            task_id=task_id,
+            **_stage_kwargs(anchor, request_idempotency_key=stage_key),
+        )
+        db.commit()
+        db.execute(
+            sa.update(TaskInteractionRequest)
+            .where(TaskInteractionRequest.id == r.staged_db_id)
+            .values(
+                status="terminated",
+                active_slot=None,
+                terminal_reason="deadline_elapsed",
+                terminated_at=_now(),
+            )
+        )
+        db.commit()
+        expect_signal = ops_signals.INTERACTION_HANDOFF_DEGRADED
+    elif case == "anchor-corrupt":
+        anchor = _anchor(anchor_id, resume_event_id="")
+        expect_signal = ops_signals.INTERACTION_HANDOFF_DEGRADED
+    elif case == "attempt-mismatch":
+        lease = _force_attempt_mismatch(db, task_id)
+        db.commit()
+        expect_signal = ops_signals.INTERACTION_HANDOFF_DEGRADED
+    elif case == "run-partition-mismatch":
+        anchor = _anchor(anchor_id, run_partition="some-other-run")
+        expect_signal = ops_signals.INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED
+    else:
+        assert case == "replay-after-conflict"
+        expect_signal = None
+
+    task = db.get(Task, task_id)
+    _mark_caller_write(db, task_id, f"caller-write-{case}")
+
+    if case == "replay-after-conflict":
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            first = h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=stage_key,
+                expires_at=_now() + timedelta(minutes=15),
+            )
+        db.commit()
+        assert first.created is True
+        db.close()
+        assert ops_signals.active_degradations() == {}
+        return
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=stage_key,
+            expires_at=_now() + timedelta(minutes=15),
+        )
+
+    db.commit()
+    assert _caller_write_survived(db, task_id, f"caller-write-{case}")
+    signals = ops_signals.active_degradations()
+    assert expect_signal in signals
+    db.close()
+
+
+def test_cm2_owner_state_error_propagates_uncaught(tmp_path: Path) -> None:
+    """T-CM-2: InteractionOwnerStateError is the one exception this module
+    raises that is never swallowed -- it propagates out of the with-block,
+    and the CM's own savepoint has already been rolled back by the time it
+    does.
+
+    The doomed write is added *inside* the with-block, right before
+    ``stage()`` -- not before ``interaction_handoff`` is even entered --
+    so its flush happens inside ``stage_interaction_request``'s own step-3
+    flush, reached through the CM's ``except`` clause around ``yield``, the
+    same path a real caller's own pending write would take. Adding it
+    before the ``with`` line instead would only exercise the CM's *other*
+    IntegrityError guard, the one around its own ``db.begin_nested()`` --
+    a real gap an earlier version of this test had, which a
+    _SWALLOWED-widening mutation could pass right through undetected."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with pytest.raises(InteractionOwnerStateError) as excinfo:
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            doomed = Task(user_id=10**9, title=None)
+            db.add(doomed)
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+    assert not isinstance(excinfo.value, IntegrityError)
+    assert db.in_transaction()
+    db.rollback()
+    db.close()
+
+
+def test_cm3_attempt_assertion_gates_on_not_none(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    task = db.get(Task, task_id)
+
+    # attempt_id is None -> assertion is skipped even though task's own
+    # lease_attempt_id disagrees.
+    db.execute(
+        sa.update(Task).where(Task.id == task_id).values(lease_attempt_id="whatever")
+    )
+    db.commit()
+    lease = _lease(task_id, attempt_id=None)
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        result = h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+    assert result.created is True
+    assert ops_signals.active_degradations() == {}
+    db.close()
+
+
+def test_cm6_assertions_precede_any_staging_statement(tmp_path: Path) -> None:
+    """T-CM-6 (post-fix form): the attempt and anchor assertions run at the
+    very start of ``stage()``, before the reclaim UPDATE and before the
+    INSERT's own savepoint -- so a mismatched attempt never reaches SQL and
+    never leaves a row behind. A mutation that ran the assertions after
+    stage_interaction_request's own work would let a stale attempt's
+    request through and this test would catch it via the row count."""
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _force_attempt_mismatch(db, task_id)
+    db.commit()
+    task = db.get(Task, task_id)
+
+    before = len(statements)
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    issued = statements[before:]
+    assert not any(
+        s.strip()
+        .upper()
+        .startswith(
+            (
+                "INSERT INTO task_interaction_requests".upper(),
+                "UPDATE task_interaction_requests".upper(),
+            )
+        )
+        for s in issued
+    ), issued
+    db.commit()
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == 0
+    db.close()
+
+
+@pytest.mark.parametrize("case", ["attempt-mismatch", "anchor-corrupt"])
+def test_v_n4_degrade_still_lets_caller_commit_run(tmp_path: Path, case: str) -> None:
+    """v-n4, made executable: after a degrade, code placed *after* the
+    with-block -- standing in for the caller's own commit -- still runs and
+    its effects are durable. This is the invariant the generator-yield
+    finding rescued: before the fix, __enter__ raised
+    RuntimeError('generator didn't yield') and nothing after the with-block
+    ever executed."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    task = db.get(Task, task_id)
+
+    if case == "attempt-mismatch":
+        anchor = _anchor(anchor_id)
+        lease = _force_attempt_mismatch(db, task_id)
+        db.commit()
+    else:
+        anchor = _anchor(anchor_id, resume_event_id="")
+        lease = _lease(task_id)
+
+    ran_after_with = False
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    # This line standing in for "the caller's own commit" -- reaching it at
+    # all is the assertion.
+    ran_after_with = True
+    db.execute(
+        sa.update(Task).where(Task.id == task_id).values(title="post-with-write")
+    )
+    db.commit()
+
+    assert ran_after_with is True
+    db2 = session_factory()
+    assert (
+        db2.execute(sa.select(Task.title).where(Task.id == task_id)).scalar_one()
+        == "post-with-write"
+    )
+    db2.close()
+    db.close()
+
+
+def test_cm4_no_notification_and_no_outer_commit() -> None:
+    import ast
+
+    from xagent.web.services import task_interaction_staging
+
+    tree = ast.parse(Path(task_interaction_staging.__file__).read_text())
+    roots = ("notify", "notification", "dispatch", "publish", "broadcast")
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            names.add(node.attr)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update(a.name.split(".")[-1] for a in node.names)
+            names.update(a.asname for a in node.names if a.asname)
+    offenders = sorted(n for n in names if any(r in n.lower() for r in roots))
+    assert offenders == [], offenders
+
+
+def test_cm4_with_exit_does_not_commit_outer_transaction(tmp_path: Path) -> None:
+    """The CM must not itself commit the caller's outer transaction, checked
+    three ways: (a) ``db.in_transaction()`` is still true right after the
+    ``with`` exits; (b) the row is not visible to a second connection before
+    the caller's own commit; (c) rolling back instead of committing removes
+    the row entirely -- from both this session's own point of view and a
+    fresh session's.
+
+    (b) and (c) are the regression pin for a real bug found and fixed while
+    building this module: on SQLite, a session whose first write-adjacent
+    statement is ``interaction_handoff``'s own outer ``db.begin_nested()`` --
+    exactly this test's shape, where the only earlier statement on ``db`` is
+    a plain SELECT -- breaks pysqlite's transaction tracking badly enough
+    that the savepoint's release becomes a real, permanent commit; a
+    rollback afterward silently does nothing. See the zero-row UPDATE
+    ``interaction_handoff`` issues immediately before opening its savepoint,
+    and that function's docstring, for the fix and the full explanation.
+    Without it, this test fails at (b) (the row leaks to another connection
+    before commit) and, worse, at (c) even after ``db.rollback()``."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    assert db.in_transaction()
+
+    other = session_factory()
+    visible_before_commit = other.execute(
+        sa.select(TaskInteractionRequest.id).where(
+            TaskInteractionRequest.task_id == task_id
+        )
+    ).first()
+    assert visible_before_commit is None, (
+        "the row must not be visible before the caller commits"
+    )
+    other.close()
+
+    db.rollback()
+    assert (
+        db.execute(
+            sa.select(TaskInteractionRequest.id).where(
+                TaskInteractionRequest.task_id == task_id
+            )
+        ).first()
+        is None
+    ), "a caller rollback must remove the staged row from this session's own view"
+    db.close()
+
+    fresh = session_factory()
+    assert (
+        fresh.execute(
+            sa.select(TaskInteractionRequest.id).where(
+                TaskInteractionRequest.task_id == task_id
+            )
+        ).first()
+        is None
+    ), "a caller rollback must remove the staged row entirely, not just locally"
+    fresh.close()
+
+
+# --------------------------------------------------------------------------
+# T-SP group -- savepoint containment (SQLite half; PostgreSQL half repeats
+# this group in test_interaction_staging_postgresql.py)
+# --------------------------------------------------------------------------
+
+
+def test_sp1_slot_taken_rolls_back_cleanly(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
+    )
+    db.commit()
+    _mark_caller_write(db, task_id, "sp1-write")
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+    assert _caller_write_survived(db, task_id, "sp1-write")
+    db.close()
+
+
+def test_sp2_replay_after_conflict_commits_cleanly(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    key = _next_key()
+
+    a = session_factory()
+    b = session_factory()
+    from xagent.web.services.task_interaction_staging import _identity_lookup_stmt
+
+    a.execute(
+        _identity_lookup_stmt(
+            task_id=task_id, run_id="run-a", request_idempotency_key=key
+        )
+    ).first()
+
+    task_b = b.get(Task, task_id)
+    with interaction_handoff(b, lease, task=task_b, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=key,
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    b.commit()
+    b.close()
+
+    task_a = a.get(Task, task_id)
+    _mark_caller_write(a, task_id, "sp2-write")
+    with interaction_handoff(a, lease, task=task_a, anchor=anchor, now=_now()) as h:
+        result = h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=key,
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    a.commit()
+    assert result.created is False
+    assert _caller_write_survived(a, task_id, "sp2-write")
+    a.close()
+
+
+def test_sp3_clean_stage_commits_with_caller(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+    _mark_caller_write(db, task_id, "sp3-write")
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        result = h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+    assert _caller_write_survived(db, task_id, "sp3-write")
+    other = session_factory()
+    row = other.get(TaskInteractionRequest, result.staged_db_id)
+    assert row is not None
+    other.close()
     db.close()

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1788,29 +1788,25 @@ def test_cm1_seven_cell_exit_matrix(
     ).scalar_one()
     assert row_count == _T_CM_1_ROW_COUNT_AFTER_DEGRADE[case]
 
-    # F-10: the degradation log record's `extra` payload is exactly the six
-    # keys the swallow handler emits -- pinned by diffing this record's
-    # attributes against a bare LogRecord's, rather than merely checking
+    # The degradation log record's `extra` payload is exactly the six keys
+    # the swallow handler emits -- pinned by diffing this record's
+    # attributes against a control record's, rather than merely checking
     # the six are present, so a key added to that call site without a
-    # matching test update is caught too.
+    # matching test update is caught too. The control record is emitted
+    # through the same logger and captured by the same caplog handler, so
+    # every environment-dependent built-in attribute (which varies across
+    # Python versions and capture setups) appears on both sides and cancels
+    # out of the diff; a hand-constructed bare LogRecord does not have that
+    # property.
     degraded_records = [
         r for r in caplog.records if r.message == "interaction handoff degraded"
     ]
     assert len(degraded_records) == 1, degraded_records
     record = degraded_records[0]
-    baseline = logging.LogRecord(
-        name="baseline",
-        level=logging.ERROR,
-        pathname="x",
-        lineno=1,
-        msg="m",
-        args=None,
-        exc_info=None,
+    logging.getLogger("xagent.web.services.task_interaction_staging").error(
+        "caplog baseline probe"
     )
-    # caplog's own capture handler formats every record it stores (to build
-    # its text log), which is what stamps `.message` onto it -- an artifact
-    # of capture, not part of the `extra` dict logger.error was called with.
-    baseline.message = baseline.getMessage()
+    baseline = next(r for r in caplog.records if r.message == "caplog baseline probe")
     extra_keys = set(vars(record)) - set(vars(baseline))
     assert extra_keys == _DEGRADATION_LOG_EXTRA_KEYS
     assert record.task_id == task_id

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -246,6 +246,7 @@ _T_P_1_CASES = [
     ),
     pytest.param({"request_payload": None}, ValueError, id="payload-none"),
     pytest.param({"run_id": ""}, ValueError, id="run-id-empty"),
+    pytest.param({"run_id": "x" * 65}, ValueError, id="run-id-too-long"),
     pytest.param({"now": datetime.now()}, ValueError, id="now-naive"),
     pytest.param(
         {"now": _now().replace(tzinfo=timezone(timedelta(hours=8)))},
@@ -278,6 +279,24 @@ _T_P_1_ANCHOR_CASES = [
         {},
         InteractionAnchorCorrupt,
         id="anchor-checkpoint-type-wrong",
+    ),
+    pytest.param(
+        {"resume_event_id": "x" * 256},
+        {},
+        InteractionAnchorCorrupt,
+        id="anchor-event-id-too-long",
+    ),
+    pytest.param(
+        {"resume_execution_id": "x" * 256},
+        {},
+        InteractionAnchorCorrupt,
+        id="anchor-execution-id-too-long",
+    ),
+    pytest.param(
+        {"resume_run_partition": "x" * 65},
+        {"run_id": "run-a"},
+        InteractionAnchorCorrupt,
+        id="anchor-run-partition-too-long",
     ),
 ]
 

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -38,6 +38,7 @@ from xagent.web.services import ops_signals
 from xagent.web.services.task_interaction_staging import (
     InteractionAnchor,
     InteractionAnchorCorrupt,
+    InteractionHandoffMisuse,
     InteractionOwnerStateError,
     InteractionRequestClosed,
     InteractionRunPartitionMismatch,
@@ -1489,6 +1490,55 @@ def test_cm6_assertions_precede_any_staging_statement(tmp_path: Path) -> None:
         .where(TaskInteractionRequest.task_id == task_id)
     ).scalar_one()
     assert row_count == 0
+    db.close()
+
+
+def test_cm7_second_stage_in_one_handoff_is_rejected(tmp_path: Path) -> None:
+    """T-CM-7: ``stage()`` may be called at most once per handoff. A second
+    call inside the same ``with`` block raises ``InteractionHandoffMisuse``,
+    which is not one of the five swallowed types -- it propagates through
+    the CM's ``except BaseException`` branch, which rolls back the *outer*
+    savepoint before re-raising. That rollback discards the first call's
+    already-inner-committed row along with it: the whole handoff is loud
+    (the exception is visible to the caller) and leaves nothing behind,
+    never a silent ``created=True`` receipt for the first call while the
+    second is dropped on the floor."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with pytest.raises(InteractionHandoffMisuse):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "first"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "second"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+
+    # Not swallowed: no degradation signal, same as InteractionOwnerStateError.
+    assert ops_signals.active_degradations() == {}
+    assert db.in_transaction()
+    db.commit()
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == 0, "the outer savepoint rollback must discard the first row too"
     db.close()
 
 

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -288,6 +288,11 @@ _T_P_1_CASES = [
     # instead of failing loudly on the real problem -- a caller passing the
     # wrong type.
     pytest.param({"run_id": ["not", "a", "string"]}, ValueError, id="run-id-not-str"),
+    # None is caught by the same isinstance(run_id, str) guard as the list
+    # case above, not the `if not run_id` emptiness check right after it --
+    # pinned separately since both branches raise ValueError here, and only
+    # running this case proves which one actually fired.
+    pytest.param({"run_id": None}, ValueError, id="run-id-none"),
     pytest.param({"now": datetime.now()}, ValueError, id="now-naive"),
     pytest.param(
         {"now": _now().replace(tzinfo=timezone(timedelta(hours=8)))},
@@ -2012,7 +2017,7 @@ def test_v_n4_degrade_still_lets_caller_commit_run(tmp_path: Path, case: str) ->
     db.close()
 
 
-def test_cm4_no_notification_and_no_outer_commit() -> None:
+def test_cm4_no_notification() -> None:
     import ast
 
     from xagent.web.services import task_interaction_staging

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1231,7 +1231,7 @@ _T_CM_1_CASES = [
 @pytest.mark.parametrize("case", _T_CM_1_CASES)
 def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
     """T-CM-1, widened to six cells: the four exceptions the book's design
-    names, plus InteractionRunPartitionMismatch (swallowed under PR-C2a's
+    names, plus InteractionRunPartitionMismatch (swallowed under this module's
     F-3 override, see the CM's docstring), plus REPLAY-after-conflict as
     the successful-return control. Every cell: (a) the with-block exits
     without the exception escaping; (b) exactly the swallowed exceptions
@@ -1740,4 +1740,47 @@ def test_sp3_clean_stage_commits_with_caller(tmp_path: Path) -> None:
     row = other.get(TaskInteractionRequest, result.staged_db_id)
     assert row is not None
     other.close()
+    db.close()
+
+
+@pytest.mark.parametrize("bad_id", _T_P_TASK_ID_CASES)
+def test_step_one_rejects_non_integer_anchor_row_ids_without_sql(
+    tmp_path: Path, bad_id: Any
+) -> None:
+    """The anchor's row id is a database identity: a bool coerces to a valid
+    foreign key pointing at a different trace row, so it is rejected before
+    any SQL, on the same footing as ``task_id``. Classified as anchor
+    corruption, consistent with the ``None`` case."""
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(bad_id)
+    kwargs = _stage_kwargs(anchor)
+    before = len(statements)
+    with pytest.raises(InteractionAnchorCorrupt):
+        stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
+    db.close()
+
+
+def test_step_one_rejects_boolean_protocol_version_without_sql(
+    tmp_path: Path,
+) -> None:
+    """``True == 1`` in Python, so the equality check alone would admit a
+    bool; the strict guard keeps the vocabulary genuinely integer-valued."""
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    kwargs = _stage_kwargs(anchor, protocol_version=True)
+    before = len(statements)
+    with pytest.raises(ValueError):
+        stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
     db.close()

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1712,6 +1712,49 @@ def test_cm8_degradation_registers_even_after_caller_deactivates_savepoint(
     db.close()
 
 
+@pytest.mark.parametrize("caller_action", ["rollback", "commit"])
+def test_cm8b_normal_exit_after_caller_deactivates_savepoint_raises_misuse(
+    tmp_path: Path, caller_action: str
+) -> None:
+    """T-CM-8's success-path twin: ``h.stage()`` succeeds first, then the
+    caller violates the "no I/O in between" contract by calling
+    ``db.rollback()`` or ``db.commit()`` from inside the with-block. Both
+    end the whole transaction, deactivating this context manager's own
+    outer savepoint the same way T-CM-8 does for the swallowed-exception
+    path -- but here the block's body raises nothing, so the generator
+    resumes at the normal-exit branch, where the savepoint no longer exists
+    to commit. Raising ``InteractionHandoffMisuse`` there instead of
+    silently skipping the now-impossible commit is what this commit fixes:
+    silently skipping would report success for a row whose containment is
+    already gone (see that exception's own docstring)."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with pytest.raises(InteractionHandoffMisuse):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+            if caller_action == "rollback":
+                db.rollback()
+            else:
+                db.commit()
+
+    # Not swallowed: no degradation signal, same as InteractionOwnerStateError.
+    assert ops_signals.active_degradations() == {}
+    db.close()
+
+
 def test_cm9_out_of_vocabulary_task_source_degrades(tmp_path: Path) -> None:
     """T-CM-9: ``origin`` is a frozen copy of ``task.source`` -- an audit
     column recording which surface raised the interaction. A ``task.source``

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -224,6 +224,12 @@ def _reset_ops_signals():
 # --------------------------------------------------------------------------
 
 
+# A payload json.dumps cannot walk without recursing forever -- built once,
+# module level, since a circular structure cannot be expressed as a literal
+# inline in a pytest.param call.
+_circular_payload: dict[str, Any] = {}
+_circular_payload["self"] = _circular_payload
+
 _T_P_1_CASES = [
     pytest.param({"kind": "approval"}, ValueError, id="illegal-kind"),
     pytest.param({"kind": 123}, ValueError, id="kind-not-str"),
@@ -248,6 +254,21 @@ _T_P_1_CASES = [
         id="expires-at-non-utc",
     ),
     pytest.param({"request_payload": None}, ValueError, id="payload-none"),
+    pytest.param(
+        {"request_payload": {"when": datetime.now(timezone.utc)}},
+        ValueError,
+        id="payload-not-json-serializable-datetime",
+    ),
+    pytest.param(
+        {"request_payload": _circular_payload},
+        ValueError,
+        id="payload-not-json-serializable-circular",
+    ),
+    pytest.param(
+        {"request_payload": {"value": float("nan")}},
+        ValueError,
+        id="payload-not-json-serializable-nan",
+    ),
     pytest.param({"run_id": ""}, ValueError, id="run-id-empty"),
     pytest.param({"run_id": "x" * 65}, ValueError, id="run-id-too-long"),
     # A list, not any non-str: it has a __len__ (so it would have survived
@@ -1477,6 +1498,41 @@ def test_cm2_owner_state_error_propagates_uncaught(tmp_path: Path) -> None:
                 expires_at=_now() + timedelta(minutes=15),
             )
     assert not isinstance(excinfo.value, IntegrityError)
+    assert db.in_transaction()
+    db.rollback()
+    db.close()
+
+
+def test_cm2b_non_serializable_payload_propagates_through_handoff(
+    tmp_path: Path,
+) -> None:
+    """A request_payload the JSON-serialization probe rejects raises
+    ValueError from stage_interaction_request's own validation block, before
+    any staging SQL is issued -- and, called through interaction_handoff,
+    that ValueError is not one of the six swallowed types, so it propagates
+    out of the with-block uncaught, the same as InteractionOwnerStateError
+    and InteractionHandoffMisuse. A caller must see this as a loud
+    programming-error failure, not a silently degraded turn."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with pytest.raises(ValueError, match="not JSON-serializable"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"self": _circular_payload},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+
+    assert ops_signals.active_degradations() == {}
     assert db.in_transaction()
     db.rollback()
     db.close()

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -152,6 +152,52 @@ def _row_state(db: Session, staged_db_id: int):
     ).one()
 
 
+def _force_next_identity_select_to_miss(
+    monkeypatch: pytest.MonkeyPatch, db: Session
+) -> dict[str, bool]:
+    """Force the *next* ``SELECT`` issued on ``db`` to report no row, no
+    matter what is actually committed, then let every later statement on
+    ``db`` -- including any later ``SELECT`` -- run for real.
+
+    Exists because two sessions racing naturally (the winner commits, then
+    the loser's own pre-read runs) does not reach step 7's post-conflict
+    re-check on either backend this suite runs against: by the time the
+    loser's own step-3 pre-read fires, the winner's row is already
+    committed and visible to it (SQLite: a bare, non-transactional SELECT
+    sees the latest commit; PostgreSQL READ COMMITTED takes a fresh
+    per-statement snapshot), so the loser's call returns straight from
+    step 3 and never reaches its own INSERT at all. Forcing that one read
+    to lie is what actually drives the interleaving step 7 exists for: the
+    call proceeds to the reclaim UPDATE and its own INSERT, collides with
+    the winner's real, already-committed row on the database's own unique
+    constraints, rolls back its own inner savepoint, and only then does
+    step 7's second, *unpatched* identity SELECT run -- for real, against
+    the real database -- and find the winner's row.
+
+    Only the first ``SELECT`` on ``db`` after this is called is faked;
+    every other statement (the reclaim ``UPDATE``, the ``INSERT``, step 7's
+    own re-check ``SELECT``) goes through unpatched. Non-``SELECT``
+    statements (a caller's own prior write, the reclaim ``UPDATE``) are
+    never intercepted at all, regardless of ordering.
+    """
+
+    original_execute = Session.execute
+    state = {"armed": True}
+
+    class _MissResult:
+        def first(self) -> None:
+            return None
+
+    def _patched(self: Session, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        if self is db and state["armed"] and isinstance(statement, sa.Select):
+            state["armed"] = False
+            return _MissResult()
+        return original_execute(self, statement, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "execute", _patched)
+    return state
+
+
 def _clear_signals() -> None:
     for name in list(ops_signals.active_degradations()):
         ops_signals.clear_degradation(name)
@@ -689,10 +735,21 @@ def test_p8_owner_state_error_is_not_integrity_error(tmp_path: Path) -> None:
 
 
 def test_p9_replay_after_conflict(tmp_path: Path) -> None:
-    """Two sessions race on the same (task_id, run_id, key). The loser's
-    step-4 pre-read misses (it ran before the winner committed), but its
-    INSERT collides with the winner's row; the post-conflict re-check finds
-    the winner's row and replays it rather than raising SlotTaken."""
+    """Two sessions race on the same (task_id, run_id, key). ``a``'s own
+    manual pre-read (below, before ``b`` commits) misses, as intended -- but
+    that is not the read that decides this test's path. By the time ``a``'s
+    own call to ``stage_interaction_request`` runs its *own* step-3
+    pre-read, ``b`` has already committed, and a fresh SELECT on SQLite sees
+    a just-committed row immediately (no persistent snapshot outside an
+    explicit transaction) -- so ``a``'s call returns straight from step 3's
+    hit, exactly like a same-key replay with no race at all. It never
+    reaches its own INSERT, and therefore never reaches step 7's
+    post-conflict re-check. This test pins that pre-read replay path (a
+    real, separate contract this module makes) and that the loser's own
+    call never inserts a duplicate row -- not step 7. See
+    ``test_p9b_replay_after_conflict_via_insert_collision`` below for the
+    dedicated test that reaches step 7 for real, by forcing the second
+    call's own pre-read to miss despite the row already being committed."""
 
     engine = _engine(tmp_path)
     session_factory = _session_factory(engine)
@@ -721,7 +778,9 @@ def test_p9_replay_after_conflict(tmp_path: Path) -> None:
     b.commit()
     b.close()
 
-    # A now finishes its own call; its INSERT collides with B's committed row.
+    # A now finishes its own call. B has already committed, so A's own
+    # step-3 pre-read hits B's row directly here -- no INSERT is attempted
+    # on this path (see test_p9b for the construction that forces one).
     a_result = stage_interaction_request(
         a, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
     )
@@ -734,8 +793,8 @@ def test_p9_replay_after_conflict(tmp_path: Path) -> None:
     # a_result is a StagedInteractionRequest by construction -- it is never
     # an InteractionSlotTaken instance, so asserting that in isolation pins
     # nothing about this test's outcome. What actually needs pinning: A's
-    # own failed INSERT, having lost the race, must not have left a second
-    # row behind alongside B's winning one.
+    # own call, having replayed B's row from its step-3 pre-read, must not
+    # have inserted a second row of its own alongside B's.
     verify = session_factory()
     row_count = verify.execute(
         sa.select(sa.func.count())
@@ -746,7 +805,91 @@ def test_p9_replay_after_conflict(tmp_path: Path) -> None:
         )
     ).scalar_one()
     verify.close()
-    assert row_count == 1, "the loser's own failed INSERT must not leave a second row"
+    assert row_count == 1, "the loser's own replayed call must not leave a second row"
+
+
+def test_p9b_replay_after_conflict_via_insert_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dedicated test for step 7's post-conflict re-check itself --
+    T-P-9 above pins the pre-read replay path (step 3), which is what every
+    naturally-racing construction on this codebase's two backends actually
+    exercises; it does not reach step 7 (confirmed: replacing step 7's
+    REPLAY return with an unconditional raise leaves T-P-9, T-SP-2, and
+    T-CM-1's ``replay-after-conflict`` cell all green).
+
+    Reaching step 7 for real requires the loser's own step-3 pre-read to
+    miss despite the winner's row already being committed -- an
+    interleaving that does not occur naturally on either backend this suite
+    runs against, so it is driven directly via
+    ``_force_next_identity_select_to_miss`` instead. B stages and commits
+    for real first. A's own pre-read is then forced to report a miss, so
+    A's call proceeds to the reclaim UPDATE and its own INSERT, which
+    collides for real with B's already-committed row (both
+    ``uq_task_interaction_active_slot`` and
+    ``uq_task_interaction_request_identity`` are live collision surfaces
+    here, since A and B share both ``task_id`` and ``run_id``). That
+    collision rolls back A's own inner savepoint, and step 7's own
+    re-check -- an unpatched, real SELECT by the time it runs -- finds B's
+    row and replays it.
+    """
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    anchor = _anchor(anchor_id)
+    key = _next_key()
+
+    b = session_factory()
+    b_result = stage_interaction_request(
+        b, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+    )
+    b.commit()
+    b.close()
+    assert b_result.created is True
+
+    a = session_factory()
+    _mark_caller_write(a, task_id, "p9b-write")
+
+    _force_next_identity_select_to_miss(monkeypatch, a)
+    before = len(statements)
+    a_result = stage_interaction_request(
+        a, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+    )
+    issued = statements[before:]
+
+    # The INSERT was genuinely attempted and genuinely collided.
+    insert_count = sum(1 for s in issued if s.strip().upper().startswith("INSERT"))
+    assert insert_count == 1, issued
+    # ...and its own inner savepoint rolled back rather than committed --
+    # this is what makes step 7's re-check possible at all (see the
+    # module's own docstring on why a shared savepoint breaks this).
+    assert any("ROLLBACK TO SAVEPOINT" in s.upper() for s in issued), issued
+    assert not any("RELEASE SAVEPOINT" in s.upper() for s in issued), issued
+
+    # Step 7's own re-check ran and replayed B's row -- not a fresh insert
+    # of A's own, and not InteractionSlotTaken.
+    assert a_result.created is False
+    assert a_result.staged_db_id == b_result.staged_db_id
+    assert a_result.status == "active"
+    assert a_result.active_slot == b_result.active_slot
+
+    a.commit()
+    assert _caller_write_survived(a, task_id, "p9b-write")
+
+    verify = session_factory()
+    row_count = verify.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.request_idempotency_key == key,
+        )
+    ).scalar_one()
+    verify.close()
+    assert row_count == 1, "A's own losing INSERT must not leave a second row"
+    a.close()
 
 
 def test_p10_slot_taken_does_not_retry(tmp_path: Path) -> None:
@@ -955,7 +1098,19 @@ def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
     the successful-return control. Every cell: (a) the with-block exits
     without the exception escaping; (b) exactly the swallowed exceptions
     register a degradation and log; (c) the caller's own pre-with pending
-    write survives and commits alongside the caller."""
+    write survives and commits alongside the caller.
+
+    The ``replay-after-conflict`` cell's own construction (below) pins the
+    step-3 pre-read replay path through the full context manager -- the
+    same path T-P-9 pins at the primitive level, not step 7's
+    post-conflict re-check: by the time this cell's own ``h.stage()`` call
+    runs its step-3 pre-read, the winner session has already committed, and
+    that pre-read hits directly (see T-P-9's docstring for why). Step 7 is
+    reached and pinned separately, by
+    ``test_p9b_replay_after_conflict_via_insert_collision`` at the
+    primitive level -- confirmed by the same poison-probe check T-P-9's
+    docstring describes: this cell stays green with step 7's REPLAY return
+    replaced by an unconditional raise."""
 
     engine = _engine(tmp_path)
     session_factory = _session_factory(engine)
@@ -1008,15 +1163,13 @@ def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
         expect_signal = None
 
     if case == "replay-after-conflict":
-        # A real REPLAY-after-conflict, not a clean insert: db's own step-3
-        # pre-read must miss before a second session commits the
-        # conflicting row, so db's own INSERT below collides and it is
-        # step 7's post-conflict re-check -- not step 4's pre-read -- that
-        # returns the existing row. Same construction as T-P-9 / T-SP-2:
-        # db's first statement on this session has to happen before the
-        # winner's commit, or this session's own later reads would just see
-        # the winner's row directly instead of missing it (see _engine's
-        # docstring on this backend's pre-outer-commit visibility gap).
+        # A REPLAY-after-conflict via the step-3 pre-read, not a clean
+        # insert and not step 7 (see this test's own docstring): db's first
+        # statement on this session has to happen before the winner's
+        # commit, purely so this session's own connection exists before
+        # that commit -- db's own later pre-read inside h.stage() still
+        # hits the winner's row directly once it runs, since that commit
+        # has already happened by then. Same construction as T-P-9 / T-SP-2.
         from xagent.web.services.task_interaction_staging import (
             _identity_lookup_stmt,
         )

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -962,17 +962,22 @@ def test_p8b_inner_savepoint_cleans_up_on_non_integrity_error_during_insert(
     db.close()
 
 
+@pytest.mark.parametrize("raiser", ["logger_error", "register_degradation"])
 def test_cm10_logger_error_raising_still_rolls_savepoint_back(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raiser: str
 ) -> None:
-    """If ``logger.error`` itself raises inside ``interaction_handoff``'s
-    swallowed-exception handler (a misconfigured logging handler, for
-    instance), the savepoint rollback must still happen -- it now lives in
-    that handler's own ``finally``, not as a bare statement after
-    ``logger.error`` that only runs if logging itself succeeds. Before this
-    commit, a raise from ``logger.error`` skipped the rollback entirely,
-    leaking the outer savepoint open on top of replacing the swallowed
-    exception with whatever the logging call raised."""
+    """If ``logger.error`` or ``register_degradation`` itself raises inside
+    ``interaction_handoff``'s swallowed-exception handler (a misconfigured
+    logging handler, or a bug in the signal registry, for instance), the
+    savepoint rollback must still happen -- it lives in that handler's own
+    ``finally``, not as a bare statement after either call that only runs if
+    both of them succeed. Before the fix this pins, a raise from
+    ``logger.error`` skipped the rollback entirely, leaking the outer
+    savepoint open on top of replacing the swallowed exception with
+    whatever the logging call raised. Both calls are wrapped in the same
+    ``try``: a handler failure -- from either one -- escapes uncaught by
+    design (it is not one of the six swallowed types), but must never leak
+    the savepoint it was about to roll back."""
 
     from xagent.web.services import task_interaction_staging as staging_module
 
@@ -985,11 +990,15 @@ def test_cm10_logger_error_raising_still_rolls_savepoint_back(
     task = db.get(Task, task_id)
 
     def _boom(*args: Any, **kwargs: Any) -> None:
-        raise RuntimeError("logging backend unavailable")
+        raise RuntimeError("handoff signal handler failure")
 
-    monkeypatch.setattr(staging_module.logger, "error", _boom)
+    if raiser == "logger_error":
+        monkeypatch.setattr(staging_module.logger, "error", _boom)
+    else:
+        assert raiser == "register_degradation"
+        monkeypatch.setattr(staging_module, "register_degradation", _boom)
 
-    with pytest.raises(RuntimeError, match="logging backend unavailable"):
+    with pytest.raises(RuntimeError, match="handoff signal handler failure"):
         with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
             h.stage(
                 kind="clarification",
@@ -1445,16 +1454,19 @@ _T_CM_1_CASES = [
     "anchor-corrupt",
     "attempt-mismatch",
     "run-partition-mismatch",
+    "origin-unknown",
     "replay-after-conflict",
 ]
 
 
 @pytest.mark.parametrize("case", _T_CM_1_CASES)
-def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
-    """T-CM-1, widened to six cells: the four dedicated exception types,
-    plus InteractionRunPartitionMismatch (swallowed under this module's
-    F-3 override, see the CM's docstring), plus REPLAY-after-conflict as
-    the successful-return control. Every cell: (a) the with-block exits
+def test_cm1_seven_cell_exit_matrix(tmp_path: Path, case: str) -> None:
+    """T-CM-1, widened to seven cells: the six swallowed types
+    (InteractionSlotTaken, InteractionRequestClosed, InteractionAnchorCorrupt,
+    InteractionAttemptMismatch, InteractionRunPartitionMismatch -- swallowed
+    under this module's F-3 override, see the CM's docstring -- and
+    InteractionOriginUnknown), plus REPLAY-after-conflict as the
+    successful-return control. Every cell: (a) the with-block exits
     without the exception escaping; (b) exactly the swallowed exceptions
     register a degradation and log; (c) the caller's own pre-with pending
     write survives and commits alongside the caller.
@@ -1517,6 +1529,10 @@ def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
     elif case == "run-partition-mismatch":
         anchor = _anchor(anchor_id, run_partition="some-other-run")
         expect_signal = ops_signals.INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED
+    elif case == "origin-unknown":
+        db.execute(sa.update(Task).where(Task.id == task_id).values(source="web"))
+        db.commit()
+        expect_signal = ops_signals.INTERACTION_HANDOFF_DEGRADED
     else:
         assert case == "replay-after-conflict"
         expect_signal = None
@@ -1590,7 +1606,13 @@ def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
     db.commit()
     assert _caller_write_survived(db, task_id, f"caller-write-{case}")
     signals = ops_signals.active_degradations()
-    assert expect_signal in signals
+    # An exact-set comparison, not `expect_signal in signals`, but scoped to
+    # this module's own signal names: the module-global registry
+    # (ops_signals._signals) can carry residue from other tests that share
+    # the same process, and a global equality check would be flaky against
+    # that residue, not against this test's own behavior.
+    interaction_signals = {name for name in signals if name.startswith("interaction_")}
+    assert interaction_signals == {expect_signal}
     db.close()
 
 
@@ -1696,6 +1718,45 @@ def test_cm3_attempt_assertion_gates_on_not_none(tmp_path: Path) -> None:
     db.commit()
     assert result.created is True
     assert ops_signals.active_degradations() == {}
+    db.close()
+
+
+def test_cm5_in_block_write_is_discarded_with_the_degraded_row(
+    tmp_path: Path,
+) -> None:
+    """Pins the module docstring's containment boundary: a write the caller
+    issues *inside* the ``with`` block shares this function's own savepoint
+    with the interaction row itself, so a degrade's ``ROLLBACK TO
+    SAVEPOINT`` discards both together -- unlike a write flushed *before*
+    the block opens (see the other ``test_cm*`` cases, which all mark their
+    caller write ahead of ``with`` and assert it survives). This is exactly
+    why the caller contract restricts the ``with`` body to handoff
+    operations alone: a write placed inside it is not merely at risk of
+    being rolled back on a degrade, it *will* be, indistinguishably from
+    the interaction row it was staged alongside."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _force_attempt_mismatch(db, task_id)
+    db.commit()
+    task = db.get(Task, task_id)
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        _mark_caller_write(db, task_id, "in-block-write")
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+
+    assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
+    assert not _caller_write_survived(db, task_id, "in-block-write")
     db.close()
 
 
@@ -1936,9 +1997,10 @@ def test_cm8c_normal_exit_after_deactivation_without_a_stage_call_names_no_row(
     the ``with`` block deactivates this context manager's own outer
     savepoint the same way T-CM-8b's does -- the misuse detection does not
     require a prior ``stage()`` call to fire. The two variants must not
-    share a message that claims a staged row exists when ``handoff._staged``
-    is still ``False``: this pins the "no interaction row was staged"
-    wording for that case, while T-CM-8b pins the other."""
+    share a message that claims a staged row exists when
+    ``handoff._staged_row`` is still ``False``: this pins the "no
+    interaction row was staged" wording for that case, while T-CM-8b pins
+    the other."""
 
     engine = _engine(tmp_path)
     session_factory = _session_factory(engine)
@@ -1954,6 +2016,53 @@ def test_cm8c_normal_exit_after_deactivation_without_a_stage_call_names_no_row(
                 db.rollback()
             else:
                 db.commit()
+
+    assert ops_signals.active_degradations() == {}
+    db.close()
+
+
+def test_cm8d_stage_call_that_raises_before_staging_names_no_row(
+    tmp_path: Path,
+) -> None:
+    """The case the ``_staged`` / ``_staged_row`` split exists for:
+    ``h.stage()`` is called (so ``_staged`` -- the one-call-per-handoff
+    reentry counter -- is ``True`` from the first line of ``stage()``,
+    before any of its own checks run), but this call's ``lease`` has no
+    ``run_id``, so ``stage()`` raises ``ValueError`` before it ever calls
+    ``stage_interaction_request`` -- no row was staged, so ``_staged_row``
+    stays ``False``. The caller here catches that ``ValueError`` itself,
+    inside the ``with`` block, and then commits from inside it -- the same
+    no-I/O-in-between violation T-CM-8b/T-CM-8c construct, deactivating
+    this handoff's own savepoint. The misuse message that follows must
+    describe this the same way T-CM-8c's zero-call case does ("no
+    interaction row was staged"), not T-CM-8b's ("the staged interaction
+    row no longer exists") -- ``_staged`` alone cannot tell these two cases
+    apart, because it is already ``True`` in both by the time the ``with``
+    block exits."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = TaskLease(
+        task_id=task_id, runner_id="runner-1", run_id=None, attempt_id=None
+    )
+    task = db.get(Task, task_id)
+
+    with pytest.raises(InteractionHandoffMisuse, match="no interaction row was staged"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            try:
+                h.stage(
+                    kind="clarification",
+                    protocol_version=1,
+                    request_payload={"prompt": "p"},
+                    request_idempotency_key=_next_key(),
+                    expires_at=_now() + timedelta(minutes=15),
+                )
+            except ValueError:
+                pass
+            db.commit()
 
     assert ops_signals.active_degradations() == {}
     db.close()
@@ -2397,6 +2506,53 @@ def test_cm11_swallow_handler_survives_a_non_object_anchor(tmp_path: Path) -> No
     db.close()
 
 
+def test_cm12_lease_without_run_id_is_rejected_in_stage(tmp_path: Path) -> None:
+    """A ``TaskLease`` with no ``run_id`` at all (the pre-attempt-column
+    rolling-restart window and the ``_task_lease_snapshot`` ambient sentinel
+    can both produce one, and here it is built directly with both
+    ``run_id`` and ``attempt_id`` set to ``None``) cannot stage anything:
+    ``stage()``'s own ``ValueError`` for this ("lease has no run_id; cannot
+    stage an interaction request without one") is a programming-error
+    signal, not one of the six swallowed types, so it propagates out of the
+    with-block uncaught instead of degrading -- there is no
+    ``anchor.resume_run_partition`` for a ``None`` ``run_id`` to even be
+    compared against."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = TaskLease(
+        task_id=task_id, runner_id="runner-1", run_id=None, attempt_id=None
+    )
+    task = db.get(Task, task_id)
+
+    with pytest.raises(ValueError, match="lease has no run_id"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+
+    assert ops_signals.active_degradations() == {}
+    assert db.in_transaction()
+    db.rollback()
+
+    verify = session_factory()
+    row_count = verify.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    verify.close()
+    assert row_count == 0
+    db.close()
+
+
 def test_handoff_never_writes_any_task_column(tmp_path: Path) -> None:
     """The module docstring's own invariant: neither entry point writes any
     *data* column of ``tasks``. The SQLite-only savepoint guard
@@ -2406,12 +2562,22 @@ def test_handoff_never_writes_any_task_column(tmp_path: Path) -> None:
     ``sa.update(Task)`` with no ``.values()`` at all would instead compile a
     SET clause naming every column SQLAlchemy maps on ``Task`` (lease-fencing
     columns included), and even ``.values(id=-1)`` alone still picks up
-    ``updated_at`` from its ``onupdate=func.now()``. This pins that a
-    successful handoff+stage leaves the task row's every column
-    byte-identical -- not just that ``lease_attempt_id``/``updated_at``
-    happen to survive -- by snapshotting the whole row before and after."""
+    ``updated_at`` from its ``onupdate=func.now()``.
+
+    A before/after column snapshot alone cannot catch every way this
+    invariant could break: an UPDATE whose SET clause names every column on
+    ``tasks`` but whose WHERE clause matches zero rows (``WHERE id = -1``,
+    for instance) would leave the snapshot byte-identical even though the
+    statement itself was wrong. The statements this handoff actually issues
+    are the real subject, so a ``before_cursor_execute`` listener
+    (``_count_cursor_executions``) captures every one of them, and this
+    asserts the only UPDATE that ever targets ``tasks`` is the guard's own
+    single-column self-assignment -- not merely that its (zero) rowcount
+    happened to leave no trace. The column snapshot is kept as a secondary,
+    redundant check."""
 
     engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
     session_factory = _session_factory(engine)
     task_id, anchor_id = _seed(session_factory)
     db = session_factory()
@@ -2422,6 +2588,7 @@ def test_handoff_never_writes_any_task_column(tmp_path: Path) -> None:
     before = {
         column.name: getattr(task, column.name) for column in Task.__table__.columns
     }
+    before_statement_count = len(statements)
 
     with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
         staged = h.stage(
@@ -2433,6 +2600,26 @@ def test_handoff_never_writes_any_task_column(tmp_path: Path) -> None:
         )
     db.commit()
     assert staged.created is True
+
+    issued = statements[before_statement_count:]
+    task_updates = [
+        statement
+        for statement in issued
+        if statement.split(None, 2)[:2] == ["UPDATE", Task.__tablename__]
+    ]
+    guard_sql = f"UPDATE {Task.__tablename__} SET id = id WHERE id = -1"
+    assert task_updates == [guard_sql], task_updates
+    for statement in task_updates:
+        set_clause = statement.upper().split(" SET ", 1)[1].split(" WHERE ")[0]
+        for column in (
+            "runner_id",
+            "lease_attempt_id",
+            "run_id",
+            "status",
+            "lease_expires_at",
+        ):
+            assert column.upper() not in set_clause, (column, statement)
+
     db.close()
 
     fresh = session_factory()

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1608,6 +1608,47 @@ def test_cm8_degradation_registers_even_after_caller_deactivates_savepoint(
     db.close()
 
 
+def test_cm9_out_of_vocabulary_task_source_degrades(tmp_path: Path) -> None:
+    """T-CM-9: ``origin`` is a frozen copy of ``task.source`` -- an audit
+    column recording which surface raised the interaction. A ``task.source``
+    outside the frozen origin vocabulary (drift: e.g. a value some other,
+    newer code path started writing after this vocabulary was fixed) must
+    not be silently coerced to ``"internal"``, which would write a false
+    provenance. It degrades instead: no row is written, no exception
+    escapes, and the shared handoff signal is registered -- the same
+    treatment as the other four originally-swallowed types."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+
+    db.execute(sa.update(Task).where(Task.id == task_id).values(source="web"))
+    db.commit()
+    task = db.get(Task, task_id)
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+
+    assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == 0
+    db.close()
+
+
 @pytest.mark.parametrize("case", ["attempt-mismatch", "anchor-corrupt"])
 def test_v_n4_degrade_still_lets_caller_commit_run(tmp_path: Path, case: str) -> None:
     """v-n4, made executable: after a degrade, code placed *after* the

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -484,6 +484,44 @@ def test_p3_clean_stage_is_not_visible_before_commit(tmp_path: Path) -> None:
     assert visible_after is not None
 
 
+def test_p3b_stale_caller_clock_does_not_misclassify_as_slot_taken(
+    tmp_path: Path,
+) -> None:
+    """A caller clock running 20 minutes behind wall-clock time must not
+    make a legitimate 15-minute TTL misclassify as InteractionSlotTaken.
+
+    Before created_at was bound to the caller's own now (see the model's
+    "Clock source" docstring on ck_task_interaction_requests_expiry_after_creation),
+    created_at came from server_default=func.now() -- real wall-clock time --
+    while expires_at was computed from the caller's stale now. A caller
+    running behind produces an expires_at that lands *before* the server's
+    real created_at, which the database's CHECK rejects as an
+    IntegrityError on the INSERT. Because this table was otherwise empty,
+    step 7's post-conflict re-check found no identity row at this call's own
+    identity and misclassified that CHECK violation as InteractionSlotTaken
+    -- the false diagnosis this test pins: a stale-but-internally-consistent
+    caller clock silently swallowed the caller's turn instead of staging its
+    request. Binding created_at to the same caller now used for expires_at
+    retires this on both backends: both operands now come from one clock, so
+    a stale caller now is accepted exactly like a fresh one."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+
+    stale_now = _now() - timedelta(minutes=20)
+    kwargs = _stage_kwargs(
+        anchor, now=stale_now, expires_at=stale_now + timedelta(minutes=15)
+    )
+    result = stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert result.created is True
+    assert result.status == "active"
+    db.commit()
+    db.close()
+
+
 def test_p4_precheck_branches(tmp_path: Path) -> None:
     engine = _engine(tmp_path)
     statements = _count_cursor_executions(engine)

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -2492,6 +2492,76 @@ def test_cm9_out_of_vocabulary_task_source_degrades(tmp_path: Path) -> None:
     db.close()
 
 
+def test_cm9b_vocabulary_binding_is_the_origin_set_not_the_gating_set() -> None:
+    """The staging validation must bind to the model's six-member origin
+    vocabulary (INTERACTION_ORIGIN_VOCABULARY), not the rollout gate's
+    seven-member gating vocabulary (INTERACTION_GATING_SOURCES), whose extra
+    synthetic "channel" key exists only as an operator gating token. Binding
+    to the wrong set would let "channel" pass Python-side validation, hit
+    the database CHECK, and come back misclassified as a slot conflict.
+    Identity, not equality: an equal-but-distinct copy would already be a
+    second source."""
+
+    from xagent.web.models.task_interaction import INTERACTION_ORIGIN_VOCABULARY
+    from xagent.web.services import task_interaction_staging
+    from xagent.web.services.interaction_rollout import INTERACTION_GATING_SOURCES
+
+    assert task_interaction_staging._ORIGIN_VOCABULARY is INTERACTION_ORIGIN_VOCABULARY
+    assert task_interaction_staging._ORIGIN_VOCABULARY != INTERACTION_GATING_SOURCES
+    assert "channel" in INTERACTION_GATING_SOURCES
+    assert "channel" not in task_interaction_staging._ORIGIN_VOCABULARY
+
+
+def test_cm9c_gating_only_channel_source_degrades(tmp_path: Path) -> None:
+    """The gating-only "channel" token, read back as a ``task.source``, must
+    take the unknown-origin degrade path exactly like any other
+    out-of-vocabulary source: no row, no escaping exception, the shared
+    handoff signal registered. This is the behavioral half of the binding
+    pin above -- if validation ever bound to INTERACTION_GATING_SOURCES,
+    "channel" would pass Python-side validation and reach the database
+    CHECK instead."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+
+    db.execute(sa.update(Task).where(Task.id == task_id).values(source="channel"))
+    db.commit()
+    task = db.get(Task, task_id)
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+
+    degradations = ops_signals.active_degradations()
+    assert ops_signals.INTERACTION_HANDOFF_DEGRADED in degradations
+    # The degrade must be the unknown-origin classification made BEFORE any
+    # SQL. If validation were bound to the gating set instead, "channel"
+    # would reach the database CHECK and come back reclassified as a slot
+    # conflict -- same signal, same zero rows, different exception type --
+    # which is exactly the failure this assertion distinguishes.
+    assert (
+        "InteractionOriginUnknown"
+        in degradations[ops_signals.INTERACTION_HANDOFF_DEGRADED]
+    )
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == 0
+    db.close()
+
+
 @pytest.mark.parametrize("case", ["attempt-mismatch", "anchor-corrupt"])
 def test_v_n4_degrade_still_lets_caller_commit_run(tmp_path: Path, case: str) -> None:
     """v-n4, made executable: after a degrade, code placed *after* the

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -872,6 +872,102 @@ def test_p8_owner_state_error_is_not_integrity_error(tmp_path: Path) -> None:
     db.close()
 
 
+def test_p8b_inner_savepoint_cleans_up_on_non_integrity_error_during_insert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The inner savepoint opened around the INSERT (``inner =
+    db.begin_nested()``) must roll itself back on any exception the flush
+    raises, not only ``IntegrityError`` -- the one type the ``except``
+    clause right after it names. Before this commit, an exception of any
+    other type propagated straight out of ``stage_interaction_request``
+    with that savepoint still open (neither the ``except`` branch's
+    ``inner.rollback()`` nor the ``else`` branch's ``inner.commit()`` runs
+    on the path that isn't either of theirs), leaking it into whatever the
+    caller does next. The ``finally`` this commit adds closes it on every
+    exit, not just the two paths this function names explicitly.
+
+    Simulated here by making the third ``db.flush()`` call on this session
+    raise ``TypeError`` -- standing in for a bind-time serialization failure
+    the pre-INSERT JSON-serializability probe (added in an earlier commit)
+    did not catch. The first two calls must run for real or this never
+    reaches the savepoint this test targets: call 1 is
+    ``stage_interaction_request``'s own step-2 caller-write flush, and call
+    2 is ``db.begin_nested()``'s own implicit flush (``Session.begin_nested()``
+    always flushes first, to establish the SAVEPOINT after whatever is
+    already pending) -- failing that one instead would mean ``inner =
+    db.begin_nested()`` itself never returns, so no savepoint would exist
+    for this test to find still open. Only call 3, the explicit
+    ``db.flush()`` right after ``db.add(new_row)`` inside the already-open
+    savepoint, exercises the ``finally`` this commit adds."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+
+    original_flush = Session.flush
+    state = {"calls": 0}
+
+    def _patched_flush(self: Session, *args: Any, **kwargs: Any) -> Any:
+        if self is db:
+            state["calls"] += 1
+            if state["calls"] == 3:
+                raise TypeError("simulated bind-time serialization failure")
+        return original_flush(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "flush", _patched_flush)
+
+    with pytest.raises(TypeError, match="simulated bind-time serialization failure"):
+        stage_interaction_request(db, task_id=task_id, **_stage_kwargs(anchor))
+
+    assert db.in_nested_transaction() is False
+    db.rollback()
+    db.close()
+
+
+def test_cm10_logger_error_raising_still_rolls_savepoint_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``logger.error`` itself raises inside ``interaction_handoff``'s
+    swallowed-exception handler (a misconfigured logging handler, for
+    instance), the savepoint rollback must still happen -- it now lives in
+    that handler's own ``finally``, not as a bare statement after
+    ``logger.error`` that only runs if logging itself succeeds. Before this
+    commit, a raise from ``logger.error`` skipped the rollback entirely,
+    leaking the outer savepoint open on top of replacing the swallowed
+    exception with whatever the logging call raised."""
+
+    from xagent.web.services import task_interaction_staging as staging_module
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id, resume_event_id="")  # triggers InteractionAnchorCorrupt
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("logging backend unavailable")
+
+    monkeypatch.setattr(staging_module.logger, "error", _boom)
+
+    with pytest.raises(RuntimeError, match="logging backend unavailable"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+
+    assert db.in_nested_transaction() is False
+    db.rollback()
+    db.close()
+
+
 def test_p9_replay_after_conflict(tmp_path: Path) -> None:
     """Two sessions race on the same (task_id, run_id, key). ``a``'s own
     manual pre-read (below, before ``b`` commits) misses, as intended -- but

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1800,7 +1800,7 @@ def test_cm_swallows_subclasses_of_swallowed_types(
     task_id, anchor_id = _seed(session_factory)
     db = session_factory()
     task = db.get(Task, task_id)
-    lease = _lease(task)
+    lease = _lease(task_id)
 
     class _SubSlotTaken(InteractionSlotTaken):
         pass
@@ -1824,3 +1824,21 @@ def test_cm_swallows_subclasses_of_swallowed_types(
     assert caller_ran_after_with
     assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
     db.close()
+
+
+def test_every_swallowed_type_has_a_degradation_signal() -> None:
+    """Structural pin for the fallback in the CM's signal lookup: the
+    fallback exists so a mapping gap degrades generically instead of
+    crashing, and this test exists so such a gap cannot ship unnoticed."""
+
+    from xagent.web.services.task_interaction_staging import (
+        _DEGRADATION_SIGNALS,
+        _SWALLOWED,
+    )
+
+    unmapped = [
+        cls.__name__
+        for cls in _SWALLOWED
+        if not any(issubclass(cls, mapped) for mapped in _DEGRADATION_SIGNALS)
+    ]
+    assert unmapped == []

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -234,6 +234,16 @@ _T_P_1_CASES = [
     pytest.param({"kind": "approval"}, ValueError, id="illegal-kind"),
     pytest.param({"kind": 123}, ValueError, id="kind-not-str"),
     pytest.param({"protocol_version": 2}, ValueError, id="protocol-not-1"),
+    # 1.0 == 1 numerically, so the old `protocol_version != _PROTOCOL_VERSION`
+    # check alone let a float silently through; the isinstance(int) guard
+    # added ahead of it is what this case pins.
+    pytest.param({"protocol_version": 1.0}, ValueError, id="protocol-version-float"),
+    pytest.param(
+        {"expires_at": "not-a-datetime"}, ValueError, id="expires-at-not-datetime"
+    ),
+    pytest.param({"expires_at": None}, ValueError, id="expires-at-none"),
+    pytest.param({"now": "not-a-datetime"}, ValueError, id="now-not-datetime"),
+    pytest.param({"now": None}, ValueError, id="now-none"),
     pytest.param({"origin": "email"}, ValueError, id="illegal-origin"),
     pytest.param({"origin": 123}, ValueError, id="origin-not-str"),
     pytest.param(
@@ -376,6 +386,27 @@ def test_step_one_rejects_missing_anchor_trace_event_id_without_sql(
     anchor = _anchor(anchor_id)
     object.__setattr__(anchor, "trace_event_id", None)
     kwargs = _stage_kwargs(anchor)
+    before = len(statements)
+    with pytest.raises(InteractionAnchorCorrupt):
+        stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
+    db.close()
+
+
+def test_step_one_rejects_wrong_type_anchor_without_sql(tmp_path: Path) -> None:
+    """An ``anchor`` that is not an ``InteractionAnchor`` at all (a caller
+    passing a plain dict, say) must raise ``InteractionAnchorCorrupt`` from
+    the isinstance guard at the top of ``_validate_anchor_fields``, not an
+    ``AttributeError`` from the first ``anchor.<field>`` access that guard
+    exists to preempt."""
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    kwargs = _stage_kwargs(_anchor(anchor_id))
+    kwargs["anchor"] = {"trace_event_id": anchor_id}
     before = len(statements)
     with pytest.raises(InteractionAnchorCorrupt):
         stage_interaction_request(db, task_id=task_id, **kwargs)
@@ -1758,6 +1789,45 @@ def test_cm7_second_stage_in_one_handoff_is_rejected(tmp_path: Path) -> None:
         .where(TaskInteractionRequest.task_id == task_id)
     ).scalar_one()
     assert row_count == 0, "the outer savepoint rollback must discard the first row too"
+    db.close()
+
+
+def test_cm7b_lease_task_mismatch_raises_before_any_staging_statement(
+    tmp_path: Path,
+) -> None:
+    """``stage()`` must reject a lease that names a different task than the
+    one this handoff was constructed with -- a caller bug distinct from
+    ``InteractionAttemptMismatch`` (same task, stale attempt): here the
+    lease and the task disagree about which row is even in play. Raised as
+    a plain ``ValueError``, not swallowed, before the attempt or anchor
+    assertions or any staging SQL against ``task_interaction_requests``."""
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id + 1)
+    task = db.get(Task, task_id)
+
+    before = len(statements)
+    with pytest.raises(ValueError, match="lease names task"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+    issued = statements[before:]
+    assert not any(
+        s.strip().upper().startswith("INSERT INTO task_interaction_requests".upper())
+        for s in issued
+    ), issued
+    assert ops_signals.active_degradations() == {}
+    db.rollback()
     db.close()
 
 

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1926,6 +1926,39 @@ def test_cm8b_normal_exit_after_caller_deactivates_savepoint_raises_misuse(
     db.close()
 
 
+@pytest.mark.parametrize("caller_action", ["rollback", "commit"])
+def test_cm8c_normal_exit_after_deactivation_without_a_stage_call_names_no_row(
+    tmp_path: Path, caller_action: str
+) -> None:
+    """T-CM-8b's zero-``stage()``-call twin: calling ``h.stage()`` zero
+    times is legal on its own (a caller may decide not to ask), but a
+    caller that never calls it and still commits or rolls back from inside
+    the ``with`` block deactivates this context manager's own outer
+    savepoint the same way T-CM-8b's does -- the misuse detection does not
+    require a prior ``stage()`` call to fire. The two variants must not
+    share a message that claims a staged row exists when ``handoff._staged``
+    is still ``False``: this pins the "no interaction row was staged"
+    wording for that case, while T-CM-8b pins the other."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with pytest.raises(InteractionHandoffMisuse, match="no interaction row was staged"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()):
+            if caller_action == "rollback":
+                db.rollback()
+            else:
+                db.commit()
+
+    assert ops_signals.active_degradations() == {}
+    db.close()
+
+
 def test_cm9_out_of_vocabulary_task_source_degrades(tmp_path: Path) -> None:
     """T-CM-9: ``origin`` is a frozen copy of ``task.source`` -- an audit
     column recording which surface raised the interaction. A ``task.source``

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1,0 +1,822 @@
+"""Contract tests for ``stage_interaction_request`` (the T-P group).
+
+The context manager (``interaction_handoff``) and its own tests (T-CM,
+T-SP) land in a follow-up commit -- this file's own docstring will grow to
+describe both once they do.
+
+Each test builds its own file-backed sqlite database under ``tmp_path``
+rather than the process-wide singleton, for the same reason
+``test_trace_event_staging.py`` does: T-P-9 needs two independent sessions
+with genuine transaction isolation between them (REPLAY-after-conflict),
+which an in-memory database shared over one pooled connection does not
+give.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from itertools import count
+from pathlib import Path
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from tests.web.services.task_interaction_schema_shared import (
+    make_task,
+    make_trace_event,
+    make_user,
+)
+from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task
+from xagent.web.models.task_interaction import TaskInteractionRequest
+from xagent.web.services import ops_signals
+from xagent.web.services.task_interaction_staging import (
+    InteractionAnchor,
+    InteractionAnchorCorrupt,
+    InteractionOwnerStateError,
+    InteractionRequestClosed,
+    InteractionRunPartitionMismatch,
+    InteractionSlotTaken,
+    stage_interaction_request,
+)
+
+_key_counter = count()
+
+
+def _engine(tmp_path: Path):
+    """A file-backed sqlite engine, private to one test, configured exactly
+    like the process-wide engine (``apply_sqlite_concurrency_pragmas`` --
+    WAL journaling, busy_timeout, foreign keys).
+
+    This module's own two-session tests (T-P-9, T-SP-2) need this exact
+    configuration, not a "more correct" one: an earlier version of this
+    helper additionally disabled pysqlite's own (non-standard) transaction
+    handling, the workaround SQLAlchemy's docs recommend for serializable
+    isolation. That workaround does fix a real gap -- a released SAVEPOINT
+    (``sp.commit()`` on ``Session.begin_nested()``) is visible to a second
+    connection on the same file before the outer transaction ever commits,
+    confirmed by direct reproduction -- but it also makes SQLite refuse a
+    session's write once its own read transaction has gone stale relative
+    to another session's intervening commit ("database is locked"), which
+    breaks the exact interleaving REPLAY-after-conflict depends on. Since
+    the process-wide engine (``xagent/db/sqlite.py``) does not apply that
+    workaround either, using it here would test a configuration this
+    codebase does not actually run. The pre-outer-commit cross-connection
+    visibility gap this leaves is real on SQLite as this codebase
+    configures it today; this suite avoids asserting the opposite -- see
+    the tests that would have depended on it for what they check instead.
+    """
+    db_path = tmp_path / "interaction_staging.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    apply_sqlite_concurrency_pragmas(engine)
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def _session_factory(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _seed(session_factory) -> tuple[int, int]:
+    db = session_factory()
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    anchor_id = make_trace_event(db, task_id=task_id)
+    db.close()
+    return task_id, anchor_id
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _anchor(
+    trace_event_id: int, *, run_partition: str = "run-a", **overrides: Any
+) -> InteractionAnchor:
+    values: dict[str, Any] = {
+        "trace_event_id": trace_event_id,
+        "resume_event_id": "resume-event-1",
+        "resume_execution_id": "resume-exec-1",
+        "resume_run_partition": run_partition,
+    }
+    values.update(overrides)
+    return InteractionAnchor(**values)
+
+
+def _next_key() -> str:
+    return f"key-{next(_key_counter)}"
+
+
+def _stage_kwargs(anchor: InteractionAnchor, **overrides: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "run_id": anchor.resume_run_partition,
+        "anchor": anchor,
+        "kind": "clarification",
+        "protocol_version": 1,
+        "origin": "internal",
+        "request_payload": {"prompt": "example"},
+        "request_idempotency_key": _next_key(),
+        "expires_at": _now() + timedelta(minutes=15),
+        "now": _now(),
+    }
+    values.update(overrides)
+    return values
+
+
+def _count_cursor_executions(engine) -> list[str]:
+    statements: list[str] = []
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _count(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001, ARG001
+        statements.append(statement)
+
+    return statements
+
+
+def _row_state(db: Session, staged_db_id: int):
+    return db.execute(
+        sa.select(
+            TaskInteractionRequest.run_id,
+            TaskInteractionRequest.status,
+            TaskInteractionRequest.active_slot,
+            TaskInteractionRequest.terminal_reason,
+            TaskInteractionRequest.terminated_at,
+        ).where(TaskInteractionRequest.id == staged_db_id)
+    ).one()
+
+
+def _clear_signals() -> None:
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+
+
+@pytest.fixture(autouse=True)
+def _reset_ops_signals():
+    _clear_signals()
+    yield
+    _clear_signals()
+
+
+# --------------------------------------------------------------------------
+# T-P group -- the primitive
+# --------------------------------------------------------------------------
+
+
+_T_P_1_CASES = [
+    pytest.param({"kind": "approval"}, ValueError, id="illegal-kind"),
+    pytest.param({"protocol_version": 2}, ValueError, id="protocol-not-1"),
+    pytest.param({"origin": "email"}, ValueError, id="illegal-origin"),
+    pytest.param(
+        {"request_idempotency_key": "has a space"}, ValueError, id="key-bad-pattern"
+    ),
+    pytest.param({"request_idempotency_key": ""}, ValueError, id="key-empty"),
+    pytest.param(
+        {"expires_at": _now() - timedelta(minutes=1)}, ValueError, id="ttl-non-positive"
+    ),
+    pytest.param({"expires_at": datetime.now()}, ValueError, id="expires-at-naive"),
+    pytest.param(
+        {
+            "expires_at": _now().replace(tzinfo=timezone(timedelta(hours=8)))
+            + timedelta(minutes=15)
+        },
+        ValueError,
+        id="expires-at-non-utc",
+    ),
+    pytest.param({"request_payload": None}, ValueError, id="payload-none"),
+]
+
+
+@pytest.mark.parametrize("override, expected_exc", _T_P_1_CASES)
+def test_step_one_rejections_send_no_sql(
+    tmp_path: Path, override: dict[str, Any], expected_exc: type[Exception]
+) -> None:
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    kwargs = _stage_kwargs(anchor, **override)
+    before = len(statements)
+    with pytest.raises(expected_exc):
+        stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
+    db.close()
+
+
+def test_step_one_rejects_empty_anchor_fields_without_sql(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id, resume_event_id="")
+    kwargs = _stage_kwargs(anchor)
+    before = len(statements)
+    with pytest.raises(InteractionAnchorCorrupt):
+        stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
+    db.close()
+
+
+def test_step_one_rejects_missing_anchor_trace_event_id_without_sql(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    object.__setattr__(anchor, "trace_event_id", None)
+    kwargs = _stage_kwargs(anchor)
+    before = len(statements)
+    with pytest.raises(InteractionAnchorCorrupt):
+        stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
+    db.close()
+
+
+def test_p2_run_partition_mismatch_is_not_a_slot_taken_subclass(
+    tmp_path: Path,
+) -> None:
+    """T-P-2: run_id != resume_run_partition raises
+    InteractionRunPartitionMismatch, and that type is not a subclass of
+    InteractionSlotTaken -- the two must stay distinguishable so a
+    corruption is never observably confused with an ordinary slot race."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id, run_partition="run-b")
+    kwargs = _stage_kwargs(anchor, run_id="run-a")
+    with pytest.raises(InteractionRunPartitionMismatch) as excinfo:
+        stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert not isinstance(excinfo.value, InteractionSlotTaken)
+    db.close()
+
+
+def test_p3_clean_stage_is_not_visible_before_commit(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    result = stage_interaction_request(db, task_id=task_id, **_stage_kwargs(anchor))
+    assert result.created is True
+    assert result.status == "active"
+    assert result.active_slot == 1
+    assert result.staged_db_id > 0
+
+    other = session_factory()
+    visible = other.execute(
+        sa.select(TaskInteractionRequest.id).where(
+            TaskInteractionRequest.task_id == task_id
+        )
+    ).first()
+    assert visible is None, "uncommitted row must not be visible on another session"
+    other.close()
+
+    db.commit()
+    visible_after = other.execute(
+        sa.select(TaskInteractionRequest.id).where(
+            TaskInteractionRequest.task_id == task_id
+        )
+    ).first()
+    db.close()
+    assert visible_after is not None
+
+
+def test_p4_precheck_branches(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    key = _next_key()
+
+    created = stage_interaction_request(
+        db, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+    )
+    db.commit()
+    assert created.created is True
+
+    before = len(statements)
+    replay = stage_interaction_request(
+        db, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+    )
+    issued = statements[before:]
+    assert replay.created is False
+    assert replay.status == "active"
+    assert replay.staged_db_id == created.staged_db_id
+    assert not any(
+        s.strip().upper().startswith(("UPDATE", "INSERT")) for s in issued
+    ), issued
+    db.close()
+
+
+def test_p4_answered_and_terminated_hits_raise_request_closed(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+
+    key_answered = _next_key()
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(anchor, request_idempotency_key=key_answered),
+    )
+    db.commit()
+    db.execute(
+        sa.update(TaskInteractionRequest)
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.request_idempotency_key == key_answered,
+        )
+        .values(
+            status="answered",
+            active_slot=None,
+            response_payload={"answer": "x"},
+            responded_at=_now(),
+            responder_identity="user:1",
+        )
+    )
+    db.commit()
+    with pytest.raises(InteractionRequestClosed):
+        stage_interaction_request(
+            db,
+            task_id=task_id,
+            **_stage_kwargs(anchor, request_idempotency_key=key_answered),
+        )
+    db.rollback()
+
+    key_terminated = _next_key()
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(anchor, request_idempotency_key=key_terminated),
+    )
+    db.commit()
+    db.execute(
+        sa.update(TaskInteractionRequest)
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.request_idempotency_key == key_terminated,
+        )
+        .values(
+            status="terminated",
+            active_slot=None,
+            terminal_reason="deadline_elapsed",
+            terminated_at=_now(),
+        )
+    )
+    db.commit()
+    with pytest.raises(InteractionRequestClosed):
+        stage_interaction_request(
+            db,
+            task_id=task_id,
+            **_stage_kwargs(anchor, request_idempotency_key=key_terminated),
+        )
+    db.rollback()
+    db.close()
+
+
+def test_p5_same_run_tombstone_stays_closed(tmp_path: Path) -> None:
+    """k-N1: a key reclaimed to deadline_elapsed earlier in the *same* run
+    still raises InteractionRequestClosed on reuse -- it is not REPLAY and
+    not a fresh CREATED row."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id, run_partition="run-a")
+    key = _next_key()
+
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            anchor,
+            request_idempotency_key=key,
+            expires_at=_now() + timedelta(minutes=1),
+        ),
+    )
+    db.commit()
+
+    # A second request in the same run, different key, reclaims the first
+    # (now past its short TTL) via the deadline_elapsed branch.
+    later = _now() + timedelta(minutes=5)
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            anchor,
+            request_idempotency_key=_next_key(),
+            expires_at=later + timedelta(minutes=15),
+            now=later,
+        ),
+    )
+    db.commit()
+
+    with pytest.raises(InteractionRequestClosed):
+        stage_interaction_request(
+            db,
+            task_id=task_id,
+            **_stage_kwargs(anchor, request_idempotency_key=key, now=later),
+        )
+    db.rollback()
+    db.close()
+
+
+def test_p5b_identity_is_run_scoped_not_task_scoped(tmp_path: Path) -> None:
+    """§7.1: the same idempotency key used by two different runs on the same
+    task must not be conflated -- each run's step-4 pre-read must only ever
+    see rows from its own run. Regression for a step-4 predicate that
+    forgets run_id and falls back to task-scoped identity: without run_id in
+    the WHERE clause, run-b's pre-read for a shared key would find run-a's
+    still-active row and incorrectly replay it as if it were run-b's own,
+    short-circuiting before the reclaim that should have superseded it."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    shared_key = "shared-key"
+
+    run_a = stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            _anchor(anchor_id, run_partition="run-a"),
+            request_idempotency_key=shared_key,
+        ),
+    )
+    db.commit()
+
+    run_b = stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            _anchor(anchor_id, run_partition="run-b"),
+            request_idempotency_key=shared_key,
+        ),
+    )
+    db.commit()
+
+    assert run_b.created is True, "run-b must get its own fresh row, not replay run-a's"
+    assert run_b.staged_db_id != run_a.staged_db_id
+
+    row_a = _row_state(db, run_a.staged_db_id)
+    assert row_a.run_id == "run-a"
+    assert row_a.status == "terminated"
+    assert row_a.terminal_reason == "run_superseded"
+
+    row_b = _row_state(db, run_b.staged_db_id)
+    assert row_b.run_id == "run-b"
+    assert row_b.status == "active"
+    db.close()
+
+
+_T_P_6_CASES = [
+    pytest.param("run-a", "run-a", 1, False, id="same-run-expired"),
+    pytest.param("run-a", "run-a", 15, True, id="same-run-unexpired-control"),
+    pytest.param("run-a", "run-b", 1, False, id="cross-run-expired"),
+    pytest.param("run-a", "run-b", 15, False, id="cross-run-unexpired"),
+    pytest.param("run-b", "run-a", 1, False, id="reverse-cross-run-expired"),
+    pytest.param("run-b", "run-a", 15, False, id="reverse-cross-run-unexpired"),
+]
+
+
+@pytest.mark.parametrize(
+    "existing_run, reclaiming_run, ttl_minutes, expect_untouched", _T_P_6_CASES
+)
+def test_p6_reclaim_six_cells(
+    tmp_path: Path,
+    existing_run: str,
+    reclaiming_run: str,
+    ttl_minutes: int,
+    expect_untouched: bool,
+) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+
+    existing_anchor = _anchor(anchor_id, run_partition=existing_run)
+    existing = stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            existing_anchor, expires_at=_now() + timedelta(minutes=ttl_minutes)
+        ),
+    )
+    db.commit()
+
+    reclaim_now = _now() + timedelta(minutes=5)
+    if expect_untouched:
+        # Same run, unexpired: the reclaim predicate does not match, so the
+        # slot is still held -> the new INSERT collides with it.
+        with pytest.raises(InteractionSlotTaken):
+            stage_interaction_request(
+                db,
+                task_id=task_id,
+                **_stage_kwargs(
+                    _anchor(anchor_id, run_partition=reclaiming_run),
+                    now=reclaim_now,
+                    expires_at=reclaim_now + timedelta(minutes=15),
+                ),
+            )
+        db.rollback()
+        row = _row_state(db, existing.staged_db_id)
+        assert row.status == "active"
+        assert row.active_slot == 1
+        assert row.terminal_reason is None
+        assert row.terminated_at is None
+        db.close()
+        return
+
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            _anchor(anchor_id, run_partition=reclaiming_run),
+            now=reclaim_now,
+            expires_at=reclaim_now + timedelta(minutes=15),
+        ),
+    )
+    db.commit()
+    row = _row_state(db, existing.staged_db_id)
+    assert row.status == "terminated"
+    assert row.active_slot is None
+    assert row.terminated_at is not None
+    expected_reason = (
+        "run_superseded" if existing_run != reclaiming_run else "deadline_elapsed"
+    )
+    assert row.terminal_reason == expected_reason
+    db.close()
+
+
+def test_p7_case_branch_prioritizes_run_superseded(tmp_path: Path) -> None:
+    """A row that is both cross-run *and* expired is recorded as
+    run_superseded, not deadline_elapsed -- the CASE checks run identity
+    first."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    existing = stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            _anchor(anchor_id, run_partition="run-a"),
+            expires_at=_now() + timedelta(minutes=1),
+        ),
+    )
+    db.commit()
+    later = _now() + timedelta(minutes=10)
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            _anchor(anchor_id, run_partition="run-b"),
+            now=later,
+            expires_at=later + timedelta(minutes=15),
+        ),
+    )
+    db.commit()
+    row = _row_state(db, existing.staged_db_id)
+    assert row.terminal_reason == "run_superseded"
+    db.close()
+
+
+def test_p8_owner_state_error_is_not_integrity_error(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+
+    # A doomed pending write: a Task row with a NOT NULL column left unset
+    # (title is nullable=False) added directly, bypassing the ORM's default.
+    doomed = Task(user_id=10**9, title=None)  # user_id references nothing
+    db.add(doomed)
+
+    with pytest.raises(InteractionOwnerStateError) as excinfo:
+        stage_interaction_request(
+            db, task_id=task_id, **_stage_kwargs(_anchor(anchor_id))
+        )
+    assert not isinstance(excinfo.value, IntegrityError)
+    db.rollback()
+    db.close()
+
+
+def test_p9_replay_after_conflict(tmp_path: Path) -> None:
+    """Two sessions race on the same (task_id, run_id, key). The loser's
+    step-4 pre-read misses (it ran before the winner committed), but its
+    INSERT collides with the winner's row; the post-conflict re-check finds
+    the winner's row and replays it rather than raising SlotTaken."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    anchor = _anchor(anchor_id)
+    key = _next_key()
+
+    a = session_factory()
+    b = session_factory()
+
+    # A performs its own step-1..4 manually up through the pre-read miss,
+    # then pauses (does not reclaim/insert yet).
+    from xagent.web.services.task_interaction_staging import _identity_lookup_stmt
+
+    a_hit = a.execute(
+        _identity_lookup_stmt(
+            task_id=task_id, run_id="run-a", request_idempotency_key=key
+        )
+    ).first()
+    assert a_hit is None
+
+    # B runs the whole call and commits, winning the race.
+    b_result = stage_interaction_request(
+        b, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+    )
+    b.commit()
+    b.close()
+
+    # A now finishes its own call; its INSERT collides with B's committed row.
+    a_result = stage_interaction_request(
+        a, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+    )
+    a.commit()
+    a.close()
+
+    assert a_result.created is False
+    assert a_result.staged_db_id == b_result.staged_db_id
+    assert not isinstance(a_result, InteractionSlotTaken)
+
+
+def test_p10_slot_taken_does_not_retry(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
+    )
+    db.commit()
+
+    before = len(statements)
+    with pytest.raises(InteractionSlotTaken):
+        stage_interaction_request(
+            db,
+            task_id=task_id,
+            **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
+        )
+    db.rollback()
+    issued = statements[before:]
+    insert_count = sum(1 for s in issued if s.strip().upper().startswith("INSERT"))
+    assert insert_count == 1, issued
+    db.close()
+
+
+def test_p11_replay_ignores_expiry(tmp_path: Path) -> None:
+    """k-N2: step 4 replays an already-expired active row without
+    consulting expires_at."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    key = _next_key()
+
+    created = stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            anchor,
+            request_idempotency_key=key,
+            expires_at=_now() + timedelta(minutes=1),
+        ),
+    )
+    db.commit()
+
+    much_later = _now() + timedelta(hours=1)
+    replay = stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(
+            anchor,
+            request_idempotency_key=key,
+            now=much_later,
+            expires_at=much_later + timedelta(minutes=15),
+        ),
+    )
+    assert replay.created is False
+    assert replay.staged_db_id == created.staged_db_id
+    assert replay.status == "active"
+    db.close()
+
+
+def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """M-3 regression: the reclaim UPDATE (step 5) stays in the outer
+    transaction, not the inner savepoint that wraps the INSERT (step 6), so
+    an INSERT-time conflict on this same call does not undo a genuine
+    reclaim that same call already performed.
+
+    Not constructed with two naturally-racing sessions the way T-P-9 is,
+    for two independent reasons. First, ``uq_task_interaction_active_slot``
+    caps a task at one active row, so a call whose own reclaim frees that
+    slot for real leaves nothing left to collide with on the slot
+    dimension -- the only collision surface left
+    (``uq_task_interaction_request_identity``) is only reachable by a
+    session whose *entire* call, reclaim included, commits before this
+    one's own INSERT fires, which means the reclaim that actually happened
+    would belong to the other session's already-committed transaction, not
+    this one's, and could not tell this mutation apart from correct code.
+    Second, and more fundamentally on SQLite: this call's own reclaim
+    UPDATE is itself an uncommitted write, and SQLite's writer lock is
+    database-wide, not per-row (confirmed directly: a second session
+    attempting any write while this one holds an uncommitted write blocks
+    with "database is locked" regardless of which row it targets) -- true
+    concurrent interleaving with a write already in flight is not
+    constructible on this backend at all.
+
+    So this drives the interleaving directly instead -- sanctioned by this
+    PR's own design record (§3.3 A-2: construct REPLAY-after-conflict with
+    two sessions *or* by calling the primitive's internals directly) -- by
+    forcing the INSERT's own flush to fail exactly once, without a second
+    connection: what matters for this mutation is only where the reclaim
+    statement sits relative to the inner savepoint boundary, not why the
+    INSERT failed.
+    """
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+
+    # A stale, cross-run active row this call's own reclaim will terminate.
+    victim = stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(_anchor(anchor_id, run_partition="run-victim")),
+    )
+    db.commit()
+
+    race_anchor = _anchor(anchor_id, run_partition="run-race")
+
+    original_flush = Session.flush
+    flush_calls_on_db = {"n": 0}
+
+    def _fail_third_flush(self: Session, *args: Any, **kwargs: Any) -> Any:
+        if self is db:
+            flush_calls_on_db["n"] += 1
+            # Three flush() calls happen on this session before step 6's
+            # INSERT would otherwise succeed: (1) step 3's explicit flush of
+            # the caller's own pending writes -- none here; (2) the implicit
+            # snapshot flush Session.begin_nested() always issues to
+            # establish the inner savepoint; (3) step 6's own explicit
+            # flush, right as the INSERT is attempted, immediately after
+            # this call's own reclaim UPDATE has already run -- exactly the
+            # point a genuinely racing session's conflict would surface.
+            if flush_calls_on_db["n"] == 3:
+                raise IntegrityError("simulated identity conflict", None, None)
+        return original_flush(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "flush", _fail_third_flush)
+
+    with pytest.raises(InteractionSlotTaken):
+        stage_interaction_request(
+            db,
+            task_id=task_id,
+            **_stage_kwargs(race_anchor, request_idempotency_key=_next_key()),
+        )
+
+    # The INSERT's own attempt failed and its inner savepoint rolled back;
+    # the reclaim issued before that savepoint even opened must still be
+    # intact in this session's own (still uncommitted) view.
+    row = _row_state(db, victim.staged_db_id)
+    assert row.status == "terminated"
+    assert row.terminal_reason == "run_superseded"
+    db.rollback()
+    db.close()

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -190,6 +190,34 @@ _T_P_1_CASES = [
         id="expires-at-non-utc",
     ),
     pytest.param({"request_payload": None}, ValueError, id="payload-none"),
+    pytest.param({"run_id": ""}, ValueError, id="run-id-empty"),
+]
+
+_T_P_1_ANCHOR_CASES = [
+    pytest.param(
+        {"resume_execution_id": ""},
+        {},
+        InteractionAnchorCorrupt,
+        id="anchor-execution-id-empty",
+    ),
+    pytest.param(
+        {"resume_run_partition": ""},
+        {"run_id": "run-a"},
+        InteractionAnchorCorrupt,
+        id="anchor-run-partition-empty",
+    ),
+    pytest.param(
+        {"resume_locator_format": "wrong_format"},
+        {},
+        InteractionAnchorCorrupt,
+        id="anchor-locator-format-wrong",
+    ),
+    pytest.param(
+        {"resume_checkpoint_type": "wrong_type"},
+        {},
+        InteractionAnchorCorrupt,
+        id="anchor-checkpoint-type-wrong",
+    ),
 ]
 
 
@@ -239,6 +267,42 @@ def test_step_one_rejects_missing_anchor_trace_event_id_without_sql(
     kwargs = _stage_kwargs(anchor)
     before = len(statements)
     with pytest.raises(InteractionAnchorCorrupt):
+        stage_interaction_request(db, task_id=task_id, **kwargs)
+    assert statements[before:] == []
+    db.close()
+
+
+@pytest.mark.parametrize(
+    "anchor_override, kwargs_override, expected_exc", _T_P_1_ANCHOR_CASES
+)
+def test_step_one_rejects_anchor_field_variants_without_sql(
+    tmp_path: Path,
+    anchor_override: dict[str, Any],
+    kwargs_override: dict[str, Any],
+    expected_exc: type[Exception],
+) -> None:
+    """The remaining ``_validate_anchor_fields`` branches
+    ``test_step_one_rejects_empty_anchor_fields_without_sql`` and
+    ``test_step_one_rejects_missing_anchor_trace_event_id_without_sql`` don't
+    already cover: an empty ``resume_execution_id`` or
+    ``resume_run_partition``, and a wrong-vocabulary ``resume_locator_format``
+    or ``resume_checkpoint_type``. The run-partition case also overrides
+    ``run_id`` so the top-level ``run_id must not be empty`` check
+    (``_validate_request_fields``, checked before ``_validate_anchor_fields``
+    is ever called) doesn't fire first and mask the anchor check this case
+    means to exercise -- ``_stage_kwargs`` defaults ``run_id`` from
+    ``anchor.resume_run_partition``, so leaving it alone here would make
+    both empty together."""
+
+    engine = _engine(tmp_path)
+    statements = _count_cursor_executions(engine)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id, **anchor_override)
+    kwargs = _stage_kwargs(anchor, **kwargs_override)
+    before = len(statements)
+    with pytest.raises(expected_exc):
         stage_interaction_request(db, task_id=task_id, **kwargs)
     assert statements[before:] == []
     db.close()
@@ -666,7 +730,23 @@ def test_p9_replay_after_conflict(tmp_path: Path) -> None:
 
     assert a_result.created is False
     assert a_result.staged_db_id == b_result.staged_db_id
-    assert not isinstance(a_result, InteractionSlotTaken)
+
+    # a_result is a StagedInteractionRequest by construction -- it is never
+    # an InteractionSlotTaken instance, so asserting that in isolation pins
+    # nothing about this test's outcome. What actually needs pinning: A's
+    # own failed INSERT, having lost the race, must not have left a second
+    # row behind alongside B's winning one.
+    verify = session_factory()
+    row_count = verify.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.request_idempotency_key == key,
+        )
+    ).scalar_one()
+    verify.close()
+    assert row_count == 1, "the loser's own failed INSERT must not leave a second row"
 
 
 def test_p10_slot_taken_does_not_retry(tmp_path: Path) -> None:
@@ -927,10 +1007,46 @@ def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
         assert case == "replay-after-conflict"
         expect_signal = None
 
-    task = db.get(Task, task_id)
-    _mark_caller_write(db, task_id, f"caller-write-{case}")
-
     if case == "replay-after-conflict":
+        # A real REPLAY-after-conflict, not a clean insert: db's own step-3
+        # pre-read must miss before a second session commits the
+        # conflicting row, so db's own INSERT below collides and it is
+        # step 7's post-conflict re-check -- not step 4's pre-read -- that
+        # returns the existing row. Same construction as T-P-9 / T-SP-2:
+        # db's first statement on this session has to happen before the
+        # winner's commit, or this session's own later reads would just see
+        # the winner's row directly instead of missing it (see _engine's
+        # docstring on this backend's pre-outer-commit visibility gap).
+        from xagent.web.services.task_interaction_staging import (
+            _identity_lookup_stmt,
+        )
+
+        db.execute(
+            _identity_lookup_stmt(
+                task_id=task_id,
+                run_id=lease.run_id,
+                request_idempotency_key=stage_key,
+            )
+        ).first()
+
+        winner = session_factory()
+        winner_task = winner.get(Task, task_id)
+        with interaction_handoff(
+            winner, lease, task=winner_task, anchor=anchor, now=_now()
+        ) as h:
+            winner_result = h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=stage_key,
+                expires_at=_now() + timedelta(minutes=15),
+            )
+        winner.commit()
+        winner.close()
+        assert winner_result.created is True
+
+        task = db.get(Task, task_id)
+        _mark_caller_write(db, task_id, f"caller-write-{case}")
         with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
             first = h.stage(
                 kind="clarification",
@@ -940,10 +1056,15 @@ def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
                 expires_at=_now() + timedelta(minutes=15),
             )
         db.commit()
-        assert first.created is True
+        assert first.created is False
+        assert first.staged_db_id == winner_result.staged_db_id
+        assert _caller_write_survived(db, task_id, f"caller-write-{case}")
         db.close()
         assert ops_signals.active_degradations() == {}
         return
+
+    task = db.get(Task, task_id)
+    _mark_caller_write(db, task_id, f"caller-write-{case}")
 
     with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
         h.stage(

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -14,6 +14,7 @@ connection does not give.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from itertools import count
 from pathlib import Path
@@ -22,7 +23,7 @@ from typing import Any
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import create_engine, event
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, StatementError
 from sqlalchemy.orm import Session, sessionmaker
 
 from tests.web.services.task_interaction_schema_shared import (
@@ -205,6 +206,47 @@ def _force_next_identity_select_to_miss(
 
     monkeypatch.setattr(Session, "execute", _patched)
     return state
+
+
+def _defeat_json_probe_but_not_bind_time_serialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Patch ``json.dumps`` so this module's own pre-INSERT probe
+    (``json.dumps(request_payload, allow_nan=False)`` in
+    ``_validate_request_fields``) unconditionally reports success, while
+    SQLAlchemy's own bind-time JSON serialization -- inside the INSERT's own
+    flush, past that probe -- keeps failing for real on whatever
+    non-serializable value the caller passed.
+
+    An unconditional ``json.dumps = lambda *a, **k: "{}"`` does not achieve
+    this: ``json`` is one process-wide module object, and both this
+    module's probe (``import json`` in ``task_interaction_staging.py``) and
+    SQLAlchemy's own JSON column type (``import json`` in
+    ``sqlalchemy/sql/sqltypes.py``) hold the *same* object, confirmed
+    directly -- patching ``dumps`` on it patches both callers identically,
+    which fakes out the real bind-time serialization too and makes the
+    INSERT succeed instead of failing, defeating the point of this
+    construction entirely.
+
+    The two call sites are distinguishable by their call signature, not by
+    identity: this module's probe always passes ``allow_nan=False``: see
+    ``_validate_request_fields``. SQLAlchemy's ``JSON._make_bind_processor``
+    calls its serializer as ``json_serializer(value)`` -- one positional
+    argument, no keywords at all (confirmed by reading
+    ``sqlalchemy/sql/sqltypes.py`` directly). This patch keys off exactly
+    that: a call carrying ``allow_nan`` in its keyword arguments is the
+    probe and gets faked out; every other call is real serialization and
+    runs the real ``json.dumps``.
+    """
+
+    real_dumps = json.dumps
+
+    def _patched(*args: Any, **kwargs: Any) -> Any:
+        if "allow_nan" in kwargs:
+            return "{}"
+        return real_dumps(*args, **kwargs)
+
+    monkeypatch.setattr(json, "dumps", _patched)
 
 
 def _clear_signals() -> None:
@@ -912,29 +954,35 @@ def test_p8b_inner_savepoint_cleans_up_on_non_integrity_error_during_insert(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The inner savepoint opened around the INSERT (``inner =
-    db.begin_nested()``) must roll itself back on any exception the flush
-    raises, not only ``IntegrityError`` -- the one type the ``except``
-    clause right after it names. Before this commit, an exception of any
-    other type propagated straight out of ``stage_interaction_request``
-    with that savepoint still open (neither the ``except`` branch's
-    ``inner.rollback()`` nor the ``else`` branch's ``inner.commit()`` runs
-    on the path that isn't either of theirs), leaking it into whatever the
-    caller does next. The ``finally`` this commit adds closes it on every
-    exit, not just the two paths this function names explicitly.
+    db.begin_nested()``) must unwind on a bind-time failure inside flush,
+    not only on ``IntegrityError`` -- the one type the ``except`` clause
+    right after it names.
 
-    Simulated here by making the third ``db.flush()`` call on this session
-    raise ``TypeError`` -- standing in for a bind-time serialization failure
-    the pre-INSERT JSON-serializability probe (added in an earlier commit)
-    did not catch. The first two calls must run for real or this never
-    reaches the savepoint this test targets: call 1 is
-    ``stage_interaction_request``'s own step-2 caller-write flush, and call
-    2 is ``db.begin_nested()``'s own implicit flush (``Session.begin_nested()``
-    always flushes first, to establish the SAVEPOINT after whatever is
-    already pending) -- failing that one instead would mean ``inner =
-    db.begin_nested()`` itself never returns, so no savepoint would exist
-    for this test to find still open. Only call 3, the explicit
-    ``db.flush()`` right after ``db.add(new_row)`` inside the already-open
-    savepoint, exercises the ``finally`` this commit adds."""
+    An earlier version of this test simulated the failure with a mocked
+    ``Session.flush`` raising a plain ``TypeError``. That mock left
+    ``inner.is_active`` True the whole time, so it passed for the wrong
+    reason -- it never exercised what a real bind-time failure actually
+    does to the savepoint. The real failure is worse: SQLAlchemy's JSON
+    column type serializes ``request_payload`` at bind time, inside the
+    INSERT's own flush -- past this module's pre-INSERT
+    ``json.dumps(..., allow_nan=False)`` probe -- and when that
+    serialization fails, SQLAlchemy marks the open SAVEPOINT inactive
+    *before* the ``StatementError`` it raises ever surfaces here (measured
+    directly). By the time control reaches the ``finally``,
+    ``inner.is_active`` is already False even though the SAVEPOINT itself is
+    still open in the database, waiting to be unwound -- an ``if
+    inner.is_active: inner.rollback()`` guard reads that False and skips the
+    call entirely, leaking the savepoint open. Only an unconditional
+    ``rollback()`` (guarded solely against an already-*closed* transaction,
+    via ``ResourceClosedError``) actually pops it.
+
+    To reach that path without this module's own pre-INSERT probe catching
+    the payload first, the probe is defeated here (see
+    ``_defeat_json_probe_but_not_bind_time_serialization`` for why an
+    unconditional ``json.dumps`` patch would silently defang the real
+    serialization too, and how this one avoids that) so real serialization
+    is left free to fail for real on the non-serializable ``datetime`` in
+    the payload below."""
 
     engine = _engine(tmp_path)
     session_factory = _session_factory(engine)
@@ -942,22 +990,19 @@ def test_p8b_inner_savepoint_cleans_up_on_non_integrity_error_during_insert(
     db = session_factory()
     anchor = _anchor(anchor_id)
 
-    original_flush = Session.flush
-    state = {"calls": 0}
+    _defeat_json_probe_but_not_bind_time_serialization(monkeypatch)
 
-    def _patched_flush(self: Session, *args: Any, **kwargs: Any) -> Any:
-        if self is db:
-            state["calls"] += 1
-            if state["calls"] == 3:
-                raise TypeError("simulated bind-time serialization failure")
-        return original_flush(self, *args, **kwargs)
+    kwargs = _stage_kwargs(anchor, request_payload={"bad": datetime.now(timezone.utc)})
 
-    monkeypatch.setattr(Session, "flush", _patched_flush)
-
-    with pytest.raises(TypeError, match="simulated bind-time serialization failure"):
-        stage_interaction_request(db, task_id=task_id, **_stage_kwargs(anchor))
+    with pytest.raises(StatementError):
+        stage_interaction_request(db, task_id=task_id, **kwargs)
 
     assert db.in_nested_transaction() is False
+
+    # The session must accept the next statement -- proving the savepoint
+    # was actually unwound, not merely marked inactive and left open
+    # underneath (which would instead surface as PendingRollbackError here).
+    db.execute(sa.select(sa.literal(1)))
     db.rollback()
     db.close()
 
@@ -1688,6 +1733,93 @@ def test_cm2b_non_serializable_payload_propagates_through_handoff(
 
     assert ops_signals.active_degradations() == {}
     assert db.in_transaction()
+    db.rollback()
+    db.close()
+
+
+def test_cm2c_statement_error_at_bind_time_propagates_uncaught(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unlike ``test_cm2b`` above (a ``ValueError`` this module's own
+    pre-INSERT probe catches in plain Python), a bind-time
+    ``StatementError`` -- the probe defeated the same way
+    ``test_p8b_inner_savepoint_cleans_up_on_non_integrity_error_during_insert``
+    defeats it -- is not one of the six swallowed types either, so it must
+    propagate out of the with-block the same way, through the CM's
+    ``except BaseException`` branch, with the outer savepoint actually
+    unwound behind it (not merely marked inactive) and no degradation
+    signal registered."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    _defeat_json_probe_but_not_bind_time_serialization(monkeypatch)
+
+    with pytest.raises(StatementError):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"bad": datetime.now(timezone.utc)},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+
+    assert db.in_nested_transaction() is False
+    assert ops_signals.active_degradations() == {}
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == 0
+    db.rollback()
+    db.close()
+
+
+def test_cm2d_bare_runtime_error_from_with_body_propagates_and_unwinds(
+    tmp_path: Path,
+) -> None:
+    """A caller bug inside the with-block that is none of the six swallowed
+    types, ``InteractionOwnerStateError``, or ``InteractionHandoffMisuse``
+    must still propagate uncaught, through the CM's ``except BaseException``
+    branch -- and that branch's own savepoint rollback must actually unwind
+    it, discarding the row ``stage()`` already staged, rather than leaking
+    it open the way an ``is_active``-guarded rollback would on a
+    flush-deactivated savepoint."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with pytest.raises(RuntimeError, match="caller bug inside the with block"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+            raise RuntimeError("caller bug inside the with block")
+
+    assert db.in_nested_transaction() is False
+    assert ops_signals.active_degradations() == {}
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == 0
     db.rollback()
     db.close()
 

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -1561,6 +1561,53 @@ def test_cm7_second_stage_in_one_handoff_is_rejected(tmp_path: Path) -> None:
     db.close()
 
 
+@pytest.mark.parametrize("caller_action", ["rollback", "commit"])
+def test_cm8_degradation_registers_even_after_caller_deactivates_savepoint(
+    tmp_path: Path, caller_action: str
+) -> None:
+    """T-CM-8: a caller that violates the "no I/O in between" contract by
+    calling ``db.rollback()`` or ``db.commit()`` from inside the with-block
+    (both end the whole transaction, deactivating this CM's own outer
+    savepoint along with it) must not turn a swallowed exception into an
+    unrelated crash, and must not lose the degradation signal either.
+
+    Registration and logging now run before the guarded rollback
+    (``if savepoint.is_active: savepoint.rollback()``): the savepoint this
+    handler would otherwise try to roll back a second time is already
+    inactive by the time ``h.stage()`` raises, so the guard skips it, the
+    swallowed exception still does not escape, and the signal is still
+    registered -- the ordering this test pins is what makes that possible;
+    an unguarded ``savepoint.rollback()`` here would raise
+    ``ResourceClosedError`` in its place, both replacing the swallowed
+    exception and skipping the degradation signal."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _force_attempt_mismatch(db, task_id)
+    db.commit()
+    task = db.get(Task, task_id)
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        if caller_action == "rollback":
+            db.rollback()
+        else:
+            db.commit()
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+
+    signals = ops_signals.active_degradations()
+    assert ops_signals.INTERACTION_HANDOFF_DEGRADED in signals
+    db.close()
+
+
 @pytest.mark.parametrize("case", ["attempt-mismatch", "anchor-corrupt"])
 def test_v_n4_degrade_still_lets_caller_commit_run(tmp_path: Path, case: str) -> None:
     """v-n4, made executable: after a degrade, code placed *after* the

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -2317,3 +2317,97 @@ def test_every_swallowed_type_has_a_degradation_signal() -> None:
         if not any(issubclass(cls, mapped) for mapped in _DEGRADATION_SIGNALS)
     ]
     assert unmapped == []
+
+
+def test_cm11_swallow_handler_survives_a_non_object_anchor(tmp_path: Path) -> None:
+    """Regression pin for ``_safe()``. A caller passing a dict as ``anchor``
+    (not an ``InteractionAnchor`` at all -- the same shape
+    ``test_step_one_rejects_wrong_type_anchor_without_sql`` uses against
+    ``stage_interaction_request`` directly) makes ``_validate_anchor_fields``
+    raise ``InteractionAnchorCorrupt`` from its own ``isinstance`` guard,
+    before ever touching ``anchor.resume_run_partition``. But the *swallow
+    handler* in ``interaction_handoff`` used to read that exact attribute
+    straight off the same object while building its log line -- a dict has
+    no ``resume_run_partition``, so that read crashed with ``AttributeError``
+    and replaced the swallowed ``InteractionAnchorCorrupt`` instead of
+    degrading. This pins that a dict anchor degrades the same way every
+    other ``InteractionAnchorCorrupt`` does: no exception escapes, the
+    shared signal registers, and no row is written."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+    bad_anchor = {"trace_event_id": anchor_id}
+
+    with interaction_handoff(db, lease, task=task, anchor=bad_anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    caller_ran_after_with = True
+    assert caller_ran_after_with
+    db.commit()
+
+    assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == 0
+    db.close()
+
+
+def test_handoff_never_writes_any_task_column(tmp_path: Path) -> None:
+    """The module docstring's own invariant: neither entry point writes any
+    *data* column of ``tasks``. The SQLite-only savepoint guard
+    (``interaction_handoff``'s zero-row ``UPDATE tasks SET id = id WHERE id
+    = -1``) is written with ``sa.text()`` specifically so its SET clause
+    names exactly one column, a self-assignment matching zero rows --
+    ``sa.update(Task)`` with no ``.values()`` at all would instead compile a
+    SET clause naming every column SQLAlchemy maps on ``Task`` (lease-fencing
+    columns included), and even ``.values(id=-1)`` alone still picks up
+    ``updated_at`` from its ``onupdate=func.now()``. This pins that a
+    successful handoff+stage leaves the task row's every column
+    byte-identical -- not just that ``lease_attempt_id``/``updated_at``
+    happen to survive -- by snapshotting the whole row before and after."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    before = {
+        column.name: getattr(task, column.name) for column in Task.__table__.columns
+    }
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        staged = h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+    assert staged.created is True
+    db.close()
+
+    fresh = session_factory()
+    fresh_task = fresh.get(Task, task_id)
+    after = {
+        column.name: getattr(fresh_task, column.name)
+        for column in Task.__table__.columns
+    }
+    fresh.close()
+
+    assert after == before

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -632,7 +632,7 @@ def test_p5_same_run_tombstone_stays_closed(tmp_path: Path) -> None:
 
 
 def test_p5b_identity_is_run_scoped_not_task_scoped(tmp_path: Path) -> None:
-    """§7.1: the same idempotency key used by two different runs on the same
+    """The same idempotency key used by two different runs on the same
     task must not be conflated -- each run's step-4 pre-read must only ever
     see rows from its own run. Regression for a step-4 predicate that
     forgets run_id and falls back to task-scoped identity: without run_id in
@@ -1131,7 +1131,7 @@ def test_p11_replay_ignores_expiry(tmp_path: Path) -> None:
 def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """M-3 regression: the reclaim UPDATE (step 5) stays in the outer
+    """Regression pin: the reclaim UPDATE (step 5) stays in the outer
     transaction, not the inner savepoint that wraps the INSERT (step 6), so
     an INSERT-time conflict on this same call does not undo a genuine
     reclaim that same call already performed.
@@ -1154,13 +1154,13 @@ def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
     concurrent interleaving with a write already in flight is not
     constructible on this backend at all.
 
-    So this drives the interleaving directly instead -- sanctioned by this
-    PR's own design record (§3.3 A-2: construct REPLAY-after-conflict with
-    two sessions *or* by calling the primitive's internals directly) -- by
-    forcing the INSERT's own flush to fail exactly once, without a second
-    connection: what matters for this mutation is only where the reclaim
-    statement sits relative to the inner savepoint boundary, not why the
-    INSERT failed.
+    So this drives the interleaving directly instead -- constructing
+    REPLAY-after-conflict via two racing sessions or by calling the
+    primitive's internals directly are both valid, and this uses the
+    latter -- by forcing the INSERT's own flush to fail exactly once,
+    without a second connection: what matters for this mutation is only
+    where the reclaim statement sits relative to the inner savepoint
+    boundary, not why the INSERT failed.
     """
 
     engine = _engine(tmp_path)
@@ -1260,8 +1260,8 @@ _T_CM_1_CASES = [
 
 @pytest.mark.parametrize("case", _T_CM_1_CASES)
 def test_cm1_six_cell_exit_matrix(tmp_path: Path, case: str) -> None:
-    """T-CM-1, widened to six cells: the four exceptions the book's design
-    names, plus InteractionRunPartitionMismatch (swallowed under this module's
+    """T-CM-1, widened to six cells: the four dedicated exception types,
+    plus InteractionRunPartitionMismatch (swallowed under this module's
     F-3 override, see the CM's docstring), plus REPLAY-after-conflict as
     the successful-return control. Every cell: (a) the with-block exits
     without the exception escaping; (b) exactly the swallowed exceptions

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -15,6 +15,7 @@ connection does not give.
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from itertools import count
 from pathlib import Path
@@ -23,7 +24,7 @@ from typing import Any
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import create_engine, event
-from sqlalchemy.exc import IntegrityError, StatementError
+from sqlalchemy.exc import DataError, IntegrityError, StatementError
 from sqlalchemy.orm import Session, sessionmaker
 
 from tests.web.services.task_interaction_schema_shared import (
@@ -163,29 +164,29 @@ def _force_next_identity_select_to_miss(
 
     Exists because two sessions racing the way this suite constructs a race
     (the winner commits and closes *before* the loser's own call even
-    starts) does not reach step 7's post-conflict re-check on either
+    starts) does not reach step 6's post-conflict re-check on either
     backend: by the time the loser's own step-3 pre-read fires, the
     winner's row is already committed and visible to it (SQLite: a bare,
     non-transactional SELECT sees the latest commit; PostgreSQL READ
     COMMITTED takes a fresh per-statement snapshot), so the loser's call
     returns straight from step 3 and never reaches its own INSERT at all.
     That is a fact about this suite's sequential, same-process
-    construction, not a general claim that step 7 is unreachable by
+    construction, not a general claim that step 6 is unreachable by
     natural interleaving: on PostgreSQL specifically, a genuinely
     concurrent INSERT that blocks on another session's still-uncommitted
     duplicate row -- true overlap, not this suite's commit-then-run
-    ordering -- reaches step 7 naturally once the blocking transaction
+    ordering -- reaches step 6 naturally once the blocking transaction
     commits and the waiting session's own INSERT then fails with a real
     IntegrityError. Forcing one read to lie is what drives the same
     interleaving inside this suite's own sequential constructions: the
     call proceeds to the reclaim UPDATE and its own INSERT, collides with
     the winner's real, already-committed row on the database's own unique
     constraints, rolls back its own inner savepoint, and only then does
-    step 7's second, *unpatched* identity SELECT run -- for real, against
+    step 6's second, *unpatched* identity SELECT run -- for real, against
     the real database -- and find the winner's row.
 
     Only the first ``SELECT`` on ``db`` after this is called is faked;
-    every other statement (the reclaim ``UPDATE``, the ``INSERT``, step 7's
+    every other statement (the reclaim ``UPDATE``, the ``INSERT``, step 6's
     own re-check ``SELECT``) goes through unpatched. Non-``SELECT``
     statements (a caller's own prior write, the reclaim ``UPDATE``) are
     never intercepted at all, regardless of ordering.
@@ -247,6 +248,39 @@ def _defeat_json_probe_but_not_bind_time_serialization(
         return real_dumps(*args, **kwargs)
 
     monkeypatch.setattr(json, "dumps", _patched)
+
+
+def _fail_next_flush_with_data_error(
+    monkeypatch: pytest.MonkeyPatch, db: Session
+) -> None:
+    """Force the *next* ``Session.flush()`` call on ``db`` to raise a real
+    ``sqlalchemy.exc.DataError``, then let every later flush on ``db`` run
+    for real.
+
+    SQLite does not enforce ``VARCHAR`` length, so a genuine column-length
+    ``DataError`` (the case (g) widens this module's two
+    ``except (IntegrityError, DataError)`` guards for -- see
+    ``task_interaction_staging.py``'s module docstring, "Three mechanisms,
+    not one") cannot be constructed on this backend by driving real data
+    through a real INSERT. Monkeypatching ``Session.flush`` itself is the
+    least invasive substitute: it raises the real exception type from
+    inside the real ``try`` block each guard wraps -- confirmed directly
+    that ``Session.begin_nested()`` calls ``self.flush()`` while
+    establishing its SAVEPOINT, so this same patch reaches both guards'
+    call sites, not just ``stage_interaction_request``'s own explicit
+    ``db.flush()``.
+    """
+
+    original_flush = Session.flush
+    state = {"armed": True}
+
+    def _patched(self: Session, *args: Any, **kwargs: Any) -> Any:
+        if self is db and state["armed"]:
+            state["armed"] = False
+            raise DataError("simulated column-length violation", None, None)
+        return original_flush(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "flush", _patched)
 
 
 def _clear_signals() -> None:
@@ -567,7 +601,6 @@ def test_p3_clean_stage_is_not_visible_before_commit(tmp_path: Path) -> None:
     assert result.created is True
     assert result.status == "active"
     assert result.active_slot == 1
-    assert result.staged_db_id > 0
 
     other = session_factory()
     visible = other.execute(
@@ -601,7 +634,7 @@ def test_p3b_stale_caller_clock_does_not_misclassify_as_slot_taken(
     running behind produces an expires_at that lands *before* the server's
     real created_at, which the database's CHECK rejects as an
     IntegrityError on the INSERT. Because this table was otherwise empty,
-    step 7's post-conflict re-check found no identity row at this call's own
+    step 6's post-conflict re-check found no identity row at this call's own
     identity and misclassified that CHECK violation as InteractionSlotTaken
     -- the false diagnosis this test pins: a stale-but-internally-consistent
     caller clock silently swallowed the caller's turn instead of staging its
@@ -775,8 +808,8 @@ def test_p5_same_run_tombstone_stays_closed(tmp_path: Path) -> None:
 
 def test_p5b_identity_is_run_scoped_not_task_scoped(tmp_path: Path) -> None:
     """The same idempotency key used by two different runs on the same
-    task must not be conflated -- each run's step-4 pre-read must only ever
-    see rows from its own run. Regression for a step-4 predicate that
+    task must not be conflated -- each run's step-3 pre-read must only ever
+    see rows from its own run. Regression for a step-3 predicate that
     forgets run_id and falls back to task-scoped identity: without run_id in
     the WHERE clause, run-b's pre-read for a shared key would find run-a's
     still-active row and incorrectly replay it as if it were run-b's own,
@@ -946,11 +979,10 @@ def test_p8_owner_state_error_is_not_integrity_error(tmp_path: Path) -> None:
     doomed = Task(user_id=10**9, title=None)  # user_id references nothing
     db.add(doomed)
 
-    with pytest.raises(InteractionOwnerStateError) as excinfo:
+    with pytest.raises(InteractionOwnerStateError):
         stage_interaction_request(
             db, task_id=task_id, **_stage_kwargs(_anchor(anchor_id))
         )
-    assert not isinstance(excinfo.value, IntegrityError)
     db.rollback()
     db.close()
 
@@ -1008,6 +1040,31 @@ def test_p8b_inner_savepoint_cleans_up_on_non_integrity_error_during_insert(
     # was actually unwound, not merely marked inactive and left open
     # underneath (which would instead surface as PendingRollbackError here).
     db.execute(sa.select(sa.literal(1)))
+    db.rollback()
+    db.close()
+
+
+def test_p8c_data_error_from_flush_is_owner_state_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Case (g): ``stage_interaction_request``'s own step-2 flush guard
+    (``except (IntegrityError, DataError)``) must convert a ``DataError``
+    the same way it already converts an ``IntegrityError`` -- both are the
+    caller's own pending write failing to flush, not a conflict on this
+    call's own INSERT. See ``_fail_next_flush_with_data_error`` for why a
+    real ``DataError`` has to be driven in via monkeypatch on this backend."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+
+    _fail_next_flush_with_data_error(monkeypatch, db)
+
+    with pytest.raises(InteractionOwnerStateError, match="before interaction staging"):
+        stage_interaction_request(db, task_id=task_id, **_stage_kwargs(anchor))
+
     db.rollback()
     db.close()
 
@@ -1072,12 +1129,12 @@ def test_p9_replay_after_conflict(tmp_path: Path) -> None:
     a just-committed row immediately (no persistent snapshot outside an
     explicit transaction) -- so ``a``'s call returns straight from step 3's
     hit, exactly like a same-key replay with no race at all. It never
-    reaches its own INSERT, and therefore never reaches step 7's
+    reaches its own INSERT, and therefore never reaches step 6's
     post-conflict re-check. This test pins that pre-read replay path (a
     real, separate contract this module makes) and that the loser's own
-    call never inserts a duplicate row -- not step 7. See
+    call never inserts a duplicate row -- not step 6. See
     ``test_p9b_replay_after_conflict_via_insert_collision`` below for the
-    dedicated test that reaches step 7 for real, by forcing the second
+    dedicated test that reaches step 6 for real, by forcing the second
     call's own pre-read to miss despite the row already being committed."""
 
     engine = _engine(tmp_path)
@@ -1089,7 +1146,7 @@ def test_p9_replay_after_conflict(tmp_path: Path) -> None:
     a = session_factory()
     b = session_factory()
 
-    # A performs its own step-1..4 manually up through the pre-read miss,
+    # A performs its own step-1..3 manually up through the pre-read miss,
     # then pauses (does not reclaim/insert yet).
     from xagent.web.services.task_interaction_staging import _identity_lookup_stmt
 
@@ -1140,14 +1197,14 @@ def test_p9_replay_after_conflict(tmp_path: Path) -> None:
 def test_p9b_replay_after_conflict_via_insert_collision(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The dedicated test for step 7's post-conflict re-check itself --
+    """The dedicated test for step 6's post-conflict re-check itself --
     T-P-9 above pins the pre-read replay path (step 3), which is what every
     naturally-racing construction on this codebase's two backends actually
-    exercises; it does not reach step 7 (confirmed: replacing step 7's
+    exercises; it does not reach step 6 (confirmed: replacing step 6's
     REPLAY return with an unconditional raise leaves T-P-9, T-SP-2, and
     T-CM-1's ``replay-after-conflict`` cell all green).
 
-    Reaching step 7 for real requires the loser's own step-3 pre-read to
+    Reaching step 6 for real requires the loser's own step-3 pre-read to
     miss despite the winner's row already being committed -- an
     interleaving that does not occur naturally on either backend this suite
     runs against, so it is driven directly via
@@ -1158,7 +1215,7 @@ def test_p9b_replay_after_conflict_via_insert_collision(
     ``uq_task_interaction_active_slot`` and
     ``uq_task_interaction_request_identity`` are live collision surfaces
     here, since A and B share both ``task_id`` and ``run_id``). That
-    collision rolls back A's own inner savepoint, and step 7's own
+    collision rolls back A's own inner savepoint, and step 6's own
     re-check -- an unpatched, real SELECT by the time it runs -- finds B's
     row and replays it.
     """
@@ -1192,12 +1249,12 @@ def test_p9b_replay_after_conflict_via_insert_collision(
     insert_count = sum(1 for s in issued if s.strip().upper().startswith("INSERT"))
     assert insert_count == 1, issued
     # ...and its own inner savepoint rolled back rather than committed --
-    # this is what makes step 7's re-check possible at all (see the
+    # this is what makes step 6's re-check possible at all (see the
     # module's own docstring on why a shared savepoint breaks this).
     assert any("ROLLBACK TO SAVEPOINT" in s.upper() for s in issued), issued
     assert not any("RELEASE SAVEPOINT" in s.upper() for s in issued), issued
 
-    # Step 7's own re-check ran and replayed B's row -- not a fresh insert
+    # Step 6's own re-check ran and replayed B's row -- not a fresh insert
     # of A's own, and not InteractionSlotTaken.
     assert a_result.created is False
     assert a_result.staged_db_id == b_result.staged_db_id
@@ -1224,7 +1281,7 @@ def test_p9b_replay_after_conflict_via_insert_collision(
 def test_p9c_post_conflict_recheck_reclassifies_terminal_identity_as_closed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """F-4 regression: when step 7's post-conflict re-check finds the
+    """F-4 regression: when step 6's post-conflict re-check finds the
     identity row it collided with in a *terminal* state, it must raise
     ``InteractionRequestClosed`` -- the same classification step 3's own
     pre-read gives that state -- not ``InteractionSlotTaken``. This is the
@@ -1246,7 +1303,7 @@ def test_p9c_post_conflict_recheck_reclassifies_terminal_identity_as_closed(
     ``_force_next_identity_select_to_miss`` machinery ``test_p9b`` uses), so
     A's call proceeds into the reclaim UPDATE and its own INSERT, which
     collides for real -- on the identity unique, not the active-slot one.
-    That collision rolls back A's own inner savepoint, and step 7's own
+    That collision rolls back A's own inner savepoint, and step 6's own
     re-check -- an unpatched, real SELECT by the time it runs -- finds B's
     now-terminal row and reclassifies the conflict accordingly."""
 
@@ -1340,7 +1397,7 @@ def test_p10_slot_taken_does_not_retry(tmp_path: Path) -> None:
 
 
 def test_p11_replay_ignores_expiry(tmp_path: Path) -> None:
-    """k-N2: step 4 replays an already-expired active row without
+    """k-N2: step 3 replays an already-expired active row without
     consulting expires_at."""
 
     engine = _engine(tmp_path)
@@ -1381,8 +1438,8 @@ def test_p11_replay_ignores_expiry(tmp_path: Path) -> None:
 def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Regression pin: the reclaim UPDATE (step 5) stays in the outer
-    transaction, not the inner savepoint that wraps the INSERT (step 6), so
+    """Regression pin: the reclaim UPDATE (step 4) stays in the outer
+    transaction, not the inner savepoint that wraps the INSERT (step 5), so
     an INSERT-time conflict on this same call does not undo a genuine
     reclaim that same call already performed.
 
@@ -1444,11 +1501,11 @@ def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
     def _fail_third_flush(self: Session, *args: Any, **kwargs: Any) -> Any:
         if self is db:
             flush_calls_on_db["n"] += 1
-            # Three flush() calls happen on this session before step 6's
-            # INSERT would otherwise succeed: (1) step 3's explicit flush of
+            # Three flush() calls happen on this session before step 5's
+            # INSERT would otherwise succeed: (1) step 2's explicit flush of
             # the caller's own pending writes -- none here; (2) the implicit
             # snapshot flush Session.begin_nested() always issues to
-            # establish the inner savepoint; (3) step 6's own explicit
+            # establish the inner savepoint; (3) step 5's own explicit
             # flush, right as the INSERT is attempted, immediately after
             # this call's own reclaim UPDATE has already run -- exactly the
             # point a genuinely racing session's conflict would surface.
@@ -1524,9 +1581,44 @@ _T_CM_1_CASES = [
     "replay-after-conflict",
 ]
 
+# F-3: expected TaskInteractionRequest row count for this task after each
+# degrading cell exits. slot-taken and request-closed each pre-stage one row
+# before the handoff runs (see the case setup below), so zero rows would be
+# wrong for those two -- the pre-staged row must survive untouched and no
+# second row must have been added. The other four cells fail before any
+# staging SQL is issued (validation, or the attempt/anchor/origin assertions
+# in stage(), all run before stage_interaction_request's own first
+# statement), so zero is the only row count consistent with that ordering.
+# replay-after-conflict is not a degrading cell (see the early `return`
+# above) and is not in this table.
+_T_CM_1_ROW_COUNT_AFTER_DEGRADE = {
+    "slot-taken": 1,
+    "request-closed": 1,
+    "anchor-corrupt": 0,
+    "attempt-mismatch": 0,
+    "run-partition-mismatch": 0,
+    "origin-unknown": 0,
+}
+
+# F-10: the exact set of keys interaction_handoff's swallowed-exception
+# handler passes as `extra` to logger.error (task_interaction_staging.py,
+# the "interaction handoff degraded" log line). Pinned here, not re-derived,
+# so a key added to or dropped from that call site's `extra` dict without a
+# matching test update fails loudly instead of silently.
+_DEGRADATION_LOG_EXTRA_KEYS = {
+    "task_id",
+    "lease_run_id",
+    "lease_attempt_id",
+    "anchor_run_partition",
+    "exception_type",
+    "degradation_signal",
+}
+
 
 @pytest.mark.parametrize("case", _T_CM_1_CASES)
-def test_cm1_seven_cell_exit_matrix(tmp_path: Path, case: str) -> None:
+def test_cm1_seven_cell_exit_matrix(
+    tmp_path: Path, case: str, caplog: pytest.LogCaptureFixture
+) -> None:
     """T-CM-1, widened to seven cells: the six swallowed types
     (InteractionSlotTaken, InteractionRequestClosed, InteractionAnchorCorrupt,
     InteractionAttemptMismatch, InteractionRunPartitionMismatch -- swallowed
@@ -1539,16 +1631,19 @@ def test_cm1_seven_cell_exit_matrix(tmp_path: Path, case: str) -> None:
 
     The ``replay-after-conflict`` cell's own construction (below) pins the
     step-3 pre-read replay path through the full context manager -- the
-    same path T-P-9 pins at the primitive level, not step 7's
+    same path T-P-9 pins at the primitive level, not step 6's
     post-conflict re-check: by the time this cell's own ``h.stage()`` call
     runs its step-3 pre-read, the winner session has already committed, and
-    that pre-read hits directly (see T-P-9's docstring for why). Step 7 is
+    that pre-read hits directly (see T-P-9's docstring for why). Step 6 is
     reached and pinned separately, by
     ``test_p9b_replay_after_conflict_via_insert_collision`` at the
     primitive level -- confirmed by the same poison-probe check T-P-9's
-    docstring describes: this cell stays green with step 7's REPLAY return
+    docstring describes: this cell stays green with step 6's REPLAY return
     replaced by an unconditional raise."""
 
+    caplog.set_level(
+        logging.ERROR, logger="xagent.web.services.task_interaction_staging"
+    )
     engine = _engine(tmp_path)
     session_factory = _session_factory(engine)
     task_id, anchor_id = _seed(session_factory)
@@ -1605,7 +1700,7 @@ def test_cm1_seven_cell_exit_matrix(tmp_path: Path, case: str) -> None:
 
     if case == "replay-after-conflict":
         # A REPLAY-after-conflict via the step-3 pre-read, not a clean
-        # insert and not step 7 (see this test's own docstring): db's first
+        # insert and not step 6 (see this test's own docstring): db's first
         # statement on this session has to happen before the winner's
         # commit, purely so this session's own connection exists before
         # that commit -- db's own later pre-read inside h.stage() still
@@ -1679,6 +1774,48 @@ def test_cm1_seven_cell_exit_matrix(tmp_path: Path, case: str) -> None:
     # that residue, not against this test's own behavior.
     interaction_signals = {name for name in signals if name.startswith("interaction_")}
     assert interaction_signals == {expect_signal}
+
+    # F-3: table state after degrade. slot-taken and request-closed each
+    # pre-staged one row before the handoff ran; the other four cells fail
+    # before any staging SQL is issued. Either way, the handoff's own
+    # savepoint rollback must leave exactly this many rows behind -- not
+    # more (a leaked INSERT) and not fewer (a rollback that undid a
+    # pre-existing row it never should have touched).
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == _T_CM_1_ROW_COUNT_AFTER_DEGRADE[case]
+
+    # F-10: the degradation log record's `extra` payload is exactly the six
+    # keys the swallow handler emits -- pinned by diffing this record's
+    # attributes against a bare LogRecord's, rather than merely checking
+    # the six are present, so a key added to that call site without a
+    # matching test update is caught too.
+    degraded_records = [
+        r for r in caplog.records if r.message == "interaction handoff degraded"
+    ]
+    assert len(degraded_records) == 1, degraded_records
+    record = degraded_records[0]
+    baseline = logging.LogRecord(
+        name="baseline",
+        level=logging.ERROR,
+        pathname="x",
+        lineno=1,
+        msg="m",
+        args=None,
+        exc_info=None,
+    )
+    # caplog's own capture handler formats every record it stores (to build
+    # its text log), which is what stamps `.message` onto it -- an artifact
+    # of capture, not part of the `extra` dict logger.error was called with.
+    baseline.message = baseline.getMessage()
+    extra_keys = set(vars(record)) - set(vars(baseline))
+    assert extra_keys == _DEGRADATION_LOG_EXTRA_KEYS
+    assert record.task_id == task_id
+    assert record.degradation_signal == expect_signal
+
     db.close()
 
 
@@ -1690,13 +1827,14 @@ def test_cm2_owner_state_error_propagates_uncaught(tmp_path: Path) -> None:
 
     The doomed write is added *inside* the with-block, right before
     ``stage()`` -- not before ``interaction_handoff`` is even entered --
-    so its flush happens inside ``stage_interaction_request``'s own step-3
+    so its flush happens inside ``stage_interaction_request``'s own step-2
     flush, reached through the CM's ``except`` clause around ``yield``, the
     same path a real caller's own pending write would take. Adding it
     before the ``with`` line instead would only exercise the CM's *other*
     IntegrityError guard, the one around its own ``db.begin_nested()`` --
-    a real gap an earlier version of this test had, which a
-    _SWALLOWED-widening mutation could pass right through undetected."""
+    covered separately by
+    ``test_cm2e_owner_state_error_from_begin_nested_propagates_uncaught``
+    below."""
 
     engine = _engine(tmp_path)
     session_factory = _session_factory(engine)
@@ -1706,7 +1844,7 @@ def test_cm2_owner_state_error_propagates_uncaught(tmp_path: Path) -> None:
     lease = _lease(task_id)
     task = db.get(Task, task_id)
 
-    with pytest.raises(InteractionOwnerStateError) as excinfo:
+    with pytest.raises(InteractionOwnerStateError):
         with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
             doomed = Task(user_id=10**9, title=None)
             db.add(doomed)
@@ -1717,8 +1855,74 @@ def test_cm2_owner_state_error_propagates_uncaught(tmp_path: Path) -> None:
                 request_idempotency_key=_next_key(),
                 expires_at=_now() + timedelta(minutes=15),
             )
-    assert not isinstance(excinfo.value, IntegrityError)
     assert db.in_transaction()
+    db.rollback()
+    db.close()
+
+
+def test_cm2e_owner_state_error_from_begin_nested_propagates_uncaught(
+    tmp_path: Path,
+) -> None:
+    """T-CM-2's own *other* IntegrityError guard: a doomed write added
+    *before* ``interaction_handoff`` is even entered is caught by
+    ``Session.begin_nested()``'s own mandatory pre-savepoint flush --
+    ``interaction_handoff``'s own ``except`` around that call, not
+    ``stage_interaction_request``'s step-2 flush T-CM-2 above exercises.
+    Both guards raise ``InteractionOwnerStateError``; only the message
+    differs (see the two raise sites in ``task_interaction_staging.py``).
+    Because the failure fires from ``__enter__``, the ``with`` block's body
+    never runs -- ``stage()`` is never reached."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    doomed = Task(user_id=10**9, title=None)
+    db.add(doomed)
+
+    with pytest.raises(InteractionOwnerStateError, match="while opening"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()):
+            pass
+
+    db.rollback()
+    # The session must accept the next statement -- proving the failure
+    # left it usable after a full rollback, not merely marked but still
+    # poisoned.
+    assert db.execute(sa.select(sa.literal(1))).scalar_one() == 1
+    db.close()
+
+
+def test_cm2f_data_error_from_begin_nested_is_owner_state_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Case (g)'s other guard: ``interaction_handoff``'s own
+    ``except (IntegrityError, DataError)`` around ``db.begin_nested()`` must
+    also convert a ``DataError`` -- the counterpart to
+    ``test_p8c_data_error_from_flush_is_owner_state_error`` above, which
+    pins the same conversion at ``stage_interaction_request``'s own step-2
+    flush. See ``_fail_next_flush_with_data_error`` for why a real
+    ``DataError`` has to be driven in via monkeypatch on this backend, and
+    ``test_cm2e`` above for why the ``with`` block's body never runs when
+    this guard is the one that fires."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    _fail_next_flush_with_data_error(monkeypatch, db)
+
+    with pytest.raises(InteractionOwnerStateError, match="while opening"):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()):
+            pass
+
     db.rollback()
     db.close()
 
@@ -1871,6 +2075,36 @@ def test_cm3_attempt_assertion_gates_on_not_none(tmp_path: Path) -> None:
     db.commit()
     assert result.created is True
     assert ops_signals.active_degradations() == {}
+    db.close()
+
+
+def test_cm3b_zero_stage_calls_is_legal(tmp_path: Path) -> None:
+    """F-11: zero stage() calls is legal (see _InteractionHandoff's own
+    docstring, task_interaction_staging.py :1038-1042) -- a caller may open
+    interaction_handoff, decide not to ask, and exit normally with nothing
+    staged."""
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()):
+        _mark_caller_write(db, task_id, "caller-write-zero-stage")
+
+    db.commit()
+
+    row_count = db.execute(
+        sa.select(sa.func.count())
+        .select_from(TaskInteractionRequest)
+        .where(TaskInteractionRequest.task_id == task_id)
+    ).scalar_one()
+    assert row_count == 0
+    assert ops_signals.active_degradations() == {}
+    assert _caller_write_survived(db, task_id, "caller-write-zero-stage")
     db.close()
 
 

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -1,0 +1,411 @@
+"""Savepoint containment (T-SP group) on PostgreSQL.
+
+Companion to test_interaction_staging.py, which carries every other group
+(T-P, T-CM, T-GATE) plus its own copy of T-SP for SQLite. Per this PR's own
+cut-line decision: T-P validates Python-side validation and statement
+sequencing, both dialect-independent; the full 23-CHECK constraint set is
+already pinned on both backends by test_task_interaction_schema.py /
+test_task_interaction_schema_postgresql.py (50 PostgreSQL tests), so
+re-running T-P and T-CM here would be duplicate coverage. What is genuinely
+dialect-specific is savepoint/failed-transaction semantics -- that is what
+this file re-runs, plus the one PostgreSQL-only case (T-SP-5) that has no
+SQLite analog: PostgreSQL poisons the rest of a transaction
+(InFailedSqlTransaction) after an uncaught IntegrityError until something
+rolls back at least to the savepoint that was open when it fired; SQLite
+does not.
+
+Fixture pattern: originally the same init_db + Base.metadata.drop_all/
+create_all against the whole XAGENT_TEST_POSTGRES_URL database that
+test_task_interaction_schema_postgresql.py uses -- an existing convention,
+not invented for this PR. Switched to a disposable, uniquely-named schema
+instead (CREATE SCHEMA / DROP SCHEMA CASCADE, matching this PR's own design
+audit probes -- see task_interaction_staging.py's module history) after
+init_db()'s automatic-upgrade check started failing here with the shared
+XAGENT_TEST_POSTGRES_URL database's alembic_version stamped to a migration
+this worktree doesn't recognize (confirmed independent of this PR: the
+same failure reproduces against test_task_interaction_schema_postgresql.py
+unchanged). That table lives in the database's default schema, is global
+to the whole server-side database, and is not itself disposable -- another
+worktree pointed at the same local Postgres instance had stamped it while
+running its own migrations. Base.metadata.create_all() against a private
+schema never touches alembic_version at all, sidestepping that contention
+entirely rather than fighting over one shared table two worktrees both
+have a legitimate claim to.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from itertools import count
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError, InternalError
+from sqlalchemy.orm import Session, sessionmaker
+
+from tests.web.services.task_interaction_schema_shared import (
+    make_task,
+    make_trace_event,
+    make_user,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task
+from xagent.web.models.task_interaction import TaskInteractionRequest
+from xagent.web.services import ops_signals
+from xagent.web.services.task_interaction_staging import (
+    InteractionAnchor,
+    InteractionSlotTaken,
+    _identity_lookup_stmt,
+    interaction_handoff,
+    stage_interaction_request,
+)
+from xagent.web.services.task_lease_service import TaskLease
+
+_key_counter = count()
+
+
+@pytest.fixture()
+def engine():
+    url = os.getenv("XAGENT_TEST_POSTGRES_URL")
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    schema = "c2a_interaction_staging_" + uuid.uuid4().hex[:8]
+    admin_engine = sa.create_engine(url)
+    with admin_engine.begin() as conn:
+        conn.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+    admin_engine.dispose()
+
+    eng = sa.create_engine(url, connect_args={"options": f"-csearch_path={schema}"})
+    Base.metadata.create_all(bind=eng)
+    yield eng
+    eng.dispose()
+
+    admin_engine = sa.create_engine(url)
+    with admin_engine.begin() as conn:
+        conn.execute(sa.text(f'DROP SCHEMA "{schema}" CASCADE'))
+    admin_engine.dispose()
+
+
+@pytest.fixture()
+def session_factory(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db_session(session_factory):
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def fixtures(db_session):
+    user_id = make_user(db_session)
+    task_id = make_task(db_session, user_id=user_id)
+    anchor_id = make_trace_event(db_session, task_id=task_id)
+    return task_id, anchor_id
+
+
+@pytest.fixture(autouse=True)
+def _reset_ops_signals():
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+    yield
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _anchor(trace_event_id: int, *, run_partition: str = "run-a") -> InteractionAnchor:
+    return InteractionAnchor(
+        trace_event_id=trace_event_id,
+        resume_event_id="resume-event-1",
+        resume_execution_id="resume-exec-1",
+        resume_run_partition=run_partition,
+    )
+
+
+def _next_key() -> str:
+    return f"pg-key-{next(_key_counter)}"
+
+
+def _stage_kwargs(anchor: InteractionAnchor, **overrides: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "run_id": anchor.resume_run_partition,
+        "anchor": anchor,
+        "kind": "clarification",
+        "protocol_version": 1,
+        "origin": "internal",
+        "request_payload": {"prompt": "example"},
+        "request_idempotency_key": _next_key(),
+        "expires_at": _now() + timedelta(minutes=15),
+        "now": _now(),
+    }
+    values.update(overrides)
+    return values
+
+
+def _lease(task_id: int) -> TaskLease:
+    return TaskLease(
+        task_id=task_id, runner_id="runner-1", run_id="run-a", attempt_id=None
+    )
+
+
+def _mark_caller_write(db: Session, task_id: int, title: str) -> None:
+    db.execute(sa.update(Task).where(Task.id == task_id).values(title=title))
+
+
+def _caller_write_survived(db: Session, task_id: int, title: str) -> bool:
+    return (
+        db.execute(sa.select(Task.title).where(Task.id == task_id)).scalar_one()
+        == title
+    )
+
+
+def test_sp1_slot_taken_rolls_back_cleanly(db_session, fixtures) -> None:
+    task_id, anchor_id = fixtures
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    db = db_session
+
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
+    )
+    db.commit()
+    task = db.get(Task, task_id)
+    _mark_caller_write(db, task_id, "pg-sp1-write")
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+    assert _caller_write_survived(db, task_id, "pg-sp1-write")
+    assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
+
+
+def test_sp2_replay_after_conflict_commits_cleanly(session_factory, fixtures) -> None:
+    task_id, anchor_id = fixtures
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    key = _next_key()
+
+    a = session_factory()
+    b = session_factory()
+    try:
+        a.execute(
+            _identity_lookup_stmt(
+                task_id=task_id, run_id="run-a", request_idempotency_key=key
+            )
+        ).first()
+
+        task_b = b.get(Task, task_id)
+        with interaction_handoff(b, lease, task=task_b, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=key,
+                expires_at=_now() + timedelta(minutes=15),
+            )
+        b.commit()
+
+        task_a = a.get(Task, task_id)
+        _mark_caller_write(a, task_id, "pg-sp2-write")
+        with interaction_handoff(a, lease, task=task_a, anchor=anchor, now=_now()) as h:
+            result = h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=key,
+                expires_at=_now() + timedelta(minutes=15),
+            )
+        a.commit()
+        assert result.created is False
+        assert _caller_write_survived(a, task_id, "pg-sp2-write")
+    finally:
+        a.close()
+        b.close()
+
+
+def test_sp3_clean_stage_commits_with_caller(db_session, fixtures) -> None:
+    task_id, anchor_id = fixtures
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    db = db_session
+    task = db.get(Task, task_id)
+    _mark_caller_write(db, task_id, "pg-sp3-write")
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        result = h.stage(
+            kind="clarification",
+            protocol_version=1,
+            request_payload={"prompt": "p"},
+            request_idempotency_key=_next_key(),
+            expires_at=_now() + timedelta(minutes=15),
+        )
+    db.commit()
+    assert _caller_write_survived(db, task_id, "pg-sp3-write")
+    row = db.get(TaskInteractionRequest, result.staged_db_id)
+    assert row is not None
+
+
+def test_sp4_all_three_cells_preserve_callers_pending_write(
+    session_factory, fixtures
+) -> None:
+    """The caller's pre-with pending write survives all three savepoint
+    exit shapes: rollback-on-exception (slot-taken), commit-on-success, and
+    commit-on-REPLAY-after-conflict -- run back to back on independent rows
+    so a leak in any one cell cannot mask another."""
+
+    task_id, anchor_id = fixtures
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+
+    for label in ("slot-taken", "clean", "replay"):
+        db = session_factory()
+        try:
+            key = _next_key()
+            if label == "slot-taken":
+                stage_interaction_request(
+                    db,
+                    task_id=task_id,
+                    **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
+                )
+                db.commit()
+            elif label == "replay":
+                stage_interaction_request(
+                    db,
+                    task_id=task_id,
+                    **_stage_kwargs(anchor, request_idempotency_key=key),
+                )
+                db.commit()
+
+            task = db.get(Task, task_id)
+            _mark_caller_write(db, task_id, f"pg-sp4-{label}")
+            with interaction_handoff(
+                db, lease, task=task, anchor=anchor, now=_now()
+            ) as h:
+                h.stage(
+                    kind="clarification",
+                    protocol_version=1,
+                    request_payload={"prompt": "p"},
+                    request_idempotency_key=key,
+                    expires_at=_now() + timedelta(minutes=15),
+                )
+            db.commit()
+            assert _caller_write_survived(db, task_id, f"pg-sp4-{label}")
+        finally:
+            db.close()
+        # Clear the active slot between iterations so each label starts clean.
+        cleanup = session_factory()
+        cleanup.execute(
+            sa.update(TaskInteractionRequest)
+            .where(
+                TaskInteractionRequest.task_id == task_id,
+                TaskInteractionRequest.active_slot.isnot(None),
+            )
+            .values(
+                status="terminated",
+                active_slot=None,
+                terminal_reason="deadline_elapsed",
+                terminated_at=_now(),
+            )
+        )
+        cleanup.commit()
+        cleanup.close()
+
+
+def test_sp5_integrity_error_poisons_transaction_until_savepoint_rollback(
+    db_session, fixtures
+) -> None:
+    """PostgreSQL-only: an uncaught IntegrityError poisons the rest of the
+    transaction (InFailedSqlTransaction) until something rolls back to the
+    savepoint open when it fired. Confirms the primitive's own inner
+    savepoint is what makes the post-conflict re-check (step 7) possible at
+    all on this backend -- without it, the very next statement issued would
+    surface as InFailedSqlTransaction (sqlalchemy.exc.InternalError) instead of running."""
+
+    task_id, anchor_id = fixtures
+    anchor = _anchor(anchor_id)
+    db = db_session
+    key = _next_key()
+
+    stage_interaction_request(
+        db,
+        task_id=task_id,
+        **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
+    )
+    db.commit()
+
+    # Manually reproduce the primitive's own inner-savepoint discipline to
+    # observe the raw backend behavior: without a savepoint, the INSERT's
+    # IntegrityError poisons the transaction and the very next statement
+    # fails with InFailedSqlTransaction.
+    row = {
+        "task_id": task_id,
+        "run_id": "run-a",
+        "kind": "clarification",
+        "protocol_version": 1,
+        "status": "active",
+        "active_slot": 1,
+        "origin": "internal",
+        "request_payload": {"prompt": "p"},
+        "response_payload": None,
+        "request_idempotency_key": key,
+        "resume_trace_event_id": anchor_id,
+        "resume_event_id": "resume-event-1",
+        "resume_execution_id": "resume-exec-1",
+        "resume_locator_format": "trace_event_pk_v1",
+        "resume_checkpoint_type": "agent_execution_checkpoint",
+        "resume_run_partition": "run-a",
+        "responder_user_id": None,
+        "responder_identity": None,
+        "terminal_reason": None,
+        "expires_at": _now() + timedelta(minutes=15),
+        "responded_at": None,
+        "terminated_at": None,
+    }
+    with pytest.raises(IntegrityError):
+        db.execute(sa.insert(TaskInteractionRequest).values(**row))
+        db.flush()
+    with pytest.raises(InternalError):
+        db.execute(
+            _identity_lookup_stmt(
+                task_id=task_id, run_id="run-a", request_idempotency_key=key
+            )
+        ).first()
+    db.rollback()
+
+    # The primitive's own inner savepoint avoids exactly this poisoning: a
+    # SlotTaken conflict on the INSERT (the first row staged above still
+    # holds the active slot) rolls back only to its own inner savepoint,
+    # and the session is immediately usable again -- the failure this test
+    # exists to contrast with.
+    with pytest.raises(InteractionSlotTaken):
+        stage_interaction_request(
+            db,
+            task_id=task_id,
+            **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
+        )
+    db.rollback()
+    still_usable = db.execute(
+        _identity_lookup_stmt(
+            task_id=task_id, run_id="run-a", request_idempotency_key=key
+        )
+    ).first()
+    assert still_usable is None

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -209,6 +209,52 @@ def _force_next_identity_select_to_miss(
     return state
 
 
+def test_p_over_length_run_id_rejected_before_sql_via_handoff(
+    engine, db_session, fixtures
+) -> None:
+    """A run_id longer than its column (VARCHAR(64)) must never reach SQL:
+    on PostgreSQL an over-length value would raise DataError, not
+    IntegrityError, so the conflict classifier in
+    stage_interaction_request's own except IntegrityError block would never
+    see it, and DataError is not in _SWALLOWED either, so it would escape
+    interaction_handoff entirely. The Python-side length check in
+    _validate_request_fields must preempt that by rejecting with ValueError
+    before any statement (besides the CM's own SAVEPOINT) is issued.
+
+    The anchor's own resume_run_partition is left short and valid on
+    purpose: only the lease's run_id is over-length here, so the failure
+    exercised is _validate_request_fields's own run_id-length check, not
+    _assert_anchor_consistent's anchor-field check (which runs first, inside
+    handoff.stage(), and would otherwise mask this one if both were long)."""
+
+    task_id, anchor_id = fixtures
+    long_run_id = "x" * 65
+    anchor = _anchor(anchor_id)
+    lease = TaskLease(
+        task_id=task_id, runner_id="runner-1", run_id=long_run_id, attempt_id=None
+    )
+    db = db_session
+    task = db.get(Task, task_id)
+
+    statements = _count_cursor_executions(engine)
+    before = len(statements)
+    with pytest.raises(ValueError) as excinfo:
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload={"prompt": "p"},
+                request_idempotency_key=_next_key(),
+                expires_at=_now() + timedelta(minutes=15),
+            )
+    assert "64" in str(excinfo.value)
+    issued = statements[before:]
+    assert not any(
+        s.strip().upper().startswith(("INSERT", "UPDATE")) for s in issued
+    ), issued
+    db.rollback()
+
+
 def test_sp1_slot_taken_rolls_back_cleanly(db_session, fixtures) -> None:
     task_id, anchor_id = fixtures
     anchor = _anchor(anchor_id)

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -66,6 +66,8 @@ from xagent.web.services.task_lease_service import TaskLease
 
 _key_counter = count()
 
+pytestmark = pytest.mark.postgresql
+
 
 @pytest.fixture()
 def engine():

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -1,8 +1,8 @@
 """Savepoint containment (T-SP group) on PostgreSQL.
 
 Companion to test_interaction_staging.py, which carries every other group
-(T-P, T-CM, T-GATE) plus its own copy of T-SP for SQLite. Per this PR's own
-cut-line decision: T-P validates Python-side validation and statement
+(T-P, T-CM, T-GATE) plus its own copy of T-SP for SQLite. Per this suite's
+own cut-line decision: T-P validates Python-side validation and statement
 sequencing, both dialect-independent; the full 23-CHECK constraint set is
 already pinned on both backends by test_task_interaction_schema.py /
 test_task_interaction_schema_postgresql.py (50 PostgreSQL tests), so
@@ -17,15 +17,14 @@ does not.
 Fixture pattern: originally the same init_db + Base.metadata.drop_all/
 create_all against the whole XAGENT_TEST_POSTGRES_URL database that
 test_task_interaction_schema_postgresql.py uses -- an existing convention,
-not invented for this PR. Switched to a disposable, uniquely-named schema
-instead (CREATE SCHEMA / DROP SCHEMA CASCADE, matching this PR's own design
-audit probes -- see task_interaction_staging.py's module history) after
-init_db()'s automatic-upgrade check started failing here with the shared
-XAGENT_TEST_POSTGRES_URL database's alembic_version stamped to a migration
-this worktree doesn't recognize (confirmed independent of this PR: the
-same failure reproduces against test_task_interaction_schema_postgresql.py
-unchanged). That table lives in the database's default schema, is global
-to the whole server-side database, and is not itself disposable -- another
+not invented here. Switched to a disposable, uniquely-named schema instead
+(CREATE SCHEMA / DROP SCHEMA CASCADE) after init_db()'s automatic-upgrade
+check started failing here with the shared XAGENT_TEST_POSTGRES_URL
+database's alembic_version stamped to a migration this worktree doesn't
+recognize (confirmed independently: the same failure reproduces against
+test_task_interaction_schema_postgresql.py unchanged). That table lives in
+the database's default schema, is global to the whole server-side database,
+and is not itself disposable -- another
 worktree pointed at the same local Postgres instance had stamped it while
 running its own migrations. Base.metadata.create_all() against a private
 schema never touches alembic_version at all, sidestepping that contention

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -556,7 +556,12 @@ def test_sp5_integrity_error_poisons_transaction_until_savepoint_rollback(
             task_id=task_id,
             **_stage_kwargs(anchor, request_idempotency_key=_next_key()),
         )
-    db.rollback()
+    # No db.rollback() here, deliberately: the whole point of this second
+    # read is to prove the session is usable again on its own, right after
+    # InteractionSlotTaken, without the caller having to roll back first.
+    # An intervening rollback would make the read succeed regardless of
+    # whether the primitive's own inner savepoint actually contained the
+    # poisoning -- this assertion is only load-bearing without it.
     still_usable = db.execute(
         _identity_lookup_stmt(
             task_id=task_id, run_id="run-a", request_idempotency_key=key

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -396,7 +396,9 @@ def test_sp6_replay_after_conflict_via_insert_collision(
         a.close()
 
 
-def test_sp3_clean_stage_commits_with_caller(db_session, fixtures) -> None:
+def test_sp3_clean_stage_commits_with_caller(
+    db_session, session_factory, fixtures
+) -> None:
     task_id, anchor_id = fixtures
     anchor = _anchor(anchor_id)
     lease = _lease(task_id)
@@ -414,8 +416,15 @@ def test_sp3_clean_stage_commits_with_caller(db_session, fixtures) -> None:
         )
     db.commit()
     assert _caller_write_survived(db, task_id, "pg-sp3-write")
-    row = db.get(TaskInteractionRequest, result.staged_db_id)
+    # A fresh session, not db.get() on the same session that staged the row:
+    # the identity map would hand back the same in-memory object regardless
+    # of whether the row is actually durable on disk, so a same-session read
+    # here would be vacuous -- it could pass even if the commit above never
+    # made the row visible to anyone else.
+    other = session_factory()
+    row = other.get(TaskInteractionRequest, result.staged_db_id)
     assert row is not None
+    other.close()
 
 
 def test_sp4_all_three_cells_preserve_callers_pending_write(

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -289,9 +289,9 @@ def test_sp2_replay_after_conflict_commits_cleanly(session_factory, fixtures) ->
     its own step-3 pre-read, ``b`` has already committed, and READ
     COMMITTED gives that pre-read a fresh snapshot that sees ``b``'s row
     directly -- so this test pins the step-3 pre-read replay path, the same
-    one T-P-9 pins on SQLite, not step 7's post-conflict re-check. See
+    one T-P-9 pins on SQLite, not step 6's post-conflict re-check. See
     ``test_sp6_replay_after_conflict_via_insert_collision`` below for the
-    construction that reaches step 7 for real on this backend."""
+    construction that reaches step 6 for real on this backend."""
 
     task_id, anchor_id = fixtures
     anchor = _anchor(anchor_id)
@@ -342,7 +342,7 @@ def test_sp6_replay_after_conflict_via_insert_collision(
     """PostgreSQL counterpart of
     test_interaction_staging.py::test_p9b_replay_after_conflict_via_insert_collision
     -- see that test's docstring for the full mechanism. Confirmed by the
-    same poison-probe check: replacing step 7's REPLAY return with an
+    same poison-probe check: replacing step 6's REPLAY return with an
     unconditional raise leaves T-SP-2 above green but fails this test."""
 
     task_id, anchor_id = fixtures
@@ -499,7 +499,7 @@ def test_sp5_integrity_error_poisons_transaction_until_savepoint_rollback(
     """PostgreSQL-only: an uncaught IntegrityError poisons the rest of the
     transaction (InFailedSqlTransaction) until something rolls back to the
     savepoint open when it fired. Confirms the primitive's own inner
-    savepoint is what makes the post-conflict re-check (step 7) possible at
+    savepoint is what makes the post-conflict re-check (step 6) possible at
     all on this backend -- without it, the very next statement issued would
     surface as InFailedSqlTransaction (sqlalchemy.exc.InternalError) instead of running."""
 

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -43,6 +43,7 @@ from typing import Any
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError, InternalError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -170,6 +171,44 @@ def _caller_write_survived(db: Session, task_id: int, title: str) -> bool:
     )
 
 
+def _count_cursor_executions(engine: sa.Engine) -> list[str]:
+    statements: list[str] = []
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _count(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001, ARG001
+        statements.append(statement)
+
+    return statements
+
+
+def _force_next_identity_select_to_miss(
+    monkeypatch: pytest.MonkeyPatch, db: Session
+) -> dict[str, bool]:
+    """PostgreSQL counterpart of the same helper in test_interaction_staging.py
+    -- see that module for the full rationale. On this backend, READ
+    COMMITTED gives the loser's own step-3 pre-read a fresh per-statement
+    snapshot, so by the time it runs after the winner has committed, it
+    sees the winner's row directly, the same as on SQLite; this forces that
+    one read to miss instead, so the call proceeds into a real INSERT that
+    genuinely collides with the winner's committed row."""
+
+    original_execute = Session.execute
+    state = {"armed": True}
+
+    class _MissResult:
+        def first(self) -> None:
+            return None
+
+    def _patched(self: Session, statement: Any, *args: Any, **kwargs: Any) -> Any:
+        if self is db and state["armed"] and isinstance(statement, sa.Select):
+            state["armed"] = False
+            return _MissResult()
+        return original_execute(self, statement, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "execute", _patched)
+    return state
+
+
 def test_sp1_slot_taken_rolls_back_cleanly(db_session, fixtures) -> None:
     task_id, anchor_id = fixtures
     anchor = _anchor(anchor_id)
@@ -199,6 +238,16 @@ def test_sp1_slot_taken_rolls_back_cleanly(db_session, fixtures) -> None:
 
 
 def test_sp2_replay_after_conflict_commits_cleanly(session_factory, fixtures) -> None:
+    """``a``'s own pre-read below (before ``b`` commits) exists only to
+    open ``a``'s connection ahead of ``b``'s commit; it is not what decides
+    this test's path. By the time ``a``'s own ``h.stage()`` call below runs
+    its own step-3 pre-read, ``b`` has already committed, and READ
+    COMMITTED gives that pre-read a fresh snapshot that sees ``b``'s row
+    directly -- so this test pins the step-3 pre-read replay path, the same
+    one T-P-9 pins on SQLite, not step 7's post-conflict re-check. See
+    ``test_sp6_replay_after_conflict_via_insert_collision`` below for the
+    construction that reaches step 7 for real on this backend."""
+
     task_id, anchor_id = fixtures
     anchor = _anchor(anchor_id)
     lease = _lease(task_id)
@@ -240,6 +289,66 @@ def test_sp2_replay_after_conflict_commits_cleanly(session_factory, fixtures) ->
     finally:
         a.close()
         b.close()
+
+
+def test_sp6_replay_after_conflict_via_insert_collision(
+    engine, session_factory, fixtures, monkeypatch
+) -> None:
+    """PostgreSQL counterpart of
+    test_interaction_staging.py::test_p9b_replay_after_conflict_via_insert_collision
+    -- see that test's docstring for the full mechanism. Confirmed by the
+    same poison-probe check: replacing step 7's REPLAY return with an
+    unconditional raise leaves T-SP-2 above green but fails this test."""
+
+    task_id, anchor_id = fixtures
+    anchor = _anchor(anchor_id)
+    key = _next_key()
+
+    statements = _count_cursor_executions(engine)
+
+    b = session_factory()
+    b_result = stage_interaction_request(
+        b, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+    )
+    b.commit()
+    b.close()
+    assert b_result.created is True
+
+    a = session_factory()
+    try:
+        _mark_caller_write(a, task_id, "pg-sp6-write")
+
+        _force_next_identity_select_to_miss(monkeypatch, a)
+        before = len(statements)
+        a_result = stage_interaction_request(
+            a, task_id=task_id, **_stage_kwargs(anchor, request_idempotency_key=key)
+        )
+        issued = statements[before:]
+
+        insert_count = sum(1 for s in issued if s.strip().upper().startswith("INSERT"))
+        assert insert_count == 1, issued
+        assert any("ROLLBACK TO SAVEPOINT" in s.upper() for s in issued), issued
+        assert not any("RELEASE SAVEPOINT" in s.upper() for s in issued), issued
+
+        assert a_result.created is False
+        assert a_result.staged_db_id == b_result.staged_db_id
+        assert a_result.status == "active"
+        assert a_result.active_slot == b_result.active_slot
+
+        a.commit()
+        assert _caller_write_survived(a, task_id, "pg-sp6-write")
+
+        row_count = a.execute(
+            sa.select(sa.func.count())
+            .select_from(TaskInteractionRequest)
+            .where(
+                TaskInteractionRequest.task_id == task_id,
+                TaskInteractionRequest.request_idempotency_key == key,
+            )
+        ).scalar_one()
+        assert row_count == 1, "A's own losing INSERT must not leave a second row"
+    finally:
+        a.close()
 
 
 def test_sp3_clean_stage_commits_with_caller(db_session, fixtures) -> None:

--- a/tests/web/services/test_interaction_staging_production_gate.py
+++ b/tests/web/services/test_interaction_staging_production_gate.py
@@ -22,7 +22,7 @@ own docstrings and this module's own definitions of the two gated names,
 forcing every future mention of ``stage_interaction_request`` or
 ``interaction_handoff`` in prose to dodge the scanner. See
 ``test_trace_event_staging.py::test_trace_event_staging_module_sends_no_notifications``
-for the precedent this follows -- PR-A's own review moved that check from
+for the precedent this follows -- the trace staging work moved that check from
 substring to AST for the identical reason.
 """
 

--- a/tests/web/services/test_interaction_staging_production_gate.py
+++ b/tests/web/services/test_interaction_staging_production_gate.py
@@ -1,0 +1,197 @@
+"""Zero-production-caller gate for ``stage_interaction_request`` and
+``interaction_handoff``.
+
+Because the delivery series intentionally ships the table with no production
+writer and no production reader, a static test asserts exactly that: no
+production code path calls the interaction staging primitive or the handoff
+context manager. The gate exists so the table cannot be half-wired -- a task
+that reports "waiting" with no answerable question, or an answerable question
+the readers cannot see, is worse than a table nothing uses yet.
+
+The gate is removable only by the change that wires all three finalizers, adds
+the Task-side protocol marker, and switches the read surface together. Removing
+it piecemeal recreates the divergence it was written to prevent.
+
+Being on the wiring batch's list of changes to make together does not, on its
+own, grant permission to remove this gate: the condition above -- all three
+finalizers, the protocol marker, and the read surface, together, in one
+change -- is what actually retires it, not mere membership in that batch.
+
+AST, not substring grep: a source-text scan would also match this test file's
+own docstrings and this module's own definitions of the two gated names,
+forcing every future mention of ``stage_interaction_request`` or
+``interaction_handoff`` in prose to dodge the scanner. See
+``test_trace_event_staging.py::test_trace_event_staging_module_sends_no_notifications``
+for the precedent this follows -- PR-A's own review moved that check from
+substring to AST for the identical reason.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import xagent
+from xagent.web.services import (  # noqa: F401 -- negative control import
+    task_interaction_staging as staging,
+)
+
+GATED_NAMES = frozenset({"stage_interaction_request", "interaction_handoff"})
+PRIMITIVE_MODULE = "task_interaction_staging"
+
+
+def _production_uses(source: str) -> set[str]:
+    """Gated names this module imports or calls."""
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.ImportFrom):
+            # Two independent forms, not one gated by the other:
+            # ``from ...task_interaction_staging import stage_interaction_request``
+            # (module path ends with the primitive's module name) versus
+            # ``from ...services import task_interaction_staging`` (the
+            # module name is imported, from its *parent* package -- gating
+            # this on the same module-path check would never fire, since
+            # the parent package's own path does not end with
+            # "task_interaction_staging").
+            if (node.module or "").split(".")[-1] == PRIMITIVE_MODULE:
+                found.update(a.name for a in node.names if a.name in GATED_NAMES)
+            found.update(a.name for a in node.names if a.name == PRIMITIVE_MODULE)
+        elif isinstance(node, ast.Import):
+            found.update(
+                a.name.split(".")[-1]
+                for a in node.names
+                if a.name.split(".")[-1] == PRIMITIVE_MODULE
+            )
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in GATED_NAMES:
+                found.add(func.id)
+            elif isinstance(func, ast.Attribute) and func.attr in GATED_NAMES:
+                found.add(func.attr)
+    return found
+
+
+def _production_modules() -> list[Path]:
+    """Every source file under the installed xagent package, excluding the
+    primitive's own definition module. Walked from the package's own
+    __path__, not a hardcoded ``src/`` path -- a hardcoded path would scan an
+    empty directory once this package is installed as a wheel, passing this
+    gate for the wrong reason (nothing to scan) instead of the right one
+    (nothing found). ``xagent.__file__`` itself is ``None`` -- the top-level
+    package is a namespace package with no ``__init__.py`` -- so this walks
+    ``__path__`` instead, which every package (namespace or regular) has."""
+
+    root = Path(next(iter(xagent.__path__)))
+    return [path for path in root.rglob("*.py") if path.stem != PRIMITIVE_MODULE]
+
+
+# --------------------------------------------------------------------------
+# T-GATE-1: the gate itself
+# --------------------------------------------------------------------------
+
+
+def test_no_production_module_imports_or_calls_the_gated_names() -> None:
+    offenders: dict[str, set[str]] = {}
+    for path in _production_modules():
+        uses = _production_uses(path.read_text())
+        if uses:
+            offenders[str(path)] = uses
+    assert offenders == {}, offenders
+
+
+# --------------------------------------------------------------------------
+# T-GATE-2: positive controls -- three import/call shapes, each must be
+# individually detected
+# --------------------------------------------------------------------------
+
+
+def test_detects_from_import_and_direct_call() -> None:
+    source = textwrap.dedent(
+        """
+        from xagent.web.services.task_interaction_staging import stage_interaction_request
+
+        def handler(db, **kwargs):
+            return stage_interaction_request(db, **kwargs)
+        """
+    )
+    assert _production_uses(source) == {"stage_interaction_request"}
+
+
+def test_detects_context_manager_call_by_name() -> None:
+    source = textwrap.dedent(
+        """
+        from xagent.web.services.task_interaction_staging import interaction_handoff
+
+        def handler(db, lease, task, anchor, now):
+            with interaction_handoff(db, lease, task=task, anchor=anchor, now=now) as h:
+                pass
+        """
+    )
+    assert _production_uses(source) == {"interaction_handoff"}
+
+
+def test_detects_module_import_and_attribute_call() -> None:
+    source = textwrap.dedent(
+        """
+        from xagent.web.services import task_interaction_staging
+
+        def handler(db, **kwargs):
+            return task_interaction_staging.stage_interaction_request(db, **kwargs)
+        """
+    )
+    uses = _production_uses(source)
+    assert "task_interaction_staging" in uses
+    assert "stage_interaction_request" in uses
+
+
+def test_detects_bare_module_import() -> None:
+    source = "import xagent.web.services.task_interaction_staging\n"
+    assert _production_uses(source) == {"task_interaction_staging"}
+
+
+# --------------------------------------------------------------------------
+# T-GATE-3: negative controls -- test consumers and the module's own
+# definitions must not be flagged
+# --------------------------------------------------------------------------
+
+
+def test_test_module_consumers_are_not_flagged() -> None:
+    """Test consumers are allowed: this file, and every other test module
+    that imports the two gated names (``test_interaction_staging.py``, this
+    file's own negative-control import above), live under ``tests/``, which
+    ``_production_modules`` never walks -- it starts from ``xagent.__path__``
+    (``src/xagent``), not the repository root. The scanner (``_production_uses``)
+    is a generic AST function that would legitimately find those imports if
+    pointed at a test file directly (already exercised by T-GATE-2); what
+    makes test consumption safe is the *scan set*, not the scanner being
+    unable to see it. This test pins that boundary directly, on the real
+    scan set, rather than re-deriving it from a synthetic source string."""
+
+    scanned = {str(path) for path in _production_modules()}
+    this_file = str(Path(__file__).resolve())
+    assert this_file not in scanned
+    assert all("/tests/" not in path for path in scanned)
+
+
+def test_primitive_module_itself_is_not_flagged() -> None:
+    """The primitive module's own body -- definitions, its one internal call
+    from ``_InteractionHandoff.stage()`` to ``stage_interaction_request``,
+    and its docstrings mentioning both names in prose -- must not trip the
+    gate. ``_production_modules()`` excludes it by filename; this test pins
+    that exclusion rather than re-deriving it."""
+
+    from xagent.web.services import task_interaction_staging as module
+
+    modules = _production_modules()
+    assert all(path.stem != "task_interaction_staging" for path in modules)
+    # Also confirm the module's own source, scanned directly, DOES contain a
+    # gated name (stage_interaction_request, called by name from
+    # _InteractionHandoff.stage()) -- proving the filename exclusion is
+    # doing real work, not vacuously passing because the file has nothing
+    # for the scanner to find. interaction_handoff itself is never called
+    # from within its own module (only entered via a caller's `with`), so
+    # it does not appear here the same way -- that asymmetry is expected,
+    # not a gap in the scanner.
+    own_source = Path(module.__file__).read_text()
+    assert "stage_interaction_request" in _production_uses(own_source)

--- a/tests/web/services/test_interaction_staging_production_gate.py
+++ b/tests/web/services/test_interaction_staging_production_gate.py
@@ -26,9 +26,26 @@ forcing every future mention of ``stage_interaction_request`` or
 for the precedent this follows -- the trace staging work moved that check from
 substring to AST for the identical reason.
 
-Dynamic access is out of scope: ``importlib.import_module(...)`` plus
-``getattr(...)`` matches none of the node shapes above. The gate pins the
-ordinary import-and-call surface, not every conceivable route.
+Known blind spots, not fixed here because closing them is out of scope for
+a static AST scan of one package tree:
+
+(a) Dynamic access: ``importlib.import_module(...)`` plus ``getattr(...)``
+    matches none of the node shapes above. The gate pins the ordinary
+    import-and-call surface, not every conceivable route.
+(b) A gated name reached through an alias chain the AST walk does not
+    resolve -- e.g. re-exporting ``stage_interaction_request`` under a
+    different name from a third module and importing *that* name
+    elsewhere. ``_production_uses`` matches names as written, not values
+    traced through re-assignment.
+(c) The primitive-module exclusion in ``_production_modules`` is
+    stem-keyed (``path.stem != PRIMITIVE_MODULE``), not path-keyed: any
+    other file anywhere under this package that happened to also be named
+    ``task_interaction_staging.py`` would be excluded from the scan right
+    alongside the real one, on filename alone.
+(d) The scan root is ``xagent.__path__`` (``src/xagent``), not the
+    repository root -- a caller under the top-level ``scripts/`` directory
+    (outside that tree) is invisible to this gate entirely, positive
+    controls and all.
 """
 
 from __future__ import annotations
@@ -61,6 +78,16 @@ def _production_uses(source: str) -> set[str]:
             # "task_interaction_staging").
             if (node.module or "").split(".")[-1] == PRIMITIVE_MODULE:
                 found.update(a.name for a in node.names if a.name in GATED_NAMES)
+                # ``from ...task_interaction_staging import *`` names neither
+                # gated name explicitly -- the loop above finds nothing --
+                # but it binds both of them into the importing module's
+                # namespace all the same. Scoped to a module-path match
+                # (not every star import in the codebase, which says
+                # nothing about this primitive at all): both gated names
+                # count as found whenever this specific module is the one
+                # being star-imported.
+                if any(a.name == "*" for a in node.names):
+                    found.update(GATED_NAMES)
             found.update(a.name for a in node.names if a.name == PRIMITIVE_MODULE)
         elif isinstance(node, ast.Import):
             found.update(
@@ -88,7 +115,15 @@ def _production_modules() -> list[Path]:
     ``__path__`` instead, which every package (namespace or regular) has."""
 
     root = Path(next(iter(xagent.__path__)))
-    return [path for path in root.rglob("*.py") if path.stem != PRIMITIVE_MODULE]
+    modules = [path for path in root.rglob("*.py") if path.stem != PRIMITIVE_MODULE]
+    # A scan set that came back empty would make test_no_production_module_
+    # imports_or_calls_the_gated_names pass vacuously -- offenders would stay
+    # {} not because nothing was found, but because nothing was scanned.
+    # xagent.__path__ resolving to the wrong root (a packaging change, a
+    # broken install) is exactly the failure mode this catches before it
+    # can masquerade as "gate still clean".
+    assert modules, "production scan set is empty"
+    return modules
 
 
 # --------------------------------------------------------------------------
@@ -153,6 +188,18 @@ def test_detects_module_import_and_attribute_call() -> None:
 def test_detects_bare_module_import() -> None:
     source = "import xagent.web.services.task_interaction_staging\n"
     assert _production_uses(source) == {"task_interaction_staging"}
+
+
+def test_detects_star_import() -> None:
+    """``from ...task_interaction_staging import *`` names neither gated
+    name in its own ``ast.ImportFrom.names`` list -- a plain per-alias scan
+    finds nothing there and would let this shape through as a false
+    negative, even though it binds both names into the importing module's
+    namespace. No call site is needed to expose the gap: the import alone
+    must report both gated names found."""
+
+    source = "from xagent.web.services.task_interaction_staging import *\n"
+    assert _production_uses(source) == GATED_NAMES
 
 
 # --------------------------------------------------------------------------

--- a/tests/web/services/test_interaction_staging_production_gate.py
+++ b/tests/web/services/test_interaction_staging_production_gate.py
@@ -253,3 +253,61 @@ def test_primitive_module_itself_is_not_flagged() -> None:
     # not a gap in the scanner.
     own_source = Path(module.__file__).read_text(encoding="utf-8")
     assert "stage_interaction_request" in _production_uses(own_source)
+
+
+def test_staging_module_defines_no_second_vocabulary_copy() -> None:
+    """The staging module must consume the model's column-domain constants,
+    never redeclare them. The merge-order rule for the origin vocabulary is
+    that the model owns the one literal list (INTERACTION_ORIGIN_VOCABULARY,
+    INTERACTION_PROTOCOL_VERSION); every other surface derives from it. This
+    guard fails if task_interaction_staging.py grows its own literal set,
+    tuple, or list re-enumerating vocabulary members, its own integer
+    protocol-version constant, or an inline origin-normalization function --
+    each of which would be a drift-capable second copy.
+    """
+    import xagent.web.services.task_interaction_staging as staging_module
+
+    source = Path(staging_module.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    from xagent.web.models.task_interaction import INTERACTION_ORIGIN_VOCABULARY
+
+    for node in ast.walk(tree):
+        # No literal collection may re-enumerate origin vocabulary members.
+        if isinstance(node, (ast.Set, ast.Tuple, ast.List)):
+            literals = {
+                el.value
+                for el in node.elts
+                if isinstance(el, ast.Constant) and isinstance(el.value, str)
+            }
+            overlap = literals & INTERACTION_ORIGIN_VOCABULARY
+            assert not overlap, (
+                f"literal collection re-enumerates origin vocabulary members "
+                f"{sorted(overlap)}; derive from the model's "
+                f"INTERACTION_ORIGIN_VOCABULARY instead"
+            )
+        # No inline origin-normalization logic.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            name = node.name.lower()
+            assert not ("normalize" in name and "origin" in name), (
+                f"{node.name} looks like inline origin normalization; the "
+                "model module owns normalize_interaction_origin"
+            )
+    # _PROTOCOL_VERSION and _ORIGIN_VOCABULARY must be Name-aliases of the
+    # model's constants, not fresh literals.
+    aliases = {
+        target.id: node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+        and target.id in {"_PROTOCOL_VERSION", "_ORIGIN_VOCABULARY"}
+    }
+    assert set(aliases) == {"_PROTOCOL_VERSION", "_ORIGIN_VOCABULARY"}
+    for name, value in aliases.items():
+        assert isinstance(value, ast.Name), (
+            f"{name} must alias the model's constant by name, got "
+            f"{ast.dump(value)[:80]}"
+        )
+    assert aliases["_ORIGIN_VOCABULARY"].id == "INTERACTION_ORIGIN_VOCABULARY"
+    assert aliases["_PROTOCOL_VERSION"].id == "INTERACTION_PROTOCOL_VERSION"

--- a/tests/web/services/test_interaction_staging_production_gate.py
+++ b/tests/web/services/test_interaction_staging_production_gate.py
@@ -134,7 +134,13 @@ def _production_modules() -> list[Path]:
 def test_no_production_module_imports_or_calls_the_gated_names() -> None:
     offenders: dict[str, set[str]] = {}
     for path in _production_modules():
-        uses = _production_uses(path.read_text())
+        try:
+            source = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(
+                f"{path}: not valid UTF-8, cannot be AST-scanned by this gate"
+            ) from exc
+        uses = _production_uses(source)
         if uses:
             offenders[str(path)] = uses
     assert offenders == {}, offenders
@@ -245,5 +251,5 @@ def test_primitive_module_itself_is_not_flagged() -> None:
     # from within its own module (only entered via a caller's `with`), so
     # it does not appear here the same way -- that asymmetry is expected,
     # not a gap in the scanner.
-    own_source = Path(module.__file__).read_text()
+    own_source = Path(module.__file__).read_text(encoding="utf-8")
     assert "stage_interaction_request" in _production_uses(own_source)

--- a/tests/web/services/test_interaction_staging_production_gate.py
+++ b/tests/web/services/test_interaction_staging_production_gate.py
@@ -12,10 +12,11 @@ The gate is removable only by the change that wires all three finalizers, adds
 the Task-side protocol marker, and switches the read surface together. Removing
 it piecemeal recreates the divergence it was written to prevent.
 
-Being on the wiring batch's list of changes to make together does not, on its
-own, grant permission to remove this gate: the condition above -- all three
-finalizers, the protocol marker, and the read surface, together, in one
-change -- is what actually retires it, not mere membership in that batch.
+Being part of the change that wires the first production caller does not, on
+its own, grant permission to remove this gate: the condition above -- all
+three finalizers, the protocol marker, and the read surface, together, in
+one change -- is what actually retires it, not mere membership in that
+change.
 
 AST, not substring grep: a source-text scan would also match this test file's
 own docstrings and this module's own definitions of the two gated names,
@@ -24,6 +25,10 @@ forcing every future mention of ``stage_interaction_request`` or
 ``test_trace_event_staging.py::test_trace_event_staging_module_sends_no_notifications``
 for the precedent this follows -- the trace staging work moved that check from
 substring to AST for the identical reason.
+
+Dynamic access is out of scope: ``importlib.import_module(...)`` plus
+``getattr(...)`` matches none of the node shapes above. The gate pins the
+ordinary import-and-call surface, not every conceivable route.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

Adds the write-side primitives for structured task interactions, with no production caller:

- **`stage_interaction_request`** — stages one interaction row inside a caller-owned transaction. It validates in Python before touching SQL (roughly thirty pure-Python precondition checks: TTL positivity, payload presence, identity-key shape, anchor consistency against the asking run, and the rest of the input space), reclaims a stale active row in the same statement shape the constraints demand (termination writes its status and timestamp together), and inserts under its own inner savepoint so a slot conflict can be re-checked and classified without poisoning the caller's transaction. Integrity errors are classified, not collapsed: a same-run replay returns the existing row, a genuine slot conflict is reported as such, and the two foreign-key cells that Python cannot pre-check are documented rather than guessed at.
- **`interaction_handoff`** — the context manager a finalizer will one day wrap around its existing transaction. Six failure classes degrade (the interaction row is skipped, the caller's own writes and commit proceed untouched); everything else propagates. The attempt-identity and anchor-consistency checks run at the start of `stage()` rather than at `with`-entry: a context manager cannot skip its body, and a pre-`yield` raise inside a generator-based context manager either propagates unswallowed or surfaces as `RuntimeError("generator didn't yield")` — a dedicated test pins that code after the `with` block still executes after every degraded cell.
- A run-partition mismatch between the asking lease and the resume anchor is one of the degrading classes, with its own operations signal: it means the checkpoint identity is suspect, so the row must not be written — but the corruption is deterministic, so failing the turn would fail every retry of it. The first wiring change must re-adjudicate this policy with real reachability data.

## Why there is no caller

The table's issue requires the runtime half of its fail-closed rule to exist before any consumer wires in; the wiring itself (three finalizers, the task-side protocol marker, and the read surface) must land together, and a static test enforces exactly that: no production module imports or calls these primitives. Removing that gate piecemeal would recreate the divergence it prevents — a task that reports waiting with no answerable question, or an answerable question no reader can see. The gate's removal condition matches the boundary recorded on #1074.

This PR does not close #1074. Neither does the series it belongs to: the existing-table field pairs and the datetime read-back half remain open there.

## One workaround, disclosed

On SQLite, opening a savepoint as a session's first write-adjacent statement leaves pysqlite's transaction tracking in a state where a later `Session.rollback()` silently fails to undo the write. The primitive guards this with one scoped dummy DML statement before the savepoint opens. The standard SQLAlchemy pysqlite recipe (taking over `BEGIN` emission) was tried and rejected with measurement: it breaks the two-session busy-snapshot race that conflict re-checking depends on, and that failure is not retriable. The reproduction, the rejected alternative, and the reasons live in the code next to the guard; the wiring batch should revisit whether the engine-level fix has become viable.

## Verification

- Six-cell degradation matrix (six swallowed classes plus replay-after-conflict) on SQLite; PostgreSQL re-runs savepoint containment, the slot-taken cell, and both replay paths; caller-code-after-`with` execution pinned on two of the six cells.
- Each fix in this series was verified by removing it and confirming the suite goes red; those runs are session records, not a harness in this tree. Examples include: reverting the inner savepoint to the shared one (both backends' cells and the exit matrix go red), moving the precondition checks after the savepoint work, removing the SQLite guard statement, and weakening each classification branch.
- Statement shapes audited against the live constraint set (23 CHECKs); no assertion binds to backend-specific constraint-name reporting; all statements built with bound parameters.
- The static no-production-caller gate covers both import forms and the call path; suite green alongside the existing schema, lease, checkpoint, and trace suites.

## Size

Two thirds of the diff is tests: the degradation matrix runs every cell on both backends, each validation rule carries a zero-SQL rejection pin, and two real bugs found while building (the context-manager pre-`yield` limitation and the SQLite first-statement savepoint behavior) each carry their own regression tests. The module itself is docstring-dense on purpose — it is the first-hand contract for the wiring work that follows, so it explains its transaction contract, degradation semantics, and each exception's meaning in full rather than tersely.




