### PR TITLE
ci(frontend): discover all App Router tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,10 +670,12 @@ jobs:
       # and App Router suites so newly added tests are discovered automatically.
       - name: Run frontend test manifest contract
         working-directory: ./frontend
+        shell: bash
         run: npm run test:ci-manifest
 
       - name: Run page component tests
         working-directory: ./frontend
+        shell: bash
         run: npm run test:pages
 
       - name: Run App Router tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,19 +666,26 @@ jobs:
         run: npm run test:widget:coverage
 
       # The widget lane above is an explicit regression suite for the widget,
-      # Session, and browser-auth contracts. Keep this broader page-directory
+      # Session, and browser-auth contracts. Keep the broader page-directory
       # suite so unrelated page components are still discovered automatically.
-      # TODO: widen this to the full `npm run test:run` suite once the known
-      # failures in src/components/kb/knowledge-base-creation-dialog.test.tsx,
-      # src/components/kb/knowledge-base-detail.component.test.tsx and
-      # src/app/workforces/workforces-routes.test.tsx are fixed.
+      # The full `npm run test:run` suite still has a known failure in
+      # src/components/kb/knowledge-base-detail.component.test.tsx, so keep
+      # these focused required lanes until that suite is green.
+      - name: Run frontend test manifest contract
+        working-directory: ./frontend
+        run: npm run test:ci-manifest
+
       - name: Run page component tests
         working-directory: ./frontend
         run: npm run test:pages
 
-      - name: Run Home and Build page tests
+      - name: Run App Router tests
         working-directory: ./frontend
-        run: npm run test:home-build-pages
+        run: npm run test:app-pages
+
+      - name: Run Home and Build supporting contract tests
+        working-directory: ./frontend
+        run: npm run test:home-build-contracts
 
       # Static export is the default build (served by FastAPI in the pip/uvx
       # deployment). Verify it produces a servable bundle: index shell plus the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,10 +667,7 @@ jobs:
 
       # The widget lane above is an explicit regression suite for the widget,
       # Session, and browser-auth contracts. Keep the broader page-directory
-      # suite so unrelated page components are still discovered automatically.
-      # The full `npm run test:run` suite still has a known failure in
-      # src/components/kb/knowledge-base-detail.component.test.tsx, so keep
-      # these focused required lanes until that suite is green.
+      # and App Router suites so newly added tests are discovered automatically.
       - name: Run frontend test manifest contract
         working-directory: ./frontend
         run: npm run test:ci-manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,8 +666,9 @@ jobs:
         run: npm run test:widget:coverage
 
       # The widget lane above is an explicit regression suite for the widget,
-      # Session, and browser-auth contracts. Keep the broader page-directory
-      # and App Router suites so newly added tests are discovered automatically.
+      # Session, and browser-auth contracts. Keep the broader page-directory,
+      # KB component, and App Router suites so newly added tests are discovered
+      # automatically.
       - name: Run frontend test manifest contract
         working-directory: ./frontend
         shell: bash
@@ -677,6 +678,10 @@ jobs:
         working-directory: ./frontend
         shell: bash
         run: npm run test:pages
+
+      - name: Run knowledge base component tests
+        working-directory: ./frontend
+        run: npm run test:kb-components
 
       - name: Run App Router tests
         working-directory: ./frontend

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -75,7 +75,8 @@
         "@types/marked": "^5.0.0",
         "@vitest/coverage-v8": "^2.1.9",
         "jsdom": "^25.0.0",
-        "vitest": "^2.1.9"
+        "vitest": "^2.1.9",
+        "yaml": "^2.8.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -12712,6 +12713,19 @@
       "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:pages": "vitest run --config vitest.config.ts src/components/pages src/ci/frontend-test-manifest.test.ts",
+    "test:kb-components": "vitest run --config vitest.config.ts src/components/kb",
     "test:ci-manifest": "vitest run --config vitest.config.ts src/ci/frontend-test-manifest.test.ts",
     "test:app-pages": "vitest run --config vitest.config.ts src/app",
     "test:home-build-contracts": "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,10 @@
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:pages": "vitest run --config vitest.config.ts src/components/pages",
-    "test:home-build-pages": "vitest run --config vitest.config.ts src/app/build/ src/app/page.test.tsx src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts",
+    "test:pages": "vitest run --config vitest.config.ts src/components/pages src/ci/frontend-test-manifest.test.ts",
+    "test:ci-manifest": "vitest run --config vitest.config.ts src/ci/frontend-test-manifest.test.ts",
+    "test:app-pages": "vitest run --config vitest.config.ts src/app",
+    "test:home-build-contracts": "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts",
     "test:widget": "vitest run --config vitest.widget.config.ts",
     "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,6 +85,7 @@
     "@types/marked": "^5.0.0",
     "@vitest/coverage-v8": "^2.1.9",
     "jsdom": "^25.0.0",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "yaml": "^2.8.1"
   }
 }

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -751,12 +751,10 @@ describe("Home", () => {
     }
   })
 
-  it("keeps the Home replacement contract, resolver, interaction owner, and cumulative manifest non-vacuously source-locked", () => {
+  it("keeps the Home replacement contract, resolver, and interaction owner non-vacuously source-locked", () => {
     const contractsSource = readFileSync("src/lib/page-extension-contracts.ts", "utf8")
     const extensionSource = readFileSync("src/lib/home-page-extension.tsx", "utf8")
     const pageSource = readFileSync("src/app/page.tsx", "utf8")
-    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as { scripts: Record<string, string> }
-    const expectedManifest = "vitest run --config vitest.config.ts src/app/build/ src/app/page.test.tsx src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts"
     const contractInterface = sourceSlice(
       contractsSource,
       "export interface HomeGetStartedDestinationOverrides",
@@ -793,7 +791,6 @@ describe("Home", () => {
     expect(cardRender.match(/resolveHomeGetStartedDestination\(/g)).toHaveLength(3)
     expect(cardRender.match(/defaultHomeGetStartedDestinations\./g)).toHaveLength(3)
     expect(cardRender).not.toMatch(/https:\/\/docs\.xagent\.co\//)
-    expect(packageJson.scripts["test:home-build-pages"]).toBe(expectedManifest)
   })
 
   it("uses the shared resolver, real task body parser, and ordered successful commit", async () => {

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -3,10 +3,12 @@
  * and vitest.config.ts discovery. test:ci-manifest and test:pages are independent
  * launchers; legitimate changes update the owner files and these invariants together.
  */
+import { spawnSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { isMap, isScalar, parseDocument } from "yaml"
+import { isMap, isScalar, isSeq, parseDocument } from "yaml"
+import type { Node } from "yaml"
 import { describe, expect, it, vi } from "vitest"
 import vitestConfig from "../../vitest.config"
 
@@ -26,6 +28,26 @@ const ciSummaryCondition =
   "always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)"
 const frontendSummaryCheckCommand =
   'check_job "frontend-build" "${{ needs[\'frontend-build\'].result }}"'
+const ciSummaryFailurePropagationCommands = [
+  "set -e",
+  "failed=0",
+  "check_job() {",
+  'local name="$1"',
+  'local result="$2"',
+  'if [ "$result" != "success" ]; then',
+  'echo "::error::$name finished with result: $result"',
+  "failed=1",
+  "fi",
+  "}",
+  'check_job "prepare-deepdoc-cache" "${{ needs[\'prepare-deepdoc-cache\'].result }}"',
+  'check_job "pre-commit" "${{ needs[\'pre-commit\'].result }}"',
+  'check_job "pytest-fast" "${{ needs[\'pytest-fast\'].result }}"',
+  'check_job "pytest-fast-deepdoc" "${{ needs[\'pytest-fast-deepdoc\'].result }}"',
+  'check_job "pytest-slow" "${{ needs[\'pytest-slow\'].result }}"',
+  'check_job "e2e" "${{ needs.e2e.result }}"',
+  frontendSummaryCheckCommand,
+  'exit "$failed"',
+] as const
 const requiredFrontendSteps = [
   { command: "npm run test:widget:coverage", requiresExplicitBash: false },
   { command: "npm run test:ci-manifest", requiresExplicitBash: true },
@@ -37,6 +59,7 @@ const requiredFrontendSteps = [
 const moduleDir = path.dirname(fileURLToPath(import.meta.url))
 const packageJsonPath = path.resolve(moduleDir, "../../package.json")
 const workflowPath = path.resolve(moduleDir, "../../../.github/workflows/ci.yml")
+const realWorkflowSource = readFileSync(workflowPath, "utf8")
 
 function replaceExactlyOnce(source: string, search: string, replacement: string, owner: string) {
   if (search.length === 0) {
@@ -65,7 +88,7 @@ function countOccurrences(source: string, search: string) {
   return count
 }
 
-function replaceWorkflowJob(source: string, jobName: string, replacement: string, owner: string) {
+function parseWorkflowDocument(source: string, owner?: string) {
   const document = parseDocument(source, {
     version: "1.2",
     uniqueKeys: true,
@@ -73,8 +96,23 @@ function replaceWorkflowJob(source: string, jobName: string, replacement: string
     keepSourceTokens: true,
   })
   if (document.errors.length > 0) {
+    if (owner !== undefined) {
+      throw new Error(`${owner} requires valid YAML`)
+    }
     throw document.errors[0]
   }
+  if (document.warnings.length > 0) {
+    const warning = document.warnings[0]!
+    if (owner !== undefined) {
+      throw new Error(`${owner} requires warning-free YAML [${warning.code ?? "UNKNOWN"}]`)
+    }
+    throw new Error(`workflow YAML warning [${warning.code ?? "UNKNOWN"}]`)
+  }
+  return document
+}
+
+function replaceWorkflowJob(source: string, jobName: string, replacement: string, owner: string) {
+  const document = parseWorkflowDocument(source, owner)
 
   const workflow = document.contents
   const jobs = isMap(workflow) ? workflow.get("jobs", true) : undefined
@@ -110,6 +148,51 @@ function replaceWorkflowJob(source: string, jobName: string, replacement: string
   return mutated
 }
 
+function removeWorkflowStepByCommand(
+  source: string,
+  jobName: string,
+  command: string,
+  owner: string,
+) {
+  const document = parseWorkflowDocument(source, owner)
+  const workflow = document.contents
+  const jobs = isMap(workflow) ? workflow.get("jobs", true) : undefined
+  if (!isMap(jobs)) {
+    throw new Error(`${owner} requires a jobs mapping`)
+  }
+
+  const job = jobs.get(jobName, true)
+  if (!isMap(job)) {
+    throw new Error(`${owner} requires jobs.${jobName} to be a mapping`)
+  }
+
+  const steps = job.get("steps", true)
+  if (!isSeq(steps)) {
+    throw new Error(`${owner} requires jobs.${jobName}.steps to be a sequence`)
+  }
+
+  const matches = steps.items.filter((step): step is Node => {
+    const run = isMap(step) ? step.get("run", true) : undefined
+    return isScalar(run) && run.value === command
+  })
+  if (matches.length !== 1) {
+    throw new Error(`${owner} must match exactly one ${jobName} step; found ${matches.length}`)
+  }
+
+  const step = matches[0]!
+  if (step.range == null) {
+    throw new Error(`${owner} matched step must have a source range`)
+  }
+  const stepStart = source.lastIndexOf("\n", step.range[0] - 1) + 1
+  const lineEnd = source.indexOf("\n", step.range[2])
+  const stepEnd = lineEnd === -1 ? source.length : lineEnd + 1
+  const mutated = `${source.slice(0, stepStart)}${source.slice(stepEnd)}`
+  if (mutated === source) {
+    throw new Error(`${owner} mutation must change the source`)
+  }
+  return mutated
+}
+
 function requireRecord(value: unknown, owner: string): asserts value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`${owner} must be an object`)
@@ -131,6 +214,83 @@ function assertBashCompatibleDefaultShell(value: Record<string, unknown>, owner:
   requireRecord(run, `${owner}.defaults.run`)
   if (run.shell !== undefined && run.shell !== "bash") {
     throw new Error(`${owner} defaults.run.shell must be bash when set`)
+  }
+}
+
+function assertWorkflowTriggerContract(workflow: Record<string, unknown>) {
+  requireRecord(workflow.on, "workflow triggers")
+  const triggers = workflow.on
+  for (const trigger of ["workflow_dispatch", "pull_request", "push", "merge_group"]) {
+    if (!Object.hasOwn(triggers, trigger)) {
+      throw new Error(`workflow triggers must include ${trigger}`)
+    }
+  }
+
+  requireRecord(triggers.pull_request, "workflow pull_request")
+  const pullRequest = triggers.pull_request
+  if (
+    !Array.isArray(pullRequest.branches) ||
+    pullRequest.branches.filter((branch) => branch === "main").length !== 1
+  ) {
+    throw new Error("workflow pull_request.branches must contain main exactly once")
+  }
+  if (pullRequest.paths !== undefined || pullRequest["paths-ignore"] !== undefined) {
+    throw new Error("workflow pull_request must not set paths or paths-ignore")
+  }
+  const requiredPullRequestTypes = ["opened", "synchronize", "reopened", "ready_for_review"]
+  const pullRequestTypes = pullRequest.types
+  if (
+    !Array.isArray(pullRequestTypes) ||
+    pullRequestTypes.length !== requiredPullRequestTypes.length ||
+    requiredPullRequestTypes.some(
+      (type) => pullRequestTypes.filter((candidate) => candidate === type).length !== 1,
+    )
+  ) {
+    throw new Error(
+      "workflow pull_request.types must contain opened, synchronize, reopened, ready_for_review exactly once",
+    )
+  }
+}
+
+function getNonEmptyScriptCommands(run: string) {
+  return run
+    .split(/\r?\n/)
+    .map((line, index) => ({ index, value: line.trim() }))
+    .filter(({ value }) => value !== "" && !value.startsWith("#"))
+}
+
+function executeCiSummaryScript(source: string) {
+  const workflow = parseWorkflowDocument(source).toJS({ maxAliasCount: 100 })
+  requireRecord(workflow, "workflow root")
+  requireRecord(workflow.jobs, "jobs")
+  requireRecord(workflow.jobs["ci-summary"], "jobs.ci-summary")
+  const ciSummary = workflow.jobs["ci-summary"]
+  if (!Array.isArray(ciSummary.steps)) {
+    throw new Error("jobs.ci-summary.steps must be an array")
+  }
+  const checkStep = ciSummary.steps.find((step) => {
+    requireRecord(step, "jobs.ci-summary.steps entry")
+    return step.name === "Check required jobs"
+  })
+  requireRecord(checkStep, "Check required jobs")
+  if (typeof checkStep.run !== "string") {
+    throw new Error("Check required jobs run must be a string")
+  }
+
+  const expandedScript = checkStep.run.replace(
+    /\$\{\{ needs(?:\[['"][^'"]+['"]\]|\.[A-Za-z0-9_-]+)\.result \}\}/g,
+    "failure",
+  )
+  return spawnSync("bash", ["-c", expandedScript], { encoding: "utf8" })
+}
+
+function assertCiSummaryFailurePropagation(run: string) {
+  const commands = getNonEmptyScriptCommands(run).map(({ value }) => value)
+  if (
+    commands.length !== ciSummaryFailurePropagationCommands.length ||
+    commands.some((command, index) => command !== ciSummaryFailurePropagationCommands[index])
+  ) {
+    throw new Error("Check required jobs must use the supported failure-propagation command sequence")
   }
 }
 
@@ -183,31 +343,23 @@ function assertCiSummaryContract(jobs: Record<string, unknown>) {
   if (frontendCheckLines.length !== 1) {
     throw new Error("Check required jobs must check frontend-build exactly once")
   }
+  assertCiSummaryFailurePropagation(run)
 }
 
 function assertSemanticWorkflowManifest(source: string) {
-  const document = parseDocument(source, {
-    version: "1.2",
-    uniqueKeys: true,
-    merge: false,
-  })
-
-  if (document.errors.length > 0) {
-    throw document.errors[0]
-  }
-  if (document.warnings.length > 0) {
-    const warning = document.warnings[0]!
-    throw new Error(`workflow YAML warning [${warning.code ?? "UNKNOWN"}]`)
-  }
-
+  const document = parseWorkflowDocument(source)
   const workflow = document.toJS({ maxAliasCount: 100 })
   requireRecord(workflow, "workflow root")
+  assertWorkflowTriggerContract(workflow)
   requireRecord(workflow.jobs, "jobs")
   assertCiSummaryContract(workflow.jobs)
   const frontendBuild = workflow.jobs["frontend-build"]
   requireRecord(frontendBuild, "jobs.frontend-build")
   if (!Array.isArray(frontendBuild.steps)) {
     throw new Error("jobs.frontend-build.steps must be an array")
+  }
+  if (frontendBuild["runs-on"] !== "ubuntu-latest") {
+    throw new Error("jobs.frontend-build.runs-on must be ubuntu-latest")
   }
 
   assertBashCompatibleDefaultShell(workflow, "workflow root")
@@ -256,16 +408,209 @@ function assertSemanticWorkflowManifest(source: string) {
   }
 }
 
-function readWorkflowSource() {
-  return readFileSync(workflowPath, "utf8")
-}
-
 describe("frontend CI test manifest", () => {
   it.each([
-    ["LF", readWorkflowSource()],
-    ["CRLF", readWorkflowSource().replace(/\r?\n/g, "\r\n")],
+    ["LF", realWorkflowSource],
+    ["CRLF", realWorkflowSource.replace(/\r?\n/g, "\r\n")],
   ])("accepts the real workflow with %s line endings", (_, source) => {
     expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+  })
+
+  it("removes the App Router step semantically when its presentation drifts", () => {
+    const workflowSource = realWorkflowSource
+    const source = replaceExactlyOnce(
+      workflowSource,
+      "      - name: Run App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n",
+      "      - run: npm run test:app-pages\n        env:\n          APP_ROUTER_TEST_MODE: manifest\n        working-directory: ./frontend\n        name: Run App Router tests\n",
+      "App Router step presentation drift",
+    )
+    const followingJobs = source.slice(source.indexOf("\n  ci-summary:\n"))
+    const withoutAppStep = removeWorkflowStepByCommand(
+      source,
+      "frontend-build",
+      "npm run test:app-pages",
+      "App Router step removal",
+    )
+
+    expect(withoutAppStep).toContain(followingJobs)
+    expect(withoutAppStep).toContain("# The widget lane above is an explicit regression suite")
+    expect(() => assertSemanticWorkflowManifest(withoutAppStep)).toThrow(
+      "npm run test:app-pages must appear in exactly one frontend step",
+    )
+  })
+
+  it("rejects pull request trigger path masking", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      "  pull_request:\n    branches: [main]\n",
+      "  pull_request:\n    branches: [main]\n    paths-ignore: [frontend/**]\n",
+      "pull_request paths-ignore insertion",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "workflow pull_request must not set paths or paths-ignore",
+    )
+  })
+
+  it("rejects a closed-only pull request trigger type", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      "    types: [opened, synchronize, reopened, ready_for_review]\n",
+      "    types: [closed]\n",
+      "closed-only pull_request type",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "workflow pull_request.types must contain opened, synchronize, reopened, ready_for_review exactly once",
+    )
+  })
+
+  it("rejects a pull request trigger without synchronize", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      "    types: [opened, synchronize, reopened, ready_for_review]\n",
+      "    types: [opened, reopened, ready_for_review]\n",
+      "missing synchronize pull_request type",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "workflow pull_request.types must contain opened, synchronize, reopened, ready_for_review exactly once",
+    )
+  })
+
+  it("rejects a pull request trigger without ready_for_review", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      "    types: [opened, synchronize, reopened, ready_for_review]\n",
+      "    types: [opened, synchronize, reopened]\n",
+      "missing ready_for_review pull_request type",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "workflow pull_request.types must contain opened, synchronize, reopened, ready_for_review exactly once",
+    )
+  })
+
+  it.each([
+    ["pull_request", "  pull_request:\n", "  pull-request:\n"],
+    ["merge_group", "  merge_group:\n", "  merge-group:\n"],
+  ])("requires the %s workflow trigger", (_, search, replacement) => {
+    const source = replaceExactlyOnce(realWorkflowSource, search, replacement, `${_} trigger`)
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      `workflow triggers must include ${_}`,
+    )
+  })
+
+  it("requires the frontend build runner contract", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      "  frontend-build:\n    runs-on: ubuntu-latest\n",
+      "  frontend-build:\n    runs-on: windows-latest\n",
+      "frontend-build runner",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "jobs.frontend-build.runs-on must be ubuntu-latest",
+    )
+  })
+
+  it("rejects a no-op summary function", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      '          check_job() {\n            local name="$1"\n            local result="$2"\n            if [ "$result" != "success" ]; then\n              echo "::error::$name finished with result: $result"\n              failed=1\n            fi\n          }\n',
+      "          check_job() {\n            :\n          }\n",
+      "check_job function body",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "Check required jobs must use the supported failure-propagation command sequence",
+    )
+  })
+
+  it("rejects an inverted summary result condition", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      'if [ "$result" != "success" ]; then',
+      'if [ "$result" = "success" ]; then',
+      "check_job result condition",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "Check required jobs must use the supported failure-propagation command sequence",
+    )
+  })
+
+  it("accepts summary comments and blank lines", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      "          failed=0\n",
+      "          # initialize the aggregate result\n\n          failed=0\n",
+      "summary comment insertion",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+  })
+
+  it("runs the accepted summary script to a failed result", () => {
+    const result = executeCiSummaryScript(realWorkflowSource)
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(1)
+  })
+
+  it("rejects an early return in check_job that leaves failed clear", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      '          check_job() {\n            local name="$1"\n',
+      '          check_job() {\n            return 0\n            local name="$1"\n',
+      "check_job early return",
+    )
+
+    expect(executeCiSummaryScript(source).status).toBe(0)
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "Check required jobs must use the supported failure-propagation command sequence",
+    )
+  })
+
+  it("rejects a later function-form check_job redefinition", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      '          }\n\n          check_job "prepare-deepdoc-cache"',
+      '          }\n\n          function check_job { :; }\n\n          check_job "prepare-deepdoc-cache"',
+      "check_job redefinition",
+    )
+
+    expect(executeCiSummaryScript(source).status).toBe(0)
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "Check required jobs must use the supported failure-propagation command sequence",
+    )
+  })
+
+  it("rejects an early successful summary exit", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      "          failed=0\n",
+      "          failed=0\n          exit 0\n",
+      "early summary exit",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "Check required jobs must use the supported failure-propagation command sequence",
+    )
+  })
+
+  it("requires the failed exit to be terminal", () => {
+    const source = replaceExactlyOnce(
+      realWorkflowSource,
+      '          exit "$failed"\n',
+      '          exit "$failed"\n          echo "summary complete"\n',
+      "summary terminal exit",
+    )
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "Check required jobs must use the supported failure-propagation command sequence",
+    )
   })
 
   it.each([
@@ -297,7 +642,7 @@ describe("frontend CI test manifest", () => {
       },
     ],
   ])("accepts %s", (_, transform) => {
-    const source = transform(readWorkflowSource())
+    const source = transform(realWorkflowSource)
 
     expect(source).toContain("&manifest_base")
     expect(source).toContain("*manifest_base")
@@ -306,13 +651,11 @@ describe("frontend CI test manifest", () => {
 
   it("accepts a folded required command with the same semantic value", () => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "        run: npm run test:app-pages\n",
       "        run: >-\n          npm run\n          test:app-pages\n",
       "App Router command",
     )
-
-    expect(source).not.toBe(readWorkflowSource())
     expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
   })
 
@@ -323,13 +666,11 @@ describe("frontend CI test manifest", () => {
     "npm run test:home-build-contracts",
   ])("accepts an explicit bash shell on the %s non-launcher step", (command) => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       `        run: ${command}\n`,
       `        shell: bash\n        run: ${command}\n`,
       `${command} shell insertion`,
     )
-
-    expect(source).not.toBe(readWorkflowSource())
     expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
   })
 
@@ -355,9 +696,7 @@ describe("frontend CI test manifest", () => {
         ),
     ],
   ])("accepts an explicit bash default at %s scope", (_, transform) => {
-    const source = transform(readWorkflowSource())
-
-    expect(source).not.toBe(readWorkflowSource())
+    const source = transform(realWorkflowSource)
     expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
   })
 
@@ -395,14 +734,14 @@ describe("frontend CI test manifest", () => {
       "npm run test:pages has an unexpected shell policy",
     ],
   ])("requires explicit bash for the %s", (_, transform, expectedError) => {
-    const source = transform(readWorkflowSource())
+    const source = transform(realWorkflowSource)
 
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(expectedError)
   })
 
   it("accepts a colon-shaped line in a block scalar", () => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "        run: npm run build\n",
       "        run: |\n          echo 'label: value'\n          npm run build\n",
       "frontend build command",
@@ -413,7 +752,7 @@ describe("frontend CI test manifest", () => {
   })
 
   it("rejects an unknown YAML directive warning before conversion", () => {
-    const workflowSource = readWorkflowSource()
+    const workflowSource = realWorkflowSource
     const source = `%BAD_DIRECTIVE\n---\n${workflowSource}`
 
     expect(source).not.toBe(workflowSource)
@@ -437,7 +776,7 @@ describe("frontend CI test manifest", () => {
       { length: 101 },
       (_, index) => `  manifest-alias-${index + 1}: *manifest_base`,
     ).join("\n")
-    const workflowSource = readWorkflowSource()
+    const workflowSource = realWorkflowSource
     const source = replaceExactlyOnce(
       workflowSource,
       "\n  ci-summary:\n",
@@ -490,14 +829,12 @@ describe("frontend CI test manifest", () => {
       "jobs.frontend-build.steps must be an array",
     ],
   ])("rejects %s at its intended owner", (_, transform, expectedError) => {
-    const source = transform(readWorkflowSource())
-
-    expect(source).not.toBe(readWorkflowSource())
+    const source = transform(realWorkflowSource)
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(expectedError)
   })
 
   it("rejects semantically complete duplicate jobs and frontend-build mappings", () => {
-    const workflowSource = readWorkflowSource()
+    const workflowSource = realWorkflowSource
     const duplicateJobs = `${replaceExactlyOnce(
       workflowSource,
       "\njobs:\n",
@@ -528,12 +865,10 @@ describe("frontend CI test manifest", () => {
   })
 
   it("rejects a required command moved to a sibling job", () => {
-    const appStep =
-      "\n      - name: Run App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n"
-    const withoutAppStep = replaceExactlyOnce(
-      readWorkflowSource(),
-      appStep,
-      "",
+    const withoutAppStep = removeWorkflowStepByCommand(
+      realWorkflowSource,
+      "frontend-build",
+      "npm run test:app-pages",
       "App Router step removal",
     )
     const source = replaceExactlyOnce(
@@ -543,33 +878,36 @@ describe("frontend CI test manifest", () => {
       "ci-summary insertion point",
     )
 
-    expect(source).not.toContain(appStep)
     expect(source).toContain("  manifest-sibling:\n")
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(
       "npm run test:app-pages must appear in exactly one frontend step",
     )
   })
 
-  it("fails the moved-to-sibling mutation when the App step owner drifts", () => {
-    const workflowSource = readWorkflowSource()
+  it("keeps the moved-to-sibling fixture live when the App step presentation drifts", () => {
+    const workflowSource = realWorkflowSource
     const driftedSource = replaceExactlyOnce(
       workflowSource,
-      "      - name: Run App Router tests\n",
-      "      - name: Renamed App Router tests\n",
-      "App Router step name",
+      "      - name: Run App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n",
+      "      - run: npm run test:app-pages\n        env:\n          APP_ROUTER_TEST_MODE: manifest\n        working-directory: ./frontend\n        name: Run App Router tests\n",
+      "App Router step presentation drift",
     )
-    const appStep =
-      "\n      - name: Run App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n"
+    const withoutAppStep = removeWorkflowStepByCommand(
+      driftedSource,
+      "frontend-build",
+      "npm run test:app-pages",
+      "App Router step removal",
+    )
 
     expect(driftedSource).not.toBe(workflowSource)
-    expect(() => replaceExactlyOnce(driftedSource, appStep, "", "App Router step removal")).toThrow(
-      "App Router step removal must appear exactly once; found 0",
+    expect(() => assertSemanticWorkflowManifest(withoutAppStep)).toThrow(
+      "npm run test:app-pages must appear in exactly one frontend step",
     )
   })
 
   it("rejects a same-job heredoc decoy after the real pages step is removed", () => {
     const withoutPagesStep = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "\n      - name: Run page component tests\n        working-directory: ./frontend\n        shell: bash\n        run: npm run test:pages\n",
       "",
       "pages launcher step removal",
@@ -589,7 +927,7 @@ describe("frontend CI test manifest", () => {
   })
 
   it("rejects missing and duplicate required semantic steps", () => {
-    const source = readWorkflowSource()
+    const source = realWorkflowSource
     const missing = replaceExactlyOnce(
       source,
       "        run: npm run test:app-pages\n",
@@ -614,7 +952,7 @@ describe("frontend CI test manifest", () => {
   })
 
   it("rejects missing and duplicate KB directory steps", () => {
-    const workflowSource = readWorkflowSource()
+    const workflowSource = realWorkflowSource
     const kbStep =
       "\n      - name: Run knowledge base component tests\n        working-directory: ./frontend\n        run: npm run test:kb-components\n"
     const missing = replaceExactlyOnce(workflowSource, kbStep, "", "KB test step removal")
@@ -637,7 +975,7 @@ describe("frontend CI test manifest", () => {
 
   it("rejects a required step with the wrong working directory", () => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "      - name: Run App Router tests\n        working-directory: ./frontend\n",
       "      - name: Run App Router tests\n        working-directory: .\n",
       "App Router working directory",
@@ -651,7 +989,7 @@ describe("frontend CI test manifest", () => {
 
   it("rejects a required step-level condition", () => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "      - name: Run App Router tests\n",
       "      - name: Run App Router tests\n        if: github.event_name == 'schedule'\n",
       "App Router step condition",
@@ -665,7 +1003,7 @@ describe("frontend CI test manifest", () => {
 
   it("rejects custom shells on non-launcher required steps", () => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "      - name: Run App Router tests\n        working-directory: ./frontend\n",
       "      - name: Run App Router tests\n        working-directory: ./frontend\n        shell: echo {0}\n",
       "App Router step shell",
@@ -699,7 +1037,7 @@ describe("frontend CI test manifest", () => {
         ),
     ],
   ])("rejects a non-bash %s launcher", (_, transform) => {
-    const source = transform(readWorkflowSource())
+    const source = transform(realWorkflowSource)
 
     expect(source).toContain("        shell: echo {0}\n")
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(
@@ -731,9 +1069,7 @@ describe("frontend CI test manifest", () => {
       "jobs.frontend-build must not set continue-on-error",
     ],
   ])("rejects %s", (_, transform, expectedError) => {
-    const source = transform(readWorkflowSource())
-
-    expect(source).not.toBe(readWorkflowSource())
+    const source = transform(realWorkflowSource)
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(expectedError)
   })
 
@@ -759,9 +1095,7 @@ describe("frontend CI test manifest", () => {
         ),
     ],
   ])("rejects a custom default shell at %s scope", (owner, transform) => {
-    const source = transform(readWorkflowSource())
-
-    expect(source).not.toBe(readWorkflowSource())
+    const source = transform(realWorkflowSource)
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(
       `${owner} defaults.run.shell must be bash when set`,
     )
@@ -791,9 +1125,7 @@ describe("frontend CI test manifest", () => {
       "jobs.ci-summary.needs must be an array",
     ],
   ])("rejects %s", (_, transform, expectedError) => {
-    const source = transform(readWorkflowSource())
-
-    expect(source).not.toBe(readWorkflowSource())
+    const source = transform(realWorkflowSource)
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(expectedError)
   })
 
@@ -830,7 +1162,7 @@ describe("frontend CI test manifest", () => {
         ),
     ],
   ])("preserves a complete %s following sibling when mutating ci-summary", (_, block, prepare) => {
-    const workflowSource = `${prepare(readWorkflowSource()).trimEnd()}${block}`
+    const workflowSource = `${prepare(realWorkflowSource).trimEnd()}${block}`
     const source = replaceWorkflowJob(workflowSource, "ci-summary", "", "ci-summary job")
 
     expect(source.slice(-block.length)).toBe(block)
@@ -841,7 +1173,7 @@ describe("frontend CI test manifest", () => {
 
   it("rejects removing frontend-build from ci-summary.needs", () => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "      - frontend-build\n",
       "",
       "ci-summary frontend-build need",
@@ -855,7 +1187,7 @@ describe("frontend CI test manifest", () => {
 
   it("rejects duplicate frontend-build entries in ci-summary.needs", () => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "      - frontend-build\n",
       "      - frontend-build\n      - frontend-build\n",
       "ci-summary frontend-build need",
@@ -869,7 +1201,7 @@ describe("frontend CI test manifest", () => {
 
   it("rejects ci-summary job-level continue-on-error", () => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "  ci-summary:\n",
       "  ci-summary:\n    continue-on-error: true\n",
       "ci-summary owner",
@@ -889,7 +1221,7 @@ describe("frontend CI test manifest", () => {
     ["a different condition", "if: always()"],
   ])("rejects ci-summary with %s", (_, replacement) => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)",
       replacement,
       "ci-summary if policy",
@@ -902,7 +1234,7 @@ describe("frontend CI test manifest", () => {
   })
 
   it("rejects missing and duplicate Check required jobs owner steps", () => {
-    const workflowSource = readWorkflowSource()
+    const workflowSource = realWorkflowSource
     const missing = replaceExactlyOnce(
       workflowSource,
       "      - name: Check required jobs\n",
@@ -938,13 +1270,11 @@ describe("frontend CI test manifest", () => {
     ],
   ])("rejects the summary check step with %s", (_, replacement) => {
     const source = replaceExactlyOnce(
-      readWorkflowSource(),
+      realWorkflowSource,
       "      - name: Check required jobs\n        shell: bash\n        run: |\n",
       `${replacement}        run: |\n`,
       "ci-summary check step contract",
     )
-
-    expect(source).not.toBe(readWorkflowSource())
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(
       _ === "a non-bash shell"
         ? "Check required jobs must use bash"
@@ -955,7 +1285,7 @@ describe("frontend CI test manifest", () => {
   })
 
   it("rejects a missing, duplicate, or non-full-line frontend summary check", () => {
-    const workflowSource = readWorkflowSource()
+    const workflowSource = realWorkflowSource
     const checkLine = 'check_job "frontend-build" "${{ needs[\'frontend-build\'].result }}"'
     const indentedCheckLine = `          ${checkLine}\n`
     const missing = replaceExactlyOnce(
@@ -992,7 +1322,7 @@ describe("frontend CI test manifest", () => {
   })
 
   it("does not accept a frontend summary check decoy outside the owned step", () => {
-    const workflowSource = readWorkflowSource()
+    const workflowSource = realWorkflowSource
     const checkLine = 'check_job "frontend-build" "${{ needs[\'frontend-build\'].result }}"'
     const withoutOwnedCheck = replaceExactlyOnce(
       workflowSource,

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { parseDocument } from "yaml"
 import { describe, expect, it, vi } from "vitest"
 import vitestConfig from "../../vitest.config"
 
@@ -15,138 +16,125 @@ const pagesCommand =
 const appPagesCommand = "vitest run --config vitest.config.ts src/app"
 const homeBuildContractsCommand =
   "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts"
+const requiredFrontendSteps = [
+  { command: "npm run test:widget:coverage", shell: undefined },
+  { command: "npm run test:ci-manifest", shell: "bash" },
+  { command: "npm run test:pages", shell: "bash" },
+  { command: "npm run test:app-pages", shell: undefined },
+  { command: "npm run test:home-build-contracts", shell: undefined },
+] as const
 const moduleDir = path.dirname(fileURLToPath(import.meta.url))
 const packageJsonPath = path.resolve(moduleDir, "../../package.json")
 const workflowPath = path.resolve(moduleDir, "../../../.github/workflows/ci.yml")
 
-function exactLineCount(lines: string[], value: string) {
-  return lines.filter((line) => line === value).length
+function requireRecord(
+  value: unknown,
+  owner: string,
+): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${owner} must be an object`)
+  }
 }
 
-function extractFrontendBuildJob(source: string) {
-  source = source.replace(/\r\n/g, "\n")
-  const yamlHeader =
-    /^( *)(?:([A-Za-z_][A-Za-z0-9_-]*)|'([A-Za-z_][A-Za-z0-9_-]*)'|"([A-Za-z_][A-Za-z0-9_-]*)"):/gm
-  const headers = Array.from(source.matchAll(yamlHeader), (match) => ({
-    indent: match[1]!.length,
-    id: match[2] ?? match[3] ?? match[4] ?? "",
-    index: match.index!,
-  }))
-  const topLevelHeaders = headers.filter(({ indent }) => indent === 0)
-  const jobsHeaders = topLevelHeaders.filter(({ id }) => id === "jobs")
-  expect(jobsHeaders).toHaveLength(1)
+function assertNoDefaultShell(value: Record<string, unknown>, owner: string) {
+  const defaults = value.defaults
+  if (defaults === undefined) {
+    return
+  }
 
-  const jobsHeader = jobsHeaders[0]!
-  const nextTopLevelHeader = topLevelHeaders.find(
-    ({ index }) => index > jobsHeader.index,
-  )
-  const jobsEnd = nextTopLevelHeader?.index ?? source.length
+  requireRecord(defaults, `${owner}.defaults`)
+  const run = defaults.run
+  if (run === undefined) {
+    return
+  }
 
-  const jobHeaders = headers.filter(
-    ({ indent, index }) =>
-      indent === 2 && index > jobsHeader.index && index < jobsEnd,
-  )
-  const frontendHeaders = jobHeaders.filter(
-    ({ id }) => id === "frontend-build",
-  )
+  requireRecord(run, `${owner}.defaults.run`)
+  if (run.shell !== undefined) {
+    throw new Error(`${owner} must not set defaults.run.shell`)
+  }
+}
 
-  expect(frontendHeaders).toHaveLength(1)
+function assertSemanticWorkflowManifest(source: string) {
+  const document = parseDocument(source, {
+    version: "1.2",
+    uniqueKeys: true,
+    merge: false,
+  })
 
-  const frontendHeader = frontendHeaders[0]!
-  const frontendHeaderIndex = jobHeaders.indexOf(frontendHeader)
-  const nextHeader = jobHeaders[frontendHeaderIndex + 1]
-  const endIndex = nextHeader?.index ?? jobsEnd
+  if (document.errors.length > 0) {
+    throw document.errors[0]
+  }
+  if (document.warnings.length > 0) {
+    throw document.warnings[0]
+  }
 
-  return source.slice(frontendHeader.index, endIndex)
+  const workflow = document.toJS({ maxAliasCount: 100 })
+  requireRecord(workflow, "workflow root")
+  requireRecord(workflow.jobs, "jobs")
+  const frontendBuild = workflow.jobs["frontend-build"]
+  requireRecord(frontendBuild, "jobs.frontend-build")
+  if (!Array.isArray(frontendBuild.steps)) {
+    throw new Error("jobs.frontend-build.steps must be an array")
+  }
+
+  assertNoDefaultShell(workflow, "workflow root")
+  assertNoDefaultShell(frontendBuild, "jobs.frontend-build")
+  if (frontendBuild["continue-on-error"] !== undefined) {
+    throw new Error("jobs.frontend-build must not set continue-on-error")
+  }
+
+  for (const step of frontendBuild.steps) {
+    requireRecord(step, "jobs.frontend-build.steps entry")
+    if (step["continue-on-error"] !== undefined) {
+      throw new Error("frontend-build steps must not set continue-on-error")
+    }
+  }
+
+  for (const requiredStep of requiredFrontendSteps) {
+    const matchingSteps = frontendBuild.steps.filter((step) => {
+      requireRecord(step, "jobs.frontend-build.steps entry")
+      return step.run === requiredStep.command
+    })
+
+    if (matchingSteps.length !== 1) {
+      throw new Error(`${requiredStep.command} must appear in exactly one frontend step`)
+    }
+
+    const step = matchingSteps[0]!
+    if (step["working-directory"] !== "./frontend") {
+      throw new Error(`${requiredStep.command} must use ./frontend`)
+    }
+    if (step.if !== undefined) {
+      throw new Error(`${requiredStep.command} must not set if`)
+    }
+    if (step["continue-on-error"] !== undefined) {
+      throw new Error(`${requiredStep.command} must not set continue-on-error`)
+    }
+    if (step.shell !== requiredStep.shell) {
+      throw new Error(`${requiredStep.command} has an unexpected shell policy`)
+    }
+  }
+
+  if (frontendBuild.steps.some((step) => step.run === "npm run test:home-build-pages")) {
+    throw new Error("legacy test:home-build-pages must not run in frontend-build")
+  }
+}
+
+function readWorkflowSource() {
+  return readFileSync(workflowPath, "utf8")
 }
 
 describe("frontend CI test manifest", () => {
-  it("extracts the same frontend-build job from LF and CRLF workflow text", () => {
-    const workflowSource = readFileSync(workflowPath, "utf8")
-    const crlfWorkflowSource = workflowSource.replace(/\r?\n/g, "\r\n")
-
-    expect(extractFrontendBuildJob(crlfWorkflowSource)).toBe(
-      extractFrontendBuildJob(workflowSource),
-    )
-  })
+  it.each([["LF", readWorkflowSource()], ["CRLF", readWorkflowSource().replace(/\r?\n/g, "\r\n")]])(
+    "accepts the real workflow with %s line endings",
+    (_, source) => {
+      expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+    },
+  )
 
   it.each([
     [
-      "a renamed successor",
-      (source: string) =>
-        source.replace("\n  ci-summary:\n", "\n  post-frontend:\n"),
-    ],
-    [
-      "an inserted unquoted successor",
-      (source: string) =>
-        source.replace(
-          "\n  ci-summary:\n",
-          "\n  manifest-sibling:\n    continue-on-error: true\n\n  ci-summary:\n",
-        ),
-    ],
-    [
-      "an inserted single-quoted successor",
-      (source: string) =>
-        source.replace(
-          "\n  ci-summary:\n",
-          "\n  'manifest-sibling':\n    runs-on: ubuntu-latest\n\n  ci-summary:\n",
-        ),
-    ],
-    [
-      "an inserted double-quoted successor",
-      (source: string) =>
-        source.replace(
-          "\n  ci-summary:\n",
-          "\n  \"manifest-sibling\":\n    runs-on: ubuntu-latest\n\n  ci-summary:\n",
-        ),
-    ],
-  ])("keeps the frontend-build slice for %s", (_, updateSource) => {
-    const workflowSource = readFileSync(workflowPath, "utf8")
-    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
-
-    expect(extractFrontendBuildJob(updateSource(workflowSource))).toBe(
-      frontendBuildJob,
-    )
-  })
-
-  it("keeps the frontend-build slice when e2e becomes its successor", () => {
-    const workflowSource = readFileSync(workflowPath, "utf8")
-    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
-    const reorderedWorkflowSource = workflowSource
-      .replace(frontendBuildJob, "")
-      .replace("  e2e:\n", `${frontendBuildJob}  e2e:\n`)
-
-    expect(extractFrontendBuildJob(reorderedWorkflowSource)).toBe(
-      frontendBuildJob,
-    )
-  })
-
-  it("keeps the frontend-build slice when it is the final job at workflow EOF", () => {
-    const workflowSource = readFileSync(workflowPath, "utf8")
-    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
-    const workflowWithoutFrontend = workflowSource.replace(frontendBuildJob, "")
-    const frontendAtEof = `${workflowWithoutFrontend.trimEnd()}\n\n${frontendBuildJob}`
-
-    expect(extractFrontendBuildJob(frontendAtEof)).toBe(frontendBuildJob)
-  })
-
-  it("stops the final frontend-build job before a later top-level workflow key", () => {
-    const workflowSource = readFileSync(workflowPath, "utf8")
-    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
-    const workflowWithoutFrontend = workflowSource.replace(frontendBuildJob, "")
-    const frontendBeforePermissions = `${workflowWithoutFrontend.trimEnd()}\n\n${frontendBuildJob}`
-    const workflowWithPermissions = `${frontendBeforePermissions}permissions:\n  contents: read\n`
-
-    const extractedFrontendBuildJob = extractFrontendBuildJob(workflowWithPermissions)
-
-    expect(extractedFrontendBuildJob).toBe(frontendBuildJob)
-    expect(extractedFrontendBuildJob).not.toContain("permissions:")
-    expect(extractedFrontendBuildJob).not.toContain("contents: read")
-  })
-
-  it.each([
-    [
-      "an anchored successor",
+      "an anchored sibling",
       (source: string) =>
         source.replace(
           "\n  ci-summary:\n",
@@ -154,81 +142,233 @@ describe("frontend CI test manifest", () => {
         ),
     ],
     [
-      "an aliased successor",
+      "an aliased sibling",
       (source: string) =>
         source
-          .replace(
-            "  prepare-deepdoc-cache:\n",
-            "  prepare-deepdoc-cache: &manifest_base\n",
-          )
-          .replace(
-            "\n  ci-summary:\n",
-            "\n  manifest-alias: *manifest_base\n\n  ci-summary:\n",
-          ),
+          .replace("  prepare-deepdoc-cache:\n", "  prepare-deepdoc-cache: &manifest_base\n")
+          .replace("\n  ci-summary:\n", "\n  manifest-alias: *manifest_base\n\n  ci-summary:\n"),
     ],
-  ])("stops before %s sibling job", (_, updateSource) => {
-    const workflowSource = readFileSync(workflowPath, "utf8")
-    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
-    const transformedWorkflowSource = updateSource(workflowSource)
+  ])("accepts %s", (_, transform) => {
+    const source = transform(readWorkflowSource())
 
-    expect(transformedWorkflowSource).not.toBe(workflowSource)
-    expect(transformedWorkflowSource).toContain("&manifest_base")
-    expect(transformedWorkflowSource).toContain("*manifest_base")
-    expect(extractFrontendBuildJob(transformedWorkflowSource)).toBe(
-      frontendBuildJob,
+    expect(source).toContain("&manifest_base")
+    expect(source).toContain("*manifest_base")
+    expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+  })
+
+  it("accepts a folded required command with the same semantic value", () => {
+    const source = readWorkflowSource().replace(
+      "        run: npm run test:app-pages\n",
+      "        run: >-\n          npm run\n          test:app-pages\n",
+    )
+
+    expect(source).not.toBe(readWorkflowSource())
+    expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+  })
+
+  it("accepts a colon-shaped line in a block scalar", () => {
+    const source = readWorkflowSource().replace(
+      "        run: npm run build\n",
+      "        run: |\n          echo 'label: value'\n          npm run build\n",
+    )
+
+    expect(source).toContain("          echo 'label: value'\n")
+    expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+  })
+
+  it("rejects an unknown YAML directive warning before conversion", () => {
+    const workflowSource = readWorkflowSource()
+    const source = `%BAD_DIRECTIVE\n---\n${workflowSource}`
+
+    expect(source).not.toBe(workflowSource)
+    expect(source).toMatch(/^%BAD_DIRECTIVE\n---\n/)
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "Unknown directive %BAD_DIRECTIVE",
     )
   })
 
-  it("rejects duplicate semantic workflow and frontend-build ownership across quoting forms", () => {
-    const workflowSource = readFileSync(workflowPath, "utf8")
-    const workflowWithDuplicateJobs = `${workflowSource.trimEnd()}\n'jobs':\n  fallback:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo duplicate jobs\n`
-    const workflowWithDuplicateFrontendBuild = workflowSource.replace(
+  it("rejects an anchored job expanded through more than 100 aliases", () => {
+    const aliases = Array.from(
+      { length: 101 },
+      (_, index) => `  manifest-alias-${index + 1}: *manifest_base`,
+    ).join("\n")
+    const workflowSource = readWorkflowSource()
+    const source = workflowSource.replace(
       "\n  ci-summary:\n",
-      "\n  'frontend-build':\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo duplicate frontend build\n\n  ci-summary:\n",
+      `\n  manifest-anchor: &manifest_base\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo manifest anchor\n${aliases}\n\n  ci-summary:\n`,
     )
 
-    expect(() => extractFrontendBuildJob(workflowWithDuplicateJobs)).toThrow()
-    expect(() => extractFrontendBuildJob(workflowWithDuplicateFrontendBuild)).toThrow()
+    expect(source).not.toBe(workflowSource)
+    expect(source).toContain("  manifest-anchor: &manifest_base\n")
+    expect(source.match(/manifest-alias-\d+: \*manifest_base/g)).toHaveLength(101)
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
   })
 
   it.each([
     ["an empty source", ""],
-    [
-      "a jobs mapping without frontend-build",
-      "name: Manifest fixture\njobs:\n  fallback:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo fallback\n",
-    ],
-  ])("rejects %s workflow ownership", (_, source) => {
-    expect(() => extractFrontendBuildJob(source)).toThrow()
+    ["malformed YAML", "jobs:\n  frontend-build: ["],
+    ["missing jobs", "name: Manifest fixture\n"],
+    ["a non-mapping jobs owner", "jobs: []\n"],
+    ["missing frontend-build", "jobs: {}\n"],
+    ["a non-mapping frontend-build owner", "jobs:\n  frontend-build: []\n"],
+    ["a non-sequence steps owner", "jobs:\n  frontend-build:\n    steps: {}\n"],
+    ["an unresolved alias", "jobs:\n  frontend-build: *missing\n"],
+  ])("rejects %s", (_, source) => {
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
   })
 
-  it("keeps App Router discovery and required frontend CI lanes source-locked", () => {
+  it("rejects semantically complete duplicate jobs and frontend-build mappings", () => {
+    const workflowSource = readWorkflowSource()
+    const duplicateJobs = `${workflowSource
+      .replace("\njobs:\n", "\njobs: &manifest_jobs\n")
+      .trimEnd()}\n'jobs': *manifest_jobs\n`
+    const duplicateFrontendBuild = workflowSource
+      .replace(
+        "  frontend-build:\n",
+        "  frontend-build: &manifest_frontend_build\n",
+      )
+      .replace(
+        "\n  ci-summary:\n",
+        "\n  'frontend-build': *manifest_frontend_build\n\n  ci-summary:\n",
+      )
+
+    expect(duplicateJobs).not.toBe(workflowSource)
+    expect(duplicateJobs).toContain("jobs: &manifest_jobs\n")
+    expect(duplicateJobs).toContain("'jobs': *manifest_jobs\n")
+    expect(duplicateFrontendBuild).not.toBe(workflowSource)
+    expect(duplicateFrontendBuild).toContain(
+      "frontend-build: &manifest_frontend_build\n",
+    )
+    expect(duplicateFrontendBuild).toContain(
+      "'frontend-build': *manifest_frontend_build\n",
+    )
+    expect(() => assertSemanticWorkflowManifest(duplicateJobs)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(duplicateFrontendBuild)).toThrow()
+  })
+
+  it("rejects a required command moved to a sibling job", () => {
+    const source = readWorkflowSource()
+      .replace(
+        "\n      - name: Run App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n",
+        "",
+      )
+      .replace(
+        "\n  ci-summary:\n",
+        "\n  manifest-sibling:\n    runs-on: ubuntu-latest\n    steps:\n      - working-directory: ./frontend\n        run: npm run test:app-pages\n\n  ci-summary:\n",
+      )
+
+    expect(source).toContain("  manifest-sibling:\n")
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("rejects a same-job heredoc decoy after the real pages step is removed", () => {
+    const source = readWorkflowSource()
+      .replace(
+        "\n      - name: Run page component tests\n        working-directory: ./frontend\n        shell: bash\n        run: npm run test:pages\n",
+        "",
+      )
+      .replace(
+        "\n      - name: Run App Router tests\n",
+        "\n      - name: Preserve page launcher text as a shell heredoc\n        run: |\n          run: npm run test:pages\n\n      - name: Run App Router tests\n",
+      )
+
+    expect(source).not.toContain("      - name: Run page component tests\n")
+    expect(source).toContain("          run: npm run test:pages\n")
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "npm run test:pages must appear in exactly one frontend step",
+    )
+  })
+
+  it("rejects missing and duplicate required semantic steps", () => {
+    const source = readWorkflowSource()
+    const missing = source.replace("        run: npm run test:app-pages\n", "")
+    const duplicate = source.replace(
+      "\n      - name: Run App Router tests\n",
+      "\n      - name: Duplicate App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n\n      - name: Run App Router tests\n",
+    )
+
+    expect(missing).not.toContain("        run: npm run test:app-pages\n")
+    expect(duplicate.match(/run: npm run test:app-pages/g)).toHaveLength(2)
+    expect(() => assertSemanticWorkflowManifest(missing)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow()
+  })
+
+  it("rejects a required step with the wrong working directory", () => {
+    const source = readWorkflowSource().replace(
+      "      - name: Run App Router tests\n        working-directory: ./frontend\n",
+      "      - name: Run App Router tests\n        working-directory: .\n",
+    )
+
+    expect(source).toContain("      - name: Run App Router tests\n        working-directory: .\n")
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("rejects a required step-level condition", () => {
+    const source = readWorkflowSource().replace(
+      "      - name: Run App Router tests\n",
+      "      - name: Run App Router tests\n        if: github.event_name == 'schedule'\n",
+    )
+
+    expect(source).toContain("        if: github.event_name == 'schedule'\n")
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("rejects custom shells on non-launcher required steps", () => {
+    const source = readWorkflowSource().replace(
+      "      - name: Run App Router tests\n        working-directory: ./frontend\n",
+      "      - name: Run App Router tests\n        working-directory: ./frontend\n        shell: echo {0}\n",
+    )
+
+    expect(source).toContain("        shell: echo {0}\n")
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it.each([
+    [
+      "test:ci-manifest",
+      (source: string) =>
+        source.replace(
+          "        shell: bash\n        run: npm run test:ci-manifest\n",
+          "        shell: echo {0}\n        run: npm run test:ci-manifest\n",
+        ),
+    ],
+    [
+      "test:pages",
+      (source: string) =>
+        source.replace(
+          "      - name: Run page component tests\n        working-directory: ./frontend\n        shell: bash\n",
+          "      - name: Run page component tests\n        working-directory: ./frontend\n        shell: echo {0}\n",
+        ),
+    ],
+  ])("rejects a non-bash %s launcher", (_, transform) => {
+    const source = transform(readWorkflowSource())
+
+    expect(source).toContain("        shell: echo {0}\n")
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it.each([
+    ["a step continue-on-error", (source: string) => source.replace("        run: npm run test:app-pages\n", "        continue-on-error: true\n        run: npm run test:app-pages\n")],
+    ["a job continue-on-error", (source: string) => source.replace("  frontend-build:\n", "  frontend-build:\n    continue-on-error: true\n")],
+    ["a workflow default shell", (source: string) => source.replace("jobs:\n", "defaults:\n  run:\n    shell: echo {0}\n\njobs:\n")],
+    ["a job default shell", (source: string) => source.replace("  frontend-build:\n", "  frontend-build:\n    defaults:\n      run:\n        shell: echo {0}\n")],
+  ])("rejects %s", (_, transform) => {
+    const source = transform(readWorkflowSource())
+
+    expect(source).not.toBe(readWorkflowSource())
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("keeps package launchers and Vitest discovery contracts source-locked", () => {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
       scripts: Record<string, string>
     }
-    const workflowSource = readFileSync(workflowPath, "utf8")
-    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
-    const frontendBuildLines = frontendBuildJob.split("\n").map((line) => line.trim())
 
     expect(packageJson.scripts["test:ci-manifest"]).toBe(manifestCommand)
     expect(packageJson.scripts["test:pages"]).toBe(pagesCommand)
     expect(packageJson.scripts["test:app-pages"]).toBe(appPagesCommand)
-    expect(packageJson.scripts["test:home-build-contracts"]).toBe(
-      homeBuildContractsCommand,
-    )
+    expect(packageJson.scripts["test:home-build-contracts"]).toBe(homeBuildContractsCommand)
     expect(packageJson.scripts["test:home-build-pages"]).toBeUndefined()
-
-    for (const command of [
-      "run: npm run test:widget:coverage",
-      "run: npm run test:ci-manifest",
-      "run: npm run test:pages",
-      "run: npm run test:app-pages",
-      "run: npm run test:home-build-contracts",
-    ]) {
-      expect(exactLineCount(frontendBuildLines, command)).toBe(1)
-    }
-
-    expect(frontendBuildLines).not.toContain("run: npm run test:home-build-pages")
-    expect(frontendBuildJob).not.toMatch(/^\s+continue-on-error:/m)
 
     const testConfig = vitestConfig.test
     expect([...(testConfig?.include ?? [])].sort()).toEqual([

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -13,13 +13,20 @@ const manifestCommand =
   "vitest run --config vitest.config.ts src/ci/frontend-test-manifest.test.ts"
 const pagesCommand =
   "vitest run --config vitest.config.ts src/components/pages src/ci/frontend-test-manifest.test.ts"
+const kbComponentsCommand =
+  "vitest run --config vitest.config.ts src/components/kb"
 const appPagesCommand = "vitest run --config vitest.config.ts src/app"
 const homeBuildContractsCommand =
   "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts"
+const ciSummaryCondition =
+  "always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)"
+const frontendSummaryCheckCommand =
+  "check_job \"frontend-build\" \"${{ needs['frontend-build'].result }}\""
 const requiredFrontendSteps = [
   { command: "npm run test:widget:coverage", shell: undefined },
   { command: "npm run test:ci-manifest", shell: "bash" },
   { command: "npm run test:pages", shell: "bash" },
+  { command: "npm run test:kb-components", shell: undefined },
   { command: "npm run test:app-pages", shell: undefined },
   { command: "npm run test:home-build-contracts", shell: undefined },
 ] as const
@@ -54,6 +61,57 @@ function assertNoDefaultShell(value: Record<string, unknown>, owner: string) {
   }
 }
 
+function assertCiSummaryContract(jobs: Record<string, unknown>) {
+  const ciSummary = jobs["ci-summary"]
+  requireRecord(ciSummary, "jobs.ci-summary")
+
+  if (!Array.isArray(ciSummary.needs)) {
+    throw new Error("jobs.ci-summary.needs must be an array")
+  }
+  if (ciSummary.needs.filter((job) => job === "frontend-build").length !== 1) {
+    throw new Error("jobs.ci-summary.needs must contain frontend-build exactly once")
+  }
+  if (ciSummary["continue-on-error"] !== undefined) {
+    throw new Error("jobs.ci-summary must not set continue-on-error")
+  }
+  if (ciSummary.if !== ciSummaryCondition) {
+    throw new Error("jobs.ci-summary has an unexpected if policy")
+  }
+  if (!Array.isArray(ciSummary.steps)) {
+    throw new Error("jobs.ci-summary.steps must be an array")
+  }
+
+  const matchingSteps = ciSummary.steps.filter((step) => {
+    requireRecord(step, "jobs.ci-summary.steps entry")
+    return step.name === "Check required jobs"
+  })
+  if (matchingSteps.length !== 1) {
+    throw new Error("Check required jobs must appear in exactly one ci-summary step")
+  }
+
+  const checkStep = matchingSteps[0]!
+  if (checkStep.shell !== "bash") {
+    throw new Error("Check required jobs must use bash")
+  }
+  if (checkStep.if !== undefined) {
+    throw new Error("Check required jobs must not set if")
+  }
+  if (checkStep["continue-on-error"] !== undefined) {
+    throw new Error("Check required jobs must not set continue-on-error")
+  }
+  const run = checkStep.run
+  if (typeof run !== "string") {
+    throw new Error("Check required jobs run must be a string")
+  }
+
+  const frontendCheckLines = run
+    .split(/\r?\n/)
+    .filter((line) => line === frontendSummaryCheckCommand)
+  if (frontendCheckLines.length !== 1) {
+    throw new Error("Check required jobs must check frontend-build exactly once")
+  }
+}
+
 function assertSemanticWorkflowManifest(source: string) {
   const document = parseDocument(source, {
     version: "1.2",
@@ -71,6 +129,7 @@ function assertSemanticWorkflowManifest(source: string) {
   const workflow = document.toJS({ maxAliasCount: 100 })
   requireRecord(workflow, "workflow root")
   requireRecord(workflow.jobs, "jobs")
+  assertCiSummaryContract(workflow.jobs)
   const frontendBuild = workflow.jobs["frontend-build"]
   requireRecord(frontendBuild, "jobs.frontend-build")
   if (!Array.isArray(frontendBuild.steps)) {
@@ -293,6 +352,19 @@ describe("frontend CI test manifest", () => {
     expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow()
   })
 
+  it("rejects missing and duplicate KB directory steps", () => {
+    const workflowSource = readWorkflowSource()
+    const kbStep =
+      "\n      - name: Run knowledge base component tests\n        working-directory: ./frontend\n        run: npm run test:kb-components\n"
+    const missing = workflowSource.replace(kbStep, "")
+    const duplicate = workflowSource.replace(kbStep, kbStep.repeat(2))
+
+    expect(missing).not.toContain("run: npm run test:kb-components")
+    expect(duplicate.match(/run: npm run test:kb-components/g)).toHaveLength(2)
+    expect(() => assertSemanticWorkflowManifest(missing)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow()
+  })
+
   it("rejects a required step with the wrong working directory", () => {
     const source = readWorkflowSource().replace(
       "      - name: Run App Router tests\n        working-directory: ./frontend\n",
@@ -359,6 +431,147 @@ describe("frontend CI test manifest", () => {
     expect(() => assertSemanticWorkflowManifest(source)).toThrow()
   })
 
+  it.each([
+    [
+      "a missing ci-summary",
+      (source: string) => source.replace(/\n  ci-summary:\n[\s\S]*$/, "\n"),
+    ],
+    [
+      "a non-mapping ci-summary",
+      (source: string) => source.replace(/\n  ci-summary:\n[\s\S]*$/, "\n  ci-summary: []\n"),
+    ],
+    [
+      "non-array ci-summary needs",
+      (source: string) =>
+        source.replace(
+          "    needs:\n      - prepare-deepdoc-cache\n",
+          "    needs: prepare-deepdoc-cache\n",
+        ),
+    ],
+  ])("rejects %s", (_, transform) => {
+    const source = transform(readWorkflowSource())
+
+    expect(source).not.toBe(readWorkflowSource())
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("rejects removing frontend-build from ci-summary.needs", () => {
+    const source = readWorkflowSource().replace("      - frontend-build\n", "")
+
+    expect(source).not.toContain("      - frontend-build\n")
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("rejects duplicate frontend-build entries in ci-summary.needs", () => {
+    const source = readWorkflowSource().replace(
+      "      - frontend-build\n",
+      "      - frontend-build\n      - frontend-build\n",
+    )
+
+    expect(source.match(/^      - frontend-build$/gm)).toHaveLength(2)
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("rejects ci-summary job-level continue-on-error", () => {
+    const source = readWorkflowSource().replace(
+      "  ci-summary:\n",
+      "  ci-summary:\n    continue-on-error: true\n",
+    )
+
+    expect(source).toContain("  ci-summary:\n    continue-on-error: true\n")
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it.each([
+    [
+      "missing always()",
+      "if: github.event_name != 'pull_request' || github.event.pull_request.draft == false",
+    ],
+    ["a different condition", "if: always()"],
+  ])("rejects ci-summary with %s", (_, replacement) => {
+    const source = readWorkflowSource().replace(
+      "if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)",
+      replacement,
+    )
+
+    expect(source).toContain(`    ${replacement}\n`)
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("rejects missing and duplicate Check required jobs owner steps", () => {
+    const workflowSource = readWorkflowSource()
+    const missing = workflowSource.replace(
+      "      - name: Check required jobs\n",
+      "      - name: Renamed required jobs\n",
+    )
+    const duplicate = workflowSource.replace(
+      "      - name: Check required jobs\n",
+      `      - name: Check required jobs\n        shell: bash\n        run: |\n          ${frontendSummaryCheckCommand}\n\n      - name: Check required jobs\n`,
+    )
+
+    expect(missing).not.toContain("      - name: Check required jobs\n")
+    expect(duplicate.match(/name: Check required jobs/g)).toHaveLength(2)
+    expect(() => assertSemanticWorkflowManifest(missing)).toThrow(
+      "Check required jobs must appear in exactly one ci-summary step",
+    )
+    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow(
+      "Check required jobs must appear in exactly one ci-summary step",
+    )
+  })
+
+  it.each([
+    ["a non-bash shell", "      - name: Check required jobs\n        shell: sh\n"],
+    [
+      "a step-level condition",
+      "      - name: Check required jobs\n        shell: bash\n        if: success()\n",
+    ],
+    [
+      "step-level continue-on-error",
+      "      - name: Check required jobs\n        shell: bash\n        continue-on-error: true\n",
+    ],
+  ])("rejects the summary check step with %s", (_, replacement) => {
+    const source = readWorkflowSource().replace(
+      "      - name: Check required jobs\n        shell: bash\n        run: |\n",
+      `${replacement}        run: |\n`,
+    )
+
+    expect(source).not.toBe(readWorkflowSource())
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
+  it("rejects a missing, duplicate, or non-full-line frontend summary check", () => {
+    const workflowSource = readWorkflowSource()
+    const checkLine =
+      "check_job \"frontend-build\" \"${{ needs['frontend-build'].result }}\""
+    const indentedCheckLine = `          ${checkLine}\n`
+    const missing = workflowSource.replace(indentedCheckLine, "")
+    const duplicate = workflowSource.replace(indentedCheckLine, indentedCheckLine.repeat(2))
+    const embedded = workflowSource.replace(indentedCheckLine, `          echo '${checkLine}'\n`)
+
+    expect(missing).not.toContain(indentedCheckLine)
+    expect(duplicate.match(/check_job "frontend-build"/g)).toHaveLength(2)
+    expect(embedded).toContain(`          echo '${checkLine}'\n`)
+    expect(() => assertSemanticWorkflowManifest(missing)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(embedded)).toThrow()
+  })
+
+  it("does not accept a frontend summary check decoy outside the owned step", () => {
+    const workflowSource = readWorkflowSource()
+    const checkLine =
+      "check_job \"frontend-build\" \"${{ needs['frontend-build'].result }}\""
+    const source = workflowSource
+      .replace(`          ${checkLine}\n`, "")
+      .replace(
+        '          exit "$failed"\n',
+        `          exit "$failed"\n\n      - name: Preserve frontend summary text outside owner\n        shell: bash\n        run: |\n          ${checkLine}\n`,
+      )
+
+    expect(source).toContain("      - name: Preserve frontend summary text outside owner\n")
+    expect(source.match(/check_job "frontend-build"/g)).toHaveLength(1)
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+  })
+
   it("keeps package launchers and Vitest discovery contracts source-locked", () => {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
       scripts: Record<string, string>
@@ -366,6 +579,7 @@ describe("frontend CI test manifest", () => {
 
     expect(packageJson.scripts["test:ci-manifest"]).toBe(manifestCommand)
     expect(packageJson.scripts["test:pages"]).toBe(pagesCommand)
+    expect(packageJson.scripts["test:kb-components"]).toBe(kbComponentsCommand)
     expect(packageJson.scripts["test:app-pages"]).toBe(appPagesCommand)
     expect(packageJson.scripts["test:home-build-contracts"]).toBe(homeBuildContractsCommand)
     expect(packageJson.scripts["test:home-build-pages"]).toBeUndefined()

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -1,4 +1,6 @@
 import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it, vi } from "vitest"
 import vitestConfig from "../../vitest.config"
 
@@ -13,28 +15,45 @@ const pagesCommand =
 const appPagesCommand = "vitest run --config vitest.config.ts src/app"
 const homeBuildContractsCommand =
   "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts"
+const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+const packageJsonPath = path.resolve(moduleDir, "../../package.json")
+const workflowPath = path.resolve(moduleDir, "../../../.github/workflows/ci.yml")
 
 function exactLineCount(lines: string[], value: string) {
   return lines.filter((line) => line === value).length
 }
 
+function extractFrontendBuildJob(source: string) {
+  source = source.replace(/\r\n/g, "\n")
+  const startMarker = "  frontend-build:\n"
+  const endMarker = "\n  ci-summary:\n"
+
+  expect(source.split(startMarker)).toHaveLength(2)
+  expect(source.split(endMarker)).toHaveLength(2)
+
+  const startIndex = source.indexOf(startMarker)
+  const endIndex = source.indexOf(endMarker)
+  expect(endIndex).toBeGreaterThan(startIndex)
+
+  return source.slice(startIndex, endIndex)
+}
+
 describe("frontend CI test manifest", () => {
+  it("extracts the same frontend-build job from LF and CRLF workflow text", () => {
+    const workflowSource = readFileSync(workflowPath, "utf8")
+    const crlfWorkflowSource = workflowSource.replace(/\r?\n/g, "\r\n")
+
+    expect(extractFrontendBuildJob(crlfWorkflowSource)).toBe(
+      extractFrontendBuildJob(workflowSource),
+    )
+  })
+
   it("keeps App Router discovery and required frontend CI lanes source-locked", () => {
-    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
       scripts: Record<string, string>
     }
-    const workflowSource = readFileSync("../.github/workflows/ci.yml", "utf8")
-    const startMarker = "  frontend-build:\n"
-    const endMarker = "\n  ci-summary:\n"
-
-    expect(workflowSource.split(startMarker)).toHaveLength(2)
-    expect(workflowSource.split(endMarker)).toHaveLength(2)
-
-    const startIndex = workflowSource.indexOf(startMarker)
-    const endIndex = workflowSource.indexOf(endMarker)
-    expect(endIndex).toBeGreaterThan(startIndex)
-
-    const frontendBuildJob = workflowSource.slice(startIndex, endIndex)
+    const workflowSource = readFileSync(workflowPath, "utf8")
+    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
     const frontendBuildLines = frontendBuildJob.split("\n").map((line) => line.trim())
 
     expect(packageJson.scripts["test:ci-manifest"]).toBe(manifestCommand)

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -25,17 +25,23 @@ function exactLineCount(lines: string[], value: string) {
 
 function extractFrontendBuildJob(source: string) {
   source = source.replace(/\r\n/g, "\n")
-  const startMarker = "  frontend-build:\n"
-  const endMarker = "\n  ci-summary:\n"
+  const jobHeader = /^  (?:([A-Za-z_][A-Za-z0-9_-]*)|'([A-Za-z_][A-Za-z0-9_-]*)'|"([A-Za-z_][A-Za-z0-9_-]*)"):[ \t]*(?:#.*)?$/gm
+  const jobHeaders = Array.from(source.matchAll(jobHeader), (match) => ({
+    id: match[1] ?? match[2] ?? match[3] ?? "",
+    index: match.index!,
+  }))
+  const frontendHeaders = jobHeaders.filter(
+    ({ id }) => id === "frontend-build",
+  )
 
-  expect(source.split(startMarker)).toHaveLength(2)
-  expect(source.split(endMarker)).toHaveLength(2)
+  expect(frontendHeaders).toHaveLength(1)
 
-  const startIndex = source.indexOf(startMarker)
-  const endIndex = source.indexOf(endMarker)
-  expect(endIndex).toBeGreaterThan(startIndex)
+  const frontendHeader = frontendHeaders[0]!
+  const frontendHeaderIndex = jobHeaders.indexOf(frontendHeader)
+  const nextHeader = jobHeaders[frontendHeaderIndex + 1]
+  expect(nextHeader).toBeDefined()
 
-  return source.slice(startIndex, endIndex)
+  return source.slice(frontendHeader.index, nextHeader!.index)
 }
 
 describe("frontend CI test manifest", () => {
@@ -45,6 +51,57 @@ describe("frontend CI test manifest", () => {
 
     expect(extractFrontendBuildJob(crlfWorkflowSource)).toBe(
       extractFrontendBuildJob(workflowSource),
+    )
+  })
+
+  it.each([
+    [
+      "a renamed successor",
+      (source: string) =>
+        source.replace("\n  ci-summary:\n", "\n  post-frontend:\n"),
+    ],
+    [
+      "an inserted unquoted successor",
+      (source: string) =>
+        source.replace(
+          "\n  ci-summary:\n",
+          "\n  manifest-sibling:\n    continue-on-error: true\n\n  ci-summary:\n",
+        ),
+    ],
+    [
+      "an inserted single-quoted successor",
+      (source: string) =>
+        source.replace(
+          "\n  ci-summary:\n",
+          "\n  'manifest-sibling':\n    runs-on: ubuntu-latest\n\n  ci-summary:\n",
+        ),
+    ],
+    [
+      "an inserted double-quoted successor",
+      (source: string) =>
+        source.replace(
+          "\n  ci-summary:\n",
+          "\n  \"manifest-sibling\":\n    runs-on: ubuntu-latest\n\n  ci-summary:\n",
+        ),
+    ],
+  ])("keeps the frontend-build slice for %s", (_, updateSource) => {
+    const workflowSource = readFileSync(workflowPath, "utf8")
+    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
+
+    expect(extractFrontendBuildJob(updateSource(workflowSource))).toBe(
+      frontendBuildJob,
+    )
+  })
+
+  it("keeps the frontend-build slice when e2e becomes its successor", () => {
+    const workflowSource = readFileSync(workflowPath, "utf8")
+    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
+    const reorderedWorkflowSource = workflowSource
+      .replace(frontendBuildJob, "")
+      .replace("  e2e:\n", `${frontendBuildJob}  e2e:\n`)
+
+    expect(extractFrontendBuildJob(reorderedWorkflowSource)).toBe(
+      frontendBuildJob,
     )
   })
 

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it, vi } from "vitest"
+import vitestConfig from "../../vitest.config"
+
+vi.mock("vitest/config", () => ({
+  defineConfig: <T>(config: T) => config,
+}))
+
+const manifestCommand =
+  "vitest run --config vitest.config.ts src/ci/frontend-test-manifest.test.ts"
+const pagesCommand =
+  "vitest run --config vitest.config.ts src/components/pages src/ci/frontend-test-manifest.test.ts"
+const appPagesCommand = "vitest run --config vitest.config.ts src/app"
+const homeBuildContractsCommand =
+  "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts"
+
+function exactLineCount(lines: string[], value: string) {
+  return lines.filter((line) => line === value).length
+}
+
+describe("frontend CI test manifest", () => {
+  it("keeps App Router discovery and required frontend CI lanes source-locked", () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+      scripts: Record<string, string>
+    }
+    const workflowSource = readFileSync("../.github/workflows/ci.yml", "utf8")
+    const startMarker = "  frontend-build:\n"
+    const endMarker = "\n  ci-summary:\n"
+
+    expect(workflowSource.split(startMarker)).toHaveLength(2)
+    expect(workflowSource.split(endMarker)).toHaveLength(2)
+
+    const startIndex = workflowSource.indexOf(startMarker)
+    const endIndex = workflowSource.indexOf(endMarker)
+    expect(endIndex).toBeGreaterThan(startIndex)
+
+    const frontendBuildJob = workflowSource.slice(startIndex, endIndex)
+    const frontendBuildLines = frontendBuildJob.split("\n").map((line) => line.trim())
+
+    expect(packageJson.scripts["test:ci-manifest"]).toBe(manifestCommand)
+    expect(packageJson.scripts["test:pages"]).toBe(pagesCommand)
+    expect(packageJson.scripts["test:app-pages"]).toBe(appPagesCommand)
+    expect(packageJson.scripts["test:home-build-contracts"]).toBe(
+      homeBuildContractsCommand,
+    )
+    expect(packageJson.scripts["test:home-build-pages"]).toBeUndefined()
+
+    for (const command of [
+      "run: npm run test:widget:coverage",
+      "run: npm run test:ci-manifest",
+      "run: npm run test:pages",
+      "run: npm run test:app-pages",
+      "run: npm run test:home-build-contracts",
+    ]) {
+      expect(exactLineCount(frontendBuildLines, command)).toBe(1)
+    }
+
+    expect(frontendBuildLines).not.toContain("run: npm run test:home-build-pages")
+    expect(frontendBuildJob).not.toMatch(/^\s+continue-on-error:/m)
+
+    const testConfig = vitestConfig.test
+    expect([...(testConfig?.include ?? [])].sort()).toEqual([
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+    ])
+    expect(testConfig?.exclude).toBeUndefined()
+    expect(testConfig?.passWithNoTests).not.toBe(true)
+  })
+})

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -1,49 +1,122 @@
+/**
+ * Guards accidental drift across .github/workflows/ci.yml, package.json launchers,
+ * and vitest.config.ts discovery. test:ci-manifest and test:pages are independent
+ * launchers; legitimate changes update the owner files and these invariants together.
+ */
 import { readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { parseDocument } from "yaml"
+import { isMap, isScalar, parseDocument } from "yaml"
 import { describe, expect, it, vi } from "vitest"
 import vitestConfig from "../../vitest.config"
 
+// jsdom can load Vitest config in a second realm where vitest/config cannot initialize.
 vi.mock("vitest/config", () => ({
   defineConfig: <T>(config: T) => config,
 }))
 
-const manifestCommand =
-  "vitest run --config vitest.config.ts src/ci/frontend-test-manifest.test.ts"
+const manifestCommand = "vitest run --config vitest.config.ts src/ci/frontend-test-manifest.test.ts"
 const pagesCommand =
   "vitest run --config vitest.config.ts src/components/pages src/ci/frontend-test-manifest.test.ts"
-const kbComponentsCommand =
-  "vitest run --config vitest.config.ts src/components/kb"
+const kbComponentsCommand = "vitest run --config vitest.config.ts src/components/kb"
 const appPagesCommand = "vitest run --config vitest.config.ts src/app"
 const homeBuildContractsCommand =
   "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts"
 const ciSummaryCondition =
   "always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)"
 const frontendSummaryCheckCommand =
-  "check_job \"frontend-build\" \"${{ needs['frontend-build'].result }}\""
+  'check_job "frontend-build" "${{ needs[\'frontend-build\'].result }}"'
 const requiredFrontendSteps = [
-  { command: "npm run test:widget:coverage", shell: undefined },
-  { command: "npm run test:ci-manifest", shell: "bash" },
-  { command: "npm run test:pages", shell: "bash" },
-  { command: "npm run test:kb-components", shell: undefined },
-  { command: "npm run test:app-pages", shell: undefined },
-  { command: "npm run test:home-build-contracts", shell: undefined },
+  { command: "npm run test:widget:coverage", requiresExplicitBash: false },
+  { command: "npm run test:ci-manifest", requiresExplicitBash: true },
+  { command: "npm run test:pages", requiresExplicitBash: true },
+  { command: "npm run test:kb-components", requiresExplicitBash: false },
+  { command: "npm run test:app-pages", requiresExplicitBash: false },
+  { command: "npm run test:home-build-contracts", requiresExplicitBash: false },
 ] as const
 const moduleDir = path.dirname(fileURLToPath(import.meta.url))
 const packageJsonPath = path.resolve(moduleDir, "../../package.json")
 const workflowPath = path.resolve(moduleDir, "../../../.github/workflows/ci.yml")
 
-function requireRecord(
-  value: unknown,
-  owner: string,
-): asserts value is Record<string, unknown> {
+function replaceExactlyOnce(source: string, search: string, replacement: string, owner: string) {
+  if (search.length === 0) {
+    throw new Error(`${owner} search marker must not be empty`)
+  }
+
+  const count = countOccurrences(source, search)
+  if (count !== 1) {
+    throw new Error(`${owner} must appear exactly once; found ${count}`)
+  }
+
+  const mutated = source.replace(search, replacement)
+  if (mutated === source) {
+    throw new Error(`${owner} mutation must change the source`)
+  }
+  return mutated
+}
+
+function countOccurrences(source: string, search: string) {
+  let count = 0
+  let offset = 0
+  while ((offset = source.indexOf(search, offset)) !== -1) {
+    count += 1
+    offset += search.length
+  }
+  return count
+}
+
+function replaceWorkflowJob(source: string, jobName: string, replacement: string, owner: string) {
+  const document = parseDocument(source, {
+    version: "1.2",
+    uniqueKeys: true,
+    merge: false,
+    keepSourceTokens: true,
+  })
+  if (document.errors.length > 0) {
+    throw document.errors[0]
+  }
+
+  const workflow = document.contents
+  const jobs = isMap(workflow) ? workflow.get("jobs", true) : undefined
+  if (!isMap(jobs)) {
+    throw new Error(`${owner} requires a jobs mapping`)
+  }
+
+  const matches = jobs.items.filter(
+    (pair) => isScalar(pair.key) && pair.key.value === jobName,
+  )
+  if (matches.length !== 1) {
+    throw new Error(`${owner} must appear exactly once; found ${matches.length}`)
+  }
+
+  const pair = matches[0]!
+  if (!isScalar(pair.key) || pair.key.range == null) {
+    throw new Error(`${owner} key must have a source range`)
+  }
+  const jobStart = source.lastIndexOf("\n", pair.key.range[0] - 1) + 1
+  const nextPair = jobs.items[jobs.items.indexOf(pair) + 1]
+  const nextKey = nextPair?.key
+  const nextPairStart = nextPair?.srcToken?.start[0]?.offset
+  let jobEnd = source.length
+  if (nextPairStart !== undefined) {
+    jobEnd = nextPairStart
+  } else if (nextKey !== undefined && isScalar(nextKey) && nextKey.range != null) {
+    jobEnd = source.lastIndexOf("\n", nextKey.range[0] - 1) + 1
+  }
+  const mutated = `${source.slice(0, jobStart)}${replacement}${source.slice(jobEnd)}`
+  if (mutated === source) {
+    throw new Error(`${owner} mutation must change the source`)
+  }
+  return mutated
+}
+
+function requireRecord(value: unknown, owner: string): asserts value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`${owner} must be an object`)
   }
 }
 
-function assertNoDefaultShell(value: Record<string, unknown>, owner: string) {
+function assertBashCompatibleDefaultShell(value: Record<string, unknown>, owner: string) {
   const defaults = value.defaults
   if (defaults === undefined) {
     return
@@ -56,8 +129,8 @@ function assertNoDefaultShell(value: Record<string, unknown>, owner: string) {
   }
 
   requireRecord(run, `${owner}.defaults.run`)
-  if (run.shell !== undefined) {
-    throw new Error(`${owner} must not set defaults.run.shell`)
+  if (run.shell !== undefined && run.shell !== "bash") {
+    throw new Error(`${owner} defaults.run.shell must be bash when set`)
   }
 }
 
@@ -123,7 +196,8 @@ function assertSemanticWorkflowManifest(source: string) {
     throw document.errors[0]
   }
   if (document.warnings.length > 0) {
-    throw document.warnings[0]
+    const warning = document.warnings[0]!
+    throw new Error(`workflow YAML warning [${warning.code ?? "UNKNOWN"}]`)
   }
 
   const workflow = document.toJS({ maxAliasCount: 100 })
@@ -136,8 +210,8 @@ function assertSemanticWorkflowManifest(source: string) {
     throw new Error("jobs.frontend-build.steps must be an array")
   }
 
-  assertNoDefaultShell(workflow, "workflow root")
-  assertNoDefaultShell(frontendBuild, "jobs.frontend-build")
+  assertBashCompatibleDefaultShell(workflow, "workflow root")
+  assertBashCompatibleDefaultShell(frontendBuild, "jobs.frontend-build")
   if (frontendBuild["continue-on-error"] !== undefined) {
     throw new Error("jobs.frontend-build must not set continue-on-error")
   }
@@ -169,7 +243,10 @@ function assertSemanticWorkflowManifest(source: string) {
     if (step["continue-on-error"] !== undefined) {
       throw new Error(`${requiredStep.command} must not set continue-on-error`)
     }
-    if (step.shell !== requiredStep.shell) {
+    const hasAllowedShell = requiredStep.requiresExplicitBash
+      ? step.shell === "bash"
+      : step.shell === undefined || step.shell === "bash"
+    if (!hasAllowedShell) {
       throw new Error(`${requiredStep.command} has an unexpected shell policy`)
     }
   }
@@ -184,28 +261,40 @@ function readWorkflowSource() {
 }
 
 describe("frontend CI test manifest", () => {
-  it.each([["LF", readWorkflowSource()], ["CRLF", readWorkflowSource().replace(/\r?\n/g, "\r\n")]])(
-    "accepts the real workflow with %s line endings",
-    (_, source) => {
-      expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
-    },
-  )
+  it.each([
+    ["LF", readWorkflowSource()],
+    ["CRLF", readWorkflowSource().replace(/\r?\n/g, "\r\n")],
+  ])("accepts the real workflow with %s line endings", (_, source) => {
+    expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+  })
 
   it.each([
     [
       "an anchored sibling",
       (source: string) =>
-        source.replace(
+        replaceExactlyOnce(
+          source,
           "\n  ci-summary:\n",
           "\n  manifest-anchor: &manifest_base\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo manifest anchor\n\n  manifest-alias: *manifest_base\n\n  ci-summary:\n",
+          "ci-summary insertion point",
         ),
     ],
     [
       "an aliased sibling",
-      (source: string) =>
-        source
-          .replace("  prepare-deepdoc-cache:\n", "  prepare-deepdoc-cache: &manifest_base\n")
-          .replace("\n  ci-summary:\n", "\n  manifest-alias: *manifest_base\n\n  ci-summary:\n"),
+      (source: string) => {
+        const anchored = replaceExactlyOnce(
+          source,
+          "  prepare-deepdoc-cache:\n",
+          "  prepare-deepdoc-cache: &manifest_base\n",
+          "prepare-deepdoc-cache anchor",
+        )
+        return replaceExactlyOnce(
+          anchored,
+          "\n  ci-summary:\n",
+          "\n  manifest-alias: *manifest_base\n\n  ci-summary:\n",
+          "ci-summary insertion point",
+        )
+      },
     ],
   ])("accepts %s", (_, transform) => {
     const source = transform(readWorkflowSource())
@@ -216,19 +305,107 @@ describe("frontend CI test manifest", () => {
   })
 
   it("accepts a folded required command with the same semantic value", () => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "        run: npm run test:app-pages\n",
       "        run: >-\n          npm run\n          test:app-pages\n",
+      "App Router command",
     )
 
     expect(source).not.toBe(readWorkflowSource())
     expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
   })
 
+  it.each([
+    "npm run test:widget:coverage",
+    "npm run test:kb-components",
+    "npm run test:app-pages",
+    "npm run test:home-build-contracts",
+  ])("accepts an explicit bash shell on the %s non-launcher step", (command) => {
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
+      `        run: ${command}\n`,
+      `        shell: bash\n        run: ${command}\n`,
+      `${command} shell insertion`,
+    )
+
+    expect(source).not.toBe(readWorkflowSource())
+    expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+  })
+
+  it.each([
+    [
+      "workflow",
+      (source: string) =>
+        replaceExactlyOnce(
+          source,
+          "jobs:\n",
+          "defaults:\n  run:\n    shell: bash\n\njobs:\n",
+          "workflow jobs owner",
+        ),
+    ],
+    [
+      "frontend-build job",
+      (source: string) =>
+        replaceExactlyOnce(
+          source,
+          "  frontend-build:\n",
+          "  frontend-build:\n    defaults:\n      run:\n        shell: bash\n",
+          "frontend-build owner",
+        ),
+    ],
+  ])("accepts an explicit bash default at %s scope", (_, transform) => {
+    const source = transform(readWorkflowSource())
+
+    expect(source).not.toBe(readWorkflowSource())
+    expect(() => assertSemanticWorkflowManifest(source)).not.toThrow()
+  })
+
+  it.each([
+    [
+      "manifest launcher with workflow defaults",
+      (source: string) =>
+        replaceExactlyOnce(
+          replaceExactlyOnce(
+            source,
+            "jobs:\n",
+            "defaults:\n  run:\n    shell: bash\n\njobs:\n",
+            "workflow jobs owner",
+          ),
+          "        shell: bash\n        run: npm run test:ci-manifest\n",
+          "        run: npm run test:ci-manifest\n",
+          "manifest launcher shell",
+        ),
+      "npm run test:ci-manifest has an unexpected shell policy",
+    ],
+    [
+      "pages launcher with job defaults",
+      (source: string) =>
+        replaceExactlyOnce(
+          replaceExactlyOnce(
+            source,
+            "  frontend-build:\n",
+            "  frontend-build:\n    defaults:\n      run:\n        shell: bash\n",
+            "frontend-build owner",
+          ),
+          "        shell: bash\n        run: npm run test:pages\n",
+          "        run: npm run test:pages\n",
+          "pages launcher shell",
+        ),
+      "npm run test:pages has an unexpected shell policy",
+    ],
+  ])("requires explicit bash for the %s", (_, transform, expectedError) => {
+    const source = transform(readWorkflowSource())
+
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(expectedError)
+  })
+
   it("accepts a colon-shaped line in a block scalar", () => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "        run: npm run build\n",
       "        run: |\n          echo 'label: value'\n          npm run build\n",
+      "frontend build command",
     )
 
     expect(source).toContain("          echo 'label: value'\n")
@@ -242,8 +419,17 @@ describe("frontend CI test manifest", () => {
     expect(source).not.toBe(workflowSource)
     expect(source).toMatch(/^%BAD_DIRECTIVE\n---\n/)
     expect(() => assertSemanticWorkflowManifest(source)).toThrow(
-      "Unknown directive %BAD_DIRECTIVE",
+      "workflow YAML warning [BAD_DIRECTIVE]",
     )
+  })
+
+  it("fails a mutation when its owner marker is missing or duplicated", () => {
+    expect(() => replaceExactlyOnce("alpha", "missing", "replacement", "fixture marker")).toThrow(
+      "fixture marker must appear exactly once; found 0",
+    )
+    expect(() =>
+      replaceExactlyOnce("alpha alpha", "alpha", "replacement", "fixture marker"),
+    ).toThrow("fixture marker must appear exactly once; found 2")
   })
 
   it("rejects an anchored job expanded through more than 100 aliases", () => {
@@ -252,9 +438,11 @@ describe("frontend CI test manifest", () => {
       (_, index) => `  manifest-alias-${index + 1}: *manifest_base`,
     ).join("\n")
     const workflowSource = readWorkflowSource()
-    const source = workflowSource.replace(
+    const source = replaceExactlyOnce(
+      workflowSource,
       "\n  ci-summary:\n",
       `\n  manifest-anchor: &manifest_base\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo manifest anchor\n${aliases}\n\n  ci-summary:\n`,
+      "ci-summary insertion point",
     )
 
     expect(source).not.toBe(workflowSource)
@@ -268,68 +456,130 @@ describe("frontend CI test manifest", () => {
     ["malformed YAML", "jobs:\n  frontend-build: ["],
     ["missing jobs", "name: Manifest fixture\n"],
     ["a non-mapping jobs owner", "jobs: []\n"],
-    ["missing frontend-build", "jobs: {}\n"],
-    ["a non-mapping frontend-build owner", "jobs:\n  frontend-build: []\n"],
-    ["a non-sequence steps owner", "jobs:\n  frontend-build:\n    steps: {}\n"],
     ["an unresolved alias", "jobs:\n  frontend-build: *missing\n"],
   ])("rejects %s", (_, source) => {
     expect(() => assertSemanticWorkflowManifest(source)).toThrow()
   })
 
+  it.each([
+    [
+      "missing frontend-build",
+      (source: string) => replaceWorkflowJob(source, "frontend-build", "", "frontend-build job"),
+      "jobs.frontend-build must be an object",
+    ],
+    [
+      "a non-mapping frontend-build owner",
+      (source: string) =>
+        replaceWorkflowJob(
+          source,
+          "frontend-build",
+          "  frontend-build: []\n",
+          "frontend-build job",
+        ),
+      "jobs.frontend-build must be an object",
+    ],
+    [
+      "a non-sequence frontend-build.steps owner",
+      (source: string) =>
+        replaceWorkflowJob(
+          source,
+          "frontend-build",
+          "  frontend-build:\n    steps: {}\n",
+          "frontend-build job",
+        ),
+      "jobs.frontend-build.steps must be an array",
+    ],
+  ])("rejects %s at its intended owner", (_, transform, expectedError) => {
+    const source = transform(readWorkflowSource())
+
+    expect(source).not.toBe(readWorkflowSource())
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(expectedError)
+  })
+
   it("rejects semantically complete duplicate jobs and frontend-build mappings", () => {
     const workflowSource = readWorkflowSource()
-    const duplicateJobs = `${workflowSource
-      .replace("\njobs:\n", "\njobs: &manifest_jobs\n")
-      .trimEnd()}\n'jobs': *manifest_jobs\n`
-    const duplicateFrontendBuild = workflowSource
-      .replace(
-        "  frontend-build:\n",
-        "  frontend-build: &manifest_frontend_build\n",
-      )
-      .replace(
-        "\n  ci-summary:\n",
-        "\n  'frontend-build': *manifest_frontend_build\n\n  ci-summary:\n",
-      )
+    const duplicateJobs = `${replaceExactlyOnce(
+      workflowSource,
+      "\njobs:\n",
+      "\njobs: &manifest_jobs\n",
+      "jobs owner",
+    ).trimEnd()}\n'jobs': *manifest_jobs\n`
+    const anchoredFrontendBuild = replaceExactlyOnce(
+      workflowSource,
+      "  frontend-build:\n",
+      "  frontend-build: &manifest_frontend_build\n",
+      "frontend-build owner",
+    )
+    const duplicateFrontendBuild = replaceExactlyOnce(
+      anchoredFrontendBuild,
+      "\n  ci-summary:\n",
+      "\n  'frontend-build': *manifest_frontend_build\n\n  ci-summary:\n",
+      "ci-summary insertion point",
+    )
 
     expect(duplicateJobs).not.toBe(workflowSource)
     expect(duplicateJobs).toContain("jobs: &manifest_jobs\n")
     expect(duplicateJobs).toContain("'jobs': *manifest_jobs\n")
     expect(duplicateFrontendBuild).not.toBe(workflowSource)
-    expect(duplicateFrontendBuild).toContain(
-      "frontend-build: &manifest_frontend_build\n",
-    )
-    expect(duplicateFrontendBuild).toContain(
-      "'frontend-build': *manifest_frontend_build\n",
-    )
+    expect(duplicateFrontendBuild).toContain("frontend-build: &manifest_frontend_build\n")
+    expect(duplicateFrontendBuild).toContain("'frontend-build': *manifest_frontend_build\n")
     expect(() => assertSemanticWorkflowManifest(duplicateJobs)).toThrow()
     expect(() => assertSemanticWorkflowManifest(duplicateFrontendBuild)).toThrow()
   })
 
   it("rejects a required command moved to a sibling job", () => {
-    const source = readWorkflowSource()
-      .replace(
-        "\n      - name: Run App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n",
-        "",
-      )
-      .replace(
-        "\n  ci-summary:\n",
-        "\n  manifest-sibling:\n    runs-on: ubuntu-latest\n    steps:\n      - working-directory: ./frontend\n        run: npm run test:app-pages\n\n  ci-summary:\n",
-      )
+    const appStep =
+      "\n      - name: Run App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n"
+    const withoutAppStep = replaceExactlyOnce(
+      readWorkflowSource(),
+      appStep,
+      "",
+      "App Router step removal",
+    )
+    const source = replaceExactlyOnce(
+      withoutAppStep,
+      "\n  ci-summary:\n",
+      "\n  manifest-sibling:\n    runs-on: ubuntu-latest\n    steps:\n      - working-directory: ./frontend\n        run: npm run test:app-pages\n\n  ci-summary:\n",
+      "ci-summary insertion point",
+    )
 
+    expect(source).not.toContain(appStep)
     expect(source).toContain("  manifest-sibling:\n")
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "npm run test:app-pages must appear in exactly one frontend step",
+    )
+  })
+
+  it("fails the moved-to-sibling mutation when the App step owner drifts", () => {
+    const workflowSource = readWorkflowSource()
+    const driftedSource = replaceExactlyOnce(
+      workflowSource,
+      "      - name: Run App Router tests\n",
+      "      - name: Renamed App Router tests\n",
+      "App Router step name",
+    )
+    const appStep =
+      "\n      - name: Run App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n"
+
+    expect(driftedSource).not.toBe(workflowSource)
+    expect(() => replaceExactlyOnce(driftedSource, appStep, "", "App Router step removal")).toThrow(
+      "App Router step removal must appear exactly once; found 0",
+    )
   })
 
   it("rejects a same-job heredoc decoy after the real pages step is removed", () => {
-    const source = readWorkflowSource()
-      .replace(
-        "\n      - name: Run page component tests\n        working-directory: ./frontend\n        shell: bash\n        run: npm run test:pages\n",
-        "",
-      )
-      .replace(
-        "\n      - name: Run App Router tests\n",
-        "\n      - name: Preserve page launcher text as a shell heredoc\n        run: |\n          run: npm run test:pages\n\n      - name: Run App Router tests\n",
-      )
+    const withoutPagesStep = replaceExactlyOnce(
+      readWorkflowSource(),
+      "\n      - name: Run page component tests\n        working-directory: ./frontend\n        shell: bash\n        run: npm run test:pages\n",
+      "",
+      "pages launcher step removal",
+    )
+    const source = replaceExactlyOnce(
+      withoutPagesStep,
+      "\n      - name: Run App Router tests\n",
+      "\n      - name: Preserve page launcher text as a shell heredoc\n        run: |\n          run: npm run test:pages\n\n      - name: Run App Router tests\n",
+      "App Router step insertion point",
+    )
 
     expect(source).not.toContain("      - name: Run page component tests\n")
     expect(source).toContain("          run: npm run test:pages\n")
@@ -340,146 +590,295 @@ describe("frontend CI test manifest", () => {
 
   it("rejects missing and duplicate required semantic steps", () => {
     const source = readWorkflowSource()
-    const missing = source.replace("        run: npm run test:app-pages\n", "")
-    const duplicate = source.replace(
+    const missing = replaceExactlyOnce(
+      source,
+      "        run: npm run test:app-pages\n",
+      "",
+      "App Router command removal",
+    )
+    const duplicate = replaceExactlyOnce(
+      source,
       "\n      - name: Run App Router tests\n",
       "\n      - name: Duplicate App Router tests\n        working-directory: ./frontend\n        run: npm run test:app-pages\n\n      - name: Run App Router tests\n",
+      "App Router duplicate insertion point",
     )
 
     expect(missing).not.toContain("        run: npm run test:app-pages\n")
     expect(duplicate.match(/run: npm run test:app-pages/g)).toHaveLength(2)
-    expect(() => assertSemanticWorkflowManifest(missing)).toThrow()
-    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(missing)).toThrow(
+      "npm run test:app-pages must appear in exactly one frontend step",
+    )
+    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow(
+      "npm run test:app-pages must appear in exactly one frontend step",
+    )
   })
 
   it("rejects missing and duplicate KB directory steps", () => {
     const workflowSource = readWorkflowSource()
     const kbStep =
       "\n      - name: Run knowledge base component tests\n        working-directory: ./frontend\n        run: npm run test:kb-components\n"
-    const missing = workflowSource.replace(kbStep, "")
-    const duplicate = workflowSource.replace(kbStep, kbStep.repeat(2))
+    const missing = replaceExactlyOnce(workflowSource, kbStep, "", "KB test step removal")
+    const duplicate = replaceExactlyOnce(
+      workflowSource,
+      kbStep,
+      kbStep.repeat(2),
+      "KB test step duplication",
+    )
 
     expect(missing).not.toContain("run: npm run test:kb-components")
     expect(duplicate.match(/run: npm run test:kb-components/g)).toHaveLength(2)
-    expect(() => assertSemanticWorkflowManifest(missing)).toThrow()
-    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(missing)).toThrow(
+      "npm run test:kb-components must appear in exactly one frontend step",
+    )
+    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow(
+      "npm run test:kb-components must appear in exactly one frontend step",
+    )
   })
 
   it("rejects a required step with the wrong working directory", () => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "      - name: Run App Router tests\n        working-directory: ./frontend\n",
       "      - name: Run App Router tests\n        working-directory: .\n",
+      "App Router working directory",
     )
 
     expect(source).toContain("      - name: Run App Router tests\n        working-directory: .\n")
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "npm run test:app-pages must use ./frontend",
+    )
   })
 
   it("rejects a required step-level condition", () => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "      - name: Run App Router tests\n",
       "      - name: Run App Router tests\n        if: github.event_name == 'schedule'\n",
+      "App Router step condition",
     )
 
     expect(source).toContain("        if: github.event_name == 'schedule'\n")
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "npm run test:app-pages must not set if",
+    )
   })
 
   it("rejects custom shells on non-launcher required steps", () => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "      - name: Run App Router tests\n        working-directory: ./frontend\n",
       "      - name: Run App Router tests\n        working-directory: ./frontend\n        shell: echo {0}\n",
+      "App Router step shell",
     )
 
     expect(source).toContain("        shell: echo {0}\n")
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "npm run test:app-pages has an unexpected shell policy",
+    )
   })
 
   it.each([
     [
       "test:ci-manifest",
       (source: string) =>
-        source.replace(
+        replaceExactlyOnce(
+          source,
           "        shell: bash\n        run: npm run test:ci-manifest\n",
           "        shell: echo {0}\n        run: npm run test:ci-manifest\n",
+          "manifest launcher shell",
         ),
     ],
     [
       "test:pages",
       (source: string) =>
-        source.replace(
+        replaceExactlyOnce(
+          source,
           "      - name: Run page component tests\n        working-directory: ./frontend\n        shell: bash\n",
           "      - name: Run page component tests\n        working-directory: ./frontend\n        shell: echo {0}\n",
+          "pages launcher shell",
         ),
     ],
   ])("rejects a non-bash %s launcher", (_, transform) => {
     const source = transform(readWorkflowSource())
 
     expect(source).toContain("        shell: echo {0}\n")
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      `npm run ${_} has an unexpected shell policy`,
+    )
   })
 
   it.each([
-    ["a step continue-on-error", (source: string) => source.replace("        run: npm run test:app-pages\n", "        continue-on-error: true\n        run: npm run test:app-pages\n")],
-    ["a job continue-on-error", (source: string) => source.replace("  frontend-build:\n", "  frontend-build:\n    continue-on-error: true\n")],
-    ["a workflow default shell", (source: string) => source.replace("jobs:\n", "defaults:\n  run:\n    shell: echo {0}\n\njobs:\n")],
-    ["a job default shell", (source: string) => source.replace("  frontend-build:\n", "  frontend-build:\n    defaults:\n      run:\n        shell: echo {0}\n")],
-  ])("rejects %s", (_, transform) => {
+    [
+      "a step continue-on-error",
+      (source: string) =>
+        replaceExactlyOnce(
+          source,
+          "        run: npm run test:app-pages\n",
+          "        continue-on-error: true\n        run: npm run test:app-pages\n",
+          "App Router continue-on-error insertion",
+        ),
+      "frontend-build steps must not set continue-on-error",
+    ],
+    [
+      "a job continue-on-error",
+      (source: string) =>
+        replaceExactlyOnce(
+          source,
+          "  frontend-build:\n",
+          "  frontend-build:\n    continue-on-error: true\n",
+          "frontend-build continue-on-error insertion",
+        ),
+      "jobs.frontend-build must not set continue-on-error",
+    ],
+  ])("rejects %s", (_, transform, expectedError) => {
     const source = transform(readWorkflowSource())
 
     expect(source).not.toBe(readWorkflowSource())
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(expectedError)
+  })
+
+  it.each([
+    [
+      "workflow root",
+      (source: string) =>
+        replaceExactlyOnce(
+          source,
+          "jobs:\n",
+          "defaults:\n  run:\n    shell: echo {0}\n\njobs:\n",
+          "workflow jobs owner",
+        ),
+    ],
+    [
+      "jobs.frontend-build",
+      (source: string) =>
+        replaceExactlyOnce(
+          source,
+          "  frontend-build:\n",
+          "  frontend-build:\n    defaults:\n      run:\n        shell: echo {0}\n",
+          "frontend-build owner",
+        ),
+    ],
+  ])("rejects a custom default shell at %s scope", (owner, transform) => {
+    const source = transform(readWorkflowSource())
+
+    expect(source).not.toBe(readWorkflowSource())
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      `${owner} defaults.run.shell must be bash when set`,
+    )
   })
 
   it.each([
     [
       "a missing ci-summary",
-      (source: string) => source.replace(/\n  ci-summary:\n[\s\S]*$/, "\n"),
+      (source: string) => replaceWorkflowJob(source, "ci-summary", "", "ci-summary job"),
+      "jobs.ci-summary must be an object",
     ],
     [
       "a non-mapping ci-summary",
-      (source: string) => source.replace(/\n  ci-summary:\n[\s\S]*$/, "\n  ci-summary: []\n"),
+      (source: string) =>
+        replaceWorkflowJob(source, "ci-summary", "  ci-summary: []\n", "ci-summary job"),
+      "jobs.ci-summary must be an object",
     ],
     [
       "non-array ci-summary needs",
       (source: string) =>
-        source.replace(
+        replaceExactlyOnce(
+          source,
           "    needs:\n      - prepare-deepdoc-cache\n",
           "    needs: prepare-deepdoc-cache\n",
+          "ci-summary needs owner",
         ),
+      "jobs.ci-summary.needs must be an array",
     ],
-  ])("rejects %s", (_, transform) => {
+  ])("rejects %s", (_, transform, expectedError) => {
     const source = transform(readWorkflowSource())
 
     expect(source).not.toBe(readWorkflowSource())
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(expectedError)
+  })
+
+  it.each([
+    [
+      "plain",
+      "\n\n  after-summary:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo after summary\n",
+      (source: string) => source,
+    ],
+    [
+      "single-quoted",
+      "\n\n  'after-summary':\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo after summary\n",
+      (source: string) => source,
+    ],
+    [
+      "double-quoted",
+      '\n\n  "after-summary":\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo after summary\n',
+      (source: string) => source,
+    ],
+    [
+      "anchored",
+      "\n\n  # anchored following job\n  after-summary: &after_summary\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo after summary\n",
+      (source: string) => source,
+    ],
+    [
+      "aliased",
+      "\n\n  # aliased following job\n  after-summary: *after_summary\n",
+      (source: string) =>
+        replaceExactlyOnce(
+          source,
+          "  prepare-deepdoc-cache:\n",
+          "  prepare-deepdoc-cache: &after_summary\n",
+          "prepare-deepdoc-cache anchor",
+        ),
+    ],
+  ])("preserves a complete %s following sibling when mutating ci-summary", (_, block, prepare) => {
+    const workflowSource = `${prepare(readWorkflowSource()).trimEnd()}${block}`
+    const source = replaceWorkflowJob(workflowSource, "ci-summary", "", "ci-summary job")
+
+    expect(source.slice(-block.length)).toBe(block)
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "jobs.ci-summary must be an object",
+    )
   })
 
   it("rejects removing frontend-build from ci-summary.needs", () => {
-    const source = readWorkflowSource().replace("      - frontend-build\n", "")
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
+      "      - frontend-build\n",
+      "",
+      "ci-summary frontend-build need",
+    )
 
     expect(source).not.toContain("      - frontend-build\n")
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "jobs.ci-summary.needs must contain frontend-build exactly once",
+    )
   })
 
   it("rejects duplicate frontend-build entries in ci-summary.needs", () => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "      - frontend-build\n",
       "      - frontend-build\n      - frontend-build\n",
+      "ci-summary frontend-build need",
     )
 
     expect(source.match(/^      - frontend-build$/gm)).toHaveLength(2)
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "jobs.ci-summary.needs must contain frontend-build exactly once",
+    )
   })
 
   it("rejects ci-summary job-level continue-on-error", () => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "  ci-summary:\n",
       "  ci-summary:\n    continue-on-error: true\n",
+      "ci-summary owner",
     )
 
     expect(source).toContain("  ci-summary:\n    continue-on-error: true\n")
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "jobs.ci-summary must not set continue-on-error",
+    )
   })
 
   it.each([
@@ -489,24 +888,32 @@ describe("frontend CI test manifest", () => {
     ],
     ["a different condition", "if: always()"],
   ])("rejects ci-summary with %s", (_, replacement) => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)",
       replacement,
+      "ci-summary if policy",
     )
 
     expect(source).toContain(`    ${replacement}\n`)
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "jobs.ci-summary has an unexpected if policy",
+    )
   })
 
   it("rejects missing and duplicate Check required jobs owner steps", () => {
     const workflowSource = readWorkflowSource()
-    const missing = workflowSource.replace(
+    const missing = replaceExactlyOnce(
+      workflowSource,
       "      - name: Check required jobs\n",
       "      - name: Renamed required jobs\n",
+      "ci-summary check step name",
     )
-    const duplicate = workflowSource.replace(
+    const duplicate = replaceExactlyOnce(
+      workflowSource,
       "      - name: Check required jobs\n",
       `      - name: Check required jobs\n        shell: bash\n        run: |\n          ${frontendSummaryCheckCommand}\n\n      - name: Check required jobs\n`,
+      "ci-summary check step duplication",
     )
 
     expect(missing).not.toContain("      - name: Check required jobs\n")
@@ -530,46 +937,81 @@ describe("frontend CI test manifest", () => {
       "      - name: Check required jobs\n        shell: bash\n        continue-on-error: true\n",
     ],
   ])("rejects the summary check step with %s", (_, replacement) => {
-    const source = readWorkflowSource().replace(
+    const source = replaceExactlyOnce(
+      readWorkflowSource(),
       "      - name: Check required jobs\n        shell: bash\n        run: |\n",
       `${replacement}        run: |\n`,
+      "ci-summary check step contract",
     )
 
     expect(source).not.toBe(readWorkflowSource())
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      _ === "a non-bash shell"
+        ? "Check required jobs must use bash"
+        : _ === "a step-level condition"
+          ? "Check required jobs must not set if"
+          : "Check required jobs must not set continue-on-error",
+    )
   })
 
   it("rejects a missing, duplicate, or non-full-line frontend summary check", () => {
     const workflowSource = readWorkflowSource()
-    const checkLine =
-      "check_job \"frontend-build\" \"${{ needs['frontend-build'].result }}\""
+    const checkLine = 'check_job "frontend-build" "${{ needs[\'frontend-build\'].result }}"'
     const indentedCheckLine = `          ${checkLine}\n`
-    const missing = workflowSource.replace(indentedCheckLine, "")
-    const duplicate = workflowSource.replace(indentedCheckLine, indentedCheckLine.repeat(2))
-    const embedded = workflowSource.replace(indentedCheckLine, `          echo '${checkLine}'\n`)
+    const missing = replaceExactlyOnce(
+      workflowSource,
+      indentedCheckLine,
+      "",
+      "frontend summary check line removal",
+    )
+    const duplicate = replaceExactlyOnce(
+      workflowSource,
+      indentedCheckLine,
+      indentedCheckLine.repeat(2),
+      "frontend summary check line duplication",
+    )
+    const embedded = replaceExactlyOnce(
+      workflowSource,
+      indentedCheckLine,
+      `          echo '${checkLine}'\n`,
+      "frontend summary check line embedding",
+    )
 
     expect(missing).not.toContain(indentedCheckLine)
     expect(duplicate.match(/check_job "frontend-build"/g)).toHaveLength(2)
     expect(embedded).toContain(`          echo '${checkLine}'\n`)
-    expect(() => assertSemanticWorkflowManifest(missing)).toThrow()
-    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow()
-    expect(() => assertSemanticWorkflowManifest(embedded)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(missing)).toThrow(
+      "Check required jobs must check frontend-build exactly once",
+    )
+    expect(() => assertSemanticWorkflowManifest(duplicate)).toThrow(
+      "Check required jobs must check frontend-build exactly once",
+    )
+    expect(() => assertSemanticWorkflowManifest(embedded)).toThrow(
+      "Check required jobs must check frontend-build exactly once",
+    )
   })
 
   it("does not accept a frontend summary check decoy outside the owned step", () => {
     const workflowSource = readWorkflowSource()
-    const checkLine =
-      "check_job \"frontend-build\" \"${{ needs['frontend-build'].result }}\""
-    const source = workflowSource
-      .replace(`          ${checkLine}\n`, "")
-      .replace(
-        '          exit "$failed"\n',
-        `          exit "$failed"\n\n      - name: Preserve frontend summary text outside owner\n        shell: bash\n        run: |\n          ${checkLine}\n`,
-      )
+    const checkLine = 'check_job "frontend-build" "${{ needs[\'frontend-build\'].result }}"'
+    const withoutOwnedCheck = replaceExactlyOnce(
+      workflowSource,
+      `          ${checkLine}\n`,
+      "",
+      "owned frontend summary check line",
+    )
+    const source = replaceExactlyOnce(
+      withoutOwnedCheck,
+      '          exit "$failed"\n',
+      `          exit "$failed"\n\n      - name: Preserve frontend summary text outside owner\n        shell: bash\n        run: |\n          ${checkLine}\n`,
+      "ci-summary decoy insertion point",
+    )
 
     expect(source).toContain("      - name: Preserve frontend summary text outside owner\n")
     expect(source.match(/check_job "frontend-build"/g)).toHaveLength(1)
-    expect(() => assertSemanticWorkflowManifest(source)).toThrow()
+    expect(() => assertSemanticWorkflowManifest(source)).toThrow(
+      "Check required jobs must check frontend-build exactly once",
+    )
   })
 
   it("keeps package launchers and Vitest discovery contracts source-locked", () => {
@@ -590,6 +1032,6 @@ describe("frontend CI test manifest", () => {
       "src/**/*.test.tsx",
     ])
     expect(testConfig?.exclude).toBeUndefined()
-    expect(testConfig?.passWithNoTests).not.toBe(true)
+    expect(testConfig?.passWithNoTests).toBeFalsy()
   })
 })

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -25,11 +25,27 @@ function exactLineCount(lines: string[], value: string) {
 
 function extractFrontendBuildJob(source: string) {
   source = source.replace(/\r\n/g, "\n")
-  const jobHeader = /^  (?:([A-Za-z_][A-Za-z0-9_-]*)|'([A-Za-z_][A-Za-z0-9_-]*)'|"([A-Za-z_][A-Za-z0-9_-]*)"):[ \t]*(?:#.*)?$/gm
-  const jobHeaders = Array.from(source.matchAll(jobHeader), (match) => ({
-    id: match[1] ?? match[2] ?? match[3] ?? "",
+  const yamlHeader =
+    /^( *)(?:([A-Za-z_][A-Za-z0-9_-]*)|'([A-Za-z_][A-Za-z0-9_-]*)'|"([A-Za-z_][A-Za-z0-9_-]*)"):/gm
+  const headers = Array.from(source.matchAll(yamlHeader), (match) => ({
+    indent: match[1]!.length,
+    id: match[2] ?? match[3] ?? match[4] ?? "",
     index: match.index!,
   }))
+  const topLevelHeaders = headers.filter(({ indent }) => indent === 0)
+  const jobsHeaders = topLevelHeaders.filter(({ id }) => id === "jobs")
+  expect(jobsHeaders).toHaveLength(1)
+
+  const jobsHeader = jobsHeaders[0]!
+  const nextTopLevelHeader = topLevelHeaders.find(
+    ({ index }) => index > jobsHeader.index,
+  )
+  const jobsEnd = nextTopLevelHeader?.index ?? source.length
+
+  const jobHeaders = headers.filter(
+    ({ indent, index }) =>
+      indent === 2 && index > jobsHeader.index && index < jobsEnd,
+  )
   const frontendHeaders = jobHeaders.filter(
     ({ id }) => id === "frontend-build",
   )
@@ -39,9 +55,9 @@ function extractFrontendBuildJob(source: string) {
   const frontendHeader = frontendHeaders[0]!
   const frontendHeaderIndex = jobHeaders.indexOf(frontendHeader)
   const nextHeader = jobHeaders[frontendHeaderIndex + 1]
-  expect(nextHeader).toBeDefined()
+  const endIndex = nextHeader?.index ?? jobsEnd
 
-  return source.slice(frontendHeader.index, nextHeader!.index)
+  return source.slice(frontendHeader.index, endIndex)
 }
 
 describe("frontend CI test manifest", () => {
@@ -103,6 +119,86 @@ describe("frontend CI test manifest", () => {
     expect(extractFrontendBuildJob(reorderedWorkflowSource)).toBe(
       frontendBuildJob,
     )
+  })
+
+  it("keeps the frontend-build slice when it is the final job at workflow EOF", () => {
+    const workflowSource = readFileSync(workflowPath, "utf8")
+    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
+    const workflowWithoutFrontend = workflowSource.replace(frontendBuildJob, "")
+    const frontendAtEof = `${workflowWithoutFrontend.trimEnd()}\n\n${frontendBuildJob}`
+
+    expect(extractFrontendBuildJob(frontendAtEof)).toBe(frontendBuildJob)
+  })
+
+  it("stops the final frontend-build job before a later top-level workflow key", () => {
+    const workflowSource = readFileSync(workflowPath, "utf8")
+    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
+    const workflowWithoutFrontend = workflowSource.replace(frontendBuildJob, "")
+    const frontendBeforePermissions = `${workflowWithoutFrontend.trimEnd()}\n\n${frontendBuildJob}`
+    const workflowWithPermissions = `${frontendBeforePermissions}permissions:\n  contents: read\n`
+
+    const extractedFrontendBuildJob = extractFrontendBuildJob(workflowWithPermissions)
+
+    expect(extractedFrontendBuildJob).toBe(frontendBuildJob)
+    expect(extractedFrontendBuildJob).not.toContain("permissions:")
+    expect(extractedFrontendBuildJob).not.toContain("contents: read")
+  })
+
+  it.each([
+    [
+      "an anchored successor",
+      (source: string) =>
+        source.replace(
+          "\n  ci-summary:\n",
+          "\n  manifest-anchor: &manifest_base\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo manifest anchor\n\n  manifest-alias: *manifest_base\n\n  ci-summary:\n",
+        ),
+    ],
+    [
+      "an aliased successor",
+      (source: string) =>
+        source
+          .replace(
+            "  prepare-deepdoc-cache:\n",
+            "  prepare-deepdoc-cache: &manifest_base\n",
+          )
+          .replace(
+            "\n  ci-summary:\n",
+            "\n  manifest-alias: *manifest_base\n\n  ci-summary:\n",
+          ),
+    ],
+  ])("stops before %s sibling job", (_, updateSource) => {
+    const workflowSource = readFileSync(workflowPath, "utf8")
+    const frontendBuildJob = extractFrontendBuildJob(workflowSource)
+    const transformedWorkflowSource = updateSource(workflowSource)
+
+    expect(transformedWorkflowSource).not.toBe(workflowSource)
+    expect(transformedWorkflowSource).toContain("&manifest_base")
+    expect(transformedWorkflowSource).toContain("*manifest_base")
+    expect(extractFrontendBuildJob(transformedWorkflowSource)).toBe(
+      frontendBuildJob,
+    )
+  })
+
+  it("rejects duplicate semantic workflow and frontend-build ownership across quoting forms", () => {
+    const workflowSource = readFileSync(workflowPath, "utf8")
+    const workflowWithDuplicateJobs = `${workflowSource.trimEnd()}\n'jobs':\n  fallback:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo duplicate jobs\n`
+    const workflowWithDuplicateFrontendBuild = workflowSource.replace(
+      "\n  ci-summary:\n",
+      "\n  'frontend-build':\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo duplicate frontend build\n\n  ci-summary:\n",
+    )
+
+    expect(() => extractFrontendBuildJob(workflowWithDuplicateJobs)).toThrow()
+    expect(() => extractFrontendBuildJob(workflowWithDuplicateFrontendBuild)).toThrow()
+  })
+
+  it.each([
+    ["an empty source", ""],
+    [
+      "a jobs mapping without frontend-build",
+      "name: Manifest fixture\njobs:\n  fallback:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo fallback\n",
+    ],
+  ])("rejects %s workflow ownership", (_, source) => {
+    expect(() => extractFrontendBuildJob(source)).toThrow()
   })
 
   it("keeps App Router discovery and required frontend CI lanes source-locked", () => {

--- a/frontend/src/components/kb/knowledge-base-detail.component.test.tsx
+++ b/frontend/src/components/kb/knowledge-base-detail.component.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@/contexts/i18n-context", () => ({
   }),
 }))
 
-vi.mock("sonner", () => ({
+vi.mock("@/components/ui/sonner", () => ({
   toast: {
     error: toastErrorMock,
     success: vi.fn(),


### PR DESCRIPTION
## Summary

- Replace the mixed Home/Build test allowlist with automatic `src/app` discovery.
- Keep widget coverage, page components, the five supporting Home/Build contract suites, and the KB component directory as required CI lanes.
- Parse the existing workflow as YAML and validate the semantic trigger, `jobs.frontend-build`, and `jobs.ci-summary` contracts, including ownership, multiplicity, runner/shell policy, and failure propagation.
- Align the KB delete-flow test mock with the local toast wrapper so the complete frontend suite remains green.

## Why

The previous CI selector could remain green while App Router tests outside its allowlist were never executed. Separating App Router discovery from the five non-App contract suites ensures new `src/app` tests enter CI automatically without dropping existing coverage.

The manifest guard uses parsed YAML ownership and CST source ranges instead of presentation-dependent workflow blocks. It locks the required PR trigger activities, branch and path policy, the Ubuntu frontend runner, each required test step, and the CI summary's direct dependency and canonical terminal failure sequence. Comments, reordered step keys, sibling jobs, aliases, conditional steps, custom shells, early exits, function redefinitions, or `continue-on-error` settings cannot satisfy or mask the required contracts. The existing workflow remains the only CI manifest.

The KB lane selects `src/components/kb` as an owned directory, so all four current suites and future sibling tests are discovered without a touched-file allowlist.

The broader gap between targeted lanes and the complete regular frontend suite is tracked separately in #1257. That follow-up will evaluate a full automatically discovered lane while preserving widget coverage thresholds and deciding the widget coverage membership policy.

## Verification

- `npm run test:ci-manifest` — 1 file / 76 tests passed
- `npm run test:pages` — 10 files / 121 tests passed
- `npm run test:kb-components` — 4 files / 25 tests passed
- `npm run test:app-pages` — 9 files / 202 tests passed
- `npm run test:home-build-contracts` — 5 files / 251 tests passed
- `npm run test:widget:coverage` — 31 files / 742 tests passed; coverage thresholds satisfied
- `npm run test:run` — 128 files / 1,984 tests passed
- `npm run type-check` — passed
- `npm ci` and `npm ls yaml --depth=0` — passed with direct `yaml@2.8.1`
- Pre-commit checks for all changed files — passed
- `actionlint -shellcheck= -pyflakes= .github/workflows/ci.yml` — passed

Mutation checks cover semantic step removal under presentation drift, trigger presence and PR activity/path policies, runner changes, same-job block-scalar decoys, sibling ownership, duplicate semantic steps and YAML keys, parser warnings, excessive aliases, conditions, custom and inherited shells, `continue-on-error`, working-directory drift, quoted/anchored/aliased job boundaries, KB selector drift, `ci-summary.needs` drift, summary masking, early return, function redefinition, successful early exit, trailing commands, and missing, duplicate, embedded, or out-of-owner frontend result checks. The accepted summary script also exits nonzero when required job results are failures.

## Risk

This changes CI and test ownership only. No production runtime behavior is changed. The manifest test runs through two required steps with explicit shells, while protected required checks and the merge queue remain the independent enforcement boundary if a workflow trigger is removed or skipped. The exact summary command sequence is intentionally fail-closed; legitimate summary changes must update the workflow and its manifest contract together.

Closes #1090
