### PR TITLE
fix: stream authenticated media via a short-lived per-file ticket

### DIFF
--- a/example.env
+++ b/example.env
@@ -629,6 +629,12 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 # XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED="false"
 # XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFIX="/_xagent_internal_files/"
 
+# Lifetime of a short-lived, per-file media-streaming ticket (see
+# GET /api/files/stream-tickets/{file_id}). Media elements load this ticket
+# directly in a URL, so it is kept far shorter than the user's own access
+# token TTL.
+# XAGENT_FILE_STREAM_TICKET_TTL_SECONDS="600"
+
 # External upload directories for knowledge base file access
 # Comma-separated list of directory paths (existing dirs only)
 # XAGENT_EXTERNAL_UPLOAD_DIRS="/path/to/uploads1,/path/to/uploads2"

--- a/example.env
+++ b/example.env
@@ -620,6 +620,10 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 # Redirect authenticated preview/download requests to short-lived durable-object
 # URLs when the storage backend can sign them. Keep disabled unless the signed
 # URL endpoint is reachable by browsers (for example public S3/MinIO or CDN).
+# For a media-streaming ticket's request (see XAGENT_FILE_STREAM_TICKET_TTL_SECONDS
+# below), this TTL governs everything after the first redirect hop, so a long
+# video's effective playback session is min(ticket TTL, this TTL) -- raising one
+# without the other doesn't extend it.
 # XAGENT_FILE_DELIVERY_REDIRECT_ENABLED="false"
 # XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS="300"
 
@@ -632,7 +636,8 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 # Lifetime of a short-lived, per-file media-streaming ticket (see
 # GET /api/files/stream-tickets/{file_id}). Media elements load this ticket
 # directly in a URL, so it is kept far shorter than the user's own access
-# token TTL.
+# token TTL. When XAGENT_FILE_DELIVERY_REDIRECT_ENABLED is also set, see
+# XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS above for how the two interact.
 # XAGENT_FILE_STREAM_TICKET_TTL_SECONDS="600"
 
 # External upload directories for knowledge base file access

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -4,6 +4,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/ui/sonner', () => ({
+  toast: { error: toastErrorMock },
+}))
 
 vi.mock('@/lib/utils', () => ({
   cn: (...classes: Array<string | undefined | false>) => classes.filter(Boolean).join(' '),
@@ -36,15 +41,21 @@ vi.mock('@/components/file/pptx-preview-renderer', () => ({
   ),
 }))
 
-import { InlineFilePreview, __resetStreamingUrlCacheForTests } from './inline-file-preview'
+import {
+  InlineFilePreview,
+  __mintStreamingUrlForTests,
+  __resetStreamingUrlCacheForTests,
+} from './inline-file-preview'
 import {
   FileAccessProvider,
   createPublicFileAccessPolicy,
+  defaultFileAccessPolicy,
 } from '@/contexts/file-access-context'
 
 describe('InlineFilePreview', () => {
   beforeEach(() => {
     apiRequestMock.mockReset()
+    toastErrorMock.mockReset()
     // Several cases below reuse the same fileId; without this, an earlier
     // case's minted (or attempted) streaming ticket would leak into a
     // later case that expects its own mock to be exercised.
@@ -474,6 +485,173 @@ describe('InlineFilePreview', () => {
     vi.restoreAllMocks()
   })
 
+  it('keeps every "Open"-minted blob alive across repeated clicks, revoking only on unmount', async () => {
+    // Regression test (N-AP9): a previous version revoked the prior
+    // Open-tab's blob URL on the *next* click. A still-open first tab's
+    // media keeps issuing Range requests against its own blob URL as the
+    // user seeks/reloads it, so revoking it out from under that tab broke
+    // playback there the moment a second "Open" click happened (e.g. on a
+    // different attachment's tab, or the same one again).
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    })
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL')
+    const fakeTab1 = { location: { href: '' }, closed: false, opener: 'x' as unknown }
+    const fakeTab2 = { location: { href: '' }, closed: false, opener: 'x' as unknown }
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValueOnce(fakeTab1 as unknown as Window)
+      .mockReturnValueOnce(fakeTab2 as unknown as Window)
+
+    const { unmount } = render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+    await screen.findByLabelText('clip.mp4')
+    const openLink = screen.getByRole('link', { name: 'Open' })
+
+    fireEvent.click(openLink)
+    await waitFor(() => expect(fakeTab1.location.href).toMatch(/^blob:/))
+    fireEvent.click(openLink)
+    await waitFor(() => expect(fakeTab2.location.href).toMatch(/^blob:/))
+
+    // Neither blob revoked yet -- both fake tabs are still "open".
+    expect(revokeSpy).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(revokeSpy).toHaveBeenCalledTimes(2)
+    expect(revokeSpy).toHaveBeenCalledWith(fakeTab1.location.href)
+    expect(revokeSpy).toHaveBeenCalledWith(fakeTab2.location.href)
+
+    openSpy.mockRestore()
+    revokeSpy.mockRestore()
+  })
+
+  it('resolves a fresh authenticated blob for "Open" on a middle click when there is no dialog and streaming is active', async () => {
+    // Regression test (N-D1): middle-click/ctrl-click fire a native
+    // 'auxclick' event that bypasses onClick entirely, so without an
+    // onAuxClick handler wired to the same recovery path, a middle click
+    // would navigate straight to the static href -- the 403-prone public
+    // preview URL while streaming is active -- even though a primary click
+    // on the exact same link works.
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    })
+    const fakeTab = { location: { href: '' }, closed: false, opener: 'set-by-code' as unknown }
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(fakeTab as unknown as Window)
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    await screen.findByLabelText('clip.mp4')
+    // testing-library 10.4's built-in fireEvent map has no auxClick helper
+    // (added later), so the native event is dispatched directly -- a
+    // middle-click (button 1) is exactly what fires 'auxclick'.
+    fireEvent(
+      screen.getByRole('link', { name: 'Open' }),
+      new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 })
+    )
+
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank')
+    expect(fakeTab.opener).toBeNull()
+    await waitFor(() => {
+      expect(fakeTab.location.href).toMatch(/^blob:/)
+    })
+
+    openSpy.mockRestore()
+  })
+
+  it('leaves a right-click on "Open" alone instead of hijacking the context menu', async () => {
+    // auxclick fires for ANY non-primary button -- right-click (button 2)
+    // included. The middle-click recovery above must not swallow it: the
+    // user wants the browser context menu, not a surprise tab.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+      }),
+    })
+    const openSpy = vi.spyOn(window, 'open')
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+    await screen.findByLabelText('clip.mp4')
+
+    const rightClick = new MouseEvent('auxclick', {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+    })
+    fireEvent(screen.getByRole('link', { name: 'Open' }), rightClick)
+
+    expect(openSpy).not.toHaveBeenCalled()
+    // preventDefault must not have run either -- that's what would suppress
+    // the browser's own handling around the gesture.
+    expect(rightClick.defaultPrevented).toBe(false)
+
+    openSpy.mockRestore()
+  })
+
+  it('notifies instead of resolving a URL when the "Open" popup is blocked', async () => {
+    // Regression test (N-AP8): window.open returning null (popup blocker,
+    // some webviews) used to be silently swallowed -- preventDefault had
+    // already run, so nothing loaded and the user got no feedback at all.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+      }),
+    })
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    await screen.findByLabelText('clip.mp4')
+    fireEvent.click(screen.getByRole('link', { name: 'Open' }))
+
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank')
+    expect(toastErrorMock).toHaveBeenCalled()
+    // The blob/mint fetch must never even be attempted once there's no tab
+    // left to redirect -- only the initial ticket mint call happened.
+    expect(apiRequestMock).toHaveBeenCalledTimes(1)
+
+    openSpy.mockRestore()
+  })
+
   it('routes "Open" through onFileClick instead of the public preview URL when a dialog is available', async () => {
     // For the default in-app policy, the credential-free fallback above is
     // the tokenless public preview route, which 403s ("Public file access
@@ -627,6 +805,52 @@ describe('InlineFilePreview', () => {
     expect(callCount).toBe(2)
   })
 
+  it('does not mint a redundant ticket per waiter when several concurrent callers race on one failed mint', async () => {
+    // Regression test (N-AP12): only the caller that originated a cached
+    // mint promise ever notices *that* promise's own failure and evicts it
+    // (in its own try/catch, a different code path from this test's
+    // target). Every OTHER concurrent waiter shares that failed promise
+    // and used to independently mint its own replacement instead of
+    // reusing whichever replacement won first -- N waiters on one failed
+    // mint paid N-1 redundant tickets. Exercises mintStreamingUrl's
+    // dedup/retry logic directly (via the test-only export) for precise
+    // control over the race, rather than through React's own effect
+    // timing across several mounted components.
+    let mintCallCount = 0
+    let rejectFirstMint: ((error: Error) => void) | undefined
+    const fileAccess = {
+      ...defaultFileAccessPolicy,
+      getStreamingUrl: (): Promise<string> => {
+        mintCallCount += 1
+        if (mintCallCount === 1) {
+          return new Promise((_resolve, reject) => {
+            rejectFirstMint = reject
+          })
+        }
+        return Promise.resolve(`https://example.test/ticket-${mintCallCount}`)
+      },
+    }
+
+    const results = Promise.all([
+      __mintStreamingUrlForTests(fileAccess, 'shared-file-id').catch((error) => error),
+      __mintStreamingUrlForTests(fileAccess, 'shared-file-id').catch((error) => error),
+      __mintStreamingUrlForTests(fileAccess, 'shared-file-id').catch((error) => error),
+    ])
+
+    await waitFor(() => expect(mintCallCount).toBe(1))
+    rejectFirstMint?.(new Error('mint failed'))
+
+    const [first, second, third] = await results
+
+    // The originating call's own promise always rejects -- it never
+    // retries itself, only evicts. Exactly one shared retry mint must
+    // cover both other waiters (mintCallCount === 2, not 3).
+    expect(first).toBeInstanceOf(Error)
+    expect(second).toBe('https://example.test/ticket-2')
+    expect(third).toBe('https://example.test/ticket-2')
+    expect(mintCallCount).toBe(2)
+  })
+
   it('falls back to blob fetch when a minted ticket fails to actually load', async () => {
     // Minting never checks file ownership -- only redemption does -- so a
     // ticket can mint successfully for a file the caller can't actually
@@ -667,29 +891,31 @@ describe('InlineFilePreview', () => {
     expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
   })
 
-  it('recovers via the blob path when a ticket expires mid-playback, resuming near the same currentTime', async () => {
-    // Regression test (F1): a MEDIA_ERR_NETWORK error after data has
-    // already loaded once (e.g. the ticket's short TTL expiring mid-
-    // session, so the browser's next Range request 401/403s) used to be
-    // silently swallowed by the "keep the player mounted, let the element
-    // handle it" guard meant for mid-playback decode hiccups -- leaving
-    // playback stalled with no recovery for the rest of the mount. It must
-    // instead trigger the same evict+re-mint+fallback recovery a pre-load
-    // failure gets, and resume near where the ticketed stream left off
-    // rather than restarting from 0.
+  it('recovers via a fresh ticket when one expires mid-playback, resuming near the same currentTime', async () => {
+    // Regression test (F1, tightened per round-5 review N-AP1): a network/
+    // src error after data has already loaded once (e.g. the ticket's
+    // short TTL expiring mid-session, so the browser's next Range request
+    // 401/403s) used to be silently swallowed by the "keep the player
+    // mounted, let the element handle it" guard meant for mid-playback
+    // decode hiccups -- leaving playback stalled with no recovery for the
+    // rest of the mount. It must instead re-mint a fresh ticket for the
+    // same fileId (minting is cheap and doesn't re-check ownership) and
+    // resume near where the ticketed stream left off rather than
+    // restarting from 0 -- NOT fall straight to a full-file blob download,
+    // which would silently reintroduce the exact #1201 symptom this PR
+    // exists to remove for any video longer than the ticket TTL.
+    let mintCount = 0
     apiRequestMock.mockImplementation(async (url: string) => {
       if (url.includes('/stream-tickets/')) {
+        mintCount += 1
         return {
           ok: true,
           json: async () => ({
-            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+            path: `/api/files/preview/video-file-id?ticket=signed-ticket-${mintCount}`,
           }),
         }
       }
-      return {
-        ok: true,
-        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
-      }
+      throw new Error(`unexpected blob fetch for ${url}`)
     })
 
     render(
@@ -700,7 +926,7 @@ describe('InlineFilePreview', () => {
 
     const streamedVideo = await screen.findByLabelText('clip.mp4')
     expect(streamedVideo.getAttribute('src')).toBe(
-      'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket'
+      'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket-1'
     )
 
     fireEvent.loadedData(streamedVideo)
@@ -721,7 +947,9 @@ describe('InlineFilePreview', () => {
 
     const recoveredVideo = await waitFor(() => {
       const element = screen.getByLabelText('clip.mp4')
-      expect(element.getAttribute('src')).toMatch(/^blob:/)
+      expect(element.getAttribute('src')).toBe(
+        'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket-2'
+      )
       return element as HTMLVideoElement
     })
     expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
@@ -732,6 +960,51 @@ describe('InlineFilePreview', () => {
     recoveredVideo.currentTime = 0
     fireEvent.loadedData(recoveredVideo)
     expect(recoveredVideo.currentTime).toBe(42)
+  })
+
+  it('falls back to the blob path when re-minting also fails after a ticket expires mid-playback', async () => {
+    // Companion to the recovery test above: if the re-mint itself fails
+    // (e.g. access was actually revoked, not just the ticket expired), the
+    // player must still fall back to the blob/direct strategy via
+    // reportLoadFailure rather than being left on a dead ticketed src.
+    let mintCount = 0
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        mintCount += 1
+        if (mintCount > 1) {
+          return { ok: false, status: 403 }
+        }
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket-1',
+          }),
+        }
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const streamedVideo = await screen.findByLabelText('clip.mp4')
+    fireEvent.loadedData(streamedVideo)
+    Object.defineProperty(streamedVideo, 'error', {
+      value: { code: 2 },
+      configurable: true,
+    })
+    fireEvent.error(streamedVideo)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('clip.mp4').getAttribute('src')).toMatch(/^blob:/)
+    })
+    expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
   })
 
   it('keeps the player mounted for a decode-hiccup error after loading, even while streaming', async () => {
@@ -769,6 +1042,49 @@ describe('InlineFilePreview', () => {
     expect(screen.getByLabelText('clip.mp4').getAttribute('src')).toBe(
       'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket'
     )
+    expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
+  })
+
+  it('also recovers via a fresh ticket for a MEDIA_ERR_SRC_NOT_SUPPORTED error while streaming', async () => {
+    // Regression test (N-AP2): browsers are inconsistent about which
+    // MediaError code an expired ticket's mid-stream 401/403 surfaces as --
+    // some report MEDIA_ERR_NETWORK (2), others MEDIA_ERR_SRC_NOT_SUPPORTED
+    // (4) because the failed fetch never yields a decodable resource.
+    // Gating recovery on code 2 alone would silently swallow the 4 case the
+    // exact same way the pre-F1 bug swallowed all of them.
+    let mintCount = 0
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        mintCount += 1
+        return {
+          ok: true,
+          json: async () => ({
+            path: `/api/files/preview/video-file-id?ticket=signed-ticket-${mintCount}`,
+          }),
+        }
+      }
+      throw new Error(`unexpected blob fetch for ${url}`)
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const streamedVideo = await screen.findByLabelText('clip.mp4')
+    fireEvent.loadedData(streamedVideo)
+    Object.defineProperty(streamedVideo, 'error', {
+      value: { code: 4 }, // MEDIA_ERR_SRC_NOT_SUPPORTED
+      configurable: true,
+    })
+    fireEvent.error(streamedVideo)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('clip.mp4').getAttribute('src')).toBe(
+        'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket-2'
+      )
+    })
     expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -36,7 +36,7 @@ vi.mock('@/components/file/pptx-preview-renderer', () => ({
   ),
 }))
 
-import { InlineFilePreview } from './inline-file-preview'
+import { InlineFilePreview, __resetStreamingUrlCacheForTests } from './inline-file-preview'
 import {
   FileAccessProvider,
   createPublicFileAccessPolicy,
@@ -45,6 +45,10 @@ import {
 describe('InlineFilePreview', () => {
   beforeEach(() => {
     apiRequestMock.mockReset()
+    // Several cases below reuse the same fileId; without this, an earlier
+    // case's minted (or attempted) streaming ticket would leak into a
+    // later case that expects its own mock to be exercised.
+    __resetStreamingUrlCacheForTests()
   })
 
   afterEach(() => {
@@ -355,9 +359,145 @@ describe('InlineFilePreview', () => {
       'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket'
     )
     expect(apiRequestMock).toHaveBeenCalledWith(
-      'http://api.local/api/files/stream-tickets/video-file-id'
+      'http://api.local/api/files/stream-tickets/video-file-id',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     )
     expect(apiRequestMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the "Open" link on the safe public preview URL when streaming succeeds', async () => {
+    // The ticketed URL is a replayable credential (unlike the blob path's
+    // session-scoped blob: URL) and must never be exposed via a link a
+    // user can put in the address bar, browser history, or copy/paste.
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      throw new Error(`unexpected blob fetch for ${url}`)
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    await screen.findByLabelText('clip.mp4')
+    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute(
+      'href',
+      'http://api.local/api/files/public/preview/video-file-id'
+    )
+  })
+
+  it('reuses a minted streaming ticket across remounts of the same file', async () => {
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      throw new Error(`unexpected blob fetch for ${url}`)
+    })
+
+    const { unmount } = render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+    await screen.findByLabelText('clip.mp4')
+    unmount()
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+    await screen.findByLabelText('clip.mp4')
+
+    expect(apiRequestMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to blob fetch when a minted ticket fails to actually load', async () => {
+    // Minting never checks file ownership -- only redemption does -- so a
+    // ticket can mint successfully for a file the caller can't actually
+    // read; the media element's own fetch then fails at redemption, and
+    // playback must still recover via the blob path rather than being
+    // left on a dead ticketed src.
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const streamedVideo = await screen.findByLabelText('clip.mp4')
+    expect(streamedVideo.getAttribute('src')).toBe(
+      'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket'
+    )
+
+    fireEvent.error(streamedVideo)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('clip.mp4').getAttribute('src')).toMatch(/^blob:/)
+    })
+    expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
+  })
+
+  it('does not get stuck loading when unmounted while a ticket mint is in flight', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let resolveMint: ((value: { ok: boolean; json: () => Promise<unknown> }) => void) | undefined
+    apiRequestMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveMint = resolve
+        })
+    )
+
+    const { unmount } = render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalled())
+    unmount()
+
+    // Resolving after unmount must not update state on an unmounted
+    // component (React would log an error) or throw -- the isCancelled
+    // guard in useResolvedMediaUrl's effect cleanup is what prevents this.
+    resolveMint?.({
+      ok: true,
+      json: async () => ({
+        path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+      }),
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    consoleErrorSpy.mockRestore()
   })
 
   it('falls back to blob fetch when ticket minting fails', async () => {

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -365,10 +365,14 @@ describe('InlineFilePreview', () => {
     expect(apiRequestMock).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps the "Open" link on the safe public preview URL when streaming succeeds', async () => {
+  it('keeps the "Open" link on the safe public preview URL when there is no click handler', async () => {
     // The ticketed URL is a replayable credential (unlike the blob path's
     // session-scoped blob: URL) and must never be exposed via a link a
-    // user can put in the address bar, browser history, or copy/paste.
+    // user can put in the address bar, browser history, or copy/paste. This
+    // fallback URL only applies to surfaces with no in-app preview dialog
+    // (e.g. the public widget) -- see the next test for the in-app case,
+    // where this same public URL would 403 on an access-controlled task and
+    // "Open" must route through onFileClick instead.
     apiRequestMock.mockImplementation(async (url: string) => {
       if (url.includes('/stream-tickets/')) {
         return {
@@ -392,6 +396,40 @@ describe('InlineFilePreview', () => {
       'href',
       'http://api.local/api/files/public/preview/video-file-id'
     )
+  })
+
+  it('routes "Open" through onFileClick instead of the public preview URL when a dialog is available', async () => {
+    // For the default in-app policy, the credential-free fallback above is
+    // the tokenless public preview route, which 403s ("Public file access
+    // token required") for any task with access control configured --
+    // every standard agent chat. All in-app chat surfaces pass onFileClick,
+    // so "Open" must route through it (same as the image/generic-file
+    // branches of InlineFilePreview already do) instead of ever landing on
+    // that URL.
+    const handleFileClick = vi.fn()
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      throw new Error(`unexpected blob fetch for ${url}`)
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+        onFileClick={handleFileClick}
+      />
+    )
+
+    await screen.findByLabelText('clip.mp4')
+    fireEvent.click(screen.getByRole('link', { name: 'Open' }))
+
+    expect(handleFileClick).toHaveBeenCalledWith('video-file-id', 'clip.mp4')
   })
 
   it('reuses a minted streaming ticket across remounts of the same file', async () => {
@@ -423,6 +461,94 @@ describe('InlineFilePreview', () => {
     await screen.findByLabelText('clip.mp4')
 
     expect(apiRequestMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares one in-flight mint across concurrent mounts of the same file', async () => {
+    // The same attachment can render twice at once (e.g. the same file
+    // referenced from two visible messages, or a trace-event artifact
+    // duplicated into the transcript). Both mounts must share one mint
+    // round trip rather than each paying their own.
+    let resolveMint: ((value: unknown) => void) | undefined
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return new Promise((resolve) => {
+          resolveMint = resolve
+        })
+      }
+      throw new Error(`unexpected blob fetch for ${url}`)
+    })
+
+    render(
+      <>
+        <InlineFilePreview
+          source={{ type: 'video', fileId: 'shared-file-id', filename: 'clip.mp4' }}
+        />
+        <InlineFilePreview
+          source={{ type: 'video', fileId: 'shared-file-id', filename: 'clip.mp4' }}
+        />
+      </>
+    )
+
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledTimes(1))
+
+    resolveMint?.({
+      ok: true,
+      json: async () => ({
+        path: '/api/files/preview/shared-file-id?ticket=signed-ticket',
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('clip.mp4')).toHaveLength(2)
+    })
+    for (const video of screen.getAllByLabelText('clip.mp4')) {
+      expect(video.getAttribute('src')).toBe(
+        'http://api.local/api/files/preview/shared-file-id?ticket=signed-ticket'
+      )
+    }
+    expect(apiRequestMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries minting on the next mount after a failed mint instead of reusing the rejection', async () => {
+    let callCount = 0
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        callCount += 1
+        if (callCount === 1) return { ok: false, status: 500 }
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/retry-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      throw new Error(`unexpected blob fetch for ${url}`)
+    })
+
+    const { unmount } = render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'retry-file-id', filename: 'clip.mp4' }}
+      />
+    )
+    // First mount: mint fails, falls back to the direct public URL (the
+    // default policy's requiresBlobFetch is true, but blob-fetch itself
+    // isn't mocked as reachable here, so this assertion only needs the
+    // player to end up off the streaming path -- confirmed by the second
+    // mount actually re-minting below rather than reusing a cached failure).
+    await waitFor(() => expect(callCount).toBe(1))
+    unmount()
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'retry-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const video = await screen.findByLabelText('clip.mp4')
+    expect(video.getAttribute('src')).toBe(
+      'http://api.local/api/files/preview/retry-file-id?ticket=signed-ticket'
+    )
+    expect(callCount).toBe(2)
   })
 
   it('falls back to blob fetch when a minted ticket fails to actually load', async () => {

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -328,6 +328,88 @@ describe('InlineFilePreview', () => {
     expect(apiRequestMock).not.toHaveBeenCalled()
   })
 
+  it('streams video directly from a minted ticket under the default policy', async () => {
+    // The default policy's getStreamingUrl mints a ticket via a dedicated
+    // endpoint; when that succeeds the media element loads the ticketed
+    // URL directly instead of blob-fetching the whole file.
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      throw new Error(`unexpected blob fetch for ${url}`)
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const video = await screen.findByLabelText('clip.mp4')
+    expect(video.getAttribute('src')).toBe(
+      'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket'
+    )
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      'http://api.local/api/files/stream-tickets/video-file-id'
+    )
+    expect(apiRequestMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to blob fetch when ticket minting fails', async () => {
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return { ok: false, status: 500 }
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const video = await screen.findByLabelText('clip.mp4')
+    await waitFor(() => {
+      expect(video.getAttribute('src')).toMatch(/^blob:/)
+    })
+    expect(apiRequestMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not attempt to mint a streaming ticket for images', async () => {
+    // Images have no seek/progressive-loading need, so the extra ticket
+    // round trip is pure overhead -- only audio/video opt into it.
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        throw new Error('images must not request a streaming ticket')
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['image-bytes'], { type: 'image/png' }),
+      }
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'image', fileId: 'image-file-id', filename: 'chart.png' }}
+      />
+    )
+
+    const image = await screen.findByAltText('chart.png')
+    await waitFor(() => {
+      expect(image.getAttribute('src')).toMatch(/^blob:/)
+    })
+    expect(apiRequestMock).toHaveBeenCalledTimes(1)
+  })
+
   it('falls back to the public video preview when authenticated loading fails', async () => {
     apiRequestMock.mockResolvedValue({ ok: false, status: 401 })
 

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -343,6 +343,34 @@ describe('InlineFilePreview', () => {
     expect(apiRequestMock).not.toHaveBeenCalled()
   })
 
+  it('lets a click on "Open" navigate natively under the public policy instead of the popup-blocker-dependent tab dance', async () => {
+    // Regression test (F2): the public policy never sets isStreamingUrl
+    // (it has no getStreamingUrl), so openUrl is already the safe,
+    // already-tokened direct URL -- opening a blank tab and redirecting it
+    // via JS exists only to smuggle a fresh URL past a 403-prone static
+    // href while streaming, which doesn't apply here. Hijacking this click
+    // anyway would make "Open" popup-blocker-dependent for no reason.
+    vi.stubGlobal('fetch', vi.fn())
+    const openSpy = vi.spyOn(window, 'open')
+
+    render(
+      <FileAccessProvider policy={createPublicFileAccessPolicy('guest-a')}>
+        <InlineFilePreview
+          source={{ type: 'video', fileId: 'video-id', filename: 'clip.mp4' }}
+        />
+      </FileAccessProvider>,
+    )
+    await screen.findByLabelText('clip.mp4')
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+    fireEvent(screen.getByRole('link', { name: 'Open' }), clickEvent)
+
+    expect(openSpy).not.toHaveBeenCalled()
+    expect(clickEvent.defaultPrevented).toBe(false)
+
+    openSpy.mockRestore()
+  })
+
   it('streams video directly from a minted ticket under the default policy', async () => {
     // The default policy's getStreamingUrl mints a ticket via a dedicated
     // endpoint; when that succeeds the media element loads the ticketed
@@ -684,6 +712,53 @@ describe('InlineFilePreview', () => {
     fireEvent.click(screen.getByRole('link', { name: 'Open' }))
 
     expect(handleFileClick).toHaveBeenCalledWith('video-file-id', 'clip.mp4')
+  })
+
+  it('resolves a fresh authenticated blob for "Open" on a middle click even when a dialog is available', async () => {
+    // Regression test (N-D1 residual): a dialog answers "open in-app" for a
+    // primary click, but a middle-click's intent is always "open in a new
+    // tab" -- onFileClick has no answer for that. Without onAuxClick wired
+    // on this branch too, a middle click fell through to the native href
+    // (the 403-prone public preview URL while streaming) on every standard
+    // in-app chat surface, even though the exact same primary click worked.
+    const handleFileClick = vi.fn()
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    })
+    const fakeTab = { location: { href: '' }, closed: false, opener: 'x' as unknown }
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(fakeTab as unknown as Window)
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+        onFileClick={handleFileClick}
+      />
+    )
+
+    await screen.findByLabelText('clip.mp4')
+    fireEvent(
+      screen.getByRole('link', { name: 'Open' }),
+      new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 })
+    )
+
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank')
+    expect(handleFileClick).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(fakeTab.location.href).toMatch(/^blob:/)
+    })
+
+    openSpy.mockRestore()
   })
 
   it('reuses a minted streaming ticket across remounts of the same file', async () => {

--- a/frontend/src/components/file/inline-file-preview.test.tsx
+++ b/frontend/src/components/file/inline-file-preview.test.tsx
@@ -365,14 +365,14 @@ describe('InlineFilePreview', () => {
     expect(apiRequestMock).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps the "Open" link on the safe public preview URL when there is no click handler', async () => {
-    // The ticketed URL is a replayable credential (unlike the blob path's
-    // session-scoped blob: URL) and must never be exposed via a link a
-    // user can put in the address bar, browser history, or copy/paste. This
-    // fallback URL only applies to surfaces with no in-app preview dialog
-    // (e.g. the public widget) -- see the next test for the in-app case,
-    // where this same public URL would 403 on an access-controlled task and
-    // "Open" must route through onFileClick instead.
+  it('keeps the public preview URL as the static href when there is no click handler', async () => {
+    // The static href stays the credential-free public URL (never the
+    // ticketed one, which is a replayable credential that must never be
+    // exposed via a link a user can put in the address bar, browser
+    // history, or copy/paste) -- this is the middle-click/right-click
+    // "open in new tab" escape hatch. The next test covers what actually
+    // happens on a primary click, where this URL would 403 on an
+    // access-controlled task.
     apiRequestMock.mockImplementation(async (url: string) => {
       if (url.includes('/stream-tickets/')) {
         return {
@@ -396,6 +396,82 @@ describe('InlineFilePreview', () => {
       'href',
       'http://api.local/api/files/public/preview/video-file-id'
     )
+  })
+
+  it('resolves a fresh authenticated blob for "Open" on a primary click when there is no dialog and streaming is active', async () => {
+    // Regression test (F2): the public preview URL used as the static href
+    // above 403s ("Public file access token required") on an
+    // access-controlled task for surfaces with no in-app dialog (a
+    // read-only transcript/log viewer, the skill-hub docs viewer, etc.),
+    // and pre-PR the Open href was the blob URL and worked everywhere. A
+    // primary click must resolve to a URL that will actually load instead
+    // of navigating to that 403-prone one.
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    })
+    const fakeTab = { location: { href: '' }, closed: false, opener: 'set-by-code' as unknown }
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(fakeTab as unknown as Window)
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    await screen.findByLabelText('clip.mp4')
+    fireEvent.click(screen.getByRole('link', { name: 'Open' }))
+
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank')
+    expect(fakeTab.opener).toBeNull()
+    await waitFor(() => {
+      expect(fakeTab.location.href).toMatch(/^blob:/)
+    })
+
+    openSpy.mockRestore()
+  })
+
+  it('falls back to the public preview URL for "Open" when the on-demand blob fetch fails', async () => {
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      return { ok: false, status: 401 }
+    })
+    const fakeTab = { location: { href: '' }, closed: false, opener: 'set-by-code' as unknown }
+    vi.spyOn(window, 'open').mockReturnValue(fakeTab as unknown as Window)
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    await screen.findByLabelText('clip.mp4')
+    fireEvent.click(screen.getByRole('link', { name: 'Open' }))
+
+    await waitFor(() => {
+      expect(fakeTab.location.href).toBe(
+        'http://api.local/api/files/public/preview/video-file-id'
+      )
+    })
+
+    vi.restoreAllMocks()
   })
 
   it('routes "Open" through onFileClick instead of the public preview URL when a dialog is available', async () => {
@@ -588,6 +664,111 @@ describe('InlineFilePreview', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('clip.mp4').getAttribute('src')).toMatch(/^blob:/)
     })
+    expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
+  })
+
+  it('recovers via the blob path when a ticket expires mid-playback, resuming near the same currentTime', async () => {
+    // Regression test (F1): a MEDIA_ERR_NETWORK error after data has
+    // already loaded once (e.g. the ticket's short TTL expiring mid-
+    // session, so the browser's next Range request 401/403s) used to be
+    // silently swallowed by the "keep the player mounted, let the element
+    // handle it" guard meant for mid-playback decode hiccups -- leaving
+    // playback stalled with no recovery for the rest of the mount. It must
+    // instead trigger the same evict+re-mint+fallback recovery a pre-load
+    // failure gets, and resume near where the ticketed stream left off
+    // rather than restarting from 0.
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      return {
+        ok: true,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const streamedVideo = await screen.findByLabelText('clip.mp4')
+    expect(streamedVideo.getAttribute('src')).toBe(
+      'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket'
+    )
+
+    fireEvent.loadedData(streamedVideo)
+    Object.defineProperty(streamedVideo, 'currentTime', {
+      value: 42,
+      writable: true,
+      configurable: true,
+    })
+    // code 2 === MediaError.MEDIA_ERR_NETWORK; jsdom has no MediaError
+    // global to construct a real instance from (see the matching comment
+    // in inline-file-preview.tsx), so the plain numeric code is faked here
+    // the same way production code reads it.
+    Object.defineProperty(streamedVideo, 'error', {
+      value: { code: 2 },
+      configurable: true,
+    })
+    fireEvent.error(streamedVideo)
+
+    const recoveredVideo = await waitFor(() => {
+      const element = screen.getByLabelText('clip.mp4')
+      expect(element.getAttribute('src')).toMatch(/^blob:/)
+      return element as HTMLVideoElement
+    })
+    expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
+
+    // A real browser resets currentTime to 0 when a new src loads; set that
+    // up explicitly so the assertion below only passes if the seek-on-load
+    // logic actually ran, not because the old value was left untouched.
+    recoveredVideo.currentTime = 0
+    fireEvent.loadedData(recoveredVideo)
+    expect(recoveredVideo.currentTime).toBe(42)
+  })
+
+  it('keeps the player mounted for a decode-hiccup error after loading, even while streaming', async () => {
+    // Contrast with the recovery test above: an error with no network-error
+    // code (or none at all) after data has loaded is the ordinary
+    // mid-playback hiccup case and must NOT trigger a re-mint/fallback --
+    // the element handles those itself. This holds regardless of whether
+    // the current src is the ticketed one.
+    apiRequestMock.mockImplementation(async (url: string) => {
+      if (url.includes('/stream-tickets/')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/api/files/preview/video-file-id?ticket=signed-ticket',
+          }),
+        }
+      }
+      throw new Error(`unexpected blob fetch for ${url}`)
+    })
+
+    render(
+      <InlineFilePreview
+        source={{ type: 'video', fileId: 'video-file-id', filename: 'clip.mp4' }}
+      />
+    )
+
+    const streamedVideo = await screen.findByLabelText('clip.mp4')
+    fireEvent.loadedData(streamedVideo)
+    Object.defineProperty(streamedVideo, 'error', {
+      value: { code: 3 }, // MEDIA_ERR_DECODE, not a network failure
+      configurable: true,
+    })
+    fireEvent.error(streamedVideo)
+
+    expect(screen.getByLabelText('clip.mp4').getAttribute('src')).toBe(
+      'http://api.local/api/files/preview/video-file-id?ticket=signed-ticket'
+    )
     expect(screen.queryByText('Failed to load preview.')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -35,36 +35,53 @@ const DEFAULT_LOAD_ERROR_TEXT = 'Failed to load preview.'
 /**
  * Resolve the URL a media element (<img>/<audio>/<video>) can load.
  *
- * The default in-app policy's authenticated preview route needs a Bearer
- * header that media elements cannot send, so managed files are fetched into
- * a blob object URL first. If that fetch fails, the public preview URL is a
- * last-resort fallback: on Agent Builder surfaces it may also require auth,
- * but a spinner with no recovery path is worse than attempting the
- * anonymous endpoint.
+ * Three strategies, tried in this order:
  *
- * A policy that declares ``requiresBlobFetch: false`` (the public
- * widget/share policy carries its guest token in the query string) hands
- * the URL to the media element directly instead: a blob fetch would add no
- * authorization there, and skipping it preserves HTTP range requests for
- * progressive audio/video playback. Policies that do not declare the
- * capability get the conservative blob path, which works everywhere.
+ * 1. ``fileAccess.getStreamingUrl`` (only the default in-app policy
+ *    implements this, and only when ``allowStreaming`` is true): mints a
+ *    short-lived, file-scoped ticket and hands the media element a direct
+ *    URL, preserving HTTP range requests for progressive playback. Falls
+ *    through to (2) if minting fails (e.g. offline) rather than leaving
+ *    the player on a permanent spinner.
+ * 2. Blob fetch: the default policy's authenticated preview route needs a
+ *    Bearer header that media elements cannot send, so managed files are
+ *    fetched into a blob object URL. If that fetch fails, the public
+ *    preview URL is a last-resort fallback: on Agent Builder surfaces it
+ *    may also require auth, but a spinner with no recovery path is worse
+ *    than attempting the anonymous endpoint.
+ * 3. Direct src: a policy that declares ``requiresBlobFetch: false`` (the
+ *    public widget/share policy carries its guest token in the query
+ *    string) hands the URL to the media element directly — a blob fetch
+ *    would add no authorization there, and skipping it also preserves
+ *    range requests. Policies that declare neither capability get the
+ *    conservative blob path, which works everywhere.
+ *
+ * ``allowStreaming`` restricts strategy (1) to audio/video: images have no
+ * seek-before-download or progressive-loading need, so paying an extra
+ * network round trip to mint a ticket before every image load would be
+ * pure overhead with no benefit.
  */
 function useResolvedMediaUrl(
   source: InlineFilePreviewSource,
   previewUrl: string,
-  fileAccess: FileAccessPolicy
+  fileAccess: FileAccessPolicy,
+  allowStreaming: boolean
 ): string {
   const fileId = source.fileId
+  const canStream =
+    allowStreaming && Boolean(fileId) && Boolean(fileAccess.getStreamingUrl)
   const needsBlobFetch = Boolean(fileId) && (fileAccess.requiresBlobFetch ?? true)
-  const [resolvedUrl, setResolvedUrl] = useState(needsBlobFetch ? '' : previewUrl)
+  const [resolvedUrl, setResolvedUrl] = useState(
+    canStream || needsBlobFetch ? '' : previewUrl
+  )
 
   useEffect(() => {
     let objectUrl: string | null = null
     let isCancelled = false
 
-    setResolvedUrl(needsBlobFetch ? '' : previewUrl)
+    setResolvedUrl(canStream || needsBlobFetch ? '' : previewUrl)
 
-    const loadAuthenticatedMedia = async () => {
+    const loadBlobOrDirect = async () => {
       if (!needsBlobFetch || !fileId) return
       try {
         const response = await fileAccess.request(fileAccess.previewUrl(fileId), {
@@ -90,13 +107,30 @@ function useResolvedMediaUrl(
       }
     }
 
-    void loadAuthenticatedMedia()
+    const loadMedia = async () => {
+      if (!fileId) return
+      if (canStream && fileAccess.getStreamingUrl) {
+        try {
+          const streamingUrl = await fileAccess.getStreamingUrl(fileId)
+          if (isCancelled) return
+          setResolvedUrl(streamingUrl)
+          return
+        } catch {
+          // Ticket minting failed -- fall through to the blob/direct path
+          // below instead of a permanent spinner.
+        }
+      }
+      if (isCancelled) return
+      await loadBlobOrDirect()
+    }
+
+    void loadMedia()
 
     return () => {
       isCancelled = true
       if (objectUrl) URL.revokeObjectURL(objectUrl)
     }
-  }, [fileAccess, fileId, needsBlobFetch, previewUrl])
+  }, [fileAccess, fileId, canStream, needsBlobFetch, previewUrl])
 
   return resolvedUrl
 }
@@ -116,7 +150,7 @@ function InlineImagePreview({
   onFileClick?: (filePath: string, fileName: string) => void
   fileAccess: FileAccessPolicy
 }) {
-  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess)
+  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess, false)
 
   const handleClick = (event: React.MouseEvent<HTMLImageElement>) => {
     if (!onFileClick || !source.fileId) return
@@ -179,7 +213,7 @@ function InlineMediaPreview({
     media: { onError: () => void; onLoaded: () => void }
   ) => React.ReactNode
 }) {
-  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess)
+  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess, true)
   const [failedUrl, setFailedUrl] = useState('')
   const [loadedUrl, setLoadedUrl] = useState('')
   // Terminal load failure only: useResolvedMediaUrl already falls back from

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -4,6 +4,7 @@ import { FileText, Loader2, Video, Volume2 } from 'lucide-react'
 import { DocxPreviewRenderer } from '@/components/file/docx-preview-renderer'
 import { ExcelPreviewRenderer } from '@/components/file/excel-preview-renderer'
 import { PptxPreviewRenderer } from '@/components/file/pptx-preview-renderer'
+import { toast } from '@/components/ui/sonner'
 import { cn, getApiUrl } from '@/lib/utils'
 import { useFileAccess, type FileAccessPolicy } from '@/contexts/file-access-context'
 import {
@@ -63,7 +64,18 @@ async function mintStreamingUrl(
     // rather than leaving a dead/expired promise for the next caller to
     // hit this same branch again, but only if nothing else already
     // replaced it (e.g. a concurrent caller's own retry).
-    if (streamingUrlCache.get(fileId) === cached) streamingUrlCache.delete(fileId)
+    if (streamingUrlCache.get(fileId) === cached) {
+      streamingUrlCache.delete(fileId)
+    } else {
+      // A concurrent caller already replaced this stale/failed entry with
+      // its own fresh mint while this call was awaiting it above -- reuse
+      // that instead of minting a second ticket for the same fileId. Every
+      // caller in a burst hits this same await, one at a time, in the
+      // order they were scheduled: whichever runs first deletes and mints;
+      // every caller after it sees a mismatch here and recurses onto that
+      // fresh entry rather than deleting-and-minting again itself.
+      return mintStreamingUrl(fileAccess, fileId)
+    }
   }
   const mintPromise = fileAccess.getStreamingUrl!(fileId).then((url) => ({
     url,
@@ -79,6 +91,19 @@ async function mintStreamingUrl(
     if (streamingUrlCache.get(fileId) === mintPromise) streamingUrlCache.delete(fileId)
     throw error
   }
+}
+
+/**
+ * Test-only escape hatch: exercises the module-level mint de-dup/retry
+ * logic directly, with exact control over concurrency (several calls for
+ * the same fileId racing on one mint), which is impractical to pin down
+ * reliably through React's own effect-scheduling timing.
+ */
+export function __mintStreamingUrlForTests(
+  fileAccess: FileAccessPolicy,
+  fileId: string
+): Promise<string> {
+  return mintStreamingUrl(fileAccess, fileId)
 }
 
 /**
@@ -103,13 +128,16 @@ export function __resetStreamingUrlCacheForTests(): void {
  *    URL, preserving HTTP range requests for progressive playback. Falls
  *    through to (2) if minting fails (e.g. offline) rather than leaving
  *    the player on a permanent spinner. If the media element itself then
- *    fails to load that URL (e.g. the ticket expired mid-session, or
- *    redemption 403s for a file minting never checked ownership on), the
- *    caller's ``onError`` should invoke the returned ``reportLoadFailure``
- *    to retry via (2)/(3) instead of leaving a dead ``src`` — this is not
- *    hypothetical: minting never checks file ownership by design (only
- *    redemption does), so a ticket can mint successfully for a file the
- *    caller can't actually read.
+ *    fails to load that URL after the ticket expires mid-session, the
+ *    caller's ``onError`` should invoke the returned ``remintStreamingUrl``
+ *    first -- minting is cheap and doesn't re-check ownership, so it's the
+ *    right recovery for the common case of "the ticket simply expired
+ *    while a long video was still playing" -- and only fall back to
+ *    ``reportLoadFailure`` (which retries via (2)/(3) instead of leaving a
+ *    dead ``src``) if the re-mint itself fails: this is not hypothetical,
+ *    minting never checks file ownership by design (only redemption does),
+ *    so a ticket can mint successfully for a file the caller can't
+ *    actually read.
  * 2. Blob fetch: the default policy's authenticated preview route needs a
  *    Bearer header that media elements cannot send, so managed files are
  *    fetched into a blob object URL. If that fetch fails, the public
@@ -158,6 +186,7 @@ function useResolvedMediaUrl(
   openUrl: string
   isStreamingUrl: boolean
   resolveOpenUrl: () => Promise<string>
+  remintStreamingUrl: () => Promise<boolean>
   reportLoadFailure: () => boolean
 } {
   const fileId = source.fileId
@@ -260,13 +289,63 @@ function useResolvedMediaUrl(
     return true // every strategy has been exhausted
   }, [isStreamingUrl, fileId])
 
-  // Only ever holds a blob URL minted on demand for a "Open" click while
-  // resolveOpenUrl below was in flight -- revoked on the next click and on
-  // unmount, not on every render, since it's independent of the playback
-  // src's own blob (which useEffect above already manages).
-  const openBlobUrlRef = useRef<string | null>(null)
+  // setResolvedUrl below fires from a callback whose completion the
+  // component's own lifecycle doesn't otherwise gate (unlike the main
+  // useEffect's isCancelled, which only covers *that* effect's run) -- this
+  // is the guard for the one async state update outside it. Re-armed in the
+  // effect body, not just initialized at declaration: StrictMode's dev-only
+  // mount->cleanup->mount double-invoke would otherwise leave it stuck
+  // false after the first cleanup, silently disabling the remint recovery.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  // A ticket that expired mid-session is cheap to replace: minting doesn't
+  // re-check file ownership (redemption does, and this fileId already
+  // loaded successfully once under it), so a fresh ticket is the right
+  // recovery -- not the full-file blob download reportLoadFailure below
+  // falls back to, which is exactly the download-before-playback symptom
+  // this streaming path exists to avoid. Returns false (falls through to
+  // reportLoadFailure) only if re-minting itself fails, e.g. the file was
+  // deleted or access was revoked since the last successful load.
+  const remintStreamingUrl = useCallback(async (): Promise<boolean> => {
+    if (!fileId) return false
+    streamingUrlCache.delete(fileId) // the cached ticket just failed to load
+    try {
+      const freshUrl = await mintStreamingUrl(fileAccess, fileId)
+      // JWT iat/exp have whole-second precision, so a mint within the same
+      // second as the failing one (a transient network error, not expiry)
+      // can be byte-identical -- setResolvedUrl would then be a no-op, the
+      // element's src never changes, and nothing ever reloads it. Treat
+      // that as a failed recovery so the caller falls back to the blob
+      // path, which does recover.
+      if (freshUrl === resolvedUrl) return false
+      if (!isMountedRef.current) return true
+      setResolvedUrl(freshUrl)
+      return true
+    } catch (error) {
+      console.warn(
+        'InlineFilePreview: failed to re-mint a media streaming ticket after mid-playback expiry, falling back.',
+        error
+      )
+      return false
+    }
+  }, [fileId, fileAccess, resolvedUrl])
+
+  // Every blob URL minted on demand for a "Open" click, kept alive until
+  // unmount rather than revoked on the *next* click: a still-open first
+  // tab's media keeps making Range requests against its blob URL as the
+  // user seeks/reloads it, and revoking it out from under that tab would
+  // break playback there the moment a second "Open" click happens on a
+  // different tab. Independent of the playback src's own blob (which
+  // useEffect above already manages on its own lifecycle).
+  const openBlobUrlsRef = useRef<string[]>([])
   useEffect(() => () => {
-    if (openBlobUrlRef.current) URL.revokeObjectURL(openBlobUrlRef.current)
+    for (const url of openBlobUrlsRef.current) URL.revokeObjectURL(url)
   }, [])
 
   const resolveOpenUrl = useCallback(async (): Promise<string> => {
@@ -284,9 +363,8 @@ function useResolvedMediaUrl(
       })
       if (!response.ok) return previewUrl
       const blob = await response.blob()
-      if (openBlobUrlRef.current) URL.revokeObjectURL(openBlobUrlRef.current)
       const objectUrl = URL.createObjectURL(blob)
-      openBlobUrlRef.current = objectUrl
+      openBlobUrlsRef.current.push(objectUrl)
       return objectUrl
     } catch {
       return previewUrl
@@ -298,6 +376,7 @@ function useResolvedMediaUrl(
     openUrl: isStreamingUrl ? previewUrl : resolvedUrl,
     isStreamingUrl,
     resolveOpenUrl,
+    remintStreamingUrl,
     reportLoadFailure,
   }
 }
@@ -396,6 +475,7 @@ function InlineMediaPreview({
     openUrl,
     isStreamingUrl,
     resolveOpenUrl,
+    remintStreamingUrl,
     reportLoadFailure,
   } = useResolvedMediaUrl(source, previewUrl, fileAccess, true)
   // No dialog available (e.g. a read-only transcript/log viewer, or the
@@ -404,18 +484,34 @@ function InlineMediaPreview({
   // public URL as above. Open a blank tab synchronously inside this click
   // handler (required so the later async navigation isn't blocked as a
   // popup) and redirect it once resolveOpenUrl settles on a URL that will
-  // actually load.
+  // actually load. Also wired to onAuxClick: middle-click/ctrl-click fire a
+  // native 'auxclick' event that bypasses onClick entirely, so without this
+  // the static href below (never the ticketed URL, by design) is what a
+  // middle-click would navigate to -- a 403 on any access-controlled task.
   const handleOpenFallbackClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    // auxclick fires for ANY non-primary button, right-click (button 2)
+    // included -- there the user wants the context menu, and hijacking it
+    // into a surprise tab (plus preventDefault) would be a regression on a
+    // gesture this handler was never meant for. Only the middle button
+    // (button 1) is the open-in-new-tab gesture being recovered here.
+    if (event.type === 'auxclick' && event.button !== 1) return
     event.preventDefault()
     const tab = window.open('about:blank', '_blank')
+    if (!tab) {
+      // Popup blocked (or a webview that refuses window.open): there is no
+      // tab left to redirect once resolveOpenUrl settles, so say so rather
+      // than resolving a URL nothing will ever navigate to.
+      toast.error('Unable to open in a new tab. Check your browser’s pop-up blocker.')
+      return
+    }
     // Severs window.opener (the reverse-tabnabbing risk rel="noreferrer"
     // normally guards against on a static <a target="_blank">) while still
     // keeping our own reference to redirect once resolveOpenUrl settles --
     // window.open's own "noopener" feature string would null out that
     // reference too, which this handler needs.
-    if (tab) tab.opener = null
+    tab.opener = null
     void resolveOpenUrl().then((url) => {
-      if (tab && !tab.closed) tab.location.href = url
+      if (!tab.closed) tab.location.href = url
     })
   }
   const [failedUrl, setFailedUrl] = useState('')
@@ -430,15 +526,18 @@ function InlineMediaPreview({
   // ticket that minted but wouldn't actually load) is exhausted. Errors
   // after data has loaded keep the player mounted by default -- most are
   // mid-playback decode hiccups the element surfaces and recovers from
-  // itself -- except a MEDIA_ERR_NETWORK error while still on the ticketed
-  // path, which the player can't recover from on its own: a ticket expiring
+  // itself -- except a network/src error while still on the ticketed path,
+  // which the player can't recover from on its own: a ticket expiring
   // mid-session makes the browser's next Range request 401/403, and without
   // this special case that error would be silently swallowed by the
   // loadedUrl-already-set guard below, leaving playback stalled for the
-  // rest of the ticket's (short, by design) TTL. Reported the same way a
-  // pre-load failure is: evict + re-mint + fall back via reportLoadFailure,
-  // remembering currentTime so the resulting reload can resume close to
-  // where playback stopped instead of restarting from 0.
+  // rest of the ticket's (short, by design) TTL. Recovered in place first --
+  // remintStreamingUrl swaps in a fresh ticket for the same fileId, which is
+  // cheap because minting doesn't re-check ownership -- and only falls back
+  // to reportLoadFailure's full blob download if the re-mint itself fails
+  // (e.g. access was actually revoked, not just the ticket expired).
+  // currentTime is saved first so playback can resume close to where it
+  // stopped instead of restarting from 0, whichever recovery path is taken.
   const failed = Boolean(resolvedUrl) && failedUrl === resolvedUrl
 
   return (
@@ -456,6 +555,7 @@ function InlineMediaPreview({
           <a
             href={openUrl}
             onClick={canOpenFilePreview ? onOpenPreview : handleOpenFallbackClick}
+            onAuxClick={canOpenFilePreview ? undefined : handleOpenFallbackClick}
             className="shrink-0 text-foreground hover:underline"
           >
             {openLabel}
@@ -471,18 +571,33 @@ function InlineMediaPreview({
               onError: (event) => {
                 if (loadedUrl === resolvedUrl) {
                   const element = event.currentTarget
-                  // 2 === MediaError.MEDIA_ERR_NETWORK -- the numeric value
-                  // rather than the global is deliberate: MediaError's
-                  // codes are a stable, unchanging part of the spec (unlike
-                  // most enums, no browser has ever needed a 5th), and the
+                  // 2 === MediaError.MEDIA_ERR_NETWORK, 4 ===
+                  // MEDIA_ERR_SRC_NOT_SUPPORTED -- numeric literals rather
+                  // than the MediaError global are deliberate: these codes
+                  // are a stable, unchanging part of the spec, and the
                   // constructor itself isn't implemented in every test
                   // environment (jsdom has no MediaError global), so a
                   // ReferenceError there must not be how this finds out.
-                  const isNetworkError = element.error?.code === 2
-                  if (!isStreamingUrl || !isNetworkError) return // a hiccup the element handles itself
+                  // Both codes are treated as recoverable: browsers are
+                  // inconsistent about which one an expired ticket's
+                  // mid-stream 401/403 surfaces as -- some report NETWORK,
+                  // others SRC_NOT_SUPPORTED because the failed fetch never
+                  // yields a decodable resource. MEDIA_ERR_DECODE (3) is
+                  // deliberately excluded: that's a genuine mid-playback
+                  // decode hiccup the element already retries on its own,
+                  // and forcing a re-mint there would interrupt playback
+                  // that didn't need recovering.
+                  const isRecoverableWhileStreaming =
+                    isStreamingUrl && (element.error?.code === 2 || element.error?.code === 4)
+                  if (!isRecoverableWhileStreaming) return // a hiccup the element handles itself
                   resumeAtRef.current = element.currentTime || null
                   setLoadedUrl('') // this url is dead; a future load must not be swallowed by this guard
-                  reportLoadFailure() // always non-terminal here: isStreamingUrl was just checked true
+                  void remintStreamingUrl().then((reminted) => {
+                    // Re-mint failed too (e.g. access was actually revoked,
+                    // not just the ticket expired) -- fall back to the full
+                    // blob/direct strategy rather than leaving a dead src.
+                    if (!reminted) reportLoadFailure()
+                  })
                   return
                 }
                 if (reportLoadFailure()) setFailedUrl(resolvedUrl)

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -35,21 +35,50 @@ const DEFAULT_LOAD_ERROR_TEXT = 'Failed to load preview.'
 // A minted streaming URL is cached briefly per fileId so remounts/rerenders
 // of the same attachment (common in a chat transcript) don't each pay an
 // extra mint round trip. Deliberately much shorter than the server's own
-// ticket TTL default (10 minutes) rather than trying to track the real
-// expiry -- this is a de-dup window for near-simultaneous mounts, not an
-// attempt to use a ticket right up to the edge of its validity.
+// operator-configurable ticket TTL (XAGENT_FILE_STREAM_TICKET_TTL_SECONDS,
+// default 600s / 10min, validated only as >0) rather than trying to track
+// the real expiry -- this is a de-dup window for near-simultaneous mounts,
+// not an attempt to use a ticket right up to the edge of its validity. A
+// deployment that lowers the server TTL below this window can have a
+// client serve an already-expired ticket from cache; that self-heals via
+// reportLoadFailure (one dead load, then a fresh mint), so it costs one
+// failed request rather than a stuck player.
 const STREAMING_URL_CACHE_TTL_MS = 4 * 60 * 1000
-const streamingUrlCache = new Map<string, { url: string; expiresAt: number }>()
+// Stores the in-flight mint promise, not just the settled result: two
+// mounts of the same fileId within one render burst (e.g. the same
+// attachment shown on two messages) would otherwise each pay a separate
+// mint round trip before either resolves.
+const streamingUrlCache = new Map<string, Promise<{ url: string; expiresAt: number }>>()
 
 async function mintStreamingUrl(
   fileAccess: FileAccessPolicy,
   fileId: string
 ): Promise<string> {
   const cached = streamingUrlCache.get(fileId)
-  if (cached && cached.expiresAt > Date.now()) return cached.url
-  const url = await fileAccess.getStreamingUrl!(fileId)
-  streamingUrlCache.set(fileId, { url, expiresAt: Date.now() + STREAMING_URL_CACHE_TTL_MS })
-  return url
+  if (cached) {
+    const entry = await cached.catch(() => null)
+    if (entry && entry.expiresAt > Date.now()) return entry.url
+    // Expired, or the in-flight mint this promise represented failed --
+    // either way this exact entry is now stale. Clear it before re-minting
+    // rather than leaving a dead/expired promise for the next caller to
+    // hit this same branch again, but only if nothing else already
+    // replaced it (e.g. a concurrent caller's own retry).
+    if (streamingUrlCache.get(fileId) === cached) streamingUrlCache.delete(fileId)
+  }
+  const mintPromise = fileAccess.getStreamingUrl!(fileId).then((url) => ({
+    url,
+    expiresAt: Date.now() + STREAMING_URL_CACHE_TTL_MS,
+  }))
+  streamingUrlCache.set(fileId, mintPromise)
+  try {
+    return (await mintPromise).url
+  } catch (error) {
+    // Don't let a failed mint poison the cache for the next caller --
+    // without this, every subsequent mount of this fileId would
+    // immediately re-throw this same rejection instead of retrying.
+    if (streamingUrlCache.get(fileId) === mintPromise) streamingUrlCache.delete(fileId)
+    throw error
+  }
 }
 
 /**
@@ -105,7 +134,13 @@ export function __resetStreamingUrlCacheForTests(): void {
  * direct path's already-anonymous public URL), so it must never be handed
  * to something a user can put in the address bar, browser history, or a
  * copied link -- ``openUrl`` falls back to the same credential-free
- * ``previewUrl`` the blob path itself uses on failure.
+ * ``previewUrl`` the blob path itself uses on failure. For the default
+ * policy that credential-free URL is the tokenless public preview route,
+ * which 403s once a task has access control configured -- callers with an
+ * in-app file-preview dialog available (``onFileClick``) should route
+ * "Open" through that instead of this URL, the same way the image and
+ * generic-file branches of ``InlineFilePreview`` already do; ``openUrl``
+ * exists for surfaces with no such dialog (e.g. the public widget).
  */
 function useResolvedMediaUrl(
   source: InlineFilePreviewSource,
@@ -276,6 +311,7 @@ function InlineMediaPreview({
   loadErrorText,
   className,
   fileAccess,
+  onFileClick,
   icon: Icon,
   bodyClassName,
   spinnerClassName,
@@ -288,6 +324,7 @@ function InlineMediaPreview({
   loadErrorText: string
   className?: string
   fileAccess: FileAccessPolicy
+  onFileClick?: (filePath: string, fileName: string) => void
   icon: React.ComponentType<{ className?: string }>
   bodyClassName: string
   spinnerClassName: string
@@ -302,6 +339,19 @@ function InlineMediaPreview({
     fileAccess,
     true
   )
+  // When an in-app file-preview dialog is available, route "Open" through
+  // it instead of openUrl: for the default policy openUrl is the tokenless
+  // public preview URL, which 403s for any task with access control
+  // configured (agent_config as a dict) -- the same reason the image and
+  // generic-file branches of InlineFilePreview already prefer onFileClick
+  // over a raw href. Only surfaces with no dialog (e.g. the public widget)
+  // fall back to openUrl, where it remains credential-free by design.
+  const canOpenFilePreview = Boolean(onFileClick && source.fileId)
+  const handleOpenClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!onFileClick || !source.fileId) return
+    event.preventDefault()
+    onFileClick(source.fileId, filename)
+  }
   const [failedUrl, setFailedUrl] = useState('')
   const [loadedUrl, setLoadedUrl] = useState('')
   // Terminal load failure only: an error event from a media element that
@@ -327,8 +377,9 @@ function InlineMediaPreview({
         {resolvedUrl ? (
           <a
             href={openUrl}
-            target="_blank"
-            rel="noreferrer"
+            target={canOpenFilePreview ? undefined : '_blank'}
+            rel={canOpenFilePreview ? undefined : 'noreferrer'}
+            onClick={canOpenFilePreview ? handleOpenClick : undefined}
             className="shrink-0 text-foreground hover:underline"
           >
             {openLabel}
@@ -376,6 +427,7 @@ type MediaWrapperProps = {
   loadErrorText: string
   className?: string
   fileAccess: FileAccessPolicy
+  onFileClick?: (filePath: string, fileName: string) => void
 }
 
 function InlineAudioPreview(props: MediaWrapperProps) {
@@ -618,6 +670,7 @@ export function InlineFilePreview({
         loadErrorText={loadErrorText}
         className={className}
         fileAccess={fileAccess}
+        onFileClick={onFileClick}
       />
     )
   }
@@ -632,6 +685,7 @@ export function InlineFilePreview({
         loadErrorText={loadErrorText}
         className={className}
         fileAccess={fileAccess}
+        onFileClick={onFileClick}
       />
     )
   }

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { FileText, Loader2, Video, Volume2 } from 'lucide-react'
 
 import { DocxPreviewRenderer } from '@/components/file/docx-preview-renderer'
@@ -129,25 +129,37 @@ export function __resetStreamingUrlCacheForTests(): void {
  * pure overhead with no benefit.
  *
  * Returns ``openUrl`` alongside ``resolvedUrl`` for the "Open in new tab"
- * affordance: the ticketed URL from strategy (1) is a replayable
- * credential (unlike the blob path's session-scoped ``blob:`` URL, or the
- * direct path's already-anonymous public URL), so it must never be handed
- * to something a user can put in the address bar, browser history, or a
- * copied link -- ``openUrl`` falls back to the same credential-free
- * ``previewUrl`` the blob path itself uses on failure. For the default
- * policy that credential-free URL is the tokenless public preview route,
- * which 403s once a task has access control configured -- callers with an
- * in-app file-preview dialog available (``onFileClick``) should route
- * "Open" through that instead of this URL, the same way the image and
- * generic-file branches of ``InlineFilePreview`` already do; ``openUrl``
- * exists for surfaces with no such dialog (e.g. the public widget).
+ * affordance when no in-app file-preview dialog is available (see
+ * ``resolveOpenUrl`` below for when one isn't): the ticketed URL from
+ * strategy (1) is a replayable credential (unlike the blob path's
+ * session-scoped ``blob:`` URL, or the direct path's already-anonymous
+ * public URL), so it must never be handed to something a user can put in
+ * the address bar, browser history, or a copied link -- ``openUrl`` falls
+ * back to the credential-free ``previewUrl`` the blob path itself uses on
+ * failure, which is safe to use directly except in one case: for the
+ * default policy while actively streaming, ``previewUrl`` is the tokenless
+ * public preview route, which 403s once a task has access control
+ * configured. ``resolveOpenUrl`` covers that case on demand.
+ *
+ * Callers with an in-app file-preview dialog available should route "Open"
+ * through it instead of either of these (see ``InlineMediaPreview`` below,
+ * which decides between the two using ``canOpenFilePreview``/
+ * ``onOpenPreview`` passed down from ``InlineFilePreview``) -- this hook's
+ * ``openUrl``/``resolveOpenUrl`` exist for surfaces with no such dialog
+ * (e.g. the public widget, or a read-only transcript/log viewer).
  */
 function useResolvedMediaUrl(
   source: InlineFilePreviewSource,
   previewUrl: string,
   fileAccess: FileAccessPolicy,
   allowStreaming: boolean
-): { resolvedUrl: string; openUrl: string; reportLoadFailure: () => boolean } {
+): {
+  resolvedUrl: string
+  openUrl: string
+  isStreamingUrl: boolean
+  resolveOpenUrl: () => Promise<string>
+  reportLoadFailure: () => boolean
+} {
   const fileId = source.fileId
   const canStream =
     allowStreaming && Boolean(fileId) && Boolean(fileAccess.getStreamingUrl)
@@ -204,11 +216,13 @@ function useResolvedMediaUrl(
     }
 
     const loadMedia = async () => {
-      if (!fileId) {
-        setResolvedUrl(previewUrl)
-        return
-      }
-      if (effectiveCanStream && fileAccess.getStreamingUrl) {
+      // No separate "no fileId" early-return here: canStream (and so
+      // effectiveCanStream) is already false whenever fileId is falsy, so
+      // this always falls through to loadBlobOrDirect, whose own !fileId
+      // guard produces the identical setResolvedUrl(previewUrl) outcome.
+      // The "&& fileId" below is for TypeScript's narrowing, not runtime
+      // behavior -- effectiveCanStream already guarantees it's truthy.
+      if (effectiveCanStream && fileAccess.getStreamingUrl && fileId) {
         try {
           const streamingUrl = await mintStreamingUrl(fileAccess, fileId)
           if (isCancelled) return
@@ -246,9 +260,44 @@ function useResolvedMediaUrl(
     return true // every strategy has been exhausted
   }, [isStreamingUrl, fileId])
 
+  // Only ever holds a blob URL minted on demand for a "Open" click while
+  // resolveOpenUrl below was in flight -- revoked on the next click and on
+  // unmount, not on every render, since it's independent of the playback
+  // src's own blob (which useEffect above already manages).
+  const openBlobUrlRef = useRef<string | null>(null)
+  useEffect(() => () => {
+    if (openBlobUrlRef.current) URL.revokeObjectURL(openBlobUrlRef.current)
+  }, [])
+
+  const resolveOpenUrl = useCallback(async (): Promise<string> => {
+    // Not currently on the ticketed path: resolvedUrl is already either a
+    // blob: URL or a direct src that's safe to hand to a new tab as-is.
+    if (!isStreamingUrl) return resolvedUrl
+    if (!needsBlobFetch || !fileId) return previewUrl
+    try {
+      const response = await fileAccess.request(fileAccess.previewUrl(fileId), {
+        cache: 'no-cache',
+        headers: {
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+        },
+      })
+      if (!response.ok) return previewUrl
+      const blob = await response.blob()
+      if (openBlobUrlRef.current) URL.revokeObjectURL(openBlobUrlRef.current)
+      const objectUrl = URL.createObjectURL(blob)
+      openBlobUrlRef.current = objectUrl
+      return objectUrl
+    } catch {
+      return previewUrl
+    }
+  }, [isStreamingUrl, needsBlobFetch, fileId, fileAccess, previewUrl, resolvedUrl])
+
   return {
     resolvedUrl,
     openUrl: isStreamingUrl ? previewUrl : resolvedUrl,
+    isStreamingUrl,
+    resolveOpenUrl,
     reportLoadFailure,
   }
 }
@@ -311,7 +360,8 @@ function InlineMediaPreview({
   loadErrorText,
   className,
   fileAccess,
-  onFileClick,
+  canOpenFilePreview,
+  onOpenPreview,
   icon: Icon,
   bodyClassName,
   spinnerClassName,
@@ -324,43 +374,71 @@ function InlineMediaPreview({
   loadErrorText: string
   className?: string
   fileAccess: FileAccessPolicy
-  onFileClick?: (filePath: string, fileName: string) => void
+  // Computed once by the parent InlineFilePreview from onFileClick/fileId,
+  // the same way its own image/generic-file branches do -- not re-derived
+  // here, so there's exactly one place that decides whether a dialog is
+  // available.
+  canOpenFilePreview: boolean
+  onOpenPreview: (event: React.MouseEvent<HTMLElement>) => void
   icon: React.ComponentType<{ className?: string }>
   bodyClassName: string
   spinnerClassName: string
   renderMedia: (
     resolvedUrl: string,
-    media: { onError: () => void; onLoaded: () => void }
+    media: {
+      onError: (event: React.SyntheticEvent<HTMLMediaElement>) => void
+      onLoaded: (event: React.SyntheticEvent<HTMLMediaElement>) => void
+    }
   ) => React.ReactNode
 }) {
-  const { resolvedUrl, openUrl, reportLoadFailure } = useResolvedMediaUrl(
-    source,
-    previewUrl,
-    fileAccess,
-    true
-  )
-  // When an in-app file-preview dialog is available, route "Open" through
-  // it instead of openUrl: for the default policy openUrl is the tokenless
-  // public preview URL, which 403s for any task with access control
-  // configured (agent_config as a dict) -- the same reason the image and
-  // generic-file branches of InlineFilePreview already prefer onFileClick
-  // over a raw href. Only surfaces with no dialog (e.g. the public widget)
-  // fall back to openUrl, where it remains credential-free by design.
-  const canOpenFilePreview = Boolean(onFileClick && source.fileId)
-  const handleOpenClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (!onFileClick || !source.fileId) return
+  const {
+    resolvedUrl,
+    openUrl,
+    isStreamingUrl,
+    resolveOpenUrl,
+    reportLoadFailure,
+  } = useResolvedMediaUrl(source, previewUrl, fileAccess, true)
+  // No dialog available (e.g. a read-only transcript/log viewer, or the
+  // public widget): openUrl's static href is the safe default, but while
+  // actively streaming under the default policy it's the same 403-prone
+  // public URL as above. Open a blank tab synchronously inside this click
+  // handler (required so the later async navigation isn't blocked as a
+  // popup) and redirect it once resolveOpenUrl settles on a URL that will
+  // actually load.
+  const handleOpenFallbackClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
-    onFileClick(source.fileId, filename)
+    const tab = window.open('about:blank', '_blank')
+    // Severs window.opener (the reverse-tabnabbing risk rel="noreferrer"
+    // normally guards against on a static <a target="_blank">) while still
+    // keeping our own reference to redirect once resolveOpenUrl settles --
+    // window.open's own "noopener" feature string would null out that
+    // reference too, which this handler needs.
+    if (tab) tab.opener = null
+    void resolveOpenUrl().then((url) => {
+      if (tab && !tab.closed) tab.location.href = url
+    })
   }
   const [failedUrl, setFailedUrl] = useState('')
   const [loadedUrl, setLoadedUrl] = useState('')
+  // Where to seek to after a post-load recovery reload (see the onError
+  // handler below) -- a plain ref, not state, since setting it must never
+  // itself trigger a render; it's only read once, from the *next* onLoaded.
+  const resumeAtRef = useRef<number | null>(null)
   // Terminal load failure only: an error event from a media element that
   // never loaded data means every fallback useResolvedMediaUrl has (blob
   // fetch, direct src, and -- via reportLoadFailure below -- a streaming
   // ticket that minted but wouldn't actually load) is exhausted. Errors
-  // after data has loaded (e.g. a mid-playback decode hiccup) keep the
-  // player mounted -- the element surfaces those itself. Keyed by URL so a
-  // later re-resolve (including a post-failure fallback attempt) clears it.
+  // after data has loaded keep the player mounted by default -- most are
+  // mid-playback decode hiccups the element surfaces and recovers from
+  // itself -- except a MEDIA_ERR_NETWORK error while still on the ticketed
+  // path, which the player can't recover from on its own: a ticket expiring
+  // mid-session makes the browser's next Range request 401/403, and without
+  // this special case that error would be silently swallowed by the
+  // loadedUrl-already-set guard below, leaving playback stalled for the
+  // rest of the ticket's (short, by design) TTL. Reported the same way a
+  // pre-load failure is: evict + re-mint + fall back via reportLoadFailure,
+  // remembering currentTime so the resulting reload can resume close to
+  // where playback stopped instead of restarting from 0.
   const failed = Boolean(resolvedUrl) && failedUrl === resolvedUrl
 
   return (
@@ -377,9 +455,7 @@ function InlineMediaPreview({
         {resolvedUrl ? (
           <a
             href={openUrl}
-            target={canOpenFilePreview ? undefined : '_blank'}
-            rel={canOpenFilePreview ? undefined : 'noreferrer'}
-            onClick={canOpenFilePreview ? handleOpenClick : undefined}
+            onClick={canOpenFilePreview ? onOpenPreview : handleOpenFallbackClick}
             className="shrink-0 text-foreground hover:underline"
           >
             {openLabel}
@@ -392,8 +468,23 @@ function InlineMediaPreview({
         <div className={bodyClassName}>
           {resolvedUrl ? (
             renderMedia(resolvedUrl, {
-              onError: () => {
-                if (loadedUrl === resolvedUrl) return
+              onError: (event) => {
+                if (loadedUrl === resolvedUrl) {
+                  const element = event.currentTarget
+                  // 2 === MediaError.MEDIA_ERR_NETWORK -- the numeric value
+                  // rather than the global is deliberate: MediaError's
+                  // codes are a stable, unchanging part of the spec (unlike
+                  // most enums, no browser has ever needed a 5th), and the
+                  // constructor itself isn't implemented in every test
+                  // environment (jsdom has no MediaError global), so a
+                  // ReferenceError there must not be how this finds out.
+                  const isNetworkError = element.error?.code === 2
+                  if (!isStreamingUrl || !isNetworkError) return // a hiccup the element handles itself
+                  resumeAtRef.current = element.currentTime || null
+                  setLoadedUrl('') // this url is dead; a future load must not be swallowed by this guard
+                  reportLoadFailure() // always non-terminal here: isStreamingUrl was just checked true
+                  return
+                }
                 if (reportLoadFailure()) setFailedUrl(resolvedUrl)
                 // else: reportLoadFailure disabled the streaming ticket for
                 // this fileId, which reruns useResolvedMediaUrl's effect
@@ -401,7 +492,13 @@ function InlineMediaPreview({
                 // changes on the next render, so this failedUrl is stale
                 // and `failed` above naturally goes back to false.
               },
-              onLoaded: () => setLoadedUrl(resolvedUrl),
+              onLoaded: (event) => {
+                setLoadedUrl(resolvedUrl)
+                if (resumeAtRef.current !== null) {
+                  event.currentTarget.currentTime = resumeAtRef.current
+                  resumeAtRef.current = null
+                }
+              },
             })
           ) : (
             <div
@@ -427,7 +524,8 @@ type MediaWrapperProps = {
   loadErrorText: string
   className?: string
   fileAccess: FileAccessPolicy
-  onFileClick?: (filePath: string, fileName: string) => void
+  canOpenFilePreview: boolean
+  onOpenPreview: (event: React.MouseEvent<HTMLElement>) => void
 }
 
 function InlineAudioPreview(props: MediaWrapperProps) {
@@ -670,7 +768,8 @@ export function InlineFilePreview({
         loadErrorText={loadErrorText}
         className={className}
         fileAccess={fileAccess}
-        onFileClick={onFileClick}
+        canOpenFilePreview={canOpenFilePreview}
+        onOpenPreview={handleOpenPreview}
       />
     )
   }
@@ -685,7 +784,8 @@ export function InlineFilePreview({
         loadErrorText={loadErrorText}
         className={className}
         fileAccess={fileAccess}
-        onFileClick={onFileClick}
+        canOpenFilePreview={canOpenFilePreview}
+        onOpenPreview={handleOpenPreview}
       />
     )
   }

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -50,11 +50,45 @@ const STREAMING_URL_CACHE_TTL_MS = 4 * 60 * 1000
 // attachment shown on two messages) would otherwise each pay a separate
 // mint round trip before either resolves.
 const streamingUrlCache = new Map<string, Promise<{ url: string; expiresAt: number }>>()
+// Insertion time per fileId, tracked separately from the cache above: an
+// entry's own settled `expiresAt` isn't knowable until its promise resolves,
+// but pruning needs to sweep entries for fileIds nobody has asked about
+// since, which are never re-awaited to trigger that resolution. Without this,
+// a long chat session that streams many distinct attachments over time would
+// grow this module-level Map unbounded, one entry per fileId ever mounted.
+const streamingUrlCacheInsertedAt = new Map<string, number>()
+
+function setStreamingUrlCacheEntry(
+  fileId: string,
+  promise: Promise<{ url: string; expiresAt: number }>
+): void {
+  streamingUrlCache.set(fileId, promise)
+  streamingUrlCacheInsertedAt.set(fileId, Date.now())
+}
+
+function deleteStreamingUrlCacheEntry(fileId: string): void {
+  streamingUrlCache.delete(fileId)
+  streamingUrlCacheInsertedAt.delete(fileId)
+}
+
+// Opportunistic, not timer-driven: piggybacks on the natural traffic of
+// mint calls rather than running its own background interval. A fileId that
+// stops being mounted altogether would otherwise never trigger the
+// `expiresAt` check inside mintStreamingUrl (nobody's asking about it to run
+// that check), so it needs its own sweep independent of any particular
+// fileId's own access pattern.
+function pruneStaleStreamingUrlCacheEntries(): void {
+  const now = Date.now()
+  for (const [id, insertedAt] of streamingUrlCacheInsertedAt) {
+    if (now - insertedAt > STREAMING_URL_CACHE_TTL_MS) deleteStreamingUrlCacheEntry(id)
+  }
+}
 
 async function mintStreamingUrl(
   fileAccess: FileAccessPolicy,
   fileId: string
 ): Promise<string> {
+  pruneStaleStreamingUrlCacheEntries()
   const cached = streamingUrlCache.get(fileId)
   if (cached) {
     const entry = await cached.catch(() => null)
@@ -65,7 +99,7 @@ async function mintStreamingUrl(
     // hit this same branch again, but only if nothing else already
     // replaced it (e.g. a concurrent caller's own retry).
     if (streamingUrlCache.get(fileId) === cached) {
-      streamingUrlCache.delete(fileId)
+      deleteStreamingUrlCacheEntry(fileId)
     } else {
       // A concurrent caller already replaced this stale/failed entry with
       // its own fresh mint while this call was awaiting it above -- reuse
@@ -81,14 +115,14 @@ async function mintStreamingUrl(
     url,
     expiresAt: Date.now() + STREAMING_URL_CACHE_TTL_MS,
   }))
-  streamingUrlCache.set(fileId, mintPromise)
+  setStreamingUrlCacheEntry(fileId, mintPromise)
   try {
     return (await mintPromise).url
   } catch (error) {
     // Don't let a failed mint poison the cache for the next caller --
     // without this, every subsequent mount of this fileId would
     // immediately re-throw this same rejection instead of retrying.
-    if (streamingUrlCache.get(fileId) === mintPromise) streamingUrlCache.delete(fileId)
+    if (streamingUrlCache.get(fileId) === mintPromise) deleteStreamingUrlCacheEntry(fileId)
     throw error
   }
 }
@@ -115,6 +149,7 @@ export function __mintStreamingUrlForTests(
  */
 export function __resetStreamingUrlCacheForTests(): void {
   streamingUrlCache.clear()
+  streamingUrlCacheInsertedAt.clear()
 }
 
 /**
@@ -282,7 +317,7 @@ function useResolvedMediaUrl(
       // The ticket minted but the media element couldn't actually load it.
       // Evict the cache entry too, so a remount of this same fileId mints
       // fresh rather than immediately reusing the ticket that just failed.
-      streamingUrlCache.delete(fileId)
+      deleteStreamingUrlCacheEntry(fileId)
       setStreamingFailedFor(fileId)
       return false // not terminal -- a (2)/(3) fallback attempt is starting
     }
@@ -314,7 +349,7 @@ function useResolvedMediaUrl(
   // deleted or access was revoked since the last successful load.
   const remintStreamingUrl = useCallback(async (): Promise<boolean> => {
     if (!fileId) return false
-    streamingUrlCache.delete(fileId) // the cached ticket just failed to load
+    deleteStreamingUrlCacheEntry(fileId) // the cached ticket just failed to load
     try {
       const freshUrl = await mintStreamingUrl(fileAccess, fileId)
       // JWT iat/exp have whole-second precision, so a mint within the same
@@ -495,6 +530,13 @@ function InlineMediaPreview({
     // gesture this handler was never meant for. Only the middle button
     // (button 1) is the open-in-new-tab gesture being recovered here.
     if (event.type === 'auxclick' && event.button !== 1) return
+    // Not on the ticketed path: href is already resolvedUrl (a blob: URL or
+    // an already-anonymous direct src), safe for the browser's own native
+    // navigation -- popup-blocker-dependent window.open plumbing exists
+    // only to smuggle a fresh URL past the 403-prone static href while
+    // streaming, and would be pure overhead (and a needless popup-blocker
+    // dependency) here.
+    if (!isStreamingUrl) return
     event.preventDefault()
     const tab = window.open('about:blank', '_blank')
     if (!tab) {
@@ -555,7 +597,14 @@ function InlineMediaPreview({
           <a
             href={openUrl}
             onClick={canOpenFilePreview ? onOpenPreview : handleOpenFallbackClick}
-            onAuxClick={canOpenFilePreview ? undefined : handleOpenFallbackClick}
+            // Unconditional, unlike onClick: a dialog answers "open in-app"
+            // for a primary click, but a middle-click's intent is always
+            // "open in a new tab" regardless of whether a dialog exists --
+            // onOpenPreview has no answer for that, so without this a
+            // dialog-present surface's middle-click fell through to the
+            // native href (the 403-prone one while streaming) exactly like
+            // the no-dialog case this was first fixed for.
+            onAuxClick={handleOpenFallbackClick}
             className="shrink-0 text-foreground hover:underline"
           >
             {openLabel}

--- a/frontend/src/components/file/inline-file-preview.tsx
+++ b/frontend/src/components/file/inline-file-preview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { FileText, Loader2, Video, Volume2 } from 'lucide-react'
 
 import { DocxPreviewRenderer } from '@/components/file/docx-preview-renderer'
@@ -32,6 +32,37 @@ const fileNameFromSource = (source: InlineFilePreviewSource) =>
 const DEFAULT_OPEN_LABEL = 'Open'
 const DEFAULT_LOAD_ERROR_TEXT = 'Failed to load preview.'
 
+// A minted streaming URL is cached briefly per fileId so remounts/rerenders
+// of the same attachment (common in a chat transcript) don't each pay an
+// extra mint round trip. Deliberately much shorter than the server's own
+// ticket TTL default (10 minutes) rather than trying to track the real
+// expiry -- this is a de-dup window for near-simultaneous mounts, not an
+// attempt to use a ticket right up to the edge of its validity.
+const STREAMING_URL_CACHE_TTL_MS = 4 * 60 * 1000
+const streamingUrlCache = new Map<string, { url: string; expiresAt: number }>()
+
+async function mintStreamingUrl(
+  fileAccess: FileAccessPolicy,
+  fileId: string
+): Promise<string> {
+  const cached = streamingUrlCache.get(fileId)
+  if (cached && cached.expiresAt > Date.now()) return cached.url
+  const url = await fileAccess.getStreamingUrl!(fileId)
+  streamingUrlCache.set(fileId, { url, expiresAt: Date.now() + STREAMING_URL_CACHE_TTL_MS })
+  return url
+}
+
+/**
+ * Test-only escape hatch: this module-level cache persists across test
+ * cases within the same test file (no module reset between them), so a
+ * fixed test fileId reused across cases would otherwise silently return an
+ * earlier case's mocked ticket instead of exercising the current case's
+ * mock. Call from `beforeEach` in any test that mocks `getStreamingUrl`.
+ */
+export function __resetStreamingUrlCacheForTests(): void {
+  streamingUrlCache.clear()
+}
+
 /**
  * Resolve the URL a media element (<img>/<audio>/<video>) can load.
  *
@@ -42,7 +73,14 @@ const DEFAULT_LOAD_ERROR_TEXT = 'Failed to load preview.'
  *    short-lived, file-scoped ticket and hands the media element a direct
  *    URL, preserving HTTP range requests for progressive playback. Falls
  *    through to (2) if minting fails (e.g. offline) rather than leaving
- *    the player on a permanent spinner.
+ *    the player on a permanent spinner. If the media element itself then
+ *    fails to load that URL (e.g. the ticket expired mid-session, or
+ *    redemption 403s for a file minting never checked ownership on), the
+ *    caller's ``onError`` should invoke the returned ``reportLoadFailure``
+ *    to retry via (2)/(3) instead of leaving a dead ``src`` — this is not
+ *    hypothetical: minting never checks file ownership by design (only
+ *    redemption does), so a ticket can mint successfully for a file the
+ *    caller can't actually read.
  * 2. Blob fetch: the default policy's authenticated preview route needs a
  *    Bearer header that media elements cannot send, so managed files are
  *    fetched into a blob object URL. If that fetch fails, the public
@@ -60,13 +98,21 @@ const DEFAULT_LOAD_ERROR_TEXT = 'Failed to load preview.'
  * seek-before-download or progressive-loading need, so paying an extra
  * network round trip to mint a ticket before every image load would be
  * pure overhead with no benefit.
+ *
+ * Returns ``openUrl`` alongside ``resolvedUrl`` for the "Open in new tab"
+ * affordance: the ticketed URL from strategy (1) is a replayable
+ * credential (unlike the blob path's session-scoped ``blob:`` URL, or the
+ * direct path's already-anonymous public URL), so it must never be handed
+ * to something a user can put in the address bar, browser history, or a
+ * copied link -- ``openUrl`` falls back to the same credential-free
+ * ``previewUrl`` the blob path itself uses on failure.
  */
 function useResolvedMediaUrl(
   source: InlineFilePreviewSource,
   previewUrl: string,
   fileAccess: FileAccessPolicy,
   allowStreaming: boolean
-): string {
+): { resolvedUrl: string; openUrl: string; reportLoadFailure: () => boolean } {
   const fileId = source.fileId
   const canStream =
     allowStreaming && Boolean(fileId) && Boolean(fileAccess.getStreamingUrl)
@@ -74,15 +120,26 @@ function useResolvedMediaUrl(
   const [resolvedUrl, setResolvedUrl] = useState(
     canStream || needsBlobFetch ? '' : previewUrl
   )
+  const [isStreamingUrl, setIsStreamingUrl] = useState(false)
+  // Set once the *media element itself* (not just minting) has failed to
+  // load a streaming URL for this fileId, so this hook stops retrying
+  // strategy (1) and settles on (2)/(3) for the remainder of this mount.
+  const [streamingFailedFor, setStreamingFailedFor] = useState<string | null>(null)
+  const streamingDisabled = canStream && streamingFailedFor === fileId
 
   useEffect(() => {
     let objectUrl: string | null = null
     let isCancelled = false
+    const effectiveCanStream = canStream && !streamingDisabled
 
-    setResolvedUrl(canStream || needsBlobFetch ? '' : previewUrl)
+    setResolvedUrl(effectiveCanStream || needsBlobFetch ? '' : previewUrl)
+    setIsStreamingUrl(false)
 
     const loadBlobOrDirect = async () => {
-      if (!needsBlobFetch || !fileId) return
+      if (!needsBlobFetch || !fileId) {
+        setResolvedUrl(previewUrl)
+        return
+      }
       try {
         const response = await fileAccess.request(fileAccess.previewUrl(fileId), {
           cache: 'no-cache',
@@ -100,24 +157,34 @@ function useResolvedMediaUrl(
         if (isCancelled) return
         objectUrl = URL.createObjectURL(blob)
         setResolvedUrl(objectUrl)
-      } catch {
+      } catch (error) {
         if (!isCancelled) {
+          console.warn(
+            'InlineFilePreview: authenticated preview fetch failed, falling back to the public preview URL.',
+            error
+          )
           setResolvedUrl(previewUrl)
         }
       }
     }
 
     const loadMedia = async () => {
-      if (!fileId) return
-      if (canStream && fileAccess.getStreamingUrl) {
+      if (!fileId) {
+        setResolvedUrl(previewUrl)
+        return
+      }
+      if (effectiveCanStream && fileAccess.getStreamingUrl) {
         try {
-          const streamingUrl = await fileAccess.getStreamingUrl(fileId)
+          const streamingUrl = await mintStreamingUrl(fileAccess, fileId)
           if (isCancelled) return
           setResolvedUrl(streamingUrl)
+          setIsStreamingUrl(true)
           return
-        } catch {
-          // Ticket minting failed -- fall through to the blob/direct path
-          // below instead of a permanent spinner.
+        } catch (error) {
+          console.warn(
+            'InlineFilePreview: failed to mint a media streaming ticket, falling back.',
+            error
+          )
         }
       }
       if (isCancelled) return
@@ -130,9 +197,25 @@ function useResolvedMediaUrl(
       isCancelled = true
       if (objectUrl) URL.revokeObjectURL(objectUrl)
     }
-  }, [fileAccess, fileId, canStream, needsBlobFetch, previewUrl])
+  }, [fileAccess, fileId, canStream, streamingDisabled, needsBlobFetch, previewUrl])
 
-  return resolvedUrl
+  const reportLoadFailure = useCallback((): boolean => {
+    if (isStreamingUrl && fileId) {
+      // The ticket minted but the media element couldn't actually load it.
+      // Evict the cache entry too, so a remount of this same fileId mints
+      // fresh rather than immediately reusing the ticket that just failed.
+      streamingUrlCache.delete(fileId)
+      setStreamingFailedFor(fileId)
+      return false // not terminal -- a (2)/(3) fallback attempt is starting
+    }
+    return true // every strategy has been exhausted
+  }, [isStreamingUrl, fileId])
+
+  return {
+    resolvedUrl,
+    openUrl: isStreamingUrl ? previewUrl : resolvedUrl,
+    reportLoadFailure,
+  }
 }
 
 function InlineImagePreview({
@@ -150,7 +233,7 @@ function InlineImagePreview({
   onFileClick?: (filePath: string, fileName: string) => void
   fileAccess: FileAccessPolicy
 }) {
-  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess, false)
+  const { resolvedUrl } = useResolvedMediaUrl(source, previewUrl, fileAccess, false)
 
   const handleClick = (event: React.MouseEvent<HTMLImageElement>) => {
     if (!onFileClick || !source.fileId) return
@@ -213,15 +296,21 @@ function InlineMediaPreview({
     media: { onError: () => void; onLoaded: () => void }
   ) => React.ReactNode
 }) {
-  const resolvedUrl = useResolvedMediaUrl(source, previewUrl, fileAccess, true)
+  const { resolvedUrl, openUrl, reportLoadFailure } = useResolvedMediaUrl(
+    source,
+    previewUrl,
+    fileAccess,
+    true
+  )
   const [failedUrl, setFailedUrl] = useState('')
   const [loadedUrl, setLoadedUrl] = useState('')
-  // Terminal load failure only: useResolvedMediaUrl already falls back from
-  // the authenticated fetch to the public preview URL, so an error event
-  // from a media element that never loaded data means both paths are
-  // exhausted. Errors after data has loaded (e.g. a mid-playback decode
-  // hiccup) keep the player mounted — the element surfaces those itself.
-  // Keyed by URL so a later re-resolve clears the failure.
+  // Terminal load failure only: an error event from a media element that
+  // never loaded data means every fallback useResolvedMediaUrl has (blob
+  // fetch, direct src, and -- via reportLoadFailure below -- a streaming
+  // ticket that minted but wouldn't actually load) is exhausted. Errors
+  // after data has loaded (e.g. a mid-playback decode hiccup) keep the
+  // player mounted -- the element surfaces those itself. Keyed by URL so a
+  // later re-resolve (including a post-failure fallback attempt) clears it.
   const failed = Boolean(resolvedUrl) && failedUrl === resolvedUrl
 
   return (
@@ -237,7 +326,7 @@ function InlineMediaPreview({
         <span className="min-w-0 flex-1 truncate">{filename}</span>
         {resolvedUrl ? (
           <a
-            href={resolvedUrl}
+            href={openUrl}
             target="_blank"
             rel="noreferrer"
             className="shrink-0 text-foreground hover:underline"
@@ -253,7 +342,13 @@ function InlineMediaPreview({
           {resolvedUrl ? (
             renderMedia(resolvedUrl, {
               onError: () => {
-                if (loadedUrl !== resolvedUrl) setFailedUrl(resolvedUrl)
+                if (loadedUrl === resolvedUrl) return
+                if (reportLoadFailure()) setFailedUrl(resolvedUrl)
+                // else: reportLoadFailure disabled the streaming ticket for
+                // this fileId, which reruns useResolvedMediaUrl's effect
+                // and falls back to the blob/direct strategy -- resolvedUrl
+                // changes on the next render, so this failedUrl is stale
+                // and `failed` above naturally goes back to false.
               },
               onLoaded: () => setLoadedUrl(resolvedUrl),
             })

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -53,6 +53,10 @@ vi.mock('@/contexts/i18n-context', () => ({
 
 import { JsonRenderer, MarkdownRenderer } from '../markdown-renderer'
 import {
+  FileAccessProvider,
+  defaultFileAccessPolicy,
+} from '@/contexts/file-access-context'
+import {
   AgentCardPresentationCapability,
   LinksOpenInNewTabCapability,
 } from '@/contexts/presentation-capabilities'
@@ -789,29 +793,41 @@ describe('MarkdownRenderer', () => {
   })
 
   it('keeps a playing audio element mounted when surrounding page callbacks update', async () => {
-    // The mocked response has no .json(), so the leading stream-ticket
-    // mint attempt (useResolvedMediaUrl's strategy 1, audio/video only)
-    // throws and falls through to the blob fetch -- two calls per load,
-    // not one, but still none on rerender.
+    // This test is about DOM node identity across rerenders, not about
+    // streaming-ticket mechanics -- opt out of the mint attempt explicitly
+    // (rather than relying on the mocked response lacking .json(), which
+    // would make the mint throw internally and fall through to the blob
+    // fetch for an incidental reason unrelated to what this test verifies).
     apiRequestMock.mockResolvedValue({
       ok: true,
       blob: async () => new Blob(['audio-bytes'], { type: 'audio/mpeg' }),
     })
     const content = '![podcast.mp3](file:output/podcast.mp3)'
+    // Stable across both renders: a fresh object literal per render would
+    // change useResolvedMediaUrl's fileAccess dependency identity and
+    // reset it to its loading state, unmounting/remounting the <audio>
+    // element for a reason unrelated to what this test verifies.
+    const testPolicy = { ...defaultFileAccessPolicy, getStreamingUrl: undefined }
     const { rerender } = render(
-      <MarkdownRenderer content={content} onFileClick={vi.fn()} />
+      <FileAccessProvider policy={testPolicy}>
+        <MarkdownRenderer content={content} onFileClick={vi.fn()} />
+      </FileAccessProvider>
     )
 
     const audioBeforeUpdate = await screen.findByLabelText('podcast.mp3')
-    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledTimes(1))
 
     // Trace and task events update the surrounding chat message and create new
     // callback props. The media DOM node must survive that rerender so the
     // browser keeps its currentTime and playing state.
-    rerender(<MarkdownRenderer content={content} onFileClick={vi.fn()} />)
+    rerender(
+      <FileAccessProvider policy={testPolicy}>
+        <MarkdownRenderer content={content} onFileClick={vi.fn()} />
+      </FileAccessProvider>
+    )
 
     expect(await screen.findByLabelText('podcast.mp3')).toBe(audioBeforeUpdate)
-    expect(apiRequestMock).toHaveBeenCalledTimes(2)
+    expect(apiRequestMock).toHaveBeenCalledTimes(1)
   })
 
   it('prefers link label over generic file id when determining preview kind', async () => {

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -789,6 +789,10 @@ describe('MarkdownRenderer', () => {
   })
 
   it('keeps a playing audio element mounted when surrounding page callbacks update', async () => {
+    // The mocked response has no .json(), so the leading stream-ticket
+    // mint attempt (useResolvedMediaUrl's strategy 1, audio/video only)
+    // throws and falls through to the blob fetch -- two calls per load,
+    // not one, but still none on rerender.
     apiRequestMock.mockResolvedValue({
       ok: true,
       blob: async () => new Blob(['audio-bytes'], { type: 'audio/mpeg' }),
@@ -799,6 +803,7 @@ describe('MarkdownRenderer', () => {
     )
 
     const audioBeforeUpdate = await screen.findByLabelText('podcast.mp3')
+    await waitFor(() => expect(apiRequestMock).toHaveBeenCalledTimes(2))
 
     // Trace and task events update the surrounding chat message and create new
     // callback props. The media DOM node must survive that rerender so the
@@ -806,7 +811,7 @@ describe('MarkdownRenderer', () => {
     rerender(<MarkdownRenderer content={content} onFileClick={vi.fn()} />)
 
     expect(await screen.findByLabelText('podcast.mp3')).toBe(audioBeforeUpdate)
-    expect(apiRequestMock).toHaveBeenCalledTimes(1)
+    expect(apiRequestMock).toHaveBeenCalledTimes(2)
   })
 
   it('prefers link label over generic file id when determining preview kind', async () => {

--- a/frontend/src/contexts/file-access-context.test.tsx
+++ b/frontend/src/contexts/file-access-context.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 
 import React from "react"
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
@@ -49,6 +49,27 @@ function DefaultFileAccessProbe() {
   )
 }
 
+function StreamingUrlProbe() {
+  const fileAccess = useFileAccess()
+  const [result, setResult] = React.useState<string>("pending")
+
+  return (
+    <button
+      type="button"
+      data-testid="streaming"
+      data-result={result}
+      onClick={() => {
+        fileAccess
+          .getStreamingUrl?.("file/id")
+          .then((url) => setResult(url))
+          .catch((error: Error) => setResult(`error:${error.message}`))
+      }}
+    >
+      streaming
+    </button>
+  )
+}
+
 describe("FileAccessProvider", () => {
   afterEach(() => {
     cleanup()
@@ -78,6 +99,55 @@ describe("FileAccessProvider", () => {
     expect(apiRequestMock).toHaveBeenCalledWith(
       "/api/files/list?page=1&size=20&search=report",
     )
+  })
+
+  it("mints a streaming URL from the ticket endpoint's response path", async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        path: "/api/files/preview/file%2Fid?ticket=signed-ticket",
+      }),
+    })
+    render(
+      <FileAccessProvider>
+        <StreamingUrlProbe />
+      </FileAccessProvider>,
+    )
+
+    screen.getByTestId("streaming").click()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("streaming")).toHaveAttribute(
+        "data-result",
+        "/api/files/preview/file%2Fid?ticket=signed-ticket",
+      )
+    })
+    expect(apiRequestMock).toHaveBeenCalledWith(
+      "/api/files/stream-tickets/file%2Fid",
+    )
+  })
+
+  it("rejects the streaming URL promise when ticket minting fails", async () => {
+    apiRequestMock.mockResolvedValue({ ok: false, status: 500 })
+    render(
+      <FileAccessProvider>
+        <StreamingUrlProbe />
+      </FileAccessProvider>,
+    )
+
+    screen.getByTestId("streaming").click()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("streaming")).toHaveAttribute(
+        "data-result",
+        "error:Failed to mint stream ticket: 500",
+      )
+    })
+  })
+
+  it("does not expose getStreamingUrl on the public policy", () => {
+    const policy = createPublicFileAccessPolicy("guest-token")
+    expect(policy.getStreamingUrl).toBeUndefined()
   })
 
   it("keeps public file URLs and requests scoped to each provider", async () => {

--- a/frontend/src/contexts/file-access-context.test.tsx
+++ b/frontend/src/contexts/file-access-context.test.tsx
@@ -124,6 +124,7 @@ describe("FileAccessProvider", () => {
     })
     expect(apiRequestMock).toHaveBeenCalledWith(
       "/api/files/stream-tickets/file%2Fid",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
   })
 
@@ -141,6 +142,49 @@ describe("FileAccessProvider", () => {
       expect(screen.getByTestId("streaming")).toHaveAttribute(
         "data-result",
         "error:Failed to mint stream ticket: 500",
+      )
+    })
+  })
+
+  it("rejects the streaming URL promise when the mint request itself throws", async () => {
+    // Distinct from a resolved-but-not-ok response: a network-level
+    // rejection (offline, DNS failure, an aborted request) must also
+    // surface as a caught rejection so useResolvedMediaUrl's fallback
+    // fires, not as an unhandled rejection.
+    apiRequestMock.mockRejectedValue(new TypeError("Failed to fetch"))
+    render(
+      <FileAccessProvider>
+        <StreamingUrlProbe />
+      </FileAccessProvider>,
+    )
+
+    screen.getByTestId("streaming").click()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("streaming")).toHaveAttribute(
+        "data-result",
+        "error:Failed to fetch",
+      )
+    })
+  })
+
+  it("rejects the streaming URL promise when the mint response has an unexpected shape", async () => {
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ notPath: "/api/files/preview/file-id" }),
+    })
+    render(
+      <FileAccessProvider>
+        <StreamingUrlProbe />
+      </FileAccessProvider>,
+    )
+
+    screen.getByTestId("streaming").click()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("streaming")).toHaveAttribute(
+        "data-result",
+        "error:Stream ticket response has an unexpected shape",
       )
     })
   })

--- a/frontend/src/contexts/file-access-context.test.tsx
+++ b/frontend/src/contexts/file-access-context.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/lib/api-wrapper", () => ({
 import {
   FileAccessProvider,
   createPublicFileAccessPolicy,
+  defaultFileAccessPolicy,
   useFileAccess,
 } from "./file-access-context"
 
@@ -172,6 +173,57 @@ describe("FileAccessProvider", () => {
     apiRequestMock.mockResolvedValue({
       ok: true,
       json: async () => ({ notPath: "/api/files/preview/file-id" }),
+    })
+    render(
+      <FileAccessProvider>
+        <StreamingUrlProbe />
+      </FileAccessProvider>,
+    )
+
+    screen.getByTestId("streaming").click()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("streaming")).toHaveAttribute(
+        "data-result",
+        "error:Stream ticket response has an unexpected shape",
+      )
+    })
+  })
+
+  it("accepts a mint response whose fileId segment the server encoded differently than encodeURIComponent would", async () => {
+    // Regression test: the server encodes file_id via Python's
+    // urllib.parse.quote(file_id, safe="") when building the ticket path
+    // (src/xagent/web/api/files.py), which escapes a different character
+    // set than JS's encodeURIComponent -- "!*'()" round-trip unescaped
+    // through encodeURIComponent but ARE escaped by quote(safe=""). A fix
+    // that re-encodes fileId with encodeURIComponent and string-matches
+    // against the response path would reject this genuinely valid
+    // response for any fileId containing one of those characters.
+    const fileId = "file!*'()id"
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        // Exactly what Python's quote(fileId, safe="") produces.
+        path: "/api/files/preview/file%21%2A%27%28%29id?ticket=signed-ticket",
+      }),
+    })
+
+    const url = await defaultFileAccessPolicy.getStreamingUrl?.(fileId)
+
+    expect(url).toBe("/api/files/preview/file%21%2A%27%28%29id?ticket=signed-ticket")
+  })
+
+  it("rejects a mint response whose path is scoped to a different fileId", async () => {
+    // Regression test (F5): a prefix-only check ("starts with
+    // /api/files/preview/") would accept a path with extra segments after
+    // it -- including one naming a completely different fileId, or a
+    // dot-segment -- as long as it still started with the generic preview
+    // prefix. The path must be scoped to the exact fileId requested.
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        path: "/api/files/preview/a-different-file-id?ticket=signed-ticket",
+      }),
     })
     render(
       <FileAccessProvider>

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -104,10 +104,39 @@ export const defaultFileAccessPolicy: FileAccessPolicy = {
     // doesn't otherwise validate; a malformed/unexpected payload must
     // surface as a caught rejection (so the caller falls back to the blob
     // path) rather than silently becoming a broken `undefined`-based URL.
+    // Bound to this exact fileId, not just the generic preview prefix: a
+    // prefix-only check would pass a path with extra segments after it
+    // (e.g. a dot-segment escaping to a different route) as long as it
+    // still started with "/api/files/preview/" -- exploitability is ~nil
+    // today (this server is the sole minter, and the ticket's own file_id
+    // claim is re-checked at redemption regardless of what path string got
+    // us there), but there's no reason to accept a shape looser than what
+    // this server actually returns. Decoded and compared, not re-encoded
+    // and string-matched: the server encodes file_id with Python's
+    // urllib.parse.quote(safe=""), which escapes a different character set
+    // than encodeURIComponent does (e.g. "!*'()" round-trip unescaped
+    // through encodeURIComponent but ARE escaped by quote) -- re-encoding
+    // fileId here and comparing strings would reject a genuinely valid
+    // response for any fileId containing one of those characters.
+    // decodeURIComponent has no such mismatch: it decodes any valid
+    // percent-encoded UTF-8 sequence regardless of which safe-set the
+    // encoder chose, so it round-trips correctly against either encoder.
+    const previewPrefix = `${FILES_API_PREFIX}/preview/`
     const data: unknown = await response.json()
     const path =
       data && typeof data === "object" ? (data as { path?: unknown }).path : undefined
-    if (typeof path !== "string" || !path.startsWith(`${FILES_API_PREFIX}/preview/`)) {
+    if (typeof path !== "string" || !path.startsWith(previewPrefix)) {
+      throw new Error("Stream ticket response has an unexpected shape")
+    }
+    const encodedFileIdAndQuery = path.slice(previewPrefix.length)
+    const encodedFileId = encodedFileIdAndQuery.split("?")[0]
+    let decodedFileId: string
+    try {
+      decodedFileId = decodeURIComponent(encodedFileId)
+    } catch {
+      throw new Error("Stream ticket response has an unexpected shape")
+    }
+    if (decodedFileId !== fileId) {
       throw new Error("Stream ticket response has an unexpected shape")
     }
     return buildUrl(path)

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -43,7 +43,13 @@ const encodeFileId = (fileId: string) => encodeURIComponent(fileId)
 
 const buildUrl = (path: string): string => `${getApiUrl()}${path}`
 
-const defaultFileAccessPolicy: FileAccessPolicy = {
+const STREAM_TICKET_MINT_TIMEOUT_MS = 10_000
+
+// Exported so tests unrelated to streaming-ticket mechanics can spread this
+// and override just `getStreamingUrl` (e.g. to undefined), rather than
+// depending on an incidental mock-shape quirk (a mocked response missing
+// `.json()`) to keep a ticket mint attempt from participating in the test.
+export const defaultFileAccessPolicy: FileAccessPolicy = {
   previewUrl: (fileId) => buildUrl(`/api/files/preview/${encodeFileId(fileId)}`),
   downloadUrl: (fileId) => buildUrl(`/api/files/download/${encodeFileId(fileId)}`),
   inlinePreviewUrl: (fileId) => buildUrl(`/api/files/public/preview/${encodeFileId(fileId)}`),
@@ -68,14 +74,38 @@ const defaultFileAccessPolicy: FileAccessPolicy = {
   // streaming ticket is available (see getStreamingUrl below).
   requiresBlobFetch: true,
   getStreamingUrl: async (fileId) => {
-    const response = await apiRequest(
-      buildUrl(`/api/files/stream-tickets/${encodeFileId(fileId)}`),
-    )
+    // A hung mint request would otherwise leave a media element stuck
+    // loading indefinitely, with nothing to time it out -- the caller's own
+    // unmount handling (isCancelled checks in useResolvedMediaUrl) ignores
+    // a late response but doesn't abort the underlying request.
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), STREAM_TICKET_MINT_TIMEOUT_MS)
+    let response: Response
+    try {
+      response = await apiRequest(
+        buildUrl(`/api/files/stream-tickets/${encodeFileId(fileId)}`),
+        { signal: controller.signal },
+      )
+    } finally {
+      clearTimeout(timeout)
+    }
     if (!response.ok) {
       throw new Error(`Failed to mint stream ticket: ${response.status}`)
     }
-    const data: { path: string } = await response.json()
-    return buildUrl(data.path)
+    // The mint endpoint's response shape is a server contract this client
+    // doesn't otherwise validate; a malformed/unexpected payload must
+    // surface as a caught rejection (so the caller falls back to the blob
+    // path) rather than silently becoming a broken `undefined`-based URL.
+    const data: unknown = await response.json()
+    if (
+      !data
+      || typeof data !== "object"
+      || typeof (data as { path?: unknown }).path !== "string"
+      || !(data as { path: string }).path.startsWith("/api/files/preview/")
+    ) {
+      throw new Error("Stream ticket response has an unexpected shape")
+    }
+    return buildUrl((data as { path: string }).path)
   },
 }
 

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -45,29 +45,37 @@ const buildUrl = (path: string): string => `${getApiUrl()}${path}`
 
 const STREAM_TICKET_MINT_TIMEOUT_MS = 10_000
 
+// Single source of truth for the files router's mount prefix, shared between
+// every URL builder below and the mint-response shape check -- otherwise the
+// two could drift the way files.py's own prefix derivation was written to
+// avoid on the server side.
+const FILES_API_PREFIX = "/api/files"
+
 // Exported so tests unrelated to streaming-ticket mechanics can spread this
 // and override just `getStreamingUrl` (e.g. to undefined), rather than
 // depending on an incidental mock-shape quirk (a mocked response missing
 // `.json()`) to keep a ticket mint attempt from participating in the test.
 export const defaultFileAccessPolicy: FileAccessPolicy = {
-  previewUrl: (fileId) => buildUrl(`/api/files/preview/${encodeFileId(fileId)}`),
-  downloadUrl: (fileId) => buildUrl(`/api/files/download/${encodeFileId(fileId)}`),
-  inlinePreviewUrl: (fileId) => buildUrl(`/api/files/public/preview/${encodeFileId(fileId)}`),
-  inlineDownloadUrl: (fileId) => buildUrl(`/api/files/public/download/${encodeFileId(fileId)}`),
+  previewUrl: (fileId) => buildUrl(`${FILES_API_PREFIX}/preview/${encodeFileId(fileId)}`),
+  downloadUrl: (fileId) => buildUrl(`${FILES_API_PREFIX}/download/${encodeFileId(fileId)}`),
+  inlinePreviewUrl: (fileId) =>
+    buildUrl(`${FILES_API_PREFIX}/public/preview/${encodeFileId(fileId)}`),
+  inlineDownloadUrl: (fileId) =>
+    buildUrl(`${FILES_API_PREFIX}/public/download/${encodeFileId(fileId)}`),
   relativePreviewUrl: (fileId, relativePath) => {
     const url = new URL(
-      buildUrl(`/api/files/public/preview/${encodeFileId(fileId)}`),
+      buildUrl(`${FILES_API_PREFIX}/public/preview/${encodeFileId(fileId)}`),
       typeof window === "undefined" ? "http://localhost" : window.location.origin,
     )
     url.searchParams.set("relative_path", relativePath)
     return getApiUrl() ? url.toString() : `${url.pathname}${url.search}${url.hash}`
   },
-  pdfPreviewUrl: (fileId) => buildUrl(`/api/files/preview-pdf/${encodeFileId(fileId)}`),
+  pdfPreviewUrl: (fileId) => buildUrl(`${FILES_API_PREFIX}/preview-pdf/${encodeFileId(fileId)}`),
   request: apiRequest,
   listFiles: (query) => {
     const params = new URLSearchParams({ page: "1", size: "20" })
     if (query.trim()) params.set("search", query.trim())
-    return apiRequest(buildUrl(`/api/files/list?${params.toString()}`))
+    return apiRequest(buildUrl(`${FILES_API_PREFIX}/list?${params.toString()}`))
   },
   // previewUrl needs the Bearer header apiRequest attaches; media elements
   // cannot send it, so they must go through the blob fetch unless a
@@ -83,7 +91,7 @@ export const defaultFileAccessPolicy: FileAccessPolicy = {
     let response: Response
     try {
       response = await apiRequest(
-        buildUrl(`/api/files/stream-tickets/${encodeFileId(fileId)}`),
+        buildUrl(`${FILES_API_PREFIX}/stream-tickets/${encodeFileId(fileId)}`),
         { signal: controller.signal },
       )
     } finally {
@@ -97,15 +105,12 @@ export const defaultFileAccessPolicy: FileAccessPolicy = {
     // surface as a caught rejection (so the caller falls back to the blob
     // path) rather than silently becoming a broken `undefined`-based URL.
     const data: unknown = await response.json()
-    if (
-      !data
-      || typeof data !== "object"
-      || typeof (data as { path?: unknown }).path !== "string"
-      || !(data as { path: string }).path.startsWith("/api/files/preview/")
-    ) {
+    const path =
+      data && typeof data === "object" ? (data as { path?: unknown }).path : undefined
+    if (typeof path !== "string" || !path.startsWith(`${FILES_API_PREFIX}/preview/`)) {
       throw new Error("Stream ticket response has an unexpected shape")
     }
-    return buildUrl((data as { path: string }).path)
+    return buildUrl(path)
   },
 }
 
@@ -148,9 +153,9 @@ const appendPublicToken = (url: string, accessToken: string): string => {
 export function createPublicFileAccessPolicy(accessToken: string): FileAccessPolicy {
   const publicUrl = (path: string) => appendPublicToken(buildUrl(path), accessToken)
   const inlinePreviewUrl = (fileId: string) =>
-    publicUrl(`/api/files/public/preview/${encodeFileId(fileId)}`)
+    publicUrl(`${FILES_API_PREFIX}/public/preview/${encodeFileId(fileId)}`)
   const inlineDownloadUrl = (fileId: string) =>
-    publicUrl(`/api/files/public/download/${encodeFileId(fileId)}`)
+    publicUrl(`${FILES_API_PREFIX}/public/download/${encodeFileId(fileId)}`)
 
   return {
     previewUrl: inlinePreviewUrl,

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -29,6 +29,14 @@ export interface FileAccessPolicy {
    * capability get the conservative blob path.
    */
   requiresBlobFetch?: boolean
+  /**
+   * Mint a short-lived, file-scoped ticket and return a URL a media
+   * element can load directly, preserving HTTP range requests even under
+   * a policy whose previewUrl otherwise requires an Authorization header.
+   * When present, this takes priority over requiresBlobFetch; failure
+   * (e.g. offline) falls back to that capability instead.
+   */
+  getStreamingUrl?: (fileId: string) => Promise<string>
 }
 
 const encodeFileId = (fileId: string) => encodeURIComponent(fileId)
@@ -56,8 +64,19 @@ const defaultFileAccessPolicy: FileAccessPolicy = {
     return apiRequest(buildUrl(`/api/files/list?${params.toString()}`))
   },
   // previewUrl needs the Bearer header apiRequest attaches; media elements
-  // cannot send it, so they must go through the blob fetch.
+  // cannot send it, so they must go through the blob fetch unless a
+  // streaming ticket is available (see getStreamingUrl below).
   requiresBlobFetch: true,
+  getStreamingUrl: async (fileId) => {
+    const response = await apiRequest(
+      buildUrl(`/api/files/stream-tickets/${encodeFileId(fileId)}`),
+    )
+    if (!response.ok) {
+      throw new Error(`Failed to mint stream ticket: ${response.status}`)
+    }
+    const data: { path: string } = await response.json()
+    return buildUrl(data.path)
+  },
 }
 
 const FileAccessContext = createContext<FileAccessPolicy>(defaultFileAccessPolicy)

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -79,6 +79,7 @@ FILE_DELIVERY_REDIRECT_ENABLED = "XAGENT_FILE_DELIVERY_REDIRECT_ENABLED"
 FILE_DELIVERY_SIGNED_URL_TTL_SECONDS = "XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS"
 FILE_DELIVERY_ACCEL_REDIRECT_ENABLED = "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED"
 FILE_DELIVERY_ACCEL_REDIRECT_PREFIX = "XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_PREFIX"
+FILE_STREAM_TICKET_TTL_SECONDS = "XAGENT_FILE_STREAM_TICKET_TTL_SECONDS"
 SANDBOX_IMAGE = "SANDBOX_IMAGE"
 LANCEDB_PATH = "LANCEDB_PATH"
 KB_COLLECTIONS_TIMEOUT_SECONDS = "XAGENT_KB_COLLECTIONS_TIMEOUT_SECONDS"
@@ -1778,6 +1779,42 @@ def get_file_delivery_signed_url_ttl_seconds() -> int:
     if ttl <= 0:
         raise ValueError(
             f"Invalid {FILE_DELIVERY_SIGNED_URL_TTL_SECONDS} value: {env_value!r}. "
+            "Value must be positive."
+        )
+
+    return ttl
+
+
+def get_file_stream_ticket_ttl_seconds() -> int:
+    """Get the lifetime of a media-streaming preview ticket.
+
+    Priority:
+        1. XAGENT_FILE_STREAM_TICKET_TTL_SECONDS environment variable
+        2. Default of 600 (10 minutes)
+
+    Kept independent of, and far shorter than, the user's own access token
+    TTL: unlike a Bearer header, this credential rides in a URL a media
+    element loads directly (address bar, browser history, proxy/CDN access
+    logs, the file's "Open" link), so a leaked or logged ticket should stop
+    being replayable long before a stolen access token would need to.
+
+    Returns:
+        Ticket lifetime in seconds.
+    """
+    env_value = os.getenv(FILE_STREAM_TICKET_TTL_SECONDS)
+    if env_value is None or not env_value.strip():
+        return 600
+
+    try:
+        ttl = int(env_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid {FILE_STREAM_TICKET_TTL_SECONDS} value: {env_value!r}."
+        ) from exc
+
+    if ttl <= 0:
+        raise ValueError(
+            f"Invalid {FILE_STREAM_TICKET_TTL_SECONDS} value: {env_value!r}. "
             "Value must be positive."
         )
 

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1794,9 +1794,11 @@ def get_file_stream_ticket_ttl_seconds() -> int:
 
     Kept independent of, and far shorter than, the user's own access token
     TTL: unlike a Bearer header, this credential rides in a URL a media
-    element loads directly (address bar, browser history, proxy/CDN access
-    logs, the file's "Open" link), so a leaked or logged ticket should stop
-    being replayable long before a stolen access token would need to.
+    element loads directly. The frontend never puts it anywhere a user could
+    put it in the address bar, browser history, or a copied link, so the
+    realistic exposure is proxy/CDN/server access logs and a devtools
+    network panel -- a leaked or logged ticket should still stop being
+    replayable long before a stolen access token would need to.
 
     Returns:
         Ticket lifetime in seconds.

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from datetime import timedelta
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, Optional, Tuple, cast
@@ -13,6 +14,8 @@ from fastapi.responses import (
     RedirectResponse,
     Response,
 )
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
@@ -30,6 +33,7 @@ from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
 from ...core.utils.svg import rasterize_svg_bytes
 from ...core.workspace import scoped_user_root
+from ..auth_config import ACCESS_TOKEN_EXPIRE_MINUTES, JWT_ALGORITHM, JWT_SECRET_KEY
 from ..auth_dependencies import get_current_user, is_admin_user
 from ..config import (
     BINARY_EXTENSIONS,
@@ -65,6 +69,7 @@ from ..services.uploaded_file_store import (
     delete_registered_preview_caches,
     register_local_uploads_sync,
 )
+from .auth import create_access_token
 from .legacy_file import (
     infer_user_id_from_legacy_path,
     is_valid_uuid,
@@ -196,10 +201,11 @@ async def _inline_preview_response(
     media type is served as-is.
 
     ``extra_headers`` lets a caller layer route-specific headers (e.g. the
-    public/tokened route's ``Cache-Control``) without changing behavior for
-    other callers — this helper is shared by both the authenticated and
-    public preview endpoints, and the authenticated in-app path relies on
-    normal browser caching for repeatedly-rendered chat images.
+    public/tokened route's or a ticket-authenticated request's
+    ``Cache-Control``) without changing behavior for other callers — this
+    helper is shared by the authenticated, public, and ticket-authenticated
+    preview endpoints, and the plain Bearer-authenticated in-app path relies
+    on normal browser caching for repeatedly-rendered chat images.
     """
 
     if media_type == "image/svg+xml":
@@ -1453,12 +1459,116 @@ async def download_file(
     )
 
 
+# Media elements (<video>/<audio>) cannot attach an Authorization header, so
+# the authenticated preview route also accepts a short-lived, file-scoped
+# ticket via the ``ticket`` query param as an alternative to the Bearer
+# header. This lets those elements load the route's URL directly instead of
+# blob-fetching the whole file first, which restores HTTP range requests
+# (seek-before-download, progressive playback) on the authenticated path —
+# the public/tokened route already gets this by carrying its own token in
+# the query string; see ``createPublicFileAccessPolicy`` on the frontend.
+#
+# The ticket only proves "a recent Bearer-authenticated request minted this
+# for this exact file_id" — it resolves the *same* User the Bearer header
+# would, so it grants no privilege beyond what that user's own Bearer token
+# already grants, and _check_file_access/_is_admin_user below still enforce
+# ownership exactly as they do for the Bearer path. Binding the ticket to one
+# file_id means a leaked ticket can only be replayed against that one file,
+# not enumerated against others. TTL matches the user's own access token,
+# since the ticket's authority is strictly narrower (one file, read-only,
+# inline preview) than the Bearer token it stands in for.
+FILE_STREAM_TICKET_TYPE = "file_stream_ticket"
+FILE_STREAM_TICKET_TTL_SECONDS = ACCESS_TOKEN_EXPIRE_MINUTES * 60
+
+# A ticket rides in the query string of a URL a media element auto-fetches
+# on render, so — like the public/tokened preview route — it must never be
+# written to browser disk cache, where it could outlive its own TTL's
+# intent of being "short-lived".
+_TICKET_PREVIEW_CACHE_HEADERS = {"Cache-Control": "private, no-store"}
+
+_optional_bearer = HTTPBearer(auto_error=False)
+
+
+def _user_from_stream_ticket(db: Session, ticket: str, file_id: str) -> User:
+    try:
+        claims = jwt.decode(ticket, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid or expired ticket")
+
+    if (
+        claims.get("type") != FILE_STREAM_TICKET_TYPE
+        or claims.get("file_id") != file_id
+    ):
+        raise HTTPException(status_code=401, detail="Invalid or expired ticket")
+
+    username = claims.get("sub")
+    user_id = claims.get("user_id")
+    if username is None or user_id is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired ticket")
+
+    user = db.query(User).filter(User.username == username, User.id == user_id).first()
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired ticket")
+    return user
+
+
+def _user_from_bearer_or_stream_ticket(
+    file_id: str,
+    ticket: Optional[str] = Query(default=None),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_optional_bearer),
+    db: Session = Depends(get_db),
+) -> User:
+    if ticket:
+        return _user_from_stream_ticket(db, ticket, file_id)
+    if credentials is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return get_current_user(credentials, db)
+
+
+@file_router.get("/stream-tickets/{file_id:path}", response_model=None)
+async def issue_preview_stream_ticket(
+    file_id: str,
+    user: User = Depends(get_current_user),
+) -> dict[str, str]:
+    """Mint a short-lived ticket for streaming this one file via query param.
+
+    Deliberately a sibling route under its own ``/stream-tickets/`` prefix
+    rather than a suffix nested under ``/preview/{file_id:path}``: the
+    ``:path`` converter matches slashes, and a legacy ``file_id`` can be an
+    arbitrary relative path (e.g. ``web_task_235/output/ticket``) — nesting
+    would risk a real file literally named ``ticket`` colliding with this
+    endpoint. A disjoint URL prefix makes that collision structurally
+    impossible regardless of ``file_id`` content.
+
+    Authorization for the file itself is deferred to (and fully enforced
+    by) ``preview_file`` when the ticket is redeemed — this endpoint only
+    needs to know a Bearer-authenticated user is asking, the same
+    precondition ``preview_file`` already requires today.
+    """
+    ticket = create_access_token(
+        {
+            "type": FILE_STREAM_TICKET_TYPE,
+            "sub": user.username,
+            "user_id": user.id,
+            "file_id": file_id,
+        },
+        expires_delta=timedelta(seconds=FILE_STREAM_TICKET_TTL_SECONDS),
+    )
+    return {"path": f"/api/files/preview/{quote(file_id, safe='')}?ticket={ticket}"}
+
+
 @file_router.get("/preview/{file_id:path}", response_model=None)
 async def preview_file(
     file_id: str,
-    user: User = Depends(get_current_user),
+    ticket: Optional[str] = Query(default=None),
+    user: User = Depends(_user_from_bearer_or_stream_ticket),
     db: Session = Depends(get_db),
 ) -> Any:
+    cache_headers = _TICKET_PREVIEW_CACHE_HEADERS if ticket else None
     file_record, full_path, owner_user_id = _resolve_file_path(
         db, file_id, _user_id_value(user)
     )
@@ -1470,7 +1580,7 @@ async def preview_file(
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
         local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
-        if _preview_can_redirect(full_path, media_type):
+        if not ticket and _preview_can_redirect(full_path, media_type):
             redirect_response = _durable_redirect_response(
                 file_ref,
                 filename=file_name,
@@ -1506,6 +1616,7 @@ async def preview_file(
                 filename=file_name,
                 media_type=media_type,
                 file_id=file_id if is_valid_uuid(file_id) else None,
+                extra_headers=cache_headers,
             )
     else:
         # For legacy files without records, check ownership
@@ -1519,7 +1630,7 @@ async def preview_file(
     if not full_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
 
-    if _preview_can_redirect(full_path, media_type):
+    if not ticket and _preview_can_redirect(full_path, media_type):
         accel_response = _accel_redirect_response(
             full_path,
             owner_user_id=owner_user_id,
@@ -1535,6 +1646,7 @@ async def preview_file(
         filename=file_name,
         media_type=media_type,
         file_id=file_id if is_valid_uuid(file_id) else None,
+        extra_headers=cache_headers,
     )
 
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -4,7 +4,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, Optional, Tuple, cast
+from typing import Any, Dict, NamedTuple, Optional, Tuple, cast
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -1585,21 +1585,36 @@ def _user_from_stream_ticket(db: Session, ticket: str, file_id: str) -> User:
     return user
 
 
+class _AuthenticatedFileRequest(NamedTuple):
+    """Which user asked, and whether a stream ticket is what let them in.
+
+    ``via_stream_ticket`` is a plain bool, not the raw ticket string: nothing
+    downstream needs the ticket's own content again (redemption already
+    happened above), only whether the ticket path is what authenticated this
+    request -- resolve_file_path takes the user separately, and the only
+    other read site (``cache_headers`` below) only ever checks truthiness.
+    """
+
+    user: User
+    via_stream_ticket: bool
+
+
 def _user_from_bearer_or_stream_ticket(
     file_id: str,
     ticket: Optional[str] = Query(default=None),
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(optional_security),
     db: Session = Depends(get_db),
-) -> Tuple[User, Optional[str]]:
+) -> _AuthenticatedFileRequest:
     """Resolve the requesting user, and echo back which credential won.
 
-    Returning ``ticket`` alongside ``user`` lets ``preview_file`` below read
-    whether a ticket authenticated this request (to decide ``cache_headers``)
-    without redeclaring its own ``ticket: Query(...)`` parameter -- FastAPI
-    would resolve that redeclaration to the same value from the same request
-    every time, but two independent declarations of the same query param
-    with no shared source is the kind of thing that can silently drift if
-    one is ever edited (e.g. a default) without the other.
+    Returning ``via_stream_ticket`` alongside ``user`` lets ``preview_file``
+    below read whether a ticket authenticated this request (to decide
+    ``cache_headers``) without redeclaring its own ``ticket: Query(...)``
+    parameter -- FastAPI would resolve that redeclaration to the same value
+    from the same request every time, but two independent declarations of
+    the same query param with no shared source is the kind of thing that
+    can silently drift if one is ever edited (e.g. a default) without the
+    other.
     """
     if ticket:
         # A present ticket is checked on its own and never falls through to
@@ -1610,7 +1625,9 @@ def _user_from_bearer_or_stream_ticket(
         # mask exactly the failure (expired mid-session, wrong file_id) the
         # caller's fallback-and-remint logic (reportLoadFailure on the
         # frontend) exists to detect and recover from.
-        return _user_from_stream_ticket(db, ticket, file_id), ticket
+        return _AuthenticatedFileRequest(
+            _user_from_stream_ticket(db, ticket, file_id), True
+        )
     if credentials is None:
         # This endpoint predates the ticket param and used the default
         # HTTPBearer(auto_error=True), which raises 403 "Not authenticated"
@@ -1640,7 +1657,7 @@ def _user_from_bearer_or_stream_ticket(
         # -- see test_mint_endpoint_requires_a_bearer_credential, which
         # deliberately doesn't assert a specific code for that case.
         raise HTTPException(status_code=403, detail="Not authenticated")
-    return get_current_user(credentials, db), None
+    return _AuthenticatedFileRequest(get_current_user(credentials, db), False)
 
 
 @file_router.get("/stream-tickets/{file_id:path}", response_model=None)
@@ -1687,11 +1704,11 @@ async def issue_preview_stream_ticket(
 @file_router.get("/preview/{file_id:path}", response_model=None)
 async def preview_file(
     file_id: str,
-    auth: Tuple[User, Optional[str]] = Depends(_user_from_bearer_or_stream_ticket),
+    auth: _AuthenticatedFileRequest = Depends(_user_from_bearer_or_stream_ticket),
     db: Session = Depends(get_db),
 ) -> Any:
-    user, ticket = auth
-    cache_headers = _PUBLIC_PREVIEW_CACHE_HEADERS if ticket else None
+    user, via_stream_ticket = auth
+    cache_headers = _PUBLIC_PREVIEW_CACHE_HEADERS if via_stream_ticket else None
     file_record, full_path, owner_user_id = _resolve_file_path(
         db, file_id, _user_id_value(user)
     )

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -43,7 +43,12 @@ from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
 from ...core.utils.svg import rasterize_svg_bytes
 from ...core.workspace import scoped_user_root
 from ..auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
-from ..auth_dependencies import get_current_user, is_admin_user
+from ..auth_dependencies import (
+    _AccessTokenRejected,
+    _validate_access_token_claim_bindability,
+    get_current_user,
+    is_admin_user,
+)
 from ..config import (
     BINARY_EXTENSIONS,
     MAX_FILE_SIZE,
@@ -264,6 +269,17 @@ async def _inline_preview_response(
 # its bytes to disk cache, where they can outlive the guest session. This
 # header must NOT be applied to the authenticated preview route: chat images
 # there rely on ordinary browser caching across repeated renders.
+#
+# Reused as-is (not a separate constant) for the ticket-authenticated branch
+# of the Bearer preview route below: a stream ticket rides in a URL a media
+# element auto-fetches on render too, so the same disk-cache exposure and
+# the same fix apply -- see where this is threaded through preview_file as
+# ``cache_headers``, which is the single choke point for every
+# content-serving exit of that endpoint that can serve a ticket-
+# authenticated request (the redirect fast paths included; error exits
+# raise a bare HTTPException and carry no Cache-Control at all, which is
+# fine since 404 is the only heuristically-cacheable one and no content is
+# at stake there).
 _PUBLIC_PREVIEW_CACHE_HEADERS = {"Cache-Control": "private, no-store"}
 
 
@@ -1504,19 +1520,10 @@ async def download_file(
 # minutes not hours) rather than matching the user's own access token.
 FILE_STREAM_TICKET_TYPE = "file_stream_ticket"
 
-# A ticket rides in the query string of a URL a media element auto-fetches
-# on render, so — like the public/tokened preview route (#1227) — it must
-# never be written to browser disk cache, where it could outlive its own
-# TTL's intent of being "short-lived". This is the single choke point for
-# that decision: every response exit of preview_file that can serve a
-# ticket-authenticated request must apply it, including the redirect
-# fast paths below (see the comment where the ``not ticket`` guards were
-# removed) -- not just the two direct _inline_preview_response calls.
-_TICKET_PREVIEW_CACHE_HEADERS = {"Cache-Control": "private, no-store"}
-
-
-def _preview_cache_headers(ticket: Optional[str]) -> Optional[Dict[str, str]]:
-    return _TICKET_PREVIEW_CACHE_HEADERS if ticket else None
+# See _PUBLIC_PREVIEW_CACHE_HEADERS above: a stream ticket rides in a URL a
+# media element auto-fetches on render too, so preview_file below reuses
+# that same constant/rationale as ``cache_headers`` whenever a ticket
+# authenticated the request, rather than a second identical constant.
 
 
 _optional_bearer = HTTPBearer(auto_error=False)
@@ -1534,10 +1541,21 @@ def _user_from_stream_ticket(db: Session, ticket: str, file_id: str) -> User:
     ):
         raise HTTPException(status_code=401, detail="Invalid or expired ticket")
 
-    username = claims.get("sub")
-    user_id = claims.get("user_id")
-    if username is None or user_id is None:
-        raise HTTPException(status_code=401, detail="Invalid or expired ticket")
+    # Reuse the same claim-bindability hardening access tokens get
+    # (_resolve_access_token_user in auth_dependencies.py) rather than a
+    # second, weaker copy: exact str/int typing, utf-8-strict encodability,
+    # and the Postgres NUL-byte guard all apply identically to a ticket's
+    # sub/user_id claims. This server is the sole minter, so malformed
+    # claims aren't attacker-reachable today, but a second bespoke check
+    # here would silently drift from the first if either is ever changed.
+    try:
+        username, user_id = _validate_access_token_claim_bindability(
+            claims.get("sub"), claims.get("user_id"), db
+        )
+    except _AccessTokenRejected:
+        raise HTTPException(
+            status_code=401, detail="Invalid or expired ticket"
+        ) from None
 
     user = db.query(User).filter(User.username == username, User.id == user_id).first()
     if user is None:
@@ -1550,20 +1568,57 @@ def _user_from_bearer_or_stream_ticket(
     ticket: Optional[str] = Query(default=None),
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(_optional_bearer),
     db: Session = Depends(get_db),
-) -> User:
+) -> Tuple[User, Optional[str]]:
+    """Resolve the requesting user, and echo back which credential won.
+
+    Returning ``ticket`` alongside ``user`` lets ``preview_file`` below read
+    whether a ticket authenticated this request (to decide ``cache_headers``)
+    without redeclaring its own ``ticket: Query(...)`` parameter -- FastAPI
+    would resolve that redeclaration to the same value from the same request
+    every time, but two independent declarations of the same query param
+    with no shared source is the kind of thing that can silently drift if
+    one is ever edited (e.g. a default) without the other.
+    """
     if ticket:
-        return _user_from_stream_ticket(db, ticket, file_id)
+        # A present ticket is checked on its own and never falls through to
+        # the Bearer header below, even if the ticket is garbage/expired and
+        # a valid Bearer header is also present: a ticket is the credential
+        # this specific request opted into (e.g. a media element's src), so
+        # treating a broken one as "ignore it, try the header instead" would
+        # mask exactly the failure (expired mid-session, wrong file_id) the
+        # caller's fallback-and-remint logic (reportLoadFailure on the
+        # frontend) exists to detect and recover from.
+        return _user_from_stream_ticket(db, ticket, file_id), ticket
     if credentials is None:
         # This endpoint predates the ticket param and used the default
-        # HTTPBearer(auto_error=True), which FastAPI raises as 403 "Not
-        # authenticated" -- not 401 -- when the Authorization header is
-        # absent entirely (401 is reserved for a credential that IS
-        # present but rejected: an invalid ticket here, or an invalid/
-        # expired Bearer token via get_current_user below). Switching a
-        # completely-missing credential to 401 would be an unannounced
-        # breaking change to this pre-existing endpoint's error contract.
+        # HTTPBearer(auto_error=True), which raises 403 "Not authenticated"
+        # -- not 401 -- when the Authorization header is absent entirely
+        # (401 is reserved for a credential that IS present but rejected: an
+        # invalid ticket above, or an invalid/expired Bearer token via
+        # get_current_user below). Switching a completely-missing credential
+        # to 401 would be an unannounced breaking change to this
+        # pre-existing endpoint's error contract. Not preserved exactly: a
+        # malformed (non-"Bearer ...") Authorization header used to get its
+        # own "Invalid authentication credentials" detail from HTTPBearer;
+        # optional_security collapses that case into this same branch, so it
+        # now reads "Not authenticated" too. Status code is unaffected
+        # (still 403); only the message text differs, which no client here
+        # parses. Whether a missing header actually gets 403 (vs. FastAPI's
+        # own default auto_error=True behavior, which changed to 401 on
+        # some later FastAPI release) depends on the installed FastAPI
+        # version: uv.lock pins 0.115.14 (403), but pyproject.toml's own
+        # constraint is an unbounded ">=0.35.0", and an environment resolved
+        # against that constraint rather than the lock file can land on a
+        # version where this is 401 instead -- confirmed empirically against
+        # fastapi==0.135.1 while writing this. This function's own explicit
+        # 403 raise below is unaffected either way; only the *other* file
+        # routes' plain Depends(get_current_user) dependencies (which rely
+        # on HTTPBearer's built-in auto_error, not a manual check like this
+        # one) are exposed to that drift for a missing header specifically
+        # -- see test_mint_endpoint_requires_a_bearer_credential, which
+        # deliberately doesn't assert a specific code for that case.
         raise HTTPException(status_code=403, detail="Not authenticated")
-    return get_current_user(credentials, db)
+    return get_current_user(credentials, db), None
 
 
 @file_router.get("/stream-tickets/{file_id:path}", response_model=None)
@@ -1610,11 +1665,11 @@ async def issue_preview_stream_ticket(
 @file_router.get("/preview/{file_id:path}", response_model=None)
 async def preview_file(
     file_id: str,
-    ticket: Optional[str] = Query(default=None),
-    user: User = Depends(_user_from_bearer_or_stream_ticket),
+    auth: Tuple[User, Optional[str]] = Depends(_user_from_bearer_or_stream_ticket),
     db: Session = Depends(get_db),
 ) -> Any:
-    cache_headers = _preview_cache_headers(ticket)
+    user, ticket = auth
+    cache_headers = _PUBLIC_PREVIEW_CACHE_HEADERS if ticket else None
     file_record, full_path, owner_user_id = _resolve_file_path(
         db, file_id, _user_id_value(user)
     )
@@ -1632,9 +1687,9 @@ async def preview_file(
         # matters most for. Excluding it here would force large media
         # through the app process on every ticketed request, defeating the
         # performance goal this ticket mechanism exists for. cache_headers
-        # is still threaded through (see _preview_cache_headers) so the
-        # no-store invariant travels with the request regardless of which
-        # exit serves it.
+        # (computed above, per-request, from whether a ticket was used) is
+        # still threaded through so the no-store invariant travels with the
+        # request regardless of which exit serves it.
         if _preview_can_redirect(full_path, media_type):
             redirect_response = _durable_redirect_response(
                 file_ref,

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -8,7 +8,15 @@ from typing import Any, Dict, Optional, Tuple, cast
 from urllib.parse import quote
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    UploadFile,
+)
 from fastapi.responses import (
     FileResponse,
     RedirectResponse,
@@ -24,6 +32,7 @@ from ...config import (
     get_file_delivery_accel_redirect_prefix,
     get_file_delivery_redirect_enabled,
     get_file_delivery_signed_url_ttl_seconds,
+    get_file_stream_ticket_ttl_seconds,
     get_storage_root,
     get_uploads_dir,
 )
@@ -33,7 +42,7 @@ from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
 from ...core.utils.svg import rasterize_svg_bytes
 from ...core.workspace import scoped_user_root
-from ..auth_config import ACCESS_TOKEN_EXPIRE_MINUTES, JWT_ALGORITHM, JWT_SECRET_KEY
+from ..auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
 from ..auth_dependencies import get_current_user, is_admin_user
 from ..config import (
     BINARY_EXTENSIONS,
@@ -264,6 +273,7 @@ def _durable_redirect_response(
     filename: str,
     media_type: str,
     disposition: str,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> RedirectResponse | None:
     if not get_file_delivery_redirect_enabled():
         return None
@@ -282,7 +292,13 @@ def _durable_redirect_response(
     if not signed_url:
         return None
 
-    return RedirectResponse(url=signed_url, status_code=307)
+    # extra_headers (e.g. a ticket-authenticated request's Cache-Control) is
+    # best-effort on this response only: browsers don't cache a 307 without
+    # explicit caching headers regardless, and the bytes the client actually
+    # receives come from ``signed_url`` (the durable-object provider), whose
+    # own headers -- governed by its short, provider-side expiry -- are what
+    # actually controls caching for that content, not anything set here.
+    return RedirectResponse(url=signed_url, status_code=307, headers=extra_headers)
 
 
 def _accel_redirect_response(
@@ -292,6 +308,7 @@ def _accel_redirect_response(
     filename: str,
     media_type: str,
     disposition: str,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> Response | None:
     if not get_file_delivery_accel_redirect_enabled():
         return None
@@ -309,10 +326,16 @@ def _accel_redirect_response(
     internal_uri = (
         internal_prefix.rstrip("/") + "/" + quote(relative_path.as_posix(), safe="/")
     )
+    # extra_headers is best-effort here too: whether it survives nginx's
+    # internal X-Accel-Redirect (which by default regenerates the response
+    # for the internal location rather than forwarding these headers
+    # verbatim) is reverse-proxy-config-dependent, same caveat that already
+    # applies to Content-Disposition on this exact response.
     return Response(
         status_code=200,
         media_type=media_type,
         headers={
+            **(extra_headers or {}),
             "X-Accel-Redirect": internal_uri,
             "Content-Disposition": _content_disposition_header(disposition, filename),
         },
@@ -1474,17 +1497,27 @@ async def download_file(
 # already grants, and _check_file_access/_is_admin_user below still enforce
 # ownership exactly as they do for the Bearer path. Binding the ticket to one
 # file_id means a leaked ticket can only be replayed against that one file,
-# not enumerated against others. TTL matches the user's own access token,
-# since the ticket's authority is strictly narrower (one file, read-only,
-# inline preview) than the Bearer token it stands in for.
+# not enumerated against others. Unlike a Bearer header, though, this
+# credential rides in a URL a media element loads directly — address bar,
+# browser history, the file's "Open" link, proxy/CDN access logs — so its
+# TTL is kept independently short (get_file_stream_ticket_ttl_seconds(),
+# minutes not hours) rather than matching the user's own access token.
 FILE_STREAM_TICKET_TYPE = "file_stream_ticket"
-FILE_STREAM_TICKET_TTL_SECONDS = ACCESS_TOKEN_EXPIRE_MINUTES * 60
 
 # A ticket rides in the query string of a URL a media element auto-fetches
-# on render, so — like the public/tokened preview route — it must never be
-# written to browser disk cache, where it could outlive its own TTL's
-# intent of being "short-lived".
+# on render, so — like the public/tokened preview route (#1227) — it must
+# never be written to browser disk cache, where it could outlive its own
+# TTL's intent of being "short-lived". This is the single choke point for
+# that decision: every response exit of preview_file that can serve a
+# ticket-authenticated request must apply it, including the redirect
+# fast paths below (see the comment where the ``not ticket`` guards were
+# removed) -- not just the two direct _inline_preview_response calls.
 _TICKET_PREVIEW_CACHE_HEADERS = {"Cache-Control": "private, no-store"}
+
+
+def _preview_cache_headers(ticket: Optional[str]) -> Optional[Dict[str, str]]:
+    return _TICKET_PREVIEW_CACHE_HEADERS if ticket else None
+
 
 _optional_bearer = HTTPBearer(auto_error=False)
 
@@ -1521,11 +1554,15 @@ def _user_from_bearer_or_stream_ticket(
     if ticket:
         return _user_from_stream_ticket(db, ticket, file_id)
     if credentials is None:
-        raise HTTPException(
-            status_code=401,
-            detail="Not authenticated",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        # This endpoint predates the ticket param and used the default
+        # HTTPBearer(auto_error=True), which FastAPI raises as 403 "Not
+        # authenticated" -- not 401 -- when the Authorization header is
+        # absent entirely (401 is reserved for a credential that IS
+        # present but rejected: an invalid ticket here, or an invalid/
+        # expired Bearer token via get_current_user below). Switching a
+        # completely-missing credential to 401 would be an unannounced
+        # breaking change to this pre-existing endpoint's error contract.
+        raise HTTPException(status_code=403, detail="Not authenticated")
     return get_current_user(credentials, db)
 
 
@@ -1556,9 +1593,18 @@ async def issue_preview_stream_ticket(
             "user_id": user.id,
             "file_id": file_id,
         },
-        expires_delta=timedelta(seconds=FILE_STREAM_TICKET_TTL_SECONDS),
+        expires_delta=timedelta(seconds=get_file_stream_ticket_ttl_seconds()),
     )
-    return {"path": f"/api/files/preview/{quote(file_id, safe='')}?ticket={ticket}"}
+    # Derived from the router's own mount prefix rather than hardcoded, so
+    # this can't silently drift from preview_file's actual path if either
+    # ever changes. Deliberately not request.url_for(...): verified it does
+    # NOT percent-encode a path-converter parameter at all (a file_id
+    # containing e.g. "?" would corrupt the query string boundary this
+    # ticket is appended to) -- quote(..., safe='') is the safe primitive
+    # here, and a Starlette round-trip confirms it handles slash-bearing
+    # legacy file_id values correctly against ``{file_id:path}``.
+    preview_path = f"{file_router.prefix}/preview/{quote(file_id, safe='')}"
+    return {"path": f"{preview_path}?ticket={ticket}"}
 
 
 @file_router.get("/preview/{file_id:path}", response_model=None)
@@ -1568,7 +1614,7 @@ async def preview_file(
     user: User = Depends(_user_from_bearer_or_stream_ticket),
     db: Session = Depends(get_db),
 ) -> Any:
-    cache_headers = _TICKET_PREVIEW_CACHE_HEADERS if ticket else None
+    cache_headers = _preview_cache_headers(ticket)
     file_record, full_path, owner_user_id = _resolve_file_path(
         db, file_id, _user_id_value(user)
     )
@@ -1580,12 +1626,22 @@ async def preview_file(
         file_name = str(file_record.filename)
         media_type = guess_media_type(file_name)
         local_path_is_trusted = _is_under_uploads(full_path, owner_user_id)
-        if not ticket and _preview_can_redirect(full_path, media_type):
+        # Deliberately not gated on "not ticket": a ticket-authenticated
+        # request is a media element loading this URL for progressive
+        # playback, which is exactly the case object-storage/nginx offload
+        # matters most for. Excluding it here would force large media
+        # through the app process on every ticketed request, defeating the
+        # performance goal this ticket mechanism exists for. cache_headers
+        # is still threaded through (see _preview_cache_headers) so the
+        # no-store invariant travels with the request regardless of which
+        # exit serves it.
+        if _preview_can_redirect(full_path, media_type):
             redirect_response = _durable_redirect_response(
                 file_ref,
                 filename=file_name,
                 media_type=media_type,
                 disposition="inline",
+                extra_headers=cache_headers,
             )
             if redirect_response is not None:
                 return redirect_response
@@ -1596,6 +1652,7 @@ async def preview_file(
                     filename=file_name,
                     media_type=media_type,
                     disposition="inline",
+                    extra_headers=cache_headers,
                 )
                 if accel_response is not None:
                     return accel_response
@@ -1630,13 +1687,16 @@ async def preview_file(
     if not full_path.exists():
         raise HTTPException(status_code=404, detail="File not found")
 
-    if not ticket and _preview_can_redirect(full_path, media_type):
+    if _preview_can_redirect(full_path, media_type):
+        # See the comment on the equivalent branch above: not gated on
+        # ticket presence, for the same reason.
         accel_response = _accel_redirect_response(
             full_path,
             owner_user_id=owner_user_id,
             filename=file_name,
             media_type=media_type,
             disposition="inline",
+            extra_headers=cache_headers,
         )
         if accel_response is not None:
             return accel_response

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -57,6 +57,7 @@ from ..config import (
     get_upload_path,
     is_allowed_file,
 )
+from ..jwt_validation import has_matching_temporal_claim_conversion_failure
 from ..models.database import get_db, release_db_connection_if_clean
 from ..models.task import Task
 from ..models.uploaded_file import UploadedFile
@@ -1533,9 +1534,28 @@ FILE_STREAM_TICKET_TYPE = "file_stream_ticket"
 
 def _user_from_stream_ticket(db: Session, ticket: str, file_id: str) -> User:
     try:
-        claims = jwt.decode(ticket, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        claims = jwt.decode(
+            ticket,
+            JWT_SECRET_KEY,
+            algorithms=[JWT_ALGORITHM],
+            options={"verify_sub": False},
+        )
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid or expired ticket")
+    except (TypeError, OverflowError) as error:
+        # Mirrors _resolve_access_token_user's guard (auth_dependencies.py):
+        # python-jose can raise these from its own temporal-claim (exp/nbf/
+        # iat) comparisons instead of JWTError for a garbage-typed claim, and
+        # this server is the sole minter today so that shouldn't happen --
+        # but a bare TypeError/OverflowError propagating out of this
+        # endpoint would 500 instead of the 401 every other malformed-ticket
+        # path here returns. Re-raise anything that *doesn't* reproduce a
+        # temporal-claim failure rather than swallowing an unrelated bug.
+        if not has_matching_temporal_claim_conversion_failure(ticket, error):
+            raise
+        raise HTTPException(
+            status_code=401, detail="Invalid or expired ticket"
+        ) from None
 
     if (
         claims.get("type") != FILE_STREAM_TICKET_TYPE

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -22,7 +22,7 @@ from fastapi.responses import (
     RedirectResponse,
     Response,
 )
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials
 from jose import JWTError, jwt
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
@@ -48,6 +48,7 @@ from ..auth_dependencies import (
     _validate_access_token_claim_bindability,
     get_current_user,
     is_admin_user,
+    optional_security,
 )
 from ..config import (
     BINARY_EXTENSIONS,
@@ -1514,19 +1515,20 @@ async def download_file(
 # ownership exactly as they do for the Bearer path. Binding the ticket to one
 # file_id means a leaked ticket can only be replayed against that one file,
 # not enumerated against others. Unlike a Bearer header, though, this
-# credential rides in a URL a media element loads directly — address bar,
-# browser history, the file's "Open" link, proxy/CDN access logs — so its
-# TTL is kept independently short (get_file_stream_ticket_ttl_seconds(),
-# minutes not hours) rather than matching the user's own access token.
+# credential rides in a URL a media element loads directly — the frontend
+# (inline-file-preview.tsx) never puts the ticketed URL anywhere a user
+# could put it in the address bar, browser history, or a copied link (the
+# "Open" affordance deliberately never exposes it either), so the realistic
+# exposure is proxy/CDN/server access logs and a devtools network panel.
+# Its TTL is kept independently short regardless
+# (get_file_stream_ticket_ttl_seconds(), minutes not hours) rather than
+# matching the user's own access token, since those vectors are still real.
 FILE_STREAM_TICKET_TYPE = "file_stream_ticket"
 
 # See _PUBLIC_PREVIEW_CACHE_HEADERS above: a stream ticket rides in a URL a
 # media element auto-fetches on render too, so preview_file below reuses
 # that same constant/rationale as ``cache_headers`` whenever a ticket
 # authenticated the request, rather than a second identical constant.
-
-
-_optional_bearer = HTTPBearer(auto_error=False)
 
 
 def _user_from_stream_ticket(db: Session, ticket: str, file_id: str) -> User:
@@ -1566,7 +1568,7 @@ def _user_from_stream_ticket(db: Session, ticket: str, file_id: str) -> User:
 def _user_from_bearer_or_stream_ticket(
     file_id: str,
     ticket: Optional[str] = Query(default=None),
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_optional_bearer),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(optional_security),
     db: Session = Depends(get_db),
 ) -> Tuple[User, Optional[str]]:
     """Resolve the requesting user, and echo back which credential won.
@@ -1690,6 +1692,17 @@ async def preview_file(
         # (computed above, per-request, from whether a ticket was used) is
         # still threaded through so the no-store invariant travels with the
         # request regardless of which exit serves it.
+        #
+        # On this exit specifically, the bytes a ticketed request actually
+        # streams are governed by get_file_delivery_signed_url_ttl_seconds()
+        # (XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS, default 300s) -- not
+        # the stream ticket's own TTL (default 600s) -- since the ticket
+        # only authorizes minting this redirect once; the object store's own
+        # signed URL governs everything after that first hop. The effective
+        # session for a long video is therefore min(ticket TTL at the first
+        # hop, signed-URL TTL thereafter), and an operator tuning either
+        # XAGENT_*_TTL_SECONDS knob in isolation can unexpectedly cut
+        # playback off at the other one.
         if _preview_can_redirect(full_path, media_type):
             redirect_response = _durable_redirect_response(
                 file_ref,

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -36,6 +36,7 @@ from xagent.config import (
     FILE_STORAGE_OPTIONS,
     FILE_STORAGE_STARTUP_SYNC_ENABLED,
     FILE_STORAGE_URI,
+    FILE_STREAM_TICKET_TTL_SECONDS,
     FRONTEND_DIST_DIR,
     GMAIL_PUBSUB_PROJECT_ID,
     GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT,
@@ -134,6 +135,7 @@ from xagent.config import (
     get_file_storage_options,
     get_file_storage_startup_sync_enabled,
     get_file_storage_uri,
+    get_file_stream_ticket_ttl_seconds,
     get_frontend_dist_dir,
     get_gmail_pubsub_project_id,
     get_gmail_pubsub_push_service_account,
@@ -911,6 +913,23 @@ class TestFileStorageConfig:
             ValueError, match="XAGENT_FILE_DELIVERY_SIGNED_URL_TTL_SECONDS"
         ):
             get_file_delivery_signed_url_ttl_seconds()
+
+    def test_file_stream_ticket_ttl_defaults_to_600(self, monkeypatch):
+        monkeypatch.delenv(FILE_STREAM_TICKET_TTL_SECONDS, raising=False)
+
+        assert get_file_stream_ticket_ttl_seconds() == 600
+
+    def test_file_stream_ticket_ttl_with_env_var(self, monkeypatch):
+        monkeypatch.setenv(FILE_STREAM_TICKET_TTL_SECONDS, "120")
+
+        assert get_file_stream_ticket_ttl_seconds() == 120
+
+    @pytest.mark.parametrize("value", ["0", "-1", "abc"])
+    def test_file_stream_ticket_ttl_rejects_invalid(self, monkeypatch, value):
+        monkeypatch.setenv(FILE_STREAM_TICKET_TTL_SECONDS, value)
+
+        with pytest.raises(ValueError, match="XAGENT_FILE_STREAM_TICKET_TTL_SECONDS"):
+            get_file_stream_ticket_ttl_seconds()
 
     def test_file_delivery_accel_redirect_enabled_defaults_false(self, monkeypatch):
         monkeypatch.delenv(FILE_DELIVERY_ACCEL_REDIRECT_ENABLED, raising=False)

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -869,6 +869,57 @@ class TestAdminFileAccess:
 
         assert response.status_code == 401
 
+    def test_mint_endpoint_requires_a_bearer_credential(
+        self, test_db, temp_uploads_dir
+    ):
+        # issue_preview_stream_ticket uses the standard get_current_user
+        # dependency, same as every other authenticated file route -- no
+        # special-cased auth logic to verify here beyond that it's actually
+        # wired up. A garbage/expired Bearer is rejected 401 by
+        # get_current_user's own code (_required_http_rejection), which is
+        # deterministic regardless of FastAPI version. A completely missing
+        # Authorization header is instead rejected directly by FastAPI's
+        # HTTPBearer(auto_error=True) before get_current_user's body ever
+        # runs, and that status code is NOT asserted here: it's 403 on the
+        # project's locked fastapi==0.115.14 (uv.lock) but empirically 401
+        # against fastapi==0.135.1, whatever happens to be installed in a
+        # given environment -- this is the version sensitivity documented
+        # at _user_from_bearer_or_stream_ticket's own "Not authenticated"
+        # comment, and this endpoint has no equivalent explicit-403 guard.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=107,
+            user_id=regular_user_id,
+            title="Mint auth test",
+            description="mint auth test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+
+        no_header_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}"
+        )
+        assert no_header_response.status_code in (401, 403)
+
+        garbage_bearer_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}",
+            headers={"Authorization": "Bearer not-a-real-token"},
+        )
+        assert garbage_bearer_response.status_code == 401
+
     def test_preview_rejects_ticket_signed_with_wrong_secret(
         self, test_db, temp_uploads_dir
     ):
@@ -1005,9 +1056,22 @@ class TestAdminFileAccess:
         # ever looking at the Bearer header -- confirm a valid ticket for
         # one user is honored even when a *different* user's Bearer
         # header is also present, rather than the two being reconciled or
-        # the Bearer header silently winning.
+        # the Bearer header silently winning. The mismatched Bearer must
+        # belong to a non-admin user with no access to the file: an admin
+        # Bearer would also pass _check_file_access on its own, making a
+        # 200 non-discriminating between "the ticket won" and "the admin
+        # Bearer silently won instead".
         admin_user, regular_user, test_app, session = test_db
+        del admin_user
         regular_user_id = int(cast(Any, regular_user.id))
+        other_user = User(
+            username="precedence-other",
+            password_hash=hash_password("precedence-other"),
+            is_admin=False,
+        )
+        session.add(other_user)
+        session.commit()
+
         task = Task(
             id=102,
             user_id=regular_user_id,
@@ -1034,15 +1098,54 @@ class TestAdminFileAccess:
         )
         ticket = ticket_response.json()["path"].split("ticket=")[1]
 
-        admin_headers = create_auth_headers(admin_user)
+        other_user_headers = create_auth_headers(other_user)
         response = client.get(
             f"/api/files/preview/{uploaded_file.file_id}",
             params={"ticket": ticket},
-            headers=admin_headers,
+            headers=other_user_headers,
         )
 
         assert response.status_code == 200
         assert response.content == b"video bytes"
+
+    def test_preview_rejects_garbage_ticket_even_with_a_valid_bearer_header(
+        self, test_db, temp_uploads_dir
+    ):
+        # Completes the precedence test above from the other direction: a
+        # present-but-broken ticket short-circuits before the Bearer header
+        # is ever examined, so a valid Bearer for the file's own owner does
+        # NOT rescue a garbage ticket via fallthrough.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=106,
+            user_id=regular_user_id,
+            title="Garbage ticket precedence test",
+            description="garbage ticket precedence test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": "not-a-real-ticket"},
+            headers=user_headers,
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid or expired ticket"
 
     def test_ticket_authenticated_preview_can_use_accel_redirect(
         self, test_db, temp_uploads_dir, monkeypatch
@@ -1085,6 +1188,111 @@ class TestAdminFileAccess:
 
         assert response.status_code == 200
         assert "x-accel-redirect" in response.headers
+        assert response.headers["cache-control"] == "private, no-store"
+
+    def test_ticket_authenticated_preview_serves_partial_content_for_range_requests(
+        self, test_db, temp_uploads_dir
+    ):
+        # The entire point of the ticket mechanism is progressive playback
+        # via HTTP Range requests -- this exercises that end-to-end on a
+        # ticket-authenticated request against the direct content-serving
+        # exit (Starlette's FileResponse implements Range support; the
+        # accel/durable redirect exits delegate real Range serving to
+        # nginx/the object store instead and are covered separately).
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=104,
+            user_id=regular_user_id,
+            title="Ticket range request test",
+            description="ticket range request test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "0123456789video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}",
+            headers=user_headers,
+        )
+        path = ticket_response.json()["path"]
+
+        response = client.get(path, headers={"Range": "bytes=0-4"})
+
+        assert response.status_code == 206
+        assert response.content == b"01234"
+        assert response.headers["content-range"] == "bytes 0-4/21"
+        assert response.headers["cache-control"] == "private, no-store"
+
+    def test_ticket_authenticated_preview_can_use_durable_redirect(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        # Mirrors test_ticket_authenticated_preview_can_use_accel_redirect
+        # for the other redirect fast path: the durable-object signed-URL
+        # 307, which was also previously gated on "not ticket" before this
+        # PR's fix and is where a real deployment would delegate Range
+        # serving to the object store for large ticketed media.
+        from xagent.web.services.managed_file_ref import ManagedFileRef
+
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=105,
+            user_id=regular_user_id,
+            title="Ticket durable redirect test",
+            description="ticket durable redirect test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+        uploaded_file.storage_status = "available"
+        uploaded_file.storage_key = (
+            f"users/{regular_user_id}/uploads/{uploaded_file.file_id}/clip.mp4"
+        )
+        uploaded_file.storage_backend = "s3"
+        session.commit()
+
+        monkeypatch.setattr(
+            ManagedFileRef,
+            "signed_access_url",
+            lambda self, **kwargs: "https://durable.example/clip.mp4?sig=abc",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}",
+            headers=user_headers,
+        )
+        path = ticket_response.json()["path"]
+
+        response = client.get(path, follow_redirects=False)
+
+        assert response.status_code == 307
+        assert (
+            response.headers["location"] == "https://durable.example/clip.mp4?sig=abc"
+        )
         assert response.headers["cache-control"] == "private, no-store"
 
     def test_preview_rejects_garbage_ticket(self, test_db, temp_uploads_dir):

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import quote
 
 import pytest
 from fastapi import FastAPI
@@ -741,6 +742,351 @@ class TestAdminFileAccess:
 
         assert response.status_code == 403
 
+    def test_stream_ticket_mint_and_redeem_for_slash_bearing_legacy_file_id(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        # A legacy file_id can be an arbitrary relative path containing
+        # slashes, with no UploadedFile DB record at all -- confirm the
+        # mint response's quote(..., safe='')-encoded path round-trips
+        # correctly through {file_id:path} on redemption.
+        import xagent.web.api.legacy_file as legacy_file_module
+
+        # resolve_legacy_file_path resolves get_uploads_dir() through its
+        # own module-local import binding, separate from the one
+        # temp_uploads_dir already patches on xagent.web.api.files -- both
+        # must point at the same temp directory for this filesystem-scan
+        # path (unlike the DB-record path other tests exercise, which
+        # stores an absolute path directly and never calls this).
+        monkeypatch.setattr(
+            legacy_file_module, "get_uploads_dir", lambda: temp_uploads_dir
+        )
+
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+
+        legacy_relative_path = "web_task_235/output/clip.mp4"
+        legacy_file_path = (
+            temp_uploads_dir / f"user_{regular_user_id}" / legacy_relative_path
+        )
+        legacy_file_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_file_path.write_bytes(b"legacy video bytes")
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{quote(legacy_relative_path, safe='')}",
+            headers=user_headers,
+        )
+        assert ticket_response.status_code == 200
+        path = ticket_response.json()["path"]
+        assert path.startswith(
+            f"/api/files/preview/{quote(legacy_relative_path, safe='')}?ticket="
+        )
+
+        preview_response = client.get(path)
+
+        assert preview_response.status_code == 200
+        assert preview_response.content == b"legacy video bytes"
+
+    def test_preview_rejects_an_access_token_used_as_a_ticket(
+        self, test_db, temp_uploads_dir
+    ):
+        # type: "access" must not be redeemable via ?ticket= -- the two
+        # credential kinds must stay disjoint even though both are signed
+        # with the same secret.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=97,
+            user_id=regular_user_id,
+            title="Access token as ticket test",
+            description="access token as ticket test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        access_token = create_auth_headers(regular_user)["Authorization"].removeprefix(
+            "Bearer "
+        )
+
+        client = TestClient(test_app)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": access_token},
+        )
+
+        assert response.status_code == 401
+
+    def test_stream_ticket_rejected_as_a_bearer_credential(
+        self, test_db, temp_uploads_dir
+    ):
+        # The symmetric direction: type: "file_stream_ticket" must not be
+        # accepted as a plain Bearer credential either.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=98,
+            user_id=regular_user_id,
+            title="Ticket as bearer test",
+            description="ticket as bearer test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}",
+            headers=user_headers,
+        )
+        ticket = ticket_response.json()["path"].split("ticket=")[1]
+
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            headers={"Authorization": f"Bearer {ticket}"},
+        )
+
+        assert response.status_code == 401
+
+    def test_preview_rejects_ticket_signed_with_wrong_secret(
+        self, test_db, temp_uploads_dir
+    ):
+        import jwt as pyjwt
+
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=99,
+            user_id=regular_user_id,
+            title="Wrong secret ticket test",
+            description="wrong secret ticket test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        forged_ticket = pyjwt.encode(
+            {
+                "type": "file_stream_ticket",
+                "sub": regular_user.username,
+                "user_id": regular_user.id,
+                "file_id": uploaded_file.file_id,
+            },
+            "not-the-real-secret",
+            algorithm="HS256",
+        )
+
+        client = TestClient(test_app)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": forged_ticket},
+        )
+
+        assert response.status_code == 401
+
+    def test_preview_rejects_ticket_for_a_deleted_user(self, test_db, temp_uploads_dir):
+        import jwt as pyjwt
+
+        from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user, regular_user
+        deleted_user = User(
+            username="soon_deleted",
+            password_hash=hash_password("soon_deleted"),
+            is_admin=False,
+        )
+        session.add(deleted_user)
+        session.commit()
+
+        deleted_user_id = int(cast(Any, deleted_user.id))
+        deleted_username = str(deleted_user.username)
+
+        # _user_from_stream_ticket rejects on the user lookup alone, before
+        # ever resolving a file -- no task/upload needs to exist for this
+        # deleted user, which also avoids a real cascade-delete headache.
+        ticket = pyjwt.encode(
+            {
+                "type": "file_stream_ticket",
+                "sub": deleted_username,
+                "user_id": deleted_user_id,
+                "file_id": "irrelevant-file-id",
+            },
+            JWT_SECRET_KEY,
+            algorithm=JWT_ALGORITHM,
+        )
+
+        session.delete(deleted_user)
+        session.commit()
+
+        client = TestClient(test_app)
+        response = client.get(
+            "/api/files/preview/irrelevant-file-id",
+            params={"ticket": ticket},
+        )
+
+        assert response.status_code == 401
+
+    def test_empty_ticket_query_param_falls_through_to_bearer_path(
+        self, test_db, temp_uploads_dir
+    ):
+        # ?ticket= with an empty string must not short-circuit into the
+        # ticket branch (an empty ticket would then fail JWT decoding);
+        # it should behave exactly as if no ticket param were sent.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=101,
+            user_id=regular_user_id,
+            title="Empty ticket test",
+            description="empty ticket test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": ""},
+            headers=user_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.content == b"video bytes"
+        # No ticket was actually redeemed, so this must not get the
+        # ticket path's no-store override.
+        assert "cache-control" not in response.headers
+
+    def test_ticket_takes_precedence_over_a_mismatched_bearer_header(
+        self, test_db, temp_uploads_dir
+    ):
+        # _user_from_bearer_or_stream_ticket checks `if ticket:` before
+        # ever looking at the Bearer header -- confirm a valid ticket for
+        # one user is honored even when a *different* user's Bearer
+        # header is also present, rather than the two being reconciled or
+        # the Bearer header silently winning.
+        admin_user, regular_user, test_app, session = test_db
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=102,
+            user_id=regular_user_id,
+            title="Precedence test",
+            description="precedence test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        regular_user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}",
+            headers=regular_user_headers,
+        )
+        ticket = ticket_response.json()["path"].split("ticket=")[1]
+
+        admin_headers = create_auth_headers(admin_user)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": ticket},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.content == b"video bytes"
+
+    def test_ticket_authenticated_preview_can_use_accel_redirect(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        # The redirect fast paths are no longer gated on "not ticket" --
+        # confirm a ticketed request actually reaches the accel-redirect
+        # branch instead of being forced through the app process, and
+        # still carries the no-store guard on that response.
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED", "true")
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=103,
+            user_id=regular_user_id,
+            title="Ticket accel redirect test",
+            description="ticket accel redirect test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}",
+            headers=user_headers,
+        )
+        path = ticket_response.json()["path"]
+
+        response = client.get(path, follow_redirects=False)
+
+        assert response.status_code == 200
+        assert "x-accel-redirect" in response.headers
+        assert response.headers["cache-control"] == "private, no-store"
+
     def test_preview_rejects_garbage_ticket(self, test_db, temp_uploads_dir):
         admin_user, regular_user, test_app, session = test_db
         del admin_user
@@ -820,6 +1166,11 @@ class TestAdminFileAccess:
         assert response.status_code == 401
 
     def test_preview_requires_bearer_or_ticket(self, test_db, temp_uploads_dir):
+        # 403, matching this pre-existing endpoint's error contract from
+        # before the ticket param existed: FastAPI's default
+        # HTTPBearer(auto_error=True) raises 403 "Not authenticated" for a
+        # completely absent Authorization header, not 401 (401 is reserved
+        # for a credential that IS present but rejected).
         admin_user, regular_user, test_app, session = test_db
         del admin_user
         regular_user_id = int(cast(Any, regular_user.id))
@@ -844,4 +1195,4 @@ class TestAdminFileAccess:
         client = TestClient(test_app)
         response = client.get(f"/api/files/preview/{uploaded_file.file_id}")
 
-        assert response.status_code == 401
+        assert response.status_code == 403

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -742,6 +742,64 @@ class TestAdminFileAccess:
 
         assert response.status_code == 403
 
+    def test_stream_ticket_cannot_bypass_ownership_check_for_legacy_file_id(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        # test_stream_ticket_cannot_bypass_file_ownership_check above only
+        # exercises the DB-record branch of preview_file's access check
+        # (_check_file_access via file_record); this covers the other
+        # branch -- a legacy file_id with no UploadedFile record at all,
+        # where ownership is instead enforced by comparing owner_user_id
+        # (derived from the filesystem path, via a Task-id lookup for a
+        # cross-user request -- see infer_user_id_from_legacy_path) against
+        # the requester.
+        import xagent.web.api.legacy_file as legacy_file_module
+
+        monkeypatch.setattr(
+            legacy_file_module, "get_uploads_dir", lambda: temp_uploads_dir
+        )
+
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        owner_id = int(cast(Any, regular_user.id))
+        other_user = User(
+            username="legacy-ticket-other",
+            password_hash=hash_password("legacy-ticket-other"),
+            is_admin=False,
+        )
+        session.add(other_user)
+        session.commit()
+
+        task = Task(
+            id=236,
+            user_id=owner_id,
+            title="Owner-only legacy task",
+            description="owner-only legacy task",
+        )
+        session.add(task)
+        session.commit()
+
+        legacy_relative_path = "web_task_236/output/private.mp4"
+        legacy_file_path = temp_uploads_dir / f"user_{owner_id}" / legacy_relative_path
+        legacy_file_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_file_path.write_bytes(b"private legacy video bytes")
+
+        client = TestClient(test_app)
+        other_user_headers = create_auth_headers(other_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{quote(legacy_relative_path, safe='')}",
+            headers=other_user_headers,
+        )
+        assert ticket_response.status_code == 200
+        ticket = ticket_response.json()["path"].split("ticket=")[1]
+
+        response = client.get(
+            f"/api/files/preview/{quote(legacy_relative_path, safe='')}",
+            params={"ticket": ticket},
+        )
+
+        assert response.status_code == 403
+
     def test_stream_ticket_mint_and_redeem_for_slash_bearing_legacy_file_id(
         self, test_db, temp_uploads_dir, monkeypatch
     ):
@@ -788,6 +846,56 @@ class TestAdminFileAccess:
 
         assert preview_response.status_code == 200
         assert preview_response.content == b"legacy video bytes"
+
+    def test_minted_ticket_expiry_honors_the_configured_ttl(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        # tests/core/test_config.py already covers
+        # get_file_stream_ticket_ttl_seconds() parsing/validating the env
+        # var in isolation; this instead confirms the mint endpoint actually
+        # wires that configured value into the minted JWT's own exp claim,
+        # not just some other hardcoded default.
+        import time
+
+        import jwt as pyjwt
+
+        monkeypatch.setenv("XAGENT_FILE_STREAM_TICKET_TTL_SECONDS", "120")
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=108,
+            user_id=regular_user_id,
+            title="TTL config test",
+            description="ttl config test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        before_mint = time.time()
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}",
+            headers=user_headers,
+        )
+        assert ticket_response.status_code == 200
+        ticket = ticket_response.json()["path"].split("ticket=")[1]
+
+        claims = pyjwt.decode(ticket, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+
+        # Bounded rather than exact: real wall-clock elapses between
+        # before_mint and the token's own iat/exp computation.
+        assert 110 <= claims["exp"] - before_mint <= 120
 
     def test_preview_rejects_an_access_token_used_as_a_ticket(
         self, test_db, temp_uploads_dir
@@ -1190,6 +1298,49 @@ class TestAdminFileAccess:
         assert "x-accel-redirect" in response.headers
         assert response.headers["cache-control"] == "private, no-store"
 
+    def test_bearer_authenticated_preview_keeps_default_caching_on_accel_redirect(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        # test_authenticated_preview_keeps_default_caching only exercises
+        # the direct content-serving exit; without this, a regression that
+        # threaded no-store unconditionally into _accel_redirect_response
+        # (instead of only via cache_headers, gated on ticket presence)
+        # would pass the whole suite undetected, since no other Bearer
+        # request reaches this exit.
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_ACCEL_REDIRECT_ENABLED", "true")
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=109,
+            user_id=regular_user_id,
+            title="Bearer accel redirect caching test",
+            description="bearer accel redirect caching test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            headers=user_headers,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 200
+        assert "x-accel-redirect" in response.headers
+        assert "cache-control" not in response.headers
+
     def test_ticket_authenticated_preview_serves_partial_content_for_range_requests(
         self, test_db, temp_uploads_dir
     ):
@@ -1295,6 +1446,64 @@ class TestAdminFileAccess:
         )
         assert response.headers["cache-control"] == "private, no-store"
 
+    def test_bearer_authenticated_preview_keeps_default_caching_on_durable_redirect(
+        self, test_db, temp_uploads_dir, monkeypatch
+    ):
+        # Durable-redirect counterpart to
+        # test_bearer_authenticated_preview_keeps_default_caching_on_accel_redirect:
+        # without this, a regression that threaded no-store unconditionally
+        # into _durable_redirect_response would also pass the whole suite
+        # undetected, since no other Bearer request reaches this exit either.
+        from xagent.web.services.managed_file_ref import ManagedFileRef
+
+        monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "true")
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=110,
+            user_id=regular_user_id,
+            title="Bearer durable redirect caching test",
+            description="bearer durable redirect caching test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+        uploaded_file.storage_status = "available"
+        uploaded_file.storage_key = (
+            f"users/{regular_user_id}/uploads/{uploaded_file.file_id}/clip.mp4"
+        )
+        uploaded_file.storage_backend = "s3"
+        session.commit()
+
+        monkeypatch.setattr(
+            ManagedFileRef,
+            "signed_access_url",
+            lambda self, **kwargs: "https://durable.example/clip.mp4?sig=abc",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            headers=user_headers,
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 307
+        assert (
+            response.headers["location"] == "https://durable.example/clip.mp4?sig=abc"
+        )
+        assert "cache-control" not in response.headers
+
     def test_preview_rejects_garbage_ticket(self, test_db, temp_uploads_dir):
         admin_user, regular_user, test_app, session = test_db
         del admin_user
@@ -1372,6 +1581,64 @@ class TestAdminFileAccess:
         )
 
         assert response.status_code == 401
+
+    def test_preview_rejects_ticket_with_malformed_claims(
+        self, test_db, temp_uploads_dir
+    ):
+        # A ticket signed with the real secret but carrying a string
+        # user_id (instead of int) exercises the _AccessTokenRejected path
+        # inside _validate_access_token_claim_bindability -- distinct from
+        # the JWTError paths already covered by the garbage/expired ticket
+        # tests above. This server is the sole minter today, so malformed
+        # claims aren't attacker-reachable, but the shared hardening this
+        # ticket path reuses from access tokens should still be verified.
+        from datetime import datetime, timedelta, timezone
+
+        import jwt as pyjwt
+
+        from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=96,
+            user_id=regular_user_id,
+            title="Malformed claim ticket test",
+            description="malformed claim ticket test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        malformed_ticket = pyjwt.encode(
+            {
+                "type": "file_stream_ticket",
+                "sub": regular_user.username,
+                "user_id": str(regular_user_id),
+                "file_id": uploaded_file.file_id,
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            JWT_SECRET_KEY,
+            algorithm=JWT_ALGORITHM,
+        )
+
+        client = TestClient(test_app)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": malformed_ticket},
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid or expired ticket"
 
     def test_preview_requires_bearer_or_ticket(self, test_db, temp_uploads_dir):
         # 403, matching this pre-existing endpoint's error contract from

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -894,8 +894,13 @@ class TestAdminFileAccess:
         claims = pyjwt.decode(ticket, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
 
         # Bounded rather than exact: real wall-clock elapses between
-        # before_mint and the token's own iat/exp computation.
-        assert 110 <= claims["exp"] - before_mint <= 120
+        # before_mint and the token's own iat/exp computation, and
+        # python-jose floors exp to an integer second (timegm), so a naive
+        # ..120 upper bound flakes whenever that floor rounds up relative to
+        # before_mint's own fractional second -- tightened to 119..121 (0
+        # failures simulated across 400k runs) rather than widened, to keep
+        # the lower bound meaningfully close to the configured 120s.
+        assert 119 <= claims["exp"] - before_mint <= 121
 
     def test_preview_rejects_an_access_token_used_as_a_ticket(
         self, test_db, temp_uploads_dir
@@ -1626,6 +1631,62 @@ class TestAdminFileAccess:
                 "user_id": str(regular_user_id),
                 "file_id": uploaded_file.file_id,
                 "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            JWT_SECRET_KEY,
+            algorithm=JWT_ALGORITHM,
+        )
+
+        client = TestClient(test_app)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": malformed_ticket},
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid or expired ticket"
+
+    def test_preview_rejects_ticket_with_non_convertible_temporal_claim(
+        self, test_db, temp_uploads_dir
+    ):
+        # python-jose's own jwt.decode can raise a bare OverflowError (not
+        # JWTError) for a garbage-typed exp claim -- it does int(exp)
+        # internally without catching that -- which would 500 instead of
+        # the 401 every other malformed-ticket case here returns, without
+        # _user_from_stream_ticket's own guard mirroring the one
+        # get_current_user already has for access tokens
+        # (has_matching_temporal_claim_conversion_failure).
+        import jwt as pyjwt
+
+        from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=111,
+            user_id=regular_user_id,
+            title="Non-convertible temporal claim ticket test",
+            description="non-convertible temporal claim ticket test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        malformed_ticket = pyjwt.encode(
+            {
+                "type": "file_stream_ticket",
+                "sub": regular_user.username,
+                "user_id": regular_user_id,
+                "file_id": uploaded_file.file_id,
+                "exp": float("inf"),
             },
             JWT_SECRET_KEY,
             algorithm=JWT_ALGORITHM,

--- a/tests/web/test_admin_file_access.py
+++ b/tests/web/test_admin_file_access.py
@@ -601,3 +601,247 @@ class TestAdminFileAccess:
         # that exactly, not just "not the public value" -- a regression that
         # set some other Cache-Control here would slip past a weaker check.
         assert "cache-control" not in response.headers
+
+    def test_stream_ticket_authorizes_preview_without_bearer_header(
+        self, test_db, temp_uploads_dir
+    ):
+        # A media element (<video>/<audio>) cannot send an Authorization
+        # header, so it loads the preview URL directly using a ticket minted
+        # by a Bearer-authenticated request instead.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=90,
+            user_id=regular_user_id,
+            title="Stream ticket test",
+            description="stream ticket test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{uploaded_file.file_id}",
+            headers=user_headers,
+        )
+        assert ticket_response.status_code == 200
+        path = ticket_response.json()["path"]
+        assert path.startswith(f"/api/files/preview/{uploaded_file.file_id}?ticket=")
+
+        preview_response = client.get(path)
+
+        assert preview_response.status_code == 200
+        assert preview_response.content == b"video bytes"
+        assert preview_response.headers["cache-control"] == "private, no-store"
+
+    def test_stream_ticket_cannot_be_replayed_against_a_different_file(
+        self, test_db, temp_uploads_dir
+    ):
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=91,
+            user_id=regular_user_id,
+            title="Stream ticket scope test",
+            description="stream ticket scope test",
+        )
+        session.add(task)
+        session.commit()
+
+        clip = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+        other_clip = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "other.mp4",
+            "other video bytes",
+        )
+
+        client = TestClient(test_app)
+        user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{clip.file_id}", headers=user_headers
+        )
+        ticket = ticket_response.json()["path"].split("ticket=")[1]
+
+        response = client.get(
+            f"/api/files/preview/{other_clip.file_id}", params={"ticket": ticket}
+        )
+
+        assert response.status_code == 401
+
+    def test_stream_ticket_cannot_bypass_file_ownership_check(
+        self, test_db, temp_uploads_dir
+    ):
+        # Minting a ticket never checks ownership -- it defers to the same
+        # _check_file_access the Bearer path enforces at redemption time. A
+        # ticket minted for a file the caller doesn't own must still 403
+        # rather than leak the file.
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        another_user = User(
+            username="another_ticket_user",
+            password_hash=hash_password("another"),
+            is_admin=False,
+        )
+        session.add(another_user)
+        session.commit()
+
+        another_user_id = int(cast(Any, another_user.id))
+        task = Task(
+            id=92,
+            user_id=another_user_id,
+            title="Owner-only file",
+            description="owner-only file",
+        )
+        session.add(task)
+        session.commit()
+
+        owners_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            another_user_id,
+            int(cast(Any, task.id)),
+            "private.mp4",
+            "private video bytes",
+        )
+
+        client = TestClient(test_app)
+        regular_user_headers = create_auth_headers(regular_user)
+        ticket_response = client.get(
+            f"/api/files/stream-tickets/{owners_file.file_id}",
+            headers=regular_user_headers,
+        )
+        assert ticket_response.status_code == 200
+        ticket = ticket_response.json()["path"].split("ticket=")[1]
+
+        response = client.get(
+            f"/api/files/preview/{owners_file.file_id}", params={"ticket": ticket}
+        )
+
+        assert response.status_code == 403
+
+    def test_preview_rejects_garbage_ticket(self, test_db, temp_uploads_dir):
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=93,
+            user_id=regular_user_id,
+            title="Garbage ticket test",
+            description="garbage ticket test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": "not-a-real-jwt"},
+        )
+
+        assert response.status_code == 401
+
+    def test_preview_rejects_expired_ticket(self, test_db, temp_uploads_dir):
+        from datetime import datetime, timedelta, timezone
+
+        import jwt as pyjwt
+
+        from xagent.web.auth_config import JWT_ALGORITHM, JWT_SECRET_KEY
+
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=94,
+            user_id=regular_user_id,
+            title="Expired ticket test",
+            description="expired ticket test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        expired_ticket = pyjwt.encode(
+            {
+                "type": "file_stream_ticket",
+                "sub": regular_user.username,
+                "user_id": regular_user.id,
+                "file_id": uploaded_file.file_id,
+                "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            },
+            JWT_SECRET_KEY,
+            algorithm=JWT_ALGORITHM,
+        )
+
+        client = TestClient(test_app)
+        response = client.get(
+            f"/api/files/preview/{uploaded_file.file_id}",
+            params={"ticket": expired_ticket},
+        )
+
+        assert response.status_code == 401
+
+    def test_preview_requires_bearer_or_ticket(self, test_db, temp_uploads_dir):
+        admin_user, regular_user, test_app, session = test_db
+        del admin_user
+        regular_user_id = int(cast(Any, regular_user.id))
+        task = Task(
+            id=95,
+            user_id=regular_user_id,
+            title="No credential test",
+            description="no credential test",
+        )
+        session.add(task)
+        session.commit()
+
+        uploaded_file = create_uploaded_file(
+            session,
+            temp_uploads_dir,
+            regular_user_id,
+            int(cast(Any, task.id)),
+            "clip.mp4",
+            "video bytes",
+        )
+
+        client = TestClient(test_app)
+        response = client.get(f"/api/files/preview/{uploaded_file.file_id}")
+
+        assert response.status_code == 401

--- a/tests/web/test_auth_dependencies.py
+++ b/tests/web/test_auth_dependencies.py
@@ -654,6 +654,12 @@ def test_auth_consumer_topology_is_closed_across_source_tree() -> None:
             "get_authenticated_user",
             terminated,
         ),
+        (
+            "web/api/files.py",
+            "_user_from_bearer_or_stream_ticket",
+            "get_current_user",
+            (),
+        ),
     )
     modules = {"xagent.web.auth_dependencies", "xagent.web.api.websocket_auth"}
     source_root = Path(auth_dependencies.__file__).parents[1]


### PR DESCRIPTION
Fixes #1201.

## Problem

Under the default (Bearer-authenticated) `FileAccessPolicy`, inline video/audio previews fully download the file into a memory blob before playback starts — no progressive playback, no seek-before-download. This exists because the authenticated preview route needs a Bearer header, and `<video>`/`<audio>` elements can't send one.

PR #1196 already solved this for the public/share policy, whose guest token rides the query string. This PR gives the authenticated path the same capability.

(Generated videos having no size cap on the write path is a related but separate risk, tracked in #1336 — not addressed by this PR.)

## Fix

**Backend**
- `GET /api/files/stream-tickets/{file_id}` (Bearer-authenticated): mints a short-lived JWT scoped to exactly one `file_id`. TTL is independently configurable via `XAGENT_FILE_STREAM_TICKET_TTL_SECONDS` (default 600s) rather than matching the user's own access token — the ticket rides in a URL a media element auto-fetches on render (address bar, browser history, proxy/CDN logs), so its exposure is wider than a Bearer header's, and its authority is strictly narrower (one file, read-only, inline preview only) to match.
- `GET /api/files/preview/{file_id}` now also accepts that ticket via `?ticket=` as an alternative to the `Authorization` header. It resolves the *same* `User` the header would and runs through the exact same `_check_file_access`/`_is_admin_user` checks — a ticket grants no privilege beyond what its owner's Bearer token already grants. Binding it to one `file_id` means a leaked ticket can only be replayed against that one file.
- The ticket-minting endpoint is deliberately a sibling route under its own `/stream-tickets/` prefix rather than a path suffix nested under `/preview/{file_id:path}`: that `:path` converter matches slashes, and a legacy `file_id` can be an arbitrary relative path (e.g. `web_task_235/output/ticket`) — nesting risked a real file literally named "ticket" colliding with the ticket-minting route.
- Ticket-authenticated preview responses get the same `Cache-Control: private, no-store` treatment as the public/tokened route (see #1226 for that same guard on the public path), threaded through every content-serving exit including the accel/durable redirect fast paths. The Bearer-only path is untouched and keeps default caching.

**Frontend**
- `FileAccessPolicy` gains an optional `getStreamingUrl(fileId): Promise<string>`. The default policy implements it against the new ticket endpoint; the public policy doesn't need it (already direct-URL).
- `useResolvedMediaUrl` tries it first (falling back to the existing blob-fetch/direct-src strategies if minting fails, e.g. offline), but **only for audio/video** — images have no seek/progressive-loading need. Minted URLs are cached briefly per `fileId` (de-duping concurrent/repeat mounts) and self-heal via a fallback chain if a ticket mints but then fails to actually load (e.g. expired mid-session).
- Media "Open" links route through the in-app file-preview dialog (`onFileClick`) when one is available, the same as the image/generic-file branches of `InlineFilePreview` already do, rather than a credential-free public URL that 403s on access-controlled tasks.

## Testing

- `tests/web/test_admin_file_access.py`: ticket mint + redeem round trip, cross-file replay rejection, ownership-check enforcement at redemption (minting never checks ownership — it's fully enforced when the ticket is used), garbage/expired ticket rejection, missing-credential rejection, ticket-vs-Bearer precedence in both directions, `Cache-Control` on every content-serving exit (direct, accel redirect, durable redirect), an end-to-end Range/206 request against a ticket-authenticated response, and a regression guard that the Bearer-only path keeps default caching.
- `frontend/src/contexts/file-access-context.test.tsx` + `frontend/src/components/file/inline-file-preview.test.tsx`: ticket-URL streaming, fallback to blob-fetch on mint failure or a post-mint load failure, mint de-duplication/retry-after-failure, that images never request a ticket, and that "Open" routes through `onFileClick` when available.

`ruff`, `mypy`, `tsc`, `eslint`, and the full backend + frontend suites pass (pre-existing unrelated baseline failures noted in the branch history, not reintroduced here).
