### PR TITLE
Resolve MCP connector visibility from the governing agent's team

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -2207,6 +2207,16 @@ class AgentTool(AbstractBaseTool):
                     "scope_segments": _scope_segments,
                 },
                 execution_scope=self._execution_scope,
+                # Delegated sub-agents stay closed: identity here is restored
+                # from a persisted workforce snapshot with no re-authorization
+                # at consumption, so opening team connector visibility would
+                # grant a team's connectors -- and the shared definition row's
+                # credentials, for static-auth transports -- off a snapshot
+                # nobody re-checks at delegation time. A spec naming a
+                # team-only server resolves to an empty tool set, silently,
+                # not an error; this is the deliberate scope this parameter
+                # enforces, not an oversight.
+                connector_team_id=None,
             )
 
             async def execute_delegated_runtime() -> tuple[dict[str, Any], Any]:

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -782,9 +782,17 @@ class MCPToolAdapter(AbstractBaseTool):
             "Retrying MCP tool %s after delegated authorization failure",
             self.mcp_tool.name,
         )
-        refreshed = refresh()
-        if inspect.isawaitable(refreshed):
-            refreshed = await refreshed
+        try:
+            refreshed = refresh()
+            if inspect.isawaitable(refreshed):
+                refreshed = await refreshed
+        except (BaseExceptionGroup, Exception) as refresh_exc:
+            logger.error(
+                "MCP tool %s delegated authorization refresh failed with %s",
+                self.mcp_tool.name,
+                type(refresh_exc).__name__,
+            )
+            return _delegated_authorization_failed_result()
         if not isinstance(refreshed, dict):
             return _delegated_authorization_failed_result()
         try:

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -1657,6 +1657,11 @@ async def preview_agent(
             include_mcp_tools=should_load_mcp_server_configs(tool_selection_spec),
             task_id=preview_task_id,
             workspace_base_dir=str(get_uploads_dir() / "preview"),
+            # A preview request carries tool_categories, not an agent id, so
+            # there is no governing agent to key team connector visibility
+            # on. The live agent (once promoted) can still diverge from
+            # this preview for a team connector -- a known, accepted gap.
+            connector_team_id=None,
         )
 
         # Determine execution mode (default to "think")

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -45,6 +45,7 @@ from ...core.tools.adapters.vibe.config import (
     MCPFailurePolicy,
     RequiredMCPUnavailableError,
 )
+from ...core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from ...core.tools.adapters.vibe.selection_spec import should_load_mcp_server_configs
 from ...sandbox import SandboxMountIntent
 from ..auth_dependencies import get_current_user
@@ -591,6 +592,7 @@ async def create_default_tools(
     mcp_failure_policy: MCPFailurePolicy = MCPFailurePolicy.BEST_EFFORT,
     mcp_load_summary_tracer: Optional[Any] = None,
     mcp_load_summary_trace_task_id: Optional[str] = None,
+    connector_team_id: Optional[int] = None,
 ) -> tuple[list[Any], Any]:
     """Create default tools and tool_config for AgentService using ToolFactory.
 
@@ -599,6 +601,11 @@ async def create_default_tools(
     can skip creators (and their internal DB / network I/O) for tool
     categories / MCP servers the agent does not need. ``None`` preserves
     the original "build everything" behavior for backward compat.
+
+    ``connector_team_id`` is the *governing agent's* owning team, never the
+    calling user's own team membership. It threads into ``WebToolConfig`` so
+    the connector-visibility team-scope hook (when installed) resolves that
+    team's connectors instead of the run owner's personal set only.
     """
     if not user:
         raise ValueError("User is required for tool creation")
@@ -663,6 +670,7 @@ async def create_default_tools(
         mcp_failure_policy=mcp_failure_policy,
         mcp_load_summary_tracer=mcp_load_summary_tracer,
         mcp_load_summary_trace_task_id=mcp_load_summary_trace_task_id,
+        connector_team_id=connector_team_id,
     )
 
     # Store excluded_agent_id in tool_config for agent tool filtering
@@ -1908,12 +1916,33 @@ class AgentServiceManager:
         if task_setup_snapshot is not None:
             workforce_runtime = task_setup_snapshot.workforce_runtime
             excluded_agent_id = task_setup_snapshot.excluded_agent_id
+            connector_team_id = (
+                task_setup_snapshot.agent.team_id
+                if task_setup_snapshot.agent is not None
+                else None
+            )
         else:
             if db is None:
                 raise ValueError("Database session or task snapshot is required")
             workforce_runtime = resolve_workforce_task_runtime(db, task)
             excluded_agent_id = None
             current_agent = _load_agent_for_task_runtime(db, task, workforce_runtime)
+            # Hardening, not a pinned invariant: this branch is not reachable
+            # from production today (the only caller always supplies a
+            # snapshot). Capture the team id before the exclusion branches
+            # below can reassign ``current_agent`` to an unpublished preview
+            # agent, so a future snapshot-less path cannot silently key the
+            # tool set on the preview agent's team instead of the governing
+            # agent's.
+            # Explicit int(...)/None-check here, unlike the two snapshot-branch
+            # sites above and below: current_agent is a live ORM row (its
+            # team_id is a Column), not the frozen AgentRuntimeFields snapshot
+            # those two already read as a typed Optional[int].
+            connector_team_id = (
+                int(current_agent.team_id)
+                if current_agent is not None and current_agent.team_id is not None
+                else None
+            )
             if current_agent and _is_published_agent(current_agent):
                 excluded_agent_id = int(current_agent.id)
                 logger.info(
@@ -2000,6 +2029,7 @@ class AgentServiceManager:
             mcp_failure_policy=_mcp_failure_policy_for_task_source(task.source),
             mcp_load_summary_tracer=parent_tracer,
             mcp_load_summary_trace_task_id=str(task_id),
+            connector_team_id=connector_team_id,
         )
 
     async def get_agent_for_task(
@@ -2637,6 +2667,11 @@ class AgentServiceManager:
                     ),
                     mcp_load_summary_tracer=tracer,
                     mcp_load_summary_trace_task_id=str(task_id),
+                    connector_team_id=(
+                        snapshot.agent.team_id
+                        if snapshot is not None and snapshot.agent is not None
+                        else None
+                    ),
                 )
 
                 with UserContext(runtime_user_id):
@@ -4075,6 +4110,10 @@ async def create_task(
 
     except HTTPException:
         raise
+    except ConnectorRuntimeError as exc:
+        raise HTTPException(
+            status_code=exc.status_code, detail=exc.safe_message
+        ) from exc
     except Exception as e:
         logger.error(f"Create task failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -8,6 +8,7 @@ consume the resolved runtime view later in the execution path.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from threading import RLock
@@ -44,6 +45,8 @@ from ..models.agent import Agent
 from ..models.custom_api import CustomApi, UserCustomApi
 from ..models.mcp import MCPServer, UserMCPServer
 from ..models.task import Task, TaskConnectorRuntimeContext
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -244,6 +247,7 @@ def load_connector_runtime_view(
     task_id: int,
     turn_id: str | None,
     user_id: int | None,
+    agent_team_id: int | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Resolve task-bound and per-turn runtime values for tool creation."""
 
@@ -264,15 +268,25 @@ def load_connector_runtime_view(
     ephemeral_manifest = (
         get_ephemeral_runtime_manifest(turn_id) if isinstance(turn_id, str) else None
     )
-    visible = _load_visible_runtime_connectors(db, user_id=task_owner_user_id)
+    visible = _load_visible_runtime_connectors(
+        db, user_id=task_owner_user_id, agent_team_id=agent_team_id
+    )
 
     runtime_view: dict[str, dict[str, Any]] = {}
     for ref in selected_refs:
         connector = visible.get(ref)
         if connector is None:
-            # Tool loading applies the same visibility filter before instantiating
-            # MCP/Custom API tools, so a now-hidden historical ref has no runtime
-            # tool to receive values on this turn.
+            # Tool loading applies the same visibility filter before
+            # instantiating a tool, so a now-hidden historical ref has no
+            # runtime tool to receive values on this turn. This holds for
+            # MCP on both the new-hook and legacy-hook branches, and for
+            # Custom API on the new-hook branch too (narrowed to the
+            # junction-only set until a follow-up team-keys the Custom API
+            # tool loaders and this branch's Custom API set to match). On
+            # the legacy-hook branch the filters diverge for Custom API: a
+            # legacy user-keyed hook can grant a team-shared Custom API
+            # here while the Custom API tool loader resolves junction-only,
+            # so such a ref stays visible without a runtime tool.
             continue
         raw_ephemeral = (
             ephemeral_by_ref.get(ref.storage_key, {})
@@ -329,7 +343,11 @@ def prepare_create_connector_runtime(
     connector visibility and must be the same owner later persisted on Task.
     """
 
-    visible = _load_visible_runtime_connectors(db, user_id=int(connector_user_id))
+    visible = _load_visible_runtime_connectors(
+        db,
+        user_id=int(connector_user_id),
+        agent_team_id=int(agent.team_id) if agent.team_id is not None else None,
+    )
     selected_refs = _plan_selected_refs(agent, visible)
     payload_by_ref = _parse_payload_items(payload_items)
     if not allow_ephemeral:
@@ -383,10 +401,13 @@ def prepare_connector_runtime_selection_snapshot(
     This helper is intentionally selection-only: non-/v1 task creation paths do
     not accept per-invocation runtime payloads in this phase. ``agent`` supplies
     the agent's tool-selection policy, while ``connector_user_id`` supplies the
-    same connector visibility scope used by normal web tool loading
-    (``WebToolConfig`` loads MCP/Custom API junction rows for the task runtime
-    owner). For published-agent chats, this therefore follows the task owner
-    rather than the published agent owner, matching existing tool loading.
+    same connector visibility scope used by normal web tool loading:
+    ``connector_user_id``'s personal MCP/Custom API links, unioned with
+    ``agent``'s owning team's connectors for MCP when a team-keyed hook is
+    installed (Custom API stays junction-only for now). For published-agent
+    chats, personal visibility still follows the task owner rather than the
+    published agent's owner; team visibility follows the agent regardless of
+    who is running it.
     """
 
     if agent is None or connector_user_id is None:
@@ -467,7 +488,11 @@ def prepare_append_connector_runtime(
     task_source = _task_source(task)
     selected_refs = _load_task_selected_refs(task)
     payload_by_ref = _parse_payload_items(payload_items)
-    visible = _load_visible_runtime_connectors(db, user_id=task_owner_user_id)
+    visible = _load_visible_runtime_connectors(
+        db,
+        user_id=task_owner_user_id,
+        agent_team_id=int(agent.team_id) if agent.team_id is not None else None,
+    )
     _validate_payload_refs(payload_by_ref, visible=visible, selected_refs=selected_refs)
 
     persisted_context = _load_task_context_rows(db, task_id=int(task.id))
@@ -565,12 +590,51 @@ def _optional_mapping(value: Any) -> dict[str, Any]:
 
 
 def _load_visible_runtime_connectors(
-    db: Session, *, user_id: int
+    db: Session, *, user_id: int, agent_team_id: int | None = None
 ) -> dict[ConnectorRef, Any]:
-    from .connector_team_scope import visible_team_connector_ids
+    from .connector_team_scope import (
+        team_connector_hook_installed,
+        team_connector_ids,
+        visible_team_connector_ids,
+    )
 
     visible: dict[ConnectorRef, Any] = {}
-    team_ids = visible_team_connector_ids(db, int(user_id))
+    if team_connector_hook_installed():
+        # Team ownership is resolved from the team that owns the governing
+        # agent. A run with no governing agent resolves personal links only.
+        try:
+            team_ids = team_connector_ids(db, team_id=agent_team_id)
+        except ConnectorRuntimeError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve team connector scope for user %s",
+                user_id,
+                exc_info=True,
+            )
+            raise ConnectorRuntimeError(
+                ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+                "Connector team scope is unavailable.",
+                details={"reason": "team_scope_resolution_failed"},
+                status_code=503,
+            ) from exc
+        # Custom API is not team-keyed on either side of this seam yet: the
+        # tool-build loaders (WebToolConfig's custom-API paths) stay
+        # junction-only until a follow-up team-keys them too. Consuming the
+        # "custom_api" half here without a matching consumer would let a
+        # team-owned custom API be selected into a task's runtime snapshot
+        # and then fail at runtime-view resolution (no personal link to
+        # satisfy it) while never building a tool either -- so this side
+        # stays MCP-only until both halves move together.
+        team_ids = {"mcp": team_ids["mcp"], "custom_api": set()}
+    else:
+        # No team-keyed hook: keep the legacy user-keyed overlay exactly as
+        # it is, so an installation that adopts this revision without
+        # installing the new hook behaves as it did before. Selection is on
+        # hook presence, never on an empty result -- an installed hook
+        # answers with empty sets for a team that owns nothing, and that
+        # answer is authoritative.
+        team_ids = visible_team_connector_ids(db, int(user_id))
 
     own_mcp = (
         db.query(MCPServer)
@@ -615,7 +679,11 @@ def resolve_agent_selected_connectors(
     iterate deterministically by ``(connector_type, connector_id)``.
     """
 
-    visible = _load_visible_runtime_connectors(db, user_id=int(connector_user_id))
+    visible = _load_visible_runtime_connectors(
+        db,
+        user_id=int(connector_user_id),
+        agent_team_id=int(agent.team_id) if agent.team_id is not None else None,
+    )
     return _select_agent_visible_connectors(agent, visible)
 
 

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -7,9 +7,11 @@ the application's team tables.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
+
+from sqlalchemy.sql.elements import ColumnElement
 
 ConnectorType = Literal["mcp", "custom_api"]
 ConnectorRenamedHook = Callable[[Any, int, ConnectorType, int, str, str], None]
@@ -30,9 +32,48 @@ ConnectorDeletedHook = Callable[[Any, int, ConnectorType, int], ConnectorDeleteD
 
 ConnectorVisibilityHook = Callable[[Any, int], dict[str, set[int]]]
 
+
+class TeamConnectorVisibilityHook(Protocol):
+    """Resolver for the connectors a team owns.
+
+    Typed as a ``Protocol`` with a keyword-only ``team_id`` so it cannot be
+    bound where ``ConnectorVisibilityHook`` (user-keyed) is expected, or vice
+    versa: the two shapes are otherwise identical and a swapped install would
+    type-check while resolving an unrelated team's connectors.
+
+    Keyed strictly on the team that owns the *governing agent* -- never on
+    the running user's own team membership, and the hook has no way to
+    express "is the runner a member of this team": there is no ``user_id``
+    parameter, and the hook is a process-global singleton with no
+    per-request state, so the hook body cannot learn which runner a
+    resolution is for. An application that wants runner-scoped narrowing
+    enforces it at its agent-access policy layer -- deciding who may run a
+    team's agents at all -- not at this seam, because a published team
+    agent is meant to serve runners -- including anonymous end users --
+    who are not members of the team that owns it.
+
+    A platform admin's tasks reach this seam through the agent-access
+    policy layer's admin short-circuit, which returns every agent
+    regardless of team -- so the runner of a team-governed agent is not
+    necessarily a member of that team even in deployments whose policy
+    layer is otherwise membership-scoped. This is accepted platform
+    behavior, not a defect this hook is meant to close.
+
+    Every connector id a hook returns becomes executable by *any* runner of
+    that team's agents, not only members: for stdio and other static-auth
+    transports, a team-owned server with no personal link for the running
+    user executes using the shared definition row's own stored credentials,
+    not the runner's. (OAuth transports fail closed instead, for lack of a
+    token to resolve.)
+    """
+
+    def __call__(self, db: Any, *, team_id: int) -> dict[str, set[int]]: ...
+
+
 _connector_deleted_hook: ConnectorDeletedHook | None = None
 _connector_renamed_hook: ConnectorRenamedHook | None = None
 _connector_visibility_hook: ConnectorVisibilityHook | None = None
+_team_connector_visibility_hook: TeamConnectorVisibilityHook | None = None
 
 
 def set_connector_team_hooks(
@@ -40,14 +81,22 @@ def set_connector_team_hooks(
     deleted: ConnectorDeletedHook | None = None,
     renamed: ConnectorRenamedHook | None = None,
     visibility: ConnectorVisibilityHook | None = None,
+    team_visibility: TeamConnectorVisibilityHook | None = None,
 ) -> None:
-    """Install application-owned connector lifecycle hooks."""
+    """Install application-owned connector lifecycle hooks.
+
+    Installs the complete hook set: every hook not supplied to a given call
+    is cleared, even one a previous call installed. This is a reset-all
+    setter, not a merge -- an application that installs hooks across more
+    than one call must pass its complete set each time.
+    """
 
     global _connector_deleted_hook, _connector_renamed_hook
-    global _connector_visibility_hook
+    global _connector_visibility_hook, _team_connector_visibility_hook
     _connector_deleted_hook = deleted
     _connector_renamed_hook = renamed
     _connector_visibility_hook = visibility
+    _team_connector_visibility_hook = team_visibility
 
 
 def visible_team_connector_ids(db: Any, user_id: int) -> dict[str, set[int]]:
@@ -55,6 +104,109 @@ def visible_team_connector_ids(db: Any, user_id: int) -> dict[str, set[int]]:
     if _connector_visibility_hook is None:
         return {"mcp": set(), "custom_api": set()}
     return _connector_visibility_hook(db, int(user_id))
+
+
+def _validate_team_connector_answer(answer: Any) -> dict[str, set[int]]:
+    """Validate the team-visibility hook's answer shape.
+
+    This is an authorization input, not user-facing data: a malformed
+    answer must fail loudly, never be normalized, coerced, or defaulted to
+    empty. The hook must return a ``dict`` carrying both ``"mcp"`` and
+    ``"custom_api"`` keys, each mapped to a ``set`` whose members are all
+    ``int`` (``bool`` is a subclass of ``int`` in Python but is rejected
+    here -- a truthy/falsy value is never a legitimate connector id). The
+    ``set`` requirement is exact and deliberate: ``frozenset`` and other
+    iterables are rejected too, matching the hook Protocol's declared
+    ``set[int]`` rather than duck-typing around it.
+    Extra keys beyond the two required ones are accepted and silently
+    ignored: only ``"mcp"`` and ``"custom_api"`` are ever read by callers,
+    so this function does not iterate the answer's keys at all, only probe
+    the two it needs.
+    """
+    if not isinstance(answer, dict):
+        raise ValueError(
+            "team visibility hook returned a malformed answer: expected a "
+            f"dict, got {type(answer).__name__}"
+        )
+    for key in ("mcp", "custom_api"):
+        if key not in answer:
+            raise ValueError(
+                f"team visibility hook returned a malformed answer: missing key {key!r}"
+            )
+        value = answer[key]
+        if not isinstance(value, set):
+            raise ValueError(
+                "team visibility hook returned a malformed answer: key "
+                f"{key!r} must be a set, got {type(value).__name__}"
+            )
+        for member in value:
+            if isinstance(member, bool) or not isinstance(member, int):
+                raise ValueError(
+                    "team visibility hook returned a malformed answer: key "
+                    f"{key!r} contains a member {member!r} that is not a "
+                    "connector id (must be int, not bool)"
+                )
+    # Defensive copy at the authorization boundary: callers must not be able
+    # to mutate the installing application's own answer object (or vice
+    # versa). Extra keys are dropped by the copy -- only the two probed keys
+    # are part of the contract.
+    return {"mcp": set(answer["mcp"]), "custom_api": set(answer["custom_api"])}
+
+
+def team_connector_ids(db: Any, *, team_id: int | None) -> dict[str, set[int]]:
+    """Connector ids owned by ``team_id``; empty for no team and for standalone.
+
+    ``team_id`` is the team that owns the *governing agent*, never the
+    running user's current team. ``None`` resolves empty without calling the
+    hook. A non-``None`` answer is shape-validated (see
+    ``_validate_team_connector_answer``) before it reaches any caller.
+    """
+    if team_id is None or _team_connector_visibility_hook is None:
+        return {"mcp": set(), "custom_api": set()}
+    answer = _team_connector_visibility_hook(db, team_id=int(team_id))
+    return _validate_team_connector_answer(answer)
+
+
+def team_connector_hook_installed() -> bool:
+    """Whether an application installed a team-keyed visibility hook.
+
+    Callers select on this, never on an empty return value: an installed
+    hook legitimately answers with empty sets for a team that owns nothing.
+    """
+    return _team_connector_visibility_hook is not None
+
+
+def visible_mcp_server_clause(
+    owner_user_id: int | None, team_mcp_ids: Collection[int]
+) -> ColumnElement[bool]:
+    """Predicate selecting the MCP servers visible to ``owner_user_id``.
+
+    Personal servers (an active ``UserMCPServer`` link) unioned with the
+    team-owned servers named in ``team_mcp_ids``. ``is_active`` gates only
+    the personal arm -- a team-owned server is visible regardless of the
+    member's own personal link state, which is intentional (see the
+    module's callers for the credential consequence). Pure function over
+    ORM constructs -- no I/O. An empty ``team_mcp_ids`` reduces to exactly
+    the personal semi-join, so a deployment with no team overlay compiles
+    the same query shape it always has. A ``None`` owner also reduces to
+    the personal arm regardless of ``team_mcp_ids`` -- defense in depth so
+    this function is fail-closed on its own terms, not only because of how
+    its one caller happens to be gated today.
+    """
+
+    from sqlalchemy import or_, select
+
+    from ..models.mcp import MCPServer, UserMCPServer
+
+    personal = MCPServer.id.in_(
+        select(UserMCPServer.mcpserver_id).where(
+            UserMCPServer.user_id == owner_user_id,
+            UserMCPServer.is_active,
+        )
+    )
+    if not team_mcp_ids or owner_user_id is None:
+        return personal
+    return or_(personal, MCPServer.id.in_(set(team_mcp_ids)))
 
 
 def delete_team_connector(

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -1075,6 +1075,10 @@ class AgentRuntimeFields:
     name: str
     status: Any  # AgentStatus enum (typed loosely to avoid an import cycle)
     instructions: Optional[str]
+    # ``None`` for a personal/legacy agent and for every task with no
+    # ``agent_id``. Read by the team-scope connector-visibility hook seam;
+    # a fail-closed default keeps an un-migrated construction site personal.
+    team_id: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -1297,6 +1301,9 @@ def resolve_task_runtime_config_core(
                     str(agent_row.instructions)
                     if agent_row.instructions is not None
                     else None
+                ),
+                team_id=(
+                    int(agent_row.team_id) if agent_row.team_id is not None else None
                 ),
             )
     else:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -192,6 +192,7 @@ def _refresh_delegated_mcp_connection_from_snapshot(
     connection_snapshot: Mapping[str, Any],
     runtime_bindings: Any,
     allow_delegated_authorization: bool,
+    agent_team_id: int | None = None,
 ) -> dict[str, Any] | None:
     """Refresh delegated MCP headers without retaining construction objects."""
     if task_id is None or user_id is None:
@@ -205,6 +206,7 @@ def _refresh_delegated_mcp_connection_from_snapshot(
             task_id=task_id,
             turn_id=turn_id,
             user_id=user_id,
+            agent_team_id=agent_team_id,
         )
     runtime_values = runtime_view.get(f"mcp:{server_id}")
     runtime_headers = WebToolConfig._runtime_transport_headers(
@@ -276,6 +278,10 @@ class _ToolFactoryRuntimeLoadPlan:
     load_video: bool
     load_audio: bool
     published_agent_policy: Any | None
+    # The governing agent's owning team, detached from the ORM row. ``None``
+    # is the fail-closed default: an un-migrated construction site (or a run
+    # with no governing agent) resolves personal-only connectors.
+    connector_team_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -691,6 +697,7 @@ def _load_custom_api_runtime_view_sync(
     task_id: str | None,
     connector_runtime_turn_id: str | None,
     user_id: int | None,
+    agent_team_id: int | None = None,
 ) -> dict[str, Any]:
     numeric_task_id = _parse_custom_api_task_id(task_id)
     if numeric_task_id is None or user_id is None:
@@ -703,6 +710,7 @@ def _load_custom_api_runtime_view_sync(
             task_id=numeric_task_id,
             turn_id=connector_runtime_turn_id,
             user_id=user_id,
+            agent_team_id=agent_team_id,
         )
     except ConnectorRuntimeError:
         raise
@@ -726,6 +734,7 @@ def _load_custom_api_factory_inputs(
     user_id: int | None,
     task_id: str | None,
     connector_runtime_turn_id: str | None,
+    connector_team_id: int | None = None,
 ) -> list[dict[str, Any]]:
     if user_id is None:
         return []
@@ -748,6 +757,7 @@ def _load_custom_api_factory_inputs(
         task_id=task_id,
         connector_runtime_turn_id=connector_runtime_turn_id,
         user_id=user_id,
+        agent_team_id=connector_team_id,
     )
     configs: list[dict[str, Any]] = []
     for user_api in user_apis:
@@ -920,6 +930,7 @@ def _load_tool_factory_runtime_snapshot(
                 user_id=plan.user_id,
                 task_id=plan.task_id,
                 connector_runtime_turn_id=plan.connector_runtime_turn_id,
+                connector_team_id=plan.connector_team_id,
             ),
             [],
             propagated_exceptions=(ConnectorRuntimeError,),
@@ -1147,6 +1158,7 @@ class WebToolConfig(BaseToolConfig):
         mcp_failure_policy: MCPFailurePolicy = MCPFailurePolicy.BEST_EFFORT,
         mcp_load_summary_tracer: Optional[Any] = None,
         mcp_load_summary_trace_task_id: Optional[str] = None,
+        connector_team_id: Optional[int] = None,
     ):
         # ``tool_selection_spec`` accepts :class:`ToolSelectionSpec` from
         # the tools adapter package; typed as ``Any`` here to avoid an
@@ -1157,6 +1169,11 @@ class WebToolConfig(BaseToolConfig):
         self._mcp_failure_policy = mcp_failure_policy
         self._mcp_load_summary_tracer = mcp_load_summary_tracer
         self._mcp_load_summary_trace_task_id = mcp_load_summary_trace_task_id
+        # The governing agent's owning team, never the acting/request user's
+        # own team membership. ``None`` is the closed default: no request
+        # path ever supplies this directly, it is read off a loaded ``Agent``
+        # row (or a frozen snapshot of one) by the caller.
+        self._connector_team_id = connector_team_id
         self._task_runtime_contribution: Any = None
         self._task_runtime_workspace: Any = None
         self._live_db = db
@@ -1511,6 +1528,7 @@ class WebToolConfig(BaseToolConfig):
                 task_id=task_id,
                 turn_id=self._connector_runtime_turn_id,
                 user_id=int(self._user_id),
+                agent_team_id=self._connector_team_id,
             )
         except ConnectorRuntimeError:
             raise
@@ -1705,6 +1723,11 @@ class WebToolConfig(BaseToolConfig):
             connection_snapshot=connection_snapshot,
             runtime_bindings=copy.deepcopy(runtime_bindings),
             allow_delegated_authorization=allow_delegated_authorization,
+            # Memoised at build time: the whole tool set is built for one
+            # agent, so this avoids re-deriving the agent's team id from the
+            # ORM row per tool. The team hook itself still runs on every
+            # per-tool-call refresh -- nothing in that chain caches it.
+            agent_team_id=self._connector_team_id,
         )
 
     def _mcp_auth_context_for_server(
@@ -1921,6 +1944,7 @@ class WebToolConfig(BaseToolConfig):
             user_id=int(self._user_id) if self._user_id is not None else None,
             task_id=self._task_id,
             connector_runtime_turn_id=self._connector_runtime_turn_id,
+            connector_team_id=self._connector_team_id,
             load_policy=(self._user_id is not None and has_user_tool_policy_hooks()),
             load_basic=(wants_category("basic") or wants_category("web_search")),
             load_sql=wants_category("database"),
@@ -3337,29 +3361,70 @@ class WebToolConfig(BaseToolConfig):
                 reason="config_load_failed",
             )
 
+    def _visible_mcp_server_query(self, team_mcp_ids: frozenset[int]) -> Any:
+        """Compile the production semi-join query for visible MCP servers.
+
+        No join on ``user_mcpservers`` -- an inner join would drop every
+        team-only server before the visibility predicate's ``OR`` could be
+        evaluated. Extracted to its own method so a compiled-query test can
+        exercise the exact object ``_load_mcp_server_configs`` uses, not a
+        parallel reconstruction of it.
+        """
+        from ...web.models.mcp import MCPServer
+        from ..services.connector_team_scope import visible_mcp_server_clause
+
+        return (
+            self.db.query(MCPServer)
+            .filter(visible_mcp_server_clause(self._user_id, team_mcp_ids))
+            .order_by(MCPServer.id)
+        )
+
     async def _load_mcp_server_configs(self) -> List[Dict[str, Any]]:
-        """Load MCP server configurations from database with user context."""
+        """Load MCP server configurations visible to this run: the user's
+        personal servers, unioned with the governing agent's team-owned
+        servers when a team-scope hook is installed."""
         self._mcp_oauth_diagnostics = []
         self._reset_mcp_config_load_cache_state()
 
+        # Resolved before the guarded region below: that region reports
+        # "every selected server is unavailable", which is the wrong answer
+        # for "the scope could not be resolved". The typed error is what
+        # survives the tool-creator frame -- an untyped one is dropped there
+        # with a WARNING and no tool set at all.
         try:
-            from ...web.models.mcp import MCPServer, UserMCPServer
+            from ..services.connector_team_scope import team_connector_ids
+
+            team_mcp_ids = frozenset(
+                team_connector_ids(self.db, team_id=self._connector_team_id)["mcp"]
+            )
+        except ConnectorRuntimeError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve team connector scope for user %s",
+                self._user_id,
+                exc_info=True,
+            )
+            raise ConnectorRuntimeError(
+                ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+                "Connector team scope is unavailable.",
+                details={"reason": "team_scope_resolution_failed"},
+                status_code=503,
+            ) from exc
+
+        try:
             from ..services.mcp_runtime import (
                 load_shared_env_overrides,
                 load_user_env_overrides,
                 load_user_env_sources,
             )
 
-            servers = (
-                self.db.query(MCPServer)
-                .join(UserMCPServer, MCPServer.id == UserMCPServer.mcpserver_id)
-                .filter(UserMCPServer.user_id == self._user_id, UserMCPServer.is_active)
-                .all()
-            )
+            servers = self._visible_mcp_server_query(team_mcp_ids).all()
             logger.info(
-                "Found %s active MCP servers for user %s",
+                "Found %s visible MCP servers for user %s (connector_team_id=%s)",
                 len(servers),
                 self._user_id,
+                self._connector_team_id,
             )
 
             # Prefetch shared runtime state once before entering the isolated

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1450,6 +1450,102 @@ async def test_delegated_authorization_401_refreshes_connection_once(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_delegated_authorization_401_refresh_classifies_team_hook_failure():
+    """The delegated (non-resolver) refresh branch calls the real per-tool-call
+    refresh callback -- ``_refresh_delegated_mcp_connection_from_snapshot``,
+    the function ``WebToolConfig`` binds into a connection's
+    ``_connector_runtime_refresh`` slot -- against a real, DB-backed team
+    hook that raises. Before this branch had its own try/except (mirroring
+    the sibling resolver-refresh branch at ``_retry_resolver_401``), the
+    raised exception propagated out of ``_retry_after_authorization_failure``
+    uncaught instead of surfacing as the same classified failure result the
+    resolver branch already returns.
+    """
+    from functools import partial
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    from xagent.web.models import Base, MCPServer, Task, User
+    from xagent.web.services import connector_team_scope
+    from xagent.web.tools.config import _refresh_delegated_mcp_connection_from_snapshot
+
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+
+    with session_factory() as seed_db:
+        owner = User(username="mcp-refresh-owner", password_hash="hash")
+        seed_db.add(owner)
+        seed_db.flush()
+        server = MCPServer(
+            name="team-refresh-probe",
+            managed="external",
+            transport="streamable_http",
+            url="https://mcp.example.test",
+        )
+        seed_db.add(server)
+        seed_db.flush()
+        task = Task(
+            user_id=owner.id,
+            title="mcp refresh probe task",
+            # Non-empty so ``load_connector_runtime_view`` proceeds past its
+            # early-return and reaches the team hook.
+            connector_runtime_selected_refs=[
+                {"connector_type": "mcp", "connector_id": int(server.id)}
+            ],
+        )
+        seed_db.add(task)
+        seed_db.commit()
+        owner_id = int(owner.id)
+        server_id = int(server.id)
+        task_id = int(task.id)
+
+    def _raising_team_hook(db, *, team_id):
+        raise RuntimeError("Bearer planted-refresh-secret-must-not-leak")
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_raising_team_hook)
+    try:
+        refresh = partial(
+            _refresh_delegated_mcp_connection_from_snapshot,
+            session_factory=session_factory,
+            task_id=task_id,
+            turn_id=None,
+            user_id=owner_id,
+            server_id=server_id,
+            connection_snapshot={},
+            runtime_bindings=[],
+            allow_delegated_authorization=True,
+            agent_team_id=101,
+        )
+        connection = {
+            "transport": "streamable_http",
+            "url": "https://mcp.example.test",
+            "headers": {"Authorization": "Bearer expired-token"},
+            mcp_adapter_module._RUNTIME_CONNECTION_REFRESH_KEY: refresh,
+        }
+        adapter = MCPToolAdapter(
+            mcp_tool=_mcp_tool("list_clients"), connection=connection
+        )
+
+        result = await adapter._retry_after_authorization_failure(
+            _http_status_error(), {}, {}
+        )
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+    assert result is not None
+    assert result["is_error"] is True
+    assert "delegated authorization failed" in result["content"][0]["text"]
+    # The raw hook message never reaches the caller -- only the classified,
+    # public-safe failure text does.
+    assert "planted-refresh-secret-must-not-leak" not in json.dumps(result)
+
+
+@pytest.mark.asyncio
 async def test_delegated_authorization_401_with_non_mapping_connection_does_not_crash(
     monkeypatch,
 ):

--- a/tests/core/tools/test_agent_tool_connector_team_scope.py
+++ b/tests/core/tools/test_agent_tool_connector_team_scope.py
@@ -1,0 +1,147 @@
+"""Delegated sub-agents build their ``WebToolConfig`` with
+``connector_team_id=None`` (``agent_tool.py``), a deliberate scoping
+decision -- delegated identity is restored from a persisted workforce
+snapshot with no re-authorization at consumption, so opening team connector
+visibility there would grant a team's connectors off a snapshot nobody
+re-checks. This test exercises the real construction path (not a
+reconstruction of it) and pins the consequence: a delegated agent whose
+tool categories name a server that exists only through a team grant
+resolves to an empty MCP tool set, silently, rather than raising or
+executing the team's tools.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import xagent.core.tools.adapters.vibe.agent_tool as agent_tool_module
+from xagent.core.tools.adapters.vibe.agent_tool import AgentTool
+from xagent.web.models import Base, MCPServer, User
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.services import connector_team_scope
+
+T1 = 101
+
+
+class _Stop(Exception):
+    """Halt the delegated run right after its WebToolConfig is captured."""
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks():
+    yield
+    connector_team_scope.set_connector_team_hooks()
+
+
+@pytest.mark.asyncio
+async def test_delegated_spec_naming_team_only_server_resolves_empty(monkeypatch):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+
+    with session_factory() as seed_db:
+        owner = User(username="delegated-owner", password_hash="hash")
+        seed_db.add(owner)
+        seed_db.flush()
+        # No personal UserMCPServer link for owner -- reachable only through
+        # the team hook installed below.
+        team_server = MCPServer(
+            name="team-only-delegated-probe",
+            managed="external",
+            transport="streamable_http",
+            url="https://example.com/mcp",
+        )
+        seed_db.add(team_server)
+        seed_db.flush()
+        agent = Agent(
+            user_id=owner.id,
+            name="Delegated Agent",
+            instructions="be terse",
+            status=AgentStatus.PUBLISHED,
+            execution_mode="balanced",
+            models={"general": 1},
+            knowledge_bases=[],
+            skills=[],
+            tool_categories=["mcp"],
+        )
+        seed_db.add(agent)
+        seed_db.commit()
+        agent_id = int(agent.id)
+        owner_id = int(owner.id)
+        team_server_id = int(team_server.id)
+
+    # A team hook that would grant the team-only server to team T1 -- proves
+    # the empty result below is because of the delegated scoping decision,
+    # not because no hook is installed at all.
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: (
+            {"mcp": {team_server_id}, "custom_api": set()}
+            if team_id == T1
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+
+    import xagent.core.tools.adapters.vibe.agent_model_resolution as resolution
+
+    monkeypatch.setattr(
+        resolution,
+        "resolve_agent_model_llms",
+        lambda *_args: (object(), None, None, None),
+    )
+
+    captured: dict[str, object] = {}
+    real_web_tool_config_cls = agent_tool_module.WebToolConfig
+
+    class _CapturingWebToolConfig(real_web_tool_config_cls):
+        def __init__(self, **kwargs):
+            captured["connector_team_id"] = kwargs.get("connector_team_id", "OMITTED")
+            super().__init__(**kwargs)
+            captured["instance"] = self
+
+    monkeypatch.setattr(agent_tool_module, "WebToolConfig", _CapturingWebToolConfig)
+
+    import xagent.core.agent.service as service_module
+
+    class _StoppingAgentService:
+        def __init__(self, **_kwargs):
+            return None
+
+        async def execute_task(self, **_kwargs):
+            # The WebToolConfig is already built and captured by this point
+            # (agent_tool.py constructs it before handing off to
+            # AgentService); stop here rather than running a real turn.
+            raise _Stop()
+
+    monkeypatch.setattr(service_module, "AgentService", _StoppingAgentService)
+
+    tool = AgentTool(
+        agent_id=agent_id,
+        agent_name="Delegated Agent",
+        agent_description="delegated",
+        session_factory=session_factory,
+        user_id=owner_id,
+        tool_name="delegated",
+        tool_description="delegated",
+    )
+    monkeypatch.setattr(tool, "_create_child_execution_tracer", lambda **_kwargs: None)
+
+    result = await tool.run_json_async({"task": "run"})
+
+    # The delegated run itself fails closed (the stop sentinel surfaces as a
+    # classified failure) -- that is incidental to this test, which cares
+    # about the WebToolConfig construction captured along the way.
+    assert result["success"] is False
+
+    assert captured["connector_team_id"] is None
+    tool_config = captured["instance"]
+    assert tool_config._connector_team_id is None
+
+    configs = await tool_config.get_mcp_server_configs()
+    assert configs == []

--- a/tests/web/api/test_agent_triggers.py
+++ b/tests/web/api/test_agent_triggers.py
@@ -466,6 +466,73 @@ def test_trigger_test_run_mcp_setup_failure_marks_run_failed() -> None:
     assert private_detail not in str(final_state)
 
 
+def test_trigger_run_preparation_wraps_raising_team_hook_without_leaking_message() -> (
+    None
+):
+    """``_attach_task_to_trigger_run`` -> ``prepare_create_connector_runtime`` ->
+    ``_load_visible_runtime_connectors`` invokes the team-visibility hook, and
+    ``prepare_trigger_run``'s ``except Exception`` handler stores whatever
+    exception reaches it verbatim (``error_message = f"{type(exc).__name__}:
+    {exc}"``). The typed wrap at the hook call is what keeps a raising hook's
+    raw message out of that stored text: the hook's ``RuntimeError`` becomes a
+    ``ConnectorRuntimeError`` first, so the stored message is the typed,
+    public-safe one.
+    """
+    from xagent.web.models.trigger import AgentTrigger
+    from xagent.web.services import connector_team_scope
+    from xagent.web.services.triggers import (
+        TriggerRunPreparationError,
+        prepare_trigger_run,
+    )
+
+    headers = _admin_headers()
+    agent_id = _create_agent(headers)
+    created = client.post(
+        f"/api/agents/{agent_id}/triggers",
+        headers=headers,
+        json={"type": "webhook", "name": "Raising team hook webhook"},
+    )
+    assert created.status_code == 200, created.text
+    trigger_id = int(created.json()["id"])
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        agent.team_id = 101
+        db.commit()
+
+        trigger = db.query(AgentTrigger).filter(AgentTrigger.id == trigger_id).one()
+
+        def _raising_hook(_db, *, team_id: int) -> dict[str, set[int]]:
+            raise RuntimeError(
+                "Bearer planted-hook-secret-must-not-leak: password authentication "
+                "failed for 'svc'"
+            )
+
+        connector_team_scope.set_connector_team_hooks(team_visibility=_raising_hook)
+        try:
+            with pytest.raises(TriggerRunPreparationError) as excinfo:
+                prepare_trigger_run(
+                    db,
+                    trigger=trigger,
+                    event_payload={"subject": "hello"},
+                    source_event_id="evt-raising-hook-1",
+                )
+        finally:
+            connector_team_scope.set_connector_team_hooks()
+
+        assert "planted-hook-secret-must-not-leak" not in str(excinfo.value)
+
+        run = db.query(TriggerRun).one()
+        assert str(run.status) == TriggerRunStatus.FAILED.value
+        assert run.task_id is None
+        assert run.error_message is not None
+        assert "planted-hook-secret-must-not-leak" not in run.error_message
+        assert "Connector team scope is unavailable." in run.error_message
+    finally:
+        db.close()
+
+
 def _signed_webhook_headers(
     secret: str, raw_body: bytes, *, event_id: str | None = None
 ) -> dict[str, str]:

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -1286,7 +1286,7 @@ class TestWebToolConfigMCPAuth:
         server.concurrent_tools = ["echo", "get_sum"]
 
         db = MagicMock()
-        db.query.return_value.join.return_value.filter.return_value.all.return_value = [
+        db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
             server
         ]
 
@@ -1333,7 +1333,7 @@ class TestWebToolConfigMCPAuth:
         }
 
         db = MagicMock()
-        db.query.return_value.join.return_value.filter.return_value.all.return_value = [
+        db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
             server
         ]
 

--- a/tests/web/services/test_connector_runtime_snapshot.py
+++ b/tests/web/services/test_connector_runtime_snapshot.py
@@ -336,9 +336,20 @@ def test_selected_connector_resolver_honors_all_and_none_sentinels(
     assert list(resolved) == expected
 
 
-def test_selected_connector_resolver_includes_owner_and_team_visible_connectors_only(
+def test_selected_connector_resolver_preserves_legacy_visibility_without_team_hook(
     db_session: Session,
 ) -> None:
+    """Contract event, declared: this test previously stood in for three
+    distinct contracts (team-keyed resolution for a team agent, the
+    personal-agent negative, and the legacy-hook-only fallback). Only the
+    legacy user-keyed ``visibility`` hook is installed below -- no
+    ``team_visibility`` hook -- which is the one contract unique to this
+    call path: a checkout that adopts team-keying without installing the
+    new hook is unchanged on ``resolve_agent_selected_connectors``. The
+    team-keyed and personal-agent-negative contracts are pinned directly
+    against ``_load_visible_runtime_connectors`` in
+    ``tests/web/tools/test_mcp_team_visibility.py``.
+    """
     viewer = _create_user(db_session, "viewer")
     other_user = _create_user(db_session, "other-user")
     hidden_user = _create_user(db_session, "hidden-user")
@@ -365,6 +376,7 @@ def test_selected_connector_resolver_includes_owner_and_team_visible_connectors_
         }
     )
     try:
+        assert connector_team_scope.team_connector_hook_installed() is False
         resolved = connector_runtime_service.resolve_agent_selected_connectors(
             db=db_session,
             agent=agent,
@@ -980,3 +992,205 @@ def test_resolver_registration_copies_mutable_source_scope(
         )
 
     assert exc_info.value.code == "runtime_secret_unavailable"
+
+
+def test_agent_team_id_threads_into_all_three_connector_runtime_wrappers(
+    db_session: Session,
+) -> None:
+    """Pins that the ``agent.team_id`` derivation actually reaches the three
+    ``connector_runtime`` wrapper entry points -- ``resolve_agent_selected_connectors``,
+    ``prepare_create_connector_runtime``, ``prepare_append_connector_runtime``. These
+    three are the only ones with a caller outside this module:
+    ``prepare_create_connector_runtime`` from ``web/api/v1/tasks.py`` and
+    ``web/services/triggers.py``; ``prepare_append_connector_runtime`` from
+    ``web/api/v1/tasks.py``; and ``resolve_agent_selected_connectors`` indirectly, via
+    ``prepare_connector_runtime_selection_snapshot`` (same module), which is reached
+    from the public/anonymous chat path (``public_chat_access.py``), the authenticated
+    chat path (``chat.py``), workforce runs, and channel runtime. Every other test in
+    this suite either calls ``_load_visible_runtime_connectors`` directly (which proves
+    nothing about whether the wrappers forward the argument) or installs only the
+    legacy user-keyed ``visibility=`` hook, whose fallback branch ignores
+    ``agent_team_id`` entirely. This test installs a team-keyed hook and a team agent,
+    and drives all three wrappers, asserting each one resolves a connector that is
+    visible *only* through the agent's team -- so dropping ``agent.team_id`` at any one
+    of the three call sites turns exactly that assertion red.
+    """
+    owner = _create_user(db_session, "team-wrapper-owner")
+    agent = Agent(
+        user_id=owner.id,
+        name="Team Wrapper Agent",
+        instructions="Use tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp"],
+        team_id=101,
+    )
+    db_session.add(agent)
+    db_session.flush()
+    # No personal UserMCPServer link for ``owner`` -- reachable only through the
+    # team hook, so any of the three wrappers resolving it is proof the team id
+    # actually reached ``_load_visible_runtime_connectors``. Carries a (fully
+    # optional) runtime declaration -- like ``_create_runtime_mcp`` above -- so
+    # ``prepare_create_connector_runtime``'s ``_runtime_declared_refs`` filter
+    # does not drop it before the payload/selection assertions below.
+    team_server = MCPServer(
+        name="team-wrapper-server",
+        description="team-wrapper-server description",
+        managed="external",
+        transport="streamable_http",
+        url="https://example.com/mcp",
+        runtime_input_schema={
+            "context": {"account_id": {"type": "string", "required": False}}
+        },
+        runtime_bindings=[
+            {
+                "source": {"input_type": "context", "key": "account_id"},
+                "target": {"target_type": "mcp_meta", "key": "account_id"},
+            }
+        ],
+    )
+    db_session.add(team_server)
+    db_session.flush()
+    team_ref = ConnectorRef("mcp", int(team_server.id))
+
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: (
+            {"mcp": {int(team_server.id)}, "custom_api": set()}
+            if team_id == 101
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+    try:
+        # 1. resolve_agent_selected_connectors
+        resolved = connector_runtime_service.resolve_agent_selected_connectors(
+            db=db_session, agent=agent, connector_user_id=int(owner.id)
+        )
+        assert team_ref in resolved
+
+        # 2. prepare_create_connector_runtime
+        create_plan = prepare_create_connector_runtime(
+            db=db_session,
+            agent=agent,
+            task_source="sdk",
+            connector_user_id=int(owner.id),
+            payload_items=None,
+        )
+        assert team_ref in create_plan.selected_refs
+
+        # 3. prepare_append_connector_runtime -- a minimal payload item naming the
+        # team-only connector must not raise ERROR_CONNECTOR_NOT_FOUND, which is
+        # exactly what _validate_payload_refs raises for ``ref not in visible``.
+        task = Task(
+            user_id=owner.id,
+            agent_id=agent.id,
+            title="team wrapper append task",
+            source="sdk",
+            status=TaskStatus.PENDING,
+            connector_runtime_selected_refs=[
+                {"connector_type": "mcp", "connector_id": int(team_server.id)}
+            ],
+        )
+        db_session.add(task)
+        db_session.flush()
+
+        append_plan = prepare_append_connector_runtime(
+            db=db_session,
+            agent=agent,
+            task=task,
+            connector_user_id=int(owner.id),
+            payload_items=[
+                {
+                    "connector_ref": {
+                        "connector_type": "mcp",
+                        "connector_id": int(team_server.id),
+                    }
+                }
+            ],
+        )
+        assert append_plan.ephemeral_by_ref == {}
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+def test_selection_snapshot_wraps_raising_team_hook_without_leaking_message(
+    db_session: Session,
+) -> None:
+    """The team-hook invocation inside ``_load_visible_runtime_connectors`` is
+    wrapped in the same typed ``ConnectorRuntimeError(503,
+    team_scope_resolution_failed)`` shape the two config.py seams already use
+    for their own direct hook calls. This test drives it through
+    ``prepare_connector_runtime_selection_snapshot`` -- the entry point every
+    non-/v1 task-creation path uses -- rather than through a config.py
+    wrapper, so the wrap is pinned at this read point in its own right and
+    not only behind the config.py seams. The negative assertion (the hook's
+    raw message is absent) is the one that matters: it is the leak, not the
+    type, a future refactor would silently reintroduce.
+    """
+    owner = _create_user(db_session, "raising-hook-owner")
+    agent = Agent(
+        user_id=owner.id,
+        name="Raising Hook Agent",
+        instructions="Use tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp"],
+        team_id=101,
+    )
+    db_session.add(agent)
+    db_session.flush()
+
+    def _raising_hook(db, *, team_id):
+        raise RuntimeError(
+            "Bearer planted-hook-secret-must-not-leak: password authentication failed"
+        )
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_raising_hook)
+    try:
+        with pytest.raises(ConnectorRuntimeError) as excinfo:
+            prepare_connector_runtime_selection_snapshot(
+                db=db_session, agent=agent, connector_user_id=int(owner.id)
+            )
+        assert excinfo.value.status_code == 503
+        assert excinfo.value.details["reason"] == "team_scope_resolution_failed"
+        assert "planted-hook-secret-must-not-leak" not in str(excinfo.value)
+        assert "planted-hook-secret-must-not-leak" not in excinfo.value.safe_message
+        assert "planted-hook-secret-must-not-leak" not in str(excinfo.value.details)
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+def test_selection_snapshot_wraps_malformed_team_hook_answer_without_leaking_message(
+    db_session: Session,
+) -> None:
+    """Same read point, the malformed-answer twin of the test above: a
+    hook returning ``{"mcp": "12", ...}`` raises ``ValueError`` inside
+    ``_validate_team_connector_answer`` with the same leak profile a raising
+    hook has, so this read point needs its own pin beside the two config.py
+    wrapper seams' pins.
+    """
+    owner = _create_user(db_session, "malformed-hook-owner")
+    agent = Agent(
+        user_id=owner.id,
+        name="Malformed Hook Agent",
+        instructions="Use tools.",
+        execution_mode="balanced",
+        status=AgentStatus.PUBLISHED,
+        tool_categories=["mcp"],
+        team_id=101,
+    )
+    db_session.add(agent)
+    db_session.flush()
+
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: {"mcp": "12", "custom_api": set()}
+    )
+    try:
+        with pytest.raises(ConnectorRuntimeError) as excinfo:
+            prepare_connector_runtime_selection_snapshot(
+                db=db_session, agent=agent, connector_user_id=int(owner.id)
+            )
+        assert excinfo.value.status_code == 503
+        assert excinfo.value.details["reason"] == "team_scope_resolution_failed"
+        assert isinstance(excinfo.value.__cause__, ValueError)
+    finally:
+        connector_team_scope.set_connector_team_hooks()

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -1,0 +1,583 @@
+"""Unit tests for the ``connector_team_scope`` seam itself, plus the checks
+that need a real database: agent-team-keyed visibility (never the runner's
+own membership), the legacy-hook-only fallback contract, and the
+custom-API twins of the MCP-focused checks -- team-keyed connector
+visibility covers both connector kinds, even though most of the
+surrounding tests in this file only exercise MCP.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from xagent.web.models import Base, MCPServer, Task, User, UserMCPServer
+from xagent.web.models.custom_api import CustomApi, UserCustomApi
+from xagent.web.models.task import TaskStatus
+from xagent.web.services import agent_team_scope, connector_team_scope
+from xagent.web.services.connector_runtime import _load_visible_runtime_connectors
+from xagent.web.tools.config import WebToolConfig, _load_custom_api_runtime_view_sync
+
+T1 = 101
+T2 = 102
+
+
+# ---------------------------------------------------------------------------
+# Seam unit tests -- no DB required.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks() -> Iterator[None]:
+    yield
+    connector_team_scope.set_connector_team_hooks()
+    agent_team_scope.set_agent_team_scope_hook(None)
+
+
+def test_team_connector_ids_empty_without_hook_installed():
+    assert connector_team_scope.team_connector_hook_installed() is False
+    assert connector_team_scope.team_connector_ids(None, team_id=5) == {
+        "mcp": set(),
+        "custom_api": set(),
+    }
+
+
+def test_team_connector_hook_installed_reflects_presence():
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: {"mcp": set(), "custom_api": set()}
+    )
+    try:
+        assert connector_team_scope.team_connector_hook_installed() is True
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+    assert connector_team_scope.team_connector_hook_installed() is False
+
+
+def test_team_connector_ids_resolves_none_team_without_calling_hook():
+    calls = []
+
+    def _hook(db, *, team_id):
+        calls.append(team_id)
+        return {"mcp": {1}, "custom_api": set()}
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_hook)
+    try:
+        assert connector_team_scope.team_connector_ids(None, team_id=None) == {
+            "mcp": set(),
+            "custom_api": set(),
+        }
+        assert calls == []
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+def test_team_hook_invocation_contract():
+    """The hook is called exactly once, by keyword, and never for a None team."""
+    calls: list[tuple[str, object]] = []
+
+    def _record(db, *, team_id):
+        calls.append(("kw", team_id))
+        return {"mcp": set(), "custom_api": set()}
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_record)
+    try:
+        assert connector_team_scope.team_connector_ids(None, team_id=None) == {
+            "mcp": set(),
+            "custom_api": set(),
+        }
+        assert calls == []
+        connector_team_scope.team_connector_ids(None, team_id=T1)
+        assert calls == [("kw", T1)]
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+def test_team_hook_positional_only_callable_raises():
+    """Positive control: a positional-only hook must not type-check
+    silently -- the keyword call is what stands between a swapped install and
+    an unrelated team's connectors on every run."""
+
+    def _positional_only(db, team_id, /):
+        return {"mcp": set(), "custom_api": set()}
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_positional_only)
+    try:
+        with pytest.raises(TypeError):
+            connector_team_scope.team_connector_ids(None, team_id=T1)
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+# ---------------------------------------------------------------------------
+# DB-backed fixtures for the checks below.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+def _create_user(db: Session, username: str) -> User:
+    user = User(username=username, password_hash="hash")
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _create_mcp(db: Session, name: str, *, owner: User | None = None) -> MCPServer:
+    server = MCPServer(
+        name=name,
+        description=f"{name} description",
+        managed="external",
+        transport="streamable_http",
+        url="https://example.com/mcp",
+    )
+    db.add(server)
+    db.flush()
+    if owner is not None:
+        db.add(
+            UserMCPServer(
+                user_id=owner.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=True,
+            )
+        )
+        db.flush()
+    return server
+
+
+def _create_custom_api(
+    db: Session, name: str, *, owner: User | None = None
+) -> CustomApi:
+    api = CustomApi(
+        name=name,
+        description=f"{name} description",
+        url="https://example.com/api",
+        method="GET",
+    )
+    db.add(api)
+    db.flush()
+    if owner is not None:
+        db.add(
+            UserCustomApi(
+                user_id=owner.id,
+                custom_api_id=api.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=True,
+            )
+        )
+        db.flush()
+    return api
+
+
+@pytest.fixture()
+def seed(db_session: Session):
+    c = _create_user(db_session, "run-owner")
+    active_own = _create_mcp(db_session, "active-own", owner=c)
+    team_s = _create_mcp(db_session, "team-s")
+    team_x = _create_mcp(db_session, "team-x")
+    capi_own = _create_custom_api(db_session, "capi-own", owner=c)
+    a_capi = _create_custom_api(db_session, "a-capi")
+    return SimpleNamespace(
+        c=c,
+        active_own=active_own,
+        team_s=team_s,
+        team_x=team_x,
+        capi_own=capi_own,
+        a_capi=a_capi,
+    )
+
+
+def _team_hook(seed):
+    def _hook(db, *, team_id):
+        if team_id == T1:
+            return {"mcp": {int(seed.team_s.id)}, "custom_api": {int(seed.a_capi.id)}}
+        if team_id == T2:
+            return {"mcp": {int(seed.team_x.id)}, "custom_api": set()}
+        return {"mcp": set(), "custom_api": set()}
+
+    return _hook
+
+
+# ---------------------------------------------------------------------------
+# visible_mcp_server_clause is fail-closed on its own terms, not only
+# because of how its one production caller happens to be gated today.
+# ---------------------------------------------------------------------------
+
+
+def test_visible_mcp_server_clause_matches_nothing_for_none_owner_even_with_team_ids(
+    db_session, seed
+):
+    """With ``owner_user_id=None``, the clause reduces to the personal arm
+    regardless of ``team_mcp_ids`` -- it never matches a team-owned row even
+    when one is named, rather than relying on a caller to have already
+    checked identity first."""
+    from xagent.web.services.connector_team_scope import visible_mcp_server_clause
+
+    clause = visible_mcp_server_clause(None, {int(seed.team_s.id)})
+    matches = db_session.query(MCPServer).filter(clause).all()
+    assert matches == []
+
+
+# ---------------------------------------------------------------------------
+# Keyed on the agent's team; the run owner's own membership is irrelevant.
+# Parameterised over three run-owner states, each encoded by the
+# agent-team-scope hook -- a negative control for a runner-keyed
+# implementation: if visibility were keyed on the runner instead of the
+# governing agent, this would flip for the T2 and no-team parameters.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner_team", [T2, T1, None])
+async def test_scope_keys_on_agent_team_not_runner(db_session, seed, owner_team):
+    connector_team_scope.set_connector_team_hooks(team_visibility=_team_hook(seed))
+    if owner_team is not None:
+        agent_team_scope.set_agent_team_scope_hook(
+            lambda db, user_id, _team=owner_team: agent_team_scope.AgentTeamScope(
+                team_id=_team, is_team_admin=False
+            )
+        )
+    try:
+        cfg = WebToolConfig(
+            db=db_session,
+            request=None,
+            user_id=int(seed.c.id),
+            connector_team_id=T1,
+            include_mcp_tools=True,
+        )
+        configs = await cfg._load_mcp_server_configs()
+        assert {c["name"] for c in configs} == {
+            seed.active_own.name,
+            seed.team_s.name,
+        }
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+        agent_team_scope.set_agent_team_scope_hook(None)
+
+
+# ---------------------------------------------------------------------------
+# A checkout that adopts this revision without installing the new team hook
+# is unchanged on both read points, for both connector kinds.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_visibility_hook_alone_is_unchanged(db_session, seed):
+    connector_team_scope.set_connector_team_hooks(
+        # Also matches ``T1``: a hypothetical implementation that put the
+        # fallback inside the shared helper instead of at this one read
+        # point would call this hook with the *team* id misread as a user
+        # id. Real user ids and team ids are unrelated dense integers, so
+        # that collision isn't guaranteed by construction -- matching T1
+        # here makes the assertion below deterministic rather than leaving
+        # it to an incidental id coincidence.
+        visibility=lambda db, user_id: (
+            {"mcp": {int(seed.team_s.id)}, "custom_api": {int(seed.a_capi.id)}}
+            if user_id in (int(seed.c.id), T1)
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+    try:
+        assert connector_team_scope.team_connector_hook_installed() is False
+
+        # The tool loader consults no hook today and must not widen.
+        cfg = WebToolConfig(
+            db=db_session,
+            request=None,
+            user_id=int(seed.c.id),
+            connector_team_id=T1,
+            include_mcp_tools=True,
+        )
+        configs = await cfg._load_mcp_server_configs()
+        assert {c["name"] for c in configs} == {seed.active_own.name}
+
+        # The runtime-connector loader keeps exactly today's answer via the
+        # fallback, for both connector kinds.
+        visible = _load_visible_runtime_connectors(
+            db_session, user_id=int(seed.c.id), agent_team_id=T1
+        )
+        mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
+        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+        assert mcp_ids == {int(seed.active_own.id), int(seed.team_s.id)}
+        assert capi_ids == {int(seed.capi_own.id), int(seed.a_capi.id)}
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+# ---------------------------------------------------------------------------
+# A personal agent (no governing team) resolves no team custom API -- the
+# custom-API twin of the MCP-side check with the same shape.
+# ---------------------------------------------------------------------------
+
+
+def test_personal_agent_gets_no_team_custom_api(db_session, seed):
+    connector_team_scope.set_connector_team_hooks(team_visibility=_team_hook(seed))
+    try:
+        visible = _load_visible_runtime_connectors(
+            db_session, user_id=int(seed.c.id), agent_team_id=None
+        )
+        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+        assert capi_ids == {int(seed.capi_own.id)}
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+# ---------------------------------------------------------------------------
+# The fallback selects on hook presence, never on an empty answer: an
+# installed hook legitimately answering "this team owns nothing" must not
+# be silently overridden by the legacy runner-keyed hook.
+# ---------------------------------------------------------------------------
+
+
+def test_installed_hook_returning_empty_does_not_fall_back(db_session, seed):
+    connector_team_scope.set_connector_team_hooks(
+        visibility=lambda db, user_id: (
+            {"mcp": {int(seed.team_s.id)}, "custom_api": {int(seed.a_capi.id)}}
+            if user_id == int(seed.c.id)
+            else {"mcp": set(), "custom_api": set()}
+        ),
+        team_visibility=lambda db, *, team_id: {"mcp": set(), "custom_api": set()},
+    )
+    try:
+        visible = _load_visible_runtime_connectors(
+            db_session, user_id=int(seed.c.id), agent_team_id=T1
+        )
+        mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
+        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+        assert mcp_ids == {int(seed.active_own.id)}
+        assert capi_ids == {int(seed.capi_own.id)}
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+# ---------------------------------------------------------------------------
+# Installing a team-keyed hook fully supersedes the legacy user-keyed
+# overlay for every resolution, including a run with no governing agent.
+# This is deliberate, not an oversight: falling back to the legacy overlay
+# whenever there is no governing agent would re-introduce runner-keyed
+# visibility for exactly the population this design excludes -- most
+# visibly, a personal agent would inherit its own owner's team connectors,
+# which the personal-agent checks above exist to forbid. It is also the
+# actual configuration a deployment that installs both the legacy and the
+# new hook together runs with on every agent-less resolution, not a
+# hypothetical corner case.
+# ---------------------------------------------------------------------------
+
+
+def test_installed_hook_with_no_governing_agent_supersedes_legacy_overlay(
+    db_session, seed
+):
+    connector_team_scope.set_connector_team_hooks(
+        visibility=lambda db, user_id: (
+            {"mcp": {int(seed.team_s.id)}, "custom_api": {int(seed.a_capi.id)}}
+            if user_id == int(seed.c.id)
+            else {"mcp": set(), "custom_api": set()}
+        ),
+        team_visibility=_team_hook(seed),
+    )
+    try:
+        visible = _load_visible_runtime_connectors(
+            db_session, user_id=int(seed.c.id), agent_team_id=None
+        )
+        mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
+        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+        # Personal-only on both connector kinds: seed.team_s / seed.a_capi
+        # (the legacy hook's answer) do NOT appear, even though the legacy
+        # hook alone would have granted them.
+        assert mcp_ids == {int(seed.active_own.id)}
+        assert capi_ids == {int(seed.capi_own.id)}
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+# ---------------------------------------------------------------------------
+# The new-hook branch narrows to MCP only: a team hook's "custom_api" grant
+# is not consumed at this seam. Custom API is not team-keyed on either side
+# yet -- the tool-build loaders (WebToolConfig's custom-API paths) stay
+# junction-only until a follow-up change team-keys them too. Unioning the
+# custom_api set here without a matching consumer would let a team-owned
+# custom API enter a task's runtime selection snapshot with no personal
+# link to satisfy its runtime-view resolution, and no tool loader able to
+# build it either -- selectable and persistable, never executable. This is
+# distinct from the legacy branch above (test_legacy_visibility_hook_alone_
+# is_unchanged), which keeps granting team custom APIs through the legacy
+# user-keyed hook -- the narrowing applies only to the new team-keyed hook.
+# ---------------------------------------------------------------------------
+
+
+def test_new_hook_branch_does_not_union_team_custom_api(db_session, seed):
+    connector_team_scope.set_connector_team_hooks(team_visibility=_team_hook(seed))
+    try:
+        visible = _load_visible_runtime_connectors(
+            db_session, user_id=int(seed.c.id), agent_team_id=T1
+        )
+        mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
+        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+        # T1's hook (see _team_hook above) grants both seed.team_s (mcp) and
+        # seed.a_capi (custom_api). The mcp grant still unions in; the
+        # custom_api grant does not -- that is the narrowing under test.
+        assert mcp_ids == {int(seed.active_own.id), int(seed.team_s.id)}
+        assert capi_ids == {int(seed.capi_own.id)}
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+# ---------------------------------------------------------------------------
+# The factory-runtime prefetch plan actually carries the agent's team
+# id. Without this pin, the custom-API prefetch path silently resolves
+# personal-only for every team agent while every other custom-API invariant
+# stays green because none of them build the plan.
+# ---------------------------------------------------------------------------
+
+
+def test_factory_runtime_plan_carries_agent_team_id(db_session, seed):
+    cfg = WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        connector_team_id=T1,
+    )
+    plan = cfg._build_factory_runtime_load_plan()
+    assert plan.connector_team_id == T1 == cfg._connector_team_id
+
+
+# ---------------------------------------------------------------------------
+# Shape validation on the team-visibility hook's answer. This is an
+# authorization input -- a malformed answer must fail loudly (raise), never
+# be normalized, coerced, or defaulted to empty. Extra keys are accepted and
+# ignored: only "mcp" and "custom_api" are ever read.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "malformed_answer",
+    [
+        None,
+        "not-a-dict",
+        {"mcp": set()},  # missing "custom_api"
+        {"custom_api": set()},  # missing "mcp"
+        {"mcp": [1, 2], "custom_api": set()},  # list, not a set
+        {"mcp": {"1", "2"}, "custom_api": set()},  # set of strings, not ints
+        {"mcp": {True}, "custom_api": set()},  # bool, not accepted as int
+    ],
+    ids=[
+        "none",
+        "non-dict",
+        "missing-custom_api",
+        "missing-mcp",
+        "list-not-set",
+        "set-of-strings",
+        "set-of-bools",
+    ],
+)
+def test_team_connector_ids_raises_on_malformed_hook_answer(malformed_answer):
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: malformed_answer
+    )
+    try:
+        with pytest.raises(ValueError):
+            connector_team_scope.team_connector_ids(None, team_id=T1)
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+def test_team_connector_ids_accepts_and_ignores_extra_keys():
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: {
+            "mcp": {1, 2},
+            "custom_api": {3},
+            # An unknown extra key with a value that would itself be
+            # malformed if it were ever inspected -- proves the validator
+            # only probes "mcp"/"custom_api" and does not iterate every key.
+            "unexpected_extra_key": object(),
+        }
+    )
+    try:
+        result = connector_team_scope.team_connector_ids(None, team_id=T1)
+        assert result["mcp"] == {1, 2}
+        assert result["custom_api"] == {3}
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+@pytest.mark.asyncio
+async def test_mcp_loader_seam_retypes_malformed_hook_answer(db_session, seed):
+    # A hook that (through a type coercion bug on the application side)
+    # returns the "mcp" id set as a string instead of a set. Without shape
+    # validation this is a SQLite type-affinity fail-open case: the string
+    # is silently iterated into single-character values rather than raising.
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: {"mcp": "12", "custom_api": set()}
+    )
+    try:
+        cfg = WebToolConfig(
+            db=db_session,
+            request=None,
+            user_id=int(seed.c.id),
+            connector_team_id=T1,
+            include_mcp_tools=True,
+        )
+        with pytest.raises(ConnectorRuntimeError) as excinfo:
+            await cfg._load_mcp_server_configs()
+        assert excinfo.value.status_code == 503
+        assert excinfo.value.details["reason"] == "team_scope_resolution_failed"
+        assert isinstance(excinfo.value.__cause__, ValueError)
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+def test_runtime_view_seam_retypes_malformed_hook_answer(db_session, seed):
+    task = Task(
+        user_id=seed.c.id,
+        title="malformed hook runtime task",
+        status=TaskStatus.PENDING,
+        source="sdk",
+        connector_runtime_selected_refs=[
+            {"connector_type": "mcp", "connector_id": int(seed.active_own.id)}
+        ],
+    )
+    db_session.add(task)
+    db_session.flush()
+
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: {"mcp": "12", "custom_api": set()}
+    )
+    try:
+        with pytest.raises(ConnectorRuntimeError) as excinfo:
+            _load_custom_api_runtime_view_sync(
+                db_session,
+                task_id=str(task.id),
+                connector_runtime_turn_id=None,
+                user_id=int(seed.c.id),
+                agent_team_id=T1,
+            )
+        assert excinfo.value.status_code == 503
+        assert isinstance(excinfo.value.__cause__, ValueError)
+    finally:
+        connector_team_scope.set_connector_team_hooks()

--- a/tests/web/services/test_connector_visibility_parity.py
+++ b/tests/web/services/test_connector_visibility_parity.py
@@ -1,0 +1,203 @@
+"""The runtime-context view and the tool loader agree on MCP visibility.
+
+One fixture seeded with all four connector categories (owner-active,
+owner-inactive, team-only, stranger) simultaneously, plus one
+OAuth-without-grant row so the ``config["server_id"]`` fallback below is
+actually exercised (the tool loader's "unavailable" shape has no top-level
+``id``). The matrix varies the team parameter over ``{T1, None}`` on the run
+owner, plus one ``T2`` cell -- trimmed to the cells that each discriminate a
+distinct case rather than repeating one already covered.
+
+Scope note: this asserts ``connector_type == "mcp"`` parity only. The
+custom-API half is deliberately NOT team-keyed on either side: the new-hook
+branch of ``_load_visible_runtime_connectors`` narrows its custom-API set
+to the junction-only view (pinned by
+``test_new_hook_branch_does_not_union_team_custom_api``), matching the
+custom-API tool loaders in ``config.py``, until both sides are team-keyed
+together. Custom-API parity therefore holds trivially today; the cells
+here pin the MCP half, where the union is live.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.web.models import Base, MCPServer, User, UserMCPServer
+from xagent.web.services import agent_team_scope, connector_team_scope
+from xagent.web.services.connector_runtime import _load_visible_runtime_connectors
+from xagent.web.tools.config import WebToolConfig
+
+T1 = 101
+T2 = 102
+
+
+@pytest.fixture()
+def db_session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks() -> Iterator[None]:
+    yield
+    connector_team_scope.set_connector_team_hooks()
+    agent_team_scope.set_agent_team_scope_hook(None)
+
+
+def _create_user(db: Session, username: str) -> User:
+    user = User(username=username, password_hash="hash")
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _create_mcp(
+    db: Session,
+    name: str,
+    *,
+    owner: User | None = None,
+    active: bool = True,
+    transport: str = "streamable_http",
+) -> MCPServer:
+    server = MCPServer(
+        name=name,
+        description=f"{name} description",
+        managed="external",
+        transport=transport,
+        url="https://example.com/mcp" if transport != "oauth" else None,
+    )
+    db.add(server)
+    db.flush()
+    if owner is not None:
+        db.add(
+            UserMCPServer(
+                user_id=owner.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=active,
+            )
+        )
+        db.flush()
+    return server
+
+
+@pytest.fixture()
+def seed(db_session: Session):
+    c = _create_user(db_session, "run-owner")
+    stranger_owner = _create_user(db_session, "stranger-owner")
+    active_own = _create_mcp(db_session, "active-own", owner=c, active=True)
+    inactive_own = _create_mcp(db_session, "inactive-own", owner=c, active=False)
+    stranger = _create_mcp(db_session, "stranger", owner=stranger_owner)
+    team_s = _create_mcp(db_session, "team-s")
+    team_x = _create_mcp(db_session, "team-x")
+    # OAuth server with no matching catalog app: exercises the tool loader's
+    # "unavailable" shape, whose id lives at config["server_id"], not "id".
+    oauth_no_grant = _create_mcp(
+        db_session, "oauth-no-grant", owner=c, transport="oauth"
+    )
+    connector_team_scope.set_connector_team_hooks(
+        # inactive_own also carries a live T1 team grant here, pinning the
+        # deliberate "no is_active veto" decision: a member's deactivated
+        # personal link must not silently hide a connector the team still
+        # shares. Without this, ``inactive_own`` only ever pinned "inactive
+        # personal link alone -> not visible", never the combination that
+        # actually matters.
+        team_visibility=lambda db, *, team_id: (
+            {"mcp": {int(team_s.id), int(inactive_own.id)}, "custom_api": set()}
+            if team_id == T1
+            else {"mcp": {int(team_x.id)}, "custom_api": set()}
+            if team_id == T2
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+    # Negative-control fixture (see test_mcp_team_visibility.py's
+    # ``_install_env_t`` docstring): maps the run owner to T1 so a
+    # runner-keyed misimplementation is distinguishable from the correct
+    # agent-keyed one on the ``team=None`` cell.
+    agent_team_scope.set_agent_team_scope_hook(
+        lambda db, user_id: agent_team_scope.AgentTeamScope(
+            team_id=T1, is_team_admin=False
+        )
+        if user_id == int(c.id)
+        else None
+    )
+    return SimpleNamespace(
+        c=c,
+        active_own=active_own,
+        inactive_own=inactive_own,
+        stranger=stranger,
+        team_s=team_s,
+        team_x=team_x,
+        oauth_no_grant=oauth_no_grant,
+    )
+
+
+async def _parity_ids(
+    db_session: Session, seed, *, team: int | None
+) -> tuple[set[int], set[int]]:
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=team
+    )
+    runtime_ids = {ref.connector_id for ref in visible if ref.connector_type == "mcp"}
+
+    cfg = WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        connector_team_id=team,
+        include_mcp_tools=True,
+    )
+    configs = await cfg._load_mcp_server_configs()
+    loader_ids = {c.get("id") or c.get("config", {}).get("server_id") for c in configs}
+    return runtime_ids, loader_ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("team", [T1, None, T2])
+async def test_runtime_view_and_tool_config_agree(db_session, seed, team):
+    runtime_ids, loader_ids = await _parity_ids(db_session, seed, team=team)
+    assert runtime_ids == loader_ids
+
+    # Every seeded category is represented in the agreed-on set so the
+    # parity assertion isn't vacuous for any row of the trimmed matrix.
+    assert int(seed.active_own.id) in loader_ids
+    assert int(seed.oauth_no_grant.id) in loader_ids
+    assert int(seed.stranger.id) not in loader_ids
+    if team == T1:
+        assert int(seed.team_s.id) in loader_ids
+        assert int(seed.team_x.id) not in loader_ids
+        # Plan §6's "no is_active veto": a deactivated personal link plus a
+        # live T1 team grant still resolves visible, in parity on both
+        # read points -- the team grant is not blocked by the member's own
+        # inactive association.
+        assert int(seed.inactive_own.id) in loader_ids
+    elif team == T2:
+        assert int(seed.team_x.id) in loader_ids
+        assert int(seed.team_s.id) not in loader_ids
+        # inactive_own has no T2 grant -- the deactivated personal link
+        # alone stays not-visible.
+        assert int(seed.inactive_own.id) not in loader_ids
+    else:
+        assert int(seed.team_s.id) not in loader_ids
+        assert int(seed.team_x.id) not in loader_ids
+        assert int(seed.inactive_own.id) not in loader_ids

--- a/tests/web/services/test_task_setup_snapshot_agent_team.py
+++ b/tests/web/services/test_task_setup_snapshot_agent_team.py
@@ -1,0 +1,128 @@
+"""The task-setup snapshot actually carries the governing agent's team id,
+which is what makes team-keyed connector visibility representable on the
+snapshot branch (``chat.py``'s only production-reachable tool-build path).
+
+``AgentRuntimeFields.team_id`` has a closed (``None``) default, so a
+forgotten production construction site is otherwise silent across every
+existing ``AgentRuntimeFields(`` test file -- this is the one pin that would
+catch it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import AgentRuntimeFields
+from xagent.web.services.task_setup_snapshot import load_task_setup_snapshot_sync
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'snapshot_agent_team.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+def _create_user(db) -> User:
+    user = User(username="snap-team-user", password_hash="hash", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _create_agent(db, user_id: int, **overrides) -> Agent:
+    defaults = dict(
+        user_id=user_id,
+        name="snap-team-agent",
+        instructions="be terse",
+        status=AgentStatus.PUBLISHED,
+        execution_mode="balanced",
+        models={},
+        knowledge_bases=[],
+        skills=[],
+        tool_categories=["basic"],
+    )
+    defaults.update(overrides)
+    agent = Agent(**defaults)
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def _create_task(db, user_id: int, **overrides) -> Task:
+    defaults = dict(
+        user_id=user_id,
+        title="Snapshot agent-team test",
+        description="snapshot",
+        status=TaskStatus.PENDING,
+        execution_mode="flash",
+        source="sdk",
+    )
+    defaults.update(overrides)
+    task = Task(**defaults)
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def test_snapshot_carries_agent_team_id(db_session) -> None:
+    user = _create_user(db_session)
+    agent = _create_agent(db_session, user_id=int(user.id), team_id=101)
+    task = _create_task(db_session, user_id=int(user.id), agent_id=int(agent.id))
+
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
+
+    assert snapshot is not None
+    assert snapshot.agent is not None
+    assert isinstance(snapshot.agent, AgentRuntimeFields)
+    assert snapshot.agent.team_id == 101
+
+
+def test_snapshot_agent_team_id_defaults_to_none_for_personal_agent(db_session) -> None:
+    """Negative sibling of ``test_snapshot_carries_agent_team_id``. A bare
+    "personal agent resolves None" assertion would be near-tautological on
+    its own -- ``None`` is also the dataclass's closed default, so the
+    assertion cannot distinguish "correctly resolved no team" from "the
+    field was never wired and just fell through". This test first
+    resolves a *team* agent's snapshot in the same session and confirms it
+    reads back 101, then resolves the personal agent and confirms it reads
+    back ``None`` -- so a bug where the resolution leaks or caches the prior
+    team id across agents (rather than reading each row's own column) would
+    turn this red, which the original standalone assertion could not catch.
+    """
+    user = _create_user(db_session)
+    team_agent = _create_agent(db_session, user_id=int(user.id), team_id=101)
+    team_task = _create_task(
+        db_session, user_id=int(user.id), agent_id=int(team_agent.id)
+    )
+    team_snapshot = load_task_setup_snapshot_sync(
+        task_id=int(team_task.id), task_owner_user_id=int(user.id)
+    )
+    assert team_snapshot is not None and team_snapshot.agent is not None
+    assert team_snapshot.agent.team_id == 101
+
+    agent = _create_agent(
+        db_session, user_id=int(user.id), name="snap-team-agent-personal"
+    )  # team_id left unset
+    task = _create_task(db_session, user_id=int(user.id), agent_id=int(agent.id))
+
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(user.id)
+    )
+
+    assert snapshot is not None
+    assert snapshot.agent is not None
+    assert snapshot.agent.team_id is None

--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -493,6 +493,57 @@ def test_web_chat_create_filters_runtime_declared_connectors_and_ignores_payload
     assert _context_row_count(int(task.id)) == 0
 
 
+def test_web_chat_create_surfaces_typed_503_without_leaking_hook_message(
+    e2e_db: None,
+) -> None:
+    """A team hook that raises while resolving the new task's connector
+    selection snapshot must surface here as a typed 503, with the hook's
+    raw message absent from the response body. Without the endpoint-side
+    ``ConnectorRuntimeError`` mapping, ``create_task``'s blanket
+    ``except Exception`` handler would return HTTP 500 with ``str(exc)`` as
+    the response ``detail`` -- which for the already-wrapped error is the
+    typed safe message, not the raw hook text, but with the wrong status.
+    """
+    from xagent.web.services import connector_team_scope
+
+    headers = _setup_admin_headers()
+    db = _db_session()
+    try:
+        user = _admin_user(db)
+        agent = _create_agent(
+            db, user, name="Raising Hook Web Chat Agent", tool_categories=["mcp"]
+        )
+        agent.team_id = 101
+        db.commit()
+        db.refresh(agent)
+        agent_id = int(agent.id)
+    finally:
+        db.close()
+
+    def _raising_hook(db: Session, *, team_id: int) -> dict[str, set[int]]:
+        raise RuntimeError(
+            "Bearer planted-hook-secret-must-not-leak: password authentication "
+            "failed for 'svc'"
+        )
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_raising_hook)
+    try:
+        response = client.post(
+            "/api/chat/task/create",
+            headers=headers,
+            json={
+                "title": "raising hook web chat",
+                "description": "create task",
+                "agent_id": agent_id,
+            },
+        )
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+    assert response.status_code == 503, response.text
+    assert "planted-hook-secret-must-not-leak" not in response.text
+
+
 def test_web_chat_preview_placeholder_snapshot_is_empty_and_payload_is_ignored(
     e2e_db: None,
 ) -> None:

--- a/tests/web/test_connector_team_agent_e2e.py
+++ b/tests/web/test_connector_team_agent_e2e.py
@@ -1,0 +1,227 @@
+"""The ``chat.py`` derivation actually threads the governing agent's team id
+down to ``WebToolConfig``, on the snapshot branch.
+
+The snapshot branch in ``_build_tools_for_task`` is the only branch
+production reaches (``_build_tools_for_task`` has exactly one production
+caller, and it cannot reach it with a ``None`` snapshot). This test is the
+only one that exercises the
+``snapshot -> chat.py derivation -> WebToolConfig._connector_team_id`` link
+end to end; the team-keyed resolution itself and the personal-agent negative
+are pinned directly against the lower-level functions in
+``tests/web/tools/test_mcp_team_visibility.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from xagent.web.api.chat import AgentServiceManager
+from xagent.web.models.database import Base, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import AgentRuntimeFields
+from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
+    TaskSetupSnapshot,
+    _TaskFields,
+)
+
+
+@pytest.fixture(autouse=True)
+def _init_db(tmp_path):
+    # ``db=None`` on the snapshot branch still routes through
+    # ``create_default_tools``'s worker session factory
+    # (``get_session_local()``), so a real (if unused-by-the-assertion)
+    # SessionLocal must exist.
+    init_db(db_url=f"sqlite:///{tmp_path / 'e2e.db'}")
+    yield
+    Base.metadata.drop_all(bind=get_engine())
+
+
+def _task_fields(task: Task) -> _TaskFields:
+    return _TaskFields(
+        id=int(task.id),
+        user_id=int(task.user_id),
+        status=task.status,
+        agent_id=task.agent_id,
+        agent_config=task.agent_config,
+        model_name=task.model_name,
+        compact_model_name=task.compact_model_name,
+        execution_mode=task.execution_mode,
+        agent_type=task.agent_type,
+        source=task.source,
+    )
+
+
+async def _noop_create_all_tools(
+    config, apply_user_override_filter=True, additional_tools=()
+):
+    return list(additional_tools)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_branch_threads_agent_team_to_tool_config(monkeypatch):
+    manager = AgentServiceManager()
+    user = User(id=1, username="e2e-team-user", password_hash="hash", is_admin=False)
+    task = Task(
+        id=1,
+        user_id=1,
+        title="team-derivation task",
+        description="e2e",
+        status=TaskStatus.PENDING,
+        model_name="gpt-4",
+        small_fast_model_name="gpt-3.5-turbo",
+        agent_type="standard",
+    )
+    agent_config = {"tool_categories": ["basic"], "knowledge_bases": [], "skills": []}
+    snapshot = TaskSetupSnapshot(
+        task=_task_fields(task),
+        runtime_user=RuntimeUserFields(id=int(user.id), is_admin=False),
+        has_reconstructable_history=False,
+        task_pattern="dag_plan_execute",
+        task_llm=None,
+        task_fast_llm=None,
+        task_vision_llm=None,
+        task_compact_llm=None,
+        agent=AgentRuntimeFields(
+            id=99,
+            name="team-agent",
+            status="published",
+            instructions=None,
+            team_id=101,
+        ),
+        agent_config=agent_config,
+        excluded_agent_id=99,
+    )
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        _noop_create_all_tools,
+    )
+
+    with patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None):
+        _tools, tool_config = await manager._build_tools_for_task(
+            task_id=int(task.id),
+            task=task,
+            db=None,
+            user=user,
+            agent_config=agent_config,
+            task_llm=None,
+            task_vision_llm=None,
+            task_setup_snapshot=snapshot,
+        )
+
+    assert tool_config._connector_team_id == 101
+
+
+@pytest.mark.asyncio
+async def test_snapshot_branch_with_no_governing_agent_stays_personal(monkeypatch):
+    """The negative case: no ``snapshot.agent`` resolves ``None``, not some
+    inherited or stale team id.
+
+    A bare "no agent resolves None" assertion would be near-tautological on
+    its own, since ``None`` is also the parameter's closed default -- it
+    cannot tell "correctly resolved no team" apart from "the derivation was
+    never reached". This test first drives ``_build_tools_for_task`` with a
+    *team* snapshot (team_id=101, same manager instance) and confirms 101
+    comes through, then immediately drives it again with no governing agent
+    and confirms ``None`` -- so a bug where the team id leaks across builds
+    (e.g. a shared-default-argument or manager-level caching mistake) would
+    turn this red, which a standalone assertion could not catch.
+    """
+    manager = AgentServiceManager()
+    user = User(
+        id=1, username="e2e-personal-user", password_hash="hash", is_admin=False
+    )
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        _noop_create_all_tools,
+    )
+
+    team_task = Task(
+        id=3,
+        user_id=1,
+        title="personal-negative team baseline",
+        description="e2e",
+        status=TaskStatus.PENDING,
+        model_name="gpt-4",
+        small_fast_model_name="gpt-3.5-turbo",
+        agent_type="standard",
+    )
+    team_agent_config = {
+        "tool_categories": ["basic"],
+        "knowledge_bases": [],
+        "skills": [],
+    }
+    team_snapshot = TaskSetupSnapshot(
+        task=_task_fields(team_task),
+        runtime_user=RuntimeUserFields(id=int(user.id), is_admin=False),
+        has_reconstructable_history=False,
+        task_pattern="dag_plan_execute",
+        task_llm=None,
+        task_fast_llm=None,
+        task_vision_llm=None,
+        task_compact_llm=None,
+        agent=AgentRuntimeFields(
+            id=98,
+            name="team-agent-baseline",
+            status="published",
+            instructions=None,
+            team_id=101,
+        ),
+        agent_config=team_agent_config,
+        excluded_agent_id=98,
+    )
+    with patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None):
+        _tools, team_tool_config = await manager._build_tools_for_task(
+            task_id=int(team_task.id),
+            task=team_task,
+            db=None,
+            user=user,
+            agent_config=team_agent_config,
+            task_llm=None,
+            task_vision_llm=None,
+            task_setup_snapshot=team_snapshot,
+        )
+    assert team_tool_config._connector_team_id == 101
+
+    task = Task(
+        id=2,
+        user_id=1,
+        title="personal task",
+        description="e2e",
+        status=TaskStatus.PENDING,
+        model_name="gpt-4",
+        small_fast_model_name="gpt-3.5-turbo",
+        agent_type="standard",
+    )
+    snapshot = TaskSetupSnapshot(
+        task=_task_fields(task),
+        runtime_user=RuntimeUserFields(id=int(user.id), is_admin=False),
+        has_reconstructable_history=False,
+        task_pattern="dag_plan_execute",
+        task_llm=None,
+        task_fast_llm=None,
+        task_vision_llm=None,
+        task_compact_llm=None,
+        agent=None,
+        agent_config=None,
+        excluded_agent_id=None,
+    )
+
+    with patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None):
+        _tools, tool_config = await manager._build_tools_for_task(
+            task_id=int(task.id),
+            task=task,
+            db=None,
+            user=user,
+            agent_config=None,
+            task_llm=None,
+            task_vision_llm=None,
+            task_setup_snapshot=snapshot,
+        )
+
+    assert tool_config._connector_team_id is None

--- a/tests/web/test_team_sharing_hooks.py
+++ b/tests/web/test_team_sharing_hooks.py
@@ -28,6 +28,7 @@ def test_connector_team_hooks_delegate_and_reset():
 
     connector_scope.set_connector_team_hooks(
         visibility=lambda db, user_id: {"mcp": {11}, "custom_api": {22}},
+        team_visibility=lambda db, *, team_id: {"mcp": {33}, "custom_api": {44}},
         deleted=lambda db, user_id, kind, connector_id: (
             deleted_calls.append((db, user_id, kind, connector_id))
             or connector_scope.ConnectorDeleteDecision(
@@ -43,6 +44,10 @@ def test_connector_team_hooks_delegate_and_reset():
             "mcp": {11},
             "custom_api": {22},
         }
+        assert connector_scope.team_connector_ids(None, team_id=9) == {
+            "mcp": {33},
+            "custom_api": {44},
+        }
         decision = connector_scope.delete_team_connector(None, 7, "mcp", 11)
         assert decision.team_owned and decision.authorized
         connector_scope.rename_team_connector(None, 7, "mcp", 11, "old", "new")
@@ -50,6 +55,7 @@ def test_connector_team_hooks_delegate_and_reset():
         assert renamed_calls == [(None, 7, "mcp", 11, "old", "new")]
     finally:
         connector_scope.set_connector_team_hooks()
+    assert connector_scope.team_connector_hook_installed() is False
 
 
 def test_knowledge_base_team_hooks_delegate_with_none_session():

--- a/tests/web/tools/test_mcp_team_visibility.py
+++ b/tests/web/tools/test_mcp_team_visibility.py
@@ -1,0 +1,436 @@
+"""Team-scope connector visibility at the MCP tool-load boundary.
+
+``WebToolConfig._load_mcp_server_configs`` resolves the servers visible to a
+run from ``personal ∪ the governing agent's team`` instead of ``personal
+only``, through the optional ``team_visibility`` hook on
+``connector_team_scope``. These tests pin the closed-by-default shape (no
+hook installed, or a hook installed but no team supplied) as well as the
+positive team-keyed case and the two failure-contract invariants the seam
+now carries (a broken hook fails the turn instead of dropping the MCP tool
+set silently).
+
+Fixture seed (five MCP rows, run owner ``C`` throughout unless noted):
+
+    active_own    -- C holds an active personal link
+    inactive_own  -- C holds an inactive personal link
+    stranger      -- owned by a third user, no link to anything
+    team_s        -- reachable only through a team hook keyed on T1
+    team_x        -- reachable only through a team hook keyed on T2
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from xagent.core.tools.adapters.vibe.mcp_tools import create_mcp_tools
+from xagent.web.models import Base, MCPServer, User, UserMCPServer
+from xagent.web.services import agent_team_scope, connector_team_scope
+from xagent.web.tools.config import WebToolConfig
+
+T1 = 101
+T2 = 102
+
+
+class _ProbeError(RuntimeError):
+    """Distinguishable failure raised by a broken team-visibility hook."""
+
+
+@pytest.fixture()
+def db_session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks() -> Iterator[None]:
+    yield
+    connector_team_scope.set_connector_team_hooks()
+    agent_team_scope.set_agent_team_scope_hook(None)
+
+
+def _create_user(db: Session, username: str) -> User:
+    user = User(username=username, password_hash="hash")
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _create_mcp(
+    db: Session, name: str, *, owner: User | None = None, active: bool = True
+) -> MCPServer:
+    server = MCPServer(
+        name=name,
+        description=f"{name} description",
+        managed="external",
+        transport="streamable_http",
+        url="https://example.com/mcp",
+    )
+    db.add(server)
+    db.flush()
+    if owner is not None:
+        db.add(
+            UserMCPServer(
+                user_id=owner.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=active,
+            )
+        )
+        db.flush()
+    return server
+
+
+@pytest.fixture()
+def seed(db_session: Session):
+    c = _create_user(db_session, "run-owner")
+    z = _create_user(db_session, "stranger-owner")
+    active_own = _create_mcp(db_session, "active-own", owner=c, active=True)
+    inactive_own = _create_mcp(db_session, "inactive-own", owner=c, active=False)
+    stranger = _create_mcp(db_session, "stranger", owner=z)
+    team_s = _create_mcp(db_session, "team-s")
+    team_x = _create_mcp(db_session, "team-x")
+    return SimpleNamespace(
+        c=c,
+        z=z,
+        active_own=active_own,
+        inactive_own=inactive_own,
+        stranger=stranger,
+        team_s=team_s,
+        team_x=team_x,
+    )
+
+
+def _team_visibility_hook(seed):
+    """A team_visibility hook whose answer is disjoint per team, empty otherwise."""
+
+    def _hook(db, *, team_id):
+        if team_id == T1:
+            return {"mcp": {int(seed.team_s.id)}, "custom_api": set()}
+        if team_id == T2:
+            return {"mcp": {int(seed.team_x.id)}, "custom_api": set()}
+        return {"mcp": set(), "custom_api": set()}
+
+    return _hook
+
+
+def _install_env_t(seed) -> None:
+    """Install the team_visibility hook *and* the agent-team-scope hook
+    mapping the run owner C -> T1 (the team that owns ``team_s``).
+
+    The scope-hook mapping is a negative-control fixture, not something
+    production code consults for this decision (the MCP loader keys on
+    ``self._connector_team_id``, never on ``get_agent_team_scope(db, owner)``)
+    -- but without it installed, a runner-keyed misimplementation would be
+    indistinguishable from the correct one on these fixtures, since
+    ``get_agent_team_scope`` would resolve ``None`` for everybody either way.
+    """
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=_team_visibility_hook(seed)
+    )
+    agent_team_scope.set_agent_team_scope_hook(
+        lambda db, user_id: agent_team_scope.AgentTeamScope(
+            team_id=T1, is_team_admin=False
+        )
+        if user_id == int(seed.c.id)
+        else None
+    )
+
+
+def _cfg(db_session: Session, seed, *, connector_team_id: int | None) -> WebToolConfig:
+    return WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        connector_team_id=connector_team_id,
+        include_mcp_tools=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Standalone (no hooks installed) is result-identical to today, regardless
+# of what connector_team_id is passed -- there is nothing for it to resolve
+# against without a hook.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("connector_team_id", [None, 7])
+async def test_no_hooks_matches_legacy_result_set(db_session, seed, connector_team_id):
+    from xagent.web.services.connector_runtime import _load_visible_runtime_connectors
+
+    cfg = _cfg(db_session, seed, connector_team_id=connector_team_id)
+    configs = await cfg._load_mcp_server_configs()
+    assert {c["name"] for c in configs} == {seed.active_own.name}
+
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=None
+    )
+    mcp_ids = {ref.connector_id for ref in visible if ref.connector_type == "mcp"}
+    assert mcp_ids == {int(seed.active_own.id)}
+
+
+# ---------------------------------------------------------------------------
+# A team agent resolves its team's connector for a run owner with no
+# personal row on that server.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_agent_loads_team_connector(db_session, seed):
+    _install_env_t(seed)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+    configs = await cfg._load_mcp_server_configs()
+    assert {c["name"] for c in configs} == {seed.active_own.name, seed.team_s.name}
+
+
+# ---------------------------------------------------------------------------
+# A personal agent (no governing team) gets nothing from any team, and the
+# authorization path is read-only: no personal link is materialized.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_personal_agent_gets_no_team_connector(db_session, seed):
+    from xagent.web.services.connector_runtime import _load_visible_runtime_connectors
+
+    _install_env_t(seed)
+    cfg = _cfg(db_session, seed, connector_team_id=None)
+    configs = await cfg._load_mcp_server_configs()
+    assert {c["name"] for c in configs} == {seed.active_own.name}
+
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=None
+    )
+    mcp_ids = {ref.connector_id for ref in visible if ref.connector_type == "mcp"}
+    assert mcp_ids == {int(seed.active_own.id)}
+
+    before = db_session.query(UserMCPServer).filter_by(user_id=int(seed.c.id)).count()
+    assert before == 2  # active_own + inactive_own, seeded, unchanged by resolution
+
+
+# ---------------------------------------------------------------------------
+# The production MCP query is a semi-join with a deterministic order.
+# Compiled on the production query object, not a parallel reconstruction.
+# ---------------------------------------------------------------------------
+
+
+def test_production_mcp_query_shape(db_session, seed):
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+    sql = str(
+        cfg._visible_mcp_server_query(
+            frozenset({int(seed.team_s.id)})
+        ).statement.compile(dialect=postgresql.dialect())
+    )
+    norm = " ".join(sql.split()).upper()
+    assert norm.startswith("SELECT")
+    assert "MCP_SERVERS" in norm
+    assert "JOIN USER_MCPSERVERS" not in norm
+    assert "ORDER BY" in norm
+
+
+# ---------------------------------------------------------------------------
+# A team-hook failure is not folded into MCPConfigLoadError -- it is raised
+# from outside that error's guarded region -- and it survives the
+# tool-creator boundary as ConnectorRuntimeError instead of being dropped
+# into an empty MCP tool set (checked at two frames: the direct creator
+# call, and through the tool registry).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_hook_failure_is_not_mcp_config_load_error(db_session, seed):
+    def _boom(db, *, team_id):
+        raise _ProbeError("boom")
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_boom)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        await cfg._load_mcp_server_configs()
+
+    assert excinfo.value.details["reason"] == "team_scope_resolution_failed"
+    assert isinstance(excinfo.value.__cause__, _ProbeError)
+
+
+@pytest.mark.asyncio
+async def test_team_hook_failure_surfaces_as_connector_runtime_error(db_session, seed):
+    def _boom(db, *, team_id):
+        raise _ProbeError("boom")
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_boom)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+
+    # Positive control: prove the creator is not short-circuiting before the
+    # seam because no selection spec excludes MCP.
+    assert cfg.get_tool_selection_spec() is None
+
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        await create_mcp_tools(cfg)
+    assert excinfo.value.details["reason"] == "team_scope_resolution_failed"
+
+
+@pytest.mark.asyncio
+async def test_team_hook_failure_survives_tool_registry_boundary(db_session, seed):
+    """Companion to the direct-creator assertion above: without this frame the
+    test proves only that the seam raises, not that anybody downstream is
+    left to hear it. ``factory.py``'s registry loop re-raises
+    ``ConnectorRuntimeError`` specifically and would otherwise swallow an
+    untyped exception into a WARNING and an empty tool list.
+    """
+    from xagent.core.tools.adapters.vibe.factory import ToolRegistry
+    from xagent.core.tools.adapters.vibe.mcp_tools import (
+        create_mcp_tools as real_create_mcp_tools,
+    )
+
+    def _boom(db, *, team_id):
+        raise _ProbeError("boom")
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_boom)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+
+    saved_creators = list(ToolRegistry._tool_creators)
+    saved_imported = ToolRegistry._modules_imported
+    ToolRegistry._tool_creators = []
+    ToolRegistry._modules_imported = True
+    try:
+        ToolRegistry.register(
+            real_create_mcp_tools, categories={"mcp"}, selection_gate="mcp"
+        )
+        with pytest.raises(ConnectorRuntimeError) as excinfo:
+            await ToolRegistry.create_registered_tools(cfg)
+    finally:
+        ToolRegistry._tool_creators = saved_creators
+        ToolRegistry._modules_imported = saved_imported
+
+    assert excinfo.value.details["reason"] == "team_scope_resolution_failed"
+
+
+# ---------------------------------------------------------------------------
+# The omitted connector_team_id parameter's default is the closed one.
+#
+# Upstream commit 9891cad8 ("fix(auth): preserve infrastructure failures at
+# authentication boundaries") removed WebToolConfig's id-1 authentication
+# fallback. Before that commit, an unidentified construction (``user_id``
+# omitted, no request-derived identity) silently became user 1. After that
+# commit, an unidentified construction keeps ``_user_id`` as ``None`` --
+# there is no fallback identity to silently become. This is a stronger
+# closed-default contract, not a weaker one: the production entry point,
+# ``get_mcp_server_configs()``, now short-circuits to ``[]`` whenever
+# ``self._user_id is None``, before this seam's team-scope resolution is
+# ever reached in production -- so an unauthenticated construction gets
+# nothing at all, not merely "personal-only". Split into three tests below:
+# the closed default itself, the production-reachable guarantee (via the
+# public entry point), and one test documenting -- not fixing -- the
+# private loader's own lack of an independent identity guard, since this
+# suite calls that private method directly throughout for granularity.
+# ---------------------------------------------------------------------------
+
+
+def test_omitted_connector_team_id_defaults_to_none(db_session, seed):
+    # ``connector_team_id`` omitted entirely -- not even ``None`` passed --
+    # so this actually exercises the constructor's own default, not merely
+    # an explicit None round-tripping.
+    cfg = WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        include_mcp_tools=True,
+    )
+    assert cfg._connector_team_id is None
+
+
+@pytest.mark.asyncio
+async def test_unidentified_construction_resolves_no_mcp_configs_regardless_of_team(
+    db_session,
+):
+    """The production-reachable contract: no identity means no MCP tools,
+    even when a team grant exists and ``connector_team_id`` names it -- the
+    identity guard in ``get_mcp_server_configs()`` sits before the
+    team-scope resolution entirely, so a team grant cannot leak through for
+    an unauthenticated build."""
+    team_server = _create_mcp(db_session, "team-only-unidentified-probe")
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: (
+            {"mcp": {int(team_server.id)}, "custom_api": set()}
+            if team_id == T1
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+    try:
+        cfg = WebToolConfig(
+            db=db_session,
+            request=None,
+            user_id=None,
+            connector_team_id=T1,
+            include_mcp_tools=True,
+        )
+        assert cfg._user_id is None
+
+        configs = await cfg.get_mcp_server_configs()
+        assert configs == []
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+@pytest.mark.asyncio
+async def test_direct_private_loader_call_resolves_nothing_without_identity(db_session):
+    """``_load_mcp_server_configs()`` has no identity guard of its own;
+    ``get_mcp_server_configs()`` is its only production caller (``grep -n
+    "_load_mcp_server_configs\\b" src/xagent/web/tools/config.py`` shows
+    exactly one call site, inside that wrapper), and that wrapper's identity
+    guard is what keeps an unauthenticated build from ever reaching this
+    seam's team-scope resolution in production.
+
+    Calling the private method directly -- as this test suite already does
+    throughout, for granularity -- bypasses that guard, but resolves
+    nothing rather than leaking the team connector: the visibility
+    predicate itself short-circuits to the personal arm whenever the owner
+    id is ``None``, regardless of any team ids supplied, so the query never
+    matches the team-only server in the first place and no per-server
+    config is ever built for it. This test exists so a future reader of
+    this file's many other ``_load_mcp_server_configs()`` calls does not
+    mistake "reachable in a unit test" for "reachable in production", and
+    knows the measured behaviour without identity is silence, not a leak.
+    """
+    team_server = _create_mcp(db_session, "team-only-private-loader-probe")
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: (
+            {"mcp": {int(team_server.id)}, "custom_api": set()}
+            if team_id == T1
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+    try:
+        cfg = WebToolConfig(
+            db=db_session,
+            request=None,
+            user_id=None,
+            connector_team_id=T1,
+            include_mcp_tools=True,
+        )
+        configs = await cfg._load_mcp_server_configs()
+        assert configs == []
+    finally:
+        connector_team_scope.set_connector_team_hooks()

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -151,6 +151,9 @@ class _Chain:
     def join(self, *a, **k):
         return self
 
+    def order_by(self, *a, **k):
+        return self
+
     def all(self):
         return []
 
@@ -187,6 +190,9 @@ class _ListChain:
         return self
 
     def join(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
         return self
 
     def all(self):


### PR DESCRIPTION
## Summary

Connector visibility at tool-build time is resolved from the governing agent's owning team,
through an optional application hook, instead of from the running user's personal association
rows only. Standalone deployments and deployments that never install a team hook are unchanged.

Today, an MCP server that a team member has shared with their team is only usable by agents
whose selection resolves through the *running user's own* personal links. A published team
agent that another team member runs cannot see a server that a teammate shared, even though the
server is meant to be team-wide. This change fixes that by keying visibility on the agent's team
instead of the runner's personal association, while keeping every existing deployment's behavior
identical unless it opts in by installing the new hook.

Two runtime read points change:

- **`WebToolConfig._load_mcp_server_configs`** (the MCP tool loader) now resolves
  `personal ∪ the governing agent's team` instead of `personal only`, dropping the inner join on
  the personal-ownership table in favor of a predicate that matches personal rows or team-owned
  rows.
- **`_load_visible_runtime_connectors`** (used by the connector-runtime-context loader) now
  resolves the same union when a team-keyed hook is installed, replacing its previous
  hand-rolled user-keyed lookup for that case.

The team hook is a `Protocol` with a keyword-only parameter
(`def __call__(self, db, *, team_id: int) -> dict[str, set[int]]`), installed through
`connector_team_scope.set_connector_team_hooks(team_visibility=...)`. It is invoked by keyword
everywhere it is called, so a hook accidentally bound into the wrong slot (there is a
similarly-shaped, pre-existing user-keyed hook in the same module) raises a `TypeError` instead
of silently resolving an unrelated team's connectors.

## Behavior and compatibility

- **No hook installed (standalone or any deployment that hasn't adopted this):** both read
  points return the same row set as before. The MCP tool loader's row order becomes
  deterministic where it was previously database-planner-dependent, because this change adds
  `ORDER BY id` where there was none before — a real, if small, user-visible-in-principle
  change, stated here rather than folded into "identical."
- **A deployment that adopts this revision without installing the new team hook (only the
  pre-existing legacy user-keyed hook, or no hook at all):** the MCP tool loader is unchanged
  (personal-only; it never had a team overlay, and none is added when the new hook is absent —
  adding one there would newly expose the runner's own team's servers, which is not what this
  change does). The connector-runtime-context loader falls back to its existing user-keyed
  overlay whenever no team-keyed hook is present, so its answer is exactly what it returned
  before this change, in that state.
- **A team-visibility hook that raises an exception now fails the turn** instead of the run
  silently continuing with an empty MCP tool set. The failure is wrapped in a typed
  `ConnectorRuntimeError` (503, `details={"reason": "team_scope_resolution_failed"}`) at every
  seam where team scope is resolved — both the MCP tool loader's own direct hook call and the
  connector-runtime-context loader's, using the same wrap shape (log the failure with a
  traceback, then raise the typed error) throughout. The web chat task-creation endpoint maps
  this typed error onto an HTTP 503 with the safe message only, and the `/v1` task API already
  had that mapping at its three connector-runtime sites; the other task-creation entry
  points (widget chat, share chat, workforce runs, channel tasks) do not yet have that mapping
  and surface a generic 500 instead — still without the raw hook message, since the wrap already
  removed it before any of those paths see the exception, but without the 503 status code. A
  trigger run whose task creation fails this way stores the typed, safe message on the run
  rather than the hook's raw text. A malformed hook answer — the wrong shape entirely, a missing
  key, a value that is not a set, or a set containing something other than an integer — fails
  the same way through the same typed error, rather than being silently coerced or
  misinterpreted downstream. No MCP load-summary event is emitted for either failure kind — the
  observable effect elsewhere is that the turn fails rather than completing with a silently
  narrower tool set.
- **Custom API connectors are not team-keyed at this seam yet.** Team-shared custom APIs reach
  the runtime view only through the pre-existing legacy *user-keyed* hook's overlay, exactly as
  they always have; the new *team-keyed* hook's `"custom_api"` answer is not consumed anywhere
  in this PR. MCP is fully team-keyed on both the tool-build and connector-runtime-context
  sides; Custom API stays junction-only (personal links only) on both until a follow-up
  team-keys its tool loaders and widens this side to match. This is a staged rollout, not a gap
  this PR overlooked: unioning the custom-API grant early, before its tool loaders could act on it,
  would let a team-owned custom API be selected into a task's connector snapshot with no
  personal link to satisfy its runtime values and no tool loader able to build it either —
  persistable and selectable, never executable.
- **A per-tool-call MCP connection refresh that fails because of a broken team hook now returns
  a classified tool failure result** instead of raising an unhandled exception out of the tool
  call. This mirrors the handling its sibling OAuth-resolver refresh path already had; the
  underlying error is still whatever the seam above produces (the typed `ConnectorRuntimeError`
  when a hook raises, or the hook's own exception type for any other refresh failure), just
  classified at the point where a tool call would otherwise crash instead of failing gracefully.
- **No identity, no MCP tools, regardless of team.** An unauthenticated or unidentified
  `WebToolConfig` construction resolves no MCP configurations at all through the production
  entry point, before this change's team-scope resolution is ever reached — a team grant cannot
  surface through an unidentified build.
- **Once a team-keyed hook is installed, it fully supersedes the legacy user-keyed overlay for
  every resolution — not only for runs that have a governing team agent.** This includes a run
  with no governing agent at all (an unpublished/removed agent, an agent-builder preview, or a
  personal agent with no team of its own): such a run resolves personal-only, even if the legacy
  hook alone would have granted a team-shared connector. This is deliberate, not an oversight —
  falling back to the legacy hook whenever there is no governing agent would re-introduce
  runner-keyed visibility for exactly the case this change removes it from, most visibly a
  personal agent silently inheriting its own owner's team connectors. It is also the actual
  configuration a deployment that installs both the legacy hook and the new one runs with on
  every agent-less resolution, not a narrow edge case.
- **A member's own connector being personally deactivated does not hide it from their team.**
  The team arm of the visibility rule carries no `is_active` check; only the personal arm does.
  So if a member deactivates their own personal link to a connector they previously shared with
  their team, the connector stays visible to the team's agents — a member's personal toggle
  cannot silently disable something the team is relying on. The credential consequence: in that
  state, the connection runs on the shared definition row's own stored credentials (for stdio and
  other static-auth transports) rather than on the member's now-deactivated personal
  configuration, because the personal credential layer is keyed on that same active link.
- **The hook has no way to ask "is the runner a member of this team," by design.** Visibility is
  keyed strictly on the team that owns the governing agent, never on who is currently running it
  — a published team agent is meant to serve any runner of that team's agents, including
  end users who are not members of the team at all. Every connector id a hook returns is
  therefore executable by any runner of that team's agents, and for stdio and other
  static-auth transports the connection runs on the shared definition row's own stored
  credentials, not the runner's. (OAuth transports fail closed instead, for lack of a token to
  resolve.) An application that wants narrower, membership-based visibility enforces it at its own
  agent-access policy layer (deciding who may run a team's agents at all) — the hook itself
  receives only the team id and, as a process-global singleton with no per-request state,
  cannot know which runner a resolution is for. A platform admin's tasks reach this seam
  through the agent-access policy layer's admin short-circuit, which returns every agent
  regardless of team — so the runner of a team-governed agent is not necessarily a member of
  that team even in deployments whose policy layer is otherwise membership-scoped. This is
  accepted platform behavior, not a defect this hook is meant to close.

## Verification

Every item below was run against the code in this PR, not assumed.

**A pattern sweep over every added line** (checked for internal paths, unrelated tracker
references, and non-public terminology) returned no matches.

**The hook is invoked by keyword, never positionally:**
```
$ grep -n "_team_connector_visibility_hook(db, team_id=int(team_id))" src/xagent/web/services/connector_team_scope.py
87:    return _team_connector_visibility_hook(db, team_id=int(team_id))
```
Backed by two tests: one records the call and asserts it was made with `team_id=` as a keyword
and never for a `None` team; a second installs a positional-only callable and asserts it raises
`TypeError`. Both pass.

**The failure wrap matches the existing wrap shape used at the sibling read point** (log with a
traceback, then raise the same typed error class with the same status code and error code, only
the identifying value and the `reason` differ, as they must — different seams, different
resources):
```python
# MCP team-scope seam
except Exception as exc:
    logger.warning(
        "Failed to resolve team connector scope for user %s",
        self._user_id,
        exc_info=True,
    )
    raise ConnectorRuntimeError(
        ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
        "Connector team scope is unavailable.",
        details={"reason": "team_scope_resolution_failed"},
        status_code=503,
    ) from exc

# connector-runtime-context seam (pre-existing, for comparison)
except Exception as exc:
    logger.warning(
        "Failed to resolve connector runtime view for task %s",
        task_id,
        exc_info=True,
    )
    raise ConnectorRuntimeError(
        ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
        "Connector runtime context is unavailable.",
        details={"reason": "runtime_view_resolution_failed"},
        status_code=503,
    ) from exc
```

**The new field on the detached tool-factory prefetch plan carries a closed default,** so the
two pre-existing test call sites that construct it with every field as a keyword argument stay
green without modification:
```
$ uv run pytest tests/web/tools/test_web_tool_config_session_factory.py -p no:warnings
74 passed in 3.54s
```

## Behavior pinned by reverting each piece of the change

For each row below, the described edit was applied on its own, the named tests were run and
confirmed to fail with the given reason, then the edit was reverted and the same tests confirmed
to pass again. This shows each piece of the change is load-bearing — removing any one of them by
itself produces an observable, test-caught regression.

| # | Change reverted | What breaks |
|---|---|---|
| 1 | Restore the inner join on the personal-ownership table (drop the union predicate) | Team-agent resolution loses the team's servers; the query shape check (no join, has `ORDER BY`) fails; agent-team-keying tests fail for every team parameter |
| 2 | Resolve the runner's own team, instead of the agent's, when no team id is supplied | A personal agent gains a team's connectors it should not have; the two read points disagree on a no-team case |
| 3 | Key the MCP loader's team lookup on the runner's team instead of the agent's | A team agent loses the team's servers unless the runner happens to be in that same team; the same read points disagree |
| 4 | Move the emptiness/fallback logic into the shared connector-id lookup instead of the one caller that legitimately needs it | A deployment running only the legacy hook widens beyond what it did before |
| 5 | Drop the `ORDER BY` on the visibility query | The deterministic-order check fails; everything else stays green |
| 6 | Fold the team-scope failure into the existing "servers unavailable" error path instead of keeping its own typed wrap | A broken hook now reports as "every server unavailable" instead of failing the turn with a distinct, typed error |
| 7 | Default the new team-id parameter to a specific team instead of `None` | An unidentified/no-team build silently gains that team's connectors |
| 8 | Drop the team id from the frozen snapshot the tool-build path reads | The snapshot no longer carries the governing agent's team, breaking every downstream consumer that depends on it |
| 9 | Team-key only one of the two read points, leaving the other on its old logic | The two read points disagree for a team agent |
| 10 | Delete the legacy-hook fallback branch entirely | A deployment running only the legacy hook loses connectors it should still see |
| 11 | Select the fallback based on an empty answer instead of hook presence | An installed team hook that legitimately answers "this team owns nothing" gets silently overridden by the old per-user behavior |
| 12 | Call the hook positionally instead of by keyword | Hook-invocation tests fail with a `TypeError`; several other tests whose fixtures use keyword-only hook signatures also fail for the same underlying reason |
| 13 | Remove the typed failure wrap and let a raw hook exception propagate | The exception type changes to an untyped one, which a broader upstream handler silently drops with only a log warning instead of failing the turn |
| 14 | Drop the team id from the detached tool-factory prefetch plan | The prefetch plan's team id silently reverts to `None`, undetected without a dedicated test |
| 15 | Delete the team-id derivation on the snapshot branch that builds the tool config | The tool config never receives the agent's team id, so its selected connectors stay personal-only |
| 16 | Remove the team id argument from any of the three connector-runtime helper functions individually | Each is independently required: dropping it from any one causes that function's own selection or validation logic to lose the team connector, while the other two continue to work |
| 17 | Remove the shape check on the team-visibility hook's answer | A hook returning a malformed answer (for example, a string where a set of ids belongs) no longer raises anywhere: it is silently misinterpreted deeper in the call chain instead of failing clearly and immediately at the point of resolution |
| 18 | Fall back to the legacy user-keyed overlay whenever there is no governing agent, even with the new hook installed | A personal agent (or any agent-less run) would inherit its owner's team-shared connectors again — the runner-keyed behavior this change removes, reintroduced for exactly the population it was removed from |
| 19 | Let a delegated sub-agent's tool config inherit its parent's governing team instead of staying closed | A delegated sub-agent — whose identity is restored from a persisted snapshot with no re-authorization at that point — would gain a team's connectors, and their credentials, off state nobody re-checks at delegation time |
| 20 | Union the new-hook branch's `"custom_api"` grant instead of narrowing it to an empty set | A team-owned custom API becomes visible at the connector-runtime-context seam again, with no tool loader able to build it — selectable and persistable, never executable |
| 21 | Remove the typed wrap around the team-hook call inside the connector-runtime-context loader | A raising hook's raw message reaches task creation, the web chat endpoint's HTTP response, and a trigger run's stored error message unwrapped, instead of the typed, safe `ConnectorRuntimeError` |
| 22 | Remove the `except ConnectorRuntimeError` mapping in the web chat task-creation endpoint | A raising team hook surfaces as a generic HTTP 500 instead of a 503 with the typed reason |
| 23 | Remove the classified-failure wrap around the per-tool-call MCP connection refresh's delegated (non-resolver) branch | A team hook failure during a per-tool-call refresh propagates as an unhandled exception out of the tool call instead of returning a classified failure result |

Every row above was executed for real, individually, with the exact edit undone before moving to
the next row.

## Test totals

```
$ uv run pytest <touched/added test files> -p no:warnings
365 passed in 18.68s

$ uv run pytest tests/web/tools/ --timeout=300 -p no:warnings
507 passed in 12.86s

$ uv run pytest tests/web/services/ --timeout=300 -p no:warnings
1005 passed, 79 skipped in 47.41s

$ uv run pytest tests/web/tools/ tests/web/services/ tests/core/tools/adapters/vibe/ \
    tests/core/tools/test_agent_tool_connector_team_scope.py tests/web/api/ \
    tests/web/test_connector_team_agent_e2e.py tests/web/test_team_sharing_hooks.py \
    tests/web/test_agent_manager_reconstruction.py tests/web/test_connector_runtime_entrypoints_e2e.py \
    --timeout=500 -p no:warnings
3644 passed, 79 skipped (postgres-only tests, no local Postgres configured) in 322.35s
```

`pre-commit` (ruff, mypy, isort, codespell) passes clean on every changed file.
