### PR TITLE
fix(share): stamp both entity markers on share task-create (#1132)

### DIFF
--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -1118,10 +1118,15 @@ async def create_share_chat_task(
     # independent of the sanitizer's reserved-key set.
     #
     # The workforce marker is a literal None rather than a context read because
-    # this branch is unreachable with a workforce: create_share_chat_task
-    # early-returns into _create_workforce_share_chat_task whenever
-    # access_context.workforce is set. If that dispatch is ever restructured,
-    # this literal becomes a lie — derive it from the context instead.
+    # the dispatch above already guarantees it: this branch is reached only
+    # after the early return into _create_workforce_share_chat_task, so
+    # access_context.workforce is None here. That guard is what keeps the
+    # literal honest — preserve it rather than re-deriving the value here.
+    # Reading the id off the context instead would be actively wrong: this
+    # branch builds an *agent* task (agent_id=share_agent_id below), and
+    # entity_rate_limit_key prefers workforce whenever both markers are set,
+    # so a non-None workforce id would charge an agent-share run to a
+    # workforce bucket — the exact misattribution this stamping prevents.
     agent_config["share_agent_id"] = share_agent_id
     agent_config["share_workforce_id"] = None
 

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -1050,8 +1050,11 @@ async def _create_workforce_share_chat_task(
             # Null the agent marker for symmetry with the agent path (#1132),
             # mirroring the widget workforce branch: entity_rate_limit_key
             # prefers workforce, so a stray agent id would be ignored anyway,
-            # but stamping both keeps the run-quota key unambiguous and
-            # independent of merge ordering.
+            # but stamping both keeps the run-quota key unambiguous. Safe
+            # because the snapshot-built config never sets either marker --
+            # not because merge order is irrelevant: _merge_agent_config
+            # returns {**extra_agent_config, **task_config}, so the built
+            # config wins every collision and this dict loses.
             "share_agent_id": None,
             # Per-guest isolation (#973). extra_agent_config is overlaid under
             # the snapshot-built config, which never sets guest_id, so this is
@@ -1117,16 +1120,16 @@ async def create_share_chat_task(
     # already strips both, but stamping explicitly keeps this correct
     # independent of the sanitizer's reserved-key set.
     #
-    # The workforce marker is a literal None rather than a context read because
-    # the dispatch above already guarantees it: this branch is reached only
-    # after the early return into _create_workforce_share_chat_task, so
-    # access_context.workforce is None here. That guard is what keeps the
-    # literal honest — preserve it rather than re-deriving the value here.
-    # Reading the id off the context instead would be actively wrong: this
-    # branch builds an *agent* task (agent_id=share_agent_id below), and
-    # entity_rate_limit_key prefers workforce whenever both markers are set,
-    # so a non-None workforce id would charge an agent-share run to a
-    # workforce bucket — the exact misattribution this stamping prevents.
+    # The workforce marker is a literal None because the dispatch above forces
+    # it: this branch runs only after the early return into
+    # _create_workforce_share_chat_task, so access_context.workforce is None
+    # here and a context read would yield the same value today. Preserving that
+    # guard is what keeps the literal honest. If it were ever removed, a
+    # context read would not be the safe fallback it looks like: this branch
+    # builds an *agent* task (agent_id=share_agent_id below), and
+    # entity_rate_limit_key prefers workforce whenever both markers are set, so
+    # a non-None workforce id here would charge an agent-share run to a
+    # workforce bucket — the misattribution this stamping exists to prevent.
     agent_config["share_agent_id"] = share_agent_id
     agent_config["share_workforce_id"] = None
 

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -1047,6 +1047,12 @@ async def _create_workforce_share_chat_task(
         extra_agent_config={
             "auth_mode": "share",
             "share_workforce_id": int(workforce.id),
+            # Null the agent marker for symmetry with the agent path (#1132),
+            # mirroring the widget workforce branch: entity_rate_limit_key
+            # prefers workforce, so a stray agent id would be ignored anyway,
+            # but stamping both keeps the run-quota key unambiguous and
+            # independent of merge ordering.
+            "share_agent_id": None,
             # Per-guest isolation (#973). extra_agent_config is overlaid under
             # the snapshot-built config, which never sets guest_id, so this is
             # preserved; the run-critical workforce_run_id is added by the
@@ -1101,8 +1107,23 @@ async def create_share_chat_task(
     # on the validated access context (#973).
     agent_config = sanitize_client_agent_config(request.agent_config)
     agent_config["auth_mode"] = "share"
-    agent_config["share_agent_id"] = share_agent_id
     agent_config["guest_id"] = access_context.guest_id
+    # Stamp BOTH entity markers from the validated access context, writing the
+    # inapplicable one as None — the share-path counterpart of the widget
+    # stamping above (#1132). The share run quota keys off these at the
+    # execute_task chokepoint (chat.py) and entity_rate_limit_key prefers
+    # workforce, so a client-injected share_workforce_id must never survive to
+    # redirect an agent-share task's bucket onto a workforce. The sanitizer
+    # already strips both, but stamping explicitly keeps this correct
+    # independent of the sanitizer's reserved-key set.
+    #
+    # The workforce marker is a literal None rather than a context read because
+    # this branch is unreachable with a workforce: create_share_chat_task
+    # early-returns into _create_workforce_share_chat_task whenever
+    # access_context.workforce is set. If that dispatch is ever restructured,
+    # this literal becomes a lie — derive it from the context instead.
+    agent_config["share_agent_id"] = share_agent_id
+    agent_config["share_workforce_id"] = None
 
     task_title = request.title or task_description or "Untitled Task"
     if task_title and len(task_title) > 50:

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -162,8 +162,10 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 # (3) the widget/share workforce paths pass them as ``extra_agent_config=``
 # server literals, which ``_merge_agent_config`` places *under* the built
 # config, and the snapshot never sets these keys, so no client can win a
-# collision. The widget agent-create path additionally stamps both entity
-# markers explicitly (one as ``None``) as belt-and-suspenders.
+# collision. All four public task-create paths -- widget and share, agent and
+# workforce -- additionally stamp both of their channel's entity markers
+# explicitly (the inapplicable one as ``None``) as belt-and-suspenders, so
+# those boundaries stay correct even if this set changes (#1132).
 CLIENT_RESERVED_AGENT_CONFIG_KEYS: frozenset[str] = frozenset(
     {
         TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -453,6 +453,77 @@ def test_workforce_share_task_without_guest_id_is_denied(
     assert _upload_to_task(guest, task_id).status_code == 403
 
 
+def test_agent_share_task_create_ignores_client_injected_entity_markers() -> None:
+    """Share-path counterpart of
+    ``test_share_rate_limit_endpoints.py::
+    test_widget_task_create_ignores_client_injected_entity_markers`` (#1132).
+
+    An anonymous share guest must not be able to seed the identity/entity
+    markers of their own task: the share run quota reads them back as
+    authoritative at the ``execute_task`` chokepoint, and
+    ``entity_rate_limit_key`` prefers workforce over agent — so a forged
+    ``share_workforce_id`` on an agent-share task would redirect the bucket
+    onto an unrelated workforce. The server stamps both entity markers from
+    the validated access context, writing the inapplicable one as ``None``.
+    """
+    agent_id = _create_published_agent("Forged Marker Agent", "forged-marker-tok")
+    guest = _authenticate_share_guest("forged-marker-tok")
+
+    created = client.post(
+        "/api/share/chat/task/create",
+        headers=guest,
+        json={
+            "title": "forged",
+            "description": "forged",
+            "agent_config": {
+                # A forged workforce id would win over the real agent entity.
+                "share_workforce_id": 999999,
+                "share_agent_id": 888888,
+                "share_token": "forged",
+                "auth_mode": "widget",
+                "guest_id": "injected-guest",
+                # Widget-channel markers have no business on a share task
+                # either: they select the *widget* quota branch.
+                "widget_agent_id": 777777,
+                "widget_workforce_id": 666666,
+                "widget_client_ip": "1.2.3.4",
+                "keep_me": "client value",
+            },
+        },
+    )
+    assert created.status_code == 200, created.text
+    task_id = int(created.json()["task_id"])
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        cfg = task.agent_config
+        # Entity markers: server-stamped from the access context. Workforce is
+        # cleared to None on the agent path, so the forged id can never key the
+        # quota bucket; the agent id is the shared agent, not the injected one.
+        #
+        # Assert the key is *present and None*, not merely `.get(...) is None`:
+        # the sanitizer alone would leave it absent, which `.get` cannot
+        # distinguish from the stamp. Only membership pins the layer-2 stamp
+        # (#1132) — without it this test would pass on the sanitizer alone and
+        # silently stop guarding what it is named for.
+        assert "share_workforce_id" in cfg
+        assert cfg["share_workforce_id"] is None
+        assert cfg.get("share_agent_id") == agent_id
+        # Identity/quota markers: server values win, injected copies stripped.
+        assert cfg.get("auth_mode") == "share"
+        assert cfg.get("guest_id") == _share_guest_id(guest["Authorization"])
+        assert "share_token" not in cfg
+        assert "widget_agent_id" not in cfg
+        assert "widget_workforce_id" not in cfg
+        assert "widget_client_ip" not in cfg
+        # Non-reserved client keys still ride through this path (unlike the
+        # workforce branch below, which never reads the client body at all).
+        assert cfg.get("keep_me") == "client value"
+    finally:
+        db.close()
+
+
 def test_workforce_share_task_create_discards_forged_agent_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -481,6 +552,14 @@ def test_workforce_share_task_create_discards_forged_agent_config(
                     "memory_dimensions": {"tenant": "victim"},
                 },
                 SELECTED_FILE_IDS_AGENT_CONFIG_KEY: ["victim-file-id"],
+                # Entity/identity markers select the run-quota bucket at the
+                # execute_task chokepoint (#1132): a forged agent id would move
+                # this workforce run's charge onto an unrelated agent bucket.
+                "share_workforce_id": 999999,
+                "share_agent_id": 888888,
+                "share_token": "forged",
+                "auth_mode": "widget",
+                "guest_id": "injected-guest",
                 "keep_me": "client value",
             },
         },
@@ -498,6 +577,16 @@ def test_workforce_share_task_create_discards_forged_agent_config(
         assert task.agent_config.get("guest_id") == _share_guest_id(
             guest["Authorization"]
         )
+        # The handler's own extra_agent_config is the only source of the entity
+        # markers; the snapshot-built config never sets them, so nothing from
+        # the request body can win the merge. Both are stamped (the
+        # inapplicable one as None), so assert presence rather than absence —
+        # `not in` would pin the pre-#1132 asymmetric shape and break the day
+        # this branch reaches parity with the widget one.
+        assert task.agent_config.get("share_workforce_id") == workforce_id
+        assert "share_agent_id" in task.agent_config
+        assert task.agent_config["share_agent_id"] is None
+        assert "share_token" not in task.agent_config
     finally:
         db.close()
 

--- a/tests/web/api/test_share_guest_isolation.py
+++ b/tests/web/api/test_share_guest_isolation.py
@@ -531,9 +531,9 @@ def test_workforce_share_task_create_discards_forged_agent_config(
     ``_create_workforce_share_chat_task`` never reads
     ``TaskCreateRequest.agent_config`` -- ``create_workforce_run`` only sees
     the handler's own ``extra_agent_config`` (``auth_mode``,
-    ``share_workforce_id``, ``guest_id``). A forged reserved key in the
-    request body must not survive into the persisted config, and neither
-    should an ordinary client key."""
+    ``share_workforce_id``, ``share_agent_id``, ``guest_id``). A forged
+    reserved key in the request body must not survive into the persisted
+    config, and neither should an ordinary client key."""
     workforce_id = _create_workforce("Forged Config Share WF")
     token = _enable_workforce_share(workforce_id)
     guest = _authenticate_share_guest(token)
@@ -553,8 +553,11 @@ def test_workforce_share_task_create_discards_forged_agent_config(
                 },
                 SELECTED_FILE_IDS_AGENT_CONFIG_KEY: ["victim-file-id"],
                 # Entity/identity markers select the run-quota bucket at the
-                # execute_task chokepoint (#1132): a forged agent id would move
-                # this workforce run's charge onto an unrelated agent bucket.
+                # execute_task chokepoint (#1132). Two layers make a forged one
+                # inert here and both are worth pinning: this handler never
+                # reads the request body at all, and entity_rate_limit_key
+                # prefers workforce regardless, so a stray agent id could not
+                # move the charge even if it did land in the config.
                 "share_workforce_id": 999999,
                 "share_agent_id": 888888,
                 "share_token": "forged",
@@ -581,8 +584,8 @@ def test_workforce_share_task_create_discards_forged_agent_config(
         # markers; the snapshot-built config never sets them, so nothing from
         # the request body can win the merge. Both are stamped (the
         # inapplicable one as None), so assert presence rather than absence —
-        # `not in` would pin the pre-#1132 asymmetric shape and break the day
-        # this branch reaches parity with the widget one.
+        # `not in` would pin the pre-#1132 asymmetric shape this commit
+        # replaced when it brought the branch to parity with the widget one.
         assert task.agent_config.get("share_workforce_id") == workforce_id
         assert "share_agent_id" in task.agent_config
         assert task.agent_config["share_agent_id"] is None

--- a/tests/web/test_share_run_quota_gate.py
+++ b/tests/web/test_share_run_quota_gate.py
@@ -43,8 +43,11 @@ class _FakeAgentService:
         pass
 
 
-def _make_task(db_session, *, agent_config: dict) -> Task:
-    user = User(username="share-quota-user", password_hash="h", is_admin=False)
+def _make_task(
+    db_session, *, agent_config: dict, username: str = "share-quota-user"
+) -> Task:
+    # ``username`` is unique, so a test creating two tasks must vary it.
+    user = User(username=username, password_hash="h", is_admin=False)
     db_session.add(user)
     db_session.commit()
     task = Task(
@@ -112,6 +115,102 @@ async def test_share_run_quota_skips_non_share_task(
     )
 
     assert result.get("error_code") != "share_run_quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_share_run_quota_blocks_workforce_share_task(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Share mirror of ``test_widget_run_quota_blocks_workforce_widget_task``:
+    the workforce share marker keys the quota too.
+
+    Built in the shape ``_create_workforce_share_chat_task`` now persists
+    (#1132) -- ``share_agent_id`` present and ``None`` beside the real
+    ``share_workforce_id`` -- so the chokepoint is exercised against what the
+    handler actually writes, not a hand-trimmed config.
+    """
+    monkeypatch.setenv("XAGENT_SHARE_RUN_QUOTA", "0/day")
+    reset_share_rate_limiter()
+
+    task = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "share",
+            "guest_id": "wf-guest",
+            "share_workforce_id": 77,
+            "share_agent_id": None,
+        },
+    )
+
+    result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(task.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "share_run_quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_share_run_quota_prefers_workforce_when_both_markers_are_set(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``entity_rate_limit_key`` prefers workforce when both markers are set.
+
+    Every stamping site in ``public_chat_access.py`` leans on this to argue a
+    stray agent id is inert on a workforce task and a stray workforce id would
+    hijack an agent task's bucket, but nothing pinned it on the share channel.
+
+    Discriminating setup: one slot, spent by a workforce-keyed run, then a
+    second run carrying *both* markers under a different guest (so only the
+    entity key varies -- the per-guest bucket defaults to 60/hour and cannot
+    be what refuses it). Keyed on workforce it is refused; keyed on the agent
+    it would find a fresh bucket and pass.
+    """
+    monkeypatch.setenv("XAGENT_SHARE_RUN_QUOTA", "1/day")
+    reset_share_rate_limiter()
+
+    first = _make_task(
+        db_session,
+        agent_config={
+            "auth_mode": "share",
+            "guest_id": "guest-first",
+            "share_workforce_id": 77,
+            "share_agent_id": None,
+        },
+    )
+    first_result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(first.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+    assert first_result.get("error_code") != "share_run_quota_exceeded"
+
+    both = _make_task(
+        db_session,
+        username="share-quota-user-2",
+        agent_config={
+            "auth_mode": "share",
+            "guest_id": "guest-second",
+            "share_workforce_id": 77,
+            "share_agent_id": 4242,
+        },
+    )
+    both_result = await AgentServiceManager().execute_task(
+        agent_service=_FakeAgentService(),
+        task="hello",
+        tracking_task_id=str(both.id),
+        db_session=db_session,
+        manage_task_lease=False,
+    )
+
+    assert both_result["success"] is False
+    assert both_result["error_code"] == "share_run_quota_exceeded"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1132. Share-path counterpart of the widget F1 fix in #1124.

## Problem

The widget task-create path stamps both of its channel's entity markers server-side (the inapplicable one as `None`) so a client-injected `widget_workforce_id` can never redirect the run-quota bucket, independent of the sanitizer's reserved-key set. The share path had only layer 1 (the shared sanitizer) plus a partial layer 2: `create_share_chat_task` stamped `auth_mode` / `share_agent_id` / `guest_id`, but not `share_workforce_id`.

That asymmetry matters because the run-quota chokepoint (`_public_run_denial_channel` in `api/chat.py`) keys off these markers via `entity_rate_limit_key`, which **prefers workforce over agent**. A `share_workforce_id` surviving onto an agent-share task would charge the run to an unrelated workforce bucket.

The shared sanitizer already strips the key today, so this is defense in depth rather than an open hole — it keeps the boundary correct if the reserved-key set ever changes, or if a new share entry point misses the sanitizer.

## Changes

- `create_share_chat_task` now stamps both entity markers, writing `share_workforce_id = None`. A comment pins the literal to the dispatch guard that makes it true (the function early-returns into the workforce handler whenever `access_context.workforce` is set).
- `_create_workforce_share_chat_task` now stamps `share_agent_id: None` alongside `share_workforce_id`, completing the mirror of the widget workforce branch, which already did this.
- Comment-only update to `CLIENT_RESERVED_AGENT_CONFIG_KEYS` in `services/task_runtime.py`: all four public task-create paths now stamp both of their channel's markers, not just the widget one.

## Reader safety of the explicit `None`

Both readers treat an explicit `None` as indistinguishable from an absent key:

- `_public_run_denial_channel` coerces via `_coerce_optional_entity_id(None)` → `None`, so `entity_rate_limit_key` still keys `agent:<id>`.
- `_get_task_for_workforce_share_context` compares `int(... or 0)`, so the 403 behaviour is unchanged.

No reader branches on key presence, and there is no frontend reference.

## Tests

- New `test_agent_share_task_create_ignores_client_injected_entity_markers`: posts a forged `share_workforce_id` / `share_agent_id` / `share_token` / `auth_mode` / `guest_id` plus the whole `widget_*` marker set, and asserts the persisted `Task.agent_config` reflects only the server-resolved entity. It also asserts a non-reserved client key still rides through, separating "sanitized" from "emptied".

  The workforce assertion is a **membership** check (`"share_workforce_id" in cfg` then `is None`), not `cfg.get(...) is None`. The latter passes on the sanitizer alone and would silently stop guarding the layer-2 stamp; verified the test fails when the stamp is reverted.

- `test_workforce_share_task_create_discards_forged_agent_config` extended with the entity and identity markers, confirming `create_workforce_run` only ever sees the handler's own `extra_agent_config`.

Local run: 100 passed across `test_share_guest_isolation.py`, `test_share_rate_limit_endpoints.py`, `test_share_run_quota_gate.py`, `test_workforce_run_service.py`, `test_task_runtime_bindings.py`. Full `tests/web`: 4617 passed, 71 skipped, 6 failed — the 6 are `test_sandbox_reconcile_e2e.py` failing on a missing local Docker credential helper, and they fail identically on `main`.

## Follow-up

The widget counterpart `test_widget_task_create_ignores_client_injected_entity_markers` (`test_share_rate_limit_endpoints.py`) has the same blind spot this PR fixes on the share side: its `cfg.get("widget_workforce_id") is None` passes even if the widget stamp is deleted. Worth tightening separately.