### PR TITLE
feat: let team users create a knowledge base as team-owned

### DIFF
--- a/frontend/src/components/kb/knowledge-base-creation-dialog.test.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.test.tsx
@@ -5,6 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
 const toastSuccessMock = vi.hoisted(() => vi.fn())
+const toastWarningMock = vi.hoisted(() => vi.fn())
+const inTeamMock = vi.hoisted(() => ({ value: false }))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ inTeam: inTeamMock.value }),
+}))
 
 vi.mock("@/lib/api-wrapper", () => ({
   apiRequest: apiRequestMock,
@@ -42,7 +48,7 @@ vi.mock("@/components/ui/sonner", () => ({
   toast: {
     error: toastErrorMock,
     success: toastSuccessMock,
-    warning: vi.fn(),
+    warning: toastWarningMock,
   },
 }))
 
@@ -63,6 +69,8 @@ vi.mock("lucide-react", () => {
     ChevronUp: Icon,
     ArrowRight: Icon,
     ArrowLeft: Icon,
+    User: Icon,
+    Users: Icon,
   }
 })
 
@@ -182,6 +190,9 @@ function installApiMocks() {
     if (url === "http://api.local/api/jobs/capabilities") {
       return Promise.resolve(createJsonResponse({ kb_ingest_mode: "celery" }))
     }
+    if (url.endsWith("/reserve-team") || url.endsWith("/release-team-claim")) {
+      return Promise.resolve(createJsonResponse(null, true, 204))
+    }
     if (url === "http://api.local/api/kb/ingest/jobs") {
       return Promise.resolve(
         createJsonResponse(
@@ -261,6 +272,8 @@ describe("KnowledgeBaseCreationDialog collection naming", () => {
     apiRequestMock.mockReset()
     toastErrorMock.mockReset()
     toastSuccessMock.mockReset()
+    toastWarningMock.mockReset()
+    inTeamMock.value = false
     installApiMocks()
   })
 
@@ -609,5 +622,243 @@ describe("KnowledgeBaseCreationDialog collection naming", () => {
     } finally {
       consoleErrorSpy.mockRestore()
     }
+  })
+})
+
+const RESERVE_URL = "http://api.local/api/knowledge-bases/team-docs/reserve-team"
+const RELEASE_URL = "http://api.local/api/knowledge-bases/team-docs/release-team-claim"
+
+function callsTo(url: string) {
+  return apiRequestMock.mock.calls.filter(([called]) => called === url)
+}
+
+/** Override one route, leaving every other route on the installed mock. */
+function mockRoute(
+  match: (url: string) => boolean,
+  respond: (url: string, options?: RequestInit) => unknown
+) {
+  const base = apiRequestMock.getMockImplementation()!
+  apiRequestMock.mockImplementation((url: string, options?: RequestInit) =>
+    match(url) ? respond(url, options) : base(url, options)
+  )
+}
+
+/** Name the knowledge base and pick Team, which only renders when `inTeam`. */
+function nameAndChooseTeam(container: HTMLElement) {
+  fireEvent.change(container.querySelector("#collection_name") as HTMLInputElement, {
+    target: { value: "team-docs" },
+  })
+  fireEvent.click(container.querySelector("#kb-ownership-team") as HTMLElement)
+}
+
+describe("KnowledgeBaseCreationDialog ownership", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    toastErrorMock.mockReset()
+    toastSuccessMock.mockReset()
+    toastWarningMock.mockReset()
+    inTeamMock.value = true
+    installApiMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("hides the selector and never touches the team endpoints outside a team", async () => {
+    // The open-source single-node build has no team and no /api/knowledge-bases
+    // routes: the selector must not render and no request may be made.
+    inTeamMock.value = false
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+
+    fireEvent.change(container.querySelector("#collection_name") as HTMLInputElement, {
+      target: { value: "team-docs" },
+    })
+    expect(container.querySelector("#kb-ownership-team")).toBeNull()
+    expect(container.querySelector("#kb-ownership-personal")).toBeNull()
+
+    await goToStep3(container, "file")
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(callsTo("http://api.local/api/kb/ingest/jobs")).toHaveLength(1)
+    })
+    expect(
+      apiRequestMock.mock.calls.filter(([url]) => String(url).includes("/api/knowledge-bases/"))
+    ).toHaveLength(0)
+  })
+
+  it("defaults to personal inside a team and reserves nothing", async () => {
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+
+    expect(container.querySelector("#kb-ownership-personal")?.className).toContain("border-primary")
+
+    fireEvent.change(container.querySelector("#collection_name") as HTMLInputElement, {
+      target: { value: "team-docs" },
+    })
+    await goToStep3(container, "file")
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(callsTo("http://api.local/api/kb/ingest/jobs")).toHaveLength(1)
+    })
+    expect(callsTo(RESERVE_URL)).toHaveLength(0)
+  })
+
+  it("moves the ownership choice with the keyboard, not just the mouse", () => {
+    // These are Cards standing in for radios, so the keyboard handling a real
+    // radio group gets for free is written out — pin the essentials.
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+
+    const personal = container.querySelector("#kb-ownership-personal") as HTMLElement
+    const team = container.querySelector("#kb-ownership-team") as HTMLElement
+    expect(personal.getAttribute("role")).toBe("radio")
+    expect(personal.getAttribute("tabindex")).toBe("0")
+    expect(team.getAttribute("tabindex")).toBe("-1")
+
+    fireEvent.keyDown(personal, { key: "ArrowRight" })
+    expect(team.getAttribute("aria-checked")).toBe("true")
+    // The tab stop and focus follow the selection, or the arrow key would
+    // strand the user on a card that is no longer tabbable.
+    expect(team.getAttribute("tabindex")).toBe("0")
+    expect(document.activeElement).toBe(team)
+
+    fireEvent.keyDown(team, { key: " " })
+    expect(team.getAttribute("aria-checked")).toBe("true")
+    fireEvent.keyDown(team, { key: "ArrowRight" })
+    expect(personal.getAttribute("aria-checked")).toBe("true")
+  })
+
+  it("reserves the name exactly once before a multi-file team ingest", async () => {
+    const onSuccess = vi.fn()
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={onSuccess} />
+    )
+    nameAndChooseTeam(container)
+    await goToStep3(container, "file", 2)
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(["team-docs", "team-docs"])
+    })
+    expect(callsTo(RESERVE_URL)).toHaveLength(1)
+    // The claim lands before the first byte does.
+    const reserveIndex = apiRequestMock.mock.calls.findIndex(([url]) => url === RESERVE_URL)
+    const ingestIndex = apiRequestMock.mock.calls.findIndex(
+      ([url]) => url === "http://api.local/api/kb/ingest/jobs"
+    )
+    expect(reserveIndex).toBeGreaterThan(-1)
+    expect(reserveIndex).toBeLessThan(ingestIndex)
+    expect(callsTo(RELEASE_URL)).toHaveLength(0)
+  })
+
+  it.each([
+    ["web", "http://api.local/api/kb/ingest-web/jobs"],
+    ["cloud", "http://api.local/api/kb/ingest-cloud"],
+  ] as const)("reserves once before the %s ingest too", async (tab, ingestUrl) => {
+    mockRoute(
+      (url) => url === ingestUrl,
+      () =>
+        createJsonResponse(
+          tab === "web"
+            ? createSucceededJob({
+                status: "success",
+                collection: "team-docs",
+                total_urls_found: 1,
+                pages_crawled: 1,
+                pages_failed: 0,
+                documents_created: 1,
+                chunks_created: 1,
+                embeddings_created: 1,
+                crawled_urls: [],
+                failed_urls: {},
+                message: "ok",
+                warnings: [],
+                elapsed_time_ms: 0,
+              })
+            : [{ status: "success", collection: "team-docs", message: "ok", document_count: 1, chunks_count: 1 }]
+        )
+    )
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+    nameAndChooseTeam(container)
+    await goToStep3(container, tab)
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(callsTo(ingestUrl)).toHaveLength(1)
+    })
+    expect(callsTo(RESERVE_URL)).toHaveLength(1)
+  })
+
+  it("rejects the name and skips the ingest when the reserve answers 409", async () => {
+    mockRoute(
+      (url) => url === RESERVE_URL,
+      () => createJsonResponse({ detail: "name taken" }, false, 409)
+    )
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+    nameAndChooseTeam(container)
+    await goToStep3(container, "file")
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("kb.errors.nameUnavailable", expect.anything())
+    })
+    expect(callsTo("http://api.local/api/kb/ingest/jobs")).toHaveLength(0)
+    expect(callsTo(RELEASE_URL)).toHaveLength(0)
+    // Back on step 1, at the field where the name can actually be changed.
+    expect(screen.getByText("kb.errors.nameUnavailableHint")).toBeInTheDocument()
+    expect(container.querySelector("#collection_name")).not.toBeNull()
+  })
+
+  it("releases the claim once when the ingest fails", async () => {
+    mockRoute(
+      (url) => url === "http://api.local/api/kb/ingest/jobs",
+      () => createJsonResponse({ detail: "ingest exploded" }, false, 500)
+    )
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+    nameAndChooseTeam(container)
+    await goToStep3(container, "file")
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(callsTo(RELEASE_URL)).toHaveLength(1)
+    })
+    expect(toastErrorMock).toHaveBeenCalled()
+    // A clean release says nothing: the ingest error is what the user needs.
+    expect(toastWarningMock).not.toHaveBeenCalled()
+  })
+
+  it("warns without clobbering the ingest error when the release also fails", async () => {
+    mockRoute(
+      (url) => url === "http://api.local/api/kb/ingest/jobs",
+      () => createJsonResponse({ detail: "ingest exploded" }, false, 500)
+    )
+    mockRoute(
+      (url) => url === RELEASE_URL,
+      () => createJsonResponse({ detail: "storage offline" }, false, 500)
+    )
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+    nameAndChooseTeam(container)
+    await goToStep3(container, "file")
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(toastWarningMock).toHaveBeenCalledWith("kb.ownership.releaseFailed")
+    })
+    expect(toastErrorMock).toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.test.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.test.tsx
@@ -729,10 +729,21 @@ describe("KnowledgeBaseCreationDialog ownership", () => {
     expect(team.getAttribute("tabindex")).toBe("0")
     expect(document.activeElement).toBe(team)
 
-    fireEvent.keyDown(team, { key: " " })
-    expect(team.getAttribute("aria-checked")).toBe("true")
     fireEvent.keyDown(team, { key: "ArrowRight" })
     expect(personal.getAttribute("aria-checked")).toBe("true")
+
+    // Space and Enter select the card under focus, not the current selection.
+    fireEvent.keyDown(team, { key: " " })
+    expect(team.getAttribute("aria-checked")).toBe("true")
+    fireEvent.keyDown(personal, { key: "Enter" })
+    expect(personal.getAttribute("aria-checked")).toBe("true")
+
+    fireEvent.keyDown(personal, { key: "End" })
+    expect(team.getAttribute("aria-checked")).toBe("true")
+    expect(document.activeElement).toBe(team)
+    fireEvent.keyDown(team, { key: "Home" })
+    expect(personal.getAttribute("aria-checked")).toBe("true")
+    expect(document.activeElement).toBe(personal)
   })
 
   it("reserves the name exactly once before a multi-file team ingest", async () => {
@@ -838,6 +849,63 @@ describe("KnowledgeBaseCreationDialog ownership", () => {
     expect(toastErrorMock).toHaveBeenCalled()
     // A clean release says nothing: the ingest error is what the user needs.
     expect(toastWarningMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps the claim when part of a multi-file upload already landed", async () => {
+    // File 1 put data behind the claim, so the failure of file 2 must not
+    // release the name out from under a live team collection.
+    let ingestCalls = 0
+    mockRoute(
+      (url) => url === "http://api.local/api/kb/ingest/jobs",
+      () => {
+        ingestCalls += 1
+        return ingestCalls === 1
+          ? createJsonResponse(
+              createSucceededJob({
+                status: "success",
+                collection: "team-docs",
+                document_count: 1,
+                chunks_count: 1,
+                message: "ok",
+              })
+            )
+          : createJsonResponse({ detail: "ingest exploded" }, false, 500)
+      }
+    )
+    const onSuccess = vi.fn()
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={onSuccess} />
+    )
+    nameAndChooseTeam(container)
+    await goToStep3(container, "file", 2)
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(["team-docs"])
+    })
+    expect(toastErrorMock).toHaveBeenCalled()
+    expect(callsTo(RELEASE_URL)).toHaveLength(0)
+  })
+
+  it.each([
+    ["a network error", () => Promise.reject(new Error("connection reset"))],
+    ["a 5xx", () => Promise.resolve(createJsonResponse({ detail: "boom" }, false, 503))],
+  ])("releases an ambiguous claim when the reserve dies with %s", async (_label, respond) => {
+    // A thrown or 5xx reserve may still have committed server-side, so the
+    // ingest must not start and the possible claim is given back.
+    mockRoute((url) => url === RESERVE_URL, respond)
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+    nameAndChooseTeam(container)
+    await goToStep3(container, "file")
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(callsTo(RELEASE_URL)).toHaveLength(1)
+    })
+    expect(toastErrorMock).toHaveBeenCalled()
+    expect(callsTo("http://api.local/api/kb/ingest/jobs")).toHaveLength(0)
   })
 
   it("warns without clobbering the ingest error when the release also fails", async () => {

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
@@ -29,6 +29,8 @@ import {
   normalizeKnowledgeBaseIngestionResult,
 } from "@/lib/kb-ingest-feedback"
 import { useI18n } from "@/contexts/i18n-context"
+import type { TranslationKey } from "@/i18n/translations"
+import { useAuth } from "@/contexts/auth-context"
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper"
 import { Model } from "@/lib/models"
 import {
@@ -46,6 +48,8 @@ import {
   ChevronUp,
   ArrowRight,
   ArrowLeft,
+  User,
+  Users,
 } from "lucide-react"
 import { toast } from "@/components/ui/sonner"
 import { CloudConnectDialog, CloudFile } from "./cloud-connect-dialog"
@@ -104,6 +108,111 @@ function buildWebIngestionErrorResult(
   }
 }
 
+/** Carries the response status out of a helper, so a failure detected before
+ *  the ingest request reaches the same toast classifier one detected during it
+ *  does — otherwise a reserve-time 409 loses the "pick another name" advice. */
+class RequestFailure extends Error {
+  constructor(message: string, readonly status?: number) {
+    super(message)
+  }
+}
+
+const failureStatus = (error: unknown, fromIngest?: number) =>
+  fromIngest ?? (error instanceof RequestFailure ? error.status : undefined)
+
+const SELECTABLE_CARD_SIZES = {
+  sm: { card: "p-4 gap-1", icon: "w-5 h-5 mb-1", label: "text-sm" },
+  md: { card: "p-6 gap-2", icon: "w-6 h-6 mb-2", label: "text-base" },
+}
+
+interface SelectableCardOption<T extends string> {
+  value: T
+  id?: string
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  description: string
+}
+
+/** Cards standing in for radios: a Card gives none of the keyboard behaviour a
+ *  radio group gets for free, so the tab stop follows the selection and the
+ *  arrow keys move it. */
+function SelectableCardGroup<T extends string>({
+  options,
+  selected,
+  onSelect,
+  size = "sm",
+  className,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+}: {
+  options: ReadonlyArray<SelectableCardOption<T>>
+  selected: T
+  onSelect: (value: T) => void
+  size?: keyof typeof SELECTABLE_CARD_SIZES
+  className?: string
+  "aria-label"?: string
+  "aria-labelledby"?: string
+}) {
+  const styles = SELECTABLE_CARD_SIZES[size]
+
+  // One handler on the group: keydown bubbles, and the card's position among its
+  // siblings is the index into `options`. Resolve through `closest` so a key
+  // pressed while the icon or a label holds focus still finds its card.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const cards = Array.from(event.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]'))
+    const card = (event.target as HTMLElement).closest('[role="radio"]')
+    const index = card ? cards.indexOf(card as HTMLElement) : -1
+    if (index < 0) return
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      onSelect(options[index].value)
+      return
+    }
+
+    const step = event.key === "ArrowRight" || event.key === "ArrowDown"
+      ? 1
+      : event.key === "ArrowLeft" || event.key === "ArrowUp"
+        ? -1
+        : 0
+    const jump = event.key === "Home" ? 0 : event.key === "End" ? options.length - 1 : -1
+    if (step === 0 && jump < 0) return
+    event.preventDefault()
+    const next = step === 0 ? jump : (index + step + options.length) % options.length
+    onSelect(options[next].value)
+    cards[next].focus()
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      className={className}
+      onKeyDown={handleKeyDown}
+    >
+      {options.map((option) => {
+        const isSelected = option.value === selected
+        return (
+          <Card
+            key={option.value}
+            id={option.id}
+            role="radio"
+            tabIndex={isSelected ? 0 : -1}
+            aria-checked={isSelected}
+            className={`${styles.card} cursor-pointer flex flex-col items-center justify-center border-2 transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${isSelected ? "border-primary bg-primary/5" : "border-border hover:bg-muted"}`}
+            onClick={() => onSelect(option.value)}
+          >
+            <option.icon className={`${styles.icon} text-primary`} />
+            <span className={`font-bold ${styles.label}`}>{option.label}</span>
+            <span className="text-xs text-muted-foreground">{option.description}</span>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}
+
 interface KnowledgeBaseCreationDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -112,10 +221,12 @@ interface KnowledgeBaseCreationDialogProps {
 
 export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: KnowledgeBaseCreationDialogProps) {
   const { t } = useI18n()
+  const { inTeam } = useAuth()
 
   // State from KnowledgeBasePage
   const [newCollectionName, setNewCollectionName] = useState("")
   const [newCollectionDescription, setNewCollectionDescription] = useState("")
+  const [ownership, setOwnership] = useState<"personal" | "team">("personal")
   const [activeImportTab, setActiveImportTab] = useState<"file" | "web" | "cloud">("file")
   const [currentStep, setCurrentStep] = useState(1)
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false)
@@ -174,15 +285,16 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
 
   // Embedding models state
   const [embeddingModels, setEmbeddingModels] = useState<Model[]>([])
-  // Flag only: the message itself stays in i18n so it follows a language switch.
-  const [nameError, setNameError] = useState(false)
+  // The i18n key, not the message: rendering it through `t` follows a language switch.
+  const [nameError, setNameError] = useState<TranslationKey | null>(null)
   const trimmedCollectionName = newCollectionName.trim()
 
   useEffect(() => {
     if (open) {
       // Clearing on open covers every close path (cancel, escape, overlay, the
       // close button), which `resetState` alone does not.
-      setNameError(false)
+      setNameError(null)
+      setOwnership("personal")
       fetchEmbeddingModels()
     }
   }, [open])
@@ -320,18 +432,77 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i]
   }
 
+  /** Step 1 is the only step showing the name field, so a rejected name has to
+   *  send the user back there rather than leave them on a later step. */
+  const rejectName = (messageKey: TranslationKey) => {
+    setNameError(messageKey)
+    setCurrentStep(1)
+  }
+
   /** Every way forward out of step 1 goes through here, so no later step ever
    *  has to invent a collection name. Returns false when the name is missing. */
   const requireCollectionName = () => {
     if (trimmedCollectionName) return true
     toast.error(t("kb.errors.nameRequired"))
-    setNameError(true)
-    setCurrentStep(1)
+    rejectName("kb.errors.nameRequired")
     return false
+  }
+
+  /** Ownership is resolved before the first byte is written (`reserve-team` is
+   *  a promote over an empty collection), so a team knowledge base has to claim
+   *  its name before the ingest or the files land in personal storage.
+   *
+   *  Gated on `ownership`, not `inTeam`: the server is the authority on team
+   *  membership, and a stale `inTeam` must not silently turn a requested team
+   *  knowledge base into a personal one. Sets `claimed` before awaiting: a
+   *  request that throws may still have committed server-side, and releasing a
+   *  claim that never existed is a harmless 404. */
+  const reserveTeamName = async (collection: string, claimed: { current: boolean }) => {
+    if (ownership !== "team") return
+    claimed.current = true
+    const response = await apiRequest(
+      `${getApiUrl()}/api/knowledge-bases/${encodeURIComponent(collection)}/reserve-team`,
+      { method: "POST" },
+    )
+    if (response.ok) return
+    if (response.status < 500) claimed.current = false
+    // Taken by another collection, a teammate's reservation, or a leaked claim
+    // of our own: the client cannot tell them apart, so just advise a rename.
+    if (response.status === 409) {
+      rejectName("kb.errors.nameUnavailableHint")
+      throw new RequestFailure(t("kb.errors.nameUnavailable"), response.status)
+    }
+    const parsed = await parseApiResponse(response)
+    const detail = isJsonRecord(parsed.data) && typeof parsed.data.detail === "string"
+      ? parsed.data.detail
+      : null
+    throw new RequestFailure(detail || t("kb.ownership.reserveFailed"), response.status)
+  }
+
+  /** Best-effort, fire-and-forget: a failed ingest gives the name back so a
+   *  teammate's later knowledge base under it is not resolved into team storage.
+   *  409 means data exists behind the claim (keeping it is correct) and 404
+   *  means there was no claim; anything else leaks the claim, which only the
+   *  creator can reuse — reserving the same name again answers 204 — so warn
+   *  and move on rather than retry.
+   *  ponytail: no retry/settle tracking; a leaked claim is recoverable by the
+   *  creator and blocks teammates with an explicit 409 server-side. */
+  const releaseTeamName = async (collection: string) => {
+    try {
+      const response = await apiRequest(
+        `${getApiUrl()}/api/knowledge-bases/${encodeURIComponent(collection)}/release-team-claim`,
+        { method: "POST" },
+      )
+      if (response.ok || response.status === 409 || response.status === 404) return
+    } catch {
+      // Fall through to the warning: the claim state is unknown either way.
+    }
+    toast.warning(t("kb.ownership.releaseFailed", { name: collection }))
   }
 
   const resetState = () => {
     setSelectedFiles([])
+    setOwnership("personal")
     setUploadProgress(0)
     setIngestionResults([])
     setWebIngestionResult(null)
@@ -372,16 +543,19 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
     setIngestionResults([])
     setCompletedUploadCount(0)
 
+    const collectionName = trimmedCollectionName
     const successfulCollections: string[] = []
+    const teamClaimed = { current: false }
 
     try {
       const apiUrl = getApiUrl()
       const useBackgroundJobs = await shouldUseBackgroundJobs(apiUrl)
+      // Once, before the loop: every file shares one collection.
+      await reserveTeamName(collectionName, teamClaimed)
       for (let i = 0; i < selectedFiles.length; i++) {
         const file = selectedFiles[i]
         const formData = new FormData()
 
-        const collectionName = trimmedCollectionName
         setCurrentUploadFileName(file.name)
         setCurrentUploadCollection(collectionName)
         setUploadProgressDetail(null)
@@ -494,11 +668,14 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         getKnowledgeBaseToastCopy(t, t("kb.errors.uploadFailed")),
         // Creating a knowledge base: the ingest endpoints answer 409 only when the
         // chosen name is already taken.
-        { status: failedStatus, adviseRename: true }
+        { status: failureStatus(err, failedStatus), adviseRename: true }
       )
       toast.error(toastContent.title, {
         description: toastContent.description,
       })
+      // Not awaited: the failure is already on screen, and a slow release must
+      // not keep the button reading "Processing".
+      if (teamClaimed.current) void releaseTeamName(collectionName)
       if (successfulCollections.length > 0) {
         onSuccess?.(successfulCollections)
       }
@@ -521,12 +698,14 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
     setWebIngestionProgress(0)
     setWebIngestionResult(null)
 
+    const collectionName = trimmedCollectionName
+    const teamClaimed = { current: false }
+
     try {
       const apiUrl = getApiUrl()
       const useBackgroundJobs = await shouldUseBackgroundJobs(apiUrl)
+      await reserveTeamName(collectionName, teamClaimed)
       const formData = new FormData()
-
-      const collectionName = trimmedCollectionName
 
       formData.append("collection", collectionName)
       formData.append("start_url", webIngestionConfig.start_url)
@@ -627,11 +806,12 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
       const toastContent = getKnowledgeBaseErrorToastContent(
         rawMessage,
         getKnowledgeBaseToastCopy(t, t("kb.errors.webIngestFailed")),
-        { status: failedStatus, adviseRename: true }
+        { status: failureStatus(err, failedStatus), adviseRename: true }
       )
       toast.error(toastContent.title, {
         description: toastContent.description,
       })
+      if (teamClaimed.current) void releaseTeamName(collectionName)
     } finally {
       setIsWebIngesting(false)
       setWebIngestionProgress(0)
@@ -645,13 +825,16 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
     let failedStatus: number | undefined
     setIngestionResults([])
 
+    const collectionName = trimmedCollectionName
+    const teamClaimed = { current: false }
+
     try {
       // Aggregate all selected files from all providers
       const filesToIngest = Object.entries(cloudSelections).flatMap(([provider, files]) =>
         files.map(file => ({ provider, fileId: file.id, fileName: file.name }))
       )
 
-      const collectionName = trimmedCollectionName
+      await reserveTeamName(collectionName, teamClaimed)
 
       // Prepare separators
       let separators: string[] | undefined = undefined
@@ -745,11 +928,12 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
           t,
           t("kb.errors.cloudIngestFailed")
         ),
-        { status: failedStatus, adviseRename: true }
+        { status: failureStatus(error, failedStatus), adviseRename: true }
       )
       toast.error(toastContent.title, {
         description: toastContent.description,
       })
+      if (teamClaimed.current) void releaseTeamName(collectionName)
     } finally {
       setIsCloudConnecting(false)
     }
@@ -783,6 +967,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
             <div className="mt-6">
               <Stepper
                 currentStep={currentStep}
+                contentClassName="pt-6"
                 steps={[
                   { label: t("kb.dialog.steps.nameIt"), content: <div /> },
                   { label: t("kb.dialog.steps.addContent"), content: <div /> },
@@ -794,7 +979,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
 
           <div className="flex-1 overflow-y-auto px-6 pb-6">
             {currentStep === 1 && (
-              <div className="space-y-6 mt-4">
+              <div className="space-y-6">
                 <div>
                   <Label htmlFor="collection_name" className="text-sm font-medium">{t("kb.dialog.basicInfo.nameLabel")} <span className="text-destructive">*</span></Label>
                   <Input
@@ -802,17 +987,17 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
                     value={newCollectionName}
                     onChange={(e) => {
                       setNewCollectionName(e.target.value)
-                      setNameError(false)
+                      setNameError(null)
                     }}
                     placeholder={t("kb.dialog.basicInfo.namePlaceholder")}
                     className="mt-1.5"
                     aria-required="true"
-                    aria-invalid={nameError}
+                    aria-invalid={nameError !== null}
                     aria-describedby={nameError ? "collection_name_error" : undefined}
                   />
                   {nameError && (
                     <p id="collection_name_error" className="mt-2 text-sm text-destructive">
-                      {t("kb.errors.nameRequired")}
+                      {t(nameError)}
                     </p>
                   )}
                 </div>
@@ -826,38 +1011,69 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
                     className="mt-1.5 h-32"
                   />
                 </div>
+                {/* Also rendered once Team is chosen, whatever `inTeam` says
+                    afterwards: losing membership mid-dialog would otherwise take
+                    the control away while every submit still tried to reserve,
+                    leaving no way back to Personal short of reopening. */}
+                {(inTeam || ownership === "team") && (
+                  <div className="space-y-1.5">
+                    <Label id="kb-ownership-label">{t("kb.ownership.label")}</Label>
+                    <SelectableCardGroup
+                      aria-labelledby="kb-ownership-label"
+                      className="grid grid-cols-2 gap-4"
+                      selected={ownership}
+                      onSelect={setOwnership}
+                      options={[
+                        {
+                          value: "personal",
+                          id: "kb-ownership-personal",
+                          icon: User,
+                          label: t("kb.ownership.personal"),
+                          description: t("kb.ownership.personalDesc"),
+                        },
+                        {
+                          value: "team",
+                          id: "kb-ownership-team",
+                          icon: Users,
+                          label: t("kb.ownership.team"),
+                          description: t("kb.ownership.teamDesc"),
+                        },
+                      ]}
+                    />
+                  </div>
+                )}
               </div>
             )}
 
             {currentStep === 2 && (
-              <div className="space-y-6 mt-4">
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-                  <Card
-                    className={`p-6 cursor-pointer flex flex-col items-center justify-center gap-2 transition-all text-center ${activeImportTab === 'file' ? 'border-primary bg-primary/5 border-2' : 'hover:bg-muted'}`}
-                    onClick={() => setActiveImportTab('file')}
-                  >
-                    <Upload className="w-6 h-6 text-primary mb-2" />
-                    <span className="font-bold text-base">{t("kb.dialog.tabs.file")}</span>
-                    <span className="text-xs text-muted-foreground">{t("kb.dialog.fileUpload.supportedFormats")}</span>
-                  </Card>
-                  <Card
-                    className={`p-6 cursor-pointer flex flex-col items-center justify-center gap-2 transition-all text-center ${activeImportTab === 'web' ? 'border-primary bg-primary/5 border-2' : 'hover:bg-muted'}`}
-                    onClick={() => setActiveImportTab('web')}
-                  >
-                    <Globe className="w-6 h-6 text-primary mb-2" />
-                    <span className="font-bold text-base">{t("kb.dialog.tabs.web")}</span>
-                    <span className="text-xs text-muted-foreground">{t("kb.dialog.tabs.webDesc")}</span>
-                  </Card>
-                  <Card
-                    className={`p-6 cursor-pointer flex flex-col items-center justify-center gap-2 transition-all text-center ${activeImportTab === 'cloud' ? 'border-primary bg-primary/5 border-2' : 'hover:bg-muted'}`}
-                    onClick={() => setActiveImportTab('cloud')}
-                  >
-                    <Cloud className="w-6 h-6 text-primary mb-2" />
-                    <span className="font-bold text-base">{t("kb.dialog.tabs.cloud")}</span>
-                    <span className="text-xs text-muted-foreground">{t("kb.dialog.tabs.cloudDesc")}</span>
-                  </Card>
-
-                </div>
+              <div className="space-y-6">
+                <SelectableCardGroup
+                  aria-label={t("kb.dialog.steps.addContentTitle")}
+                  className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6"
+                  size="md"
+                  selected={activeImportTab}
+                  onSelect={setActiveImportTab}
+                  options={[
+                    {
+                      value: "file",
+                      icon: Upload,
+                      label: t("kb.dialog.tabs.file"),
+                      description: t("kb.dialog.fileUpload.supportedFormats"),
+                    },
+                    {
+                      value: "web",
+                      icon: Globe,
+                      label: t("kb.dialog.tabs.web"),
+                      description: t("kb.dialog.tabs.webDesc"),
+                    },
+                    {
+                      value: "cloud",
+                      icon: Cloud,
+                      label: t("kb.dialog.tabs.cloud"),
+                      description: t("kb.dialog.tabs.cloudDesc"),
+                    },
+                  ]}
+                />
 
                 {activeImportTab === 'file' && (
                   <div className="space-y-4 w-full bg-white rounded-lg p-4 border border-dashed">
@@ -930,7 +1146,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
                       {cloudProviders.map((provider) => (
                         <Card
                           key={provider.id}
-                          className={`p-4 cursor-pointer transition-all hover:border-blue-500 relative ${cloudSelections[provider.id]?.length > 0 ? "border-blue-500 border-2" : ""}`}
+                          className={`p-4 cursor-pointer border-2 transition-colors hover:border-blue-500 relative ${cloudSelections[provider.id]?.length > 0 ? "border-blue-500" : "border-transparent"}`}
                           onClick={() => {
                             setSelectedCloudProvider(provider.id)
                             setIsCloudDialogOpen(true)
@@ -1041,7 +1257,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
             )}
 
             {currentStep === 3 && (
-              <div className="space-y-6 mt-4">
+              <div className="space-y-6">
                 <div className="bg-primary/5 rounded-lg p-4 flex flex-col gap-2 border border-primary/20">
                   <div className="flex items-center gap-2 font-bold text-sm">
                     <Database className="w-4 h-4 text-primary" />

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
@@ -108,9 +108,8 @@ function buildWebIngestionErrorResult(
   }
 }
 
-/** Carries the response status out of a helper, so a failure detected before
- *  the ingest request reaches the same toast classifier one detected during it
- *  does — otherwise a reserve-time 409 loses the "pick another name" advice. */
+/** Carries the response status into the toast classifier, so a reserve-time
+ *  409 keeps the "pick another name" advice. */
 class RequestFailure extends Error {
   constructor(message: string, readonly status?: number) {
     super(message)
@@ -133,9 +132,8 @@ interface SelectableCardOption<T extends string> {
   description: string
 }
 
-/** Cards standing in for radios: a Card gives none of the keyboard behaviour a
- *  radio group gets for free, so the tab stop follows the selection and the
- *  arrow keys move it. */
+/** Cards standing in for radios, with the APG radiogroup keyboard behaviour
+ *  (roving tab stop, arrows, Home/End) written out. */
 function SelectableCardGroup<T extends string>({
   options,
   selected,
@@ -155,9 +153,8 @@ function SelectableCardGroup<T extends string>({
 }) {
   const styles = SELECTABLE_CARD_SIZES[size]
 
-  // One handler on the group: keydown bubbles, and the card's position among its
-  // siblings is the index into `options`. Resolve through `closest` so a key
-  // pressed while the icon or a label holds focus still finds its card.
+  // One bubbling handler on the group; `closest` finds the card even when a
+  // nested icon or label holds focus.
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const cards = Array.from(event.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]'))
     const card = (event.target as HTMLElement).closest('[role="radio"]')
@@ -448,15 +445,9 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
     return false
   }
 
-  /** Ownership is resolved before the first byte is written (`reserve-team` is
-   *  a promote over an empty collection), so a team knowledge base has to claim
-   *  its name before the ingest or the files land in personal storage.
-   *
-   *  Gated on `ownership`, not `inTeam`: the server is the authority on team
-   *  membership, and a stale `inTeam` must not silently turn a requested team
-   *  knowledge base into a personal one. Sets `claimed` before awaiting: a
-   *  request that throws may still have committed server-side, and releasing a
-   *  claim that never existed is a harmless 404. */
+  /** Claim the name before the first ingest byte, or the files land in personal
+   *  storage. Gated on `ownership`, not `inTeam` — the server owns membership.
+   *  `claimed` is set before the await: a thrown request may have committed. */
   const reserveTeamName = async (collection: string, claimed: { current: boolean }) => {
     if (ownership !== "team") return
     claimed.current = true
@@ -479,14 +470,9 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
     throw new RequestFailure(detail || t("kb.ownership.reserveFailed"), response.status)
   }
 
-  /** Best-effort, fire-and-forget: a failed ingest gives the name back so a
-   *  teammate's later knowledge base under it is not resolved into team storage.
-   *  409 means data exists behind the claim (keeping it is correct) and 404
-   *  means there was no claim; anything else leaks the claim, which only the
-   *  creator can reuse — reserving the same name again answers 204 — so warn
-   *  and move on rather than retry.
-   *  ponytail: no retry/settle tracking; a leaked claim is recoverable by the
-   *  creator and blocks teammates with an explicit 409 server-side. */
+  /** Best-effort release, no retry: 409 means data exists (keep the claim),
+   *  404 means there was no claim, anything else just warns — a leaked claim
+   *  stays reusable by its creator and blocks teammates server-side. */
   const releaseTeamName = async (collection: string) => {
     try {
       const response = await apiRequest(
@@ -673,9 +659,11 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
       toast.error(toastContent.title, {
         description: toastContent.description,
       })
-      // Not awaited: the failure is already on screen, and a slow release must
-      // not keep the button reading "Processing".
-      if (teamClaimed.current) void releaseTeamName(collectionName)
+      // Fire-and-forget, and only when nothing landed: once any file succeeded
+      // the collection has data and the claim must stay.
+      if (teamClaimed.current && successfulCollections.length === 0) {
+        void releaseTeamName(collectionName)
+      }
       if (successfulCollections.length > 0) {
         onSuccess?.(successfulCollections)
       }
@@ -827,6 +815,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
 
     const collectionName = trimmedCollectionName
     const teamClaimed = { current: false }
+    let succeededCloudFiles = 0
 
     try {
       // Aggregate all selected files from all providers
@@ -906,6 +895,7 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
         : []
       setIngestionResults(results)
 
+      succeededCloudFiles = results.filter(result => result.status === "success").length
       const failedResults = results.filter(result => result.status !== "success")
       if (failedResults.length > 0) {
         throw new Error(failedResults[0].message || t("kb.errors.cloudIngestFailed"))
@@ -933,7 +923,10 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
       toast.error(toastContent.title, {
         description: toastContent.description,
       })
-      if (teamClaimed.current) void releaseTeamName(collectionName)
+      // Same zero-success gate as the file path.
+      if (teamClaimed.current && succeededCloudFiles === 0) {
+        void releaseTeamName(collectionName)
+      }
     } finally {
       setIsCloudConnecting(false)
     }
@@ -976,9 +969,8 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
             </div>
           </div>
 
-          {/* This dialog renders its step bodies here, outside the Stepper, so
-              the gap the stepper's dropped `mb-6` used to provide lives on the
-              real content container — not on the Stepper's empty tabpanel. */}
+          {/* Step bodies render here, outside the Stepper, so the spacing the
+              stepper's dropped `mb-6` provided lives on this container. */}
           <div className="flex-1 overflow-y-auto px-6 pt-6 pb-6">
             {currentStep === 1 && (
               <div className="space-y-6">
@@ -1013,10 +1005,8 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
                     className="mt-1.5 h-32"
                   />
                 </div>
-                {/* Also rendered once Team is chosen, whatever `inTeam` says
-                    afterwards: losing membership mid-dialog would otherwise take
-                    the control away while every submit still tried to reserve,
-                    leaving no way back to Personal short of reopening. */}
+                {/* Stays rendered once Team is chosen, so losing `inTeam`
+                    mid-dialog cannot strand the user on Team. */}
                 {(inTeam || ownership === "team") && (
                   <div className="space-y-1.5">
                     <Label id="kb-ownership-label">{t("kb.ownership.label")}</Label>

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
@@ -180,7 +180,7 @@ function SelectableCardGroup<T extends string>({
     event.preventDefault()
     const next = step === 0 ? jump : (index + step + options.length) % options.length
     onSelect(options[next].value)
-    cards[next].focus()
+    cards[next]?.focus()
   }
 
   return (
@@ -967,7 +967,6 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
             <div className="mt-6">
               <Stepper
                 currentStep={currentStep}
-                contentClassName="pt-6"
                 steps={[
                   { label: t("kb.dialog.steps.nameIt"), content: <div /> },
                   { label: t("kb.dialog.steps.addContent"), content: <div /> },
@@ -977,7 +976,10 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
             </div>
           </div>
 
-          <div className="flex-1 overflow-y-auto px-6 pb-6">
+          {/* This dialog renders its step bodies here, outside the Stepper, so
+              the gap the stepper's dropped `mb-6` used to provide lives on the
+              real content container — not on the Stepper's empty tabpanel. */}
+          <div className="flex-1 overflow-y-auto px-6 pt-6 pb-6">
             {currentStep === 1 && (
               <div className="space-y-6">
                 <div>

--- a/frontend/src/components/pages/admin-mcp.tsx
+++ b/frontend/src/components/pages/admin-mcp.tsx
@@ -688,6 +688,7 @@ export default function AdminMcpPage() {
             </>
           ) : (
             <Stepper
+              contentClassName="pt-6"
               steps={[
                 {
                   label: t("adminMcp.modal.step1"),

--- a/frontend/src/components/pages/model-management-dialog.tsx
+++ b/frontend/src/components/pages/model-management-dialog.tsx
@@ -861,7 +861,10 @@ export function ModelManagementDialog({
               <DialogDescription className="text-left">{t('models.dialog.connect.description')}</DialogDescription>
             </DialogHeader>
 
+            {/* The step bodies have no padding of their own, so they need the
+                gap the stepper's dropped `mb-6` used to provide. */}
             <Stepper
+              contentClassName="pt-6"
               steps={[
                 {
                   label: t('models.dialog.connect.step1'),

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -28,7 +28,9 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        // border-2, not border: a 1px primary ring is near-invisible on the
+        // light theme, leaving an unselected option looking like a bare label.
+        "aspect-square h-4 w-4 rounded-full border-2 border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -28,9 +28,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        // border-2, not border: a 1px primary ring is near-invisible on the
-        // light theme, leaving an unselected option looking like a bare label.
-        "aspect-square h-4 w-4 rounded-full border-2 border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/stepper.tsx
+++ b/frontend/src/components/ui/stepper.tsx
@@ -30,7 +30,7 @@ export function Stepper({
       {...props}
     >
       <div
-        className="flex items-center gap-4 mb-6 overflow-x-auto overflow-y-hidden py-2"
+        className="flex items-center gap-4 overflow-x-auto overflow-y-hidden py-2"
         role="list"
         aria-label="Steps"
       >

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1891,13 +1891,18 @@ Build when you need.`,
   },
   kb: {
     ownership: {
+      label: "Ownership",
       personal: "Personal",
       team: "Team",
+      personalDesc: "Only you can see it",
+      teamDesc: "Everyone on your team can see it",
       makeTeam: "Share with team",
       makePersonal: "Make personal",
       teamSuccess: "Knowledge base shared with your team.",
       personalSuccess: "Knowledge base is personal again.",
       failed: "Failed to update knowledge base ownership",
+      reserveFailed: "Failed to reserve this name for your team",
+      releaseFailed: "The team reservation for \"{name}\" was not released. Creating it again under your account reuses it.",
     },
     errors: {
       loadFailed: "Failed to load knowledge base",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1891,13 +1891,18 @@ const zh = {
   },
   kb: {
     ownership: {
+      label: "归属",
       personal: "个人",
       team: "团队",
+      personalDesc: "仅你自己可见",
+      teamDesc: "团队成员都可见",
       makeTeam: "转为团队知识库",
       makePersonal: "转回个人",
       teamSuccess: "知识库已共享给团队。",
       personalSuccess: "知识库已转回个人。",
       failed: "更新知识库归属失败",
+      reserveFailed: "无法为团队登记该名称",
+      releaseFailed: "名称“{name}”的团队登记未能释放，用你的账号再次创建会沿用这条登记。",
     },
     errors: {
       loadFailed: "知识库加载失败",


### PR DESCRIPTION
Replaces #1205.

## Problem

The creation dialog has no ownership control: every knowledge base starts personal, and making it team-owned takes a second step on the list page, which physically relocates files and vector rows as a background job.

## Change

An ownership choice (Personal / Team) on step 1, gated on `inTeam` from `useAuth()`. Standalone builds never render it and never touch a team endpoint — a test asserts exactly that.

When Team is picked, the name is claimed once before the first ingest request via `reserve-team` (provided by multi-tenant deployments; a promote over an empty collection, idempotent per creator). A reserve 409 rejects the name on step 1 before anything is created.

## Rollback

If the ingest fails, one best-effort `release-team-claim` follows. A failed release only warns: the claim stays reusable by its creator (reserving the same name again answers 204) and blocks teammates with an explicit server-side 409, so the client keeps no release/retry state machine — the browser cannot guarantee that lifecycle, which is what sank #1205.

## Carried over from #1205's review

The dialog's selection cards are one keyboard-accessible radiogroup (APG pattern) with constant border width, the stepper's fixed bottom margin moved into per-dialog padding, and the unselected radio ring is visible on the light theme.

## Testing

19/19 dialog tests (8 new: standalone gating, default-Personal reserves nothing, exactly one reserve before file/web/cloud ingest, 409 → step-1 error with no ingest, one release on failure, release failure warns without clobbering the ingest error, keyboard radiogroup). `tsc --noEmit` clean; the full frontend suite's single failure predates this branch and reproduces on main.
