### PR TITLE
feat: add task runtime UI extension slots

### DIFF
--- a/frontend/src/app/settings/page.test.tsx
+++ b/frontend/src/app/settings/page.test.tsx
@@ -18,8 +18,12 @@ vi.mock("@/contexts/i18n-context", () => ({
 }))
 vi.mock("@/lib/api-wrapper", () => ({ apiRequest }))
 vi.mock("@/lib/task-runtime-ui-extension", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/task-runtime-ui-extension")
+  >("@/lib/task-runtime-ui-extension")
   const ReactModule = await vi.importActual<typeof import("react")>("react")
   return {
+    ...actual,
     TaskRuntimeSettingsExtension: () => ReactModule.createElement(
       "section",
       { "data-testid": "task-runtime-settings-extension" },

--- a/frontend/src/app/settings/page.test.tsx
+++ b/frontend/src/app/settings/page.test.tsx
@@ -17,6 +17,16 @@ vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({ t: i18nState.t, locale: "en", setLocale: i18nState.setLocale }),
 }))
 vi.mock("@/lib/api-wrapper", () => ({ apiRequest }))
+vi.mock("@/lib/task-runtime-ui-extension", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react")
+  return {
+    TaskRuntimeSettingsExtension: () => ReactModule.createElement(
+      "section",
+      { "data-testid": "task-runtime-settings-extension" },
+      "runtime settings",
+    ),
+  }
+})
 
 afterEach(() => { cleanup(); vi.restoreAllMocks() })
 
@@ -46,6 +56,19 @@ describe("SettingsPage auth profile synchronization", () => {
     })
     if (created.status !== "created") throw new Error("expected session")
     authState.session = created.projection.snapshot
+  })
+
+  it("renders the distribution task runtime settings slot", async () => {
+    apiRequest.mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      user: authState.user,
+    }), { headers: { "Content-Type": "application/json" } }))
+
+    render(<SettingsPage />)
+
+    expect(screen.getByTestId("task-runtime-settings-extension")).toHaveTextContent(
+      "runtime settings",
+    )
   })
 
   it("does not apply an old profile response to a replacement login", async () => {

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -17,6 +17,7 @@ import { useAuth } from "@/contexts/auth-context"
 import { useI18n } from "@/contexts/i18n-context"
 import { Select } from "@/components/ui/select"
 import { inspectAuthSession, updateAuthSessionUser } from "@/lib/auth-cache"
+import { TaskRuntimeSettingsExtension } from "@/lib/task-runtime-ui-extension"
 
 export default function SettingsPage() {
   const { user, session } = useAuth()
@@ -83,6 +84,8 @@ export default function SettingsPage() {
       </div>
 
       <div className="space-y-6">
+        <TaskRuntimeSettingsExtension />
+
         {/* Language Section */}
         <Card>
           <CardHeader>

--- a/frontend/src/components/chat/ChatInput.runtime-extension.test.tsx
+++ b/frontend/src/components/chat/ChatInput.runtime-extension.test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper",
+  );
+  return { ...actual, apiRequest: apiRequestMock };
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
+  generateClientMessageId: () => "client-message-runtime",
+  getApiUrl: () => "http://api.local",
+  getUploadApiUrl: () => "http://upload.local",
+}));
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({ openFilePreview: vi.fn() }),
+}));
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ user: { id: "2", is_admin: false } }),
+}));
+
+vi.mock("@/components/config-dialog", () => ({
+  ConfigDialog: ({ trigger }: { trigger: unknown }) => trigger,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-file-mention", () => ({
+  useFileMention: () => ({
+    checkTrigger: vi.fn(),
+    dropdownPosition: null,
+    fileList: [],
+    filteredFiles: [],
+    handleKeyDown: vi.fn(() => false),
+    insertFile: vi.fn(),
+    isLoadingFiles: false,
+    resetMention: vi.fn(),
+    selectedFileIndex: 0,
+    showFilePicker: false,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/task-runtime-ui-extension", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react");
+  return {
+    hasTaskRuntimeComposerExtension: true,
+    TaskRuntimeComposerMenuExtension: ({
+      disabled,
+      onSelectionChange,
+      onRequestClose,
+    }: {
+      disabled: boolean;
+      onSelectionChange: (selection: unknown) => void;
+      onRequestClose: () => void;
+    }) => ReactModule.createElement("button", {
+      type: "button",
+      disabled,
+      onClick: () => {
+        onSelectionChange({
+          runtimeExtensions: { browser_relay: { target: "approved_tab" } },
+        });
+        onRequestClose();
+      },
+    }, "My browser"),
+    TaskRuntimeComposerSelectionExtension: ({ selection }: {
+      selection: unknown;
+    }) => selection
+      ? ReactModule.createElement("span", null, "My browser selected")
+      : null,
+  };
+});
+
+import { ChatInput } from "./ChatInput";
+
+describe("ChatInput task runtime UI extension", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset();
+    apiRequestMock.mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ));
+  });
+
+  it("submits a distribution-provided runtime without exposing local browser", async () => {
+    const onSend = vi.fn();
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect my signed-in tab"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+        taskConfig={{ model: "model-1" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"));
+    expect(screen.queryByText("chatPage.input.localBrowser.label")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "My browser" }));
+    expect(screen.getByText("My browser selected")).toBeInTheDocument();
+
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement);
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith(
+      "inspect my signed-in tab",
+      expect.objectContaining({
+        runtimeExtensions: {
+          browser_relay: { target: "approved_tab" },
+        },
+      }),
+    ));
+  });
+});

--- a/frontend/src/components/chat/ChatInput.runtime-extension.test.tsx
+++ b/frontend/src/components/chat/ChatInput.runtime-extension.test.tsx
@@ -62,8 +62,12 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/lib/task-runtime-ui-extension", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/task-runtime-ui-extension")
+  >("@/lib/task-runtime-ui-extension");
   const ReactModule = await vi.importActual<typeof import("react")>("react");
   return {
+    ...actual,
     hasTaskRuntimeComposerExtension: true,
     TaskRuntimeComposerMenuExtension: ({
       disabled,
@@ -96,6 +100,31 @@ vi.mock("@/lib/task-runtime-ui-extension", async () => {
 });
 
 import { ChatInput } from "./ChatInput";
+
+function enableLocalBrowserWindow() {
+  authUserMock.current = { id: "2", is_admin: true };
+  apiRequestMock.mockImplementation((url: string) => Promise.resolve(
+    new Response(JSON.stringify(
+      url === "http://api.local/api/computer/local-browser/readiness"
+        ? {
+            ready: true,
+            application: "Google Chrome",
+            windows: [{
+              pid: 100,
+              window_id: 20,
+              application: "Google Chrome",
+              title: "GitHub",
+            }],
+            issues: [],
+            message: "",
+          }
+        : [],
+    ), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  ));
+}
 
 describe("ChatInput task runtime UI extension", () => {
   beforeEach(() => {
@@ -144,28 +173,7 @@ describe("ChatInput task runtime UI extension", () => {
   });
 
   it("replaces a local-browser target when the selection slot chooses a runtime", async () => {
-    authUserMock.current = { id: "2", is_admin: true };
-    apiRequestMock.mockImplementation((url: string) => Promise.resolve(
-      new Response(JSON.stringify(
-        url === "http://api.local/api/computer/local-browser/readiness"
-          ? {
-              ready: true,
-              application: "Google Chrome",
-              windows: [{
-                pid: 100,
-                window_id: 20,
-                application: "Google Chrome",
-                title: "GitHub",
-              }],
-              issues: [],
-              message: "",
-            }
-          : [],
-      ), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    ));
+    enableLocalBrowserWindow();
     const onSend = vi.fn();
     const { container } = render(
       <ChatInput
@@ -184,6 +192,84 @@ describe("ChatInput task runtime UI extension", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Select My browser" }));
     expect(screen.queryByLabelText("Google Chrome · GitHub")).not.toBeInTheDocument();
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement);
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith(
+      "inspect my signed-in tab",
+      expect.objectContaining({
+        runtimeExtensions: {
+          browser_relay: { target: "approved_tab" },
+        },
+      }),
+    ));
+  });
+
+  it("clears an extension selection when a local-browser window is picked", async () => {
+    enableLocalBrowserWindow();
+    const onSend = vi.fn();
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect the selected window"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+        taskConfig={{ model: "model-1" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"));
+    fireEvent.click(screen.getByRole("button", { name: "My browser" }));
+    expect(screen.getByRole("button", { name: "My browser selected" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "My browser" })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"));
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"));
+    fireEvent.click(await screen.findByText("GitHub"));
+    expect(screen.getByLabelText("Google Chrome · GitHub")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Select My browser" })).toBeInTheDocument();
+
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement);
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith(
+      "inspect the selected window",
+      expect.objectContaining({
+        runtimeExtensions: {
+          local_browser: {
+            pid: 100,
+            window_id: 20,
+            application: "Google Chrome",
+            title: "GitHub",
+          },
+        },
+      }),
+    ));
+  });
+
+  it("clears a local-browser target when the menu chooses a runtime", async () => {
+    enableLocalBrowserWindow();
+    const onSend = vi.fn();
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect my signed-in tab"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+        taskConfig={{ model: "model-1" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"));
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"));
+    fireEvent.click(await screen.findByText("GitHub"));
+    expect(screen.getByLabelText("Google Chrome · GitHub")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"));
+    fireEvent.click(screen.getByRole("button", { name: "My browser" }));
+    expect(screen.queryByLabelText("Google Chrome · GitHub")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "My browser selected" })).toBeInTheDocument();
+
     fireEvent.submit(container.querySelector("form") as HTMLFormElement);
 
     await waitFor(() => expect(onSend).toHaveBeenCalledWith(

--- a/frontend/src/components/chat/ChatInput.runtime-extension.test.tsx
+++ b/frontend/src/components/chat/ChatInput.runtime-extension.test.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiRequestMock = vi.hoisted(() => vi.fn());
+const authUserMock = vi.hoisted(() => ({
+  current: { id: "2", is_admin: false },
+}));
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -28,7 +31,7 @@ vi.mock("@/contexts/app-context-chat", () => ({
 }));
 
 vi.mock("@/contexts/auth-context", () => ({
-  useAuth: () => ({ user: { id: "2", is_admin: false } }),
+  useAuth: () => ({ user: authUserMock.current }),
 }));
 
 vi.mock("@/components/config-dialog", () => ({
@@ -80,11 +83,15 @@ vi.mock("@/lib/task-runtime-ui-extension", async () => {
         onRequestClose();
       },
     }, "My browser"),
-    TaskRuntimeComposerSelectionExtension: ({ selection }: {
+    TaskRuntimeComposerSelectionExtension: ({ selection, onSelectionChange }: {
       selection: unknown;
-    }) => selection
-      ? ReactModule.createElement("span", null, "My browser selected")
-      : null,
+      onSelectionChange: (selection: unknown) => void;
+    }) => ReactModule.createElement("button", {
+      type: "button",
+      onClick: () => onSelectionChange({
+        runtimeExtensions: { browser_relay: { target: "approved_tab" } },
+      }),
+    }, selection ? "My browser selected" : "Select My browser"),
   };
 });
 
@@ -92,6 +99,7 @@ import { ChatInput } from "./ChatInput";
 
 describe("ChatInput task runtime UI extension", () => {
   beforeEach(() => {
+    authUserMock.current = { id: "2", is_admin: false };
     apiRequestMock.mockReset();
     apiRequestMock.mockImplementation(() => Promise.resolve(
       new Response(JSON.stringify([]), {
@@ -100,6 +108,8 @@ describe("ChatInput task runtime UI extension", () => {
       }),
     ));
   });
+
+  afterEach(() => cleanup());
 
   it("submits a distribution-provided runtime without exposing local browser", async () => {
     const onSend = vi.fn();
@@ -118,6 +128,62 @@ describe("ChatInput task runtime UI extension", () => {
     fireEvent.click(screen.getByRole("button", { name: "My browser" }));
     expect(screen.getByText("My browser selected")).toBeInTheDocument();
 
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement);
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith(
+      "inspect my signed-in tab",
+      expect.objectContaining({
+        runtimeExtensions: {
+          browser_relay: { target: "approved_tab" },
+        },
+      }),
+    ));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Select My browser" })).toBeInTheDocument();
+    });
+  });
+
+  it("replaces a local-browser target when the selection slot chooses a runtime", async () => {
+    authUserMock.current = { id: "2", is_admin: true };
+    apiRequestMock.mockImplementation((url: string) => Promise.resolve(
+      new Response(JSON.stringify(
+        url === "http://api.local/api/computer/local-browser/readiness"
+          ? {
+              ready: true,
+              application: "Google Chrome",
+              windows: [{
+                pid: 100,
+                window_id: 20,
+                application: "Google Chrome",
+                title: "GitHub",
+              }],
+              issues: [],
+              message: "",
+            }
+          : [],
+      ), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ));
+    const onSend = vi.fn();
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="inspect my signed-in tab"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+        taskConfig={{ model: "model-1" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("chatPage.input.actions.add"));
+    fireEvent.click(screen.getByText("chatPage.input.localBrowser.label"));
+    fireEvent.click(await screen.findByText("GitHub"));
+    expect(screen.getByLabelText("Google Chrome · GitHub")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select My browser" }));
+    expect(screen.queryByLabelText("Google Chrome · GitHub")).not.toBeInTheDocument();
     fireEvent.submit(container.querySelector("form") as HTMLFormElement);
 
     await waitFor(() => expect(onSend).toHaveBeenCalledWith(

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -591,6 +591,9 @@ export function ChatInput({
   const showTaskRuntimeExtension =
     hasTaskRuntimeComposerExtension && !readOnlyConfig && !hideConfig;
   const activeLocalBrowserTarget = showLocalBrowser ? localBrowserTarget : null;
+  const activeTaskRuntimeSelection = showTaskRuntimeExtension
+    ? taskRuntimeSelection
+    : null;
   useEffect(() => {
     if (!showLocalBrowser) setLocalBrowserTarget(null);
   }, [showLocalBrowser]);
@@ -699,7 +702,7 @@ export function ChatInput({
       const deliveryKey = JSON.stringify([
         messageToSend,
         activeLocalBrowserTarget,
-        taskRuntimeSelection?.runtimeExtensions || null,
+        activeTaskRuntimeSelection?.runtimeExtensions || null,
         enabledFiles.map((file) => [
           file.name,
           file.size,
@@ -715,13 +718,13 @@ export function ChatInput({
       const configToSend = {
         ...agentConfig,
         clientMessageId,
-        ...(activeLocalBrowserTarget || taskRuntimeSelection
+        ...(activeLocalBrowserTarget || activeTaskRuntimeSelection
           ? {
               runtimeExtensions: {
                 ...(agentConfig.runtimeExtensions || {}),
                 ...(activeLocalBrowserTarget
                   ? { local_browser: { ...activeLocalBrowserTarget } }
-                  : taskRuntimeSelection?.runtimeExtensions || {}),
+                  : activeTaskRuntimeSelection?.runtimeExtensions || {}),
               },
             }
           : {}),

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -17,6 +17,10 @@ import { toast } from "@/components/ui/sonner";
 import { useVoiceInputControls } from "@/components/voice-input-controller";
 import { LocalBrowserMenu, type LocalBrowserTarget } from "./LocalBrowserMenu";
 import {
+  hasTaskRuntimeComposerExtension,
+  type TaskRuntimeComposerSelection,
+} from "@/lib/task-runtime-ui-extension";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -163,6 +167,8 @@ export function ChatInput({
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
   const [localBrowserTarget, setLocalBrowserTarget] =
     useState<LocalBrowserTarget | null>(null);
+  const [taskRuntimeSelection, setTaskRuntimeSelection] =
+    useState<TaskRuntimeComposerSelection | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<HTMLDivElement>(null);
@@ -582,10 +588,15 @@ export function ChatInput({
     !allowsLiveGuidanceInput &&
     !isStoppedTaskStatus(normalizedTaskStatus);
   const showLocalBrowser = Boolean(user?.is_admin) && !readOnlyConfig && !hideConfig;
+  const showTaskRuntimeExtension =
+    hasTaskRuntimeComposerExtension && !readOnlyConfig && !hideConfig;
   const activeLocalBrowserTarget = showLocalBrowser ? localBrowserTarget : null;
   useEffect(() => {
     if (!showLocalBrowser) setLocalBrowserTarget(null);
   }, [showLocalBrowser]);
+  useEffect(() => {
+    if (!showTaskRuntimeExtension) setTaskRuntimeSelection(null);
+  }, [showTaskRuntimeExtension]);
   const voiceInputLabel =
     voiceInput.status === "recording"
       ? t("voiceInput.stop")
@@ -688,6 +699,7 @@ export function ChatInput({
       const deliveryKey = JSON.stringify([
         messageToSend,
         activeLocalBrowserTarget,
+        taskRuntimeSelection?.runtimeExtensions || null,
         enabledFiles.map((file) => [
           file.name,
           file.size,
@@ -703,11 +715,13 @@ export function ChatInput({
       const configToSend = {
         ...agentConfig,
         clientMessageId,
-        ...(activeLocalBrowserTarget
+        ...(activeLocalBrowserTarget || taskRuntimeSelection
           ? {
               runtimeExtensions: {
                 ...(agentConfig.runtimeExtensions || {}),
-                local_browser: { ...activeLocalBrowserTarget },
+                ...(activeLocalBrowserTarget
+                  ? { local_browser: { ...activeLocalBrowserTarget } }
+                  : taskRuntimeSelection?.runtimeExtensions || {}),
               },
             }
           : {}),
@@ -724,6 +738,7 @@ export function ChatInput({
       await onSend(messageToSend, configToSend);
       deliveryAttemptRef.current = null;
       setLocalBrowserTarget(null);
+      setTaskRuntimeSelection(null);
       fileMention.resetMention();
 
       if (isControlled) {
@@ -1120,7 +1135,9 @@ export function ChatInput({
                   </>
                 )}
                 {/* Add files or bind this new task to a local host window. */}
-                {(!hideFileUpload && !filesDisabled) || showLocalBrowser ? (
+                {(!hideFileUpload && !filesDisabled)
+                  || showLocalBrowser
+                  || showTaskRuntimeExtension ? (
                   <>
                     {!hideFileUpload && !filesDisabled && (
                       <input
@@ -1136,12 +1153,15 @@ export function ChatInput({
                       disabled={isInputBusy}
                       selectedTarget={localBrowserTarget}
                       onTargetChange={setLocalBrowserTarget}
+                      extensionSelection={taskRuntimeSelection}
+                      onExtensionSelectionChange={setTaskRuntimeSelection}
                       onAddFiles={
                         !hideFileUpload && !filesDisabled
                           ? () => fileInputRef.current?.click()
                           : undefined
                       }
                       showLocalBrowser={showLocalBrowser}
+                      showTaskRuntimeExtension={showTaskRuntimeExtension}
                     />
                   </>
                 ) : null}

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -699,10 +699,12 @@ export function ChatInput({
       const trimmed = message.trim();
       const messageToSend = trimmed;
       const executionMode = taskConfig?.executionMode;
+      const extraRuntimeExtensions = activeLocalBrowserTarget
+        ? { local_browser: { ...activeLocalBrowserTarget } }
+        : activeTaskRuntimeSelection?.runtimeExtensions;
       const deliveryKey = JSON.stringify([
         messageToSend,
-        activeLocalBrowserTarget,
-        activeTaskRuntimeSelection?.runtimeExtensions || null,
+        extraRuntimeExtensions || null,
         enabledFiles.map((file) => [
           file.name,
           file.size,
@@ -718,13 +720,11 @@ export function ChatInput({
       const configToSend = {
         ...agentConfig,
         clientMessageId,
-        ...(activeLocalBrowserTarget || activeTaskRuntimeSelection
+        ...(extraRuntimeExtensions
           ? {
               runtimeExtensions: {
                 ...(agentConfig.runtimeExtensions || {}),
-                ...(activeLocalBrowserTarget
-                  ? { local_browser: { ...activeLocalBrowserTarget } }
-                  : activeTaskRuntimeSelection?.runtimeExtensions || {}),
+                ...extraRuntimeExtensions,
               },
             }
           : {}),

--- a/frontend/src/components/chat/ChatMessage.test.tsx
+++ b/frontend/src/components/chat/ChatMessage.test.tsx
@@ -181,6 +181,26 @@ describe("ChatMessage Session file capability", () => {
     ).toBeInTheDocument()
   })
 
+  it("does not render distribution message metadata on assistant messages", () => {
+    render(
+      <ChatMessage
+        role="assistant"
+        content="I inspected your browser"
+        taskRuntimeExtensionMetadata={{
+          bindings: ["browser_relay"],
+          publicMetadata: {
+            browser_relay: { kind: "browser_relay", connected: true },
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText("I inspected your browser")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("note", { name: "Computer use · My browser" }),
+    ).not.toBeInTheDocument()
+  })
+
   it("uses the same safe projection for normal assistant DOM and copied content", () => {
     appContextMock.filesDisabled = true
     const { container } = render(

--- a/frontend/src/components/chat/ChatMessage.test.tsx
+++ b/frontend/src/components/chat/ChatMessage.test.tsx
@@ -38,6 +38,21 @@ vi.mock("@/lib/api-wrapper", () => ({
   apiRequest: apiRequestMock,
 }))
 
+vi.mock("@/lib/task-runtime-ui-extension", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react")
+  return {
+    TaskRuntimeMessageMetadataExtension: ({ bindings }: { bindings: string[] }) => (
+      bindings.includes("browser_relay")
+        ? ReactModule.createElement(
+          "div",
+          { role: "note", "aria-label": "Computer use · My browser" },
+          "My browser",
+        )
+        : null
+    ),
+  }
+})
+
 vi.mock("@/components/file/docx-preview-renderer", () => ({
   DocxPreviewRenderer: ({ base64Content }: { base64Content: string }) => (
     <div data-testid="docx-preview">{base64Content}</div>
@@ -143,6 +158,26 @@ describe("ChatMessage Session file capability", () => {
 
     expect(
       screen.getByRole("note", { name: "Computer use · Local browser" }),
+    ).toBeInTheDocument()
+  })
+
+  it("renders distribution message metadata without replacing the message", () => {
+    render(
+      <ChatMessage
+        role="user"
+        content="Inspect my browser"
+        taskRuntimeExtensionMetadata={{
+          bindings: ["browser_relay"],
+          publicMetadata: {
+            browser_relay: { kind: "browser_relay", connected: true },
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText("Inspect my browser")).toBeInTheDocument()
+    expect(
+      screen.getByRole("note", { name: "Computer use · My browser" }),
     ).toBeInTheDocument()
   })
 

--- a/frontend/src/components/chat/ChatMessage.test.tsx
+++ b/frontend/src/components/chat/ChatMessage.test.tsx
@@ -39,8 +39,12 @@ vi.mock("@/lib/api-wrapper", () => ({
 }))
 
 vi.mock("@/lib/task-runtime-ui-extension", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/task-runtime-ui-extension")
+  >("@/lib/task-runtime-ui-extension")
   const ReactModule = await vi.importActual<typeof import("react")>("react")
   return {
+    ...actual,
     TaskRuntimeMessageMetadataExtension: ({ bindings }: { bindings: string[] }) => (
       bindings.includes("browser_relay")
         ? ReactModule.createElement(

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -15,6 +15,10 @@ import { normalizeTimestampMs } from "@/lib/time-utils";
 import { FileChip } from "./FileChip";
 import { ClarificationForm } from "./clarification-form";
 import { isStoppedTraceProcessStatus, resolveTraceProcessStatus } from "@/lib/trace-process-status";
+import {
+  TaskRuntimeMessageMetadataExtension,
+  type TaskRuntimeMessageMetadataExtensionProps,
+} from "@/lib/task-runtime-ui-extension";
 
 const MARKDOWN_FILE_REF_RE = /\[([^\]]+)\]\(file:(?:\/\/)?([^)]+)\)/g;
 const BACKTICK_FILE_REF_RE = /`([^`]+)`/g;
@@ -88,6 +92,7 @@ export interface ChatMessageProps {
     label: string;
     detail: string;
   }>;
+  taskRuntimeExtensionMetadata?: TaskRuntimeMessageMetadataExtensionProps;
 }
 
 function GeneratingIndicator({ latestTitle, taskStatus }: { latestTitle?: string, taskStatus?: string }) {
@@ -309,6 +314,7 @@ export function ChatMessage({
   onAgentExecutionClick,
   onSendInteraction,
   contextBadges,
+  taskRuntimeExtensionMetadata,
 }: ChatMessageProps) {
   const { t, tDynamic } = useI18n();
   const { filesDisabled, openFilePreview } = useApp();
@@ -526,6 +532,11 @@ export function ChatMessage({
                     </div>
                   ))}
                 </div>
+              )}
+              {isUser && taskRuntimeExtensionMetadata && (
+                <TaskRuntimeMessageMetadataExtension
+                  {...taskRuntimeExtensionMetadata}
+                />
               )}
               {!isUser && interactions && interactions.length > 0 && (
                 <div className="mt-4 border-t pt-4">

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -334,8 +334,10 @@ export function LocalBrowserMenu({
         <TaskRuntimeComposerSelectionExtension
           disabled={disabled}
           selection={extensionSelection}
-          onSelectionChange={onExtensionSelectionChange}
-          onRequestClose={() => setOpen(false)}
+          onSelectionChange={(selection) => {
+            onExtensionSelectionChange(selection);
+            if (selection) onTargetChange(null);
+          }}
         />
       )}
     </div>

--- a/frontend/src/components/chat/LocalBrowserMenu.tsx
+++ b/frontend/src/components/chat/LocalBrowserMenu.tsx
@@ -14,6 +14,11 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useI18n } from "@/contexts/i18n-context";
 import { apiRequest } from "@/lib/api-wrapper";
+import {
+  TaskRuntimeComposerMenuExtension,
+  TaskRuntimeComposerSelectionExtension,
+  type TaskRuntimeComposerSelection,
+} from "@/lib/task-runtime-ui-extension";
 import { cn, getApiUrl } from "@/lib/utils";
 
 interface ReadinessIssue {
@@ -41,16 +46,24 @@ interface LocalBrowserMenuProps {
   disabled: boolean;
   selectedTarget: LocalBrowserTarget | null;
   onTargetChange: (target: LocalBrowserTarget | null) => void;
+  extensionSelection: TaskRuntimeComposerSelection | null;
+  onExtensionSelectionChange: (
+    selection: TaskRuntimeComposerSelection | null,
+  ) => void;
   onAddFiles?: () => void;
   showLocalBrowser: boolean;
+  showTaskRuntimeExtension: boolean;
 }
 
 export function LocalBrowserMenu({
   disabled,
   selectedTarget,
   onTargetChange,
+  extensionSelection,
+  onExtensionSelectionChange,
   onAddFiles,
   showLocalBrowser,
+  showTaskRuntimeExtension,
 }: LocalBrowserMenuProps) {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
@@ -236,6 +249,7 @@ export function LocalBrowserMenu({
                           disabled={localBrowserDisabled}
                           onClick={() => {
                             onTargetChange(browserWindow);
+                            onExtensionSelectionChange(null);
                             setShowWindowPicker(false);
                             setOpen(false);
                           }}
@@ -272,6 +286,17 @@ export function LocalBrowserMenu({
               </PopoverContent>
             </Popover>
           )}
+          {showTaskRuntimeExtension && (
+            <TaskRuntimeComposerMenuExtension
+              disabled={disabled}
+              selection={extensionSelection}
+              onSelectionChange={(selection) => {
+                onExtensionSelectionChange(selection);
+                if (selection) onTargetChange(null);
+              }}
+              onRequestClose={() => setOpen(false)}
+            />
+          )}
         </PopoverContent>
       </Popover>
 
@@ -304,6 +329,14 @@ export function LocalBrowserMenu({
             <X className="h-3 w-3" />
           </button>
         </div>
+      )}
+      {showTaskRuntimeExtension && (
+        <TaskRuntimeComposerSelectionExtension
+          disabled={disabled}
+          selection={extensionSelection}
+          onSelectionChange={onExtensionSelectionChange}
+          onRequestClose={() => setOpen(false)}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -365,6 +365,10 @@ describe("TaskConversationPanel", () => {
       "data-context-badges",
       JSON.stringify([]),
     )
+    expect(screen.getByTestId("chat-message")).toHaveAttribute(
+      "data-runtime-extension-metadata",
+      JSON.stringify({ bindings: [], publicMetadata: {} }),
+    )
   })
 
   it("disables every file surface and drops staged files when the capability is disabled", async () => {

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -110,6 +110,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     showProcessView,
     onOpenExecutionPlan,
     contextBadges,
+    taskRuntimeExtensionMetadata,
   }: {
     content?: string | null
     interactionsActive?: boolean
@@ -120,6 +121,10 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     showProcessView?: boolean
     onOpenExecutionPlan?: () => void
     contextBadges?: Array<{ kind: string; label: string; detail: string }>
+    taskRuntimeExtensionMetadata?: {
+      bindings: string[]
+      publicMetadata: Record<string, Record<string, unknown>>
+    }
   }) => (
     <div
       data-testid="chat-message"
@@ -130,6 +135,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
       data-show-empty-status={showEmptyStatus ? "true" : "false"}
       data-show-process-view={showProcessView ? "true" : "false"}
       data-context-badges={JSON.stringify(contextBadges || [])}
+      data-runtime-extension-metadata={JSON.stringify(taskRuntimeExtensionMetadata || {})}
     >
       {content}
       {onOpenExecutionPlan && traceEvents?.some((event) => {
@@ -275,6 +281,33 @@ describe("TaskConversationPanel", () => {
         label: "chatPage.input.localBrowser.chipLabel",
         detail: "chatPage.input.localBrowser.label",
       }]),
+    )
+  })
+
+  it("passes bindings and public metadata through the message extension slot", () => {
+    appState.messages = [{
+      id: "user-1",
+      role: "user",
+      content: "Inspect my browser",
+      timestamp: "2026-08-07T07:00:00Z",
+    }]
+    appState.currentTask = {
+      id: "42",
+      runtimeExtensionBindings: ["browser_relay"],
+    }
+    appState.taskRuntimeExtensions = {
+      browser_relay: { kind: "browser_relay", connected: true },
+    }
+    render(<TaskConversationPanel mode="page" />)
+
+    expect(screen.getByTestId("chat-message")).toHaveAttribute(
+      "data-runtime-extension-metadata",
+      JSON.stringify({
+        bindings: ["browser_relay"],
+        publicMetadata: {
+          browser_relay: { kind: "browser_relay", connected: true },
+        },
+      }),
     )
   })
 

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -772,7 +772,10 @@ export function TaskConversationPanel({
                         showEmptyStatus={item.showEmptyStatus}
                         contextBadges={item.role === "user" ? userMessageContextBadges : undefined}
                         taskRuntimeExtensionMetadata={item.role === "user" ? {
-                          bindings: state.currentTask?.runtimeExtensionBindings || [],
+                          bindings:
+                            state.currentTask?.id === String(state.taskId)
+                              ? state.currentTask.runtimeExtensionBindings || []
+                              : [],
                           publicMetadata: state.taskRuntimeExtensions || {},
                         } : undefined}
                         onOpenExecutionPlan={showDagPreview ? openDagPreview : undefined}

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -771,6 +771,10 @@ export function TaskConversationPanel({
                         interactionsActive={item.id === activeWaitingMessageId}
                         showEmptyStatus={item.showEmptyStatus}
                         contextBadges={item.role === "user" ? userMessageContextBadges : undefined}
+                        taskRuntimeExtensionMetadata={item.role === "user" ? {
+                          bindings: state.currentTask?.runtimeExtensionBindings || [],
+                          publicMetadata: state.taskRuntimeExtensions || {},
+                        } : undefined}
                         onOpenExecutionPlan={showDagPreview ? openDagPreview : undefined}
                         onAgentExecutionClick={onAgentExecutionClick}
                       />

--- a/frontend/src/lib/task-runtime-ui-extension.test.tsx
+++ b/frontend/src/lib/task-runtime-ui-extension.test.tsx
@@ -18,22 +18,40 @@ const composerProps = {
 };
 
 describe("default task runtime UI extension", () => {
-  it("keeps every optional UI slot inert in the OSS build", () => {
+  it("disables the composer extension in the OSS build", () => {
     expect(hasTaskRuntimeComposerExtension).toBe(false);
+  });
 
+  it("keeps the composer menu slot inert", () => {
     const { container } = render(
-      <>
-        <TaskRuntimeComposerMenuExtension {...composerProps} />
-        <TaskRuntimeComposerSelectionExtension {...composerProps} />
-        <TaskRuntimeSettingsExtension />
-        <TaskRuntimeMessageMetadataExtension
-          bindings={["local_browser"]}
-          publicMetadata={{ local_browser: { kind: "local_browser" } }}
-        />
-      </>,
+      <TaskRuntimeComposerMenuExtension {...composerProps} />,
     );
-
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("keeps the composer selection slot inert", () => {
+    const { container } = render(
+      <TaskRuntimeComposerSelectionExtension
+        disabled={composerProps.disabled}
+        selection={composerProps.selection}
+        onSelectionChange={composerProps.onSelectionChange}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("keeps the settings slot inert", () => {
+    const { container } = render(<TaskRuntimeSettingsExtension />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("keeps the message metadata slot inert", () => {
+    const { container } = render(
+      <TaskRuntimeMessageMetadataExtension
+        bindings={["local_browser"]}
+        publicMetadata={{ local_browser: { kind: "local_browser" } }}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/frontend/src/lib/task-runtime-ui-extension.test.tsx
+++ b/frontend/src/lib/task-runtime-ui-extension.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  TaskRuntimeComposerMenuExtension,
+  TaskRuntimeComposerSelectionExtension,
+  TaskRuntimeMessageMetadataExtension,
+  TaskRuntimeSettingsExtension,
+  hasTaskRuntimeComposerExtension,
+} from "./task-runtime-ui-extension";
+
+const composerProps = {
+  disabled: false,
+  selection: null,
+  onSelectionChange: vi.fn(),
+  onRequestClose: vi.fn(),
+};
+
+describe("default task runtime UI extension", () => {
+  it("keeps every optional UI slot inert in the OSS build", () => {
+    expect(hasTaskRuntimeComposerExtension).toBe(false);
+
+    const { container } = render(
+      <>
+        <TaskRuntimeComposerMenuExtension {...composerProps} />
+        <TaskRuntimeComposerSelectionExtension {...composerProps} />
+        <TaskRuntimeSettingsExtension />
+        <TaskRuntimeMessageMetadataExtension
+          bindings={["local_browser"]}
+          publicMetadata={{ local_browser: { kind: "local_browser" } }}
+        />
+      </>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+});

--- a/frontend/src/lib/task-runtime-ui-extension.tsx
+++ b/frontend/src/lib/task-runtime-ui-extension.tsx
@@ -1,0 +1,46 @@
+import type { ComponentType } from "react";
+
+export type TaskRuntimeExtensionConfiguration = Record<
+  string,
+  Record<string, unknown>
+>;
+
+export interface TaskRuntimeComposerSelection {
+  runtimeExtensions: TaskRuntimeExtensionConfiguration;
+}
+
+export interface TaskRuntimeComposerExtensionProps {
+  disabled: boolean;
+  selection: TaskRuntimeComposerSelection | null;
+  onSelectionChange: (
+    selection: TaskRuntimeComposerSelection | null,
+  ) => void;
+  onRequestClose: () => void;
+}
+
+export interface TaskRuntimeMessageMetadataExtensionProps {
+  bindings: readonly string[];
+  publicMetadata: Readonly<Record<string, Record<string, unknown>>>;
+}
+
+/**
+ * Build-time extension points for distributions that provide additional
+ * task-scoped runtimes. The OSS implementation is deliberately inert. A
+ * composed distribution may replace this module without overriding the
+ * composer, Settings page, or conversation panel themselves.
+ */
+export const hasTaskRuntimeComposerExtension = false;
+
+export const TaskRuntimeComposerMenuExtension: ComponentType<
+  TaskRuntimeComposerExtensionProps
+> = () => null;
+
+export const TaskRuntimeComposerSelectionExtension: ComponentType<
+  TaskRuntimeComposerExtensionProps
+> = () => null;
+
+export const TaskRuntimeSettingsExtension: ComponentType = () => null;
+
+export const TaskRuntimeMessageMetadataExtension: ComponentType<
+  TaskRuntimeMessageMetadataExtensionProps
+> = () => null;

--- a/frontend/src/lib/task-runtime-ui-extension.tsx
+++ b/frontend/src/lib/task-runtime-ui-extension.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ComponentType } from "react";
 
 export type TaskRuntimeExtensionConfiguration = Record<
@@ -35,8 +37,14 @@ export interface TaskRuntimeMessageMetadataExtensionProps {
  * task-scoped runtimes. The OSS implementation is deliberately inert. A
  * composed distribution may replace this module without overriding the
  * composer, Settings page, or conversation panel themselves.
+ *
+ * Replacements must preserve every export in this module, accept a null
+ * composer selection, and render safely when metadata collections are empty.
+ * `hasTaskRuntimeComposerExtension` controls whether the composer menu and
+ * selected-state slots are mounted; the Settings and message slots are
+ * mounted independently at their respective integration points.
  */
-export const hasTaskRuntimeComposerExtension = false;
+export const hasTaskRuntimeComposerExtension: boolean = false;
 
 export const TaskRuntimeComposerMenuExtension: ComponentType<
   TaskRuntimeComposerMenuExtensionProps

--- a/frontend/src/lib/task-runtime-ui-extension.tsx
+++ b/frontend/src/lib/task-runtime-ui-extension.tsx
@@ -9,14 +9,21 @@ export interface TaskRuntimeComposerSelection {
   runtimeExtensions: TaskRuntimeExtensionConfiguration;
 }
 
-export interface TaskRuntimeComposerExtensionProps {
+interface TaskRuntimeComposerBaseProps {
   disabled: boolean;
   selection: TaskRuntimeComposerSelection | null;
   onSelectionChange: (
     selection: TaskRuntimeComposerSelection | null,
   ) => void;
+}
+
+export interface TaskRuntimeComposerMenuExtensionProps
+  extends TaskRuntimeComposerBaseProps {
   onRequestClose: () => void;
 }
+
+export type TaskRuntimeComposerSelectionExtensionProps =
+  TaskRuntimeComposerBaseProps;
 
 export interface TaskRuntimeMessageMetadataExtensionProps {
   bindings: readonly string[];
@@ -32,11 +39,11 @@ export interface TaskRuntimeMessageMetadataExtensionProps {
 export const hasTaskRuntimeComposerExtension = false;
 
 export const TaskRuntimeComposerMenuExtension: ComponentType<
-  TaskRuntimeComposerExtensionProps
+  TaskRuntimeComposerMenuExtensionProps
 > = () => null;
 
 export const TaskRuntimeComposerSelectionExtension: ComponentType<
-  TaskRuntimeComposerExtensionProps
+  TaskRuntimeComposerSelectionExtensionProps
 > = () => null;
 
 export const TaskRuntimeSettingsExtension: ComponentType = () => null;


### PR DESCRIPTION
## What this PR does

- adds one build-time replacement module for task-runtime UI contributions
- exposes composer menu and selected-state slots that can contribute runtime extension configuration without replacing `ChatInput`
- exposes a Settings slot without replacing the Settings page
- exposes a user-message metadata renderer slot without replacing `ChatMessage` or the conversation panel
- keeps the OSS implementation inert while preserving the built-in Local browser flow

## Boundary

This is an extensibility-only PR. It does **not** add Browser Relay, a Chrome extension, pairing, WebSocket or Redis transport, Desktop Relay, a macOS companion, or any closed-source runtime provider. It also does not change backend task-runtime lifecycle or persistence.

The purpose is to let composed distributions supply those UIs from an overlay without copying core frontend files.

## Validation

- `npm run type-check`
- `npm run lint`
- focused Vitest suite: 73 tests passed
- `pre-commit run --files ...` for all changed files