### PR TITLE
fix(rate-limit): accept X-Forwarded-For entries that carry a port (#1185)

### DIFF
--- a/src/xagent/web/services/trigger_rate_limit.py
+++ b/src/xagent/web/services/trigger_rate_limit.py
@@ -239,6 +239,14 @@ def _client_ip_from_forwarded_entry(candidate: str) -> str | None:
     quota (#1185). The port is dropped rather than kept so buckets stay keyed
     per client rather than per ephemeral connection.
     """
+    # ipaddress.ip_address() accepts an IPv6 zone-id suffix, and the zone-id
+    # itself is unbounded and unvalidated: `::1%` + 4000 characters parses and
+    # round-trips. A zone-id names a local interface, so it is meaningless for
+    # a remote client address and no proxy emits one — but leaving it accepted
+    # would defeat the bound this validation exists to enforce, since the
+    # result is persisted and used as Redis key material.
+    if "%" in candidate:
+        return None
     host, port = _split_host_port(candidate)
     if host is None:
         return None
@@ -258,7 +266,10 @@ def _split_host_port(candidate: str) -> tuple[str | None, str | None]:
     IPv6 literal is never split: ``2001:db8::1:8080`` is a valid address whose
     last group only looks like a port, so splitting on the final colon would
     silently rewrite it into a *different* address. Only the unambiguous forms
-    carry a port: bracketed IPv6, and a host with exactly one colon (IPv4).
+    carry a port: a bracketed host, and a host with exactly one colon (IPv4).
+    Brackets are not checked for IPv6 specifically — RFC 3986 reserves them for
+    it, and a bracketed IPv4 still yields the same string its bare form would,
+    so it lands in the same bucket.
     """
     if candidate.startswith("["):
         closing = candidate.find("]")

--- a/src/xagent/web/services/trigger_rate_limit.py
+++ b/src/xagent/web/services/trigger_rate_limit.py
@@ -183,7 +183,9 @@ def remote_ip_from_request(request: object) -> str | None:
 
     With ``XAGENT_TRUSTED_PROXY_HOPS=N`` (N>0), the client address is taken
     from ``X-Forwarded-For`` counting N trusted entries from the right;
-    otherwise the raw socket peer address is used.
+    otherwise the raw socket peer address is used. The returned value is
+    always a bare IP: a port appended by the proxy is stripped, and anything
+    not IP-shaped falls back to the peer address.
     """
     client = getattr(request, "client", None)
     peer_host = getattr(client, "host", None)
@@ -212,12 +214,73 @@ def remote_ip_from_request(request: object) -> str | None:
     # callers use this as rate-limit key material and persist it (#1108's
     # `widget_client_ip`), so an unvalidated header could inject an unbounded
     # arbitrary string. Fall back to the peer address rather than trusting it.
-    try:
-        ipaddress.ip_address(candidate)
-    except ValueError:
+    client_ip = _client_ip_from_forwarded_entry(candidate)
+    if client_ip is None:
         logger.warning(
             "Ignoring non-IP X-Forwarded-For entry %r; using peer address",
             candidate[:64],
         )
         return peer_ip
-    return candidate
+    return client_ip
+
+
+def _client_ip_from_forwarded_entry(candidate: str) -> str | None:
+    """Return the bare IP an X-Forwarded-For entry denotes, else None.
+
+    The entry is returned as written, not canonicalized: equivalent spellings
+    of one IPv6 address still key separate rate-limit buckets, exactly as they
+    did before ports were handled.
+
+    Bare IPs are the convention (nginx, ALB, most CDNs), but some proxies
+    (Azure App Service / Application Gateway among them) append the client's
+    source port as ``ip:port`` or ``[ipv6]:port``. Rejecting those outright
+    would silently collapse every client behind such a proxy onto the peer
+    address — one shared rate-limit bucket and, for widgets, one shared run
+    quota (#1185). The port is dropped rather than kept so buckets stay keyed
+    per client rather than per ephemeral connection.
+    """
+    host, port = _split_host_port(candidate)
+    if host is None:
+        return None
+    if port is not None and not _is_valid_port(port):
+        return None
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        return None
+    return host
+
+
+def _split_host_port(candidate: str) -> tuple[str | None, str | None]:
+    """Split an entry into (host, port), with port None when absent.
+
+    Returns ``(None, None)`` for structurally malformed bracket forms. A bare
+    IPv6 literal is never split: ``2001:db8::1:8080`` is a valid address whose
+    last group only looks like a port, so splitting on the final colon would
+    silently rewrite it into a *different* address. Only the unambiguous forms
+    carry a port: bracketed IPv6, and a host with exactly one colon (IPv4).
+    """
+    if candidate.startswith("["):
+        closing = candidate.find("]")
+        if closing < 0:
+            return None, None
+        host = candidate[1:closing]
+        rest = candidate[closing + 1 :]
+        if not rest:
+            return host, None
+        if not rest.startswith(":"):
+            return None, None
+        return host, rest[1:]
+    if candidate.count(":") == 1:
+        host, _, port = candidate.partition(":")
+        return host, port
+    return candidate, None
+
+
+def _is_valid_port(port: str) -> bool:
+    # The length bound has to come first: int() raises on digit strings longer
+    # than sys.get_int_max_str_digits() (4300 by default), so a header of the
+    # form `1.2.3.4:99…9` would otherwise escape as an unhandled ValueError.
+    # isascii() matters too: str.isdigit() also accepts non-ASCII digit
+    # characters (superscripts among them) that int() then rejects.
+    return len(port) <= 5 and port.isascii() and port.isdigit() and int(port) <= 65535

--- a/tests/web/api/test_trigger_rate_limits.py
+++ b/tests/web/api/test_trigger_rate_limits.py
@@ -313,6 +313,11 @@ class TestRemoteIpDerivation:
             "[2001:db8::1]:8080": "2001:db8::1",
             # Brackets with no port are still a valid IPv6 reference.
             "[2001:db8::1]": "2001:db8::1",
+            # Brackets are stripped without checking the host is IPv6. No real
+            # proxy emits this (RFC 3986 reserves brackets for IPv6), but it
+            # yields the same string the bare form would, so it cannot reach a
+            # different bucket than its canonical spelling.
+            "[1.2.3.4]:80": "1.2.3.4",
         }
         for forwarded, expected in cases.items():
             request = self._request("10.0.0.1", forwarded)
@@ -357,6 +362,17 @@ class TestRemoteIpDerivation:
             "[]:80",
             "[not-an-ip]:80",
             "evil:8080",
+            # Multi-colon non-IP: pins the no-bracket, no-port fallthrough in
+            # _split_host_port, which is otherwise only reached by entries that
+            # do parse as IPv6.
+            "a:b:c",
+            # ipaddress.ip_address() accepts an unbounded IPv6 zone-id, which
+            # would otherwise be returned verbatim and persisted as the client
+            # IP — the exact unbounded-string injection this validation exists
+            # to prevent.
+            "::1%eth0",
+            "::1%" + "A" * 4000,
+            "[fe80::1%eth0]:80",
         )
         for entry in forged:
             request = self._request("10.0.0.1", entry)

--- a/tests/web/api/test_trigger_rate_limits.py
+++ b/tests/web/api/test_trigger_rate_limits.py
@@ -298,6 +298,70 @@ class TestRemoteIpDerivation:
         request = self._request("10.0.0.1", None)
         assert remote_ip_from_request(request) == "10.0.0.1"
 
+    def test_port_suffixed_entries_resolve_to_the_bare_ip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#1185: some proxies append the client's source port. Rejecting
+        those would collapse every client behind such a proxy onto the peer
+        address — one shared rate-limit bucket. The port is dropped so the
+        bucket stays keyed per client, not per ephemeral connection."""
+        monkeypatch.setenv("XAGENT_TRUSTED_PROXY_HOPS", "1")
+        cases = {
+            "203.0.113.7:8080": "203.0.113.7",
+            "203.0.113.7:0": "203.0.113.7",
+            "203.0.113.7:65535": "203.0.113.7",
+            "[2001:db8::1]:8080": "2001:db8::1",
+            # Brackets with no port are still a valid IPv6 reference.
+            "[2001:db8::1]": "2001:db8::1",
+        }
+        for forwarded, expected in cases.items():
+            request = self._request("10.0.0.1", forwarded)
+            assert remote_ip_from_request(request) == expected, forwarded
+
+    def test_bare_ipv6_is_never_split_on_its_last_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#1185 regression guard: an unbracketed IPv6 literal can end in a
+        group that looks like a port. Stripping it would silently rewrite the
+        entry into a *different*, still-valid address — worse than the
+        peer-address fallback, since nothing would flag it."""
+        monkeypatch.setenv("XAGENT_TRUSTED_PROXY_HOPS", "1")
+        for forwarded in ("2001:db8::1:8080", "2001:db8::1", "::1"):
+            request = self._request("10.0.0.1", forwarded)
+            assert remote_ip_from_request(request) == forwarded, forwarded
+
+    def test_malformed_port_and_bracket_forms_fall_back_to_peer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Port stripping must not widen what counts as IP-shaped: the value
+        is persisted and used as rate-limit key material (#1108)."""
+        monkeypatch.setenv("XAGENT_TRUSTED_PROXY_HOPS", "1")
+        forged = (
+            "203.0.113.7:evil",
+            "203.0.113.7:99999",
+            "203.0.113.7:8080x",
+            # Longer than sys.get_int_max_str_digits() (4300): int() raises on
+            # these, so the length bound must reject them before conversion or
+            # a client-controlled header becomes an unhandled 500.
+            "203.0.113.7:" + "9" * 5000,
+            # str.isdigit() accepts non-ASCII digits that int() then rejects.
+            "203.0.113.7:٨٠",
+            "203.0.113.7:²",
+            "203.0.113.7:",
+            ":8080",
+            "[2001:db8::1",
+            "[2001:db8::1]8080",
+            "[2001:db8::1]:",
+            "[2001:db8::1]:evil",
+            "[]",
+            "[]:80",
+            "[not-an-ip]:80",
+            "evil:8080",
+        )
+        for entry in forged:
+            request = self._request("10.0.0.1", entry)
+            assert remote_ip_from_request(request) == "10.0.0.1", entry
+
 
 class TestLimiterConfiguration:
     def test_memory_storage_without_redis(


### PR DESCRIPTION
Closes #1185.

## Problem

`remote_ip_from_request` validated the selected `X-Forwarded-For` entry with `ipaddress.ip_address()` — added in #1124 so a client-controlled entry cannot be persisted or used as Redis key material. That validation rejects the `ip:port` and `[ipv6]:port` forms outright, so behind a proxy that appends the client's source port every request silently degraded to the peer address.

The blast radius is wider than the trigger callback path the module is named for. The helper is shared by:

- `api/triggers.py` — callback rate limiting and 429 audit dedup
- `api/widget.py` — widget rate limiting, and `client_ip` is **persisted** into `agent_config` as the per-abuser key for the #1108 run quota
- `api/share.py` and `api/public_chat_access.py` — share link and WebSocket handshake limiting

So in an affected deployment it is not just one global rate-limit bucket: the widget per-guest run quota also collapses, and a single abuser can consume the whole link's budget.

## Fix

Strip the port before validating and return the bare IP, so buckets stay keyed per client rather than per ephemeral connection. Anything still not IP-shaped keeps the peer-address fallback and the existing warning log.

Splitting only happens for forms where a port is unambiguous:

| Entry | Result |
|---|---|
| `203.0.113.7:8080` | `203.0.113.7` |
| `[2001:db8::1]:8080` | `2001:db8::1` |
| `[2001:db8::1]` | `2001:db8::1` |
| `2001:db8::1:8080` | unchanged — see below |
| `203.0.113.7:evil`, `[2001:db8::1`, `evil:8080` | peer address |

A bare IPv6 literal is never split. `2001:db8::1:8080` is a valid address whose last group only looks like a port, so splitting on the final colon would silently rewrite it into a *different*, still-valid address — worse than the peer fallback, because nothing would flag it. Only bracketed IPv6 and a host with exactly one colon are treated as carrying a port.

The port is discarded, but still range-checked so a malformed entry falls back to the peer address rather than being treated as well-formed. Two bounds are load-bearing there:

- `len(port) <= 5` **before** `int()` — `int()` raises on digit strings longer than `sys.get_int_max_str_digits()` (4300 by default), so without it a client-controlled `X-Forwarded-For: 1.2.3.4:99…9` would escape as an unhandled `ValueError` and 500 every endpoint listed above.
- `isascii()` before `isdigit()` — `str.isdigit()` also accepts non-ASCII digit characters (superscripts among them) that `int()` then rejects.

No security property from #1124 is relaxed: the returned value is still only ever an IP-shaped string, and everything else falls back to the peer address.

## Tests

Three cases added to the existing `TestRemoteIpDerivation`, alongside the non-IP / oversized / trailing-junk / bare-IPv6 cases already there:

- `test_port_suffixed_entries_resolve_to_the_bare_ip`
- `test_bare_ipv6_is_never_split_on_its_last_group`
- `test_malformed_port_and_bracket_forms_fall_back_to_peer` — 16 forged entries, including the >4300-digit port

```
pytest tests/web/api/test_trigger_rate_limits.py tests/web/api/test_share_rate_limit_endpoints.py
# 39 passed
```

`ruff format --check`, `ruff check` and `mypy src/xagent/web/services/trigger_rate_limit.py` are clean.

## Follow-up (not in this PR)

`trigger_rate_limit.py` now carries ~100 lines of generic reverse-proxy ingress parsing while being named for trigger rate limiting, and `share_rate_limit.py:59-61` already carries a comment apologising for importing from it. Extracting the helper into its own module is a pure refactor across five files and is deliberately left out of this bug fix.
