### PR TITLE
fix(gmail): stop best-effort watch provisioning from failing an OAuth callback

### DIFF
--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -34,6 +34,7 @@ from ..models.database import get_db
 from ..models.system_setting import SystemSetting
 from ..models.user import User
 from ..models.user_oauth import UserOAuth
+from ..services import gmail_provisioning
 from ..services.auth_email import send_password_reset_email
 
 logger = logging.getLogger(__name__)
@@ -54,12 +55,12 @@ def _best_effort_ensure_gmail_watches_for_user(db: Session, *, user_id: int) -> 
     failed while it is in fact connected. A best-effort side effect must not
     be able to change what the callback returns.
     """
+    # The module is imported at module level so that a genuine module
+    # resolution failure surfaces at startup instead of being logged here as a
+    # routine provisioning warning. The call stays inside the guard, and going
+    # through the module keeps the attribute lookup late so tests can patch it.
     try:
-        from ..services.gmail_provisioning import (
-            best_effort_provision_gmail_watches_for_user,
-        )
-
-        best_effort_provision_gmail_watches_for_user(
+        gmail_provisioning.best_effort_provision_gmail_watches_for_user(
             db,
             user_id=user_id,
             context="after OAuth callback",

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -46,15 +46,31 @@ EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
 def _best_effort_ensure_gmail_watches_for_user(db: Session, *, user_id: int) -> None:
-    from ..services.gmail_provisioning import (
-        best_effort_provision_gmail_watches_for_user,
-    )
+    """Provision Gmail watches without letting the outcome reach the caller.
 
-    best_effort_provision_gmail_watches_for_user(
-        db,
-        user_id=user_id,
-        context="after OAuth callback",
-    )
+    This runs after the OAuth token is committed, so the connect has already
+    succeeded. Anything raised here would be rendered by the callback's outer
+    handler as an ``Authentication Failed`` 500, telling the user a connector
+    failed while it is in fact connected. A best-effort side effect must not
+    be able to change what the callback returns.
+    """
+    try:
+        from ..services.gmail_provisioning import (
+            best_effort_provision_gmail_watches_for_user,
+        )
+
+        best_effort_provision_gmail_watches_for_user(
+            db,
+            user_id=user_id,
+            context="after OAuth callback",
+        )
+    except Exception:
+        logger.warning(
+            "Best-effort Gmail watch provisioning failed for user %s "
+            "after OAuth callback",
+            user_id,
+            exc_info=True,
+        )
 
 
 def _oauth_env_name(provider: str, suffix: str) -> str:

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -1218,17 +1218,38 @@ def best_effort_provision_gmail_watches_for_user(
 
     Used after OAuth (re)connects a Gmail account: any enabled Gmail trigger
     already bound to that mailbox gets its delivery resources re-ensured.
-    Failures are recorded on the watch state, never raised.
+    Failures are recorded on the watch state, never raised; a failure before
+    any account resolves has no watch state to land on and is only logged.
     """
-    accounts = (
-        db.query(UserOAuth)
-        .filter(UserOAuth.user_id == int(user_id), UserOAuth.provider == "gmail")
-        .all()
-    )
-    referenced_account_ids = _referenced_gmail_oauth_account_ids(
-        db,
-        [(int(account.id), str(account.email or "")) for account in accounts],
-    )
+    # The account lookup and the binding resolution are inside the guard, not
+    # just the per-account loop: the caller runs this after committing the
+    # OAuth token, so a raise here would turn an already-successful connect
+    # into an error page. A mailbox missed here is picked up by
+    # ``scan_due_gmail_watch_renewals``, which selects Gmail accounts owned by
+    # users with an enabled Gmail trigger and no watch state row at all.
+    # ``sweep_gmail_provisioning`` cannot cover this: it only retries mailboxes
+    # that already have a watch state row.
+    try:
+        accounts = (
+            db.query(UserOAuth)
+            .filter(UserOAuth.user_id == int(user_id), UserOAuth.provider == "gmail")
+            .all()
+        )
+        referenced_account_ids = _referenced_gmail_oauth_account_ids(
+            db,
+            [(int(account.id), str(account.email or "")) for account in accounts],
+        )
+    except Exception as exc:
+        db.rollback()
+        logger.warning(
+            "Failed to resolve Gmail accounts for user %s %s: %s",
+            user_id,
+            context,
+            exc,
+            exc_info=True,
+        )
+        return
+
     for account in accounts:
         email = str(account.email or "").strip().lower()
         if not email:

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -1220,15 +1220,24 @@ def best_effort_provision_gmail_watches_for_user(
     already bound to that mailbox gets its delivery resources re-ensured.
     Failures are recorded on the watch state, never raised; a failure before
     any account resolves has no watch state to land on and is only logged.
+
+    Rolls back ``db`` on failure, so callers must not hold uncommitted work on
+    that session across this call.
     """
     # The account lookup and the binding resolution are inside the guard, not
     # just the per-account loop: the caller runs this after committing the
     # OAuth token, so a raise here would turn an already-successful connect
-    # into an error page. A mailbox missed here is picked up by
-    # ``scan_due_gmail_watch_renewals``, which selects Gmail accounts owned by
-    # users with an enabled Gmail trigger and no watch state row at all.
-    # ``sweep_gmail_provisioning`` cannot cover this: it only retries mailboxes
-    # that already have a watch state row.
+    # into an error page.
+    #
+    # A mailbox missed here has no automatic retry under the default
+    # configuration. ``XAGENT_GMAIL_WATCH_ENABLED`` defaults to false and gates
+    # both ``scan_due_gmail_watch_renewals`` and ``sweep_gmail_provisioning``;
+    # only with it set does the former recover this case, by selecting Gmail
+    # accounts that back an enabled Gmail trigger and have no watch state row.
+    # (``sweep_gmail_provisioning`` never covers it either way: it only retries
+    # mailboxes that already have such a row.) Otherwise the mailbox stays
+    # unprovisioned until its trigger is next saved, which re-enters
+    # provisioning through ``GmailTriggerProvider.register``.
     try:
         accounts = (
             db.query(UserOAuth)

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import os
 import threading
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, NoReturn
 
 import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy import text as sql_text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import QueuePool
 
@@ -521,6 +522,74 @@ def test_best_effort_provision_matches_duplicate_mailboxes_by_account_id(
     )
 
     assert provisioned == [int(first.id)]
+
+
+def test_best_effort_provision_swallows_account_lookup_failure(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing account lookup must not escape the best-effort contract."""
+    user = _create_user(db_session)
+    agent = _create_agent(db_session, user)
+    account = _create_oauth(db_session, user)
+    _create_gmail_trigger(db_session, user, agent, account)
+    provisioned: list[int] = []
+
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "ensure_gmail_mailbox_provisioned",
+        lambda _db, account: provisioned.append(int(account.id)),
+    )
+
+    def raising_query(*_args: Any, **_kwargs: Any) -> NoReturn:
+        raise OperationalError("SELECT user_oauth", {}, Exception("connection lost"))
+
+    monkeypatch.setattr(db_session, "query", raising_query)
+
+    gmail_provisioning.best_effort_provision_gmail_watches_for_user(
+        db_session,
+        user_id=int(user.id),
+        context="test",
+    )
+
+    assert provisioned == []
+
+
+def test_best_effort_provision_swallows_binding_resolution_failure(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing trigger-binding lookup must not escape either."""
+    user = _create_user(db_session)
+    agent = _create_agent(db_session, user)
+    account = _create_oauth(db_session, user)
+    _create_gmail_trigger(db_session, user, agent, account)
+    provisioned: list[int] = []
+
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "ensure_gmail_mailbox_provisioned",
+        lambda _db, account: provisioned.append(int(account.id)),
+    )
+
+    def raising_resolution(*_args: Any, **_kwargs: Any) -> NoReturn:
+        raise OperationalError(
+            "SELECT agent_triggers", {}, Exception("statement timeout")
+        )
+
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "_referenced_gmail_oauth_account_ids",
+        raising_resolution,
+    )
+
+    gmail_provisioning.best_effort_provision_gmail_watches_for_user(
+        db_session,
+        user_id=int(user.id),
+        context="test",
+    )
+
+    assert provisioned == []
 
 
 def test_unregister_releases_mailbox_only_after_last_enabled_trigger_is_deleted(

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from datetime import datetime, timedelta, timezone
@@ -527,12 +528,12 @@ def test_best_effort_provision_matches_duplicate_mailboxes_by_account_id(
 def test_best_effort_provision_swallows_account_lookup_failure(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A failing account lookup must not escape the best-effort contract."""
+    # No trigger fixture here: the patched query raises on the service's first
+    # statement, so the binding data would never be read.
     user = _create_user(db_session)
-    agent = _create_agent(db_session, user)
-    account = _create_oauth(db_session, user)
-    _create_gmail_trigger(db_session, user, agent, account)
     provisioned: list[int] = []
 
     monkeypatch.setattr(
@@ -545,6 +546,7 @@ def test_best_effort_provision_swallows_account_lookup_failure(
         raise OperationalError("SELECT user_oauth", {}, Exception("connection lost"))
 
     monkeypatch.setattr(db_session, "query", raising_query)
+    caplog.set_level(logging.WARNING, logger=gmail_provisioning.__name__)
 
     gmail_provisioning.best_effort_provision_gmail_watches_for_user(
         db_session,
@@ -553,17 +555,20 @@ def test_best_effort_provision_swallows_account_lookup_failure(
     )
 
     assert provisioned == []
+    assert "Failed to resolve Gmail accounts for user" in caplog.text
+    assert "connection lost" in caplog.text
 
 
 def test_best_effort_provision_swallows_binding_resolution_failure(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A failing trigger-binding lookup must not escape either."""
+    # The account lookup runs for real here, so the mailbox fixture matters;
+    # the binding resolution it feeds is patched out.
     user = _create_user(db_session)
-    agent = _create_agent(db_session, user)
-    account = _create_oauth(db_session, user)
-    _create_gmail_trigger(db_session, user, agent, account)
+    _create_oauth(db_session, user)
     provisioned: list[int] = []
 
     monkeypatch.setattr(
@@ -582,6 +587,7 @@ def test_best_effort_provision_swallows_binding_resolution_failure(
         "_referenced_gmail_oauth_account_ids",
         raising_resolution,
     )
+    caplog.set_level(logging.WARNING, logger=gmail_provisioning.__name__)
 
     gmail_provisioning.best_effort_provision_gmail_watches_for_user(
         db_session,
@@ -590,6 +596,8 @@ def test_best_effort_provision_swallows_binding_resolution_failure(
     )
 
     assert provisioned == []
+    assert "Failed to resolve Gmail accounts for user" in caplog.text
+    assert "statement timeout" in caplog.text
 
 
 def test_unregister_releases_mailbox_only_after_last_enabled_trigger_is_deleted(

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -280,12 +280,16 @@ def test_gmail_callback_survives_a_raising_account_lookup_during_provisioning(
 
     def provision_with_failing_account_lookup(provision_db, **kwargs):
         # Fail only the lookups the service itself issues; the callback's own
-        # queries, which run before the OAuth commit, must succeed.
+        # queries, which run before the OAuth commit, must succeed. The revert
+        # has to happen here rather than at teardown, because this test queries
+        # the session again below to assert the OAuth row was committed. `pop`
+        # rather than `del` so a refactor that skips the assignment surfaces as
+        # its own failure instead of an AttributeError from this line.
         provision_db.query = failing_query
         try:
             return real_provision(provision_db, **kwargs)
         finally:
-            del provision_db.query
+            provision_db.__dict__.pop("query", None)
 
     monkeypatch.setattr(
         gmail_provisioning,

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
 from xagent.core.utils.encryption import encrypt_value
@@ -18,6 +19,7 @@ from xagent.web.models.oauth_provider import OAuthProvider
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.services import gmail_provisioning
 from xagent.web.tools import config as tool_config
 
 
@@ -160,6 +162,150 @@ def test_gmail_callback_best_effort_registers_watch_after_oauth_commit(
     )
     assert oauth_account.email == "alice@gmail.com"
     assert calls == [int(user.id)]
+
+
+def test_gmail_callback_succeeds_when_best_effort_watch_provisioning_raises(
+    db_session, monkeypatch, caplog
+):
+    """A post-commit provisioning failure must not fail the connect itself."""
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "google",
+            "app_id": "gmail",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "gmail-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "access_token": "gmail-token",
+                    "refresh_token": "gmail-refresh",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": "https://www.googleapis.com/auth/gmail.modify",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"sub": "google-user-1", "email": "alice@gmail.com"}
+            )
+        ),
+    )
+
+    def raising_best_effort_provision(_db, *, user_id: int, context: str):
+        raise RuntimeError("account lookup lost its connection")
+
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_provisioning."
+        "best_effort_provision_gmail_watches_for_user",
+        raising_best_effort_provision,
+    )
+
+    caplog.set_level(logging.WARNING, logger=auth_api.__name__)
+
+    response = generic_oauth_callback("google", request, db, _google_provider())
+
+    assert response.status_code == 200
+    assert "Authentication Failed" not in response.body.decode()
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "gmail")
+        .one()
+    )
+    assert oauth_account.email == "alice@gmail.com"
+    assert "Best-effort Gmail watch provisioning failed" in caplog.text
+
+
+def test_gmail_callback_survives_a_raising_account_lookup_during_provisioning(
+    db_session, monkeypatch, caplog
+):
+    """Exercise the callback guard and the service guard as composed.
+
+    The test above stubs provisioning out entirely, so it only proves the
+    callback guard works. Here the real service runs and its own account
+    lookup raises, which is the failure #1150 reproduced on staging.
+    """
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "google",
+            "app_id": "gmail",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "gmail-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "access_token": "gmail-token",
+                    "refresh_token": "gmail-refresh",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": "https://www.googleapis.com/auth/gmail.modify",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"sub": "google-user-1", "email": "alice@gmail.com"}
+            )
+        ),
+    )
+
+    real_provision = gmail_provisioning.best_effort_provision_gmail_watches_for_user
+
+    def failing_query(*_args, **_kwargs):
+        raise OperationalError("SELECT user_oauth", {}, Exception("connection lost"))
+
+    def provision_with_failing_account_lookup(provision_db, **kwargs):
+        # Fail only the lookups the service itself issues; the callback's own
+        # queries, which run before the OAuth commit, must succeed.
+        provision_db.query = failing_query
+        try:
+            return real_provision(provision_db, **kwargs)
+        finally:
+            del provision_db.query
+
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "best_effort_provision_gmail_watches_for_user",
+        provision_with_failing_account_lookup,
+    )
+
+    caplog.set_level(logging.WARNING, logger=gmail_provisioning.__name__)
+
+    response = generic_oauth_callback("google", request, db, _google_provider())
+
+    assert response.status_code == 200
+    assert "Authentication Failed" not in response.body.decode()
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "gmail")
+        .one()
+    )
+    assert oauth_account.email == "alice@gmail.com"
+    assert "Failed to resolve Gmail accounts for user" in caplog.text
 
 
 def test_meta_callback_exchanges_short_lived_token_and_connects_selected_app(


### PR DESCRIPTION
Closes #1150.

## Problem

`best_effort_provision_gmail_watches_for_user` documents that failures are recorded on the watch state and never raised, but its `try/except` only started inside the per-account loop. The account lookup and the trigger binding resolution ran before any guard, so a database error on either escaped the function.

The caller in `src/xagent/web/api/auth.py` invokes it after `db.commit()` with no local protection, and the callback's broad `except Exception` turned that escape into an HTTP 500 rendered as `Authentication Failed` — while the OAuth token had already been committed. The user saw a hard failure on a connector that was in fact connected.

#1147 fixed the one bug that was actually tripping this window, but not the structural gap: any other database error on those two calls — a lost connection, a statement timeout, a lock wait — reproduces the same misleading page.

## Changes

Two guards, deliberately overlapping:

1. **Service** (`gmail_provisioning.py`) — extend the existing guard to cover the account lookup and the binding resolution, keeping the loop's rollback-and-log semantics.
2. **Call site** (`api/auth.py`) — guard the wrapper itself, so a best-effort side effect running after the connect has already succeeded can never change what the callback returns.

The issue left two points open for review. Both are resolved here:

- **Where a pre-loop failure lands.** With no accounts resolved there is no watch state to record it on, so it is only logged. That is acceptable because the mailbox is not stranded: `scan_due_gmail_watch_renewals` outer-joins `UserOAuth` to `GmailWatchState` and selects rows where `GmailWatchState.id IS NULL` for users with an enabled Gmail trigger, then provisions them. `sweep_gmail_provisioning` cannot cover this case — it only retries mailboxes that already have a watch state row — and the inline comment says so explicitly.
- **Whether the callback should be insulated at all.** Yes; this is change 2 above. The redundancy with change 1 is intentional: it keeps future edits to that wrapper from reintroducing the same failure mode.

## Testing

Three regression tests, each verified to fail without the corresponding fix:

- a raising account lookup is swallowed by the service;
- a raising binding resolution is swallowed by the service;
- a raising account lookup driven through the *real* service leaves the OAuth callback successful — this reproduces the reported symptom exactly (`assert 500 == 200`, `OperationalError` on `SELECT user_oauth`) when the fix is reverted.

`tests/web/test_meta_oauth.py`, `tests/web/services/test_gmail_provisioning.py` and `tests/web/api/test_gmail_auto_triggers.py`: 118 passed, 4 skipped (the skips are the PostgreSQL-only cases). The wider `pytest tests/web -m "not slow and not postgresql"` leg was also run locally: the only failures are 5 pre-existing SVG rasterization tests that need `libcairo`, which is absent on this machine and fails identically on a clean tree.