### PR TITLE
fix(agent): disclose evidence dropped by compaction and allow re-grounding

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -43,6 +43,7 @@ COMPACT_SUMMARY_MAX_TOKENS = 1024
 COMPACT_SUMMARY_MIN_TOKENS = 256
 COMPACT_CONTEXT_REF_MAX_TOKENS = 2048
 COMPACT_DROPPED_REF_NOTICE_MAX_CHARS = 2048
+COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES = 20
 
 
 def _utcnow() -> datetime:
@@ -997,14 +998,28 @@ class ExecutionContext:
         original_count = len(self.messages)
         if self.compact_config.strategy == "truncate":
             keep_count = min(max(0, self.compact_config.max_messages), original_count)
-            self.messages = self._tail_window_preserving_tool_pairs(keep_count)
-            removed = max(0, original_count - len(self.messages))
+            retained = self._tail_window_preserving_tool_pairs(keep_count)
+            removed = max(0, original_count - len(retained))
+            # The window is a suffix minus any interior tool fragments sanitized
+            # out of it, so diff by object identity rather than slicing a prefix.
+            retained_ids = {id(message) for message in retained}
+            dropped_tool_counts = self._dropped_tool_result_counts(
+                [
+                    message
+                    for message in self.messages
+                    if id(message) not in retained_ids
+                ]
+            )
+            self.messages = retained
             return CompactResult(
                 compacted=True,
                 original_count=original_count,
                 final_count=len(self.messages),
                 strategy="truncate",
-                metadata={"removed_count": removed},
+                metadata={
+                    "removed_count": removed,
+                    "dropped_tool_result_count": sum(dropped_tool_counts.values()),
+                },
             )
 
         return CompactResult(
@@ -1049,18 +1064,27 @@ class ExecutionContext:
             self._context_refs_removed_by_compaction(latest_user)
         )
         dropped_refs_notice = self._dropped_context_refs_notice(dropped_context_refs)
+        dropped_tool_counts = self._dropped_tool_result_counts(self.messages)
+        dropped_tools_notice = self._dropped_tool_results_notice(dropped_tool_counts)
         summary_content = (
             "Compacted conversation summary:\n"
             f"{summary}\n\n"
             "Use this summary as the current execution state. Continue from the "
             "remaining work described here; do not repeat completed tool calls or "
             "regenerate completed artifacts unless the latest user request "
-            "explicitly asks to restart, revise, or regenerate them. Current system "
-            "instructions still take precedence, and the latest user request remains "
-            "the overall goal."
+            "explicitly asks to restart, revise, or regenerate them, or the detail "
+            "you need was lost in compaction. This summary is a lossy paraphrase of "
+            "the raw history, not the history itself: when the answer needs an exact "
+            "value, figure, statistic, table row, quotation, or identifier that this "
+            "summary does not literally contain, re-run the tool that produced it "
+            "instead of reconstructing the value from this summary or from memory. "
+            "Current system instructions still take precedence, and the latest user "
+            "request remains the overall goal."
         )
         if dropped_refs_notice:
             summary_content = f"{summary_content}\n\n{dropped_refs_notice}"
+        if dropped_tools_notice:
+            summary_content = f"{summary_content}\n\n{dropped_tools_notice}"
         summary_message = Message.role_system(
             summary_content,
             metadata={"compacted_context": True},
@@ -1081,6 +1105,7 @@ class ExecutionContext:
                 "compact_model": getattr(llm, "model_name", None),
                 "retained_context_ref_count": len(compacted_context_refs),
                 "dropped_context_ref_count": len(dropped_context_refs),
+                "dropped_tool_result_count": sum(dropped_tool_counts.values()),
             },
         )
         if original_tokens is not None:
@@ -1151,6 +1176,49 @@ class ExecutionContext:
             current_chars += len(line) + 1
         if omitted:
             lines.append(f"- ... {omitted} additional older reference(s) omitted")
+        return prefix + "\n".join(lines)
+
+    @staticmethod
+    def _dropped_tool_result_counts(messages: list[Message]) -> dict[str, int]:
+        """Count visible tool observations, keyed by tool name.
+
+        Hidden messages are excluded: they were already absent from the prompt
+        before compaction, so reporting them as newly dropped would be wrong.
+        """
+        counts: dict[str, int] = {}
+        for message in messages:
+            if message.hidden or message.role != "tool":
+                continue
+            metadata = message.metadata or {}
+            name = str(metadata.get("tool_name") or "").strip() or "unnamed tool"
+            counts[name] = counts.get(name, 0) + 1
+        return counts
+
+    @staticmethod
+    def _dropped_tool_results_notice(counts: dict[str, int]) -> str:
+        """Describe the tool observations this compaction removes from context.
+
+        Without this, the summary silently replaces every retrieved value and
+        the agent cannot tell a remembered figure from an invented one.
+        """
+        if not counts:
+            return ""
+        ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        listed = ordered[:COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES]
+        lines = [
+            f"- {name} x{count}" if count > 1 else f"- {name}" for name, count in listed
+        ]
+        omitted = len(ordered) - len(listed)
+        if omitted:
+            lines.append(f"- ... {omitted} additional tool(s) omitted")
+        total = sum(counts.values())
+        prefix = (
+            f"Raw observations from {total} completed tool call(s) were dropped by "
+            "this compaction. Their exact values are no longer in context; only the "
+            "summary above describes them. Treat any figure not literally present in "
+            "that summary as unavailable rather than recalled. Tools whose results "
+            "were dropped:\n"
+        )
         return prefix + "\n".join(lines)
 
     def _latest_visible_user_message(self) -> Message | None:

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -1180,16 +1180,20 @@ class ExecutionContext:
 
     @staticmethod
     def _dropped_tool_result_counts(messages: list[Message]) -> dict[str, int]:
-        """Count visible tool observations, keyed by tool name.
+        """Count tool observations whose raw result this compaction discards.
 
-        Hidden messages are excluded: they were already absent from the prompt
-        before compaction, so reporting them as newly dropped would be wrong.
+        Superseded observations are excluded: a later observation already
+        replaced their content and ``raw_result``, so compacting them away
+        destroys no evidence and counting them would overstate the loss.
+        Hidden messages are excluded because they are not in the prompt at all.
         """
         counts: dict[str, int] = {}
         for message in messages:
-            if message.hidden or message.role != "tool":
-                continue
             metadata = message.metadata or {}
+            if message.hidden or metadata.get("superseded"):
+                continue
+            if message.role != "tool":
+                continue
             name = str(metadata.get("tool_name") or "").strip() or "unnamed tool"
             counts[name] = counts.get(name, 0) + 1
         return counts

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from enum import Enum
@@ -25,6 +26,7 @@ from ..language import (
     output_language_policy,
     response_language_rules,
 )
+from ..result import CONTROL_TOOL_NAMES, tool_result_succeeded
 from .components import (
     COMPONENT_LOADERS,
     ExecutionComponent,
@@ -36,13 +38,23 @@ from .components import (
 from .enrichment import MEMORY_CONTEXT_METADATA_KEY, SKILL_CONTEXT_METADATA_KEY
 from .memory_tool import MEMORY_TOOLS_METADATA_KEY
 from .message import LLMCallRecord, Message
-from .skill_tool import LOADED_SKILLS_METADATA_KEY, SKILL_INDEX_METADATA_KEY
+from .skill_tool import (
+    LOAD_SKILL_TOOL_NAME,
+    LOADED_SKILLS_METADATA_KEY,
+    SKILL_INDEX_METADATA_KEY,
+)
 
 READ_FILE_CONTEXT_LIMIT = 12_000
 COMPACT_SUMMARY_MAX_TOKENS = 1024
 COMPACT_SUMMARY_MIN_TOKENS = 256
 COMPACT_CONTEXT_REF_MAX_TOKENS = 2048
 COMPACT_DROPPED_REF_NOTICE_MAX_CHARS = 2048
+COMPACT_DROPPED_TOOL_NOTICE_MAX_CHARS = 1024
+COMPACT_DROPPED_TOOL_NAME_MAX_CHARS = 64
+
+# load_skill retrieves guidance, not evidence, and re-running it restores
+# nothing a dropped observation held.
+NON_EVIDENCE_TOOL_NAMES = CONTROL_TOOL_NAMES | {LOAD_SKILL_TOOL_NAME}
 COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES = 20
 
 
@@ -1019,6 +1031,7 @@ class ExecutionContext:
                 metadata={
                     "removed_count": removed,
                     "dropped_tool_result_count": sum(dropped_tool_counts.values()),
+                    "dropped_tool_results_by_name": dropped_tool_counts,
                 },
             )
 
@@ -1064,6 +1077,9 @@ class ExecutionContext:
             self._context_refs_removed_by_compaction(latest_user)
         )
         dropped_refs_notice = self._dropped_context_refs_notice(dropped_context_refs)
+        # next_messages below keeps only the system summary and, at most, a
+        # role=="user" message, so no tool observation survives: here the whole
+        # list is the diff. truncate needs a real diff; this does not.
         dropped_tool_counts = self._dropped_tool_result_counts(self.messages)
         dropped_tools_notice = self._dropped_tool_results_notice(dropped_tool_counts)
         summary_content = (
@@ -1076,8 +1092,11 @@ class ExecutionContext:
             "you need was lost in compaction. This summary is a lossy paraphrase of "
             "the raw history, not the history itself: when the answer needs an exact "
             "value, figure, statistic, table row, quotation, or identifier that this "
-            "summary does not literally contain, re-run the tool that produced it "
+            "summary does not literally contain, re-read or re-query the source "
             "instead of reconstructing the value from this summary or from memory. "
+            "Only re-run tools that read; if the value came from a tool that writes, "
+            "sends, executes, or otherwise changes state, do not re-run it -- re-read "
+            "the artifact it produced, or report the value as unavailable. "
             "Current system instructions still take precedence, and the latest user "
             "request remains the overall goal."
         )
@@ -1106,6 +1125,7 @@ class ExecutionContext:
                 "retained_context_ref_count": len(compacted_context_refs),
                 "dropped_context_ref_count": len(dropped_context_refs),
                 "dropped_tool_result_count": sum(dropped_tool_counts.values()),
+                "dropped_tool_results_by_name": dropped_tool_counts,
             },
         )
         if original_tokens is not None:
@@ -1186,17 +1206,28 @@ class ExecutionContext:
         replaced their content and ``raw_result``, so compacting them away
         destroys no evidence and counting them would overstate the loss.
         Hidden messages are excluded because they are not in the prompt at all.
+        Failed and cancelled calls are excluded because they never produced a
+        value to lose, and telling the model they did would let it read a
+        failure as already-succeeded. Control pseudo-tools are excluded because
+        re-running one ends the run or re-contacts the user rather than
+        restoring evidence.
         """
-        counts: dict[str, int] = {}
+        names: list[str] = []
         for message in messages:
+            if message.role != "tool":
+                continue
             metadata = message.metadata or {}
             if message.hidden or metadata.get("superseded"):
                 continue
-            if message.role != "tool":
+            if not tool_result_succeeded(metadata.get("raw_result")):
                 continue
-            name = str(metadata.get("tool_name") or "").strip() or "unnamed tool"
-            counts[name] = counts.get(name, 0) + 1
-        return counts
+            # Whitespace-only names would silently fragment the aggregation,
+            # so normalize before using the name as a key.
+            name = " ".join(str(metadata.get("tool_name") or "").split())
+            if name in NON_EVIDENCE_TOOL_NAMES:
+                continue
+            names.append(name or "unnamed tool")
+        return dict(Counter(names))
 
     @staticmethod
     def _dropped_tool_results_notice(counts: dict[str, int]) -> str:
@@ -1207,22 +1238,36 @@ class ExecutionContext:
         """
         if not counts:
             return ""
-        ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
-        listed = ordered[:COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES]
-        lines = [
-            f"- {name} x{count}" if count > 1 else f"- {name}" for name, count in listed
-        ]
-        omitted = len(ordered) - len(listed)
-        if omitted:
-            lines.append(f"- ... {omitted} additional tool(s) omitted")
         total = sum(counts.values())
+        call_label = "call was" if total == 1 else "calls were"
         prefix = (
-            f"Raw observations from {total} completed tool call(s) were dropped by "
-            "this compaction. Their exact values are no longer in context; only the "
+            f"Raw observations from {total} tool {call_label} dropped by this "
+            "compaction. Their exact values are no longer in context; only the "
             "summary above describes them. Treat any figure not literally present in "
             "that summary as unavailable rather than recalled. Tools whose results "
             "were dropped:\n"
         )
+        # Tool names can come from dynamic MCP server config, so bound both the
+        # per-name length and the total notice size the way the sibling
+        # reference notice does.
+        ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        listed = ordered[:COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES]
+        lines: list[str] = []
+        current_chars = len(prefix)
+        omitted = len(ordered) - len(listed)
+        for name, count in listed:
+            clamped = name[:COMPACT_DROPPED_TOOL_NAME_MAX_CHARS]
+            line = f"- {clamped} x{count}" if count > 1 else f"- {clamped}"
+            if current_chars + len(line) + 1 > COMPACT_DROPPED_TOOL_NOTICE_MAX_CHARS:
+                omitted += 1
+                continue
+            lines.append(line)
+            current_chars += len(line) + 1
+        if omitted:
+            name_label = "name" if omitted == 1 else "names"
+            lines.append(
+                f"- ... {omitted} additional distinct tool {name_label} omitted"
+            )
         return prefix + "\n".join(lines)
 
     def _latest_visible_user_message(self) -> Message | None:

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -54,7 +54,11 @@ from ...context.enrichment import (
 from ...context.memory_tool import build_memory_tools
 from ...context.skill_tool import build_load_skill_tool
 from ...language import final_answer_language_rule
-from ...result import tool_result_succeeded, unwrap_final_answer_content
+from ...result import (
+    CONTROL_TOOL_NAMES,
+    tool_result_succeeded,
+    unwrap_final_answer_content,
+)
 from ...runtime import (
     ExecutionInterrupted,
     LLMCallInterrupted,
@@ -1658,7 +1662,7 @@ class ReActPattern(AgentPattern):
         return [*external_tools, *self._builtin_tool_schemas()]
 
     def _control_tool_names(self) -> set[str]:
-        return {"final_answer", "send_message", "ask_user_question"}
+        return set(CONTROL_TOOL_NAMES)
 
     async def _handle_control_tool(
         self,

--- a/src/xagent/core/agent/result.py
+++ b/src/xagent/core/agent/result.py
@@ -12,6 +12,18 @@ TOOL_FAILURE_CODES = frozenset(
     }
 )
 
+# Pseudo-tools that drive the run rather than retrieve evidence. They flow
+# through ``add_tool_result`` like real tools, so anything reasoning about
+# retrieved evidence has to exclude them: "re-running" one of these ends the
+# run or re-contacts the user instead of re-fetching a value.
+CONTROL_TOOL_NAMES = frozenset(
+    {
+        "final_answer",
+        "send_message",
+        "ask_user_question",
+    }
+)
+
 # Placeholder outputs the execution layers substitute when a run produced no
 # text of its own. They are recognized, not produced, by the delegation
 # classifier: a child that returns one of these completed without answering.

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -27,7 +27,7 @@ from xagent.core.agent.language import (
     response_language_rules,
 )
 from xagent.core.agent.utils.context_builder import ContextBuilder
-from xagent.core.context_ref import SUPERSEDES_SCOPE_KEY
+from xagent.core.context_ref import CONTEXT_REFS_KEY, SUPERSEDES_SCOPE_KEY
 from xagent.web.user_isolated_memory import current_user_id
 
 
@@ -760,7 +760,8 @@ def test_compact_with_llm_summarizes_history_and_preserves_current_user() -> Non
     assert "current execution state" in ctx.messages[0].content
     assert "do not repeat completed tool calls" in ctx.messages[0].content
     assert "lost in compaction" in ctx.messages[0].content
-    assert "re-run the tool that produced it" in ctx.messages[0].content
+    assert "re-read or re-query the source" in ctx.messages[0].content
+    assert "Only re-run tools that read" in ctx.messages[0].content
     assert "- read_file" in ctx.messages[0].content
     assert result.metadata["dropped_tool_result_count"] == 1
     assert ctx.messages[1].role == "user"
@@ -795,12 +796,16 @@ def test_compact_with_llm_reports_dropped_tool_results_by_name() -> None:
     result = ctx.compact_with_llm_response({"content": "Collected KPI inputs."})
 
     notice = ctx.messages[0].content
-    assert "3 completed tool call(s) were dropped" not in notice
-    assert "4 completed tool call(s) were dropped" in notice
+    assert "3 tool calls were dropped" not in notice
+    assert "4 tool calls were dropped" in notice
     assert "- web_search x3" in notice
     assert "- read_file" in notice
     assert "unavailable rather than recalled" in notice
     assert result.metadata["dropped_tool_result_count"] == 4
+    assert result.metadata["dropped_tool_results_by_name"] == {
+        "web_search": 3,
+        "read_file": 1,
+    }
 
 
 def test_compact_with_llm_omits_tool_notice_without_tool_results() -> None:
@@ -841,10 +846,165 @@ def test_compact_with_llm_excludes_superseded_tool_results_from_notice() -> None
     result = ctx.compact_with_llm_response({"content": "Inspected the dashboard."})
 
     notice = ctx.messages[0].content
-    assert "1 completed tool call(s) were dropped" in notice
-    assert "- computer\n" in f"{notice}\n"
+    assert "1 tool call were dropped" not in notice
+    assert "Raw observations from 1 tool call was dropped" in notice
     assert "- computer x" not in notice
     assert result.metadata["dropped_tool_result_count"] == 1
+    assert result.metadata["dropped_tool_results_by_name"] == {"computer": 1}
+
+
+def test_compact_with_llm_excludes_failed_tool_results_from_notice() -> None:
+    """A failed call produced no value, so it is not lost evidence.
+
+    Counting it would also let the model read a failure as an
+    already-completed call and skip the retry.
+    """
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Fetch the KPI rows")
+    for call_id, result_payload in (
+        ("call-fail", {"success": False, "error": "timeout"}),
+        ("call-cancel", {"success": False, "status": "cancelled"}),
+        ("call-error", {"status": "error", "message": "bad request"}),
+        ("call-ok", {"output": "revenue 1234"}),
+    ):
+        ctx.add_assistant_message(
+            "",
+            tool_calls=[
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "web_search"},
+                }
+            ],
+        )
+        ctx.add_tool_result("web_search", result_payload, call_id)
+
+    result = ctx.compact_with_llm_response({"content": "Fetched rows."})
+
+    notice = ctx.messages[0].content
+    assert "Raw observations from 1 tool call was dropped" in notice
+    # The old wording called every dropped call "completed", which a model
+    # could read as "this failure already succeeded, skip the retry".
+    assert "completed tool call(s) were dropped" not in notice
+    assert result.metadata["dropped_tool_result_count"] == 1
+
+
+def test_compact_with_llm_excludes_control_tools_from_notice() -> None:
+    """Re-running a control pseudo-tool re-contacts the user or ends the run."""
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Summarize and tell me")
+    for call_id, tool_name in (
+        ("call-send", "send_message"),
+        ("call-ask", "ask_user_question"),
+        ("call-skill", "load_skill"),
+        ("call-final", "final_answer"),
+        ("call-search", "web_search"),
+    ):
+        ctx.add_assistant_message(
+            "",
+            tool_calls=[
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool_name},
+                }
+            ],
+        )
+        ctx.add_tool_result(tool_name, {"output": "ok"}, call_id)
+
+    result = ctx.compact_with_llm_response({"content": "Answered."})
+
+    notice = ctx.messages[0].content
+    assert "Raw observations from 1 tool call was dropped" in notice
+    assert "- web_search" in notice
+    for control_name in ("send_message", "ask_user_question", "load_skill"):
+        assert control_name not in notice
+    assert result.metadata["dropped_tool_result_count"] == 1
+
+
+def test_compact_with_llm_names_tool_result_without_tool_name() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Run it")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[{"id": "call-1", "type": "function", "function": {"name": ""}}],
+    )
+    ctx.add_tool_result("   ", {"output": "rows"}, "call-1")
+
+    result = ctx.compact_with_llm_response({"content": "Ran it."})
+
+    assert "- unnamed tool" in ctx.messages[0].content
+    assert result.metadata["dropped_tool_results_by_name"] == {"unnamed tool": 1}
+
+
+def test_compact_with_llm_caps_and_clamps_dropped_tool_names() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Run many tools")
+    long_name = "mcp_" + ("x" * 200)
+    tool_names = [long_name] + [f"tool_{index:02d}" for index in range(25)]
+    for index, tool_name in enumerate(tool_names):
+        call_id = f"call-{index}"
+        ctx.add_assistant_message(
+            "",
+            tool_calls=[
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool_name},
+                }
+            ],
+        )
+        ctx.add_tool_result(tool_name, {"output": f"rows {index}"}, call_id)
+
+    result = ctx.compact_with_llm_response({"content": "Ran many tools."})
+
+    notice = ctx.messages[0].content
+    assert "additional distinct tool names omitted" in notice
+    assert long_name not in notice
+    assert len(notice) < 4000
+    assert result.metadata["dropped_tool_result_count"] == len(tool_names)
+
+
+def test_compact_with_llm_orders_ref_notice_before_tool_notice() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Look at the screenshot")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "generate_image"}}
+        ],
+    )
+    ctx.add_tool_result(
+        "generate_image",
+        {
+            "success": True,
+            CONTEXT_REFS_KEY: [
+                {
+                    "type": "image",
+                    "file_ref": {
+                        "file_id": "file-1",
+                        "filename": "chart.png",
+                        "mime_type": "image/png",
+                    },
+                }
+            ],
+        },
+        "call-1",
+    )
+
+    ctx.compact_with_llm_response({"content": "Generated a chart."})
+
+    notice = ctx.messages[0].content
+    assert "will not be automatically rematerialized" in notice
+    assert "dropped by this compaction" in notice
+    assert notice.index("will not be automatically rematerialized") < notice.index(
+        "dropped by this compaction"
+    )
 
 
 def test_compact_with_llm_ignores_hidden_tool_results_in_notice() -> None:
@@ -884,6 +1044,65 @@ def test_compact_truncate_counts_dropped_tool_results() -> None:
 
     assert result.strategy == "truncate"
     assert result.metadata["dropped_tool_result_count"] == 1
+
+
+def test_compact_truncate_counts_tool_result_excised_from_window_interior() -> None:
+    """The retained window is not always a suffix of the message list.
+
+    An assistant message whose tool calls were not all answered is sanitized
+    out of the window together with its tool messages, so a tool result can be
+    dropped from the *interior* of the window. Counting by prefix slice would
+    report zero here; only an identity diff sees the loss.
+    """
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.compact_config.max_messages = 5
+    ctx.add_user_message("u0")
+    ctx.add_user_message("u1")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "a1", "type": "function", "function": {"name": "web_search"}},
+            {"id": "a2", "type": "function", "function": {"name": "web_search"}},
+        ],
+    )
+    ctx.add_tool_result("web_search", {"output": "revenue rows"}, "a1")
+    ctx.add_user_message("u2")
+    ctx.add_user_message("u3")
+
+    result = ctx.compact_if_needed()
+
+    assert [message.content for message in ctx.messages] == ["u1", "u2", "u3"]
+    # messages[start:] would have been [tool, u2, u3]; the incomplete tool-call
+    # block is excised from inside it, so the prefix messages[:start] does not
+    # contain the dropped observation.
+    assert result.metadata["dropped_tool_result_count"] == 1
+    assert result.metadata["dropped_tool_results_by_name"] == {"web_search": 1}
+
+
+def test_compact_truncate_adds_no_in_prompt_notice() -> None:
+    """truncate keeps an exact message count; a notice would break that."""
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.compact_config.max_messages = 2
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "web_search"}}
+        ],
+    )
+    ctx.add_tool_result("web_search", {"output": "dropped rows"}, "call-1")
+    ctx.add_user_message("tail-0")
+    ctx.add_user_message("tail-1")
+
+    result = ctx.compact_if_needed()
+
+    assert result.metadata["dropped_tool_result_count"] == 1
+    assert len(ctx.messages) == 2
+    assert all(
+        "were dropped by this compaction" not in str(message.content)
+        for message in ctx.messages
+    )
 
 
 def test_compact_with_llm_preserves_waiting_for_user_response() -> None:

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 
 import pytest
 
@@ -757,8 +758,98 @@ def test_compact_with_llm_summarizes_history_and_preserves_current_user() -> Non
     assert "Used read_file" in ctx.messages[0].content
     assert "current execution state" in ctx.messages[0].content
     assert "do not repeat completed tool calls" in ctx.messages[0].content
+    assert "lost in compaction" in ctx.messages[0].content
+    assert "re-run the tool that produced it" in ctx.messages[0].content
+    assert "- read_file" in ctx.messages[0].content
+    assert result.metadata["dropped_tool_result_count"] == 1
     assert ctx.messages[1].role == "user"
     assert ctx.messages[1].content == "current request"
+
+
+def test_compact_with_llm_reports_dropped_tool_results_by_name() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Build a KPI report")
+    for index in range(3):
+        call_id = f"call-search-{index}"
+        ctx.add_assistant_message(
+            "",
+            tool_calls=[
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "web_search"},
+                }
+            ],
+        )
+        ctx.add_tool_result("web_search", {"output": f"rows {index}"}, call_id)
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-read", "type": "function", "function": {"name": "read_file"}}
+        ],
+    )
+    ctx.add_tool_result("read_file", {"output": "revenue 1234"}, "call-read")
+
+    result = ctx.compact_with_llm_response({"content": "Collected KPI inputs."})
+
+    notice = ctx.messages[0].content
+    assert "3 completed tool call(s) were dropped" not in notice
+    assert "4 completed tool call(s) were dropped" in notice
+    assert "- web_search x3" in notice
+    assert "- read_file" in notice
+    assert "unavailable rather than recalled" in notice
+    assert result.metadata["dropped_tool_result_count"] == 4
+
+
+def test_compact_with_llm_omits_tool_notice_without_tool_results() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Say hello")
+    ctx.add_assistant_message("Hello.")
+
+    ctx.compact_with_llm_response({"content": "Greeted the user."})
+
+    assert "were dropped by this compaction" not in ctx.messages[0].content
+
+
+def test_compact_with_llm_ignores_hidden_tool_results_in_notice() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Check the file twice")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
+        ],
+    )
+    superseded = ctx.add_tool_result("read_file", {"output": "stale"}, "call-1")
+    ctx.messages[ctx.messages.index(superseded)] = replace(superseded, hidden=True)
+
+    result = ctx.compact_with_llm_response({"content": "Read the file."})
+
+    assert "were dropped by this compaction" not in ctx.messages[0].content
+    assert result.metadata["dropped_tool_result_count"] == 0
+
+
+def test_compact_truncate_counts_dropped_tool_results() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.compact_config.max_messages = 4
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "web_search"}}
+        ],
+    )
+    ctx.add_tool_result("web_search", {"output": "dropped rows"}, "call-1")
+    for index in range(6):
+        ctx.add_user_message(f"tail-{index}")
+
+    result = ctx.compact_if_needed()
+
+    assert result.strategy == "truncate"
+    assert result.metadata["dropped_tool_result_count"] == 1
 
 
 def test_compact_with_llm_preserves_waiting_for_user_response() -> None:

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -13,6 +13,7 @@ from xagent.core.agent.context import (
     Message,
 )
 from xagent.core.agent.context import enrichment as enrichment_module
+from xagent.core.context_ref import SUPERSEDES_SCOPE_KEY
 from xagent.core.agent.context.enrichment import (
     MEMORY_CONTEXT_METADATA_KEY,
     SKILL_CONTEXT_METADATA_KEY,
@@ -813,6 +814,39 @@ def test_compact_with_llm_omits_tool_notice_without_tool_results() -> None:
     assert "were dropped by this compaction" not in ctx.messages[0].content
 
 
+def test_compact_with_llm_excludes_superseded_tool_results_from_notice() -> None:
+    """A superseded observation lost its raw result before compaction ran.
+
+    ``ComputerTool`` stamps a supersedes scope on every result, so counting
+    superseded messages would report a whole browser session as dropped
+    evidence when only the newest observation actually carried any.
+    """
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Browse the dashboard")
+    for index in range(3):
+        call_id = f"call-{index}"
+        ctx.add_assistant_message(
+            "",
+            tool_calls=[
+                {"id": call_id, "type": "function", "function": {"name": "computer"}}
+            ],
+        )
+        ctx.add_tool_result(
+            "computer",
+            {"output": f"view {index}", SUPERSEDES_SCOPE_KEY: "computer:task-1"},
+            call_id,
+        )
+
+    result = ctx.compact_with_llm_response({"content": "Inspected the dashboard."})
+
+    notice = ctx.messages[0].content
+    assert "1 completed tool call(s) were dropped" in notice
+    assert "- computer\n" in f"{notice}\n"
+    assert "- computer x" not in notice
+    assert result.metadata["dropped_tool_result_count"] == 1
+
+
 def test_compact_with_llm_ignores_hidden_tool_results_in_notice() -> None:
     ctx = ExecutionContext()
     ctx.compact_config.threshold = 1
@@ -823,8 +857,8 @@ def test_compact_with_llm_ignores_hidden_tool_results_in_notice() -> None:
             {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
         ],
     )
-    superseded = ctx.add_tool_result("read_file", {"output": "stale"}, "call-1")
-    ctx.messages[ctx.messages.index(superseded)] = replace(superseded, hidden=True)
+    stale = ctx.add_tool_result("read_file", {"output": "stale"}, "call-1")
+    ctx.messages[ctx.messages.index(stale)] = replace(stale, hidden=True)
 
     result = ctx.compact_with_llm_response({"content": "Read the file."})
 

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -13,7 +13,6 @@ from xagent.core.agent.context import (
     Message,
 )
 from xagent.core.agent.context import enrichment as enrichment_module
-from xagent.core.context_ref import SUPERSEDES_SCOPE_KEY
 from xagent.core.agent.context.enrichment import (
     MEMORY_CONTEXT_METADATA_KEY,
     SKILL_CONTEXT_METADATA_KEY,
@@ -28,6 +27,7 @@ from xagent.core.agent.language import (
     response_language_rules,
 )
 from xagent.core.agent.utils.context_builder import ContextBuilder
+from xagent.core.context_ref import SUPERSEDES_SCOPE_KEY
 from xagent.web.user_isolated_memory import current_user_id
 
 


### PR DESCRIPTION
## Summary

First slice of **proposal B** in #1235. Independent of #1237 (proposal A) — different files, no conflict; either can land first.

Issue §2 describes compaction as "a confabulation trap by construction": the transcript is replaced by a prose summary, the model is then told *"do not repeat completed tool calls"*, and nothing marks what went missing. The numbers the answer should be grounded in are gone, re-fetching them is discouraged, and the gap is invisible — so plausible-looking numbers are the cheapest way to satisfy the instruction.

This PR removes the trap's two prompt-side legs. It does **not** yet change how much survives compaction (items 1 and 2 below).

## Changes

**1. The post-compaction instruction now permits re-grounding.** It previously read, in full, *"do not repeat completed tool calls or regenerate completed artifacts unless the latest user request explicitly asks to restart, revise, or regenerate them."* It now adds `…or the detail you need was lost in compaction`, plus:

> This summary is a lossy paraphrase of the raw history, not the history itself: when the answer needs an exact value, figure, statistic, table row, quotation, or identifier that this summary does not literally contain, re-run the tool that produced it instead of reconstructing the value from this summary or from memory.

The original intent — don't redo already-completed work — is preserved; only the case that produces fabrication is carved out.

**2. The summary now records what was dropped.** A `ContextReference`-style notice already existed but covered images only; textual tool observations vanished silently. The summary message now appends, when any were dropped:

```
Raw observations from 4 completed tool call(s) were dropped by this compaction.
Their exact values are no longer in context; only the summary above describes
them. Treat any figure not literally present in that summary as unavailable
rather than recalled. Tools whose results were dropped:
- web_search x3
- read_file
```

Aggregated by tool name with counts (capped at 20 distinct names) so a long session costs a bounded number of tokens. Hidden messages are excluded — superseded observations were already absent from the prompt, so reporting them as newly dropped would be false.

**3. Observability.** Both strategies now report `dropped_tool_result_count` in `CompactResult.metadata`.

## Notes for reviewers

- **`truncate` gets metadata only, no in-prompt notice.** Issue §2 calls out that this fallback drops history silently too, and it deserves the same disclosure. But `truncate`'s contract is "keep exactly `max_messages` messages" and three existing tests assert exact counts and positions; inserting a system notice breaks that invariant, and the notice would itself be truncated later. Left for a follow-up rather than decided unilaterally here.
- **Identity-based diff in `truncate`.** `_tail_window_preserving_tool_pairs()` is a suffix *minus* any interior fragments `_sanitize_tool_message_pairs()` removes, so the dropped set is computed by object identity rather than by slicing a prefix — slicing would misattribute retained messages as dropped whenever sanitization fires.
- This is a prompt/accounting change. Nothing about which messages survive compaction changes in this PR.

## Testing

Four new tests in `tests/core/agent/test_context.py` covering the notice text and per-tool counts, the no-tool-results case, hidden-message exclusion, and the `truncate` count; existing compaction tests extended for the softened instruction. `tests/core/agent/`, `tests/core/test_context_ref.py`, and `tests/core/test_context_materializer.py` pass; `ruff check`, `ruff format --check`, and `mypy` clean on the touched files.

## Remaining in proposal B

1. Scale the summary budget with history size — it is currently capped at a flat 1024 tokens (`COMPACT_SUMMARY_MAX_TOKENS`) regardless of how large the history was, which is where the ~150:1 ratio comes from.
2. Retain raw tool observations, or persist them as re-materializable references the way `ContextReference` already does for images.

Item 1 needs a decision on the ceiling: `max_tokens` is passed straight to the provider, and `BaseLLM` exposes `context_window` but no max-output-tokens attribute, so a large budget risks exceeding a model's output cap. I'd add it to `config.py` as an `XAGENT_*`-configurable ratio with a conservative default rather than hardcoding a bigger constant.

Refs #1235
