### PR TITLE
fix: set no-store Cache-Control on public inline preview responses

### DIFF
--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -187,12 +187,19 @@ async def _inline_preview_response(
     filename: str,
     media_type: str,
     file_id: Optional[str] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> FileResponse:
     """Build the final inline preview FileResponse, rasterizing SVG to PNG.
 
     Raw SVG bytes are never served inline — an embedded ``<script>`` would
     execute on direct top-level navigation to this response. Every other
     media type is served as-is.
+
+    ``extra_headers`` lets a caller layer route-specific headers (e.g. the
+    public/tokened route's ``Cache-Control``) without changing behavior for
+    other callers — this helper is shared by both the authenticated and
+    public preview endpoints, and the authenticated in-app path relies on
+    normal browser caching for repeatedly-rendered chat images.
     """
 
     if media_type == "image/svg+xml":
@@ -215,6 +222,7 @@ async def _inline_preview_response(
             headers={
                 "Content-Disposition": "inline",
                 "X-Content-Type-Options": "nosniff",
+                **(extra_headers or {}),
             },
         )
     return FileResponse(
@@ -224,8 +232,19 @@ async def _inline_preview_response(
         headers={
             "Content-Disposition": "inline",
             "X-Content-Type-Options": "nosniff",
+            **(extra_headers or {}),
         },
     )
+
+
+# The public/tokened preview route (unlike the authenticated in-app one) is
+# now loaded directly as <img>/<audio>/<video> src on public share surfaces
+# (#1196), which fetches automatically on render with no user action. A
+# response with no Cache-Control lets the browser write the tokened URL and
+# its bytes to disk cache, where they can outlive the guest session. This
+# header must NOT be applied to the authenticated preview route: chat images
+# there rely on ordinary browser caching across repeated renders.
+_PUBLIC_PREVIEW_CACHE_HEADERS = {"Cache-Control": "private, no-store"}
 
 
 def _durable_redirect_response(
@@ -1724,6 +1743,7 @@ async def public_preview_file(
                 filename=str(file_record.filename),
                 media_type=guess_media_type(str(file_record.filename)),
                 file_id=file_id if is_valid_uuid(file_id) else None,
+                extra_headers=_PUBLIC_PREVIEW_CACHE_HEADERS,
             )
     else:
         # Try to resolve as legacy path across all user directories
@@ -1771,6 +1791,7 @@ async def public_preview_file(
         filename=target_path.name,
         media_type=guess_media_type(target_path.name),
         file_id=file_id if is_valid_uuid(file_id) else None,
+        extra_headers=_PUBLIC_PREVIEW_CACHE_HEADERS,
     )
 
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -220,9 +220,13 @@ async def _inline_preview_response(
             filename=Path(filename).with_suffix(".png").name,
             media_type="image/png",
             headers={
+                **(extra_headers or {}),
+                # These two win over any same-named extra_headers entry: they
+                # are security invariants (the second prevents this rasterized
+                # PNG from being sniffed back into script-executable content),
+                # not caller-tunable behavior.
                 "Content-Disposition": "inline",
                 "X-Content-Type-Options": "nosniff",
-                **(extra_headers or {}),
             },
         )
     return FileResponse(
@@ -230,9 +234,10 @@ async def _inline_preview_response(
         filename=filename,
         media_type=media_type,
         headers={
+            **(extra_headers or {}),
+            # See the invariant note in the SVG branch above.
             "Content-Disposition": "inline",
             "X-Content-Type-Options": "nosniff",
-            **(extra_headers or {}),
         },
     )
 

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+import xagent.web.api.files as files_module
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.api.auth import hash_password
 from xagent.web.api.files import file_router
@@ -520,6 +521,48 @@ class TestAdminFileAccess:
         assert response.status_code == 200
         assert response.headers["cache-control"] == "private, no-store"
 
+    def test_public_preview_sets_no_store_cache_control_for_rasterized_svg(
+        self, test_db, temp_uploads_dir, monkeypatch, tmp_path
+    ):
+        # The SVG branch of _inline_preview_response returns a separate
+        # FileResponse for the rasterized PNG -- the header must reach that
+        # branch too, not just the generic pass-through one exercised above.
+        # rasterize_svg_bytes is stubbed to avoid a hard dependency on the
+        # native cairo library in this environment; the extra_headers
+        # plumbing under test doesn't depend on the rasterized output.
+        monkeypatch.setenv("XAGENT_STORAGE_ROOT", str(tmp_path))
+        monkeypatch.setattr(
+            files_module, "rasterize_svg_bytes", lambda svg_bytes: b"fake-png-bytes"
+        )
+
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=87,
+            user_id=regular_user_id,
+            title="SVG cache header test",
+            description="public preview cache header test for svg",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "icon.svg",
+            "<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+        )
+
+        client = TestClient(test_app)
+        response = client.get(f"/api/files/public/preview/{uploaded_file.file_id}")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        assert response.headers["cache-control"] == "private, no-store"
+
     def test_authenticated_preview_keeps_default_caching(
         self, test_db, temp_uploads_dir
     ):
@@ -554,4 +597,7 @@ class TestAdminFileAccess:
         )
 
         assert response.status_code == 200
-        assert response.headers.get("cache-control") != "private, no-store"
+        # Starlette's FileResponse sets no Cache-Control by default; assert
+        # that exactly, not just "not the public value" -- a regression that
+        # set some other Cache-Control here would slip past a weaker check.
+        assert "cache-control" not in response.headers

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -485,3 +485,73 @@ class TestAdminFileAccess:
         )
 
         assert response.status_code == 403
+
+    def test_public_preview_sets_no_store_cache_control(
+        self, test_db, temp_uploads_dir
+    ):
+        # The public route is loaded directly as <img>/<audio>/<video> src on
+        # share surfaces, which fetches automatically on render. Without this
+        # header the tokened URL and its bytes could land in browser disk
+        # cache and outlive the guest session.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=85,
+            user_id=regular_user_id,
+            title="Cache header test",
+            description="public preview cache header test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.txt",
+            "media bytes",
+        )
+
+        client = TestClient(test_app)
+        response = client.get(f"/api/files/public/preview/{uploaded_file.file_id}")
+
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "private, no-store"
+
+    def test_authenticated_preview_keeps_default_caching(
+        self, test_db, temp_uploads_dir
+    ):
+        # The authenticated in-app preview route must not get the public
+        # route's no-store override: chat images there rely on ordinary
+        # browser caching across repeated renders of the same message.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=86,
+            user_id=regular_user_id,
+            title="Authenticated cache header test",
+            description="authenticated preview cache header test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.txt",
+            "media bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}", headers=user_headers
+        )
+
+        assert response.status_code == 200
+        assert response.headers.get("cache-control") != "private, no-store"


### PR DESCRIPTION
Fixes #1226.

## Problem

Since #1196, public/share inline previews are loaded directly as `<img>`/`<audio>`/`<video>` `src` on public surfaces — a URL that fetches automatically on render, with no user action, unlike a click-triggered download link. With no `Cache-Control` header, that tokened URL and its response body could be written to browser disk cache and outlive the guest session, bounded only by the token's 30-day expiry.

## Fix

- `_inline_preview_response` (`src/xagent/web/api/files.py`) gains an optional `extra_headers` parameter, merged into the response headers without changing any other caller's behavior.
- `public_preview_file`'s two call sites now pass `Cache-Control: private, no-store` via a new `_PUBLIC_PREVIEW_CACHE_HEADERS` constant.
- The authenticated in-app preview route (`preview_file`) is deliberately untouched — it shares the same helper, and chat images there rely on ordinary browser caching across repeated renders of the same message.

## Testing

Two new tests in `tests/web/test_admin_file_access.py`:
- `test_public_preview_sets_no_store_cache_control` — asserts the header on the public route.
- `test_authenticated_preview_keeps_default_caching` — asserts the header is *not* set on the authenticated route (regression guard against the shared-helper accidentally leaking the override).

`ruff`, `mypy`, and the full `tests/web/test_admin_file_access.py` + `tests/web/test_file_upload.py` suites pass (3 pre-existing `cairosvg`-dependent failures unrelated to this change, confirmed against a clean `upstream/main` checkout).
