### PR TITLE
fix: preserve model-authored media labels via markdown title syntax

### DIFF
--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -841,9 +841,9 @@ describe('MarkdownRenderer', () => {
   })
 
   it('renders image-syntax video references as an inline video preview', async () => {
-    // The backend restores the filename as the label even for ![...] refs
-    // pointing at media files; the image renderer then resolves the video
-    // kind from the label instead of falling back to a broken <img>.
+    // The image renderer resolves the video kind from alt/title text
+    // instead of falling back to a broken <img> for ![...] refs pointing
+    // at media files.
     apiRequestMock.mockResolvedValue({
       ok: true,
       blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
@@ -852,6 +852,38 @@ describe('MarkdownRenderer', () => {
     render(<MarkdownRenderer content={content} />)
 
     const video = await screen.findByLabelText('puppy_drinking.mp4')
+    expect(video.tagName.toLowerCase()).toBe('video')
+  })
+
+  it('detects video via the link title while displaying the model label', async () => {
+    // The backend (file_reference_output_service.reconcile_assistant_file_
+    // references) adds the real filename as the link *title* rather than
+    // overwriting the label, so a localized label survives while the
+    // frontend still detects the media type from the title.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+    })
+    const content =
+      '[下载视频（MP4）](file:550e8400-e29b-41d4-a716-446655440000 "puppy_drinking.mp4")'
+    render(<MarkdownRenderer content={content} />)
+
+    const video = await screen.findByLabelText('下载视频（MP4）')
+    expect(video.tagName.toLowerCase()).toBe('video')
+    expect(screen.queryByLabelText('puppy_drinking.mp4')).not.toBeInTheDocument()
+    expect(screen.getByText('下载视频（MP4）')).toBeInTheDocument()
+  })
+
+  it('detects video via the image title while displaying the model alt text', async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+    })
+    const content =
+      '![预览视频](file:550e8400-e29b-41d4-a716-446655440000 "puppy_drinking.mp4")'
+    render(<MarkdownRenderer content={content} />)
+
+    const video = await screen.findByLabelText('预览视频')
     expect(video.tagName.toLowerCase()).toBe('video')
   })
 

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -256,6 +256,21 @@ describe('MarkdownRenderer', () => {
     expect(handleFileClick).toHaveBeenCalledWith('/tmp/test.txt', 'open file')
   })
 
+  it('passes the model label, not the title, to onFileClick for a non-previewable file link', () => {
+    // "notes.txt" isn't a previewable kind, so resolvePreviewableFileLink
+    // returns null and this falls to the plain-anchor branch below --
+    // the filename handed to onFileClick must still be linkText-first,
+    // matching every other display path in this component.
+    const handleFileClick = vi.fn()
+    const content = '[Open Notes](file:some-id "notes.txt")'
+
+    render(<MarkdownRenderer content={content} onFileClick={handleFileClick} />)
+
+    fireEvent.click(screen.getByText('Open Notes'))
+
+    expect(handleFileClick).toHaveBeenCalledWith('some-id', 'Open Notes')
+  })
+
   it('renders file links and images as inert text when files are disabled', () => {
     const handleFileClick = vi.fn()
     const content = [
@@ -946,6 +961,28 @@ describe('MarkdownRenderer', () => {
     expect(screen.getByText('下载报告')).toBeInTheDocument()
     expect(screen.queryByText('annual_report_2024.pdf')).not.toBeInTheDocument()
     expect(apiRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('lets a title that classifies differently than the label win detection', async () => {
+    // resolvePreviewableFileLink tries title first and stops at the first
+    // candidate that classifies to any previewable kind -- it does not
+    // compare title's and visibleText's kinds and prefer whichever the
+    // label reveals. The backend's own gate never produces this shape (it
+    // only writes a title when the label doesn't already reveal a type),
+    // so this only arises for a hand-authored or otherwise unusual
+    // reference; pinning it here documents the actual (title-wins)
+    // behavior rather than the label-aware guarantee the code comment used
+    // to (incorrectly) claim.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([65, 66]).buffer,
+    })
+    const content = '[report.mp4](file:doc-file-id "notes.docx")'
+
+    render(<MarkdownRenderer content={content} />)
+
+    expect(await screen.findByTestId('docx-preview')).toBeInTheDocument()
+    expect(screen.queryByLabelText('report.mp4')).not.toBeInTheDocument()
   })
 
   it('renders file links as image previews when the path has an image extension', async () => {

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -887,6 +887,39 @@ describe('MarkdownRenderer', () => {
     expect(video.tagName.toLowerCase()).toBe('video')
   })
 
+  it('shows the model alt text, not the backend-injected title, when files are disabled', () => {
+    // Regression coverage for a files-disabled-only bug: the presentation
+    // branch used to resolve title-first, showing the backend-injected
+    // filename instead of the model's own alt text. The existing
+    // "sanitizes Markdown labels and titles" test uses an https:// image
+    // whose alt/title sanitize to the same basename, which masks this
+    // ordering bug entirely -- this uses non-path prose alt text so the
+    // two are guaranteed to differ.
+    render(
+      <MarkdownRenderer
+        filesDisabled
+        content='![预览视频](file:550e8400-e29b-41d4-a716-446655440000 "generated_video.mp4")'
+      />,
+    )
+
+    expect(screen.getByText('预览视频')).toBeInTheDocument()
+    expect(screen.queryByText('generated_video.mp4')).not.toBeInTheDocument()
+  })
+
+  it('displays the model label, not the title, for a non-media titled file link', () => {
+    // The title is only ever a media-type detection hint; a non-media
+    // reference's title must never leak into what the user sees as content
+    // (it's fine as an invisible <a title> tooltip), and must not make the
+    // reference misclassify as some previewable kind it isn't.
+    const content =
+      '[下载报告](file:550e8400-e29b-41d4-a716-446655440000 "annual_report_2024.pdf")'
+    render(<MarkdownRenderer content={content} />)
+
+    expect(screen.getByText('下载报告')).toBeInTheDocument()
+    expect(screen.queryByText('annual_report_2024.pdf')).not.toBeInTheDocument()
+    expect(apiRequestMock).not.toHaveBeenCalled()
+  })
+
   it('renders file links as image previews when the path has an image extension', async () => {
     apiRequestMock.mockResolvedValue({
       ok: true,

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -874,6 +874,27 @@ describe('MarkdownRenderer', () => {
     expect(screen.getByText('下载视频（MP4）')).toBeInTheDocument()
   })
 
+  it('falls back to the label for detection when a pre-existing title does not reveal the type', async () => {
+    // The backend only injects/overwrites a title when the label doesn't
+    // already reveal the media type (label_reveals_type in
+    // file_reference_output_service.py) -- so it leaves this exact
+    // combination (a label that already says .mp4, alongside an
+    // unrelated, non-descriptive pre-existing title) untouched. Detection
+    // must mirror that: falling back to the label when the title alone
+    // doesn't classify, instead of trusting a title that was never meant
+    // to be a detection hint in the first place.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+    })
+    const content =
+      '[report.mp4](file:550e8400-e29b-41d4-a716-446655440000 "See the notes")'
+    render(<MarkdownRenderer content={content} />)
+
+    const video = await screen.findByLabelText('report.mp4')
+    expect(video.tagName.toLowerCase()).toBe('video')
+  })
+
   it('detects video via the image title while displaying the model alt text', async () => {
     apiRequestMock.mockResolvedValue({
       ok: true,
@@ -888,13 +909,20 @@ describe('MarkdownRenderer', () => {
   })
 
   it('shows the model alt text, not the backend-injected title, when files are disabled', () => {
-    // Regression coverage for a files-disabled-only bug: the presentation
-    // branch used to resolve title-first, showing the backend-injected
-    // filename instead of the model's own alt text. The existing
-    // "sanitizes Markdown labels and titles" test uses an https:// image
-    // whose alt/title sanitize to the same basename, which masks this
-    // ordering bug entirely -- this uses non-path prose alt text so the
-    // two are guaranteed to differ.
+    // This exercises MarkdownRenderer's tree-level pre-sanitizer
+    // (sanitizeFilesDisabledPresentationText), NOT MarkdownImage's own
+    // internal `if (filesDisabled) return <span>...</span>` branch for a
+    // `file:` src: the pre-sanitizer converts a `![alt](file:... "title")`
+    // node to plain text before ReactMarkdown ever builds an <img> node, so
+    // that branch is unreachable through this entry point and this test
+    // cannot exercise it (confirmed: reverting that branch's fix does not
+    // change this test's outcome). It's still real, useful coverage of a
+    // real code path -- the pre-sanitizer must itself prefer alt over
+    // title when converting the node to a label -- just not what its
+    // original name/comment claimed to guard. The component-level branch
+    // is kept as defense-in-depth (see its own comment in
+    // markdown-renderer.tsx) since falling through to InlineFilePreview
+    // would render an interactive preview despite files being disabled.
     render(
       <MarkdownRenderer
         filesDisabled

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -949,18 +949,27 @@ describe('MarkdownRenderer', () => {
     expect(screen.queryByText('generated_video.mp4')).not.toBeInTheDocument()
   })
 
-  it('displays the model label, not the title, for a non-media titled file link', () => {
-    // The title is only ever a media-type detection hint; a non-media
-    // reference's title must never leak into what the user sees as content
-    // (it's fine as an invisible <a title> tooltip), and must not make the
-    // reference misclassify as some previewable kind it isn't.
-    const content =
-      '[下载报告](file:550e8400-e29b-41d4-a716-446655440000 "annual_report_2024.pdf")'
+  it('displays the model label, not the title, for a non-media titled file link', async () => {
+    // The title is only ever a media-type detection hint; even once it
+    // wins detection (the label here reveals no type of its own), the
+    // model's own label must still be what's shown as the previewed
+    // file's name, not the title. Uses a .docx title rather than .pdf
+    // deliberately: .pdf is never previewable via either title or label,
+    // so a test using it can't distinguish "display correctly stayed
+    // label-first" from "nothing preview-related could ever happen here
+    // regardless of precedence" -- this needs a title that genuinely wins
+    // detection (mounting the real office-preview header) to be
+    // load-bearing against a title-first display regression.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([65, 66]).buffer,
+    })
+    const content = '[下载报告](file:doc-file-id "annual_report_2024.docx")'
     render(<MarkdownRenderer content={content} />)
 
+    expect(await screen.findByTestId('docx-preview')).toBeInTheDocument()
     expect(screen.getByText('下载报告')).toBeInTheDocument()
-    expect(screen.queryByText('annual_report_2024.pdf')).not.toBeInTheDocument()
-    expect(apiRequestMock).not.toHaveBeenCalled()
+    expect(screen.queryByText('annual_report_2024.docx')).not.toBeInTheDocument()
   })
 
   it('lets a title that classifies differently than the label win detection', async () => {

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -261,12 +261,19 @@ function containsPreviewFileLinkNode(node: any): boolean {
     const filePath = href.replace(/^file:/, '')
     const fileNameFromPath = filePath.split('/').pop() || filePath
     const title = typeof node.properties?.title === 'string' ? node.properties.title : ''
-    const detectionName = title || hastText(node)
+    const label = hastText(node)
+    const detectionName = title || label
     if (
       resolvePreviewableFileLink({
         fileNameFromPath,
         detectionName,
-        displayName: detectionName,
+        // Only the boolean result is used at this call site (whether the
+        // node is a previewable file link at all) -- displayFilename is
+        // discarded. Still pass the correctly-ordered value (label-first)
+        // rather than detectionName, so this call site can't silently hand
+        // a future caller the wrong filename if displayFilename ever
+        // starts being consumed here.
+        displayName: label || title || fileNameFromPath,
       })
     ) {
       return true
@@ -479,7 +486,12 @@ function MarkdownImage({
     })
     const previewKind = preview?.previewKind ?? 'image'
     if (filesDisabled) {
-      return <span>{presentationTitle || presentationAlt || sanitizeFilesDisabledPresentationText(displayName)}</span>
+      // displayName is already alt-first (falling back to title, then the
+      // path) -- the same rule this component applies everywhere else, so
+      // reuse it directly rather than re-deriving the fallback order here.
+      // The previous title-first order showed the backend-injected
+      // filename instead of the model's own alt text on this one branch.
+      return <span>{sanitizeFilesDisabledPresentationText(displayName)}</span>
     }
 
     return (

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -222,33 +222,45 @@ const nodeText = (children: React.ReactNode): string => {
 
 function resolvePreviewableFileLink({
   fileNameFromPath,
-  detectionName,
-  displayName,
+  title,
+  visibleText,
 }: {
   fileNameFromPath: string
   /**
-   * Name checked for a recognizable media extension. Prefers the link
-   * title over the visible label/alt text: the backend injects the real
-   * filename into the title precisely so it survives even when the model
-   * rewrites the label into descriptive prose that drops the extension.
+   * Link title, if any. The backend injects the real filename here
+   * precisely so type detection survives when the model rewrites the
+   * visible label/alt text into descriptive prose that drops the
+   * extension — so this is tried before ``visibleText`` for detection.
    */
-  detectionName: string
+  title: string
   /**
-   * Name shown to the user (header text, aria-label). Prefers the visible
-   * label/alt text over the title, so the model's own — possibly
-   * localized — wording is what the user sees; the title is an internal
-   * detection hint, not display text.
+   * The model's own label (link) or alt text (image), if any. Preferred
+   * over the title for what's *shown* to the user — the title is a
+   * detection hint, not display text — but also tried for *detection*
+   * after the title, so a label that already reveals the type (e.g. a
+   * plain ``report.mp4``) still classifies correctly even when a
+   * pre-existing, non-descriptive title is present. This mirrors the
+   * backend's own gate for when it injects/overwrites a title
+   * (``label_reveals_type`` in file_reference_output_service.py): the
+   * backend only touches the title when the label doesn't already reveal
+   * the type, so whenever the label does, detection must fall through to
+   * it rather than trusting a title that was never meant to be a hint.
    */
-  displayName: string
+  visibleText: string
 }): { previewKind: PreviewableInlineFileKind; displayFilename: string } | null {
+  const displayFilename = visibleText || title || fileNameFromPath
+
   const pathKind = getInlineFilePreviewKind({ filename: fileNameFromPath })
   if (isPreviewableInlineFileKind(pathKind)) {
-    return { previewKind: pathKind, displayFilename: displayName }
+    return { previewKind: pathKind, displayFilename }
   }
 
-  const detectionKind = getInlineFilePreviewKind({ filename: detectionName })
-  if (isPreviewableInlineFileKind(detectionKind)) {
-    return { previewKind: detectionKind, displayFilename: displayName }
+  for (const candidate of [title, visibleText]) {
+    if (!candidate) continue
+    const kind = getInlineFilePreviewKind({ filename: candidate })
+    if (isPreviewableInlineFileKind(kind)) {
+      return { previewKind: kind, displayFilename }
+    }
   }
 
   return null
@@ -262,20 +274,7 @@ function containsPreviewFileLinkNode(node: any): boolean {
     const fileNameFromPath = filePath.split('/').pop() || filePath
     const title = typeof node.properties?.title === 'string' ? node.properties.title : ''
     const label = hastText(node)
-    const detectionName = title || label
-    if (
-      resolvePreviewableFileLink({
-        fileNameFromPath,
-        detectionName,
-        // Only the boolean result is used at this call site (whether the
-        // node is a previewable file link at all) -- displayFilename is
-        // discarded. Still pass the correctly-ordered value (label-first)
-        // rather than detectionName, so this call site can't silently hand
-        // a future caller the wrong filename if displayFilename ever
-        // starts being consumed here.
-        displayName: label || title || fileNameFromPath,
-      })
-    ) {
+    if (resolvePreviewableFileLink({ fileNameFromPath, title, visibleText: label })) {
       return true
     }
   }
@@ -358,12 +357,10 @@ function MarkdownLink({
   if (href && href.startsWith('file:')) {
     const filePath = href.replace(/^file:/, '')
     const fileNameFromPath = filePath.split('/').pop() || filePath
-    const detectionName = title || linkText || fileNameFromPath
-    const displayName = linkText || title || fileNameFromPath
     const preview = resolvePreviewableFileLink({
       fileNameFromPath,
-      detectionName,
-      displayName,
+      title: title || '',
+      visibleText: linkText,
     })
     const fileId = resolveInlineFileId(filePath)
 
@@ -477,20 +474,24 @@ function MarkdownImage({
   if (resolvedSrc.startsWith('file:')) {
     const filePath = resolvedSrc.replace(/^file:/, '')
     const fileNameFromPath = filePath.split('/').pop() || filePath
-    const detectionName = title || alt || fileNameFromPath
     const displayName = alt || title || fileNameFromPath
     const preview = resolvePreviewableFileLink({
       fileNameFromPath,
-      detectionName,
-      displayName,
+      title: title || '',
+      visibleText: alt || '',
     })
     const previewKind = preview?.previewKind ?? 'image'
     if (filesDisabled) {
-      // displayName is already alt-first (falling back to title, then the
-      // path) -- the same rule this component applies everywhere else, so
-      // reuse it directly rather than re-deriving the fallback order here.
-      // The previous title-first order showed the backend-injected
-      // filename instead of the model's own alt text on this one branch.
+      // Unreachable via MarkdownRenderer today: sanitizeFilesDisabledPresentationText
+      // (see the pre-parse step in MarkdownRenderer below) already converts
+      // any ![alt](file:...) node to plain text before ReactMarkdown ever
+      // builds this <img>, so a `file:` src can't reach this component
+      // while filesDisabled is set. Kept as defense-in-depth -- if that
+      // ever changes, falling through to InlineFilePreview below would
+      // render an interactive preview despite files being disabled, which
+      // is a much worse regression than a display-order nit. displayName
+      // is alt-first, matching the rule this component applies everywhere
+      // else (the title is a detection hint, not display text).
       return <span>{sanitizeFilesDisabledPresentationText(displayName)}</span>
     }
 
@@ -517,13 +518,16 @@ function MarkdownImage({
       || sanitizeFilesDisabledPresentationText(resolvedSrc) !== resolvedSrc
     )
   ) {
-    return <span>{presentationTitle || presentationAlt}</span>
+    return <span>{presentationAlt || presentationTitle}</span>
   }
 
   return (
     <img
       src={resolvedSrc}
       alt={presentationAlt}
+      // Title-first is correct here, unlike the filesDisabled span above:
+      // this is the standard <img title> tooltip, where the markdown title
+      // is the expected content and the alt text already rides in `alt`.
       title={presentationTitle || presentationAlt}
       {...props}
     />

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -236,15 +236,24 @@ function resolvePreviewableFileLink({
   /**
    * The model's own label (link) or alt text (image), if any. Preferred
    * over the title for what's *shown* to the user — the title is a
-   * detection hint, not display text — but also tried for *detection*
-   * after the title, so a label that already reveals the type (e.g. a
-   * plain ``report.mp4``) still classifies correctly even when a
-   * pre-existing, non-descriptive title is present. This mirrors the
-   * backend's own gate for when it injects/overwrites a title
+   * detection hint, not display text — and also tried for *detection*
+   * whenever the title itself doesn't classify as any previewable kind,
+   * so a label that reveals the type (e.g. a plain ``report.mp4``) still
+   * classifies correctly when there's no title, or a stale/irrelevant one.
+   *
+   * Detection tries ``title`` first and stops at the first candidate that
+   * classifies to *any* previewable kind — it does not compare the two and
+   * prefer visibleText's kind when it differs from title's. This is looser
+   * than the backend's own gate for when it injects/overwrites a title
    * (``label_reveals_type`` in file_reference_output_service.py): the
-   * backend only touches the title when the label doesn't already reveal
-   * the type, so whenever the label does, detection must fall through to
-   * it rather than trusting a title that was never meant to be a hint.
+   * backend only touches the title when the label doesn't already reveal a
+   * type, so in the reference-generation path the two never disagree in
+   * practice. A hand-authored or otherwise unusual reference where both
+   * title and label classify, to different kinds, resolves to title's kind
+   * here rather than label's -- pinned by the "lets a title that
+   * classifies differently than the label win detection" test in
+   * markdown-renderer.test.tsx; this component does not attempt to close
+   * that edge case.
    */
   visibleText: string
 }): { previewKind: PreviewableInlineFileKind; displayFilename: string } | null {
@@ -387,7 +396,10 @@ function MarkdownLink({
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
       if (onFileClick) {
         event.preventDefault()
-        const fallbackTitle = title || linkText || fileNameFromPath
+        // linkText-first, matching every other display path in this
+        // component: title is a detection hint (see resolvePreviewableFileLink
+        // above), not the name a user should see in the resulting preview.
+        const fallbackTitle = linkText || title || fileNameFromPath
         onFileClick(fileId, fallbackTitle)
       }
     }
@@ -518,6 +530,19 @@ function MarkdownImage({
       || sanitizeFilesDisabledPresentationText(resolvedSrc) !== resolvedSrc
     )
   ) {
+    // Rarely (if ever) reached via MarkdownRenderer: the tree-level
+    // pre-sanitizer (sanitizeFilesDisabledPresentationText) replaces any
+    // image/link node whose url is isInertFileTarget -- which includes the
+    // same isManagedFileUrl check this condition duplicates -- with its
+    // alt-first plain text before ReactMarkdown ever builds this <img>
+    // node. Every straightforward managed-URL shape is intercepted there
+    // (no current test reaches this line), but the two checks decode/
+    // normalize URLs slightly differently, so an encoding edge case
+    // slipping past the tree level while matching here has been reported
+    // in review and cannot be ruled out. Alt-first to match the rule this
+    // component applies everywhere else: the title can carry a
+    // backend-injected filename and must not replace the model's own alt
+    // text as visible content.
     return <span>{presentationAlt || presentationTitle}</span>
   }
 

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -222,19 +222,33 @@ const nodeText = (children: React.ReactNode): string => {
 
 function resolvePreviewableFileLink({
   fileNameFromPath,
-  fileName,
+  detectionName,
+  displayName,
 }: {
   fileNameFromPath: string
-  fileName: string
+  /**
+   * Name checked for a recognizable media extension. Prefers the link
+   * title over the visible label/alt text: the backend injects the real
+   * filename into the title precisely so it survives even when the model
+   * rewrites the label into descriptive prose that drops the extension.
+   */
+  detectionName: string
+  /**
+   * Name shown to the user (header text, aria-label). Prefers the visible
+   * label/alt text over the title, so the model's own — possibly
+   * localized — wording is what the user sees; the title is an internal
+   * detection hint, not display text.
+   */
+  displayName: string
 }): { previewKind: PreviewableInlineFileKind; displayFilename: string } | null {
   const pathKind = getInlineFilePreviewKind({ filename: fileNameFromPath })
   if (isPreviewableInlineFileKind(pathKind)) {
-    return { previewKind: pathKind, displayFilename: fileName }
+    return { previewKind: pathKind, displayFilename: displayName }
   }
 
-  const labelKind = getInlineFilePreviewKind({ filename: fileName })
-  if (isPreviewableInlineFileKind(labelKind)) {
-    return { previewKind: labelKind, displayFilename: fileName }
+  const detectionKind = getInlineFilePreviewKind({ filename: detectionName })
+  if (isPreviewableInlineFileKind(detectionKind)) {
+    return { previewKind: detectionKind, displayFilename: displayName }
   }
 
   return null
@@ -247,8 +261,16 @@ function containsPreviewFileLinkNode(node: any): boolean {
     const filePath = href.replace(/^file:/, '')
     const fileNameFromPath = filePath.split('/').pop() || filePath
     const title = typeof node.properties?.title === 'string' ? node.properties.title : ''
-    const label = title || hastText(node)
-    if (resolvePreviewableFileLink({ fileNameFromPath, fileName: label })) return true
+    const detectionName = title || hastText(node)
+    if (
+      resolvePreviewableFileLink({
+        fileNameFromPath,
+        detectionName,
+        displayName: detectionName,
+      })
+    ) {
+      return true
+    }
   }
   const src = node.properties?.src
   if (typeof src === 'string' && src.startsWith('file:')) {
@@ -329,8 +351,13 @@ function MarkdownLink({
   if (href && href.startsWith('file:')) {
     const filePath = href.replace(/^file:/, '')
     const fileNameFromPath = filePath.split('/').pop() || filePath
-    const fileName = title || linkText || fileNameFromPath
-    const preview = resolvePreviewableFileLink({ fileNameFromPath, fileName })
+    const detectionName = title || linkText || fileNameFromPath
+    const displayName = linkText || title || fileNameFromPath
+    const preview = resolvePreviewableFileLink({
+      fileNameFromPath,
+      detectionName,
+      displayName,
+    })
     const fileId = resolveInlineFileId(filePath)
 
     if (filesDisabled) {
@@ -443,18 +470,23 @@ function MarkdownImage({
   if (resolvedSrc.startsWith('file:')) {
     const filePath = resolvedSrc.replace(/^file:/, '')
     const fileNameFromPath = filePath.split('/').pop() || filePath
-    const fileName = title || alt || fileNameFromPath
-    const preview = resolvePreviewableFileLink({ fileNameFromPath, fileName })
+    const detectionName = title || alt || fileNameFromPath
+    const displayName = alt || title || fileNameFromPath
+    const preview = resolvePreviewableFileLink({
+      fileNameFromPath,
+      detectionName,
+      displayName,
+    })
     const previewKind = preview?.previewKind ?? 'image'
     if (filesDisabled) {
-      return <span>{presentationTitle || presentationAlt || sanitizeFilesDisabledPresentationText(fileName)}</span>
+      return <span>{presentationTitle || presentationAlt || sanitizeFilesDisabledPresentationText(displayName)}</span>
     }
 
     return (
       <InlineFilePreview
         source={{
           fileId: resolveInlineFileId(filePath),
-          filename: preview?.displayFilename ?? fileName,
+          filename: preview?.displayFilename ?? displayName,
           type: previewKind,
           mimeType: getInlineFilePreviewMimeType(previewKind),
         }}

--- a/frontend/src/lib/files-disabled-presentation.test.ts
+++ b/frontend/src/lib/files-disabled-presentation.test.ts
@@ -125,6 +125,19 @@ describe("files-disabled presentation", () => {
     ].join("\n"))
   })
 
+  it("falls back to the link title, not the literal word file, when the label is empty", () => {
+    // reconcile_assistant_file_references (file_reference_output_service.py)
+    // emits media references with an empty label and the real filename in
+    // the title -- e.g. [](file:id "generated_video.mp4") -- so the title
+    // must still surface here even though there's no label/alt text at all.
+    expect(sanitizeFilesDisabledPresentationText(
+      '[](file:tenant-secret "generated_video.mp4")',
+    )).toBe("generated_video.mp4")
+    expect(sanitizeFilesDisabledPresentationText(
+      '![](file:tenant-secret "generated_video.mp4")',
+    )).toBe("generated_video.mp4")
+  })
+
   it("preserves dotted business routes outside explicit local runtime roots", () => {
     expect(sanitizeFilesDisabledPresentationText(
       "Keep /docs/index.html, /customers/acme.com, /api/users/profile.json, and /v1/openapi.json.",

--- a/frontend/src/lib/files-disabled-presentation.ts
+++ b/frontend/src/lib/files-disabled-presentation.ts
@@ -368,7 +368,14 @@ const sanitizeFilesDisabledPresentationTextWithPaths = (
       if (node.type === "link" || node.type === "image") {
         const target = node.url ?? ""
         if (isInertFileTarget(target, knownPaths)) {
-          const label = sanitizePlainPresentationText(markdownNodeText(node), redactUnquotedPaths) || "file"
+          // markdownNodeText is alt-first for images, then link/image
+          // children text -- but an empty label/alt (e.g. a media
+          // reference emitted as ``[](file:id "generated_video.mp4")``,
+          // see file_reference_output_service.py) leaves nothing there.
+          // Falling back to the title before "file" keeps that filename
+          // visible instead of degrading to the literal word "file".
+          const rawLabel = markdownNodeText(node) || node.title || ""
+          const label = sanitizePlainPresentationText(rawLabel, redactUnquotedPaths) || "file"
           replaceNode(node, label)
           return
         }

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -37,8 +37,24 @@ logger = logging.getLogger(__name__)
 # - Control characters block the same paragraph-splitting hazard as
 #   ``_UNSAFE_LABEL_RE``/``_UNSAFE_TITLE_RE`` below.
 #
+# The whitespace immediately around a title clause is deliberately ``[ \t]``
+# (horizontal only), not ``\s`` -- ``\s`` includes newlines, which would let
+# a title clause span a CommonMark blank line, e.g.
+# ``[a](file:id\n\n"stale.mp4")`` renders as two independent, inert literal
+# paragraphs to any real CommonMark parser, but ``\s+``/``\s*`` here would
+# greedily match across that blank line and emit one live link, silently
+# merging (and mis-rendering) two paragraphs. Known cost: CommonMark also
+# permits a *single* line ending between destination and title (still one
+# link when rendered), and horizontal-only whitespace declines to match
+# that shape too -- such a reference is left byte-for-byte untouched (see
+# test_reconcile_leaves_single_newline_titled_reference_untouched), the
+# same non-destructive fallback as any other unparsable input, rather than
+# validated. Accepted: this function only ever emits a single space there,
+# so the shape is model-authored and rare, and distinguishing one newline
+# from two would complicate exactly the machinery this pass is shrinking.
+#
 # A title clause that doesn't parse as any of the three forms (duplicated,
-# unterminated, mismatched delimiters) falls through to the "junk"
+# unterminated, mismatched delimiters) falls through to the named ``junk``
 # alternative, which discards it as unstructured trailing content up to the
 # next ``)`` -- the reference is still validated, just without a title. A
 # deliberate side effect: an input like ``[x](file:id not a title)``, which
@@ -55,13 +71,32 @@ logger = logging.getLogger(__name__)
 # persisted transcript). Excluding ``(`` means this and similar malformed
 # inputs simply fail to match at all -- identical to this regex's pre-title
 # behavior of leaving an unparsable reference completely untouched, which
-# is the correct, non-destructive fallback.
+# is the correct, non-destructive fallback. But matching non-trivial junk is
+# not by itself a guarantee the reference is safe to normalize: if the id
+# turns out not to resolve to any record, ``replacement()`` below returns
+# the entire original match unchanged rather than collapsing to the bare
+# label -- otherwise the junk text (ordinary trailing prose the model wrote,
+# not link syntax) would be permanently deleted from the persisted
+# transcript alongside the invalid reference.
 #
 # Each title form also tolerates trailing whitespace before the closing
-# ``)`` (``\s*`` after the delimiter closes) -- otherwise
+# ``)`` (``[ \t]*`` after the delimiter closes) -- otherwise
 # ``[a](file:id "t.mp4"  )`` would fail title-form and fall through to junk,
 # which has no notion of title syntax and would silently discard the title
 # text with no re-injection for non-media files.
+#
+# ``target`` and ``label`` are each wrapped in an atomic group
+# (``(?>...)``, Python 3.11+). Both character classes already stop at the
+# first disallowed character, so a successful match never needs to
+# backtrack into either group -- the only case that would is an unmatchable
+# input (e.g. no ``)`` anywhere in the whole remaining string), where
+# ``target``'s ``+`` and the ``junk`` alternative's ``*`` can otherwise trade
+# an overlapping character back and forth one at a time, producing quadratic
+# blowup on attacker-influenceable content this function re-runs on every
+# read (measured: ~3.5s to fail a single ~32KB unclosed reference without
+# the atomic group; sub-millisecond with it, at 6x that size). The atomic
+# group cannot change any successful match's result, only how fast an
+# unmatchable one fails.
 #
 # This is the canonical parser for this ``[label](file:id ["title"])``
 # format -- ``reconcile_assistant_file_references`` is what actually
@@ -73,15 +108,15 @@ logger = logging.getLogger(__name__)
 # to match this pattern (or route through a shared parsing helper) rather
 # than silently mis-parsing a title clause as part of the id/label.
 _MARKDOWN_FILE_REFERENCE_RE = re.compile(
-    r"(?P<image>!)?\[(?P<label>[^\]]*)\]\("
-    r"(?P<target>file:[^)\s]+)"
+    r"(?P<image>!)?\[(?P<label>(?>[^\]]*))\]\("
+    r"(?P<target>(?>file:[^)\s]+))"
     r"(?:"
-    r"(?:\s+"
+    r"(?:[ \t]+"
     r'(?:"(?P<dtitle>(?:[^"\\)[\x00-\x1f\x7f]|\\.)*)"'
     r"|'(?P<stitle>(?:[^'\\)[\x00-\x1f\x7f]|\\.)*)'"
     r"|\((?P<ptitle>(?:[^()\\[\x00-\x1f\x7f]|\\.)*)\))"
-    r"\s*)?"
-    r"|[^()[\x00-\x1f\x7f]*"
+    r"[ \t]*)?"
+    r"|(?P<junk>[^()[\x00-\x1f\x7f]*)"
     r")"
     r"\)"
 )
@@ -164,6 +199,21 @@ _UNSAFE_LABEL_RE = re.compile(r"[\[\]\\\x00-\x1f\x7f]")
 #     raw would defeat that on the very next reconcile pass.
 #   - Control characters are unsafe for the same paragraph-splitting reason
 #     as ``_UNSAFE_LABEL_RE``.
+#
+# The ``)``/``[`` exclusions are an implementation constraint of this
+# module's own re-parse requirement, not a CommonMark rule -- CommonMark
+# itself permits an unescaped ``)`` inside a double-quoted title. A real
+# filename containing one, e.g. ``video (1).mp4``, is therefore denied a
+# title here and falls back to the pre-title mechanism instead (overwriting
+# the label directly, see below) -- media type detection still works, just
+# via the older, more destructive path. Escaping ``)``/``[`` on emission
+# (the regex's ``\\.`` alternative already accepts an escaped one) would
+# close this gap, but titles round-trip through several call sites that
+# compare the raw parsed value against the filename (self-healing, the
+# repair heuristic above) -- escaping would need a matching unescape step
+# at every one of them to stay correct, which is a larger, separate change
+# from the narrow fixes in this pass. See
+# test_reconcile_falls_back_to_label_rewrite_for_paren_in_filename.
 _UNSAFE_TITLE_RE = re.compile(r'["\\[)\x00-\x1f\x7f]')
 
 
@@ -231,6 +281,15 @@ def reconcile_assistant_file_references(
         referenced_id = parse_file_id_ref(target)
         record = records_by_id.get(referenced_id or "")
 
+        # Non-whitespace junk (see the "junk" alternative's comment above)
+        # was ordinary trailing prose the model wrote, not link syntax the
+        # regex is entitled to discard. If the reference turns out to be
+        # unrecoverable below, giving up must mean "leave the original text
+        # exactly as written" -- never "keep the junk's surrounding syntax
+        # but delete the junk itself".
+        junk = match.group("junk")
+        unrecoverable_fallback = match.group(0) if junk and junk.strip() else label
+
         if record is None:
             # Try the title before the label, but fall through to the label
             # if the title doesn't resolve to exactly one record -- not just
@@ -248,6 +307,12 @@ def reconcile_assistant_file_references(
                 if not filename_source:
                     continue
                 filename = Path(filename_source.strip()).name
+                if not filename:
+                    # filename_source was whitespace-only (or otherwise
+                    # stripped to nothing) -- skip it rather than looking up
+                    # the empty-string key, which could otherwise match a
+                    # record whose own filename is empty/whitespace-only.
+                    continue
                 filename_key = filename.casefold()
                 candidates = task_records_by_filename.get(filename_key, [])
                 if not candidates:
@@ -269,7 +334,7 @@ def reconcile_assistant_file_references(
                 referenced_id or target,
                 task_id,
             )
-            return label
+            return unrecoverable_fallback
 
         try:
             canonical_ref = build_file_id_ref(str(record.file_id))
@@ -281,7 +346,7 @@ def reconcile_assistant_file_references(
                 task_id,
                 record.file_id,
             )
-            return label
+            return unrecoverable_fallback
 
         display_label = label
         display_title = parsed_title

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -297,7 +297,11 @@ def reconcile_assistant_file_references(
         junk = match.group("junk")
         if junk and junk.strip():
             unrecoverable_fallback = match.group(0)
-        elif parsed_title:
+        elif (
+            parsed_title
+            and parsed_title.strip()
+            and parsed_title.strip() != label.strip()
+        ):
             # The title is this function's own designated channel for the
             # real filename (see below) -- on give-up, dropping it bare
             # would destroy the one piece of information naming which file
@@ -307,7 +311,10 @@ def reconcile_assistant_file_references(
             # asked this function to eliminate. Preserving it as plain text
             # alongside the label costs nothing: the reference is already
             # being unlinked, so there is no markdown structure left to
-            # keep it safe for.
+            # keep it safe for. Guarded against a whitespace-only title
+            # (nothing worth preserving) and a title identical to the label
+            # (would render a pointless "x (x)") -- both fall through to
+            # the plain label case below instead.
             unrecoverable_fallback = (
                 f"{label} ({parsed_title})" if label else parsed_title
             )
@@ -392,9 +399,9 @@ def reconcile_assistant_file_references(
             # different file than the record (see
             # test_reconcile_keeps_mismatched_label_...): there is no
             # signal that a coincidental extension match is wrong.
-            label_reveals_type = bool(suffix) and label.strip().casefold().endswith(
-                suffix
-            )
+            # _is_inline_preview_media(filename) above guarantees suffix is
+            # non-empty, so no separate bool(suffix) check is needed here.
+            label_reveals_type = label.strip().casefold().endswith(suffix)
             if not label_reveals_type:
                 if not _UNSAFE_TITLE_RE.search(filename):
                     # Primary mechanism: carry the real filename in the

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -268,6 +268,13 @@ def reconcile_assistant_file_references(
     records_by_filename: dict[str, list[UploadedFile]] = defaultdict(list)
     task_records_by_filename: dict[str, list[UploadedFile]] = defaultdict(list)
     for record in records:
+        # filename is NOT NULL in the schema, but skip defensively rather
+        # than index a None record under the literal string "none" (via
+        # str(None).casefold()) -- a title/label candidate of literally
+        # "None" is unlikely but not impossible, and there is no reason for
+        # this index to ever produce a false match for it.
+        if record.filename is None:
+            continue
         filename_key = str(record.filename).casefold()
         records_by_filename[filename_key].append(record)
         if record.task_id is not None and int(record.task_id) == int(task_id):
@@ -288,7 +295,24 @@ def reconcile_assistant_file_references(
         # exactly as written" -- never "keep the junk's surrounding syntax
         # but delete the junk itself".
         junk = match.group("junk")
-        unrecoverable_fallback = match.group(0) if junk and junk.strip() else label
+        if junk and junk.strip():
+            unrecoverable_fallback = match.group(0)
+        elif parsed_title:
+            # The title is this function's own designated channel for the
+            # real filename (see below) -- on give-up, dropping it bare
+            # would destroy the one piece of information naming which file
+            # was meant, while the label may be generic model prose with no
+            # filename in it at all. That recreates, in this function's own
+            # new code, exactly the destructive-loss failure class #1202
+            # asked this function to eliminate. Preserving it as plain text
+            # alongside the label costs nothing: the reference is already
+            # being unlinked, so there is no markdown structure left to
+            # keep it safe for.
+            unrecoverable_fallback = (
+                f"{label} ({parsed_title})" if label else parsed_title
+            )
+        else:
+            unrecoverable_fallback = label
 
         if record is None:
             # Try the title before the label, but fall through to the label

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -17,12 +17,63 @@ from ..models.uploaded_file import UploadedFile
 
 logger = logging.getLogger(__name__)
 
+# The title clause supports all three CommonMark delimiters (``"..."``,
+# ``'...'``, and ``(...)``) and backslash-escapes within them, so a
+# well-formed pre-existing title (however it was written) still lets the
+# base ``[label](file:id ...)`` match and go through id validation/repair
+# below, rather than silently bypassing it. Every title/junk alternative
+# also excludes ``)``, ``[``, and control characters:
+#
+# - ``)`` bounds a malformed title's runaway match to the current link's
+#   own closing paren, instead of spanning past it into unrelated content.
+# - ``[`` stops a title/junk span from ever crossing into what looks like
+#   the START of another ``[label](file:...)`` reference. Without this, a
+#   malformed first title can swallow a second, well-formed reference
+#   whole (verified: ``[a](file:id1 "x [b](file:id2 ")`` collapses into
+#   one match spanning both, silently dropping id2's reference from the
+#   output). With it, the malformed first fragment simply fails to match
+#   (left inert, not further mangled) and the second reference is still
+#   recovered as its own independent match.
+# - Control characters block the same paragraph-splitting hazard as
+#   ``_UNSAFE_LABEL_RE``/``_UNSAFE_TITLE_RE`` below.
+#
+# A title clause that doesn't parse as any of the three forms (duplicated,
+# unterminated, mismatched delimiters) falls through to the bare
+# alternative, which discards it as unstructured trailing content up to
+# the next ``)`` -- the reference is still validated, just without a title.
+#
+# This is the canonical parser for this ``[label](file:id ["title"])``
+# format -- ``reconcile_assistant_file_references`` is what actually
+# introduces the title clause into content. Other ``file:``-link-matching
+# regexes elsewhere in the codebase (task_execution_context_service.py,
+# websocket.py, slack/telegram channel utils) predate title support and
+# are title-blind; none currently run on reconciled/titled content, but a
+# future change piping reconciled text into one of them should update it
+# to match this pattern (or route through a shared parsing helper) rather
+# than silently mis-parsing a title clause as part of the id/label.
 _MARKDOWN_FILE_REFERENCE_RE = re.compile(
     r"(?P<image>!)?\[(?P<label>[^\]]*)\]\("
     r"(?P<target>file:[^)\s]+)"
-    r"(?:\s+\"(?P<dtitle>[^\"]*)\"|\s+'(?P<stitle>[^']*)')?"
+    r"(?:"
+    r'(?:\s+(?:"(?P<dtitle>(?:[^"\\)[\x00-\x1f\x7f]|\\.)*)"'
+    r"|'(?P<stitle>(?:[^'\\)[\x00-\x1f\x7f]|\\.)*)'"
+    r"|\((?P<ptitle>(?:[^()\\[\x00-\x1f\x7f]|\\.)*)\)))?"
+    r"|[^)[\x00-\x1f\x7f]*"
+    r")"
     r"\)"
 )
+
+
+def _parsed_title(match: re.Match[str]) -> str | None:
+    """The raw title text from whichever of the three delimiter forms matched."""
+    dtitle = match.group("dtitle")
+    if dtitle is not None:
+        return dtitle
+    stitle = match.group("stitle")
+    if stitle is not None:
+        return stitle
+    return match.group("ptitle")
+
 
 # ``artifact_type_for_filename`` only knows image/video/office extensions
 # and never returns "audio", so audio must be matched by extension here.
@@ -38,10 +89,12 @@ def _is_inline_preview_media(filename: str) -> bool:
     These types are only detected by filename extension, since
     ``[label](file:id)`` targets are opaque UUIDs. The model is free to
     rewrite the label into descriptive prose that drops the extension (e.g.
-    "下载视频（MP4）"), which silently degrades the player to a plain download
-    link — callers restore the real filename as the label in that case so
-    the extension survives into the rendered markdown. Deliberately limited
-    to lightweight media players: office types (presentation/document/
+    "下载视频（MP4）"), which would otherwise silently degrade the player to a
+    plain download link — callers carry the real filename in the link
+    *title* in that case (falling back to overwriting the label only when
+    the filename can't safely become a title) so the extension survives
+    into the rendered markdown either way. Deliberately limited to
+    lightweight media players: office types (presentation/document/
     spreadsheet) keep the model's prose label because rewriting it would
     flip existing compact links into heavy inline preview boxes that
     eagerly fetch file bytes.
@@ -73,11 +126,22 @@ _UNSAFE_LABEL_RE = re.compile(r"[\[\]\\\x00-\x1f\x7f]")
 # The primary mechanism (see ``reconcile_assistant_file_references``): carry
 # the real filename in the link *title* rather than overwriting the label,
 # so the model's own (possibly localized) prose survives in the persisted
-# transcript. A title is delimited by a double quote here, so an embedded
-# ``"`` would terminate it early — same class of hazard as ``]`` for a
-# label, same reasoning for why skipping beats escaping. Control characters
-# are unsafe for the same paragraph-splitting reason as `_UNSAFE_LABEL_RE`.
-_UNSAFE_TITLE_RE = re.compile(r'["\x00-\x1f\x7f]')
+# transcript. This must stay a superset of every character
+# ``_MARKDOWN_FILE_REFERENCE_RE``'s title groups can't round-trip, so a
+# title we emit here is always safely re-parsed by that regex on a later
+# reconcile pass:
+#   - ``"`` terminates the double-quote delimiter this function always
+#     writes early — same class of hazard as ``]`` for a label.
+#   - ``\`` (backslash) — same reasoning as ``_UNSAFE_LABEL_RE``: the regex
+#     has no notion of CommonMark backslash-escapes, so raw stored text and
+#     CommonMark-rendered text could otherwise diverge.
+#   - ``)`` / ``[`` — the regex's title-parsing bounds a title to the
+#     current link's own closing paren and never lets it cross into what
+#     looks like another link's opening bracket; emitting either character
+#     raw would defeat that on the very next reconcile pass.
+#   - Control characters are unsafe for the same paragraph-splitting reason
+#     as ``_UNSAFE_LABEL_RE``.
+_UNSAFE_TITLE_RE = re.compile(r'["\\[)\x00-\x1f\x7f]')
 
 
 def load_assistant_file_reference_records(
@@ -137,11 +201,19 @@ def reconcile_assistant_file_references(
         prefix = match.group("image") or ""
         label = match.group("label")
         target = match.group("target")
+        parsed_title = _parsed_title(match)
         referenced_id = parse_file_id_ref(target)
         record = records_by_id.get(referenced_id or "")
 
         if record is None:
-            filename = Path(label.strip()).name
+            # The title is this function's own injection slot for the real
+            # filename (see below) and takes priority over the label as the
+            # repair source: once a reference has already been reconciled
+            # once, a later pass over the same content (e.g. persist-time
+            # then read-time) finds the filename in the title, not the
+            # label, and must not lose repair capability just because of
+            # that.
+            filename = Path((parsed_title or label).strip()).name
             filename_key = filename.casefold()
             candidates = task_records_by_filename.get(filename_key, [])
             if not candidates:
@@ -177,9 +249,7 @@ def reconcile_assistant_file_references(
             return label
 
         display_label = label
-        display_title = match.group("dtitle")
-        if display_title is None:
-            display_title = match.group("stitle")
+        display_title = parsed_title
         filename = str(record.filename or "")
         # Applies to ``![...]`` references too: _is_inline_preview_media only
         # matches video/audio, so genuine image alt text is never touched,

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -38,9 +38,30 @@ logger = logging.getLogger(__name__)
 #   ``_UNSAFE_LABEL_RE``/``_UNSAFE_TITLE_RE`` below.
 #
 # A title clause that doesn't parse as any of the three forms (duplicated,
-# unterminated, mismatched delimiters) falls through to the bare
-# alternative, which discards it as unstructured trailing content up to
-# the next ``)`` -- the reference is still validated, just without a title.
+# unterminated, mismatched delimiters) falls through to the "junk"
+# alternative, which discards it as unstructured trailing content up to the
+# next ``)`` -- the reference is still validated, just without a title. A
+# deliberate side effect: an input like ``[x](file:id not a title)``, which
+# CommonMark renders as inert literal text (invalid destination/title
+# syntax), is normalized into a live ``[x](file:id)`` link when the id
+# resolves. That's this function's purpose applied to a slightly mangled
+# reference -- the model clearly meant a file link -- rather than an
+# accident; see test_reconcile_normalizes_unparsable_trailing_junk. That
+# junk alternative excludes ``(`` (as well as ``)``/``[``/control chars): if
+# it didn't, junk could cross an inner ``)`` that isn't this link's own
+# closing paren and strand the remainder of the message outside the link
+# entirely (verified: ``[x](file:id (c) 2024) tail`` would otherwise match
+# only through the first ``)``, leaving `` 2024) tail`` as stray text in the
+# persisted transcript). Excluding ``(`` means this and similar malformed
+# inputs simply fail to match at all -- identical to this regex's pre-title
+# behavior of leaving an unparsable reference completely untouched, which
+# is the correct, non-destructive fallback.
+#
+# Each title form also tolerates trailing whitespace before the closing
+# ``)`` (``\s*`` after the delimiter closes) -- otherwise
+# ``[a](file:id "t.mp4"  )`` would fail title-form and fall through to junk,
+# which has no notion of title syntax and would silently discard the title
+# text with no re-injection for non-media files.
 #
 # This is the canonical parser for this ``[label](file:id ["title"])``
 # format -- ``reconcile_assistant_file_references`` is what actually
@@ -55,10 +76,12 @@ _MARKDOWN_FILE_REFERENCE_RE = re.compile(
     r"(?P<image>!)?\[(?P<label>[^\]]*)\]\("
     r"(?P<target>file:[^)\s]+)"
     r"(?:"
-    r'(?:\s+(?:"(?P<dtitle>(?:[^"\\)[\x00-\x1f\x7f]|\\.)*)"'
+    r"(?:\s+"
+    r'(?:"(?P<dtitle>(?:[^"\\)[\x00-\x1f\x7f]|\\.)*)"'
     r"|'(?P<stitle>(?:[^'\\)[\x00-\x1f\x7f]|\\.)*)'"
-    r"|\((?P<ptitle>(?:[^()\\[\x00-\x1f\x7f]|\\.)*)\)))?"
-    r"|[^)[\x00-\x1f\x7f]*"
+    r"|\((?P<ptitle>(?:[^()\\[\x00-\x1f\x7f]|\\.)*)\))"
+    r"\s*)?"
+    r"|[^()[\x00-\x1f\x7f]*"
     r")"
     r"\)"
 )
@@ -173,11 +196,14 @@ def reconcile_assistant_file_references(
     """Canonicalize valid links, repair unique filename matches, and unlink fakes.
 
     Models occasionally copy a filename correctly while inventing the UUID in
-    ``file:<id>``. A broken UUID must never become a clickable preview. When the
-    markdown label uniquely identifies a file in the current task/user scope,
-    replace it with that record's canonical id; otherwise keep only plain text.
-    Filename repair is necessarily heuristic if an older same-named file is no
-    longer present, so every repair is logged as a warning for auditability.
+    ``file:<id>``. A broken UUID must never become a clickable preview. Repair
+    tries the markdown *title* before the label -- once a reference has
+    already been through one reconcile pass, the real filename lives there,
+    not in the label -- falling through to the label if the title doesn't
+    uniquely identify a file in the current task/user scope. If neither does,
+    keep only plain text. Filename repair is necessarily heuristic if an
+    older same-named file is no longer present, so every repair is logged as
+    a warning for auditability.
     """
     if not isinstance(content, str) or "file:" not in content:
         return content
@@ -206,27 +232,36 @@ def reconcile_assistant_file_references(
         record = records_by_id.get(referenced_id or "")
 
         if record is None:
-            # The title is this function's own injection slot for the real
-            # filename (see below) and takes priority over the label as the
-            # repair source: once a reference has already been reconciled
-            # once, a later pass over the same content (e.g. persist-time
-            # then read-time) finds the filename in the title, not the
-            # label, and must not lose repair capability just because of
-            # that.
-            filename = Path((parsed_title or label).strip()).name
-            filename_key = filename.casefold()
-            candidates = task_records_by_filename.get(filename_key, [])
-            if not candidates:
-                candidates = records_by_filename.get(filename_key, [])
-            if len(candidates) == 1:
-                record = candidates[0]
-                logger.warning(
-                    "Repaired invalid assistant FileRef %s using heuristic unique "
-                    "filename %s for task %s",
-                    referenced_id or target,
-                    filename,
-                    task_id,
-                )
+            # Try the title before the label, but fall through to the label
+            # if the title doesn't resolve to exactly one record -- not just
+            # if it's absent. The title is this function's own injection
+            # slot for the real filename (see below), so once a reference
+            # has already been reconciled once, a later pass over the same
+            # content (e.g. persist-time then read-time) finds the filename
+            # there rather than in the label, and must not lose repair
+            # capability just because of that. But an unconditional
+            # title-over-label pick would create the mirror-image gap: a
+            # model-authored title that happens to name a different (or no)
+            # file must not shadow a label that's otherwise a perfect,
+            # resolvable match.
+            for filename_source in (parsed_title, label):
+                if not filename_source:
+                    continue
+                filename = Path(filename_source.strip()).name
+                filename_key = filename.casefold()
+                candidates = task_records_by_filename.get(filename_key, [])
+                if not candidates:
+                    candidates = records_by_filename.get(filename_key, [])
+                if len(candidates) == 1:
+                    record = candidates[0]
+                    logger.warning(
+                        "Repaired invalid assistant FileRef %s using heuristic "
+                        "unique filename %s for task %s",
+                        referenced_id or target,
+                        filename,
+                        task_id,
+                    )
+                    break
 
         if record is None:
             logger.warning(
@@ -260,12 +295,14 @@ def reconcile_assistant_file_references(
         if _is_inline_preview_media(filename):
             suffix = Path(filename).suffix.casefold()
             # Only intervene when the label alone can't already be
-            # classified by the frontend -- mirrors the pre-title behavior
-            # exactly, just preferring a title over overwriting the label
-            # when intervention is needed. A label that already reveals the
-            # type is left alone even if it names a different file than the
-            # record (see test_reconcile_keeps_mismatched_label_...): there
-            # is no signal that a coincidental extension match is wrong.
+            # classified by the frontend -- the same gate the pre-title
+            # label-rewrite used (the mechanism differs: inject/overwrite a
+            # title first, only falling back to overwriting the label when
+            # the filename can't safely become a title). A label that
+            # already reveals the type is left alone even if it names a
+            # different file than the record (see
+            # test_reconcile_keeps_mismatched_label_...): there is no
+            # signal that a coincidental extension match is wrong.
             label_reveals_type = bool(suffix) and label.strip().casefold().endswith(
                 suffix
             )
@@ -296,6 +333,12 @@ def reconcile_assistant_file_references(
         # allows an embedded double quote) could be unsafe to re-emit with
         # the double-quote delimiter this function always writes. Drop it
         # rather than escape it -- same reasoning as `_UNSAFE_LABEL_RE`.
+        #
+        # This delimiter choice also means a model-authored '...' or (...)
+        # title is normalized to "..." syntax even when nothing else about
+        # the reference changed -- intentional (one consistent output form
+        # is simpler to reason about than round-tripping the original
+        # delimiter), not an oversight.
         if display_title and not _UNSAFE_TITLE_RE.search(display_title):
             return f'{prefix}[{display_label}]({canonical_ref} "{display_title}")'
         return f"{prefix}[{display_label}]({canonical_ref})"

--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -18,7 +18,10 @@ from ..models.uploaded_file import UploadedFile
 logger = logging.getLogger(__name__)
 
 _MARKDOWN_FILE_REFERENCE_RE = re.compile(
-    r"(?P<image>!)?\[(?P<label>[^\]]*)\]\((?P<target>file:[^)\s]+)\)"
+    r"(?P<image>!)?\[(?P<label>[^\]]*)\]\("
+    r"(?P<target>file:[^)\s]+)"
+    r"(?:\s+\"(?P<dtitle>[^\"]*)\"|\s+'(?P<stitle>[^']*)')?"
+    r"\)"
 )
 
 # ``artifact_type_for_filename`` only knows image/video/office extensions
@@ -61,7 +64,20 @@ def _is_inline_preview_media(filename: str) -> bool:
 # label boundary at the escaped bracket. Skipping the rewrite for these
 # filenames is the safe, idempotent choice; the link still falls back to a
 # plain download label.
+#
+# Used as the fallback path when a filename is unsafe for the *title*
+# (below) — the two hazards are mostly disjoint, so a filename can safely
+# carry a title while remaining unsafe as a label (or vice versa).
 _UNSAFE_LABEL_RE = re.compile(r"[\[\]\\\x00-\x1f\x7f]")
+
+# The primary mechanism (see ``reconcile_assistant_file_references``): carry
+# the real filename in the link *title* rather than overwriting the label,
+# so the model's own (possibly localized) prose survives in the persisted
+# transcript. A title is delimited by a double quote here, so an embedded
+# ``"`` would terminate it early — same class of hazard as ``]`` for a
+# label, same reasoning for why skipping beats escaping. Control characters
+# are unsafe for the same paragraph-splitting reason as `_UNSAFE_LABEL_RE`.
+_UNSAFE_TITLE_RE = re.compile(r'["\x00-\x1f\x7f]')
 
 
 def load_assistant_file_reference_records(
@@ -161,17 +177,57 @@ def reconcile_assistant_file_references(
             return label
 
         display_label = label
+        display_title = match.group("dtitle")
+        if display_title is None:
+            display_title = match.group("stitle")
         filename = str(record.filename or "")
         # Applies to ``![...]`` references too: _is_inline_preview_media only
         # matches video/audio, so genuine image alt text is never touched,
-        # while a model that wraps a video in image syntax still gets a label
-        # the frontend can classify (its image renderer resolves the preview
-        # kind from the label and would otherwise fall back to a broken img).
-        if _is_inline_preview_media(filename) and not _UNSAFE_LABEL_RE.search(filename):
+        # while a model that wraps a video in image syntax still gets a
+        # title the frontend can classify (its image renderer resolves the
+        # preview kind from title/alt and would otherwise fall back to a
+        # broken img).
+        if _is_inline_preview_media(filename):
             suffix = Path(filename).suffix.casefold()
-            if suffix and not label.strip().casefold().endswith(suffix):
-                display_label = filename
+            # Only intervene when the label alone can't already be
+            # classified by the frontend -- mirrors the pre-title behavior
+            # exactly, just preferring a title over overwriting the label
+            # when intervention is needed. A label that already reveals the
+            # type is left alone even if it names a different file than the
+            # record (see test_reconcile_keeps_mismatched_label_...): there
+            # is no signal that a coincidental extension match is wrong.
+            label_reveals_type = bool(suffix) and label.strip().casefold().endswith(
+                suffix
+            )
+            if not label_reveals_type:
+                if not _UNSAFE_TITLE_RE.search(filename):
+                    # Primary mechanism: carry the real filename in the
+                    # title so the frontend can still detect the media
+                    # type, while the model's own (possibly localized)
+                    # label survives untouched in the persisted transcript.
+                    # Always overwrites any parsed title so this stays
+                    # idempotent and self-heals if the canonical filename
+                    # ever changes.
+                    display_title = filename
+                elif not _UNSAFE_LABEL_RE.search(filename):
+                    # Filename has a quote character and can't safely
+                    # become a title. Fall back to the pre-title mechanism:
+                    # overwrite the label itself. Drop any parsed title
+                    # too, so a stale title never survives alongside a
+                    # freshly rewritten label.
+                    display_title = None
+                    display_label = filename
+                # else: unsafe for both title and label -- leave the
+                # reference untouched; it degrades to a plain download
+                # link on the frontend, same as any other undetectable
+                # file type.
 
+        # A pass-through title (parsed from single-quote syntax, which
+        # allows an embedded double quote) could be unsafe to re-emit with
+        # the double-quote delimiter this function always writes. Drop it
+        # rather than escape it -- same reasoning as `_UNSAFE_LABEL_RE`.
+        if display_title and not _UNSAFE_TITLE_RE.search(display_title):
+            return f'{prefix}[{display_label}]({canonical_ref} "{display_title}")'
         return f"{prefix}[{display_label}]({canonical_ref})"
 
     return _MARKDOWN_FILE_REFERENCE_RE.sub(replacement, content)

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -963,6 +963,113 @@ def test_audio_extension_detection_matches_frontend_set():
     assert frontend_audio_extensions == _AUDIO_EXTENSIONS
 
 
+def test_reconcile_does_not_strand_content_across_a_malformed_parenthetical():
+    # Regression for a real data-corruption bug: the "junk" fallback for a
+    # malformed title used to allow "(" through, so it could match only
+    # through an inner, unrelated ")" and strand everything after it (up to
+    # the link's own closing paren) as literal text outside the link. With
+    # "(" excluded, this exact input fails to match at all -- identical to
+    # this regex's behavior before title support existed at all, i.e. the
+    # correct, non-destructive "leave it untouched" outcome.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="real-id", filename="report.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[x](file:real-id (c) 2024) tail",
+        )
+
+        assert content == "[x](file:real-id (c) 2024) tail"
+    finally:
+        db.close()
+
+
+def test_reconcile_normalizes_unparsable_trailing_junk():
+    # Pins the deliberate side effect of the junk fallback: an input like
+    # this is inert literal text to CommonMark (invalid destination/title
+    # syntax), but the model clearly meant a file link, so reconciliation
+    # normalizes it into a live, validated reference and drops the junk.
+    # Contrast with the parenthetical case above, which cannot be safely
+    # bounded and is left completely untouched instead.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="real-id", filename="report.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[report.mp4](file:real-id not a title)",
+        )
+
+        assert content == "[report.mp4](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_validates_id_for_title_with_trailing_whitespace():
+    # A title clause is allowed trailing whitespace before the link's
+    # closing paren. Without this, the title-form match would fail and fall
+    # through to the junk alternative, which has no notion of title syntax
+    # and would silently discard the title text -- with no re-injection for
+    # a non-media file like this one.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="report.pdf",
+            mime_type="application/pdf",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[report](file:real-id  "annual report"  )',
+        )
+
+        assert content == '[report](file:real-id "annual report")'
+    finally:
+        db.close()
+
+
+def test_reconcile_repairs_invented_id_from_label_when_title_names_a_different_file():
+    # Mirror-image case of test_reconcile_repairs_invented_id_from_title_...:
+    # the title takes priority, but only when it actually resolves to
+    # exactly one record. Here the title is unresolvable prose while the
+    # label alone is the exact, resolvable filename -- an unconditional
+    # title-over-label pick would incorrectly unlink this instead of
+    # repairing it. The pre-existing title survives untouched afterwards:
+    # the label already reveals the media type ("report.mp4" ends in
+    # .mp4), so the title-injection step below has no reason to intervene.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="report.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[report.mp4](file:invented-id "My yearly report")',
+        )
+
+        assert content == '[report.mp4](file:real-id "My yearly report")'
+    finally:
+        db.close()
+
+
 def test_reconcile_reuses_prefetched_records_without_querying():
     db, user, task = _create_context()
     try:

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -526,8 +526,9 @@ def test_reconcile_keeps_alt_text_for_image_syntax_image_reference():
 
 def test_reconcile_adds_title_for_empty_label_media_reference():
     # The frontend falls back to the title when the label is empty
-    # (fileName = title || linkText || fileNameFromPath), so an empty label
-    # still gets a working preview once the title carries the filename.
+    # (displayFilename = visibleText || title || fileNameFromPath), so an
+    # empty label still gets a working preview once the title carries the
+    # filename.
     db, user, task = _create_context()
     try:
         _add_file(

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -154,7 +154,11 @@ def test_reconcile_unlinks_record_with_invalid_file_id():
         db.close()
 
 
-def test_reconcile_rewrites_label_to_filename_when_extension_is_missing():
+def test_reconcile_adds_title_and_keeps_label_when_extension_is_missing():
+    # The primary mechanism as of #1202: the model's own (localized) label
+    # survives untouched in the persisted transcript; the real filename
+    # rides in the link *title* instead, which the frontend already prefers
+    # for type detection over the label.
     db, user, task = _create_context()
     try:
         _add_file(
@@ -172,12 +176,12 @@ def test_reconcile_rewrites_label_to_filename_when_extension_is_missing():
             content="[下载视频（MP4）](file:real-id)",
         )
 
-        assert content == "[generated_video.mp4](file:real-id)"
+        assert content == '[下载视频（MP4）](file:real-id "generated_video.mp4")'
     finally:
         db.close()
 
 
-def test_reconcile_rewrites_label_to_filename_for_audio_when_extension_is_missing():
+def test_reconcile_adds_title_for_audio_when_extension_is_missing():
     db, user, task = _create_context()
     try:
         _add_file(
@@ -196,16 +200,16 @@ def test_reconcile_rewrites_label_to_filename_for_audio_when_extension_is_missin
             content="[下载音频（MP3）](file:real-id)",
         )
 
-        assert content == "[generated_podcast.mp3](file:real-id)"
+        assert content == '[下载音频（MP3）](file:real-id "generated_podcast.mp3")'
     finally:
         db.close()
 
 
-def test_reconcile_rewrites_label_for_m4v_extension():
+def test_reconcile_adds_title_for_m4v_extension():
     # Regression test: the frontend's video regex
     # (inline-file-preview-utils.ts) recognizes .m4v, and
-    # artifact_type_for_filename must agree or this rewrite silently
-    # no-ops for .m4v the same way it used to for all audio extensions.
+    # artifact_type_for_filename must agree or this silently no-ops for
+    # .m4v the same way it used to for all audio extensions.
     db, user, task = _create_context()
     try:
         _add_file(
@@ -224,12 +228,12 @@ def test_reconcile_rewrites_label_for_m4v_extension():
             content="[下载视频（M4V）](file:real-id)",
         )
 
-        assert content == "[generated_video.m4v](file:real-id)"
+        assert content == '[下载视频（M4V）](file:real-id "generated_video.m4v")'
     finally:
         db.close()
 
 
-def test_reconcile_rewrites_label_case_insensitively():
+def test_reconcile_adds_title_case_insensitively():
     db, user, task = _create_context()
     try:
         _add_file(
@@ -247,7 +251,33 @@ def test_reconcile_rewrites_label_case_insensitively():
             content="[下载视频](file:real-id)",
         )
 
-        assert content == "[CLIP.MP4](file:real-id)"
+        assert content == '[下载视频](file:real-id "CLIP.MP4")'
+    finally:
+        db.close()
+
+
+def test_reconcile_self_heals_stale_title_to_current_filename():
+    # The title is always overwritten (when the label doesn't already
+    # reveal the type), so a stale title from before a rename can never
+    # linger and point at the wrong file.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="renamed_video.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[下载视频（MP4）](file:real-id "old_video_name.mp4")',
+        )
+
+        assert content == '[下载视频（MP4）](file:real-id "renamed_video.mp4")'
     finally:
         db.close()
 
@@ -332,11 +362,11 @@ def test_reconcile_keeps_mismatched_label_that_already_has_media_extension():
         db.close()
 
 
-def test_reconcile_skips_label_rewrite_for_filename_with_unsafe_chars():
-    # A real filename containing "]" must never be substituted into the
-    # label unescaped -- it would terminate the markdown link early and
-    # drop the file reference entirely, which is worse than leaving the
-    # model's prose label (and its plain-download fallback) in place.
+def test_reconcile_uses_title_for_filename_with_bracket_characters():
+    # A "]" or "[" has no special meaning inside a quoted title (unlike a
+    # label, which the "]" would terminate early), so a bracket-bearing
+    # filename now takes the title path instead of degrading to a plain
+    # download link the way it did before titles existed.
     db, user, task = _create_context()
     try:
         _add_file(
@@ -354,15 +384,41 @@ def test_reconcile_skips_label_rewrite_for_filename_with_unsafe_chars():
             content="[下载视频（MP4）](file:real-id)",
         )
 
-        assert content == "[下载视频（MP4）](file:real-id)"
+        assert content == '[下载视频（MP4）](file:real-id "clip ].mp4")'
     finally:
         db.close()
 
 
-def test_reconcile_skips_label_rewrite_for_filename_with_control_chars():
+def test_reconcile_falls_back_to_label_rewrite_for_filename_with_quote():
+    # A literal double quote can't safely become a title (it would
+    # terminate the title clause early), but has no special meaning in a
+    # label -- falls back to the pre-title label-rewrite mechanism.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename='clip".mp4',
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频（MP4）](file:real-id)",
+        )
+
+        assert content == '[clip".mp4](file:real-id)'
+    finally:
+        db.close()
+
+
+def test_reconcile_skips_rewrite_for_filename_unsafe_for_both_title_and_label():
     # A filename containing a blank line would split the paragraph before
-    # CommonMark ever parses the inline link -- same failure mode as "]",
-    # through a different character class.
+    # CommonMark ever parses the inline link, whether substituted into a
+    # label or a title -- leave the reference untouched in that case.
     db, user, task = _create_context()
     try:
         _add_file(
@@ -385,10 +441,11 @@ def test_reconcile_skips_label_rewrite_for_filename_with_control_chars():
         db.close()
 
 
-def test_reconcile_rewrites_label_for_image_syntax_video_reference():
+def test_reconcile_adds_title_for_image_syntax_video_reference():
     # A model may wrap a video in image syntax. The frontend's image
-    # renderer resolves the preview kind from the label, so restoring the
-    # filename there turns a would-be broken <img> into a video player.
+    # renderer resolves the preview kind from title/alt, so adding the
+    # title turns a would-be broken <img> into a video player while the
+    # model's alt text stays untouched.
     db, user, task = _create_context()
     try:
         _add_file(
@@ -406,7 +463,7 @@ def test_reconcile_rewrites_label_for_image_syntax_video_reference():
             content="![预览视频](file:real-id)",
         )
 
-        assert content == "![generated_video.mp4](file:real-id)"
+        assert content == '![预览视频](file:real-id "generated_video.mp4")'
     finally:
         db.close()
 
@@ -437,7 +494,10 @@ def test_reconcile_keeps_alt_text_for_image_syntax_image_reference():
         db.close()
 
 
-def test_reconcile_rewrites_empty_label_to_filename_for_media():
+def test_reconcile_adds_title_for_empty_label_media_reference():
+    # The frontend falls back to the title when the label is empty
+    # (fileName = title || linkText || fileNameFromPath), so an empty label
+    # still gets a working preview once the title carries the filename.
     db, user, task = _create_context()
     try:
         _add_file(
@@ -455,7 +515,65 @@ def test_reconcile_rewrites_empty_label_to_filename_for_media():
             content="[](file:real-id)",
         )
 
-        assert content == "[generated_video.mp4](file:real-id)"
+        assert content == '[](file:real-id "generated_video.mp4")'
+    finally:
+        db.close()
+
+
+def test_reconcile_title_injection_is_idempotent():
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video.mp4",
+        )
+
+        once = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频（MP4）](file:real-id)",
+        )
+        twice = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content=once,
+        )
+
+        assert once == '[下载视频（MP4）](file:real-id "generated_video.mp4")'
+        assert twice == once
+    finally:
+        db.close()
+
+
+def test_reconcile_round_trips_single_quote_title_for_non_media_reference():
+    # Title syntax also allows single quotes. Non-media references don't
+    # go through the title-injection logic at all, so this exercises pure
+    # input parsing: the parsed title is preserved and re-serialized with
+    # the double-quote delimiter this function always writes.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="report.pdf",
+            mime_type="application/pdf",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[report](file:real-id 'annual_report_2024.pdf')",
+        )
+
+        assert content == '[report](file:real-id "annual_report_2024.pdf")'
     finally:
         db.close()
 

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -709,7 +709,10 @@ def test_reconcile_unlinks_titled_reference_with_ambiguous_filename():
             content='[下载报告](file:invented-id "report.mp4")',
         )
 
-        assert content == "下载报告"
+        # The title survives as plain text: it's this function's own
+        # channel for the real filename, and dropping it here would
+        # destroy the one clue naming which file was meant.
+        assert content == "下载报告 (report.mp4)"
         assert "file:" not in content
     finally:
         db.close()
@@ -718,7 +721,8 @@ def test_reconcile_unlinks_titled_reference_with_ambiguous_filename():
 def test_reconcile_unlinks_titled_reference_when_stored_file_id_is_invalid():
     # Title-based repair can still land on a record whose OWN stored id is
     # malformed; that must still be caught and unlinked (dropping the
-    # title along with the brackets), same as the label-based case.
+    # brackets/link structure), same as the label-based case -- but the
+    # title itself survives as plain text rather than being destroyed.
     db, user, task = _create_context()
     try:
         _add_file(
@@ -736,7 +740,7 @@ def test_reconcile_unlinks_titled_reference_when_stored_file_id_is_invalid():
             content='[下载视频](file:invented-id "generated_video.mp4")',
         )
 
-        assert content == "下载视频"
+        assert content == "下载视频 (generated_video.mp4)"
     finally:
         db.close()
 
@@ -838,7 +842,9 @@ def test_reconcile_unlinks_reference_with_escaped_quote_in_invented_titles_id():
     # [label](file:id "...") construct fail to match -- that would let an
     # invented id skip validation entirely (the pre-title-support regex
     # bypassed this kind of link completely; this asserts the id is
-    # actually evaluated and correctly unlinked, not silently ignored).
+    # actually evaluated and correctly unlinked, not silently ignored). The
+    # title itself survives as plain text (raw, backslash included -- same
+    # as the label, this function never unescapes it for display).
     db, user, task = _create_context()
     try:
         _add_file(db, user, task, file_id="real-id", filename="clip.mp4")
@@ -850,7 +856,7 @@ def test_reconcile_unlinks_reference_with_escaped_quote_in_invented_titles_id():
             content='[x](file:invented-id "we\\"ird.mp4")',
         )
 
-        assert content == "x"
+        assert content == 'x (we\\"ird.mp4)'
     finally:
         db.close()
 
@@ -1243,7 +1249,10 @@ def test_reconcile_does_not_repair_via_whitespace_only_title_or_label():
     # is literally empty, silently repairing an invented id to the wrong
     # file. Internal record construction doesn't validate filenames the way
     # the HTTP upload endpoints do, so an empty-filename record is a real
-    # (if unusual) possibility, not a hypothetical.
+    # (if unusual) possibility, not a hypothetical. Exercises both
+    # candidates from the shared (parsed_title, label) repair loop -- a
+    # title clause is present here, not just a whitespace-only label, so
+    # the title branch of that loop is actually covered.
     db, user, task = _create_context()
     try:
         _add_file(db, user, task, file_id="empty-name-id", filename="")
@@ -1252,10 +1261,10 @@ def test_reconcile_does_not_repair_via_whitespace_only_title_or_label():
             db,
             task_id=int(task.id),
             user_id=int(user.id),
-            content="[  ](file:invented-id)",
+            content='[  ](file:invented-id "   ")',
         )
 
-        assert content == "  "
+        assert "file:" not in content
     finally:
         db.close()
 

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -362,11 +362,11 @@ def test_reconcile_keeps_mismatched_label_that_already_has_media_extension():
         db.close()
 
 
-def test_reconcile_uses_title_for_filename_with_bracket_characters():
-    # A "]" or "[" has no special meaning inside a quoted title (unlike a
-    # label, which the "]" would terminate early), so a bracket-bearing
-    # filename now takes the title path instead of degrading to a plain
-    # download link the way it did before titles existed.
+def test_reconcile_uses_title_for_filename_with_closing_bracket():
+    # "]" has no special meaning inside a quoted title (unlike a label,
+    # which it would terminate early), so a filename with a closing bracket
+    # but no opening one takes the title path instead of degrading to a
+    # plain download link the way it did before titles existed.
     db, user, task = _create_context()
     try:
         _add_file(
@@ -385,6 +385,35 @@ def test_reconcile_uses_title_for_filename_with_bracket_characters():
         )
 
         assert content == '[下载视频（MP4）](file:real-id "clip ].mp4")'
+    finally:
+        db.close()
+
+
+def test_reconcile_skips_rewrite_for_filename_with_opening_bracket():
+    # Unlike "]", an opening "[" IS unsafe for a title: the title-parsing
+    # regex excludes it so a malformed title can never swallow a
+    # subsequent, well-formed [label](file:...) reference whole. A
+    # filename with "[" is therefore unsafe for both title and label (the
+    # label guard already excluded "[") and the reference is left
+    # untouched rather than getting a half-safe rewrite.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="clip [draft.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频（MP4）](file:real-id)",
+        )
+
+        assert content == "[下载视频（MP4）](file:real-id)"
     finally:
         db.close()
 
@@ -574,6 +603,335 @@ def test_reconcile_round_trips_single_quote_title_for_non_media_reference():
         )
 
         assert content == '[report](file:real-id "annual_report_2024.pdf")'
+    finally:
+        db.close()
+
+
+def test_reconcile_repairs_invented_id_from_title_when_label_is_prose():
+    # The repair heuristic must consult the title, not just the label: once
+    # a reference has already been through one title-injection pass, a
+    # later pass over content whose original id has since gone invalid can
+    # only find the real filename in the title -- the label is untouched
+    # model prose that reveals nothing about it.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="c6553861-5bdd-4628-9b15-1310e34fe499",
+            filename="generated_video_253a6da9.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content=(
+                '[下载视频（MP4）](file:invented-id "generated_video_253a6da9.mp4")'
+            ),
+        )
+
+        assert content == (
+            "[下载视频（MP4）](file:c6553861-5bdd-4628-9b15-1310e34fe499 "
+            '"generated_video_253a6da9.mp4")'
+        )
+    finally:
+        db.close()
+
+
+def test_reconcile_repairs_from_title_after_original_record_is_removed():
+    # Reproduces the repair-heuristic gap end to end: reconcile once (a
+    # title gets injected), delete the underlying record, register a
+    # replacement under a new id with the same filename, then reconcile the
+    # already-titled content again. Before the title was consulted for
+    # repair, this second pass would have dropped the reference to plain
+    # text -- the label is untouched prose, so filename-based repair had
+    # nothing to match on even though the correct filename was sitting
+    # right there in the title.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="original-id",
+            filename="generated_video.mp4",
+        )
+
+        once = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[下载视频（MP4）](file:original-id)",
+        )
+        assert once == '[下载视频（MP4）](file:original-id "generated_video.mp4")'
+
+        stale_record = (
+            db.query(UploadedFile).filter(UploadedFile.file_id == "original-id").one()
+        )
+        db.delete(stale_record)
+        db.flush()
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="replacement-id",
+            filename="generated_video.mp4",
+        )
+
+        twice = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content=once,
+        )
+
+        assert twice == ('[下载视频（MP4）](file:replacement-id "generated_video.mp4")')
+    finally:
+        db.close()
+
+
+def test_reconcile_unlinks_titled_reference_with_ambiguous_filename():
+    # The title-aware repair heuristic is still subject to the same
+    # ambiguity guard as label-based repair: a filename match that isn't
+    # unique can't be trusted to pick the right record.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="first-id", filename="report.mp4")
+        _add_file(db, user, task, file_id="second-id", filename="report.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[下载报告](file:invented-id "report.mp4")',
+        )
+
+        assert content == "下载报告"
+        assert "file:" not in content
+    finally:
+        db.close()
+
+
+def test_reconcile_unlinks_titled_reference_when_stored_file_id_is_invalid():
+    # Title-based repair can still land on a record whose OWN stored id is
+    # malformed; that must still be caught and unlinked (dropping the
+    # title along with the brackets), same as the label-based case.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="invalid/id",
+            filename="generated_video.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[下载视频](file:invented-id "generated_video.mp4")',
+        )
+
+        assert content == "下载视频"
+    finally:
+        db.close()
+
+
+def test_reconcile_keeps_pre_existing_title_when_label_already_reveals_type():
+    # When the label alone is already classifiable, the backend must not
+    # touch a pre-existing title -- there's no signal that an
+    # author-supplied title is wrong just because it differs from the
+    # record's current filename (mirrors
+    # test_reconcile_keeps_mismatched_label_that_already_has_media_extension
+    # for the title case).
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="generated_video_a1b2c3.mp4",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[my_clip.mp4](file:real-id "custom title.mp4")',
+        )
+
+        assert content == '[my_clip.mp4](file:real-id "custom title.mp4")'
+    finally:
+        db.close()
+
+
+def test_reconcile_handles_multiple_valid_links_in_one_message():
+    # The substitution is a single global regex pass over the whole
+    # message; each match must be reconciled independently rather than
+    # leaking state (e.g. a stale title) from one match into the next.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="video-id", filename="generated_video.mp4")
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="audio-id",
+            filename="generated_podcast.mp3",
+            mime_type="audio/mpeg",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content=(
+                "[下载视频（MP4）](file:video-id) and [下载音频（MP3）](file:audio-id)"
+            ),
+        )
+
+        assert content == (
+            '[下载视频（MP4）](file:video-id "generated_video.mp4") and '
+            '[下载音频（MP3）](file:audio-id "generated_podcast.mp3")'
+        )
+    finally:
+        db.close()
+
+
+def test_reconcile_drops_unsafe_pass_through_title_without_touching_label():
+    # A non-media reference's title is pure pass-through (no injection
+    # logic runs for it). Single-quote syntax lets an input title
+    # legitimately contain a literal double quote, but this function
+    # always re-emits titles with the double-quote delimiter, so that
+    # title can't be reproduced safely -- drop it rather than rewrite the
+    # label, which has nothing to do with title safety for non-media types.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="report.pdf",
+            mime_type="application/pdf",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[report](file:real-id 'annual \"2024\" report.pdf')",
+        )
+
+        assert content == "[report](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_unlinks_reference_with_escaped_quote_in_invented_titles_id():
+    # A backslash-escaped quote inside the title must not make the whole
+    # [label](file:id "...") construct fail to match -- that would let an
+    # invented id skip validation entirely (the pre-title-support regex
+    # bypassed this kind of link completely; this asserts the id is
+    # actually evaluated and correctly unlinked, not silently ignored).
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="real-id", filename="clip.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[x](file:invented-id "we\\"ird.mp4")',
+        )
+
+        assert content == "x"
+    finally:
+        db.close()
+
+
+def test_reconcile_validates_id_despite_unsafe_escaped_title():
+    # Complements the unlink case above: here the id is directly valid, so
+    # escape-aware title parsing must let the reference survive
+    # reconciliation. The raw escaped title itself is still unsafe to
+    # re-emit verbatim (see _UNSAFE_TITLE_RE) and is dropped rather than
+    # corrupting the output.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="report.pdf",
+            mime_type="application/pdf",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[report](file:real-id "we\\"ird.pdf")',
+        )
+
+        assert content == "[report](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_validates_id_for_paren_delimited_title():
+    # CommonMark also allows a (title) delimiter form. It must be
+    # recognized so id validation runs instead of silently skipping the
+    # whole reference the way the pre-escape-aware regex did.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="report.pdf",
+            mime_type="application/pdf",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[report](file:real-id (annual report))",
+        )
+
+        assert content == '[report](file:real-id "annual report")'
+    finally:
+        db.close()
+
+
+def test_reconcile_does_not_merge_adjacent_links_across_a_malformed_title():
+    # A malformed title in one reference must not swallow a second,
+    # well-formed reference whole. Before excluding "[" from the
+    # title/junk character classes, this exact input collapsed into one
+    # match spanning both links and silently dropped id2's reference from
+    # the output entirely.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="id2", filename="clip.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[a](file:id1 "x [b](file:id2 ")',
+        )
+
+        # id2's reference is recovered as its own independent, validated
+        # match; the malformed leading fragment is left as inert literal
+        # text rather than being silently merged away.
+        assert '[b](file:id2 "clip.mp4")' in content
+        assert content == '[a](file:id1 "x [b](file:id2 "clip.mp4")'
     finally:
         db.close()
 

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import patch
 
 from sqlalchemy import create_engine
@@ -1066,6 +1067,195 @@ def test_reconcile_repairs_invented_id_from_label_when_title_names_a_different_f
         )
 
         assert content == '[report.mp4](file:real-id "My yearly report")'
+    finally:
+        db.close()
+
+
+def test_reconcile_keeps_junk_untouched_when_id_does_not_resolve():
+    # Regression: the junk fallback used to be applied unconditionally --
+    # even when the id it was attached to didn't resolve to any record, the
+    # match still collapsed to the bare label, permanently deleting the
+    # junk text (ordinary trailing prose the model wrote) from the
+    # persisted transcript. No record is registered here at all, so the id
+    # can never resolve or be repaired; the whole match must survive as-is.
+    db, user, task = _create_context()
+    try:
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="Check [the docs](file:nonexistent for more details) later",
+        )
+
+        assert content == "Check [the docs](file:nonexistent for more details) later"
+    finally:
+        db.close()
+
+
+def test_reconcile_keeps_junk_untouched_when_stored_file_id_is_invalid():
+    # Same guard as above, at the second (build_file_id_ref) failure point.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="invalid/id", filename="report.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[report.mp4](file:invalid/id has more text) tail",
+        )
+
+        assert content == "[report.mp4](file:invalid/id has more text) tail"
+    finally:
+        db.close()
+
+
+def test_reconcile_still_drops_recoverable_junk_when_id_resolves():
+    # Contrast with the two tests above: when the id *does* resolve, junk
+    # attached to it is still ordinary discardable trailing text, not
+    # something this fix should start preserving. Uses a non-media
+    # extension so the assertion isn't entangled with title injection.
+    db, user, task = _create_context()
+    try:
+        _add_file(
+            db,
+            user,
+            task,
+            file_id="real-id",
+            filename="report.pdf",
+            mime_type="application/pdf",
+        )
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="Check [the docs](file:real-id for more details) later",
+        )
+
+        assert content == "Check [the docs](file:real-id) later"
+    finally:
+        db.close()
+
+
+def test_reconcile_does_not_let_a_title_span_a_blank_line():
+    # A title clause separated from the target by a blank line renders as
+    # two independent, inert literal paragraphs to any real CommonMark
+    # parser. \s+/\s* around the title forms would match across that blank
+    # line and silently merge the two paragraphs into one live link,
+    # discarding the second paragraph's text. This function never itself
+    # emits a title separated from the target by anything but a single
+    # space, so the whole construct must simply fail to match -- identical
+    # to this regex's pre-title behavior for any other unparsable input.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="real-id", filename="stale.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[a](file:real-id\n\n"stale.mp4")',
+        )
+
+        assert content == '[a](file:real-id\n\n"stale.mp4")'
+    finally:
+        db.close()
+
+
+def test_reconcile_leaves_single_newline_titled_reference_untouched():
+    # CommonMark permits one line ending between destination and title
+    # (still a single link when rendered), but the horizontal-only
+    # whitespace that keeps a title clause from spanning a blank line (see
+    # the blank-line test above) declines this shape too. Pinned: the
+    # reference is left byte-for-byte untouched -- not validated, but not
+    # mangled either -- matching the regex's fallback for every other
+    # shape it can't safely parse.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="real-id", filename="clip.mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content='[a](file:real-id\n"clip.mp4")',
+        )
+
+        assert content == '[a](file:real-id\n"clip.mp4")'
+    finally:
+        db.close()
+
+
+def test_reconcile_falls_back_to_label_rewrite_for_paren_in_filename():
+    # A real filename containing ")" can't safely become this function's
+    # own title syntax (see the _UNSAFE_TITLE_RE comment for why that's an
+    # implementation constraint, not a CommonMark one) -- it must still
+    # fall back to the older label-rewrite mechanism rather than leaving
+    # the reference undetectable.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="real-id", filename="video (1).mp4")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[clip](file:real-id)",
+        )
+
+        assert content == "[video (1).mp4](file:real-id)"
+    finally:
+        db.close()
+
+
+def test_reconcile_stays_fast_on_a_large_unresolvable_reference():
+    # Regression guard for quadratic backtracking between the atomic-group
+    # target and the junk alternative when a huge target has no closing
+    # paren anywhere: this used to take several seconds per call at ~32KB
+    # and scale quadratically, on a function that reruns on every read of
+    # attacker-influenceable chat history. Generous bound (real fix runs in
+    # well under a second even at far larger sizes) to avoid environment
+    # flakiness while still catching a real regression.
+    db, user, task = _create_context()
+    try:
+        content = "[x](file:" + "a" * 100_000
+        start = time.monotonic()
+        result = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content=content,
+        )
+        elapsed = time.monotonic() - start
+
+        assert result == content
+        assert elapsed < 2.0
+    finally:
+        db.close()
+
+
+def test_reconcile_does_not_repair_via_whitespace_only_title_or_label():
+    # Path("   ".strip()).name is "" -- without an explicit guard, a
+    # whitespace-only title/label would look up the empty-string filename
+    # key (records_by_filename keys are the raw, unstripped
+    # str(filename).casefold()) and could match a record whose own filename
+    # is literally empty, silently repairing an invented id to the wrong
+    # file. Internal record construction doesn't validate filenames the way
+    # the HTTP upload endpoints do, so an empty-filename record is a real
+    # (if unusual) possibility, not a hypothetical.
+    db, user, task = _create_context()
+    try:
+        _add_file(db, user, task, file_id="empty-name-id", filename="")
+
+        content = reconcile_assistant_file_references(
+            db,
+            task_id=int(task.id),
+            user_id=int(user.id),
+            content="[  ](file:invented-id)",
+        )
+
+        assert content == "  "
     finally:
         db.close()
 


### PR DESCRIPTION
Fixes #1202.

## Problem

Since #1196, `reconcile_assistant_file_references` restores media-type detection for video/audio file links by overwriting the model's markdown label with the real filename whenever the label doesn't already reveal the type. This runs *before* persistence, so the model's own (often localized) wording is permanently lost from the stored transcript:

```
[下载视频（MP4）](file:<uuid>)  →  [generated_video_a1b2c3.mp4](file:<uuid>)
```

## Fix

Carry the real filename in the link **title** instead, and leave the label untouched:

```
[下载视频（MP4）](file:<uuid> "generated_video_a1b2c3.mp4")
```

- `_MARKDOWN_FILE_REFERENCE_RE` parses an optional title clause in all three CommonMark delimiter forms (`"..."`, `'...'`, `(...)`) with backslash-escape awareness, so an already-titled link still goes through id validation/repair instead of silently bypassing it. `label`/`target` are wrapped in atomic groups so an unmatchable reference (no closing paren anywhere) fails fast rather than backtracking quadratically on read-time, attacker-influenceable content.
- The title is only injected when the label doesn't already reveal the media type — same trigger condition the old label-rewrite used — and is always overwritten in that case, so it self-heals if the canonical filename ever changes. Repair (an invented/stale id) tries the title before the label, falling back to the label whenever the title doesn't resolve to exactly one record.
- Filenames unsafe for a title (a literal double quote, `[`, or a control character) fall back to the pre-title label-rewrite; filenames unsafe for both leave the reference untouched. `)` is excluded too — not a CommonMark rule, but a constraint of this module's own re-parse requirement (the emitter never escapes on output) — so a filename like `video (1).mp4` deliberately falls back to the label-rewrite path rather than becoming a title. This fixes filenames containing `]`, but not `[` or `)`.
- A malformed title clause falls through to a `junk` alternative that discards it as unstructured trailing content while still validating the reference — this also normalizes CommonMark-inert input like `[x](file:id not a title)` into a live link once the id resolves, which is this function's purpose applied to a slightly mangled reference rather than an accident. If the reference turns out unrecoverable (id doesn't resolve, or the stored id is invalid), any junk is preserved verbatim in the returned text rather than deleted, and — since a title is this function's own designated channel for the real filename — an unrecoverable reference with a title keeps that title as plain text alongside the label rather than dropping it.

**Frontend fix required alongside this:** `MarkdownLink`/`MarkdownImage` already preferred the title for *type detection*, but also used it for the *displayed* filename — meaning the injected title (not the model's label) would have shown up in the chat UI, defeating the point of this change. `resolvePreviewableFileLink` now takes `(fileNameFromPath, title, visibleText)`: detection tries `title` then `visibleText` (first candidate that classifies to a previewable kind wins — it does not compare kinds and prefer whichever the label reveals), while what's *displayed* stays `visibleText`-first.

## Testing

- `tests/web/services/test_file_reference_output_service.py`: title injection for video/audio/m4v/case-insensitive extensions, self-healing a stale title, the bracket/quote/paren/control-character safety matrix, idempotency, single-quote and paren-delimited title round-tripping for non-media references, the image-syntax path, repair via title with label/title precedence in both directions, a junk-preserving unrecoverable fallback, a regex backtracking-bound regression test, and a blank-line-crossing-title regression test.
- `frontend/src/components/ui/__tests__/markdown-renderer.test.tsx`: end-to-end cases confirming the model's label/alt is what's displayed while the title still drives detection (including when title and label would classify differently), for both link and image syntax.

`ruff`, `mypy`, `tsc`, and the full backend + frontend suites pass (pre-existing unrelated baseline failures noted in the branch history, not reintroduced here).
