### PR TITLE
feat: expand HubSpot connector to Marketing Hub (forms, analytics, emails, campaigns)

### DIFF
--- a/example.env
+++ b/example.env
@@ -492,8 +492,13 @@ LINKEDIN_REDIRECT_URI=""
 # ===========================================
 # Required for the HubSpot CRM integration in MCP
 # Create a public app at https://developers.hubspot.com/ and configure the
-# app's scopes to match the connector (crm.objects.contacts/companies read+write,
-# crm.objects.deals.read)
+# app's scopes to match the connector:
+#   Required: crm.objects.contacts.read, crm.objects.contacts.write,
+#     crm.objects.companies.read, crm.objects.companies.write,
+#     crm.objects.deals.read, forms, marketing.campaigns.read
+#   Optional (tier-gated - mark these "Optional" in the app's scope
+#     configuration, not "Required", or HubSpot refuses to install the app):
+#     business-intelligence, marketing-email
 HUBSPOT_CLIENT_ID=""
 HUBSPOT_CLIENT_SECRET=""
 # Redirect URI for HubSpot OAuth callback

--- a/example.env
+++ b/example.env
@@ -495,10 +495,10 @@ LINKEDIN_REDIRECT_URI=""
 # app's scopes to match the connector:
 #   Required: crm.objects.contacts.read, crm.objects.contacts.write,
 #     crm.objects.companies.read, crm.objects.companies.write,
-#     crm.objects.deals.read, forms, marketing.campaigns.read
+#     crm.objects.deals.read, forms
 #   Optional (tier-gated - mark these "Optional" in the app's scope
 #     configuration, not "Required", or HubSpot refuses to install the app):
-#     business-intelligence, marketing-email
+#     business-intelligence, marketing-email, marketing.campaigns.read
 HUBSPOT_CLIENT_ID=""
 HUBSPOT_CLIENT_SECRET=""
 # Redirect URI for HubSpot OAuth callback

--- a/src/xagent/migrations/versions/20260720_seed_docs_slides_hubspot.py
+++ b/src/xagent/migrations/versions/20260720_seed_docs_slides_hubspot.py
@@ -130,14 +130,17 @@ def _new_app_rows() -> list[dict[str, object]]:
                 "crm.objects.companies.write",
                 "crm.objects.deals.read",
                 "forms",
-                "marketing.campaigns.read",
             ],
             # Not a public_mcp_apps column - _filter_row strips this before
             # any insert, so it never reaches the DB. Present purely so this
             # snapshot's dict equals the live registry row's dict, which is
             # what tests/alembic/test_20260720_seed_docs_slides_hubspot.py's
             # test_seed_rows_match_registry asserts.
-            "optional_oauth_scopes": ["business-intelligence", "marketing-email"],
+            "optional_oauth_scopes": [
+                "business-intelligence",
+                "marketing-email",
+                "marketing.campaigns.read",
+            ],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",

--- a/src/xagent/migrations/versions/20260720_seed_docs_slides_hubspot.py
+++ b/src/xagent/migrations/versions/20260720_seed_docs_slides_hubspot.py
@@ -118,7 +118,7 @@ def _new_app_rows() -> list[dict[str, object]]:
         {
             "app_id": "hubspot",
             "name": "HubSpot",
-            "description": "Connect to HubSpot CRM to search, create, and update contacts and companies, read deals, and log notes.",
+            "description": "Connect to HubSpot CRM and Marketing Hub to search, create, and update contacts and companies, read deals, log notes, read forms and submissions, pull traffic analytics reports, and read marketing emails and campaigns.",
             "icon": "https://www.google.com/s2/favicons?domain=hubspot.com&sz=128",
             "transport": "oauth",
             "provider_name": "hubspot",
@@ -129,6 +129,10 @@ def _new_app_rows() -> list[dict[str, object]]:
                 "crm.objects.companies.read",
                 "crm.objects.companies.write",
                 "crm.objects.deals.read",
+                "forms",
+                "business-intelligence",
+                "marketing-email",
+                "marketing.campaigns.read",
             ],
             "is_visible_in_connector": True,
             "launch_config": {

--- a/src/xagent/migrations/versions/20260720_seed_docs_slides_hubspot.py
+++ b/src/xagent/migrations/versions/20260720_seed_docs_slides_hubspot.py
@@ -132,6 +132,11 @@ def _new_app_rows() -> list[dict[str, object]]:
                 "forms",
                 "marketing.campaigns.read",
             ],
+            # Not a public_mcp_apps column - _filter_row strips this before
+            # any insert, so it never reaches the DB. Present purely so this
+            # snapshot's dict equals the live registry row's dict, which is
+            # what tests/alembic/test_20260720_seed_docs_slides_hubspot.py's
+            # test_seed_rows_match_registry asserts.
             "optional_oauth_scopes": ["business-intelligence", "marketing-email"],
             "is_visible_in_connector": True,
             "launch_config": {

--- a/src/xagent/migrations/versions/20260720_seed_docs_slides_hubspot.py
+++ b/src/xagent/migrations/versions/20260720_seed_docs_slides_hubspot.py
@@ -130,10 +130,9 @@ def _new_app_rows() -> list[dict[str, object]]:
                 "crm.objects.companies.write",
                 "crm.objects.deals.read",
                 "forms",
-                "business-intelligence",
-                "marketing-email",
                 "marketing.campaigns.read",
             ],
+            "optional_oauth_scopes": ["business-intelligence", "marketing-email"],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",

--- a/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
+++ b/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
@@ -24,6 +24,13 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
     sa.column("oauth_scopes", sa.JSON),
 )
 
+USER_OAUTH_TABLE = sa.table(
+    "user_oauth",
+    sa.column("provider", sa.String),
+    sa.column("access_token", sa.String),
+    sa.column("refresh_token", sa.String),
+)
+
 APP_ID = "hubspot"
 
 PREVIOUS_SCOPES = [
@@ -53,40 +60,116 @@ CURRENT_DESCRIPTION = (
 )
 
 
-def _set_hubspot_fields(
-    bind: sa.engine.Connection, scopes: list[str], description: str
-) -> None:
-    """Keep the persisted row in sync with the code registry's canonical values.
+def _set_hubspot_scopes(bind: sa.engine.Connection, scopes: list[str]) -> None:
+    """Keep the persisted row in sync with the code registry's canonical value.
 
-    ``oauth_scopes`` does NOT drive what scope is actually requested at
-    OAuth-authorize time: for a builtin app, _app_to_dict sources oauth_scopes
-    from get_builtin_execution_fields (the code registry), never from this DB
-    row. That write exists solely so validate_builtin_public_mcp_apps doesn't
-    report drift between the registry and an already-seeded row.
-
-    ``description`` is different: _app_to_dict reads it straight from this DB
-    row (it is not a code-registry execution field), so without this write an
-    already-seeded install would keep showing the old connector description
-    forever.
+    This does NOT drive what scope is actually requested at OAuth-authorize
+    time: for a builtin app, _app_to_dict sources oauth_scopes from
+    get_builtin_execution_fields (the code registry), never from this DB row.
+    The write here exists solely so validate_builtin_public_mcp_apps doesn't
+    report drift between the registry and an already-seeded row. Unlike
+    ``description`` below, ``oauth_scopes`` is in admin_mcp's
+    _BUILTIN_PROTECTED_FIELDS, so an operator can never have customized it
+    via the admin PATCH endpoint — safe to overwrite unconditionally.
     """
     inspector = sa.inspect(bind)
     if "public_mcp_apps" not in set(inspector.get_table_names()):
         return
 
     columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
-    if not {"app_id", "oauth_scopes", "description"}.issubset(columns):
+    if not {"app_id", "oauth_scopes"}.issubset(columns):
         return
 
     bind.execute(
         sa.update(PUBLIC_MCP_APPS_TABLE)
         .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
-        .values(oauth_scopes=scopes, description=description)
+        .values(oauth_scopes=scopes)
+    )
+
+
+def _set_hubspot_description_if_unchanged(
+    bind: sa.engine.Connection, expected_current: str, new_value: str
+) -> None:
+    """Refresh the stale default description, without clobbering a customization.
+
+    Unlike ``oauth_scopes``, ``description`` is not in admin_mcp's
+    _BUILTIN_PROTECTED_FIELDS, so an operator can legitimately have edited it
+    via the admin PATCH endpoint. Only overwrite when the persisted value
+    still equals the last-known canonical description (i.e. it was never
+    customized); an edited value matches neither PREVIOUS_DESCRIPTION nor
+    CURRENT_DESCRIPTION and is left alone in either direction.
+    """
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    if not {"app_id", "description"}.issubset(columns):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(
+            PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID,
+            PUBLIC_MCP_APPS_TABLE.c.description == expected_current,
+        )
+        .values(description=new_value)
+    )
+
+
+def _invalidate_existing_hubspot_grants(bind: sa.engine.Connection) -> None:
+    """Force reconnection so the user has a chance to grant the new scopes.
+
+    HubSpot's token-exchange response carries no `scope` field (same
+    limitation as Facebook's, see
+    20260728_add_facebook_pages_read_user_content_scope.py), so a stored
+    grant's actual permissions can't be inspected after the fact — every row
+    was necessarily authorized before these scopes existed. Without this,
+    _oauth_account_can_connect only checks token presence/expiry, so an
+    existing connection keeps showing "Connected" and fails only at call time
+    with a raw HubSpot missing-scopes error.
+
+    Unlike the Facebook migration, refresh_token must be cleared too:
+    refresh_oauth_token_if_needed (web/tools/config.py) refreshes purely off
+    expires_at + refresh_token without ever looking at access_token, and
+    HubSpot access tokens expire in ~30 minutes — so a cleared access_token
+    with a surviving refresh_token would be silently re-minted (with the old
+    scope set) on the next tool call. Meta has no such path; its refresh
+    exchanges the access token itself, which clearing already breaks.
+    """
+    inspector = sa.inspect(bind)
+    if "user_oauth" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("user_oauth")}
+    if not {"provider", "access_token"}.issubset(columns):
+        return
+
+    values: dict[str, object] = {"access_token": ""}
+    if "refresh_token" in columns:
+        values["refresh_token"] = None
+
+    bind.execute(
+        sa.update(USER_OAUTH_TABLE)
+        .where(USER_OAUTH_TABLE.c.provider == APP_ID)
+        .values(**values)
     )
 
 
 def upgrade() -> None:
-    _set_hubspot_fields(op.get_bind(), CURRENT_SCOPES, CURRENT_DESCRIPTION)
+    bind = op.get_bind()
+    _set_hubspot_scopes(bind, CURRENT_SCOPES)
+    _set_hubspot_description_if_unchanged(
+        bind, PREVIOUS_DESCRIPTION, CURRENT_DESCRIPTION
+    )
+    _invalidate_existing_hubspot_grants(bind)
 
 
 def downgrade() -> None:
-    _set_hubspot_fields(op.get_bind(), PREVIOUS_SCOPES, PREVIOUS_DESCRIPTION)
+    # The cleared access tokens are gone for good (that's the point — force a
+    # reconnect); there is nothing meaningful to restore for user_oauth here.
+    bind = op.get_bind()
+    _set_hubspot_scopes(bind, PREVIOUS_SCOPES)
+    _set_hubspot_description_if_unchanged(
+        bind, CURRENT_DESCRIPTION, PREVIOUS_DESCRIPTION
+    )

--- a/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
+++ b/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
@@ -1,7 +1,7 @@
 """add HubSpot Marketing Hub scopes (forms, analytics, marketing email, campaigns)
 
 Revision ID: 20260810_add_hubspot_marketing_scopes
-Revises: 20260806_seed_chrome_mcp_app
+Revises: 20260809_add_task_interaction_requests
 Create Date: 2026-08-10
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260810_add_hubspot_marketing_scopes"
-down_revision: Union[str, None] = "20260806_seed_chrome_mcp_app"
+down_revision: Union[str, None] = "20260809_add_task_interaction_requests"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
+++ b/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
@@ -43,10 +43,15 @@ PREVIOUS_SCOPES = [
 CURRENT_SCOPES = [
     *PREVIOUS_SCOPES,
     "forms",
-    "business-intelligence",
-    "marketing-email",
     "marketing.campaigns.read",
 ]
+# business-intelligence and marketing-email are requested separately via the
+# authorize request's optional_scope parameter (see api/auth.py and
+# get_builtin_optional_oauth_scopes) - not part of oauth_scopes at all, so
+# not persisted here. Both are tier-gated (business-intelligence: Marketing
+# Hub Basic+; marketing-email: Enterprise or the transactional email
+# add-on); requesting them as required scopes would block reconnection
+# entirely for portals below those tiers.
 
 PREVIOUS_DESCRIPTION = (
     "Connect to HubSpot CRM to search, create, and update contacts and "

--- a/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
+++ b/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
@@ -65,6 +65,23 @@ CURRENT_DESCRIPTION = (
 )
 
 
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    Shared by every guard below: this migration must be a no-op (not an
+    error) against a database mid-way through a schema this old, or an
+    admin's reduced-schema table, rather than assume a table shape that
+    matches only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {c["name"] for c in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
 def _set_hubspot_scopes(bind: sa.engine.Connection, scopes: list[str]) -> None:
     """Keep the persisted row in sync with the code registry's canonical value.
 
@@ -77,12 +94,7 @@ def _set_hubspot_scopes(bind: sa.engine.Connection, scopes: list[str]) -> None:
     _BUILTIN_PROTECTED_FIELDS, so an operator can never have customized it
     via the admin PATCH endpoint — safe to overwrite unconditionally.
     """
-    inspector = sa.inspect(bind)
-    if "public_mcp_apps" not in set(inspector.get_table_names()):
-        return
-
-    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
-    if not {"app_id", "oauth_scopes"}.issubset(columns):
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
         return
 
     bind.execute(
@@ -104,12 +116,7 @@ def _set_hubspot_description_if_unchanged(
     customized); an edited value matches neither PREVIOUS_DESCRIPTION nor
     CURRENT_DESCRIPTION and is left alone in either direction.
     """
-    inspector = sa.inspect(bind)
-    if "public_mcp_apps" not in set(inspector.get_table_names()):
-        return
-
-    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
-    if not {"app_id", "description"}.issubset(columns):
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "description"}):
         return
 
     bind.execute(
@@ -142,14 +149,10 @@ def _invalidate_existing_hubspot_grants(bind: sa.engine.Connection) -> None:
     scope set) on the next tool call. Meta has no such path; its refresh
     exchanges the access token itself, which clearing already breaks.
     """
-    inspector = sa.inspect(bind)
-    if "user_oauth" not in set(inspector.get_table_names()):
+    if not _columns_present(bind, "user_oauth", {"provider", "access_token"}):
         return
 
-    columns = {c["name"] for c in inspector.get_columns("user_oauth")}
-    if not {"provider", "access_token"}.issubset(columns):
-        return
-
+    columns = {c["name"] for c in sa.inspect(bind).get_columns("user_oauth")}
     values: dict[str, object] = {"access_token": ""}
     if "refresh_token" in columns:
         values["refresh_token"] = None

--- a/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
+++ b/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
@@ -1,7 +1,7 @@
 """add HubSpot Marketing Hub scopes (forms, analytics, marketing email, campaigns)
 
 Revision ID: 20260810_add_hubspot_marketing_scopes
-Revises: 20260809_add_task_interaction_requests
+Revises: 20260810_add_task_interaction_protocol_version
 Create Date: 2026-08-10
 
 """
@@ -15,7 +15,7 @@ from alembic import op
 logger = logging.getLogger(__name__)
 
 revision: str = "20260810_add_hubspot_marketing_scopes"
-down_revision: Union[str, None] = "20260809_add_task_interaction_requests"
+down_revision: Union[str, None] = "20260810_add_task_interaction_protocol_version"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
+++ b/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
@@ -43,15 +43,16 @@ PREVIOUS_SCOPES = [
 CURRENT_SCOPES = [
     *PREVIOUS_SCOPES,
     "forms",
-    "marketing.campaigns.read",
 ]
-# business-intelligence and marketing-email are requested separately via the
-# authorize request's optional_scope parameter (see api/auth.py and
-# get_builtin_optional_oauth_scopes) - not part of oauth_scopes at all, so
-# not persisted here. Both are tier-gated (business-intelligence: Marketing
-# Hub Basic+; marketing-email: Enterprise or the transactional email
-# add-on); requesting them as required scopes would block reconnection
-# entirely for portals below those tiers.
+# business-intelligence, marketing-email, and marketing.campaigns.read are
+# requested separately via the authorize request's optional_scope parameter
+# (see api/auth.py and get_builtin_optional_oauth_scopes) - not part of
+# oauth_scopes at all, so not persisted here. All three are tier-gated
+# (business-intelligence: Marketing Hub Basic+; marketing-email: Enterprise
+# or the transactional email add-on; marketing.campaigns.read: the
+# Campaigns API itself requires Marketing Hub Professional+); requesting
+# any of them as required scopes would block reconnection entirely for
+# portals below those tiers.
 
 PREVIOUS_DESCRIPTION = (
     "Connect to HubSpot CRM to search, create, and update contacts and "
@@ -141,13 +142,17 @@ def _invalidate_existing_hubspot_grants(bind: sa.engine.Connection) -> None:
     existing connection keeps showing "Connected" and fails only at call time
     with a raw HubSpot missing-scopes error.
 
-    Unlike the Facebook migration, refresh_token must be cleared too:
-    refresh_oauth_token_if_needed (web/tools/config.py) refreshes purely off
-    expires_at + refresh_token without ever looking at access_token, and
-    HubSpot access tokens expire in ~30 minutes — so a cleared access_token
-    with a surviving refresh_token would be silently re-minted (with the old
-    scope set) on the next tool call. Meta has no such path; its refresh
-    exchanges the access token itself, which clearing already breaks.
+    Unlike the Facebook migration, refresh_token is cleared too, as
+    defense-in-depth: the current token resolver (web/tools/config.py)
+    already short-circuits on a falsy access_token before ever reaching
+    refresh_oauth_token_if_needed, so a surviving refresh_token cannot
+    resurrect the old-scoped grant through that specific path today. It's
+    cleared anyway so this migration doesn't rely on that resolver's
+    current shape staying exactly as it is - a future resolver that checks
+    refresh_token independently of access_token would otherwise silently
+    re-mint the old-scoped access_token on its next refresh. Meta has no
+    such path to defend against; its refresh exchanges the access token
+    itself, which clearing already breaks.
     """
     if not _columns_present(bind, "user_oauth", {"provider", "access_token"}):
         return

--- a/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
+++ b/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
@@ -1,0 +1,92 @@
+"""add HubSpot Marketing Hub scopes (forms, analytics, marketing email, campaigns)
+
+Revision ID: 20260810_add_hubspot_marketing_scopes
+Revises: 20260806_seed_chrome_mcp_app
+Create Date: 2026-08-10
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260810_add_hubspot_marketing_scopes"
+down_revision: Union[str, None] = "20260806_seed_chrome_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "hubspot"
+
+PREVIOUS_SCOPES = [
+    "crm.objects.contacts.read",
+    "crm.objects.contacts.write",
+    "crm.objects.companies.read",
+    "crm.objects.companies.write",
+    "crm.objects.deals.read",
+]
+CURRENT_SCOPES = [
+    *PREVIOUS_SCOPES,
+    "forms",
+    "business-intelligence",
+    "marketing-email",
+    "marketing.campaigns.read",
+]
+
+PREVIOUS_DESCRIPTION = (
+    "Connect to HubSpot CRM to search, create, and update contacts and "
+    "companies, read deals, and log notes."
+)
+CURRENT_DESCRIPTION = (
+    "Connect to HubSpot CRM and Marketing Hub to search, create, and update "
+    "contacts and companies, read deals, log notes, read forms and "
+    "submissions, pull traffic analytics reports, and read marketing emails "
+    "and campaigns."
+)
+
+
+def _set_hubspot_fields(
+    bind: sa.engine.Connection, scopes: list[str], description: str
+) -> None:
+    """Keep the persisted row in sync with the code registry's canonical values.
+
+    ``oauth_scopes`` does NOT drive what scope is actually requested at
+    OAuth-authorize time: for a builtin app, _app_to_dict sources oauth_scopes
+    from get_builtin_execution_fields (the code registry), never from this DB
+    row. That write exists solely so validate_builtin_public_mcp_apps doesn't
+    report drift between the registry and an already-seeded row.
+
+    ``description`` is different: _app_to_dict reads it straight from this DB
+    row (it is not a code-registry execution field), so without this write an
+    already-seeded install would keep showing the old connector description
+    forever.
+    """
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    if not {"app_id", "oauth_scopes", "description"}.issubset(columns):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=scopes, description=description)
+    )
+
+
+def upgrade() -> None:
+    _set_hubspot_fields(op.get_bind(), CURRENT_SCOPES, CURRENT_DESCRIPTION)
+
+
+def downgrade() -> None:
+    _set_hubspot_fields(op.get_bind(), PREVIOUS_SCOPES, PREVIOUS_DESCRIPTION)

--- a/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
+++ b/src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py
@@ -6,10 +6,13 @@ Create Date: 2026-08-10
 
 """
 
+import logging
 from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+
+logger = logging.getLogger(__name__)
 
 revision: str = "20260810_add_hubspot_marketing_scopes"
 down_revision: Union[str, None] = "20260809_add_task_interaction_requests"
@@ -46,11 +49,11 @@ CURRENT_SCOPES = [
 ]
 # business-intelligence, marketing-email, and marketing.campaigns.read are
 # requested separately via the authorize request's optional_scope parameter
-# (see api/auth.py and get_builtin_optional_oauth_scopes) - not part of
-# oauth_scopes at all, so not persisted here. All three are tier-gated
-# (business-intelligence: Marketing Hub Basic+; marketing-email: Enterprise
-# or the transactional email add-on; marketing.campaigns.read: the
-# Campaigns API itself requires Marketing Hub Professional+); requesting
+# (see api/auth.py and get_builtin_execution_fields_and_optional_scopes) -
+# not part of oauth_scopes at all, so not persisted here. All three are
+# tier-gated (business-intelligence: Marketing Hub Basic+; marketing-email:
+# Enterprise or the transactional email add-on; marketing.campaigns.read:
+# the Campaigns API itself requires Marketing Hub Professional+); requesting
 # any of them as required scopes would block reconnection entirely for
 # portals below those tiers.
 
@@ -162,11 +165,20 @@ def _invalidate_existing_hubspot_grants(bind: sa.engine.Connection) -> None:
     if "refresh_token" in columns:
         values["refresh_token"] = None
 
-    bind.execute(
+    result = bind.execute(
         sa.update(USER_OAUTH_TABLE)
         .where(USER_OAUTH_TABLE.c.provider == APP_ID)
         .values(**values)
     )
+    if result.rowcount:
+        logger.warning(
+            "Disconnected %d existing HubSpot grant(s) for the new required "
+            "'forms' scope (business-intelligence, marketing-email, and "
+            "marketing.campaigns.read are requested as optional and do not "
+            "require reconnection on their own). Affected users must "
+            "reconnect the HubSpot connector.",
+            result.rowcount,
+        )
 
 
 def upgrade() -> None:

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1203,13 +1203,24 @@ def generic_oauth_login(
     scopes = _merge_oauth_scopes(db_provider.default_scopes or [], app_scopes)
     scope_str = _oauth_scope_separator(provider).join(scopes)
     # Sent via the authorize request's own optional_scope parameter (see
-    # get_builtin_optional_oauth_scopes) rather than merged into `scopes`
-    # above: a scope tier-gated on the connected account's plan would
-    # otherwise block the whole authorization if the account can't grant it.
-    # dict.fromkeys dedupes while keeping sorted() deterministic even if a
-    # future app_id row lists the same scope twice.
+    # get_builtin_execution_fields_and_optional_scopes) rather than merged
+    # into `scopes` above: a scope tier-gated on the connected account's
+    # plan would otherwise block the whole authorization if the account
+    # can't grant it. Scopes already in the required set are dropped here
+    # too - not just a duplicate-avoidance nicety, but correctness: HubSpot
+    # blocks installation outright if the same scope appears in both `scope`
+    # and `optional_scope` on one authorize request. dict.fromkeys then
+    # dedupes what's left before joining, in case the registry ever lists a
+    # scope twice within optional_oauth_scopes itself.
+    required_scopes = set(scopes)
     optional_scope_str = _oauth_scope_separator(provider).join(
-        sorted(dict.fromkeys(scope for scope in app_optional_scopes if scope))
+        sorted(
+            dict.fromkeys(
+                scope
+                for scope in app_optional_scopes
+                if scope and scope not in required_scopes
+            )
+        )
     )
 
     from urllib.parse import urlencode

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1195,9 +1195,9 @@ def generic_oauth_login(
 
     if app_id:
         app_info = get_app_by_id(db, app_id)
-        if app_info and "oauth_scopes" in app_info:
-            app_scopes = app_info["oauth_scopes"]
         if app_info:
+            if "oauth_scopes" in app_info:
+                app_scopes = app_info["oauth_scopes"]
             app_optional_scopes = app_info.get("optional_oauth_scopes") or []
 
     scopes = _merge_oauth_scopes(db_provider.default_scopes or [], app_scopes)
@@ -1206,8 +1206,10 @@ def generic_oauth_login(
     # get_builtin_optional_oauth_scopes) rather than merged into `scopes`
     # above: a scope tier-gated on the connected account's plan would
     # otherwise block the whole authorization if the account can't grant it.
+    # dict.fromkeys dedupes while keeping sorted() deterministic even if a
+    # future app_id row lists the same scope twice.
     optional_scope_str = _oauth_scope_separator(provider).join(
-        sorted(scope for scope in app_optional_scopes if scope)
+        sorted(dict.fromkeys(scope for scope in app_optional_scopes if scope))
     )
 
     from urllib.parse import urlencode

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1190,15 +1190,25 @@ def generic_oauth_login(
     state = create_access_token(data=state_payload, expires_delta=timedelta(minutes=10))
 
     app_scopes: list[str] | None = None
+    app_optional_scopes: list[str] = []
     from ..mcp_apps import get_app_by_id
 
     if app_id:
         app_info = get_app_by_id(db, app_id)
         if app_info and "oauth_scopes" in app_info:
             app_scopes = app_info["oauth_scopes"]
+        if app_info:
+            app_optional_scopes = app_info.get("optional_oauth_scopes") or []
 
     scopes = _merge_oauth_scopes(db_provider.default_scopes or [], app_scopes)
     scope_str = _oauth_scope_separator(provider).join(scopes)
+    # Sent via the authorize request's own optional_scope parameter (see
+    # get_builtin_optional_oauth_scopes) rather than merged into `scopes`
+    # above: a scope tier-gated on the connected account's plan would
+    # otherwise block the whole authorization if the account can't grant it.
+    optional_scope_str = _oauth_scope_separator(provider).join(
+        sorted(scope for scope in app_optional_scopes if scope)
+    )
 
     from urllib.parse import urlencode
 
@@ -1217,8 +1227,11 @@ def generic_oauth_login(
     meta_config_id = _meta_login_config_id() if provider.lower() == "meta" else ""
     if meta_config_id:
         params["config_id"] = meta_config_id
-    elif scope_str:
-        params["scope"] = scope_str
+    else:
+        if scope_str:
+            params["scope"] = scope_str
+        if optional_scope_str:
+            params["optional_scope"] = optional_scope_str
 
     separator = "&" if "?" in auth_url else "?"
     full_auth_url = f"{auth_url}{separator}{urlencode(params)}"

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -328,23 +328,29 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "crm.objects.companies.write",
                 "crm.objects.deals.read",
                 "forms",
-                "marketing.campaigns.read",
             ],
-            # Both scopes are tier-gated (business-intelligence: Marketing
-            # Hub Basic+; marketing-email: Enterprise or the transactional
-            # email add-on); requesting them as required scopes would block
-            # the whole OAuth authorization (and therefore every CRM tool
-            # too) for portals below those tiers. Sent
-            # via the authorize request's optional_scope parameter instead
-            # (see api/auth.py) so those portals still connect successfully
-            # and only hubspot_get_analytics_report /
-            # hubspot_list_marketing_emails / hubspot_get_marketing_email_statistics
-            # fail at call time if the tier doesn't grant them. This pairing
-            # must also be reflected in this app's scope configuration in the
+            # All three are tier-gated (business-intelligence: Marketing Hub
+            # Basic+; marketing-email: Enterprise or the transactional email
+            # add-on; marketing.campaigns.read: the Campaigns API itself
+            # requires Marketing Hub Professional+, confirmed against
+            # HubSpot's Campaigns API docs); requesting any of them as
+            # required scopes would block the whole OAuth authorization (and
+            # therefore every CRM tool too) for portals below those tiers.
+            # Sent via the authorize request's optional_scope parameter
+            # instead (see api/auth.py) so those portals still connect
+            # successfully and only hubspot_get_analytics_report /
+            # hubspot_list_marketing_emails / hubspot_get_marketing_email_statistics /
+            # hubspot_list_campaigns / hubspot_get_campaign_metrics fail at
+            # call time if the tier doesn't grant them. This pairing must
+            # also be reflected in this app's scope configuration in the
             # HubSpot Developer Dashboard - HubSpot blocks installation if a
             # scope's required/optional designation there disagrees with
             # which parameter it arrives in.
-            "optional_oauth_scopes": ["business-intelligence", "marketing-email"],
+            "optional_oauth_scopes": [
+                "business-intelligence",
+                "marketing-email",
+                "marketing.campaigns.read",
+            ],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",
@@ -699,6 +705,27 @@ def get_builtin_optional_oauth_scopes(app_id: str) -> list[str]:
     if row is None:
         return []
     return list(row.get("optional_oauth_scopes", []))
+
+
+def get_builtin_execution_fields_and_optional_scopes(
+    app_id: str,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Single-scan equivalent of calling get_builtin_execution_fields and
+    get_builtin_optional_oauth_scopes separately.
+
+    Each of those does its own linear scan of the registry plus a deepcopy
+    of the full matched row; a caller needing both (as _app_to_dict does
+    for every app on a listing path) would otherwise pay for that scan
+    twice per app. This does it once and derives both results from the
+    same row.
+    """
+    row = get_builtin_public_mcp_app(app_id)
+    if row is None:
+        return None, []
+    execution_fields = {
+        field_name: row[field_name] for field_name in _BUILTIN_EXECUTION_FIELD_NAMES
+    }
+    return execution_fields, list(row.get("optional_oauth_scopes", []))
 
 
 def _safe_configuration_hash(values: dict[str, Any]) -> str:

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -328,10 +328,23 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "crm.objects.companies.write",
                 "crm.objects.deals.read",
                 "forms",
-                "business-intelligence",
-                "marketing-email",
                 "marketing.campaigns.read",
             ],
+            # Both scopes are tier-gated (business-intelligence: Marketing
+            # Hub Basic+; marketing-email: Enterprise or the transactional
+            # email add-on); requesting them as required scopes would block
+            # the whole OAuth authorization (and therefore every CRM tool
+            # too) for portals below those tiers. Sent
+            # via the authorize request's optional_scope parameter instead
+            # (see api/auth.py) so those portals still connect successfully
+            # and only hubspot_get_analytics_report /
+            # hubspot_list_marketing_emails / hubspot_get_marketing_email_statistics
+            # fail at call time if the tier doesn't grant them. This pairing
+            # must also be reflected in this app's scope configuration in the
+            # HubSpot Developer Dashboard - HubSpot blocks installation if a
+            # scope's required/optional designation there disagrees with
+            # which parameter it arrives in.
+            "optional_oauth_scopes": ["business-intelligence", "marketing-email"],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",
@@ -670,6 +683,22 @@ def get_builtin_execution_fields(app_id: str) -> dict[str, Any] | None:
     return deepcopy(
         {field_name: row[field_name] for field_name in _BUILTIN_EXECUTION_FIELD_NAMES}
     )
+
+
+def get_builtin_optional_oauth_scopes(app_id: str) -> list[str]:
+    """OAuth scopes requested via the authorize request's optional_scope
+    parameter rather than its required scope parameter (see api/auth.py).
+
+    Deliberately not in _BUILTIN_EXECUTION_FIELD_NAMES: unlike oauth_scopes,
+    there is no legacy persisted-row state to drift-check against for a
+    field this new, so this reads straight from the row rather than going
+    through the DB-column drift-tracking machinery. Most builtin apps have
+    no optional scopes at all, hence the plain ``.get`` default.
+    """
+    row = get_builtin_public_mcp_app(app_id)
+    if row is None:
+        return []
+    return list(row.get("optional_oauth_scopes", []))
 
 
 def _safe_configuration_hash(values: dict[str, Any]) -> str:

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -329,13 +329,23 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "crm.objects.deals.read",
                 "forms",
             ],
-            # All three are tier-gated (business-intelligence: Marketing Hub
-            # Basic+; marketing-email: Enterprise or the transactional email
-            # add-on; marketing.campaigns.read: the Campaigns API itself
-            # requires Marketing Hub Professional+, confirmed against
-            # HubSpot's Campaigns API docs); requesting any of them as
-            # required scopes would block the whole OAuth authorization (and
-            # therefore every CRM tool too) for portals below those tiers.
+            # All three are tier-gated, each confirmed against HubSpot's own
+            # docs: business-intelligence requires Marketing Hub Basic+ (the
+            # traffic analytics tool isn't available on Free/Starter);
+            # marketing-email requires Enterprise or the transactional email
+            # add-on; marketing.campaigns.read requires Professional+ (the
+            # Campaigns API docs state this explicitly). Requesting any of
+            # them as required scopes would block the whole OAuth
+            # authorization (and therefore every CRM tool too) for portals
+            # below those tiers. Separately: GET /marketing/v3/emails (used
+            # by hubspot_list_marketing_emails and
+            # hubspot_get_marketing_email_statistics) accepts marketing-email
+            # OR content OR transactional-email - marketing-email is used
+            # here as the most narrowly-scoped of the three that still
+            # covers both read calls; content is broader (also grants
+            # pages/blog/campaigns access this connector doesn't use) and
+            # transactional-email's applicability to non-transactional
+            # marketing emails is unconfirmed.
             # Sent via the authorize request's optional_scope parameter
             # instead (see api/auth.py) so those portals still connect
             # successfully and only hubspot_get_analytics_report /
@@ -691,33 +701,24 @@ def get_builtin_execution_fields(app_id: str) -> dict[str, Any] | None:
     )
 
 
-def get_builtin_optional_oauth_scopes(app_id: str) -> list[str]:
-    """OAuth scopes requested via the authorize request's optional_scope
-    parameter rather than its required scope parameter (see api/auth.py).
-
-    Deliberately not in _BUILTIN_EXECUTION_FIELD_NAMES: unlike oauth_scopes,
-    there is no legacy persisted-row state to drift-check against for a
-    field this new, so this reads straight from the row rather than going
-    through the DB-column drift-tracking machinery. Most builtin apps have
-    no optional scopes at all, hence the plain ``.get`` default.
-    """
-    row = get_builtin_public_mcp_app(app_id)
-    if row is None:
-        return []
-    return list(row.get("optional_oauth_scopes", []))
-
-
 def get_builtin_execution_fields_and_optional_scopes(
     app_id: str,
 ) -> tuple[dict[str, Any] | None, list[str]]:
-    """Single-scan equivalent of calling get_builtin_execution_fields and
-    get_builtin_optional_oauth_scopes separately.
+    """The app's execution fields, plus OAuth scopes requested via the
+    authorize request's optional_scope parameter rather than its required
+    scope parameter (see api/auth.py).
 
-    Each of those does its own linear scan of the registry plus a deepcopy
-    of the full matched row; a caller needing both (as _app_to_dict does
-    for every app on a listing path) would otherwise pay for that scan
-    twice per app. This does it once and derives both results from the
-    same row.
+    A single registry scan (plus one deepcopy of the matched row) serving
+    both needs: _app_to_dict wants both for every app on a listing path,
+    and scanning + deepcopying the full row twice per app to get them
+    separately would be wasted work.
+
+    optional_oauth_scopes is deliberately not in
+    _BUILTIN_EXECUTION_FIELD_NAMES: unlike oauth_scopes, there is no legacy
+    persisted-row state to drift-check against for a field this new, so
+    this reads straight from the row rather than going through the
+    DB-column drift-tracking machinery. Most builtin apps have no optional
+    scopes at all, hence the plain ``.get`` default.
     """
     row = get_builtin_public_mcp_app(app_id)
     if row is None:

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -316,7 +316,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
         {
             "app_id": "hubspot",
             "name": "HubSpot",
-            "description": "Connect to HubSpot CRM to search, create, and update contacts and companies, read deals, and log notes.",
+            "description": "Connect to HubSpot CRM and Marketing Hub to search, create, and update contacts and companies, read deals, log notes, read forms and submissions, pull traffic analytics reports, and read marketing emails and campaigns.",
             "icon": "https://www.google.com/s2/favicons?domain=hubspot.com&sz=128",
             "transport": "oauth",
             "provider_name": "hubspot",
@@ -327,6 +327,10 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "crm.objects.companies.read",
                 "crm.objects.companies.write",
                 "crm.objects.deals.read",
+                "forms",
+                "business-intelligence",
+                "marketing-email",
+                "marketing.campaigns.read",
             ],
             "is_visible_in_connector": True,
             "launch_config": {

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -10,10 +10,7 @@ from typing import Any, Dict, List
 
 from sqlalchemy.orm import Session
 
-from .builtin_mcp_registry import (
-    get_builtin_execution_fields,
-    get_builtin_optional_oauth_scopes,
-)
+from .builtin_mcp_registry import get_builtin_execution_fields_and_optional_scopes
 from .models.public_mcp import PublicMCPApp
 
 # Apps that must not be satisfied by a bare provider-level OAuth grant (one
@@ -134,7 +131,11 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
 
 
 def _app_to_dict(app: PublicMCPApp) -> Dict[str, Any]:
-    execution_fields = get_builtin_execution_fields(app.app_id)
+    # One registry scan (not two - see the helper's own docstring) since
+    # this runs per app on the connector-listing path.
+    execution_fields, optional_oauth_scopes = (
+        get_builtin_execution_fields_and_optional_scopes(app.app_id)
+    )
     if execution_fields is None:
         execution_fields = {
             "name": app.name,
@@ -156,9 +157,9 @@ def _app_to_dict(app: PublicMCPApp) -> Dict[str, Any]:
         "category": app.category,
         "oauth_scopes": deepcopy(execution_fields["oauth_scopes"]),
         # Only builtin apps can declare these today (see
-        # get_builtin_optional_oauth_scopes) - a custom admin-created app
-        # has no column for it and always gets [].
-        "optional_oauth_scopes": get_builtin_optional_oauth_scopes(app.app_id),
+        # get_builtin_execution_fields_and_optional_scopes) - a custom
+        # admin-created app has no column for it and always gets [].
+        "optional_oauth_scopes": optional_oauth_scopes,
         "is_visible_in_connector": bool(app.is_visible_in_connector),
         "launch_config": launch_config,
         "auth_type": classify_app_auth(transport, launch_config),

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -10,7 +10,10 @@ from typing import Any, Dict, List
 
 from sqlalchemy.orm import Session
 
-from .builtin_mcp_registry import get_builtin_execution_fields
+from .builtin_mcp_registry import (
+    get_builtin_execution_fields,
+    get_builtin_optional_oauth_scopes,
+)
 from .models.public_mcp import PublicMCPApp
 
 # Apps that must not be satisfied by a bare provider-level OAuth grant (one
@@ -152,6 +155,10 @@ def _app_to_dict(app: PublicMCPApp) -> Dict[str, Any]:
         "provider": execution_fields["provider_name"],
         "category": app.category,
         "oauth_scopes": deepcopy(execution_fields["oauth_scopes"]),
+        # Only builtin apps can declare these today (see
+        # get_builtin_optional_oauth_scopes) - a custom admin-created app
+        # has no column for it and always gets [].
+        "optional_oauth_scopes": get_builtin_optional_oauth_scopes(app.app_id),
         "is_visible_in_connector": bool(app.is_visible_in_connector),
         "launch_config": launch_config,
         "auth_type": classify_app_auth(transport, launch_config),

--- a/src/xagent/web/tools/mcp/hubspot.py
+++ b/src/xagent/web/tools/mcp/hubspot.py
@@ -157,34 +157,64 @@ def _paged_list(
     return response
 
 
-def _success_with_capped_dict(field_name: str, data: Any, **rest: Any) -> str:
-    """Build a success payload, halving a dict's top-level keys until the
-    response fits the platform's output limit.
+def _success_with_capped_dict(field_name: str, data: Any) -> str:
+    """Build a success payload, trimming a dict until the response fits the
+    platform's output limit.
 
     HubSpot's analytics/statistics/metrics responses are dicts keyed by
     date, dimension, or id depending on the endpoint and parameters (e.g.
     one key per day for a "daily" analytics breakdown over a wide date
-    range) rather than a single flat list, so this halves top-level keys
-    instead of list items - same adaptive-halving reasoning as
-    _paged_list, applied to the shape these tools actually return. When
-    ``data`` isn't a dict, there is nothing generically safe to trim
-    without guessing at a shape this function doesn't know, so it is
-    returned as-is (``truncated`` stays False - it reports content this
-    function removed, and here nothing was).
+    range), where most of the payload's size typically lives in one or two
+    large nested list/dict values while the rest are small scalars (an
+    "offset" or "total" field alongside a big "breakdowns" list). Dropping
+    whole top-level keys to shrink such a dict can discard the entire
+    useful payload on the very first step while leaving small, mostly
+    empty scalar fields behind - and there's no cursor to retry with, so
+    that data is gone for this call. Phase 1 instead repeatedly finds the
+    largest list/dict-valued key and halves *its* contents (recursing one
+    level, not further), so small scalar keys survive untouched as long as
+    there is a bigger key left to shrink first. Phase 2 is a fallback for
+    the residual case - a dict with no list/dict-valued keys at all (e.g.
+    a handful of scalar keys with huge string values) - and drops whole
+    keys, exactly as phase 1 replaces; it's guaranteed to terminate at {}.
     """
     max_output_length = get_tool_max_output_length()
-    truncated = False
-    payload = {field_name: data, "truncated": truncated, **rest}
-    response = _success(**payload)
-    if not isinstance(data, dict):
+    response = _success(**{field_name: data, "truncated": False})
+    if not isinstance(data, dict) or len(response) <= max_output_length:
         return response
-    keys = list(data.keys())
+
+    working = dict(data)
+    truncated = False
+    while len(response) > max_output_length:
+        collection_keys = [
+            key
+            for key, value in working.items()
+            if isinstance(value, (list, dict)) and len(value) > 0
+        ]
+        if not collection_keys:
+            break
+        target_key = max(
+            collection_keys,
+            key=lambda key: len(json.dumps(working[key], ensure_ascii=False)),
+        )
+        target_value = working[target_key]
+        if isinstance(target_value, list):
+            working[target_key] = target_value[: len(target_value) // 2]
+        else:
+            sub_keys = list(target_value.keys())
+            working[target_key] = {
+                sub_key: target_value[sub_key]
+                for sub_key in sub_keys[: len(sub_keys) // 2]
+            }
+        truncated = True
+        response = _success(**{field_name: working, "truncated": truncated})
+
+    keys = list(working.keys())
     while len(response) > max_output_length and keys:
         keys = keys[: len(keys) // 2]
-        data = {key: data[key] for key in keys}
+        working = {key: working[key] for key in keys}
         truncated = True
-        payload = {field_name: data, "truncated": truncated, **rest}
-        response = _success(**payload)
+        response = _success(**{field_name: working, "truncated": truncated})
     return response
 
 
@@ -778,9 +808,19 @@ def hubspot_get_marketing_email_statistics(
             "emailIds": ids
         }
         if start_date:
-            params["startTimestamp"] = start_date
+            params["startTimestamp"] = _require_date_format(
+                start_date,
+                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z",
+                "start_date",
+                "YYYY-MM-DDTHH:MM:SSZ",
+            )
         if end_date:
-            params["endTimestamp"] = end_date
+            params["endTimestamp"] = _require_date_format(
+                end_date,
+                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z",
+                "end_date",
+                "YYYY-MM-DDTHH:MM:SSZ",
+            )
         result = _request("GET", "/marketing/v3/emails/statistics/list", params=params)
         return _success_with_capped_dict("statistics", result)
     except Exception as e:
@@ -799,6 +839,11 @@ def hubspot_list_campaigns(limit: int = 20, after: str | None = None) -> str:
     output size limit - retry with a smaller `limit` to see the trimmed
     entries. Use hubspot_get_campaign_metrics for performance metrics on
     a specific campaign.
+
+    The connector requests marketing.campaigns.read as optional (the
+    Campaigns API requires Marketing Hub Professional or higher), so this
+    call fails with a permissions error on portals below that tier - the
+    connection itself still works for every other tool.
     """
     try:
         params: dict[str, Any] = {
@@ -834,6 +879,11 @@ def hubspot_get_campaign_metrics(
     `end_date` are optional "YYYY-MM-DD" strings (a different format
     from hubspot_get_analytics_report's "YYYYMMDD" - this is a separate,
     newer HubSpot API) that limit the reporting window.
+
+    The connector requests marketing.campaigns.read as optional (the
+    Campaigns API requires Marketing Hub Professional or higher), so this
+    call fails with a permissions error on portals below that tier - the
+    connection itself still works for every other tool.
     """
     try:
         campaign_id = _url_path_id(campaign_id, "campaign_id")

--- a/src/xagent/web/tools/mcp/hubspot.py
+++ b/src/xagent/web/tools/mcp/hubspot.py
@@ -516,10 +516,16 @@ def hubspot_get_marketing_email_statistics(email_ids: str) -> str:
     fetch statistics for multiple emails at once.
     """
     try:
+        ids = [
+            email_id.strip() for email_id in email_ids.split(",") if email_id.strip()
+        ]
         result = _request(
             "GET",
             "/marketing/v3/emails/statistics/list",
-            params={"emailIds": email_ids},
+            # HubSpot's emailIds is an array param: requests serializes a
+            # list value as repeated "emailIds=<id>" pairs, matching that
+            # shape rather than a single comma-joined value.
+            params={"emailIds": ids},
         )
         return _success(statistics=result.get("results", result))
     except Exception as e:

--- a/src/xagent/web/tools/mcp/hubspot.py
+++ b/src/xagent/web/tools/mcp/hubspot.py
@@ -1,8 +1,11 @@
 import json
 import logging
 import os
+import re
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import quote
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -100,30 +103,87 @@ def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
 
 
-def _success_with_capped_list(list_field: str, items: list[Any], **rest: Any) -> str:
-    """Build a success payload, halving ``items`` until it fits the
-    platform's output limit.
+def _paged_list(
+    path: str,
+    list_field: str,
+    *,
+    params: dict[str, Any],
+    after: str | None,
+    project: Callable[[list[Any]], list[Any]] = lambda items: items,
+) -> str:
+    """Fetch one page from a HubSpot cursor-paginated list endpoint, project
+    its items, and halve them until the response fits the platform's
+    output limit.
 
     Unprojected HubSpot objects (full property maps) can serialize past the
     output filter's threshold and get hard-truncated into broken JSON, the
-    same failure mode documented in google_analytics.py's list/report tools.
-    Halving (rather than a fixed slice) keeps the cap adaptive to whatever
-    property payload size a given portal's objects happen to have.
+    same failure mode documented in google_analytics.py's list/report
+    tools. Halving (rather than a fixed slice) keeps the cap adaptive to
+    whatever property payload size a given portal's objects happen to
+    have, and continues down to zero items - a single oversized item must
+    still be capped, not silently returned whole because there's nothing
+    left to halve away from it.
 
-    ``truncated`` reports only this in-page trimming; the caller's
-    cursor-derived ``has_more``/``after`` (already in ``rest``) pass through
-    untouched, still describing whether the *server* has another page. A
-    trimmed page must be re-fetched with a smaller ``limit`` - advancing
-    ``after`` past it would silently skip the trimmed entries.
+    On truncation, the returned ``after`` is deliberately this call's own
+    input cursor, not the server's next-page cursor: the server already
+    considers the full (untruncated) page consumed, so advancing to its
+    next page would permanently skip whatever this page didn't return for
+    space reasons. Retrying with the same ``after`` and a smaller ``limit``
+    is what actually surfaces the trimmed entries.
+    """
+    result = _request("GET", path, params=params)
+    next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
+    items = project(result.get("results", []))
+
+    max_output_length = get_tool_max_output_length()
+    truncated = False
+    payload = {
+        list_field: items,
+        "truncated": truncated,
+        "has_more": bool(next_after),
+        "after": next_after,
+    }
+    response = _success(**payload)
+    while len(response) > max_output_length and items:
+        items = items[: len(items) // 2]
+        truncated = True
+        payload = {
+            list_field: items,
+            "truncated": truncated,
+            "has_more": True,
+            "after": after,
+        }
+        response = _success(**payload)
+    return response
+
+
+def _success_with_capped_dict(field_name: str, data: Any, **rest: Any) -> str:
+    """Build a success payload, halving a dict's top-level keys until the
+    response fits the platform's output limit.
+
+    HubSpot's analytics/statistics/metrics responses are dicts keyed by
+    date, dimension, or id depending on the endpoint and parameters (e.g.
+    one key per day for a "daily" analytics breakdown over a wide date
+    range) rather than a single flat list, so this halves top-level keys
+    instead of list items - same adaptive-halving reasoning as
+    _paged_list, applied to the shape these tools actually return. When
+    ``data`` isn't a dict, there is nothing generically safe to trim
+    without guessing at a shape this function doesn't know, so it is
+    returned as-is (``truncated`` stays False - it reports content this
+    function removed, and here nothing was).
     """
     max_output_length = get_tool_max_output_length()
     truncated = False
-    payload = {list_field: items, "truncated": truncated, **rest}
+    payload = {field_name: data, "truncated": truncated, **rest}
     response = _success(**payload)
-    while len(response) > max_output_length and len(items) > 1:
-        items = items[: len(items) // 2]
+    if not isinstance(data, dict):
+        return response
+    keys = list(data.keys())
+    while len(response) > max_output_length and keys:
+        keys = keys[: len(keys) // 2]
+        data = {key: data[key] for key in keys}
         truncated = True
-        payload = {list_field: items, "truncated": truncated, **rest}
+        payload = {field_name: data, "truncated": truncated, **rest}
         response = _success(**payload)
     return response
 
@@ -134,11 +194,40 @@ def _require_clean_identifier(value: str, field_name: str) -> str:
     An id copy-pasted or concatenated by a caller with accidental whitespace
     is more likely a bug worth surfacing than a value to repair - repairing
     it would mask the bug and could send a query for a different object.
+    Use this for ids that go into a JSON request body; for ids interpolated
+    into a URL path, use _url_path_id instead - encoding (not just
+    rejecting whitespace) is what actually closes path/query injection.
     """
     if not value or value.strip() != value:
         raise ValueError(
             f"{field_name} must be a non-empty id with no surrounding whitespace"
         )
+    return value
+
+
+def _url_path_id(value: str, field_name: str) -> str:
+    """Validate then percent-encode an id for safe interpolation into a URL
+    path segment.
+
+    Percent-encoding - not a blocklist of "/", "?", "#", or ".." - is what
+    actually prevents a value like "x?limit=1&foo=/reports/metrics" from
+    escaping its intended path segment: any character that could do that
+    gets encoded regardless of which one it is, rather than relying on an
+    enumeration that could miss one.
+    """
+    _require_clean_identifier(value, field_name)
+    return quote(value, safe="")
+
+
+def _require_date_format(value: str, pattern: str, field_name: str, label: str) -> str:
+    """Reject a date that doesn't match the endpoint's expected format.
+
+    The two campaign/analytics HubSpot APIs use different date formats
+    (YYYYMMDD vs YYYY-MM-DD); an LLM caller mixing them up would otherwise
+    get an opaque upstream 400 instead of a message naming the fix.
+    """
+    if not re.fullmatch(pattern, value):
+        raise ValueError(f"{field_name} must be a {label} date string")
     return value
 
 
@@ -258,6 +347,7 @@ def hubspot_get_contact(contact_id: str) -> str:
     Get a HubSpot contact by id, including associated company and deal ids.
     """
     try:
+        contact_id = _url_path_id(contact_id, "contact_id")
         contact = _request(
             "GET",
             f"/crm/v3/objects/contacts/{contact_id}",
@@ -298,6 +388,7 @@ def hubspot_update_contact(contact_id: str, properties_json: str) -> str:
     properties_json is a JSON object of the properties to change.
     """
     try:
+        contact_id = _url_path_id(contact_id, "contact_id")
         contact = _request(
             "PATCH",
             f"/crm/v3/objects/contacts/{contact_id}",
@@ -348,6 +439,7 @@ def hubspot_update_company(company_id: str, properties_json: str) -> str:
     properties_json is a JSON object of the properties to change.
     """
     try:
+        company_id = _url_path_id(company_id, "company_id")
         company = _request(
             "PATCH",
             f"/crm/v3/objects/companies/{company_id}",
@@ -367,6 +459,7 @@ def hubspot_get_contact_deals(contact_id: str, limit: int = 100) -> str:
     `has_more` is true when the contact has additional deals beyond the result.
     """
     try:
+        contact_id = _url_path_id(contact_id, "contact_id")
         deal_ids, has_more = _list_association_ids(
             f"/crm/v3/objects/contacts/{contact_id}/associations/deals",
             max(1, min(limit, 100)),
@@ -402,6 +495,7 @@ def hubspot_get_contact_notes(contact_id: str, limit: int = 20) -> str:
     (max 100); `has_more` is true when the contact has additional notes.
     """
     try:
+        contact_id = _url_path_id(contact_id, "contact_id")
         note_ids, has_more = _list_association_ids(
             f"/crm/v3/objects/contacts/{contact_id}/associations/notes",
             max(1, min(limit, 100)),
@@ -442,7 +536,18 @@ def hubspot_create_note(
     At least one of contact_id, company_id, or deal_id must be provided.
     """
     try:
-        targets = {"contact": contact_id, "company": company_id, "deal": deal_id}
+        # Truthiness (not `is not None`) keeps an empty string meaning
+        # "not provided", matching the association filter below - only a
+        # non-empty id gets validated for stray whitespace.
+        targets = {
+            "contact": _require_clean_identifier(contact_id, "contact_id")
+            if contact_id
+            else None,
+            "company": _require_clean_identifier(company_id, "company_id")
+            if company_id
+            else None,
+            "deal": _require_clean_identifier(deal_id, "deal_id") if deal_id else None,
+        }
         associations = [
             {
                 "to": {"id": object_id},
@@ -514,11 +619,12 @@ def hubspot_list_forms(limit: int = 20, after: str | None = None) -> str:
         params: dict[str, Any] = {"limit": max(1, min(limit, 100))}
         if after:
             params["after"] = after
-        result = _request("GET", "/marketing/v3/forms", params=params)
-        next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
-        forms = _project_fields(result.get("results", []), _FORM_SUMMARY_FIELDS)
-        return _success_with_capped_list(
-            "forms", forms, has_more=bool(next_after), after=next_after
+        return _paged_list(
+            "/marketing/v3/forms",
+            "forms",
+            params=params,
+            after=after,
+            project=lambda items: _project_fields(items, _FORM_SUMMARY_FIELDS),
         )
     except Exception as e:
         logger.error(f"Error listing forms: {e}")
@@ -539,19 +645,15 @@ def hubspot_get_form_submissions(
     entries.
     """
     try:
-        form_id = _require_clean_identifier(form_id, "form_id")
+        form_id = _url_path_id(form_id, "form_id")
         params: dict[str, Any] = {"limit": max(1, min(limit, 50))}
         if after:
             params["after"] = after
-        result = _request(
-            "GET", f"/form-integrations/v1/submissions/forms/{form_id}", params=params
-        )
-        next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
-        return _success_with_capped_list(
+        return _paged_list(
+            f"/form-integrations/v1/submissions/forms/{form_id}",
             "submissions",
-            result.get("results", []),
-            has_more=bool(next_after),
-            after=next_after,
+            params=params,
+            after=after,
         )
     except Exception as e:
         logger.error(f"Error getting form submissions: {e}")
@@ -593,12 +695,14 @@ def hubspot_get_analytics_report(
             raise ValueError(
                 f"breakdown must be one of {sorted(_VALID_ANALYTICS_BREAKDOWNS)}"
             )
+        _require_date_format(start_date, r"\d{8}", "start_date", "YYYYMMDD")
+        _require_date_format(end_date, r"\d{8}", "end_date", "YYYYMMDD")
         result = _request(
             "GET",
             f"/analytics/v2/reports/{normalized_report_type}/{normalized_breakdown}",
             params={"start": start_date, "end": end_date},
         )
-        return _success(report=result)
+        return _success_with_capped_dict("report", result)
     except Exception as e:
         logger.error(f"Error getting analytics report: {e}")
         return _error(str(e))
@@ -626,11 +730,12 @@ def hubspot_list_marketing_emails(limit: int = 20, after: str | None = None) -> 
         params: dict[str, Any] = {"limit": max(1, min(limit, 100))}
         if after:
             params["after"] = after
-        result = _request("GET", "/marketing/v3/emails", params=params)
-        next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
-        emails = _project_fields(result.get("results", []), _EMAIL_SUMMARY_FIELDS)
-        return _success_with_capped_list(
-            "emails", emails, has_more=bool(next_after), after=next_after
+        return _paged_list(
+            "/marketing/v3/emails",
+            "emails",
+            params=params,
+            after=after,
+            project=lambda items: _project_fields(items, _EMAIL_SUMMARY_FIELDS),
         )
     except Exception as e:
         logger.error(f"Error listing marketing emails: {e}")
@@ -677,7 +782,7 @@ def hubspot_get_marketing_email_statistics(
         if end_date:
             params["endTimestamp"] = end_date
         result = _request("GET", "/marketing/v3/emails/statistics/list", params=params)
-        return _success(statistics=result)
+        return _success_with_capped_dict("statistics", result)
     except Exception as e:
         logger.error(f"Error getting marketing email statistics: {e}")
         return _error(str(e))
@@ -702,14 +807,15 @@ def hubspot_list_campaigns(limit: int = 20, after: str | None = None) -> str:
         }
         if after:
             params["after"] = after
-        result = _request("GET", "/marketing/v3/campaigns", params=params)
-        next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
-        campaigns = [
-            {"id": item.get("id"), "properties": item.get("properties", {})}
-            for item in result.get("results", [])
-        ]
-        return _success_with_capped_list(
-            "campaigns", campaigns, has_more=bool(next_after), after=next_after
+        return _paged_list(
+            "/marketing/v3/campaigns",
+            "campaigns",
+            params=params,
+            after=after,
+            project=lambda items: [
+                {"id": item.get("id"), "properties": item.get("properties", {})}
+                for item in items
+            ],
         )
     except Exception as e:
         logger.error(f"Error listing campaigns: {e}")
@@ -730,18 +836,22 @@ def hubspot_get_campaign_metrics(
     newer HubSpot API) that limit the reporting window.
     """
     try:
-        campaign_id = _require_clean_identifier(campaign_id, "campaign_id")
+        campaign_id = _url_path_id(campaign_id, "campaign_id")
         params: dict[str, Any] = {}
         if start_date:
-            params["startDate"] = start_date
+            params["startDate"] = _require_date_format(
+                start_date, r"\d{4}-\d{2}-\d{2}", "start_date", "YYYY-MM-DD"
+            )
         if end_date:
-            params["endDate"] = end_date
+            params["endDate"] = _require_date_format(
+                end_date, r"\d{4}-\d{2}-\d{2}", "end_date", "YYYY-MM-DD"
+            )
         result = _request(
             "GET",
             f"/marketing/v3/campaigns/{campaign_id}/reports/metrics",
             params=params,
         )
-        return _success(metrics=result)
+        return _success_with_capped_dict("metrics", result)
     except Exception as e:
         logger.error(f"Error getting campaign metrics: {e}")
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/hubspot.py
+++ b/src/xagent/web/tools/mcp/hubspot.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import re
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
@@ -74,7 +73,20 @@ _NOTE_ASSOCIATION_TYPE_IDS = {"contact": 202, "company": 190, "deal": 214}
 
 _ASSOCIATION_PAGE_SIZE = 100
 
-_VALID_ANALYTICS_BREAKDOWNS = {"total", "daily", "weekly", "monthly"}
+# Per HubSpot's OpenAPI spec for this endpoint, time_period also accepts a
+# "summarize/{period}" form - a portal-wide summary across all breakdown_by
+# values rather than one row per value. The plain forms below stay listed
+# separately (not built by string-formatting a period) so a typo in one
+# doesn't silently produce a still-valid "summarize/<typo>" value.
+_VALID_ANALYTICS_BREAKDOWNS = {
+    "total",
+    "daily",
+    "weekly",
+    "monthly",
+    "summarize/daily",
+    "summarize/weekly",
+    "summarize/monthly",
+}
 # Union of the two documented /analytics/v2/reports variants: breakdowns
 # (totals, sessions, sources, ...) and content object types (forms, pages,
 # ...). Both share the same URL shape.
@@ -153,6 +165,19 @@ def _paged_list(
             "has_more": True,
             "after": after,
         }
+        response = _success(**payload)
+    if truncated and not items:
+        # Collapsing all the way to zero means even the single largest
+        # remaining record didn't fit alone - "retry with a smaller limit"
+        # (the general truncated-page guidance) isn't guaranteed to help
+        # here, so say so plainly instead of implying a fix that may not
+        # exist.
+        payload["message"] = (
+            "Every record in this page was individually too large to fit "
+            "the output size limit, so none could be returned. Retrying "
+            "with a smaller `limit` may surface different records if more "
+            "exist, but cannot shrink an individually oversized record."
+        )
         response = _success(**payload)
     return response
 
@@ -249,16 +274,42 @@ def _url_path_id(value: str, field_name: str) -> str:
     return quote(value, safe="")
 
 
-def _require_date_format(value: str, pattern: str, field_name: str, label: str) -> str:
-    """Reject a date that doesn't match the endpoint's expected format.
+def _require_date_format(
+    value: str, strptime_format: str, field_name: str, label: str
+) -> datetime:
+    """Reject a value that isn't a real calendar date in the endpoint's
+    expected format, and return the parsed date for a caller that also
+    needs to check ordering.
 
-    The two campaign/analytics HubSpot APIs use different date formats
-    (YYYYMMDD vs YYYY-MM-DD); an LLM caller mixing them up would otherwise
-    get an opaque upstream 400 instead of a message naming the fix.
+    A shape-only regex (matching digit positions but not their range) would
+    accept "20261332" or "2026-13-32" as syntactically fine and only fail
+    once the request reaches HubSpot; strptime rejects both. But strptime
+    alone is *more* lenient than a regex in the other direction: %m/%d
+    accept non-zero-padded values, and %Y will happily consume fewer than 4
+    digits if the remaining directives can still find something to match
+    (datetime.strptime("202611", "%Y%m%d") silently parses as 2026-01-01,
+    not a rejection) - so a genuinely malformed value could parse into the
+    *wrong* date instead of failing. Reformatting the parsed result and
+    comparing it back to the original string catches both failure modes.
+    The three HubSpot APIs this connector calls use three different date
+    formats (YYYYMMDD, YYYY-MM-DD, and YYYY-MM-DDTHH:MM:SSZ); an LLM caller
+    mixing them up would otherwise get an opaque upstream 400 instead of a
+    message naming the fix.
     """
-    if not re.fullmatch(pattern, value):
+    try:
+        parsed = datetime.strptime(value, strptime_format)
+    except ValueError:
+        parsed = None
+    if parsed is None or parsed.strftime(strptime_format) != value:
         raise ValueError(f"{field_name} must be a {label} date string")
-    return value
+    return parsed
+
+
+def _require_date_range_order(
+    start: datetime | None, end: datetime | None, start_field: str, end_field: str
+) -> None:
+    if start is not None and end is not None and start > end:
+        raise ValueError(f"{start_field} must not be after {end_field}")
 
 
 def _headers() -> dict[str, str]:
@@ -704,9 +755,11 @@ def hubspot_get_analytics_report(
     "utm-contents", "utm-mediums", "utm-sources", "utm-terms",
     "event-completions", "forms", "pages", or "social-assists".
     `breakdown` selects the time granularity within that window: "total"
-    (one summed value), "daily", "weekly", or "monthly". `start_date` and
-    `end_date` are required "YYYYMMDD" strings (a "daily" breakdown spans
-    at most 500 days).
+    (one summed value), "daily", "weekly", "monthly", or a
+    "summarize/daily", "summarize/weekly", "summarize/monthly" variant
+    (a portal-wide summary across all `report_type` values instead of one
+    row per value). `start_date` and `end_date` are required "YYYYMMDD"
+    strings; a "daily" breakdown spans at most 500 days.
 
     Note: this covers HubSpot's traffic/analytics dimensions, not
     custom reports or dashboards built in the HubSpot report editor -
@@ -725,8 +778,14 @@ def hubspot_get_analytics_report(
             raise ValueError(
                 f"breakdown must be one of {sorted(_VALID_ANALYTICS_BREAKDOWNS)}"
             )
-        _require_date_format(start_date, r"\d{8}", "start_date", "YYYYMMDD")
-        _require_date_format(end_date, r"\d{8}", "end_date", "YYYYMMDD")
+        start_dt = _require_date_format(start_date, "%Y%m%d", "start_date", "YYYYMMDD")
+        end_dt = _require_date_format(end_date, "%Y%m%d", "end_date", "YYYYMMDD")
+        _require_date_range_order(start_dt, end_dt, "start_date", "end_date")
+        if normalized_breakdown == "daily" and (end_dt - start_dt).days > 500:
+            raise ValueError(
+                "start_date and end_date must not span more than 500 days "
+                'for a "daily" breakdown'
+            )
         result = _request(
             "GET",
             f"/analytics/v2/reports/{normalized_report_type}/{normalized_breakdown}",
@@ -807,20 +866,18 @@ def hubspot_get_marketing_email_statistics(
             # shape rather than a single comma-joined value.
             "emailIds": ids
         }
+        start_dt = end_dt = None
         if start_date:
-            params["startTimestamp"] = _require_date_format(
-                start_date,
-                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z",
-                "start_date",
-                "YYYY-MM-DDTHH:MM:SSZ",
+            start_dt = _require_date_format(
+                start_date, "%Y-%m-%dT%H:%M:%SZ", "start_date", "YYYY-MM-DDTHH:MM:SSZ"
             )
+            params["startTimestamp"] = start_date
         if end_date:
-            params["endTimestamp"] = _require_date_format(
-                end_date,
-                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z",
-                "end_date",
-                "YYYY-MM-DDTHH:MM:SSZ",
+            end_dt = _require_date_format(
+                end_date, "%Y-%m-%dT%H:%M:%SZ", "end_date", "YYYY-MM-DDTHH:MM:SSZ"
             )
+            params["endTimestamp"] = end_date
+        _require_date_range_order(start_dt, end_dt, "start_date", "end_date")
         result = _request("GET", "/marketing/v3/emails/statistics/list", params=params)
         return _success_with_capped_dict("statistics", result)
     except Exception as e:
@@ -860,6 +917,7 @@ def hubspot_list_campaigns(limit: int = 20, after: str | None = None) -> str:
             project=lambda items: [
                 {"id": item.get("id"), "properties": item.get("properties", {})}
                 for item in items
+                if isinstance(item, dict)
             ],
         )
     except Exception as e:
@@ -888,14 +946,18 @@ def hubspot_get_campaign_metrics(
     try:
         campaign_id = _url_path_id(campaign_id, "campaign_id")
         params: dict[str, Any] = {}
+        start_dt = end_dt = None
         if start_date:
-            params["startDate"] = _require_date_format(
-                start_date, r"\d{4}-\d{2}-\d{2}", "start_date", "YYYY-MM-DD"
+            start_dt = _require_date_format(
+                start_date, "%Y-%m-%d", "start_date", "YYYY-MM-DD"
             )
+            params["startDate"] = start_date
         if end_date:
-            params["endDate"] = _require_date_format(
-                end_date, r"\d{4}-\d{2}-\d{2}", "end_date", "YYYY-MM-DD"
+            end_dt = _require_date_format(
+                end_date, "%Y-%m-%d", "end_date", "YYYY-MM-DD"
             )
+            params["endDate"] = end_date
+        _require_date_range_order(start_dt, end_dt, "start_date", "end_date")
         result = _request(
             "GET",
             f"/marketing/v3/campaigns/{campaign_id}/reports/metrics",

--- a/src/xagent/web/tools/mcp/hubspot.py
+++ b/src/xagent/web/tools/mcp/hubspot.py
@@ -61,7 +61,25 @@ _NOTE_ASSOCIATION_TYPE_IDS = {"contact": 202, "company": 190, "deal": 214}
 
 _ASSOCIATION_PAGE_SIZE = 100
 
-_VALID_ANALYTICS_BREAKDOWNS = {"total", "day", "week", "month"}
+_VALID_ANALYTICS_BREAKDOWNS = {"total", "daily", "weekly", "monthly"}
+# Union of the two documented /analytics/v2/reports variants: breakdowns
+# (totals, sessions, sources, ...) and content object types (forms, pages,
+# ...). Both share the same URL shape.
+_VALID_ANALYTICS_REPORT_TYPES = {
+    "totals",
+    "sessions",
+    "sources",
+    "geolocation",
+    "utm-campaigns",
+    "utm-contents",
+    "utm-mediums",
+    "utm-sources",
+    "utm-terms",
+    "event-completions",
+    "forms",
+    "pages",
+    "social-assists",
+}
 
 
 def _success(**payload: Any) -> str:
@@ -409,41 +427,55 @@ def hubspot_create_note(
 
 
 @mcp.tool()
-def hubspot_list_forms(limit: int = 20) -> str:
+def hubspot_list_forms(limit: int = 20, after: str | None = None) -> str:
     """
     List HubSpot marketing forms, including id and full form metadata
     (name, field groups, etc.). Returns at most `limit` forms (max 100);
     `has_more` is true when the portal has additional forms beyond the
-    result. Use hubspot_get_form_submissions to pull the submissions
+    result, and `after` is the cursor to pass back in to fetch the next
+    page. Use hubspot_get_form_submissions to pull the submissions
     collected by a specific form.
     """
     try:
-        result = _request(
-            "GET", "/marketing/v3/forms", params={"limit": max(1, min(limit, 100))}
+        params: dict[str, Any] = {"limit": max(1, min(limit, 100))}
+        if after:
+            params["after"] = after
+        result = _request("GET", "/marketing/v3/forms", params=params)
+        next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
+        return _success(
+            forms=result.get("results", []),
+            has_more=bool(next_after),
+            after=next_after,
         )
-        has_more = bool((result.get("paging") or {}).get("next"))
-        return _success(forms=result.get("results", []), has_more=has_more)
     except Exception as e:
         logger.error(f"Error listing forms: {e}")
         return _error(str(e))
 
 
 @mcp.tool()
-def hubspot_get_form_submissions(form_id: str, limit: int = 20) -> str:
+def hubspot_get_form_submissions(
+    form_id: str, limit: int = 20, after: str | None = None
+) -> str:
     """
     Get recent submissions for a HubSpot form, including submitted field
     values, submission timestamp, and page URL. Returns at most `limit`
     submissions (max 50); `has_more` is true when the form has additional
-    submissions beyond the result.
+    submissions beyond the result, and `after` is the cursor to pass back
+    in to fetch the next page.
     """
     try:
+        params: dict[str, Any] = {"limit": max(1, min(limit, 50))}
+        if after:
+            params["after"] = after
         result = _request(
-            "GET",
-            f"/form-integrations/v1/submissions/forms/{form_id}",
-            params={"limit": max(1, min(limit, 50))},
+            "GET", f"/form-integrations/v1/submissions/forms/{form_id}", params=params
         )
-        has_more = bool((result.get("paging") or {}).get("next"))
-        return _success(submissions=result.get("results", []), has_more=has_more)
+        next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
+        return _success(
+            submissions=result.get("results", []),
+            has_more=bool(next_after),
+            after=next_after,
+        )
     except Exception as e:
         logger.error(f"Error getting form submissions: {e}")
         return _error(str(e))
@@ -458,10 +490,12 @@ def hubspot_get_analytics_report(
 ) -> str:
     """
     Get a HubSpot traffic analytics report. `report_type` is a HubSpot
-    analytics dimension such as "sources", "utm-campaigns", "landing-pages",
-    "pages", or "geolocation". `breakdown` is "total", "day", "week", or
-    "month". `start_date`/`end_date` are optional "YYYYMMDD" strings that
-    limit the reporting window.
+    analytics dimension ("totals", "sessions", "sources", "geolocation",
+    "utm-campaigns", "utm-contents", "utm-mediums", "utm-sources",
+    "utm-terms") or content object type ("event-completions", "forms",
+    "pages", "social-assists"). `breakdown` is "total", "daily", "weekly",
+    or "monthly". `start_date`/`end_date` are optional "YYYYMMDD" strings
+    that limit the reporting window.
 
     Note: this covers HubSpot's traffic/analytics dimensions, not
     custom reports or dashboards built in the HubSpot report editor -
@@ -470,6 +504,10 @@ def hubspot_get_analytics_report(
     not supported by this HubSpot API.
     """
     try:
+        if report_type not in _VALID_ANALYTICS_REPORT_TYPES:
+            raise ValueError(
+                f"report_type must be one of {sorted(_VALID_ANALYTICS_REPORT_TYPES)}"
+            )
         if breakdown not in _VALID_ANALYTICS_BREAKDOWNS:
             raise ValueError(
                 f"breakdown must be one of {sorted(_VALID_ANALYTICS_BREAKDOWNS)}"
@@ -489,20 +527,26 @@ def hubspot_get_analytics_report(
 
 
 @mcp.tool()
-def hubspot_list_marketing_emails(limit: int = 20) -> str:
+def hubspot_list_marketing_emails(limit: int = 20, after: str | None = None) -> str:
     """
     List HubSpot marketing emails, including id and full email metadata
     (name, subject, state, publish date, etc.). Returns at most `limit`
     emails (max 100); `has_more` is true when the portal has additional
-    emails beyond the result. Use hubspot_get_marketing_email_statistics
-    for performance metrics on a specific email.
+    emails beyond the result, and `after` is the cursor to pass back in to
+    fetch the next page. Use hubspot_get_marketing_email_statistics for
+    performance metrics on a specific email.
     """
     try:
-        result = _request(
-            "GET", "/marketing/v3/emails", params={"limit": max(1, min(limit, 100))}
+        params: dict[str, Any] = {"limit": max(1, min(limit, 100))}
+        if after:
+            params["after"] = after
+        result = _request("GET", "/marketing/v3/emails", params=params)
+        next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
+        return _success(
+            emails=result.get("results", []),
+            has_more=bool(next_after),
+            after=next_after,
         )
-        has_more = bool((result.get("paging") or {}).get("next"))
-        return _success(emails=result.get("results", []), has_more=has_more)
     except Exception as e:
         logger.error(f"Error listing marketing emails: {e}")
         return _error(str(e))
@@ -519,6 +563,10 @@ def hubspot_get_marketing_email_statistics(email_ids: str) -> str:
         ids = [
             email_id.strip() for email_id in email_ids.split(",") if email_id.strip()
         ]
+        if not ids:
+            # Without this, an empty emailIds list is dropped from the query
+            # entirely and HubSpot returns statistics for every email.
+            raise ValueError("email_ids must contain at least one email id")
         result = _request(
             "GET",
             "/marketing/v3/emails/statistics/list",
@@ -527,29 +575,33 @@ def hubspot_get_marketing_email_statistics(email_ids: str) -> str:
             # shape rather than a single comma-joined value.
             params={"emailIds": ids},
         )
-        return _success(statistics=result.get("results", result))
+        return _success(statistics=result)
     except Exception as e:
         logger.error(f"Error getting marketing email statistics: {e}")
         return _error(str(e))
 
 
 @mcp.tool()
-def hubspot_list_campaigns(limit: int = 20) -> str:
+def hubspot_list_campaigns(limit: int = 20, after: str | None = None) -> str:
     """
     List HubSpot marketing campaigns, including id and full campaign
     properties (name, status, date range, etc.). Returns at most `limit`
     campaigns (max 100); `has_more` is true when the portal has additional
-    campaigns beyond the result. Use hubspot_get_campaign_metrics for
+    campaigns beyond the result, and `after` is the cursor to pass back in
+    to fetch the next page. Use hubspot_get_campaign_metrics for
     performance metrics on a specific campaign.
     """
     try:
-        result = _request(
-            "GET",
-            "/marketing/v3/campaigns",
-            params={"limit": max(1, min(limit, 100))},
+        params: dict[str, Any] = {"limit": max(1, min(limit, 100))}
+        if after:
+            params["after"] = after
+        result = _request("GET", "/marketing/v3/campaigns", params=params)
+        next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
+        return _success(
+            campaigns=result.get("results", []),
+            has_more=bool(next_after),
+            after=next_after,
         )
-        has_more = bool((result.get("paging") or {}).get("next"))
-        return _success(campaigns=result.get("results", []), has_more=has_more)
     except Exception as e:
         logger.error(f"Error listing campaigns: {e}")
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/hubspot.py
+++ b/src/xagent/web/tools/mcp/hubspot.py
@@ -61,6 +61,8 @@ _NOTE_ASSOCIATION_TYPE_IDS = {"contact": 202, "company": 190, "deal": 214}
 
 _ASSOCIATION_PAGE_SIZE = 100
 
+_VALID_ANALYTICS_BREAKDOWNS = {"total", "day", "week", "month"}
+
 
 def _success(**payload: Any) -> str:
     return json.dumps({"status": "success", **payload}, ensure_ascii=False)
@@ -403,6 +405,176 @@ def hubspot_create_note(
         return _success(note=note)
     except Exception as e:
         logger.error(f"Error creating note: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def hubspot_list_forms(limit: int = 20) -> str:
+    """
+    List HubSpot marketing forms, including id and full form metadata
+    (name, field groups, etc.). Returns at most `limit` forms (max 100);
+    `has_more` is true when the portal has additional forms beyond the
+    result. Use hubspot_get_form_submissions to pull the submissions
+    collected by a specific form.
+    """
+    try:
+        result = _request(
+            "GET", "/marketing/v3/forms", params={"limit": max(1, min(limit, 100))}
+        )
+        has_more = bool((result.get("paging") or {}).get("next"))
+        return _success(forms=result.get("results", []), has_more=has_more)
+    except Exception as e:
+        logger.error(f"Error listing forms: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def hubspot_get_form_submissions(form_id: str, limit: int = 20) -> str:
+    """
+    Get recent submissions for a HubSpot form, including submitted field
+    values, submission timestamp, and page URL. Returns at most `limit`
+    submissions (max 50); `has_more` is true when the form has additional
+    submissions beyond the result.
+    """
+    try:
+        result = _request(
+            "GET",
+            f"/form-integrations/v1/submissions/forms/{form_id}",
+            params={"limit": max(1, min(limit, 50))},
+        )
+        has_more = bool((result.get("paging") or {}).get("next"))
+        return _success(submissions=result.get("results", []), has_more=has_more)
+    except Exception as e:
+        logger.error(f"Error getting form submissions: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def hubspot_get_analytics_report(
+    report_type: str,
+    breakdown: str = "total",
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
+    """
+    Get a HubSpot traffic analytics report. `report_type` is a HubSpot
+    analytics dimension such as "sources", "utm-campaigns", "landing-pages",
+    "pages", or "geolocation". `breakdown` is "total", "day", "week", or
+    "month". `start_date`/`end_date` are optional "YYYYMMDD" strings that
+    limit the reporting window.
+
+    Note: this covers HubSpot's traffic/analytics dimensions, not
+    custom reports or dashboards built in the HubSpot report editor -
+    HubSpot has no public API to read those. Requires a Marketing Hub
+    Basic, Professional, or Enterprise account; Free/Starter accounts are
+    not supported by this HubSpot API.
+    """
+    try:
+        if breakdown not in _VALID_ANALYTICS_BREAKDOWNS:
+            raise ValueError(
+                f"breakdown must be one of {sorted(_VALID_ANALYTICS_BREAKDOWNS)}"
+            )
+        params: dict[str, Any] = {}
+        if start_date:
+            params["start"] = start_date
+        if end_date:
+            params["end"] = end_date
+        result = _request(
+            "GET", f"/analytics/v2/reports/{report_type}/{breakdown}", params=params
+        )
+        return _success(report=result)
+    except Exception as e:
+        logger.error(f"Error getting analytics report: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def hubspot_list_marketing_emails(limit: int = 20) -> str:
+    """
+    List HubSpot marketing emails, including id and full email metadata
+    (name, subject, state, publish date, etc.). Returns at most `limit`
+    emails (max 100); `has_more` is true when the portal has additional
+    emails beyond the result. Use hubspot_get_marketing_email_statistics
+    for performance metrics on a specific email.
+    """
+    try:
+        result = _request(
+            "GET", "/marketing/v3/emails", params={"limit": max(1, min(limit, 100))}
+        )
+        has_more = bool((result.get("paging") or {}).get("next"))
+        return _success(emails=result.get("results", []), has_more=has_more)
+    except Exception as e:
+        logger.error(f"Error listing marketing emails: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def hubspot_get_marketing_email_statistics(email_ids: str) -> str:
+    """
+    Get send/open/click/bounce statistics for HubSpot marketing emails.
+    `email_ids` is a single email id, or a comma-separated list of ids to
+    fetch statistics for multiple emails at once.
+    """
+    try:
+        result = _request(
+            "GET",
+            "/marketing/v3/emails/statistics/list",
+            params={"emailIds": email_ids},
+        )
+        return _success(statistics=result.get("results", result))
+    except Exception as e:
+        logger.error(f"Error getting marketing email statistics: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def hubspot_list_campaigns(limit: int = 20) -> str:
+    """
+    List HubSpot marketing campaigns, including id and full campaign
+    properties (name, status, date range, etc.). Returns at most `limit`
+    campaigns (max 100); `has_more` is true when the portal has additional
+    campaigns beyond the result. Use hubspot_get_campaign_metrics for
+    performance metrics on a specific campaign.
+    """
+    try:
+        result = _request(
+            "GET",
+            "/marketing/v3/campaigns",
+            params={"limit": max(1, min(limit, 100))},
+        )
+        has_more = bool((result.get("paging") or {}).get("next"))
+        return _success(campaigns=result.get("results", []), has_more=has_more)
+    except Exception as e:
+        logger.error(f"Error listing campaigns: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def hubspot_get_campaign_metrics(
+    campaign_id: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
+    """
+    Get attribution metrics for a HubSpot marketing campaign, such as
+    sessions, new contacts, and influenced contacts. `start_date`/
+    `end_date` are optional "YYYY-MM-DD" strings that limit the reporting
+    window.
+    """
+    try:
+        params: dict[str, Any] = {}
+        if start_date:
+            params["startDate"] = start_date
+        if end_date:
+            params["endDate"] = end_date
+        result = _request(
+            "GET",
+            f"/marketing/v3/campaigns/{campaign_id}/reports/metrics",
+            params=params,
+        )
+        return _success(metrics=result)
+    except Exception as e:
+        logger.error(f"Error getting campaign metrics: {e}")
         return _error(str(e))
 
 

--- a/src/xagent/web/tools/mcp/hubspot.py
+++ b/src/xagent/web/tools/mcp/hubspot.py
@@ -7,6 +7,7 @@ from typing import Any
 import requests
 from mcp.server.fastmcp import FastMCP
 
+from ....config import get_tool_max_output_length
 from .utils import setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)
@@ -55,6 +56,15 @@ DEFAULT_DEAL_PROPERTIES = [
     "closedate",
     "hs_lastmodifieddate",
 ]
+DEFAULT_CAMPAIGN_PROPERTIES = [
+    "hs_name",
+    "hs_campaign_status",
+    "hs_start_date",
+    "hs_end_date",
+    "hs_notes",
+    "hs_owner",
+]
+_MAX_EMAIL_IDS_PER_STATISTICS_REQUEST = 100
 
 # HUBSPOT_DEFINED association type ids for notes.
 _NOTE_ASSOCIATION_TYPE_IDS = {"contact": 202, "company": 190, "deal": 214}
@@ -88,6 +98,48 @@ def _success(**payload: Any) -> str:
 
 def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _success_with_capped_list(list_field: str, items: list[Any], **rest: Any) -> str:
+    """Build a success payload, halving ``items`` until it fits the
+    platform's output limit.
+
+    Unprojected HubSpot objects (full property maps) can serialize past the
+    output filter's threshold and get hard-truncated into broken JSON, the
+    same failure mode documented in google_analytics.py's list/report tools.
+    Halving (rather than a fixed slice) keeps the cap adaptive to whatever
+    property payload size a given portal's objects happen to have.
+
+    ``truncated`` reports only this in-page trimming; the caller's
+    cursor-derived ``has_more``/``after`` (already in ``rest``) pass through
+    untouched, still describing whether the *server* has another page. A
+    trimmed page must be re-fetched with a smaller ``limit`` - advancing
+    ``after`` past it would silently skip the trimmed entries.
+    """
+    max_output_length = get_tool_max_output_length()
+    truncated = False
+    payload = {list_field: items, "truncated": truncated, **rest}
+    response = _success(**payload)
+    while len(response) > max_output_length and len(items) > 1:
+        items = items[: len(items) // 2]
+        truncated = True
+        payload = {list_field: items, "truncated": truncated, **rest}
+        response = _success(**payload)
+    return response
+
+
+def _require_clean_identifier(value: str, field_name: str) -> str:
+    """Reject an empty or whitespace-padded id rather than silently fixing it.
+
+    An id copy-pasted or concatenated by a caller with accidental whitespace
+    is more likely a bug worth surfacing than a value to repair - repairing
+    it would mask the bug and could send a query for a different object.
+    """
+    if not value or value.strip() != value:
+        raise ValueError(
+            f"{field_name} must be a non-empty id with no surrounding whitespace"
+        )
+    return value
 
 
 def _headers() -> dict[str, str]:
@@ -426,15 +478,37 @@ def hubspot_create_note(
         return _error(str(e))
 
 
+_FORM_SUMMARY_FIELDS = ("id", "name", "formType", "createdAt", "updatedAt", "archived")
+_EMAIL_SUMMARY_FIELDS = (
+    "id",
+    "name",
+    "subject",
+    "state",
+    "publishDate",
+    "createdAt",
+    "updatedAt",
+)
+
+
+def _project_fields(items: list[Any], fields: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {field: item.get(field) for field in fields}
+        for item in items
+        if isinstance(item, dict)
+    ]
+
+
 @mcp.tool()
 def hubspot_list_forms(limit: int = 20, after: str | None = None) -> str:
     """
-    List HubSpot marketing forms, including id and full form metadata
-    (name, field groups, etc.). Returns at most `limit` forms (max 100);
-    `has_more` is true when the portal has additional forms beyond the
-    result, and `after` is the cursor to pass back in to fetch the next
-    page. Use hubspot_get_form_submissions to pull the submissions
-    collected by a specific form.
+    List HubSpot marketing forms: id, name, form type, created/updated
+    timestamps, and archived status. Returns at most `limit` forms (max
+    100); `has_more` is true when the portal has more forms past this
+    page (`after` is the cursor to fetch it), and `truncated` is true
+    when this page itself was trimmed to fit the output size limit -
+    retry with a smaller `limit` to see the trimmed entries. Use
+    hubspot_get_form_submissions to pull the submissions collected by a
+    specific form.
     """
     try:
         params: dict[str, Any] = {"limit": max(1, min(limit, 100))}
@@ -442,10 +516,9 @@ def hubspot_list_forms(limit: int = 20, after: str | None = None) -> str:
             params["after"] = after
         result = _request("GET", "/marketing/v3/forms", params=params)
         next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
-        return _success(
-            forms=result.get("results", []),
-            has_more=bool(next_after),
-            after=next_after,
+        forms = _project_fields(result.get("results", []), _FORM_SUMMARY_FIELDS)
+        return _success_with_capped_list(
+            "forms", forms, has_more=bool(next_after), after=next_after
         )
     except Exception as e:
         logger.error(f"Error listing forms: {e}")
@@ -459,11 +532,14 @@ def hubspot_get_form_submissions(
     """
     Get recent submissions for a HubSpot form, including submitted field
     values, submission timestamp, and page URL. Returns at most `limit`
-    submissions (max 50); `has_more` is true when the form has additional
-    submissions beyond the result, and `after` is the cursor to pass back
-    in to fetch the next page.
+    submissions (max 50); `has_more` is true when the form has more
+    submissions past this page (`after` is the cursor to fetch it), and
+    `truncated` is true when this page itself was trimmed to fit the
+    output size limit - retry with a smaller `limit` to see the trimmed
+    entries.
     """
     try:
+        form_id = _require_clean_identifier(form_id, "form_id")
         params: dict[str, Any] = {"limit": max(1, min(limit, 50))}
         if after:
             params["after"] = after
@@ -471,8 +547,9 @@ def hubspot_get_form_submissions(
             "GET", f"/form-integrations/v1/submissions/forms/{form_id}", params=params
         )
         next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
-        return _success(
-            submissions=result.get("results", []),
+        return _success_with_capped_list(
+            "submissions",
+            result.get("results", []),
             has_more=bool(next_after),
             after=next_after,
         )
@@ -484,18 +561,20 @@ def hubspot_get_form_submissions(
 @mcp.tool()
 def hubspot_get_analytics_report(
     report_type: str,
+    start_date: str,
+    end_date: str,
     breakdown: str = "total",
-    start_date: str | None = None,
-    end_date: str | None = None,
 ) -> str:
     """
-    Get a HubSpot traffic analytics report. `report_type` is a HubSpot
-    analytics dimension ("totals", "sessions", "sources", "geolocation",
-    "utm-campaigns", "utm-contents", "utm-mediums", "utm-sources",
-    "utm-terms") or content object type ("event-completions", "forms",
-    "pages", "social-assists"). `breakdown` is "total", "daily", "weekly",
-    or "monthly". `start_date`/`end_date` are optional "YYYYMMDD" strings
-    that limit the reporting window.
+    Get a HubSpot traffic analytics report over [start_date, end_date].
+    `report_type` selects the dimension or content object to report on:
+    "totals", "sessions", "sources", "geolocation", "utm-campaigns",
+    "utm-contents", "utm-mediums", "utm-sources", "utm-terms",
+    "event-completions", "forms", "pages", or "social-assists".
+    `breakdown` selects the time granularity within that window: "total"
+    (one summed value), "daily", "weekly", or "monthly". `start_date` and
+    `end_date` are required "YYYYMMDD" strings (a "daily" breakdown spans
+    at most 500 days).
 
     Note: this covers HubSpot's traffic/analytics dimensions, not
     custom reports or dashboards built in the HubSpot report editor -
@@ -504,21 +583,20 @@ def hubspot_get_analytics_report(
     not supported by this HubSpot API.
     """
     try:
-        if report_type not in _VALID_ANALYTICS_REPORT_TYPES:
+        normalized_report_type = report_type.strip().lower()
+        if normalized_report_type not in _VALID_ANALYTICS_REPORT_TYPES:
             raise ValueError(
                 f"report_type must be one of {sorted(_VALID_ANALYTICS_REPORT_TYPES)}"
             )
-        if breakdown not in _VALID_ANALYTICS_BREAKDOWNS:
+        normalized_breakdown = breakdown.strip().lower()
+        if normalized_breakdown not in _VALID_ANALYTICS_BREAKDOWNS:
             raise ValueError(
                 f"breakdown must be one of {sorted(_VALID_ANALYTICS_BREAKDOWNS)}"
             )
-        params: dict[str, Any] = {}
-        if start_date:
-            params["start"] = start_date
-        if end_date:
-            params["end"] = end_date
         result = _request(
-            "GET", f"/analytics/v2/reports/{report_type}/{breakdown}", params=params
+            "GET",
+            f"/analytics/v2/reports/{normalized_report_type}/{normalized_breakdown}",
+            params={"start": start_date, "end": end_date},
         )
         return _success(report=result)
     except Exception as e:
@@ -529,12 +607,20 @@ def hubspot_get_analytics_report(
 @mcp.tool()
 def hubspot_list_marketing_emails(limit: int = 20, after: str | None = None) -> str:
     """
-    List HubSpot marketing emails, including id and full email metadata
-    (name, subject, state, publish date, etc.). Returns at most `limit`
-    emails (max 100); `has_more` is true when the portal has additional
-    emails beyond the result, and `after` is the cursor to pass back in to
-    fetch the next page. Use hubspot_get_marketing_email_statistics for
-    performance metrics on a specific email.
+    List HubSpot marketing emails: id, name, subject, state, publish
+    date, and created/updated timestamps. Returns at most `limit` emails
+    (max 100); `has_more` is true when the portal has more emails past
+    this page (`after` is the cursor to fetch it), and `truncated` is
+    true when this page itself was trimmed to fit the output size limit
+    - retry with a smaller `limit` to see the trimmed entries. Use
+    hubspot_get_marketing_email_statistics for performance metrics on a
+    specific email.
+
+    The connector requests the required marketing-email scope as optional
+    (it's gated on Marketing Hub Enterprise, or the transactional email
+    add-on on lower tiers), so this call fails with a permissions error on
+    portals where that scope wasn't granted - the connection itself still
+    works for every other tool.
     """
     try:
         params: dict[str, Any] = {"limit": max(1, min(limit, 100))}
@@ -542,10 +628,9 @@ def hubspot_list_marketing_emails(limit: int = 20, after: str | None = None) -> 
             params["after"] = after
         result = _request("GET", "/marketing/v3/emails", params=params)
         next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
-        return _success(
-            emails=result.get("results", []),
-            has_more=bool(next_after),
-            after=next_after,
+        emails = _project_fields(result.get("results", []), _EMAIL_SUMMARY_FIELDS)
+        return _success_with_capped_list(
+            "emails", emails, has_more=bool(next_after), after=next_after
         )
     except Exception as e:
         logger.error(f"Error listing marketing emails: {e}")
@@ -553,28 +638,45 @@ def hubspot_list_marketing_emails(limit: int = 20, after: str | None = None) -> 
 
 
 @mcp.tool()
-def hubspot_get_marketing_email_statistics(email_ids: str) -> str:
+def hubspot_get_marketing_email_statistics(
+    email_ids: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
     """
     Get send/open/click/bounce statistics for HubSpot marketing emails.
-    `email_ids` is a single email id, or a comma-separated list of ids to
-    fetch statistics for multiple emails at once.
+    `email_ids` is a single email id, or a comma-separated list of ids
+    (max 100) to fetch statistics for multiple emails at once - each id
+    must be non-empty with no surrounding whitespace. `start_date`/
+    `end_date` are optional ISO 8601 timestamps ("2024-01-01T00:00:00Z")
+    that limit the reporting window; omitting both returns all-time
+    statistics.
+
+    The connector requests the required marketing-email scope as optional
+    (it's gated on Marketing Hub Enterprise, or the transactional email
+    add-on on lower tiers), so this call fails with a permissions error on
+    portals where that scope wasn't granted - the connection itself still
+    works for every other tool.
     """
     try:
-        ids = [
-            email_id.strip() for email_id in email_ids.split(",") if email_id.strip()
-        ]
-        if not ids:
-            # Without this, an empty emailIds list is dropped from the query
-            # entirely and HubSpot returns statistics for every email.
-            raise ValueError("email_ids must contain at least one email id")
-        result = _request(
-            "GET",
-            "/marketing/v3/emails/statistics/list",
+        raw_ids = email_ids.split(",")
+        ids = [_require_clean_identifier(raw_id, "each email id") for raw_id in raw_ids]
+        if len(ids) > _MAX_EMAIL_IDS_PER_STATISTICS_REQUEST:
+            raise ValueError(
+                f"email_ids must contain at most "
+                f"{_MAX_EMAIL_IDS_PER_STATISTICS_REQUEST} ids per request"
+            )
+        params: dict[str, Any] = {
             # HubSpot's emailIds is an array param: requests serializes a
             # list value as repeated "emailIds=<id>" pairs, matching that
             # shape rather than a single comma-joined value.
-            params={"emailIds": ids},
-        )
+            "emailIds": ids
+        }
+        if start_date:
+            params["startTimestamp"] = start_date
+        if end_date:
+            params["endTimestamp"] = end_date
+        result = _request("GET", "/marketing/v3/emails/statistics/list", params=params)
         return _success(statistics=result)
     except Exception as e:
         logger.error(f"Error getting marketing email statistics: {e}")
@@ -584,23 +686,30 @@ def hubspot_get_marketing_email_statistics(email_ids: str) -> str:
 @mcp.tool()
 def hubspot_list_campaigns(limit: int = 20, after: str | None = None) -> str:
     """
-    List HubSpot marketing campaigns, including id and full campaign
-    properties (name, status, date range, etc.). Returns at most `limit`
-    campaigns (max 100); `has_more` is true when the portal has additional
-    campaigns beyond the result, and `after` is the cursor to pass back in
-    to fetch the next page. Use hubspot_get_campaign_metrics for
-    performance metrics on a specific campaign.
+    List HubSpot marketing campaigns, including id and properties (name,
+    status, start/end date, notes, owner). Returns at most `limit`
+    campaigns (max 100); `has_more` is true when the portal has more
+    campaigns past this page (`after` is the cursor to fetch it), and
+    `truncated` is true when this page itself was trimmed to fit the
+    output size limit - retry with a smaller `limit` to see the trimmed
+    entries. Use hubspot_get_campaign_metrics for performance metrics on
+    a specific campaign.
     """
     try:
-        params: dict[str, Any] = {"limit": max(1, min(limit, 100))}
+        params: dict[str, Any] = {
+            "limit": max(1, min(limit, 100)),
+            "properties": ",".join(DEFAULT_CAMPAIGN_PROPERTIES),
+        }
         if after:
             params["after"] = after
         result = _request("GET", "/marketing/v3/campaigns", params=params)
         next_after = ((result.get("paging") or {}).get("next") or {}).get("after")
-        return _success(
-            campaigns=result.get("results", []),
-            has_more=bool(next_after),
-            after=next_after,
+        campaigns = [
+            {"id": item.get("id"), "properties": item.get("properties", {})}
+            for item in result.get("results", [])
+        ]
+        return _success_with_capped_list(
+            "campaigns", campaigns, has_more=bool(next_after), after=next_after
         )
     except Exception as e:
         logger.error(f"Error listing campaigns: {e}")
@@ -616,10 +725,12 @@ def hubspot_get_campaign_metrics(
     """
     Get attribution metrics for a HubSpot marketing campaign, such as
     sessions, new contacts, and influenced contacts. `start_date`/
-    `end_date` are optional "YYYY-MM-DD" strings that limit the reporting
-    window.
+    `end_date` are optional "YYYY-MM-DD" strings (a different format
+    from hubspot_get_analytics_report's "YYYYMMDD" - this is a separate,
+    newer HubSpot API) that limit the reporting window.
     """
     try:
+        campaign_id = _require_clean_identifier(campaign_id, "campaign_id")
         params: dict[str, Any] = {}
         if start_date:
             params["startDate"] = start_date

--- a/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
+++ b/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
@@ -28,27 +28,78 @@ def _operations(connection):
     return Operations(MigrationContext.configure(connection))
 
 
-def _create_table(connection):
+def _create_table(connection, description: str, with_description_column: bool = True):
+    description_column = "description TEXT," if with_description_column else ""
     connection.execute(
         text(
-            """
+            f"""
             CREATE TABLE public_mcp_apps (
                 id INTEGER PRIMARY KEY,
                 app_id VARCHAR(100) NOT NULL UNIQUE,
-                description TEXT,
+                {description_column}
                 oauth_scopes JSON
             )
             """
         )
     )
+    description_col = ", description" if with_description_column else ""
+    description_val = ", :description" if with_description_column else ""
     connection.execute(
         text(
-            "INSERT INTO public_mcp_apps (app_id, description, oauth_scopes) "
-            "VALUES ('hubspot', 'old description', "
-            '\'["crm.objects.contacts.read", "crm.objects.contacts.write", '
-            '"crm.objects.companies.read", "crm.objects.companies.write", '
-            '"crm.objects.deals.read"]\')'
+            f"INSERT INTO public_mcp_apps (app_id, oauth_scopes{description_col}) "
+            f"VALUES ('hubspot', :scopes{description_val})"
+        ),
+        {
+            "scopes": json.dumps(
+                [
+                    "crm.objects.contacts.read",
+                    "crm.objects.contacts.write",
+                    "crm.objects.companies.read",
+                    "crm.objects.companies.write",
+                    "crm.objects.deals.read",
+                ]
+            ),
+            "description": description,
+        },
+    )
+
+
+def _create_user_oauth_table(connection, with_refresh_token_column: bool = True):
+    refresh_column = "refresh_token VARCHAR," if with_refresh_token_column else ""
+    connection.execute(
+        text(
+            f"""
+            CREATE TABLE user_oauth (
+                id INTEGER PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                provider VARCHAR(50) NOT NULL,
+                {refresh_column}
+                access_token VARCHAR NOT NULL
+            )
+            """
         )
+    )
+    refresh_col = ", refresh_token" if with_refresh_token_column else ""
+    refresh_hubspot = ", 'old-hubspot-refresh'" if with_refresh_token_column else ""
+    refresh_other = ", 'old-salesforce-refresh'" if with_refresh_token_column else ""
+    connection.execute(
+        text(
+            f"INSERT INTO user_oauth (user_id, provider, access_token{refresh_col}) "
+            f"VALUES (1, 'hubspot', 'old-hubspot-token'{refresh_hubspot}), "
+            f"(1, 'salesforce', 'old-salesforce-token'{refresh_other})"
+        )
+    )
+
+
+def _access_tokens(connection):
+    return dict(
+        connection.execute(text("SELECT provider, access_token FROM user_oauth")).all()
+    )
+
+
+def _refresh_tokens(connection):
+    return dict(
+        connection.execute(text("SELECT provider, refresh_token FROM user_oauth")).all()
     )
 
 
@@ -67,7 +118,7 @@ def test_upgrade_adds_marketing_scopes_and_description(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(connection)
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
         description, scopes = _row(connection)
@@ -79,11 +130,12 @@ def test_upgrade_is_idempotent(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(connection)
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
             migration.upgrade()
-        _, scopes = _row(connection)
+        description, scopes = _row(connection)
+        assert description == migration.CURRENT_DESCRIPTION
         assert scopes == migration.CURRENT_SCOPES
 
 
@@ -91,7 +143,7 @@ def test_downgrade_restores_previous_scopes_and_description(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(connection)
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
             migration.downgrade()
@@ -100,12 +152,121 @@ def test_downgrade_restores_previous_scopes_and_description(tmp_path):
         assert scopes == migration.PREVIOUS_SCOPES
 
 
+def test_upgrade_preserves_admin_customized_description(tmp_path):
+    """description is not in _BUILTIN_PROTECTED_FIELDS (admin_mcp.py), so an
+    operator can have edited it via the admin PATCH endpoint. The migration
+    must not clobber a value that no longer matches the last-known default.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description="Our internal HubSpot connector")
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        description, scopes = _row(connection)
+        assert description == "Our internal HubSpot connector"
+        assert scopes == migration.CURRENT_SCOPES
+
+
+def test_downgrade_preserves_admin_customized_description(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "UPDATE public_mcp_apps SET description = :d "
+                    "WHERE app_id = 'hubspot'"
+                ),
+                {"d": "Our internal HubSpot connector"},
+            )
+            migration.downgrade()
+        description, scopes = _row(connection)
+        assert description == "Our internal HubSpot connector"
+        assert scopes == migration.PREVIOUS_SCOPES
+
+
+def test_upgrade_without_description_column_still_updates_scopes(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            with_description_column=False,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise when description is missing
+        scopes = connection.execute(
+            text("SELECT oauth_scopes FROM public_mcp_apps WHERE app_id='hubspot'")
+        ).scalar()
+        assert json.loads(scopes) == migration.CURRENT_SCOPES
+
+
 def test_upgrade_without_table_is_a_noop(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()  # must not raise when the table doesn't exist
+
+
+def test_upgrade_invalidates_existing_hubspot_grant_only(tmp_path):
+    """Both tokens must be cleared: refresh_oauth_token_if_needed re-mints an
+    access token off refresh_token alone, so a surviving refresh_token would
+    silently resurrect the old-scoped grant on the next tool call.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        _create_user_oauth_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        tokens = _access_tokens(connection)
+        assert tokens["hubspot"] == ""
+        assert tokens["salesforce"] == "old-salesforce-token"
+        refresh_tokens = _refresh_tokens(connection)
+        assert refresh_tokens["hubspot"] is None
+        assert refresh_tokens["salesforce"] == "old-salesforce-refresh"
+
+
+def test_upgrade_clears_access_token_without_refresh_token_column(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        _create_user_oauth_table(connection, with_refresh_token_column=False)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise when refresh_token is missing
+        tokens = _access_tokens(connection)
+        assert tokens["hubspot"] == ""
+
+
+def test_upgrade_without_user_oauth_table_is_a_noop(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise when user_oauth doesn't exist
+
+
+def test_downgrade_does_not_touch_user_oauth(tmp_path):
+    """Cleared access tokens are gone for good; downgrade only reverts
+    public_mcp_apps, mirroring the Facebook scope migration's approach."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        _create_user_oauth_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        tokens = _access_tokens(connection)
+        assert tokens["hubspot"] == ""
 
 
 def test_migration_fields_match_registry():

--- a/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
+++ b/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
@@ -152,6 +152,44 @@ def test_downgrade_restores_previous_scopes_and_description(tmp_path):
         assert scopes == migration.PREVIOUS_SCOPES
 
 
+def test_upgrade_downgrade_upgrade_round_trip(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+        description, scopes = _row(connection)
+        assert description == migration.CURRENT_DESCRIPTION
+        assert scopes == migration.CURRENT_SCOPES
+
+
+def test_upgrade_preserves_customized_description_already_at_current_scopes(tmp_path):
+    """A row already migrated once (CURRENT_SCOPES) with a since-customized
+    description must not have that customization overwritten on a repeat
+    upgrade (e.g. a second alembic run, or upgrade-downgrade-upgrade landing
+    back on CURRENT_SCOPES with the customization still in place)."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "UPDATE public_mcp_apps SET description = :d "
+                    "WHERE app_id = 'hubspot'"
+                ),
+                {"d": "Our internal HubSpot connector"},
+            )
+            migration.upgrade()
+        description, scopes = _row(connection)
+        assert description == "Our internal HubSpot connector"
+        assert scopes == migration.CURRENT_SCOPES
+
+
 def test_upgrade_preserves_admin_customized_description(tmp_path):
     """description is not in _BUILTIN_PROTECTED_FIELDS (admin_mcp.py), so an
     operator can have edited it via the admin PATCH endpoint. The migration

--- a/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
+++ b/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
@@ -273,6 +273,31 @@ def test_upgrade_invalidates_existing_hubspot_grant_only(tmp_path):
         assert refresh_tokens["salesforce"] == "old-salesforce-refresh"
 
 
+def test_upgrade_logs_a_warning_when_grants_are_disconnected(tmp_path, caplog):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        _create_user_oauth_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            with caplog.at_level("WARNING", logger=migration.logger.name):
+                migration.upgrade()
+    assert any(
+        "Disconnected" in r.message and "forms" in r.message for r in caplog.records
+    )
+
+
+def test_upgrade_does_not_log_when_no_grants_exist(tmp_path, caplog):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
+        with patch.object(migration, "op", _operations(connection)):
+            with caplog.at_level("WARNING", logger=migration.logger.name):
+                migration.upgrade()  # no user_oauth table at all
+    assert caplog.records == []
+
+
 def test_upgrade_clears_access_token_without_refresh_token_column(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()

--- a/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
+++ b/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
@@ -1,0 +1,119 @@
+"""Tests for adding HubSpot Marketing Hub OAuth scopes and description."""
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260810_add_hubspot_marketing_scopes.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "add_hubspot_marketing_scopes_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                description TEXT,
+                oauth_scopes JSON
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            "INSERT INTO public_mcp_apps (app_id, description, oauth_scopes) "
+            "VALUES ('hubspot', 'old description', "
+            '\'["crm.objects.contacts.read", "crm.objects.contacts.write", '
+            '"crm.objects.companies.read", "crm.objects.companies.write", '
+            '"crm.objects.deals.read"]\')'
+        )
+    )
+
+
+def _row(connection):
+    row = connection.execute(
+        text(
+            "SELECT description, oauth_scopes FROM public_mcp_apps "
+            "WHERE app_id='hubspot'"
+        )
+    ).first()
+    description, scopes = row[0], row[1]
+    return description, json.loads(scopes) if isinstance(scopes, str) else scopes
+
+
+def test_upgrade_adds_marketing_scopes_and_description(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        description, scopes = _row(connection)
+        assert description == migration.CURRENT_DESCRIPTION
+        assert scopes == migration.CURRENT_SCOPES
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+        _, scopes = _row(connection)
+        assert scopes == migration.CURRENT_SCOPES
+
+
+def test_downgrade_restores_previous_scopes_and_description(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        description, scopes = _row(connection)
+        assert description == migration.PREVIOUS_DESCRIPTION
+        assert scopes == migration.PREVIOUS_SCOPES
+
+
+def test_upgrade_without_table_is_a_noop(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise when the table doesn't exist
+
+
+def test_migration_fields_match_registry():
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "hubspot"
+    )
+    assert migration.CURRENT_SCOPES == registry_row["oauth_scopes"]
+    assert migration.CURRENT_DESCRIPTION == registry_row["description"]

--- a/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
+++ b/tests/alembic/test_20260810_add_hubspot_marketing_scopes.py
@@ -252,9 +252,11 @@ def test_upgrade_without_table_is_a_noop(tmp_path):
 
 
 def test_upgrade_invalidates_existing_hubspot_grant_only(tmp_path):
-    """Both tokens must be cleared: refresh_oauth_token_if_needed re-mints an
-    access token off refresh_token alone, so a surviving refresh_token would
-    silently resurrect the old-scoped grant on the next tool call.
+    """Both tokens must be cleared. The current token resolver already
+    short-circuits on a falsy access_token before reaching
+    refresh_oauth_token_if_needed, so clearing refresh_token too is
+    defense-in-depth against a future resolver shape, not a fix for a
+    live path today.
     """
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -909,6 +909,48 @@ def test_builtin_registry_helpers_use_exact_ids_and_return_defensive_copies() ->
     assert get_builtin_execution_fields("gmail") == expected_execution_fields
 
 
+def test_get_builtin_optional_oauth_scopes() -> None:
+    from xagent.web.builtin_mcp_registry import get_builtin_optional_oauth_scopes
+
+    assert get_builtin_optional_oauth_scopes("hubspot") == [
+        "business-intelligence",
+        "marketing-email",
+    ]
+    # Most builtin apps have no optional_oauth_scopes key at all.
+    assert get_builtin_optional_oauth_scopes("gmail") == []
+    assert get_builtin_optional_oauth_scopes("unknown-app") == []
+
+
+def test_app_to_dict_exposes_optional_oauth_scopes_for_builtin_and_custom_apps() -> (
+    None
+):
+    from xagent.web.mcp_apps import _app_to_dict
+    from xagent.web.models.public_mcp import PublicMCPApp
+
+    hubspot_app = PublicMCPApp(
+        app_id="hubspot",
+        name="HubSpot",
+        transport="oauth",
+        provider_name="hubspot",
+        oauth_scopes=["crm.objects.contacts.read"],
+        launch_config={},
+    )
+    assert _app_to_dict(hubspot_app)["optional_oauth_scopes"] == [
+        "business-intelligence",
+        "marketing-email",
+    ]
+
+    custom_app = PublicMCPApp(
+        app_id="some-custom-app",
+        name="Custom",
+        transport="oauth",
+        provider_name="custom",
+        oauth_scopes=["custom.scope"],
+        launch_config={},
+    )
+    assert _app_to_dict(custom_app)["optional_oauth_scopes"] == []
+
+
 def test_builtin_registry_drift_validation_reports_safe_read_only_summaries() -> None:
     from xagent.web.builtin_mcp_registry import validate_builtin_public_mcp_apps
 

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -915,10 +915,31 @@ def test_get_builtin_optional_oauth_scopes() -> None:
     assert get_builtin_optional_oauth_scopes("hubspot") == [
         "business-intelligence",
         "marketing-email",
+        "marketing.campaigns.read",
     ]
     # Most builtin apps have no optional_oauth_scopes key at all.
     assert get_builtin_optional_oauth_scopes("gmail") == []
     assert get_builtin_optional_oauth_scopes("unknown-app") == []
+
+
+def test_get_builtin_execution_fields_and_optional_scopes_matches_separate_calls() -> (
+    None
+):
+    """The combined single-scan accessor _app_to_dict uses on the
+    connector-listing path must agree with calling the two separate
+    (double-scanning) accessors it replaces there."""
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_execution_fields,
+        get_builtin_execution_fields_and_optional_scopes,
+        get_builtin_optional_oauth_scopes,
+    )
+
+    for app_id in ("hubspot", "gmail", "unknown-app"):
+        execution_fields, optional_scopes = (
+            get_builtin_execution_fields_and_optional_scopes(app_id)
+        )
+        assert execution_fields == get_builtin_execution_fields(app_id)
+        assert optional_scopes == get_builtin_optional_oauth_scopes(app_id)
 
 
 def test_app_to_dict_exposes_optional_oauth_scopes_for_builtin_and_custom_apps() -> (
@@ -938,6 +959,7 @@ def test_app_to_dict_exposes_optional_oauth_scopes_for_builtin_and_custom_apps()
     assert _app_to_dict(hubspot_app)["optional_oauth_scopes"] == [
         "business-intelligence",
         "marketing-email",
+        "marketing.campaigns.read",
     ]
 
     custom_app = PublicMCPApp(

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -909,37 +909,33 @@ def test_builtin_registry_helpers_use_exact_ids_and_return_defensive_copies() ->
     assert get_builtin_execution_fields("gmail") == expected_execution_fields
 
 
-def test_get_builtin_optional_oauth_scopes() -> None:
-    from xagent.web.builtin_mcp_registry import get_builtin_optional_oauth_scopes
+def test_get_builtin_execution_fields_and_optional_scopes() -> None:
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_execution_fields,
+        get_builtin_execution_fields_and_optional_scopes,
+    )
 
-    assert get_builtin_optional_oauth_scopes("hubspot") == [
+    execution_fields, optional_scopes = (
+        get_builtin_execution_fields_and_optional_scopes("hubspot")
+    )
+    assert execution_fields == get_builtin_execution_fields("hubspot")
+    assert optional_scopes == [
         "business-intelligence",
         "marketing-email",
         "marketing.campaigns.read",
     ]
+
     # Most builtin apps have no optional_oauth_scopes key at all.
-    assert get_builtin_optional_oauth_scopes("gmail") == []
-    assert get_builtin_optional_oauth_scopes("unknown-app") == []
-
-
-def test_get_builtin_execution_fields_and_optional_scopes_matches_separate_calls() -> (
-    None
-):
-    """The combined single-scan accessor _app_to_dict uses on the
-    connector-listing path must agree with calling the two separate
-    (double-scanning) accessors it replaces there."""
-    from xagent.web.builtin_mcp_registry import (
-        get_builtin_execution_fields,
-        get_builtin_execution_fields_and_optional_scopes,
-        get_builtin_optional_oauth_scopes,
+    gmail_fields, gmail_optional = get_builtin_execution_fields_and_optional_scopes(
+        "gmail"
     )
+    assert gmail_fields == get_builtin_execution_fields("gmail")
+    assert gmail_optional == []
 
-    for app_id in ("hubspot", "gmail", "unknown-app"):
-        execution_fields, optional_scopes = (
-            get_builtin_execution_fields_and_optional_scopes(app_id)
-        )
-        assert execution_fields == get_builtin_execution_fields(app_id)
-        assert optional_scopes == get_builtin_optional_oauth_scopes(app_id)
+    assert get_builtin_execution_fields_and_optional_scopes("unknown-app") == (
+        None,
+        [],
+    )
 
 
 def test_app_to_dict_exposes_optional_oauth_scopes_for_builtin_and_custom_apps() -> (

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -274,6 +274,48 @@ def test_hubspot_login_sends_tier_gated_scopes_as_optional(db_session):
     assert qs["optional_scope"] == ["business-intelligence marketing-email"]
 
 
+def test_non_hubspot_app_sends_no_optional_scope_param(db_session, monkeypatch):
+    """optional_oauth_scopes is a HubSpot-specific registry field today; a
+    builtin app that doesn't set it must not get a stray optional_scope
+    param on a provider whose authorize endpoint doesn't expect one."""
+    db, user = db_session
+    token = _token_for(user)
+    monkeypatch.delenv("META_CONFIG_ID", raising=False)
+    monkeypatch.delenv("META_LOGIN_CONFIG_ID", raising=False)
+    db.add(
+        PublicMCPApp(
+            app_id="facebook",
+            name="Facebook Pages",
+            description="Facebook connector",
+            transport="oauth",
+            provider_name="meta",
+            category="Marketing",
+            oauth_scopes=["pages_show_list"],
+            is_visible_in_connector=True,
+            launch_config={},
+        )
+    )
+    db.commit()
+
+    provider = _provider(
+        auth_url="https://www.facebook.com/v25.0/dialog/oauth",
+        default_scopes=["public_profile"],
+        redirect_uri="https://app.example.com/api/auth/meta/callback",
+    )
+
+    resp = generic_oauth_login(
+        provider="meta",
+        token=token,
+        app_id="facebook",
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    qs = parse_qs(urlparse(_location(resp)).query)
+
+    assert "optional_scope" not in qs
+
+
 def test_meta_login_uses_config_id_without_scope_when_configured(
     db_session, monkeypatch
 ):

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -232,10 +232,11 @@ def test_meta_login_uses_comma_separated_canonical_scopes_for_builtin_app(
 
 
 def test_hubspot_login_sends_tier_gated_scopes_as_optional(db_session):
-    """business-intelligence and marketing-email are gated on Marketing Hub
-    Basic/Pro/Enterprise - requesting them as required scopes would block
-    the whole authorization for Free/CRM-only portals. They must arrive via
-    optional_scope, not merged into the required scope param."""
+    """business-intelligence, marketing-email, and marketing.campaigns.read
+    are all gated on a Marketing Hub tier above Free/CRM-only - requesting
+    any of them as required scopes would block the whole authorization for
+    portals below that tier. They must arrive via optional_scope, not
+    merged into the required scope param."""
     db, user = db_session
     token = _token_for(user)
     db.add(
@@ -271,7 +272,10 @@ def test_hubspot_login_sends_tier_gated_scopes_as_optional(db_session):
 
     assert "business-intelligence" not in qs["scope"][0]
     assert "marketing-email" not in qs["scope"][0]
-    assert qs["optional_scope"] == ["business-intelligence marketing-email"]
+    assert "marketing.campaigns.read" not in qs["scope"][0]
+    assert qs["optional_scope"] == [
+        "business-intelligence marketing-email marketing.campaigns.read"
+    ]
 
 
 def test_non_hubspot_app_sends_no_optional_scope_param(db_session, monkeypatch):
@@ -355,6 +359,68 @@ def test_meta_login_uses_config_id_without_scope_when_configured(
 
     assert qs["config_id"] == ["1234567890"]
     assert "scope" not in qs
+    assert "optional_scope" not in qs
+
+
+def test_meta_login_suppresses_optional_scope_under_config_id(db_session, monkeypatch):
+    """config_id mode discards the registry's scope list entirely (the Meta
+    Login Configuration is the sole source of truth) - optional_scope must
+    be suppressed the same way scope already is, even for an app that DOES
+    declare optional_oauth_scopes. No builtin meta-provider app declares
+    optional_oauth_scopes today, so the registry lookup is patched to
+    simulate one rather than asserting a coincidence of current data."""
+    import xagent.web.mcp_apps as mcp_apps_module
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_execution_fields_and_optional_scopes,
+    )
+
+    def fake_lookup(app_id):
+        execution_fields, _ = get_builtin_execution_fields_and_optional_scopes(app_id)
+        optional_scopes = ["some_tier_gated_scope"] if app_id == "facebook" else []
+        return execution_fields, optional_scopes
+
+    db, user = db_session
+    token = _token_for(user)
+    monkeypatch.setenv("META_CONFIG_ID", "1234567890")
+    monkeypatch.setattr(
+        mcp_apps_module,
+        "get_builtin_execution_fields_and_optional_scopes",
+        fake_lookup,
+    )
+    db.add(
+        PublicMCPApp(
+            app_id="facebook",
+            name="Facebook Pages",
+            description="Facebook connector",
+            transport="oauth",
+            provider_name="meta",
+            category="Marketing",
+            oauth_scopes=["pages_show_list"],
+            is_visible_in_connector=True,
+            launch_config={},
+        )
+    )
+    db.commit()
+
+    provider = _provider(
+        auth_url="https://www.facebook.com/v25.0/dialog/oauth",
+        default_scopes=["public_profile"],
+        redirect_uri="https://app.example.com/api/auth/meta/callback",
+    )
+
+    resp = generic_oauth_login(
+        provider="meta",
+        token=token,
+        app_id="facebook",
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    qs = parse_qs(urlparse(_location(resp)).query)
+
+    assert qs["config_id"] == ["1234567890"]
+    assert "scope" not in qs
+    assert "optional_scope" not in qs
 
 
 def test_meta_login_uses_config_id_without_scope_for_facebook(db_session, monkeypatch):
@@ -406,6 +472,7 @@ def test_meta_login_uses_config_id_without_scope_for_facebook(db_session, monkey
 
     assert qs["config_id"] == ["1234567890"]
     assert "scope" not in qs
+    assert "optional_scope" not in qs
 
 
 def test_meta_login_ignores_undocumented_legacy_config_id_alias(

--- a/tests/web/test_generic_oauth_login.py
+++ b/tests/web/test_generic_oauth_login.py
@@ -231,6 +231,49 @@ def test_meta_login_uses_comma_separated_canonical_scopes_for_builtin_app(
     ]
 
 
+def test_hubspot_login_sends_tier_gated_scopes_as_optional(db_session):
+    """business-intelligence and marketing-email are gated on Marketing Hub
+    Basic/Pro/Enterprise - requesting them as required scopes would block
+    the whole authorization for Free/CRM-only portals. They must arrive via
+    optional_scope, not merged into the required scope param."""
+    db, user = db_session
+    token = _token_for(user)
+    db.add(
+        PublicMCPApp(
+            app_id="hubspot",
+            name="HubSpot",
+            description="HubSpot connector",
+            transport="oauth",
+            provider_name="hubspot",
+            category="CRM",
+            oauth_scopes=["crm.objects.contacts.read"],
+            is_visible_in_connector=True,
+            launch_config={},
+        )
+    )
+    db.commit()
+
+    provider = _provider(
+        auth_url="https://app.hubspot.com/oauth/authorize",
+        default_scopes=["oauth"],
+        redirect_uri="https://app.example.com/api/auth/hubspot/callback",
+    )
+
+    resp = generic_oauth_login(
+        provider="hubspot",
+        token=token,
+        app_id="hubspot",
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    qs = parse_qs(urlparse(_location(resp)).query)
+
+    assert "business-intelligence" not in qs["scope"][0]
+    assert "marketing-email" not in qs["scope"][0]
+    assert qs["optional_scope"] == ["business-intelligence marketing-email"]
+
+
 def test_meta_login_uses_config_id_without_scope_when_configured(
     db_session, monkeypatch
 ):

--- a/tests/web/tools/test_hubspot_mcp.py
+++ b/tests/web/tools/test_hubspot_mcp.py
@@ -351,6 +351,22 @@ def test_paged_list_truncates_to_empty_when_single_item_still_oversized(monkeypa
     assert result["has_more"] is True
 
 
+def test_paged_list_explains_the_dead_end_when_collapsed_to_empty(monkeypatch):
+    """has_more=true with no cursor and an empty page (the collapse case
+    above) is otherwise a dead end for the caller - a smaller `limit` than
+    1 doesn't exist, and there's no cursor to retry a different page with.
+    An explicit message must say so instead of leaving that implicit."""
+    huge_form = {"id": "f1", "name": "x" * 5000}
+    mock_request = Mock(return_value=MockResponse(json_data={"results": [huge_form]}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+    monkeypatch.setattr(hubspot, "get_tool_max_output_length", lambda: 200)
+
+    result = json.loads(hubspot.hubspot_list_forms(limit=1))
+
+    assert "message" in result
+    assert "too large" in result["message"]
+
+
 def test_paged_list_reports_input_after_not_next_after_when_truncated(monkeypatch):
     """A truncated page must report ITS OWN input cursor, not the server's
     next-page cursor: the server already considers the full page consumed,
@@ -637,6 +653,80 @@ def test_get_analytics_report_rejects_bad_end_date_with_valid_start_date(monkeyp
     mock_request.assert_not_called()
 
 
+def test_get_analytics_report_rejects_non_calendar_date(monkeypatch):
+    """ "20261332" matches a digit-position-only regex but isn't a real
+    date - month 13, day 32."""
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "20261332", "20261332")
+    )
+
+    assert result["status"] == "error"
+    assert "start_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_analytics_report_rejects_start_after_end(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "20260201", "20260101")
+    )
+
+    assert result["status"] == "error"
+    assert "start_date must not be after end_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_analytics_report_rejects_daily_span_over_500_days(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report(
+            "sources", "20250101", "20260601", breakdown="daily"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "500 days" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_analytics_report_allows_a_wide_span_for_non_daily_breakdown(monkeypatch):
+    """The 500-day cap is documented for "daily" specifically; the same
+    span must not be rejected for "monthly"."""
+    mock_request = Mock(return_value=MockResponse(json_data={"totals": {}}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report(
+            "sources", "20250101", "20260601", breakdown="monthly"
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_get_analytics_report_accepts_summarize_breakdown_variants(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"totals": {}}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report(
+            "sources", "20260101", "20260131", breakdown="summarize/daily"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/analytics/v2/reports/sources/summarize/daily"
+    )
+
+
 def test_get_analytics_report_caps_output_preserving_scalar_keys(monkeypatch):
     """The cap must shrink the CONTENTS of the largest nested list/dict
     value, not drop whole top-level keys - dropping keys could discard a
@@ -701,6 +791,17 @@ def test_get_analytics_report_does_not_truncate_a_small_response(monkeypatch):
         "report": {"totals": {"visits": 1}},
         "truncated": False,
     }
+
+
+def test_get_analytics_report_passes_through_a_non_dict_body(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data=[1, 2, 3]))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "20260101", "20260131")
+    )
+
+    assert result == {"status": "success", "report": [1, 2, 3], "truncated": False}
 
 
 def test_list_marketing_emails_projects_summary_fields(monkeypatch):
@@ -1046,6 +1147,91 @@ def test_get_campaign_metrics_rejects_bad_end_date_with_valid_start_date(monkeyp
     assert result["status"] == "error"
     assert "end_date" in result["message"]
     mock_request.assert_not_called()
+
+
+def test_get_campaign_metrics_rejects_non_calendar_date(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_campaign_metrics("campaign-1", start_date="2026-02-30")
+    )
+
+    assert result["status"] == "error"
+    assert "start_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_campaign_metrics_rejects_non_zero_padded_date(monkeypatch):
+    """Regression: datetime.strptime's %m/%d accept non-zero-padded values
+    (and %Y can under-consume digits when the remaining format directives
+    still find something to match), so a strptime-only check would parse
+    "2026-1-1" or the 6-digit "202611" into a DIFFERENT, wrong date instead
+    of rejecting it - not just be more lenient, but silently misparse."""
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_campaign_metrics("campaign-1", start_date="2026-1-1")
+    )
+
+    assert result["status"] == "error"
+    assert "start_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_analytics_report_rejects_short_yyyymmdd(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "202611", "20260131")
+    )
+
+    assert result["status"] == "error"
+    assert "start_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_campaign_metrics_rejects_start_after_end(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_campaign_metrics(
+            "campaign-1", start_date="2026-02-01", end_date="2026-01-01"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_date must not be after end_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_campaign_metrics_passes_through_a_non_dict_body(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data=[1, 2, 3]))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_campaign_metrics("campaign-1"))
+
+    assert result == {"status": "success", "metrics": [1, 2, 3], "truncated": False}
+
+
+def test_list_campaigns_skips_non_dict_items(monkeypatch):
+    """A non-dict item in the results (a malformed/unexpected upstream
+    shape) must be dropped rather than crash the whole page, matching the
+    guard _project_fields already applies for forms/emails."""
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"results": ["not-a-dict", {"id": "c1", "properties": {}}]}
+        )
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_list_campaigns())
+
+    assert result["status"] == "success"
+    assert result["campaigns"] == [{"id": "c1", "properties": {}}]
 
 
 def test_create_note_treats_empty_string_id_as_not_provided(monkeypatch):

--- a/tests/web/tools/test_hubspot_mcp.py
+++ b/tests/web/tools/test_hubspot_mcp.py
@@ -429,11 +429,14 @@ def test_get_form_submissions_reports_has_more(monkeypatch):
     )
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
-    result = json.loads(hubspot.hubspot_get_form_submissions("form-1", limit=10))
+    result = json.loads(
+        hubspot.hubspot_get_form_submissions("form-1", limit=10, after="cursor-0")
+    )
 
     assert result["status"] == "success"
     assert result["has_more"] is True
     assert result["after"] == "cursor-1"
+    assert mock_request.call_args.kwargs["params"]["after"] == "cursor-0"
     assert mock_request.call_args.kwargs["url"].endswith(
         "/form-integrations/v1/submissions/forms/form-1"
     )
@@ -621,11 +624,32 @@ def test_get_analytics_report_rejects_wrong_date_format(monkeypatch):
     mock_request.assert_not_called()
 
 
-def test_get_analytics_report_caps_output_size(monkeypatch):
-    """A "daily" breakdown over a wide date range is keyed by date at the
-    top level - many buckets, each with a nested per-dimension breakdown -
-    so the cap must halve top-level keys, not assume a flat object."""
-    report = {f"202601{day:02d}": {"sources": "x" * 200} for day in range(1, 29)}
+def test_get_analytics_report_rejects_bad_end_date_with_valid_start_date(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "20260101", "2026-01-31")
+    )
+
+    assert result["status"] == "error"
+    assert "end_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_analytics_report_caps_output_preserving_scalar_keys(monkeypatch):
+    """The cap must shrink the CONTENTS of the largest nested list/dict
+    value, not drop whole top-level keys - dropping keys could discard a
+    small summary field (offset, total) on the very first step while the
+    oversized field it summarizes survives untouched, and there's no
+    cursor to retry with to recover it."""
+    report = {
+        "offset": 0,
+        "total": 42,
+        "breakdowns": [
+            {"date": f"202601{day:02d}", "value": "x" * 200} for day in range(1, 40)
+        ],
+    }
     mock_request = Mock(return_value=MockResponse(json_data=report))
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
     monkeypatch.setattr(hubspot, "get_tool_max_output_length", lambda: 2000)
@@ -638,8 +662,30 @@ def test_get_analytics_report_caps_output_size(monkeypatch):
 
     assert result["status"] == "success"
     assert result["truncated"] is True
-    assert 0 < len(result["report"]) < len(report)
-    assert len(json.dumps(result)) <= 2000 + 200  # last halving step can overshoot
+    assert result["report"]["offset"] == 0
+    assert result["report"]["total"] == 42
+    assert 0 < len(result["report"]["breakdowns"]) < len(report["breakdowns"])
+    assert len(json.dumps(result)) <= 2000 + 400  # last halving step can overshoot
+
+
+def test_get_analytics_report_falls_back_to_dropping_keys_with_no_collections(
+    monkeypatch,
+):
+    """When a dict has no list/dict-valued keys to shrink into - e.g. a
+    handful of scalar fields with huge string values - the fallback must
+    still guarantee termination by dropping whole keys, down to {}."""
+    report = {"totals": "x" * 5000}
+    mock_request = Mock(return_value=MockResponse(json_data=report))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+    monkeypatch.setattr(hubspot, "get_tool_max_output_length", lambda: 200)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "20260101", "20260131")
+    )
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert result["report"] == {}
 
 
 def test_get_analytics_report_does_not_truncate_a_small_response(monkeypatch):
@@ -757,6 +803,40 @@ def test_get_marketing_email_statistics_passes_email_ids(monkeypatch):
     }
     assert mock_request.call_args.kwargs["params"] == {"emailIds": ["e1", "e2"]}
     assert mock_request.call_args.kwargs["method"] == "GET"
+
+
+def test_get_marketing_email_statistics_passes_through_a_non_dict_body(monkeypatch):
+    """A non-dict response body has nothing generically safe to trim
+    without guessing at a shape the capping helper doesn't know, so it
+    must pass through unmodified with truncated=False rather than crash
+    or silently corrupt the value."""
+    mock_request = Mock(return_value=MockResponse(json_data=[{"id": "e1"}]))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1"))
+
+    assert result == {
+        "status": "success",
+        "statistics": [{"id": "e1"}],
+        "truncated": False,
+    }
+
+
+def test_get_marketing_email_statistics_rejects_bad_end_date_with_valid_start_date(
+    monkeypatch,
+):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_marketing_email_statistics(
+            "e1", start_date="2026-01-01T00:00:00Z", end_date="not-a-timestamp"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "end_date" in result["message"]
+    mock_request.assert_not_called()
 
 
 def test_get_marketing_email_statistics_passes_time_window(monkeypatch):
@@ -950,6 +1030,21 @@ def test_get_campaign_metrics_rejects_wrong_date_format(monkeypatch):
 
     assert result["status"] == "error"
     assert "YYYY-MM-DD" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_campaign_metrics_rejects_bad_end_date_with_valid_start_date(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_campaign_metrics(
+            "campaign-1", start_date="2026-01-01", end_date="20260131"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "end_date" in result["message"]
     mock_request.assert_not_called()
 
 

--- a/tests/web/tools/test_hubspot_mcp.py
+++ b/tests/web/tools/test_hubspot_mcp.py
@@ -205,10 +205,22 @@ def test_get_contact_deals_empty_returns_no_more(monkeypatch):
     assert result == {"status": "success", "deals": [], "has_more": False}
 
 
-def test_list_forms_returns_raw_results(monkeypatch):
+def test_list_forms_projects_summary_fields(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
-            json_data={"results": [{"id": "f1", "name": "Contact Us"}]}
+            json_data={
+                "results": [
+                    {
+                        "id": "f1",
+                        "name": "Contact Us",
+                        "formType": "hubspot",
+                        "createdAt": "2026-01-01T00:00:00Z",
+                        "updatedAt": "2026-01-02T00:00:00Z",
+                        "archived": False,
+                        "fieldGroups": [{"huge": "payload"}],
+                    }
+                ]
+            }
         )
     )
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
@@ -217,12 +229,36 @@ def test_list_forms_returns_raw_results(monkeypatch):
 
     assert result == {
         "status": "success",
-        "forms": [{"id": "f1", "name": "Contact Us"}],
+        "forms": [
+            {
+                "id": "f1",
+                "name": "Contact Us",
+                "formType": "hubspot",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "updatedAt": "2026-01-02T00:00:00Z",
+                "archived": False,
+            }
+        ],
+        "truncated": False,
         "has_more": False,
         "after": None,
     }
     assert mock_request.call_args.kwargs["url"].endswith("/marketing/v3/forms")
     assert mock_request.call_args.kwargs["params"] == {"limit": 5}
+
+
+def test_list_forms_caps_output_size(monkeypatch):
+    big_forms = [{"id": str(i), "name": "x" * 1000} for i in range(50)]
+    mock_request = Mock(return_value=MockResponse(json_data={"results": big_forms}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+    monkeypatch.setattr(hubspot, "get_tool_max_output_length", lambda: 2000)
+
+    result = json.loads(hubspot.hubspot_list_forms(limit=100))
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert len(result["forms"]) < len(big_forms)
+    assert len(json.dumps(result)) <= 2000 + 200  # last halving step can overshoot
 
 
 def test_list_forms_clamps_limit_to_valid_range(monkeypatch):
@@ -288,6 +324,17 @@ def test_get_form_submissions_reports_has_more(monkeypatch):
     )
 
 
+def test_get_form_submissions_rejects_whitespace_padded_form_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_form_submissions(" form-1 "))
+
+    assert result["status"] == "error"
+    assert "form_id" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_get_form_submissions_wraps_request_errors(monkeypatch):
     monkeypatch.setattr(
         hubspot.requests,
@@ -305,11 +352,34 @@ def test_get_analytics_report_rejects_invalid_report_type(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
-    result = json.loads(hubspot.hubspot_get_analytics_report("not-a-real-type"))
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("not-a-real-type", "20260101", "20260131")
+    )
 
     assert result["status"] == "error"
     assert "report_type must be one of" in result["message"]
     mock_request.assert_not_called()
+
+
+# Hardcoded literal, deliberately NOT hubspot._VALID_ANALYTICS_REPORT_TYPES:
+# testing against the same constant the code validates against can't catch a
+# wrong entry in that constant (exactly how "landing-pages" - a non-existent
+# HubSpot value - made it through an earlier version of this allowlist).
+_DOCUMENTED_ANALYTICS_REPORT_TYPES = [
+    "totals",
+    "sessions",
+    "sources",
+    "geolocation",
+    "utm-campaigns",
+    "utm-contents",
+    "utm-mediums",
+    "utm-sources",
+    "utm-terms",
+    "event-completions",
+    "forms",
+    "pages",
+    "social-assists",
+]
 
 
 def test_get_analytics_report_accepts_all_documented_report_types(monkeypatch):
@@ -318,19 +388,41 @@ def test_get_analytics_report_accepts_all_documented_report_types(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={}))
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
-    for report_type in sorted(hubspot._VALID_ANALYTICS_REPORT_TYPES):
-        result = json.loads(hubspot.hubspot_get_analytics_report(report_type))
+    for report_type in _DOCUMENTED_ANALYTICS_REPORT_TYPES:
+        result = json.loads(
+            hubspot.hubspot_get_analytics_report(report_type, "20260101", "20260131")
+        )
         assert result["status"] == "success", report_type
         assert mock_request.call_args.kwargs["url"].endswith(
             f"/analytics/v2/reports/{report_type}/total"
         )
 
 
+def test_get_analytics_report_normalizes_report_type_and_breakdown_case(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report(
+            " Sources ", "20260101", "20260131", breakdown=" Daily "
+        )
+    )
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/analytics/v2/reports/sources/daily"
+    )
+
+
 def test_get_analytics_report_rejects_invalid_breakdown(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
-    result = json.loads(hubspot.hubspot_get_analytics_report("sources", "yearly"))
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report(
+            "sources", "20260101", "20260131", breakdown="yearly"
+        )
+    )
 
     assert result["status"] == "error"
     assert "breakdown must be one of" in result["message"]
@@ -343,7 +435,7 @@ def test_get_analytics_report_passes_date_range(monkeypatch):
 
     result = json.loads(
         hubspot.hubspot_get_analytics_report(
-            "sources", "daily", start_date="20260101", end_date="20260131"
+            "sources", "20260101", "20260131", breakdown="daily"
         )
     )
 
@@ -364,15 +456,32 @@ def test_get_analytics_report_wraps_request_errors(monkeypatch):
         Mock(return_value=MockResponse(status_code=500, text="boom")),
     )
 
-    result = json.loads(hubspot.hubspot_get_analytics_report("sources"))
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "20260101", "20260131")
+    )
 
     assert result["status"] == "error"
     assert "boom" in result["message"]
 
 
-def test_list_marketing_emails_returns_raw_results(monkeypatch):
+def test_list_marketing_emails_projects_summary_fields(monkeypatch):
     mock_request = Mock(
-        return_value=MockResponse(json_data={"results": [{"id": "e1"}]})
+        return_value=MockResponse(
+            json_data={
+                "results": [
+                    {
+                        "id": "e1",
+                        "name": "Welcome",
+                        "subject": "Hi there",
+                        "state": "PUBLISHED",
+                        "publishDate": "2026-01-01T00:00:00Z",
+                        "createdAt": "2025-12-01T00:00:00Z",
+                        "updatedAt": "2026-01-01T00:00:00Z",
+                        "htmlBody": "<html>huge payload</html>",
+                    }
+                ]
+            }
+        )
     )
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
@@ -380,7 +489,18 @@ def test_list_marketing_emails_returns_raw_results(monkeypatch):
 
     assert result == {
         "status": "success",
-        "emails": [{"id": "e1"}],
+        "emails": [
+            {
+                "id": "e1",
+                "name": "Welcome",
+                "subject": "Hi there",
+                "state": "PUBLISHED",
+                "publishDate": "2026-01-01T00:00:00Z",
+                "createdAt": "2025-12-01T00:00:00Z",
+                "updatedAt": "2026-01-01T00:00:00Z",
+            }
+        ],
+        "truncated": False,
         "has_more": False,
         "after": None,
     }
@@ -435,7 +555,7 @@ def test_get_marketing_email_statistics_passes_email_ids(monkeypatch):
     )
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
-    result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1, e2"))
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1,e2"))
 
     assert result == {
         "status": "success",
@@ -445,14 +565,52 @@ def test_get_marketing_email_statistics_passes_email_ids(monkeypatch):
     assert mock_request.call_args.kwargs["method"] == "GET"
 
 
+def test_get_marketing_email_statistics_passes_time_window(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    hubspot.hubspot_get_marketing_email_statistics(
+        "e1", start_date="2026-01-01T00:00:00Z", end_date="2026-01-31T00:00:00Z"
+    )
+
+    assert mock_request.call_args.kwargs["params"] == {
+        "emailIds": ["e1"],
+        "startTimestamp": "2026-01-01T00:00:00Z",
+        "endTimestamp": "2026-01-31T00:00:00Z",
+    }
+
+
+def test_get_marketing_email_statistics_rejects_whitespace_padded_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1, e2"))
+
+    assert result["status"] == "error"
+    assert "each email id" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_get_marketing_email_statistics_rejects_empty_email_ids(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
-    result = json.loads(hubspot.hubspot_get_marketing_email_statistics(" , "))
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics(""))
 
     assert result["status"] == "error"
-    assert "at least one email id" in result["message"]
+    assert "each email id" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_marketing_email_statistics_rejects_too_many_ids(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    too_many = ",".join(str(i) for i in range(101))
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics(too_many))
+
+    assert result["status"] == "error"
+    assert "at most 100 ids" in result["message"]
     mock_request.assert_not_called()
 
 
@@ -469,9 +627,19 @@ def test_get_marketing_email_statistics_wraps_request_errors(monkeypatch):
     assert "boom" in result["message"]
 
 
-def test_list_campaigns_returns_raw_results(monkeypatch):
+def test_list_campaigns_sends_default_properties_and_trims_results(monkeypatch):
     mock_request = Mock(
-        return_value=MockResponse(json_data={"results": [{"id": "c1"}]})
+        return_value=MockResponse(
+            json_data={
+                "results": [
+                    {
+                        "id": "c1",
+                        "properties": {"hs_name": "Spring Launch"},
+                        "extraServerField": "should be dropped",
+                    }
+                ]
+            }
+        )
     )
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
@@ -479,11 +647,15 @@ def test_list_campaigns_returns_raw_results(monkeypatch):
 
     assert result == {
         "status": "success",
-        "campaigns": [{"id": "c1"}],
+        "campaigns": [{"id": "c1", "properties": {"hs_name": "Spring Launch"}}],
+        "truncated": False,
         "has_more": False,
         "after": None,
     }
     assert mock_request.call_args.kwargs["url"].endswith("/marketing/v3/campaigns")
+    assert mock_request.call_args.kwargs["params"]["properties"] == ",".join(
+        hubspot.DEFAULT_CAMPAIGN_PROPERTIES
+    )
 
 
 def test_list_campaigns_clamps_limit_to_valid_range(monkeypatch):
@@ -501,7 +673,7 @@ def test_list_campaigns_reports_has_more_and_after(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
             json_data={
-                "results": [{"id": "c1"}],
+                "results": [{"id": "c1", "properties": {}}],
                 "paging": {"next": {"after": "cursor-1"}},
             }
         )
@@ -546,6 +718,17 @@ def test_get_campaign_metrics_passes_date_range(monkeypatch):
         "startDate": "2026-01-01",
         "endDate": "2026-01-31",
     }
+
+
+def test_get_campaign_metrics_rejects_whitespace_padded_campaign_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_campaign_metrics(" campaign-1 "))
+
+    assert result["status"] == "error"
+    assert "campaign_id" in result["message"]
+    mock_request.assert_not_called()
 
 
 def test_get_campaign_metrics_wraps_request_errors(monkeypatch):

--- a/tests/web/tools/test_hubspot_mcp.py
+++ b/tests/web/tools/test_hubspot_mcp.py
@@ -80,6 +80,77 @@ def test_association_listing_uses_the_longer_timeout(monkeypatch):
     )
 
 
+def test_url_path_id_percent_encodes_path_and_query_metacharacters():
+    """Percent-encoding, not a blocklist, is what actually prevents an id
+    from escaping its intended URL path segment."""
+    assert (
+        hubspot._url_path_id("x?limit=1&foo=/reports/metrics", "campaign_id")
+        == "x%3Flimit%3D1%26foo%3D%2Freports%2Fmetrics"
+    )
+
+
+def test_url_path_id_rejects_whitespace_padded_value():
+    with pytest.raises(ValueError, match="contact_id"):
+        hubspot._url_path_id(" c1 ", "contact_id")
+
+
+def test_get_contact_encodes_and_fetches_by_id(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "c1"}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_contact("c1/../2"))
+
+    assert result == {"status": "success", "contact": {"id": "c1"}}
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/crm/v3/objects/contacts/c1%2F..%2F2"
+    )
+
+
+def test_get_contact_rejects_whitespace_padded_contact_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_contact(" c1 "))
+
+    assert result["status"] == "error"
+    assert "contact_id" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_update_company_encodes_company_id(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "co1"}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_update_company("co 1/2", '{"name": "Acme"}'))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/crm/v3/objects/companies/co%201%2F2"
+    )
+
+
+def test_update_company_rejects_whitespace_padded_company_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_update_company(" co1 ", '{"name": "Acme"}'))
+
+    assert result["status"] == "error"
+    assert "company_id" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_contact_deals_rejects_whitespace_padded_contact_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_contact_deals(" c1 "))
+
+    assert result["status"] == "error"
+    assert "contact_id" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_create_note_assembles_associations(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"id": "note-1"}))
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
@@ -261,6 +332,50 @@ def test_list_forms_caps_output_size(monkeypatch):
     assert len(json.dumps(result)) <= 2000 + 200  # last halving step can overshoot
 
 
+def test_paged_list_truncates_to_empty_when_single_item_still_oversized(monkeypatch):
+    """Regression for an off-by-one in the halving loop: a page that
+    shrinks to exactly one item which is STILL over budget on its own must
+    still truncate down to zero items with truncated=True, not silently
+    return the oversized single item untouched (a `len(items) > 1` guard
+    would stop shrinking right before this point)."""
+    huge_form = {"id": "f1", "name": "x" * 5000}
+    mock_request = Mock(return_value=MockResponse(json_data={"results": [huge_form]}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+    monkeypatch.setattr(hubspot, "get_tool_max_output_length", lambda: 200)
+
+    result = json.loads(hubspot.hubspot_list_forms(limit=1))
+
+    assert result["status"] == "success"
+    assert result["forms"] == []
+    assert result["truncated"] is True
+    assert result["has_more"] is True
+
+
+def test_paged_list_reports_input_after_not_next_after_when_truncated(monkeypatch):
+    """A truncated page must report ITS OWN input cursor, not the server's
+    next-page cursor: the server already considers the full page consumed,
+    so advancing to its next page would permanently skip whatever this
+    page didn't return for space reasons."""
+    forms = [{"id": str(i), "name": "x" * 200} for i in range(4)]
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "results": forms,
+                "paging": {"next": {"after": "server-next-cursor"}},
+            }
+        )
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+    monkeypatch.setattr(hubspot, "get_tool_max_output_length", lambda: 500)
+
+    result = json.loads(hubspot.hubspot_list_forms(after="caller-input-cursor"))
+
+    assert result["truncated"] is True
+    assert 0 < len(result["forms"]) < 4
+    assert result["has_more"] is True
+    assert result["after"] == "caller-input-cursor"
+
+
 def test_list_forms_clamps_limit_to_valid_range(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
@@ -321,6 +436,28 @@ def test_get_form_submissions_reports_has_more(monkeypatch):
     assert result["after"] == "cursor-1"
     assert mock_request.call_args.kwargs["url"].endswith(
         "/form-integrations/v1/submissions/forms/form-1"
+    )
+
+
+def test_get_form_submissions_clamps_limit_to_valid_range(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    hubspot.hubspot_get_form_submissions("form-1", limit=0)
+    assert mock_request.call_args.kwargs["params"]["limit"] == 1
+
+    hubspot.hubspot_get_form_submissions("form-1", limit=1000)
+    assert mock_request.call_args.kwargs["params"]["limit"] == 50
+
+
+def test_get_form_submissions_encodes_special_characters_in_form_id(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    hubspot.hubspot_get_form_submissions("form/1?x=1")
+
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/form-integrations/v1/submissions/forms/form%2F1%3Fx%3D1"
     )
 
 
@@ -439,7 +576,11 @@ def test_get_analytics_report_passes_date_range(monkeypatch):
         )
     )
 
-    assert result == {"status": "success", "report": {"totals": {}}}
+    assert result == {
+        "status": "success",
+        "report": {"totals": {}},
+        "truncated": False,
+    }
     assert mock_request.call_args.kwargs["url"].endswith(
         "/analytics/v2/reports/sources/daily"
     )
@@ -462,6 +603,58 @@ def test_get_analytics_report_wraps_request_errors(monkeypatch):
 
     assert result["status"] == "error"
     assert "boom" in result["message"]
+
+
+def test_get_analytics_report_rejects_wrong_date_format(monkeypatch):
+    """The analytics API wants YYYYMMDD; the campaign-metrics API wants
+    YYYY-MM-DD. Mixing them up must produce a message naming the fix, not
+    an opaque upstream 400."""
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "2026-01-01", "2026-01-31")
+    )
+
+    assert result["status"] == "error"
+    assert "YYYYMMDD" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_analytics_report_caps_output_size(monkeypatch):
+    """A "daily" breakdown over a wide date range is keyed by date at the
+    top level - many buckets, each with a nested per-dimension breakdown -
+    so the cap must halve top-level keys, not assume a flat object."""
+    report = {f"202601{day:02d}": {"sources": "x" * 200} for day in range(1, 29)}
+    mock_request = Mock(return_value=MockResponse(json_data=report))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+    monkeypatch.setattr(hubspot, "get_tool_max_output_length", lambda: 2000)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report(
+            "sources", "20260101", "20260131", breakdown="daily"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert 0 < len(result["report"]) < len(report)
+    assert len(json.dumps(result)) <= 2000 + 200  # last halving step can overshoot
+
+
+def test_get_analytics_report_does_not_truncate_a_small_response(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"totals": {"visits": 1}}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report("sources", "20260101", "20260131")
+    )
+
+    assert result == {
+        "status": "success",
+        "report": {"totals": {"visits": 1}},
+        "truncated": False,
+    }
 
 
 def test_list_marketing_emails_projects_summary_fields(monkeypatch):
@@ -560,6 +753,7 @@ def test_get_marketing_email_statistics_passes_email_ids(monkeypatch):
     assert result == {
         "status": "success",
         "statistics": {"results": [{"id": "e1"}]},
+        "truncated": False,
     }
     assert mock_request.call_args.kwargs["params"] == {"emailIds": ["e1", "e2"]}
     assert mock_request.call_args.kwargs["method"] == "GET"
@@ -612,6 +806,17 @@ def test_get_marketing_email_statistics_rejects_too_many_ids(monkeypatch):
     assert result["status"] == "error"
     assert "at most 100 ids" in result["message"]
     mock_request.assert_not_called()
+
+
+def test_get_marketing_email_statistics_accepts_exactly_the_id_cap(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    exactly_100 = ",".join(str(i) for i in range(100))
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics(exactly_100))
+
+    assert result["status"] == "success"
+    assert len(mock_request.call_args.kwargs["params"]["emailIds"]) == 100
 
 
 def test_get_marketing_email_statistics_wraps_request_errors(monkeypatch):
@@ -710,7 +915,11 @@ def test_get_campaign_metrics_passes_date_range(monkeypatch):
         )
     )
 
-    assert result == {"status": "success", "metrics": {"sessions": 10}}
+    assert result == {
+        "status": "success",
+        "metrics": {"sessions": 10},
+        "truncated": False,
+    }
     assert mock_request.call_args.kwargs["url"].endswith(
         "/marketing/v3/campaigns/campaign-1/reports/metrics"
     )
@@ -728,6 +937,46 @@ def test_get_campaign_metrics_rejects_whitespace_padded_campaign_id(monkeypatch)
 
     assert result["status"] == "error"
     assert "campaign_id" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_campaign_metrics_rejects_wrong_date_format(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_campaign_metrics("campaign-1", start_date="20260101")
+    )
+
+    assert result["status"] == "error"
+    assert "YYYY-MM-DD" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_create_note_treats_empty_string_id_as_not_provided(monkeypatch):
+    """An empty-string id keeps its pre-existing meaning of "not provided"
+    (an LLM caller often sends "" instead of omitting the param); only a
+    non-empty id gets whitespace validation."""
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "note-1"}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_create_note("summary", contact_id="", deal_id="d1")
+    )
+
+    assert result["status"] == "success"
+    associations = mock_request.call_args.kwargs["json"]["associations"]
+    assert [a["to"]["id"] for a in associations] == ["d1"]
+
+
+def test_create_note_rejects_whitespace_padded_id(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_create_note("summary", contact_id=" c1 "))
+
+    assert result["status"] == "error"
+    assert "contact_id" in result["message"]
     mock_request.assert_not_called()
 
 

--- a/tests/web/tools/test_hubspot_mcp.py
+++ b/tests/web/tools/test_hubspot_mcp.py
@@ -203,3 +203,137 @@ def test_get_contact_deals_empty_returns_no_more(monkeypatch):
     result = json.loads(hubspot.hubspot_get_contact_deals("c1"))
 
     assert result == {"status": "success", "deals": [], "has_more": False}
+
+
+def test_list_forms_returns_raw_results(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"results": [{"id": "f1", "name": "Contact Us"}]}
+        )
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_list_forms(limit=5))
+
+    assert result == {
+        "status": "success",
+        "forms": [{"id": "f1", "name": "Contact Us"}],
+        "has_more": False,
+    }
+    assert mock_request.call_args.kwargs["url"].endswith("/marketing/v3/forms")
+    assert mock_request.call_args.kwargs["params"] == {"limit": 5}
+
+
+def test_get_form_submissions_reports_has_more(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "results": [{"submittedAt": 1, "values": []}],
+                "paging": {"next": {"after": "cursor-1"}},
+            }
+        )
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_form_submissions("form-1", limit=10))
+
+    assert result["status"] == "success"
+    assert result["has_more"] is True
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/form-integrations/v1/submissions/forms/form-1"
+    )
+
+
+def test_get_analytics_report_rejects_invalid_breakdown(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_analytics_report("sources", "yearly"))
+
+    assert result["status"] == "error"
+    assert "breakdown must be one of" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_analytics_report_passes_date_range(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"totals": {}}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_analytics_report(
+            "sources", "day", start_date="20260101", end_date="20260131"
+        )
+    )
+
+    assert result == {"status": "success", "report": {"totals": {}}}
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/analytics/v2/reports/sources/day"
+    )
+    assert mock_request.call_args.kwargs["params"] == {
+        "start": "20260101",
+        "end": "20260131",
+    }
+
+
+def test_list_marketing_emails_returns_raw_results(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"results": [{"id": "e1"}]})
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_list_marketing_emails())
+
+    assert result == {
+        "status": "success",
+        "emails": [{"id": "e1"}],
+        "has_more": False,
+    }
+    assert mock_request.call_args.kwargs["url"].endswith("/marketing/v3/emails")
+
+
+def test_get_marketing_email_statistics_passes_email_ids(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"results": [{"id": "e1"}]})
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1,e2"))
+
+    assert result == {"status": "success", "statistics": [{"id": "e1"}]}
+    assert mock_request.call_args.kwargs["params"] == {"emailIds": "e1,e2"}
+
+
+def test_list_campaigns_returns_raw_results(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"results": [{"id": "c1"}]})
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_list_campaigns())
+
+    assert result == {
+        "status": "success",
+        "campaigns": [{"id": "c1"}],
+        "has_more": False,
+    }
+    assert mock_request.call_args.kwargs["url"].endswith("/marketing/v3/campaigns")
+
+
+def test_get_campaign_metrics_passes_date_range(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"sessions": 10}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(
+        hubspot.hubspot_get_campaign_metrics(
+            "campaign-1", start_date="2026-01-01", end_date="2026-01-31"
+        )
+    )
+
+    assert result == {"status": "success", "metrics": {"sessions": 10}}
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/marketing/v3/campaigns/campaign-1/reports/metrics"
+    )
+    assert mock_request.call_args.kwargs["params"] == {
+        "startDate": "2026-01-01",
+        "endDate": "2026-01-31",
+    }

--- a/tests/web/tools/test_hubspot_mcp.py
+++ b/tests/web/tools/test_hubspot_mcp.py
@@ -297,10 +297,10 @@ def test_get_marketing_email_statistics_passes_email_ids(monkeypatch):
     )
     monkeypatch.setattr(hubspot.requests, "request", mock_request)
 
-    result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1,e2"))
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1, e2"))
 
     assert result == {"status": "success", "statistics": [{"id": "e1"}]}
-    assert mock_request.call_args.kwargs["params"] == {"emailIds": "e1,e2"}
+    assert mock_request.call_args.kwargs["params"] == {"emailIds": ["e1", "e2"]}
 
 
 def test_list_campaigns_returns_raw_results(monkeypatch):

--- a/tests/web/tools/test_hubspot_mcp.py
+++ b/tests/web/tools/test_hubspot_mcp.py
@@ -219,9 +219,52 @@ def test_list_forms_returns_raw_results(monkeypatch):
         "status": "success",
         "forms": [{"id": "f1", "name": "Contact Us"}],
         "has_more": False,
+        "after": None,
     }
     assert mock_request.call_args.kwargs["url"].endswith("/marketing/v3/forms")
     assert mock_request.call_args.kwargs["params"] == {"limit": 5}
+
+
+def test_list_forms_clamps_limit_to_valid_range(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    hubspot.hubspot_list_forms(limit=0)
+    assert mock_request.call_args.kwargs["params"]["limit"] == 1
+
+    hubspot.hubspot_list_forms(limit=1000)
+    assert mock_request.call_args.kwargs["params"]["limit"] == 100
+
+
+def test_list_forms_reports_has_more_and_passes_after_cursor(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "results": [{"id": "f1"}],
+                "paging": {"next": {"after": "cursor-1"}},
+            }
+        )
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_list_forms(after="cursor-0"))
+
+    assert result["has_more"] is True
+    assert result["after"] == "cursor-1"
+    assert mock_request.call_args.kwargs["params"]["after"] == "cursor-0"
+
+
+def test_list_forms_wraps_request_errors(monkeypatch):
+    monkeypatch.setattr(
+        hubspot.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="boom")),
+    )
+
+    result = json.loads(hubspot.hubspot_list_forms())
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
 
 
 def test_get_form_submissions_reports_has_more(monkeypatch):
@@ -239,9 +282,48 @@ def test_get_form_submissions_reports_has_more(monkeypatch):
 
     assert result["status"] == "success"
     assert result["has_more"] is True
+    assert result["after"] == "cursor-1"
     assert mock_request.call_args.kwargs["url"].endswith(
         "/form-integrations/v1/submissions/forms/form-1"
     )
+
+
+def test_get_form_submissions_wraps_request_errors(monkeypatch):
+    monkeypatch.setattr(
+        hubspot.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="boom")),
+    )
+
+    result = json.loads(hubspot.hubspot_get_form_submissions("form-1"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
+
+
+def test_get_analytics_report_rejects_invalid_report_type(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_analytics_report("not-a-real-type"))
+
+    assert result["status"] == "error"
+    assert "report_type must be one of" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_analytics_report_accepts_all_documented_report_types(monkeypatch):
+    """Every documented dimension and content object type must pass the
+    allowlist - a wrong entry here actively blocks valid HubSpot values."""
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    for report_type in sorted(hubspot._VALID_ANALYTICS_REPORT_TYPES):
+        result = json.loads(hubspot.hubspot_get_analytics_report(report_type))
+        assert result["status"] == "success", report_type
+        assert mock_request.call_args.kwargs["url"].endswith(
+            f"/analytics/v2/reports/{report_type}/total"
+        )
 
 
 def test_get_analytics_report_rejects_invalid_breakdown(monkeypatch):
@@ -261,18 +343,31 @@ def test_get_analytics_report_passes_date_range(monkeypatch):
 
     result = json.loads(
         hubspot.hubspot_get_analytics_report(
-            "sources", "day", start_date="20260101", end_date="20260131"
+            "sources", "daily", start_date="20260101", end_date="20260131"
         )
     )
 
     assert result == {"status": "success", "report": {"totals": {}}}
     assert mock_request.call_args.kwargs["url"].endswith(
-        "/analytics/v2/reports/sources/day"
+        "/analytics/v2/reports/sources/daily"
     )
     assert mock_request.call_args.kwargs["params"] == {
         "start": "20260101",
         "end": "20260131",
     }
+
+
+def test_get_analytics_report_wraps_request_errors(monkeypatch):
+    monkeypatch.setattr(
+        hubspot.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="boom")),
+    )
+
+    result = json.loads(hubspot.hubspot_get_analytics_report("sources"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
 
 
 def test_list_marketing_emails_returns_raw_results(monkeypatch):
@@ -287,8 +382,51 @@ def test_list_marketing_emails_returns_raw_results(monkeypatch):
         "status": "success",
         "emails": [{"id": "e1"}],
         "has_more": False,
+        "after": None,
     }
     assert mock_request.call_args.kwargs["url"].endswith("/marketing/v3/emails")
+
+
+def test_list_marketing_emails_clamps_limit_to_valid_range(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    hubspot.hubspot_list_marketing_emails(limit=0)
+    assert mock_request.call_args.kwargs["params"]["limit"] == 1
+
+    hubspot.hubspot_list_marketing_emails(limit=1000)
+    assert mock_request.call_args.kwargs["params"]["limit"] == 100
+
+
+def test_list_marketing_emails_reports_has_more_and_after(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "results": [{"id": "e1"}],
+                "paging": {"next": {"after": "cursor-1"}},
+            }
+        )
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_list_marketing_emails(after="cursor-0"))
+
+    assert result["has_more"] is True
+    assert result["after"] == "cursor-1"
+    assert mock_request.call_args.kwargs["params"]["after"] == "cursor-0"
+
+
+def test_list_marketing_emails_wraps_request_errors(monkeypatch):
+    monkeypatch.setattr(
+        hubspot.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="boom")),
+    )
+
+    result = json.loads(hubspot.hubspot_list_marketing_emails())
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
 
 
 def test_get_marketing_email_statistics_passes_email_ids(monkeypatch):
@@ -299,8 +437,36 @@ def test_get_marketing_email_statistics_passes_email_ids(monkeypatch):
 
     result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1, e2"))
 
-    assert result == {"status": "success", "statistics": [{"id": "e1"}]}
+    assert result == {
+        "status": "success",
+        "statistics": {"results": [{"id": "e1"}]},
+    }
     assert mock_request.call_args.kwargs["params"] == {"emailIds": ["e1", "e2"]}
+    assert mock_request.call_args.kwargs["method"] == "GET"
+
+
+def test_get_marketing_email_statistics_rejects_empty_email_ids(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics(" , "))
+
+    assert result["status"] == "error"
+    assert "at least one email id" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_get_marketing_email_statistics_wraps_request_errors(monkeypatch):
+    monkeypatch.setattr(
+        hubspot.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="boom")),
+    )
+
+    result = json.loads(hubspot.hubspot_get_marketing_email_statistics("e1"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
 
 
 def test_list_campaigns_returns_raw_results(monkeypatch):
@@ -315,8 +481,51 @@ def test_list_campaigns_returns_raw_results(monkeypatch):
         "status": "success",
         "campaigns": [{"id": "c1"}],
         "has_more": False,
+        "after": None,
     }
     assert mock_request.call_args.kwargs["url"].endswith("/marketing/v3/campaigns")
+
+
+def test_list_campaigns_clamps_limit_to_valid_range(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    hubspot.hubspot_list_campaigns(limit=0)
+    assert mock_request.call_args.kwargs["params"]["limit"] == 1
+
+    hubspot.hubspot_list_campaigns(limit=1000)
+    assert mock_request.call_args.kwargs["params"]["limit"] == 100
+
+
+def test_list_campaigns_reports_has_more_and_after(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "results": [{"id": "c1"}],
+                "paging": {"next": {"after": "cursor-1"}},
+            }
+        )
+    )
+    monkeypatch.setattr(hubspot.requests, "request", mock_request)
+
+    result = json.loads(hubspot.hubspot_list_campaigns(after="cursor-0"))
+
+    assert result["has_more"] is True
+    assert result["after"] == "cursor-1"
+    assert mock_request.call_args.kwargs["params"]["after"] == "cursor-0"
+
+
+def test_list_campaigns_wraps_request_errors(monkeypatch):
+    monkeypatch.setattr(
+        hubspot.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="boom")),
+    )
+
+    result = json.loads(hubspot.hubspot_list_campaigns())
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]
 
 
 def test_get_campaign_metrics_passes_date_range(monkeypatch):
@@ -337,3 +546,16 @@ def test_get_campaign_metrics_passes_date_range(monkeypatch):
         "startDate": "2026-01-01",
         "endDate": "2026-01-31",
     }
+
+
+def test_get_campaign_metrics_wraps_request_errors(monkeypatch):
+    monkeypatch.setattr(
+        hubspot.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="boom")),
+    )
+
+    result = json.loads(hubspot.hubspot_get_campaign_metrics("campaign-1"))
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]


### PR DESCRIPTION
## Summary
- Adds HubSpot Marketing Hub tools: forms + form submissions, traffic analytics reports, marketing email listing/statistics, and campaign listing/metrics.
- Adds the matching OAuth scopes (`forms`, `business-intelligence`, `marketing-email`, `marketing.campaigns.read`) and updates the connector description.
- Adds a migration to sync the new scopes/description into already-seeded HubSpot rows, so `validate_builtin_public_mcp_apps` doesn't report drift and existing installs pick up the updated description (execution fields like `oauth_scopes` are read from the code registry at runtime, but `description` is read straight from the DB row).

Note: HubSpot has no public API for reading custom reports/dashboards built in its report editor, so "Reporting" is covered only via the traffic Analytics API dimensions, not arbitrary custom dashboards. Analytics endpoints also require a Marketing Hub Basic/Professional/Enterprise account.

Already-connected users will need to reconnect once this ships, since existing OAuth tokens won't carry the new scopes.

## Test plan
- [x] `pytest tests/web/tools/test_hubspot_mcp.py tests/alembic/test_20260810_add_hubspot_marketing_scopes.py tests/web/api/test_public_mcp_connector_visibility.py`
- [x] `ruff check` / `ruff format --check` / `mypy` on all touched files
- [x] Full `alembic upgrade head` on a scratch sqlite DB to verify the migration chain