### PR TITLE
feat(tasks): add the interaction protocol version marker column

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -223,6 +223,10 @@ jobs:
         env:
           DATABASE_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      # Any new migration test file with postgresql-marked tests must be
+      # added to this list -- the fast job deselects the marker and
+      # provisions no database, so an unlisted file's postgres tests run
+      # nowhere.
       - name: Test Gmail provisioning Postgres-only behavior
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
@@ -252,10 +256,6 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
-      # Any new migration test file with postgresql-marked tests must be
-      # added to this list -- the fast job deselects the marker and
-      # provisions no database, so an unlisted file's postgres tests run
-      # nowhere.
       - name: Test task_interaction_requests migration (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -252,6 +252,10 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      # Any new migration test file with postgresql-marked tests must be
+      # added to this list -- the fast job deselects the marker and
+      # provisions no database, so an unlisted file's postgres tests run
+      # nowhere.
       - name: Test task_interaction_requests migration (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
@@ -278,6 +282,20 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/web/services/test_interaction_staging_postgresql.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test task_interaction_protocol_version migration (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/alembic/test_20260810_add_task_interaction_protocol_version.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test task_interaction_protocol_version create_all/migration parity (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/migrations/test_task_interaction_protocol_version_parity.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
+++ b/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
@@ -116,6 +116,12 @@ def upgrade() -> None:
 def downgrade() -> None:
     context = op.get_context()
 
+    # Constraint dropped before column, both here and in the online branch
+    # below. PostgreSQL does not require this order -- DROP COLUMN auto-drops
+    # a single-column CHECK that depends on the dropped column, no CASCADE
+    # needed. The explicit drop_constraint keeps the downgrade symmetric with
+    # upgrade's add-column-then-add-constraint sequence and independent of
+    # that auto-drop behaviour.
     if context.as_sql:
         if context.dialect.name == "postgresql":
             op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check")

--- a/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
+++ b/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
@@ -1,7 +1,7 @@
 """add tasks.interaction_protocol_version
 
 Revision ID: 20260810_add_task_interaction_protocol_version
-Revises: 20260806_seed_chrome_mcp_app
+Revises: 20260809_add_task_interaction_requests
 Create Date: 2026-08-10
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260810_add_task_interaction_protocol_version"
-down_revision: Union[str, None] = "20260806_seed_chrome_mcp_app"
+down_revision: Union[str, None] = "20260809_add_task_interaction_requests"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
+++ b/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
@@ -83,8 +83,8 @@ def upgrade() -> None:
     # requirement -- so only PostgreSQL gets the constraint here. Online,
     # batch_alter_table could add the CHECK to an existing SQLite table the
     # same way downgrade() already removes it; that convergence is
-    # deliberately deferred to the first production writer of this column
-    # (see the model's __table_args__ comment and
+    # deliberately deferred to the first production writer of this column,
+    # tracked in #1290 (see the model's __table_args__ comment and
     # test_sqlite_check_asymmetry_is_expected in
     # tests/migrations/test_task_interaction_protocol_version_parity.py).
     if context.as_sql:

--- a/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
+++ b/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
@@ -116,12 +116,15 @@ def upgrade() -> None:
 def downgrade() -> None:
     context = op.get_context()
 
-    # Constraint dropped before column, both here and in the online branch
-    # below. PostgreSQL does not require this order -- DROP COLUMN auto-drops
-    # a single-column CHECK that depends on the dropped column, no CASCADE
-    # needed. The explicit drop_constraint keeps the downgrade symmetric with
-    # upgrade's add-column-then-add-constraint sequence and independent of
-    # that auto-drop behaviour.
+    # Constraint dropped before column, both here and in the online
+    # PostgreSQL branch below. PostgreSQL does not require this order --
+    # DROP COLUMN auto-drops a single-column CHECK that depends on the
+    # dropped column, no CASCADE needed. The explicit drop_constraint keeps
+    # the downgrade symmetric with upgrade's add-column-then-add-constraint
+    # sequence and independent of that auto-drop behaviour. This offline
+    # branch is PostgreSQL-oriented and stays untouched by the SQLite fix
+    # below: batch mode (needed for SQLite) cannot run in --sql mode on
+    # either dialect.
     if context.as_sql:
         if context.dialect.name == "postgresql":
             op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check")
@@ -137,5 +140,23 @@ def downgrade() -> None:
         if CONSTRAINT_NAME in _online_check_constraints(schema):
             op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check", schema=schema)
 
+        if COLUMN in _online_columns(schema):
+            op.drop_column(TABLE, COLUMN, schema=schema)
+        return
+
+    # Non-PostgreSQL (SQLite): a fresh install stamps head and then builds
+    # the schema via create_all (see src/xagent/db/migration.py's empty-DB
+    # stamp path and database.py's create_all call), so the fresh-install
+    # shape DOES carry ck_tasks_interaction_protocol_version on SQLite even
+    # though the migration's own upgrade() never adds it there (see the
+    # upgrade() branch above and test_sqlite_check_asymmetry_is_expected).
+    # SQLite 3.35+ refuses to DROP a column a CHECK constraint references, so
+    # a plain drop_column() breaks on that shape. batch_alter_table rebuilds
+    # the table (copy/rename/drop) instead, which drops the constraint and
+    # the column together regardless of which shape this database has.
     if COLUMN in _online_columns(schema):
-        op.drop_column(TABLE, COLUMN, schema=schema)
+        constraint_present = CONSTRAINT_NAME in _online_check_constraints(schema)
+        with op.batch_alter_table(TABLE, schema=schema) as batch_op:
+            if constraint_present:
+                batch_op.drop_constraint(CONSTRAINT_NAME, type_="check")
+            batch_op.drop_column(COLUMN)

--- a/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
+++ b/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
@@ -1,0 +1,135 @@
+"""add tasks.interaction_protocol_version
+
+Revision ID: 20260810_add_task_interaction_protocol_version
+Revises: 20260806_seed_chrome_mcp_app
+Create Date: 2026-08-10
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260810_add_task_interaction_protocol_version"
+down_revision: Union[str, None] = "20260806_seed_chrome_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "tasks"
+COLUMN = "interaction_protocol_version"
+CONSTRAINT_NAME = "ck_tasks_interaction_protocol_version"
+CONSTRAINT_CONDITION = (
+    "interaction_protocol_version IS NULL OR interaction_protocol_version = 1"
+)
+
+# The schema of the *visible* tasks relation. version_table_schema names only
+# the Alembic version table, and current_schema() is merely the first entry on
+# search_path, so neither identifies the relation an unqualified reference
+# actually resolves to. Ask PostgreSQL which one it resolves.
+POSTGRES_VISIBLE_TABLE_SCHEMA_SQL = sa.text(
+    """
+    SELECT ns.nspname
+    FROM pg_catalog.pg_class AS cls
+    JOIN pg_catalog.pg_namespace AS ns ON ns.oid = cls.relnamespace
+    WHERE cls.oid = pg_catalog.to_regclass(:table_name)
+    """
+)
+
+
+def _target_schema() -> str | None:
+    """The schema holding the tasks relation this migration operates on."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        resolved = bind.execute(
+            POSTGRES_VISIBLE_TABLE_SCHEMA_SQL, {"table_name": TABLE}
+        ).scalar()
+        if resolved:
+            return str(resolved)
+    schema = op.get_context().version_table_schema
+    return str(schema) if schema else None
+
+
+def _online_columns(schema: str | None) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names(schema=schema):
+        return set()
+    return {str(item["name"]) for item in inspector.get_columns(TABLE, schema=schema)}
+
+
+def _online_table_exists(schema: str | None) -> bool:
+    return TABLE in sa.inspect(op.get_bind()).get_table_names(schema=schema)
+
+
+def _online_check_constraints(schema: str | None) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in inspector.get_table_names(schema=schema):
+        return set()
+    return {
+        str(item["name"])
+        for item in inspector.get_check_constraints(TABLE, schema=schema)
+        if item.get("name")
+    }
+
+
+def upgrade() -> None:
+    context = op.get_context()
+
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable. Emit the unconditional DDL instead of inspecting. Adding a
+    # CHECK to an existing table has no --sql-mode-safe path on SQLite (see
+    # the migration docstring in the model's __table_args__ comment), so only
+    # PostgreSQL gets the constraint here.
+    if context.as_sql:
+        op.add_column(TABLE, sa.Column(COLUMN, sa.Integer(), nullable=True))
+        if context.dialect.name == "postgresql":
+            op.create_check_constraint(CONSTRAINT_NAME, TABLE, CONSTRAINT_CONDITION)
+        return
+
+    # Address the same relation the catalog lookup inspects, so reflection and
+    # DDL can never diverge onto different schemas.
+    schema = _target_schema()
+
+    if not _online_table_exists(schema):
+        return
+
+    if COLUMN not in _online_columns(schema):
+        op.add_column(
+            TABLE,
+            sa.Column(COLUMN, sa.Integer(), nullable=True),
+            schema=schema,
+        )
+
+    # The column guard above can skip add_column (e.g. a create_all-built
+    # database already has the column), but the CHECK must still be checked
+    # independently -- otherwise upgrading such a database would silently
+    # leave it without the constraint.
+    if context.dialect.name != "postgresql":
+        return
+
+    if CONSTRAINT_NAME not in _online_check_constraints(schema):
+        op.create_check_constraint(
+            CONSTRAINT_NAME, TABLE, CONSTRAINT_CONDITION, schema=schema
+        )
+
+
+def downgrade() -> None:
+    context = op.get_context()
+
+    if context.as_sql:
+        if context.dialect.name == "postgresql":
+            op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check")
+        op.drop_column(TABLE, COLUMN)
+        return
+
+    schema = _target_schema()
+
+    if not _online_table_exists(schema):
+        return
+
+    if context.dialect.name == "postgresql":
+        if CONSTRAINT_NAME in _online_check_constraints(schema):
+            op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check", schema=schema)
+
+    if COLUMN in _online_columns(schema):
+        op.drop_column(TABLE, COLUMN, schema=schema)

--- a/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
+++ b/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
@@ -50,26 +50,26 @@ def _target_schema() -> str | None:
     return str(schema) if schema else None
 
 
-def _online_columns(schema: str | None) -> set[str]:
+def _online_inventory(schema: str | None) -> tuple[set[str], set[str]] | None:
+    """One inspector, one table-names fetch: the tasks columns and the names
+    of its ck_ CHECK constraints, or None when tasks does not exist. No
+    branch in this migration creates or drops tasks -- only columns and
+    constraints on it -- so a single fetch cannot go stale. Do not reuse the
+    returned sets after a DDL statement: they are a snapshot, and the
+    inspector behind them caches.
+    """
     inspector = sa.inspect(op.get_bind())
     if TABLE not in inspector.get_table_names(schema=schema):
-        return set()
-    return {str(item["name"]) for item in inspector.get_columns(TABLE, schema=schema)}
-
-
-def _online_table_exists(schema: str | None) -> bool:
-    return TABLE in sa.inspect(op.get_bind()).get_table_names(schema=schema)
-
-
-def _online_check_constraints(schema: str | None) -> set[str]:
-    inspector = sa.inspect(op.get_bind())
-    if TABLE not in inspector.get_table_names(schema=schema):
-        return set()
-    return {
+        return None
+    columns = {
+        str(item["name"]) for item in inspector.get_columns(TABLE, schema=schema)
+    }
+    checks = {
         str(item["name"])
         for item in inspector.get_check_constraints(TABLE, schema=schema)
         if item.get("name")
     }
+    return columns, checks
 
 
 def upgrade() -> None:
@@ -97,10 +97,12 @@ def upgrade() -> None:
     # DDL can never diverge onto different schemas.
     schema = _target_schema()
 
-    if not _online_table_exists(schema):
+    inventory = _online_inventory(schema)
+    if inventory is None:
         return
+    columns, checks = inventory
 
-    if COLUMN not in _online_columns(schema):
+    if COLUMN not in columns:
         op.add_column(
             TABLE,
             sa.Column(COLUMN, sa.Integer(), nullable=True),
@@ -122,7 +124,7 @@ def upgrade() -> None:
     # cannot fail -- but on a large deployment, a NOT VALID constraint
     # followed by a separate VALIDATE CONSTRAINT would move validation out
     # of the lock window if that ever becomes a concern.
-    if CONSTRAINT_NAME not in _online_check_constraints(schema):
+    if CONSTRAINT_NAME not in checks:
         op.create_check_constraint(
             CONSTRAINT_NAME, TABLE, CONSTRAINT_CONDITION, schema=schema
         )
@@ -166,14 +168,16 @@ def downgrade() -> None:
 
     schema = _target_schema()
 
-    if not _online_table_exists(schema):
+    inventory = _online_inventory(schema)
+    if inventory is None:
         return
+    columns, checks = inventory
 
     if context.dialect.name == "postgresql":
-        if CONSTRAINT_NAME in _online_check_constraints(schema):
+        if CONSTRAINT_NAME in checks:
             op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check", schema=schema)
 
-        if COLUMN in _online_columns(schema):
+        if COLUMN in columns:
             op.drop_column(TABLE, COLUMN, schema=schema)
         return
 
@@ -188,8 +192,8 @@ def downgrade() -> None:
     # a plain drop_column() breaks on that shape. batch_alter_table rebuilds
     # the table (copy/rename/drop) instead, which drops the constraint and
     # the column together regardless of which shape this database has.
-    if COLUMN in _online_columns(schema):
-        constraint_present = CONSTRAINT_NAME in _online_check_constraints(schema)
+    if COLUMN in columns:
+        constraint_present = CONSTRAINT_NAME in checks
         with op.batch_alter_table(TABLE, schema=schema) as batch_op:
             if constraint_present:
                 batch_op.drop_constraint(CONSTRAINT_NAME, type_="check")

--- a/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
+++ b/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
@@ -114,6 +114,14 @@ def upgrade() -> None:
     if context.dialect.name != "postgresql":
         return
 
+    # On PostgreSQL create_check_constraint takes an ACCESS EXCLUSIVE lock on
+    # tasks and validates every existing row before returning (see
+    # 20260804_add_task_checkpoint_trace_event_anchor.py for the same note
+    # against create_foreign_key). Here the column was added moments earlier
+    # in this same migration, so every row is still NULL and validation
+    # cannot fail -- but on a large deployment, a NOT VALID constraint
+    # followed by a separate VALIDATE CONSTRAINT would move validation out
+    # of the lock window if that ever becomes a concern.
     if CONSTRAINT_NAME not in _online_check_constraints(schema):
         op.create_check_constraint(
             CONSTRAINT_NAME, TABLE, CONSTRAINT_CONDITION, schema=schema

--- a/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
+++ b/src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py
@@ -76,10 +76,17 @@ def upgrade() -> None:
     context = op.get_context()
 
     # Offline (--sql) generation has a MockConnection, so reflection is
-    # unavailable. Emit the unconditional DDL instead of inspecting. Adding a
-    # CHECK to an existing table has no --sql-mode-safe path on SQLite (see
-    # the migration docstring in the model's __table_args__ comment), so only
-    # PostgreSQL gets the constraint here.
+    # unavailable. Emit the unconditional DDL instead of inspecting. Adding
+    # a CHECK to an existing table has no --sql-mode-safe path on SQLite --
+    # the batch_alter_table rebuild that could add it cannot render under
+    # --sql mode on either dialect, and offline SQL support is a hard
+    # requirement -- so only PostgreSQL gets the constraint here. Online,
+    # batch_alter_table could add the CHECK to an existing SQLite table the
+    # same way downgrade() already removes it; that convergence is
+    # deliberately deferred to the first production writer of this column
+    # (see the model's __table_args__ comment and
+    # test_sqlite_check_asymmetry_is_expected in
+    # tests/migrations/test_task_interaction_protocol_version_parity.py).
     if context.as_sql:
         op.add_column(TABLE, sa.Column(COLUMN, sa.Integer(), nullable=True))
         if context.dialect.name == "postgresql":
@@ -121,10 +128,28 @@ def downgrade() -> None:
     # DROP COLUMN auto-drops a single-column CHECK that depends on the
     # dropped column, no CASCADE needed. The explicit drop_constraint keeps
     # the downgrade symmetric with upgrade's add-column-then-add-constraint
-    # sequence and independent of that auto-drop behaviour. This offline
-    # branch is PostgreSQL-oriented and stays untouched by the SQLite fix
-    # below: batch mode (needed for SQLite) cannot run in --sql mode on
-    # either dialect.
+    # sequence and independent of that auto-drop behaviour.
+    #
+    # The SQLite side of this offline branch stays a plain drop_column,
+    # unlike the batch_alter_table rebuild the online branch below uses.
+    # Offline (--sql) generation cannot run batch mode, so that rebuild has
+    # no offline rendering here -- see
+    # 20260804_add_task_checkpoint_trace_event_anchor.py, which takes the
+    # same shape on this same table and documents accepting the loud
+    # first-statement failure this produces against a create_all-built
+    # SQLite database. Fixing this revision alone would not make the
+    # offline downgrade chain traversable for that shape either: two
+    # revisions further down, 20260804 fails the same way, so the failure
+    # is a property of the repository's offline-downgrade support, not of
+    # this revision. The alternative -- an offline batch_alter_table
+    # rebuild via copy_from=<a frozen Table object> -- needs a full table
+    # definition frozen inside the migration; if that frozen copy ever
+    # drifts from the real table, the rendered rebuild silently drops the
+    # missing columns' data instead of failing, which is strictly worse
+    # than today's loud first-statement error. Downgrading a
+    # create_all-built SQLite database over a live connection takes the
+    # rebuilding branch below instead, which reflects the real table and
+    # needs no frozen copy.
     if context.as_sql:
         if context.dialect.name == "postgresql":
             op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check")
@@ -146,8 +171,9 @@ def downgrade() -> None:
 
     # Non-PostgreSQL (SQLite): a fresh install stamps head and then builds
     # the schema via create_all (see src/xagent/db/migration.py's empty-DB
-    # stamp path and database.py's create_all call), so the fresh-install
-    # shape DOES carry ck_tasks_interaction_protocol_version on SQLite even
+    # stamp path and src/xagent/web/models/database.py's create_all call,
+    # at its _initialize_database_schema site), so the fresh-install shape
+    # DOES carry ck_tasks_interaction_protocol_version on SQLite even
     # though the migration's own upgrade() never adds it there (see the
     # upgrade() branch above and test_sqlite_check_asymmetry_is_expected).
     # SQLite 3.35+ refuses to DROP a column a CHECK constraint references, so

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -95,6 +95,11 @@ class Task(Base):  # type: ignore
         # CHECK, so the constraint's behaviour stays covered by tests. The
         # asymmetry is asserted as expected, not merely left uncovered -- see
         # tests/migrations/test_task_interaction_protocol_version_parity.py.
+        #
+        # Unlike task_interaction_requests' floor-plus-active-pin split
+        # (which lets terminated rows carry future versions), this is a
+        # single mutable current-wait pointer with no historical rows, so an
+        # unconditional NULL-or-1 pin is the whole contract.
         CheckConstraint(
             "interaction_protocol_version IS NULL OR interaction_protocol_version = 1",
             name="ck_tasks_interaction_protocol_version",
@@ -166,13 +171,31 @@ class Task(Base):  # type: ignore
     # compare in Python -- so an index would be pure write cost.
     lease_attempt_id = Column(String(64), nullable=True)
 
-    # Protocol version of the interaction row that backs this task's current
-    # wait. Written by the three wait finalizers (1 when a row was staged,
-    # NULL when staging degraded) and cleared by the three legacy-resume
-    # injection sites. Readers must gate on status == WAITING_FOR_USER first:
-    # a task that left the waiting state by a path with no injection site
-    # (cancel, delete, failure, TTL reclaim, admin cleanup) can still carry a
-    # stale 1, and the next wait overwrites it either way.
+    # Protocol version of the interaction row that will back this task's
+    # current wait. Each of its two writer groups is spoken for, and none of
+    # those writers exists yet: the three wait finalizers will write it (1
+    # when a row was staged, NULL when staging degraded), and the three
+    # legacy-resume injection sites will clear it. Readers will need to gate
+    # on status == WAITING_FOR_USER first: a task that left the waiting
+    # state by a path with no injection site (cancel, delete, failure, TTL
+    # reclaim, admin cleanup) will be able to carry a stale 1, and the next
+    # wait will overwrite it either way.
+    #
+    # Why a column on tasks rather than an EXISTS over
+    # task_interaction_requests: the read surface's first check is
+    # "interaction_protocol_version != 1 -> legacy path, ask the interaction
+    # table nothing". All four waiting-question consumers already hold a
+    # loaded Task row when they need the answer, so that check is a free
+    # attribute access -- while an EXISTS derivation would cost one
+    # cross-table query per waiting-status read, on paths that include the
+    # websocket's synchronous snapshot. While every waiting task predates
+    # the native protocol (and during any rollback), the marker is NULL for
+    # all of them and the interaction table receives zero queries from the
+    # read path. The marker only ever decides priority, never whether the
+    # legacy fallback exists: readers fall back unconditionally when no
+    # active row matches, so a stale marker degrades to the legacy question
+    # rather than corrupting anything. Re-examine the status coupling when
+    # the first writer lands.
     interaction_protocol_version = Column(Integer, nullable=True)
 
     # Model configuration

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -4,6 +4,7 @@ from typing import Any, Collection
 from sqlalchemy import (
     JSON,
     Boolean,
+    CheckConstraint,
     Column,
     DateTime,
     Enum,
@@ -79,6 +80,25 @@ class Task(Base):  # type: ignore
             "lease_expires_at",
             "id",
         ),
+        # The task-level marker for the protocol version of the interaction
+        # row this task's readers should expect. NULL means "no v1 row was
+        # staged for the current wait" and readers fall back to the legacy
+        # transcript path; 1 means a protocol v1 interaction row exists.
+        #
+        # Only create_all-built databases and PostgreSQL carry this CHECK.
+        # The SQLite migration branch cannot emit it: adding a constraint to
+        # an existing table raises NotImplementedError on that dialect both
+        # online and offline, and the batch_alter_table workaround cannot run
+        # in --sql mode on either dialect, which the offline-SQL requirement
+        # rules out. SQLite is development and test only; production is
+        # PostgreSQL, and create_all-built SQLite test databases do carry the
+        # CHECK, so the constraint's behaviour stays covered by tests. The
+        # asymmetry is asserted as expected, not merely left uncovered -- see
+        # tests/migrations/test_task_interaction_protocol_version_parity.py.
+        CheckConstraint(
+            "interaction_protocol_version IS NULL OR interaction_protocol_version = 1",
+            name="ck_tasks_interaction_protocol_version",
+        ),
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -145,6 +165,15 @@ class Task(Base):  # type: ignore
     # never a WHERE predicate -- consumers read the row by primary key and
     # compare in Python -- so an index would be pure write cost.
     lease_attempt_id = Column(String(64), nullable=True)
+
+    # Protocol version of the interaction row that backs this task's current
+    # wait. Written by the three wait finalizers (1 when a row was staged,
+    # NULL when staging degraded) and cleared by the three legacy-resume
+    # injection sites. Readers must gate on status == WAITING_FOR_USER first:
+    # a task that left the waiting state by a path with no injection site
+    # (cancel, delete, failure, TTL reclaim, admin cleanup) can still carry a
+    # stale 1, and the next wait overwrites it either way.
+    interaction_protocol_version = Column(Integer, nullable=True)
 
     # Model configuration
     model_name = Column(String(255), nullable=True)  # Main model used for the task

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -85,15 +85,26 @@ class Task(Base):  # type: ignore
         # staged for the current wait" and readers fall back to the legacy
         # transcript path; 1 means a protocol v1 interaction row exists.
         #
-        # Only create_all-built databases and PostgreSQL carry this CHECK.
-        # The SQLite migration branch cannot emit it: adding a constraint to
-        # an existing table raises NotImplementedError on that dialect both
-        # online and offline, and the batch_alter_table workaround cannot run
-        # in --sql mode on either dialect, which the offline-SQL requirement
-        # rules out. SQLite is development and test only; production is
-        # PostgreSQL, and create_all-built SQLite test databases do carry the
-        # CHECK, so the constraint's behaviour stays covered by tests. The
-        # asymmetry is asserted as expected, not merely left uncovered -- see
+        # Only create_all-built databases and PostgreSQL carry this CHECK
+        # through the migration's upgrade(): the SQLite migration branch
+        # cannot add a CHECK to an existing table -- that raises
+        # NotImplementedError on that dialect both online and offline, and
+        # the batch_alter_table workaround cannot run in --sql mode on
+        # either dialect, which the offline-SQL requirement rules out.
+        # SQLite is the default self-hosted backend (get_database_url()
+        # falls back to it when DATABASE_URL is unset); PostgreSQL is the
+        # recommended backend at production scale. A fresh SQLite install
+        # stamps head and builds its schema via create_all rather than
+        # walking the revision chain, so it carries this CHECK even though
+        # upgrade() never adds it there -- the migration's downgrade()
+        # accounts for that by rebuilding the table on SQLite (dropping the
+        # CHECK when present, alongside the column) instead of a plain
+        # drop_column, so both the fresh-install and migration-chain SQLite
+        # shapes downgrade cleanly. create_all-built SQLite test databases
+        # also carry the CHECK, so the constraint's behaviour stays covered
+        # by tests. The asymmetry between upgrade() (never adds the CHECK on
+        # SQLite) and a fresh install (has it anyway) is asserted as
+        # expected, not merely left uncovered -- see
         # tests/migrations/test_task_interaction_protocol_version_parity.py.
         #
         # Unlike task_interaction_requests' floor-plus-active-pin split

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -86,11 +86,16 @@ class Task(Base):  # type: ignore
         # transcript path; 1 means a protocol v1 interaction row exists.
         #
         # Only create_all-built databases and PostgreSQL carry this CHECK
-        # through the migration's upgrade(): the SQLite migration branch
-        # cannot add a CHECK to an existing table -- that raises
-        # NotImplementedError on that dialect both online and offline, and
-        # the batch_alter_table workaround cannot run in --sql mode on
-        # either dialect, which the offline-SQL requirement rules out.
+        # through the migration's upgrade(). SQLite is excluded there for
+        # two separate reasons. Offline (--sql generation), a plain
+        # CHECK-add raises NotImplementedError on SQLite, and the
+        # batch_alter_table rebuild that could add it instead cannot
+        # render under --sql mode on either dialect -- offline SQL support
+        # is a hard requirement, so upgrade() has no path to the CHECK on
+        # SQLite there. Online, batch_alter_table could add the CHECK to
+        # an existing SQLite table the same way downgrade() already
+        # removes it; that convergence is deliberately deferred to the
+        # first production writer of this column rather than done now.
         # SQLite is the default self-hosted backend (get_database_url()
         # falls back to it when DATABASE_URL is unset); PostgreSQL is the
         # recommended backend at production scale. A fresh SQLite install

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -95,7 +95,8 @@ class Task(Base):  # type: ignore
         # SQLite there. Online, batch_alter_table could add the CHECK to
         # an existing SQLite table the same way downgrade() already
         # removes it; that convergence is deliberately deferred to the
-        # first production writer of this column rather than done now.
+        # first production writer of this column rather than done now,
+        # tracked in #1290.
         # SQLite is the default self-hosted backend (get_database_url()
         # falls back to it when DATABASE_URL is unset); PostgreSQL is the
         # recommended backend at production scale. A fresh SQLite install

--- a/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
+++ b/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
@@ -1,0 +1,436 @@
+"""Tests for the tasks.interaction_protocol_version migration."""
+
+import importlib.util
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from tests.web.services.checkpoint_anchor_shared import (
+    reset_checkpoint_anchor_fk_create_rule,
+)
+from xagent.web.models.database import Base
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py"
+)
+TABLE = "tasks"
+COLUMN = "interaction_protocol_version"
+CONSTRAINT_NAME = "ck_tasks_interaction_protocol_version"
+
+
+def _migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "task_interaction_protocol_version_migration", MIGRATION_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection: sa.Connection) -> Operations:
+    return Operations(MigrationContext.configure(connection))
+
+
+def _offline_sql(migration, dialect_name: str, operation: str) -> str:
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name=dialect_name,
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    with Operations.context(context):
+        getattr(migration, operation)()
+    return output.getvalue()
+
+
+def _legacy_tasks_table(engine) -> None:
+    """Migration-only schema: just the columns this migration reads."""
+    metadata = sa.MetaData()
+    sa.Table(
+        TABLE,
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True),
+    )
+    metadata.create_all(engine)
+
+
+def _column_names(connection) -> set[str]:
+    return {column["name"] for column in sa.inspect(connection).get_columns(TABLE)}
+
+
+def _check_constraint_names(connection) -> set[str]:
+    return {
+        item["name"]
+        for item in sa.inspect(connection).get_check_constraints(TABLE)
+        if item.get("name")
+    }
+
+
+# ---- T-M-1a / T-M-1b: offline upgrade content ----
+
+
+def test_offline_upgrade_postgresql_emits_add_column_and_check() -> None:
+    migration = _migration_module()
+
+    with patch.object(
+        migration.sa,
+        "inspect",
+        side_effect=AssertionError("offline branch must not reflect"),
+    ):
+        sql = _offline_sql(migration, "postgresql", "upgrade")
+
+    assert f"ALTER TABLE {TABLE} ADD COLUMN {COLUMN} INTEGER" in sql
+    assert (
+        f"ALTER TABLE {TABLE} ADD CONSTRAINT {CONSTRAINT_NAME} CHECK "
+        f"({migration.CONSTRAINT_CONDITION})"
+    ) in sql
+
+
+def test_offline_upgrade_sqlite_emits_add_column_only() -> None:
+    migration = _migration_module()
+
+    with patch.object(
+        migration.sa,
+        "inspect",
+        side_effect=AssertionError("offline branch must not reflect"),
+    ):
+        sql = _offline_sql(migration, "sqlite", "upgrade")
+
+    assert f"ALTER TABLE {TABLE} ADD COLUMN {COLUMN} INTEGER" in sql
+    assert "ADD CONSTRAINT" not in sql
+    assert "CHECK" not in sql
+
+
+# ---- T-M-1c / T-M-1d: offline downgrade content and ordering ----
+
+
+def test_offline_downgrade_postgresql_drops_constraint_before_column() -> None:
+    migration = _migration_module()
+
+    with patch.object(
+        migration.sa,
+        "inspect",
+        side_effect=AssertionError("offline branch must not reflect"),
+    ):
+        sql = _offline_sql(migration, "postgresql", "downgrade")
+
+    drop_constraint_at = sql.index(
+        f"ALTER TABLE {TABLE} DROP CONSTRAINT {CONSTRAINT_NAME}"
+    )
+    drop_column_at = sql.index(f"ALTER TABLE {TABLE} DROP COLUMN {COLUMN}")
+    assert drop_constraint_at < drop_column_at
+
+
+def test_offline_downgrade_sqlite_only_drops_column() -> None:
+    migration = _migration_module()
+
+    with patch.object(
+        migration.sa,
+        "inspect",
+        side_effect=AssertionError("offline branch must not reflect"),
+    ):
+        sql = _offline_sql(migration, "sqlite", "downgrade")
+
+    assert f"ALTER TABLE {TABLE} DROP COLUMN {COLUMN}" in sql
+    assert "DROP CONSTRAINT" not in sql
+
+
+# ---- T-M-1e: no bind parameters on either dialect or direction ----
+
+
+@pytest.mark.parametrize("dialect_name", ["sqlite", "postgresql"])
+def test_offline_sql_carries_no_bind_parameters(dialect_name) -> None:
+    migration = _migration_module()
+
+    upgrade_sql = _offline_sql(migration, dialect_name, "upgrade")
+    downgrade_sql = _offline_sql(migration, dialect_name, "downgrade")
+
+    for sql in (upgrade_sql, downgrade_sql):
+        assert "%(" not in sql
+        assert ":table_name" not in sql
+
+
+# ---- T-M-1f: the offline branch never reflects ----
+
+
+@pytest.mark.parametrize("dialect_name", ["sqlite", "postgresql"])
+@pytest.mark.parametrize("operation", ["upgrade", "downgrade"])
+def test_offline_branch_does_not_reflect(dialect_name, operation) -> None:
+    migration = _migration_module()
+
+    with patch.object(
+        migration.sa,
+        "inspect",
+        side_effect=AssertionError("offline branch must not reflect"),
+    ):
+        sql = _offline_sql(migration, dialect_name, operation)
+
+    assert sql  # rendered without tripping the reflect-call trap above
+
+
+# ---- T-M-1g: online SQLite upgrade/downgrade ----
+
+
+def test_online_sqlite_upgrade_adds_column_without_check_and_downgrade_removes_it() -> (
+    None
+):
+    migration = _migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        _legacy_tasks_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+            columns = {c["name"]: c for c in sa.inspect(connection).get_columns(TABLE)}
+            assert COLUMN in columns
+            assert columns[COLUMN]["nullable"] is True
+            assert CONSTRAINT_NAME not in _check_constraint_names(connection)
+
+            migration.downgrade()
+            assert COLUMN not in _column_names(connection)
+
+
+# ---- T-M-1h: online PostgreSQL upgrade/downgrade (disposable database) ----
+
+
+def test_online_postgresql_upgrade_adds_column_and_check_and_downgrade_removes_both() -> (
+    None
+):
+    migration = _migration_module()
+
+    with disposable_database_factory("xagent_w1_migration") as make_database:
+        engine = make_database("upgrade_downgrade")
+
+        with engine.begin() as connection:
+            _legacy_tasks_table(connection)
+            with patch.object(migration, "op", _operations(connection)):
+                migration.upgrade()
+
+                columns = {
+                    c["name"]: c for c in sa.inspect(connection).get_columns(TABLE)
+                }
+                assert COLUMN in columns
+                assert columns[COLUMN]["nullable"] is True
+                assert CONSTRAINT_NAME in _check_constraint_names(connection)
+
+                migration.downgrade()
+                assert COLUMN not in _column_names(connection)
+                assert CONSTRAINT_NAME not in _check_constraint_names(connection)
+
+
+# ---- T-M-3a: online upgrade is idempotent on both backends ----
+
+
+def _assert_idempotent_upgrade(migration, engine) -> None:
+    with engine.begin() as connection:
+        _legacy_tasks_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+
+            columns = [c["name"] for c in sa.inspect(connection).get_columns(TABLE)]
+            assert columns.count(COLUMN) == 1
+
+            constraint_hits = [
+                name
+                for name in _check_constraint_names(connection)
+                if name == CONSTRAINT_NAME
+            ]
+            if connection.dialect.name == "postgresql":
+                assert len(constraint_hits) == 1
+            else:
+                assert len(constraint_hits) == 0
+
+
+def test_online_upgrade_is_idempotent_sqlite() -> None:
+    migration = _migration_module()
+    _assert_idempotent_upgrade(migration, sa.create_engine("sqlite:///:memory:"))
+
+
+def test_online_upgrade_is_idempotent_postgresql() -> None:
+    migration = _migration_module()
+    with disposable_database_factory("xagent_w1_migration") as make_database:
+        _assert_idempotent_upgrade(migration, make_database("idempotent_upgrade"))
+
+
+# ---- T-M-3b: online downgrade is idempotent when the column is absent ----
+
+
+def _assert_idempotent_downgrade_when_absent(migration, engine) -> None:
+    with engine.begin() as connection:
+        _legacy_tasks_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+            migration.downgrade()
+
+            assert COLUMN not in _column_names(connection)
+
+
+def test_online_downgrade_is_idempotent_when_column_is_absent_sqlite() -> None:
+    migration = _migration_module()
+    _assert_idempotent_downgrade_when_absent(
+        migration, sa.create_engine("sqlite:///:memory:")
+    )
+
+
+def test_online_downgrade_is_idempotent_when_column_is_absent_postgresql() -> None:
+    migration = _migration_module()
+    with disposable_database_factory("xagent_w1_migration") as make_database:
+        _assert_idempotent_downgrade_when_absent(
+            migration, make_database("idempotent_downgrade")
+        )
+
+
+# ---- T-M-3c: no-op when the tasks table itself does not exist ----
+
+
+def test_online_upgrade_and_downgrade_noop_without_the_tasks_table() -> None:
+    migration = _migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+
+        assert TABLE not in sa.inspect(connection).get_table_names()
+
+
+# ---- T-M-3d: upgrading a create_all-built database is a no-op ----
+
+
+def _assert_create_all_then_upgrade_is_noop(migration, engine) -> None:
+    reset_checkpoint_anchor_fk_create_rule()
+    Base.metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise on a duplicate constraint name
+
+        columns = {c["name"]: c for c in sa.inspect(connection).get_columns(TABLE)}
+        assert COLUMN in columns
+        if connection.dialect.name == "postgresql":
+            assert CONSTRAINT_NAME in _check_constraint_names(connection)
+
+
+def test_create_all_then_upgrade_is_noop_sqlite() -> None:
+    migration = _migration_module()
+    _assert_create_all_then_upgrade_is_noop(
+        migration, sa.create_engine("sqlite:///:memory:")
+    )
+
+
+def test_create_all_then_upgrade_is_noop_postgresql() -> None:
+    migration = _migration_module()
+    with disposable_database_factory("xagent_w1_migration") as make_database:
+        _assert_create_all_then_upgrade_is_noop(
+            migration, make_database("create_all_then_upgrade")
+        )
+
+
+# ---- T-M-4: CHECK semantics -- NULL/1 accepted, 2/0 rejected ----
+
+
+def _assert_check_constraint_semantics(engine, extra_columns: dict) -> None:
+    tasks = sa.Table(TABLE, sa.MetaData(), autoload_with=engine)
+
+    for value in (None, 1):
+        with engine.begin() as connection:
+            connection.execute(
+                sa.insert(tasks).values(
+                    interaction_protocol_version=value, **extra_columns
+                )
+            )
+
+    for value in (2, 0):
+        with pytest.raises(sa.exc.IntegrityError):
+            with engine.begin() as connection:
+                connection.execute(
+                    sa.insert(tasks).values(
+                        interaction_protocol_version=value, **extra_columns
+                    )
+                )
+
+
+def test_check_constraint_semantics_on_an_online_migrated_postgresql_database() -> None:
+    migration = _migration_module()
+    with disposable_database_factory("xagent_w1_migration") as make_database:
+        engine = make_database("check_semantics")
+        with engine.begin() as connection:
+            _legacy_tasks_table(connection)
+            with patch.object(migration, "op", _operations(connection)):
+                migration.upgrade()
+
+        _assert_check_constraint_semantics(engine, extra_columns={})
+
+
+def test_check_constraint_semantics_on_a_create_all_built_sqlite_database() -> None:
+    reset_checkpoint_anchor_fk_create_rule()
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    _assert_check_constraint_semantics(
+        engine, extra_columns={"user_id": 1, "title": "probe"}
+    )
+
+
+# ---- _target_schema(): catalog hit / empty-catalog fallback (mocked) ----
+
+
+def test_target_schema_resolves_the_visible_tasks_relation() -> None:
+    """version_table_schema names only the Alembic version table and
+    current_schema() is merely the first search_path entry, so neither
+    identifies the relation the unqualified DDL resolves to."""
+
+    migration = _migration_module()
+    sql = str(migration.POSTGRES_VISIBLE_TABLE_SCHEMA_SQL)
+
+    assert "to_regclass" in sql
+    assert "pg_catalog.pg_namespace" in sql
+
+    # Non-PostgreSQL falls back to version_table_schema, and None keeps every
+    # operation on plain unqualified behaviour.
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            assert migration._target_schema() is None
+
+
+def test_target_schema_uses_the_catalog_answer_on_postgresql() -> None:
+    """On PostgreSQL, ``_target_schema`` trusts the catalog lookup over
+    ``version_table_schema`` whenever the catalog resolves the relation, and
+    only falls back to the version table's configured schema when the
+    catalog has nothing to say (e.g. the relation is not visible yet)."""
+
+    migration = _migration_module()
+
+    resolving_op = MagicMock()
+    resolving_op.get_bind.return_value.dialect.name = "postgresql"
+    resolving_op.get_bind.return_value.execute.return_value.scalar.return_value = (
+        "tenant_x"
+    )
+
+    with patch.object(migration, "op", resolving_op):
+        assert migration._target_schema() == "tenant_x"
+
+    resolving_op.get_bind.return_value.execute.assert_called_once_with(
+        migration.POSTGRES_VISIBLE_TABLE_SCHEMA_SQL, {"table_name": TABLE}
+    )
+
+    empty_catalog_op = MagicMock()
+    empty_catalog_op.get_bind.return_value.dialect.name = "postgresql"
+    empty_catalog_op.get_bind.return_value.execute.return_value.scalar.return_value = (
+        None
+    )
+    empty_catalog_op.get_context.return_value.version_table_schema = "fallback_schema"
+
+    with patch.object(migration, "op", empty_catalog_op):
+        assert migration._target_schema() == "fallback_schema"

--- a/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
+++ b/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
@@ -82,11 +82,12 @@ def test_offline_upgrade_postgresql_emits_add_column_and_check() -> None:
     ):
         sql = _offline_sql(migration, "postgresql", "upgrade")
 
-    assert f"ALTER TABLE {TABLE} ADD COLUMN {COLUMN} INTEGER" in sql
-    assert (
+    add_column_at = sql.index(f"ALTER TABLE {TABLE} ADD COLUMN {COLUMN} INTEGER")
+    add_constraint_at = sql.index(
         f"ALTER TABLE {TABLE} ADD CONSTRAINT {CONSTRAINT_NAME} CHECK "
         f"({migration.CONSTRAINT_CONDITION})"
-    ) in sql
+    )
+    assert add_column_at < add_constraint_at
 
 
 def test_offline_upgrade_sqlite_emits_add_column_only() -> None:

--- a/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
+++ b/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
@@ -69,6 +69,10 @@ def _check_constraint_names(connection) -> set[str]:
 
 
 def test_offline_upgrade_postgresql_emits_add_column_and_check() -> None:
+    """A rendering check: it proves the offline SQL emits the expected ADD
+    COLUMN and CHECK statements, not that they execute against a live
+    database -- the execution half is covered by the online migration
+    tests."""
     migration = load_migration_module(MIGRATION_PATH)
 
     with patch.object(
@@ -121,6 +125,10 @@ def test_offline_downgrade_postgresql_drops_constraint_before_column() -> None:
 
 
 def test_offline_downgrade_sqlite_only_drops_column() -> None:
+    """Pins the plain DROP COLUMN as the offline SQLite downgrade's
+    rendering. That rendering is not executable against a create_all-built
+    SQLite database -- see the migration's downgrade() comment for why that
+    is accepted rather than fixed."""
     migration = load_migration_module(MIGRATION_PATH)
 
     with patch.object(

--- a/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
+++ b/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
@@ -403,7 +403,7 @@ def test_sqlite_create_all_downgrade_upgrade_round_trip_loses_the_check() -> Non
     into the migration shape (which never has it on SQLite), and nothing
     restores it afterwards. The convergence that would restore the CHECK
     belongs to the change that lands this column's first production writer,
-    not to this migration.
+    not to this migration (tracked in #1290).
     """
     migration = load_migration_module(MIGRATION_PATH)
     reset_checkpoint_anchor_fk_create_rule()

--- a/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
+++ b/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
@@ -1,6 +1,5 @@
 """Tests for the tasks.interaction_protocol_version migration."""
 
-import importlib.util
 from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -10,7 +9,10 @@ import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 
-from tests.shared.postgres_disposable import disposable_database_factory
+from tests.shared.postgres_disposable import (
+    disposable_database_factory,
+    load_migration_module,
+)
 from tests.web.services.checkpoint_anchor_shared import (
     reset_checkpoint_anchor_fk_create_rule,
 )
@@ -23,16 +25,6 @@ MIGRATION_PATH = (
 TABLE = "tasks"
 COLUMN = "interaction_protocol_version"
 CONSTRAINT_NAME = "ck_tasks_interaction_protocol_version"
-
-
-def _migration_module():
-    spec = importlib.util.spec_from_file_location(
-        "task_interaction_protocol_version_migration", MIGRATION_PATH
-    )
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 def _operations(connection: sa.Connection) -> Operations:
@@ -77,7 +69,7 @@ def _check_constraint_names(connection) -> set[str]:
 
 
 def test_offline_upgrade_postgresql_emits_add_column_and_check() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
 
     with patch.object(
         migration.sa,
@@ -94,7 +86,7 @@ def test_offline_upgrade_postgresql_emits_add_column_and_check() -> None:
 
 
 def test_offline_upgrade_sqlite_emits_add_column_only() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
 
     with patch.object(
         migration.sa,
@@ -112,7 +104,7 @@ def test_offline_upgrade_sqlite_emits_add_column_only() -> None:
 
 
 def test_offline_downgrade_postgresql_drops_constraint_before_column() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
 
     with patch.object(
         migration.sa,
@@ -129,7 +121,7 @@ def test_offline_downgrade_postgresql_drops_constraint_before_column() -> None:
 
 
 def test_offline_downgrade_sqlite_only_drops_column() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
 
     with patch.object(
         migration.sa,
@@ -147,7 +139,7 @@ def test_offline_downgrade_sqlite_only_drops_column() -> None:
 
 @pytest.mark.parametrize("dialect_name", ["sqlite", "postgresql"])
 def test_offline_sql_carries_no_bind_parameters(dialect_name) -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
 
     upgrade_sql = _offline_sql(migration, dialect_name, "upgrade")
     downgrade_sql = _offline_sql(migration, dialect_name, "downgrade")
@@ -163,7 +155,7 @@ def test_offline_sql_carries_no_bind_parameters(dialect_name) -> None:
 @pytest.mark.parametrize("dialect_name", ["sqlite", "postgresql"])
 @pytest.mark.parametrize("operation", ["upgrade", "downgrade"])
 def test_offline_branch_does_not_reflect(dialect_name, operation) -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
 
     with patch.object(
         migration.sa,
@@ -181,7 +173,7 @@ def test_offline_branch_does_not_reflect(dialect_name, operation) -> None:
 def test_online_sqlite_upgrade_adds_column_without_check_and_downgrade_removes_it() -> (
     None
 ):
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     engine = sa.create_engine("sqlite:///:memory:")
 
     with engine.begin() as connection:
@@ -205,7 +197,7 @@ def test_online_sqlite_upgrade_adds_column_without_check_and_downgrade_removes_i
 def test_online_postgresql_upgrade_adds_column_and_check_and_downgrade_removes_both() -> (
     None
 ):
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
 
     with disposable_database_factory("xagent_w1_migration") as make_database:
         engine = make_database("upgrade_downgrade")
@@ -252,13 +244,13 @@ def _assert_idempotent_upgrade(migration, engine) -> None:
 
 
 def test_online_upgrade_is_idempotent_sqlite() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     _assert_idempotent_upgrade(migration, sa.create_engine("sqlite:///:memory:"))
 
 
 @pytest.mark.postgresql
 def test_online_upgrade_is_idempotent_postgresql() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     with disposable_database_factory("xagent_w1_migration") as make_database:
         _assert_idempotent_upgrade(migration, make_database("idempotent_upgrade"))
 
@@ -277,7 +269,7 @@ def _assert_idempotent_downgrade_when_absent(migration, engine) -> None:
 
 
 def test_online_downgrade_is_idempotent_when_column_is_absent_sqlite() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     _assert_idempotent_downgrade_when_absent(
         migration, sa.create_engine("sqlite:///:memory:")
     )
@@ -285,7 +277,7 @@ def test_online_downgrade_is_idempotent_when_column_is_absent_sqlite() -> None:
 
 @pytest.mark.postgresql
 def test_online_downgrade_is_idempotent_when_column_is_absent_postgresql() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     with disposable_database_factory("xagent_w1_migration") as make_database:
         _assert_idempotent_downgrade_when_absent(
             migration, make_database("idempotent_downgrade")
@@ -296,7 +288,7 @@ def test_online_downgrade_is_idempotent_when_column_is_absent_postgresql() -> No
 
 
 def test_online_upgrade_and_downgrade_noop_without_the_tasks_table() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     engine = sa.create_engine("sqlite:///:memory:")
 
     with engine.begin() as connection:
@@ -325,7 +317,7 @@ def _assert_create_all_then_upgrade_is_noop(migration, engine) -> None:
 
 
 def test_create_all_then_upgrade_is_noop_sqlite() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     _assert_create_all_then_upgrade_is_noop(
         migration, sa.create_engine("sqlite:///:memory:")
     )
@@ -333,7 +325,7 @@ def test_create_all_then_upgrade_is_noop_sqlite() -> None:
 
 @pytest.mark.postgresql
 def test_create_all_then_upgrade_is_noop_postgresql() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     with disposable_database_factory("xagent_w1_migration") as make_database:
         _assert_create_all_then_upgrade_is_noop(
             migration, make_database("create_all_then_upgrade")
@@ -366,7 +358,7 @@ def _assert_check_constraint_semantics(engine, extra_columns: dict) -> None:
 
 @pytest.mark.postgresql
 def test_check_constraint_semantics_on_an_online_migrated_postgresql_database() -> None:
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     with disposable_database_factory("xagent_w1_migration") as make_database:
         engine = make_database("check_semantics")
         with engine.begin() as connection:
@@ -395,7 +387,7 @@ def test_target_schema_resolves_the_visible_tasks_relation() -> None:
     current_schema() is merely the first search_path entry, so neither
     identifies the relation the unqualified DDL resolves to."""
 
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
     sql = str(migration.POSTGRES_VISIBLE_TABLE_SCHEMA_SQL)
 
     assert "to_regclass" in sql
@@ -415,7 +407,7 @@ def test_target_schema_uses_the_catalog_answer_on_postgresql() -> None:
     only falls back to the version table's configured schema when the
     catalog has nothing to say (e.g. the relation is not visible yet)."""
 
-    migration = _migration_module()
+    migration = load_migration_module(MIGRATION_PATH)
 
     resolving_op = MagicMock()
     resolving_op.get_bind.return_value.dialect.name = "postgresql"

--- a/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
+++ b/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
@@ -387,6 +387,62 @@ def test_check_constraint_semantics_on_a_create_all_built_sqlite_database() -> N
     )
 
 
+# ---- SQLite downgrade/upgrade round trip permanently drops the CHECK ----
+
+
+def test_sqlite_create_all_downgrade_upgrade_round_trip_loses_the_check() -> None:
+    """downgrade() rebuilds the tasks table via batch_alter_table on SQLite,
+    which drops the CHECK constraint along with the column it references;
+    upgrade() then adds the column back but, on SQLite, deliberately does
+    not re-add the CHECK (unqualified CHECK-add has no offline rendering
+    and no online implementation here -- see the migration's upgrade()
+    branch and test_sqlite_check_asymmetry_is_expected in
+    tests/migrations/test_task_interaction_protocol_version_parity.py). So
+    one downgrade()/upgrade() cycle permanently converts a SQLite database
+    with the fresh-install shape (create_all, which does carry the CHECK)
+    into the migration shape (which never has it on SQLite), and nothing
+    restores it afterwards. The convergence that would restore the CHECK
+    belongs to the change that lands this column's first production writer,
+    not to this migration.
+    """
+    migration = load_migration_module(MIGRATION_PATH)
+    reset_checkpoint_anchor_fk_create_rule()
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        assert CONSTRAINT_NAME in _check_constraint_names(connection)
+
+    tasks_before = sa.Table(TABLE, sa.MetaData(), autoload_with=engine)
+    with pytest.raises(sa.exc.IntegrityError):
+        with engine.begin() as connection:
+            connection.execute(
+                sa.insert(tasks_before).values(
+                    interaction_protocol_version=99, user_id=1, title="probe"
+                )
+            )
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+            migration.upgrade()
+
+        assert COLUMN in _column_names(connection)
+        ddl = connection.execute(
+            sa.text("SELECT sql FROM sqlite_master WHERE type='table' AND name=:name"),
+            {"name": TABLE},
+        ).scalar()
+        assert CONSTRAINT_NAME not in ddl
+
+    tasks_after = sa.Table(TABLE, sa.MetaData(), autoload_with=engine)
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(tasks_after).values(
+                interaction_protocol_version=99, user_id=1, title="probe"
+            )
+        )
+
+
 # ---- _target_schema(): catalog hit / empty-catalog fallback (mocked) ----
 
 

--- a/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
+++ b/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
@@ -201,6 +201,7 @@ def test_online_sqlite_upgrade_adds_column_without_check_and_downgrade_removes_i
 # ---- T-M-1h: online PostgreSQL upgrade/downgrade (disposable database) ----
 
 
+@pytest.mark.postgresql
 def test_online_postgresql_upgrade_adds_column_and_check_and_downgrade_removes_both() -> (
     None
 ):
@@ -255,6 +256,7 @@ def test_online_upgrade_is_idempotent_sqlite() -> None:
     _assert_idempotent_upgrade(migration, sa.create_engine("sqlite:///:memory:"))
 
 
+@pytest.mark.postgresql
 def test_online_upgrade_is_idempotent_postgresql() -> None:
     migration = _migration_module()
     with disposable_database_factory("xagent_w1_migration") as make_database:
@@ -281,6 +283,7 @@ def test_online_downgrade_is_idempotent_when_column_is_absent_sqlite() -> None:
     )
 
 
+@pytest.mark.postgresql
 def test_online_downgrade_is_idempotent_when_column_is_absent_postgresql() -> None:
     migration = _migration_module()
     with disposable_database_factory("xagent_w1_migration") as make_database:
@@ -328,6 +331,7 @@ def test_create_all_then_upgrade_is_noop_sqlite() -> None:
     )
 
 
+@pytest.mark.postgresql
 def test_create_all_then_upgrade_is_noop_postgresql() -> None:
     migration = _migration_module()
     with disposable_database_factory("xagent_w1_migration") as make_database:
@@ -360,6 +364,7 @@ def _assert_check_constraint_semantics(engine, extra_columns: dict) -> None:
                 )
 
 
+@pytest.mark.postgresql
 def test_check_constraint_semantics_on_an_online_migrated_postgresql_database() -> None:
     migration = _migration_module()
     with disposable_database_factory("xagent_w1_migration") as make_database:

--- a/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
+++ b/tests/alembic/test_20260810_add_task_interaction_protocol_version.py
@@ -208,7 +208,9 @@ def test_online_postgresql_upgrade_adds_column_and_check_and_downgrade_removes_b
 ):
     migration = load_migration_module(MIGRATION_PATH)
 
-    with disposable_database_factory("xagent_w1_migration") as make_database:
+    with disposable_database_factory(
+        "xagent_protocol_marker_migration"
+    ) as make_database:
         engine = make_database("upgrade_downgrade")
 
         with engine.begin() as connection:
@@ -260,7 +262,9 @@ def test_online_upgrade_is_idempotent_sqlite() -> None:
 @pytest.mark.postgresql
 def test_online_upgrade_is_idempotent_postgresql() -> None:
     migration = load_migration_module(MIGRATION_PATH)
-    with disposable_database_factory("xagent_w1_migration") as make_database:
+    with disposable_database_factory(
+        "xagent_protocol_marker_migration"
+    ) as make_database:
         _assert_idempotent_upgrade(migration, make_database("idempotent_upgrade"))
 
 
@@ -287,7 +291,9 @@ def test_online_downgrade_is_idempotent_when_column_is_absent_sqlite() -> None:
 @pytest.mark.postgresql
 def test_online_downgrade_is_idempotent_when_column_is_absent_postgresql() -> None:
     migration = load_migration_module(MIGRATION_PATH)
-    with disposable_database_factory("xagent_w1_migration") as make_database:
+    with disposable_database_factory(
+        "xagent_protocol_marker_migration"
+    ) as make_database:
         _assert_idempotent_downgrade_when_absent(
             migration, make_database("idempotent_downgrade")
         )
@@ -335,7 +341,9 @@ def test_create_all_then_upgrade_is_noop_sqlite() -> None:
 @pytest.mark.postgresql
 def test_create_all_then_upgrade_is_noop_postgresql() -> None:
     migration = load_migration_module(MIGRATION_PATH)
-    with disposable_database_factory("xagent_w1_migration") as make_database:
+    with disposable_database_factory(
+        "xagent_protocol_marker_migration"
+    ) as make_database:
         _assert_create_all_then_upgrade_is_noop(
             migration, make_database("create_all_then_upgrade")
         )
@@ -368,7 +376,9 @@ def _assert_check_constraint_semantics(engine, extra_columns: dict) -> None:
 @pytest.mark.postgresql
 def test_check_constraint_semantics_on_an_online_migrated_postgresql_database() -> None:
     migration = load_migration_module(MIGRATION_PATH)
-    with disposable_database_factory("xagent_w1_migration") as make_database:
+    with disposable_database_factory(
+        "xagent_protocol_marker_migration"
+    ) as make_database:
         engine = make_database("check_semantics")
         with engine.begin() as connection:
             _legacy_tasks_table(connection)

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -1,0 +1,328 @@
+"""Schema-parity tests for tasks.interaction_protocol_version.
+
+The model's ``CheckConstraint`` in ``Task.__table_args__`` and the
+``20260810_add_task_interaction_protocol_version`` migration are two
+independent implementations of the same constraint: one runs whenever a test
+calls ``Base.metadata.create_all()``, the other runs when a real database is
+carried forward through the Alembic revision chain. Nothing keeps them in
+sync automatically -- this module is that check.
+
+The comparison is same-backend only: create_all-built SQLite against
+migration-shaped SQLite, and create_all-built PostgreSQL against
+migration-shaped PostgreSQL. It never compares a SQLite CHECK sqltext
+against a PostgreSQL one. PostgreSQL is known to rewrite some CHECK
+expressions on reflection (e.g. an ``IN (...)`` list becomes
+``= ANY (ARRAY[...])``); this constraint's simple comparison happens not to
+trigger that rewrite, but the comparison does not rely on that being true
+forever.
+
+Both PostgreSQL fixtures mint their own throwaway database via
+``disposable_database_factory`` and drop it on teardown. Neither ever
+touches the database XAGENT_TEST_POSTGRES_URL names -- that database hosts
+fixtures other suites depend on. ``tests/migrations/test_migration_integration.py``
+and ``tests/web/services/test_task_interaction_schema_postgresql.py`` are the
+reason that rule exists: both run ``DROP SCHEMA public CASCADE`` /
+``Base.metadata.drop_all()`` against whatever database that environment
+variable names, so exporting it in a shell that also runs either of those
+suites is destructive.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from tests.shared.postgres_disposable import (
+    disposable_database_factory,
+    load_migration_module,
+)
+from tests.web.services.checkpoint_anchor_shared import (
+    reset_checkpoint_anchor_fk_create_rule,
+)
+from xagent.web.models.database import Base
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/xagent/migrations/versions/20260810_add_task_interaction_protocol_version.py"
+)
+TABLE = "tasks"
+COLUMN = "interaction_protocol_version"
+CONSTRAINT_NAME = "ck_tasks_interaction_protocol_version"
+
+# Strip the column definition and its CHECK constraint out of a create_all
+# -rendered CREATE TABLE statement, to reach the shape a database carried
+# through the real revision chain would have (SQLite never receives the
+# CHECK -- see the module docstring and T-M-5 below). Same rename/recreate
+# technique as reset_checkpoint_anchor_fk_create_rule's sibling helper in
+# tests/web/services/checkpoint_anchor_shared.py, extended to also drop a
+# column rather than just one FK clause.
+_COLUMN_CLAUSE = re.compile(r"\s*interaction_protocol_version INTEGER,\s*")
+_CHECK_CLAUSE = re.compile(
+    r",\s*CONSTRAINT ck_tasks_interaction_protocol_version CHECK \([^)]*\)"
+)
+
+
+def _operations(connection: sa.Connection) -> Operations:
+    return Operations(MigrationContext.configure(connection))
+
+
+def _column_names(connection) -> set[str]:
+    return {column["name"] for column in sa.inspect(connection).get_columns(TABLE)}
+
+
+def _reflect_narrow_inventory(engine) -> dict:
+    """The only slice of the tasks schema this migration touches: whether
+    the column exists and is nullable, and the {name: sqltext} of every
+    ck_tasks_* CHECK constraint (prefix-filtered so unrelated CHECKs already
+    on tasks never enter the comparison)."""
+    inspector = sa.inspect(engine)
+    columns = {c["name"]: c for c in inspector.get_columns(TABLE)}
+    checks = {
+        str(item["name"]): str(item["sqltext"])
+        for item in inspector.get_check_constraints(TABLE)
+        if item.get("name") and str(item["name"]).startswith("ck_tasks_")
+    }
+    return {
+        "column_present": COLUMN in columns,
+        "column_nullable": columns[COLUMN]["nullable"] if COLUMN in columns else None,
+        "checks": checks,
+    }
+
+
+def _diff_narrow_inventory(left: dict, right: dict) -> list[str]:
+    """Human-readable differences between two narrow inventories, or an
+    empty list when they match exactly. A comparison that only checks
+    constraint *names* would pass even if a CHECK's condition were silently
+    weakened -- this compares the {name: sqltext} maps, not just their key
+    sets."""
+    differences = []
+    if left["column_present"] != right["column_present"]:
+        differences.append(
+            f"column present: {left['column_present']!r} != {right['column_present']!r}"
+        )
+    if left["column_nullable"] != right["column_nullable"]:
+        differences.append(
+            f"column nullable: {left['column_nullable']!r} != "
+            f"{right['column_nullable']!r}"
+        )
+    if left["checks"] != right["checks"]:
+        differences.append(f"checks: {left['checks']!r} != {right['checks']!r}")
+    return differences
+
+
+def _build_migration_shaped_sqlite_engine():
+    """create_all(), then strip the column and its CHECK via SQLite's
+    rename/recreate/copy/drop procedure, then run the migration's upgrade()
+    -- so the resulting schema is what a database walked through the real
+    revision chain would have, not create_all wearing a different name."""
+    reset_checkpoint_anchor_fk_create_rule()
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        original_sql = connection.execute(
+            sa.text("SELECT sql FROM sqlite_master WHERE type='table' AND name=:name"),
+            {"name": TABLE},
+        ).scalar()
+        assert original_sql is not None
+
+        stripped_sql, check_hits = _CHECK_CLAUSE.subn("", original_sql)
+        assert check_hits == 1, (
+            f"expected exactly one {CONSTRAINT_NAME} clause in the tasks "
+            f"DDL, found {check_hits}"
+        )
+        stripped_sql, column_hits = _COLUMN_CLAUSE.subn("", stripped_sql)
+        assert column_hits == 1, (
+            f"expected exactly one {COLUMN} column clause in the tasks "
+            f"DDL, found {column_hits}"
+        )
+        assert COLUMN not in stripped_sql
+
+        legacy_columns = [name for name in _column_names(connection) if name != COLUMN]
+        column_list = ", ".join(legacy_columns)
+
+        connection.execute(sa.text(f"ALTER TABLE {TABLE} RENAME TO {TABLE}_old"))
+        connection.execute(sa.text(stripped_sql))
+        connection.execute(
+            sa.text(
+                f"INSERT INTO {TABLE} ({column_list}) "
+                f"SELECT {column_list} FROM {TABLE}_old"
+            )
+        )
+        connection.execute(sa.text(f"DROP TABLE {TABLE}_old"))
+
+        migration = load_migration_module(MIGRATION_PATH)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+    return engine
+
+
+def _build_migration_shaped_postgresql_engine(engine):
+    """create_all(), then use the migration's own downgrade() to strip the
+    column and CHECK back off (PostgreSQL can do this; SQLite cannot -- see
+    T-M-5), then upgrade() to rebuild them through the migration path rather
+    than through create_all."""
+    reset_checkpoint_anchor_fk_create_rule()
+    Base.metadata.create_all(engine)
+
+    migration = load_migration_module(MIGRATION_PATH)
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+            migration.upgrade()
+
+    return engine
+
+
+def _build_create_all_sqlite_engine():
+    reset_checkpoint_anchor_fk_create_rule()
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+# ---- T-M-2a / T-M-2b: SQLite -- column parity, CHECK asymmetry ----
+
+
+def test_sqlite_column_matches_between_migration_and_create_all() -> None:
+    migration_engine = _build_migration_shaped_sqlite_engine()
+    create_all_engine = _build_create_all_sqlite_engine()
+
+    migration_inv = _reflect_narrow_inventory(migration_engine)
+    create_all_inv = _reflect_narrow_inventory(create_all_engine)
+
+    assert migration_inv["column_present"] is True
+    assert create_all_inv["column_present"] is True
+    assert migration_inv["column_nullable"] == create_all_inv["column_nullable"]
+
+
+def test_sqlite_check_asymmetry_is_expected() -> None:
+    """SQLite cannot receive this CHECK through the migration path: adding a
+    constraint to an existing table raises NotImplementedError on SQLite
+    both online and offline, and the batch_alter_table workaround cannot run
+    in --sql mode on either dialect, which the offline-SQL requirement rules
+    out (see the migration and the model's __table_args__ comment). So a
+    migration-shaped SQLite database has no ck_tasks_interaction_protocol_version
+    CHECK, while a create_all-built one does (it comes straight from the
+    model). This asymmetry is expected, not a defect: if this assertion goes
+    red, check whether someone changed the SQLite branch of the migration to
+    emit the CHECK -- that would break `alembic upgrade --sql` on SQLite.
+    """
+    migration_engine = _build_migration_shaped_sqlite_engine()
+    create_all_engine = _build_create_all_sqlite_engine()
+
+    migration_checks = _reflect_narrow_inventory(migration_engine)["checks"]
+    create_all_checks = _reflect_narrow_inventory(create_all_engine)["checks"]
+
+    assert CONSTRAINT_NAME not in migration_checks
+    assert CONSTRAINT_NAME in create_all_checks
+
+
+# ---- T-M-2c: PostgreSQL -- column and CHECK match exactly ----
+
+
+def test_postgresql_column_and_check_match_between_migration_and_create_all() -> None:
+    with disposable_database_factory("xagent_w1_parity") as make_database:
+        migration_engine = _build_migration_shaped_postgresql_engine(
+            make_database("migration_side")
+        )
+        create_all_engine = _build_create_all_engine_postgresql(
+            make_database("create_all_side")
+        )
+
+        migration_inv = _reflect_narrow_inventory(migration_engine)
+        create_all_inv = _reflect_narrow_inventory(create_all_engine)
+
+        differences = _diff_narrow_inventory(migration_inv, create_all_inv)
+        assert differences == []
+
+
+def _build_create_all_engine_postgresql(engine):
+    reset_checkpoint_anchor_fk_create_rule()
+    Base.metadata.create_all(engine)
+    return engine
+
+
+# ---- T-M-2d: the comparator itself catches a changed CHECK expression ----
+
+
+def test_diff_narrow_inventory_flags_a_changed_check_expression() -> None:
+    baseline = {
+        "column_present": True,
+        "column_nullable": True,
+        "checks": {
+            CONSTRAINT_NAME: (
+                "interaction_protocol_version IS NULL "
+                "OR interaction_protocol_version = 1"
+            )
+        },
+    }
+    changed = {
+        "column_present": True,
+        "column_nullable": True,
+        "checks": {
+            CONSTRAINT_NAME: (
+                "interaction_protocol_version IS NULL "
+                "OR interaction_protocol_version >= 1"
+            )
+        },
+    }
+
+    differences = _diff_narrow_inventory(baseline, changed)
+
+    assert differences
+    assert any("checks" in difference for difference in differences)
+
+
+def test_diff_narrow_inventory_reports_no_differences_for_identical_inventories() -> (
+    None
+):
+    inventory = {
+        "column_present": True,
+        "column_nullable": True,
+        "checks": {
+            CONSTRAINT_NAME: "interaction_protocol_version IS NULL OR interaction_protocol_version = 1"
+        },
+    }
+
+    assert _diff_narrow_inventory(inventory, dict(inventory)) == []
+
+
+# ---- T-M-5: create_all SQLite cannot be downgraded; migration-chain can ----
+
+
+def test_create_all_sqlite_downgrade_fails_but_migration_shaped_sqlite_succeeds() -> (
+    None
+):
+    """SQLite refuses to DROP a column that a CHECK constraint references,
+    so calling downgrade() on a create_all-built SQLite database raises
+    OperationalError("no such column: interaction_protocol_version"). This
+    is a direct consequence of the CHECK asymmetry above, not a bug: it only
+    happens on a shape that never goes through a real downgrade. A database
+    maintained through the revision chain never received the CHECK on
+    SQLite in the first place (T-M-1b/T-M-1d), so its downgrade() has no
+    CHECK-referenced column to trip over. Both halves are asserted here so a
+    reader who only sees the first half does not read it as a defect to fix
+    -- "fixing" it by making downgrade() smarter would not change the fact
+    that no real database ever hits this path.
+    """
+    migration = load_migration_module(MIGRATION_PATH)
+
+    create_all_engine = _build_create_all_sqlite_engine()
+    with create_all_engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            with pytest.raises(sa.exc.OperationalError, match="no such column"):
+                migration.downgrade()
+
+    migration_engine = _build_migration_shaped_sqlite_engine()
+    with migration_engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+            assert COLUMN not in _column_names(connection)

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -210,9 +210,8 @@ def _build_migration_shaped_postgresql_engine(engine):
     return engine
 
 
-def _build_create_all_sqlite_engine():
+def _build_create_all_engine(engine):
     reset_checkpoint_anchor_fk_create_rule()
-    engine = sa.create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     return engine
 
@@ -222,7 +221,7 @@ def _build_create_all_sqlite_engine():
 
 def test_sqlite_column_matches_between_migration_and_create_all() -> None:
     migration_engine = _build_migration_shaped_sqlite_engine()
-    create_all_engine = _build_create_all_sqlite_engine()
+    create_all_engine = _build_create_all_engine(sa.create_engine("sqlite:///:memory:"))
 
     migration_inv = _reflect_narrow_inventory(migration_engine)
     create_all_inv = _reflect_narrow_inventory(create_all_engine)
@@ -233,19 +232,29 @@ def test_sqlite_column_matches_between_migration_and_create_all() -> None:
 
 
 def test_sqlite_check_asymmetry_is_expected() -> None:
-    """SQLite cannot receive this CHECK through the migration path: adding a
-    constraint to an existing table raises NotImplementedError on SQLite
-    both online and offline, and the batch_alter_table workaround cannot run
-    in --sql mode on either dialect, which the offline-SQL requirement rules
-    out (see the migration and the model's __table_args__ comment). So a
-    migration-shaped SQLite database has no ck_tasks_interaction_protocol_version
-    CHECK, while a create_all-built one does (it comes straight from the
-    model). This asymmetry is expected, not a defect: if this assertion goes
-    red, check whether someone changed the SQLite branch of the migration to
-    emit the CHECK -- that would break `alembic upgrade --sql` on SQLite.
+    """Two SQLite deployments of the same xagent version can enforce
+    different invariants on this column depending on install history: a
+    fresh install (stamp head, then create_all) HAS the CHECK, while a
+    database that walked the revision chain does NOT -- upgrade() cannot
+    add a CHECK to an existing table on SQLite (NotImplementedError, both
+    online and offline; the batch_alter_table workaround cannot run in
+    --sql mode on either dialect, which the offline-SQL requirement rules
+    out -- see the migration and the model's __table_args__ comment).
+    Concretely: inserting interaction_protocol_version=2 succeeds on the
+    chain-walked shape and raises IntegrityError on the fresh-install shape.
+    This asymmetry is expected today because the column has zero writers --
+    nothing has ever inserted a non-NULL value, so nothing observes the
+    divergence. The change that adds the first writer to this column must
+    either converge the two shapes (e.g. teach upgrade() to add the CHECK on
+    SQLite via batch_alter_table the way downgrade() now removes it) or
+    explicitly justify writing to a column whose constraint isn't uniformly
+    enforced. If this assertion goes red because someone changed the SQLite
+    branch of upgrade() to emit the CHECK, that is this convergence
+    happening -- update this test to match, don't just re-pin the old
+    asymmetry.
     """
     migration_engine = _build_migration_shaped_sqlite_engine()
-    create_all_engine = _build_create_all_sqlite_engine()
+    create_all_engine = _build_create_all_engine(sa.create_engine("sqlite:///:memory:"))
 
     migration_checks = _reflect_narrow_inventory(migration_engine)["checks"]
     create_all_checks = _reflect_narrow_inventory(create_all_engine)["checks"]
@@ -263,21 +272,13 @@ def test_postgresql_column_and_check_match_between_migration_and_create_all() ->
         migration_engine = _build_migration_shaped_postgresql_engine(
             make_database("migration_side")
         )
-        create_all_engine = _build_create_all_engine_postgresql(
-            make_database("create_all_side")
-        )
+        create_all_engine = _build_create_all_engine(make_database("create_all_side"))
 
         migration_inv = _reflect_narrow_inventory(migration_engine)
         create_all_inv = _reflect_narrow_inventory(create_all_engine)
 
         differences = _diff_narrow_inventory(migration_inv, create_all_inv)
         assert differences == []
-
-
-def _build_create_all_engine_postgresql(engine):
-    reset_checkpoint_anchor_fk_create_rule()
-    Base.metadata.create_all(engine)
-    return engine
 
 
 # ---- T-M-2d: the comparator itself catches a changed CHECK expression ----
@@ -311,27 +312,12 @@ def test_diff_narrow_inventory_flags_a_changed_check_expression() -> None:
     assert any("checks" in difference for difference in differences)
 
 
-def test_diff_narrow_inventory_reports_no_differences_for_identical_inventories() -> (
-    None
-):
-    inventory = {
-        "column_present": True,
-        "column_nullable": True,
-        "checks": {
-            CONSTRAINT_NAME: "interaction_protocol_version IS NULL OR interaction_protocol_version = 1"
-        },
-    }
-
-    assert _diff_narrow_inventory(inventory, dict(inventory)) == []
-
-
 # ---- T-M-5: create_all SQLite cannot be downgraded; migration-chain can ----
 
 
 def test_sqlite_downgrade_succeeds_on_both_install_shapes() -> None:
-    """The reviewer's round-2 Finding 1 established that a fresh install
-    stamps head and then builds its schema via create_all (see
-    src/xagent/db/migration.py's empty-DB stamp path and database.py's
+    """A fresh install stamps head and then builds its schema via create_all
+    (see src/xagent/db/migration.py's empty-DB stamp path and database.py's
     create_all call), so the create_all-built SQLite shape is a real
     downgrade-reachable production shape, not a synthetic one -- and SQLite
     3.35+ refuses to DROP a column a CHECK constraint references, so the old
@@ -345,7 +331,7 @@ def test_sqlite_downgrade_succeeds_on_both_install_shapes() -> None:
     """
     migration = load_migration_module(MIGRATION_PATH)
 
-    create_all_engine = _build_create_all_sqlite_engine()
+    create_all_engine = _build_create_all_engine(sa.create_engine("sqlite:///:memory:"))
     with create_all_engine.begin() as connection:
         with patch.object(migration, "op", _operations(connection)):
             migration.downgrade()

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -243,8 +243,8 @@ def test_sqlite_check_asymmetry_is_expected() -> None:
     batch_alter_table could add the CHECK to an existing SQLite table the
     same way downgrade() already removes it -- upgrade() does not do that
     today; that convergence is deliberately deferred to the first
-    production writer of this column (see the migration and the model's
-    __table_args__ comment). Concretely: inserting
+    production writer of this column, tracked in #1290 (see the migration
+    and the model's __table_args__ comment). Concretely: inserting
     interaction_protocol_version=2 succeeds on the chain-walked shape and
     raises IntegrityError on the fresh-install shape.
     This asymmetry is expected today because the column has zero writers --

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -167,7 +167,16 @@ def _build_migration_shaped_sqlite_engine():
         legacy_columns = [name for name in _column_names(connection) if name != COLUMN]
         column_list = ", ".join(legacy_columns)
 
+        # Without legacy_alter_table, SQLite's RENAME rewrites every sibling
+        # table's stored FK DDL to point at the renamed name (tasks_old),
+        # and the DROP TABLE below then leaves the whole schema with
+        # dangling references -- any later operation that reflects the
+        # dependency graph (op.batch_alter_table does) fails with
+        # NoSuchTableError. legacy_alter_table=ON makes RENAME touch only
+        # the tasks table itself, matching a real ALTER TABLE RENAME.
+        connection.execute(sa.text("PRAGMA legacy_alter_table=ON"))
         connection.execute(sa.text(f"ALTER TABLE {TABLE} RENAME TO {TABLE}_old"))
+        connection.execute(sa.text("PRAGMA legacy_alter_table=OFF"))
         connection.execute(sa.text(stripped_sql))
         connection.execute(
             sa.text(
@@ -319,28 +328,34 @@ def test_diff_narrow_inventory_reports_no_differences_for_identical_inventories(
 # ---- T-M-5: create_all SQLite cannot be downgraded; migration-chain can ----
 
 
-def test_create_all_sqlite_downgrade_fails_but_migration_shaped_sqlite_succeeds() -> (
-    None
-):
-    """SQLite refuses to DROP a column that a CHECK constraint references,
-    so calling downgrade() on a create_all-built SQLite database raises
-    OperationalError("no such column: interaction_protocol_version"). This
-    is a direct consequence of the CHECK asymmetry above, not a bug: it only
-    happens on a shape that never goes through a real downgrade. A database
-    maintained through the revision chain never received the CHECK on
-    SQLite in the first place (T-M-1b/T-M-1d), so its downgrade() has no
-    CHECK-referenced column to trip over. Both halves are asserted here so a
-    reader who only sees the first half does not read it as a defect to fix
-    -- "fixing" it by making downgrade() smarter would not change the fact
-    that no real database ever hits this path.
+def test_sqlite_downgrade_succeeds_on_both_install_shapes() -> None:
+    """The reviewer's round-2 Finding 1 established that a fresh install
+    stamps head and then builds its schema via create_all (see
+    src/xagent/db/migration.py's empty-DB stamp path and database.py's
+    create_all call), so the create_all-built SQLite shape is a real
+    downgrade-reachable production shape, not a synthetic one -- and SQLite
+    3.35+ refuses to DROP a column a CHECK constraint references, so the old
+    unconditional drop_column() broke downgrade() on that shape. downgrade()
+    now rebuilds the table via batch_alter_table on SQLite (see the
+    migration's downgrade() online branch), which drops the CHECK and the
+    column together regardless of which shape the database has. Both shapes
+    are asserted here: the migration-shaped database never had the CHECK to
+    begin with (T-M-1b/T-M-1d), while the create_all-built one does and must
+    have both the column and the CHECK clause removed from the table DDL.
     """
     migration = load_migration_module(MIGRATION_PATH)
 
     create_all_engine = _build_create_all_sqlite_engine()
     with create_all_engine.begin() as connection:
         with patch.object(migration, "op", _operations(connection)):
-            with pytest.raises(sa.exc.OperationalError, match="no such column"):
-                migration.downgrade()
+            migration.downgrade()
+            assert COLUMN not in _column_names(connection)
+
+        ddl = connection.execute(
+            sa.text("SELECT sql FROM sqlite_master WHERE type='table' AND name=:name"),
+            {"name": TABLE},
+        ).scalar()
+        assert CONSTRAINT_NAME not in ddl
 
     migration_engine = _build_migration_shaped_sqlite_engine()
     with migration_engine.begin() as connection:

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -228,6 +228,7 @@ def test_sqlite_check_asymmetry_is_expected() -> None:
 # ---- T-M-2c: PostgreSQL -- column and CHECK match exactly ----
 
 
+@pytest.mark.postgresql
 def test_postgresql_column_and_check_match_between_migration_and_create_all() -> None:
     with disposable_database_factory("xagent_w1_parity") as make_database:
         migration_engine = _build_migration_shaped_postgresql_engine(

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -63,6 +63,16 @@ CONSTRAINT_NAME = "ck_tasks_interaction_protocol_version"
 # technique as reset_checkpoint_anchor_fk_create_rule's sibling helper in
 # tests/web/services/checkpoint_anchor_shared.py, extended to also drop a
 # column rather than just one FK clause.
+#
+# Both patterns assume today's exact column/constraint shape and fail
+# differently if it changes. _COLUMN_CLAUSE requires a trailing comma, so a
+# column rendered last in CREATE TABLE (no comma after it) stops matching --
+# the hit-count assertion below catches that loudly (0 hits instead of 1).
+# _CHECK_CLAUSE's `\([^)]*\)` stops at the first closing paren, so a CHECK
+# condition with a nested parenthesised expression truncates instead of
+# matching the whole clause; the hit count stays 1, so that assertion does
+# NOT catch it, and the stripped SQL is left with an orphan `)` that only
+# fails later, when connection.execute(sa.text(...)) hits a syntax error.
 _COLUMN_CLAUSE = re.compile(r"\s*interaction_protocol_version INTEGER,\s*")
 _CHECK_CLAUSE = re.compile(
     r",\s*CONSTRAINT ck_tasks_interaction_protocol_version CHECK \([^)]*\)"

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -84,7 +84,7 @@ def test_model_and_migration_constraint_texts_are_identical() -> None:
     model_conditions = {
         item.name: str(item.sqltext)
         for item in Task.__table_args__
-        if type(item).__name__ == "CheckConstraint"
+        if isinstance(item, sa.CheckConstraint)
     }
 
     migration = load_migration_module(MIGRATION_PATH)
@@ -235,13 +235,18 @@ def test_sqlite_check_asymmetry_is_expected() -> None:
     """Two SQLite deployments of the same xagent version can enforce
     different invariants on this column depending on install history: a
     fresh install (stamp head, then create_all) HAS the CHECK, while a
-    database that walked the revision chain does NOT -- upgrade() cannot
-    add a CHECK to an existing table on SQLite (NotImplementedError, both
-    online and offline; the batch_alter_table workaround cannot run in
-    --sql mode on either dialect, which the offline-SQL requirement rules
-    out -- see the migration and the model's __table_args__ comment).
-    Concretely: inserting interaction_protocol_version=2 succeeds on the
-    chain-walked shape and raises IntegrityError on the fresh-install shape.
+    database that walked the revision chain does NOT. Offline, upgrade()
+    cannot add a CHECK to an existing table on SQLite: a plain CHECK-add
+    raises NotImplementedError there, and the batch_alter_table rebuild
+    that could add it cannot render under --sql mode on either dialect,
+    which offline SQL support (a hard requirement) rules out. Online,
+    batch_alter_table could add the CHECK to an existing SQLite table the
+    same way downgrade() already removes it -- upgrade() does not do that
+    today; that convergence is deliberately deferred to the first
+    production writer of this column (see the migration and the model's
+    __table_args__ comment). Concretely: inserting
+    interaction_protocol_version=2 succeeds on the chain-walked shape and
+    raises IntegrityError on the fresh-install shape.
     This asymmetry is expected today because the column has zero writers --
     nothing has ever inserted a non-NULL value, so nothing observes the
     divergence. The change that adds the first writer to this column must
@@ -317,12 +322,13 @@ def test_diff_narrow_inventory_flags_a_changed_check_expression() -> None:
 
 def test_sqlite_downgrade_succeeds_on_both_install_shapes() -> None:
     """A fresh install stamps head and then builds its schema via create_all
-    (see src/xagent/db/migration.py's empty-DB stamp path and database.py's
-    create_all call), so the create_all-built SQLite shape is a real
-    downgrade-reachable production shape, not a synthetic one -- and SQLite
-    3.35+ refuses to DROP a column a CHECK constraint references, so the old
-    unconditional drop_column() broke downgrade() on that shape. downgrade()
-    now rebuilds the table via batch_alter_table on SQLite (see the
+    (see src/xagent/db/migration.py's empty-DB stamp path and
+    src/xagent/web/models/database.py's create_all call, at its
+    _initialize_database_schema site), so the create_all-built SQLite shape
+    is a real downgrade-reachable production shape, not a synthetic one --
+    and SQLite 3.35+ refuses to DROP a column a CHECK constraint references,
+    so the old unconditional drop_column() broke downgrade() on that shape.
+    downgrade() now rebuilds the table via batch_alter_table on SQLite (see the
     migration's downgrade() online branch), which drops the CHECK and the
     column together regardless of which shape the database has. Both shapes
     are asserted here: the migration-shaped database never had the CHECK to

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -283,7 +283,7 @@ def test_sqlite_check_asymmetry_is_expected() -> None:
 
 @pytest.mark.postgresql
 def test_postgresql_column_and_check_match_between_migration_and_create_all() -> None:
-    with disposable_database_factory("xagent_w1_parity") as make_database:
+    with disposable_database_factory("xagent_protocol_marker_parity") as make_database:
         migration_engine = _build_migration_shaped_postgresql_engine(
             make_database("migration_side")
         )

--- a/tests/migrations/test_task_interaction_protocol_version_parity.py
+++ b/tests/migrations/test_task_interaction_protocol_version_parity.py
@@ -46,6 +46,7 @@ from tests.web.services.checkpoint_anchor_shared import (
     reset_checkpoint_anchor_fk_create_rule,
 )
 from xagent.web.models.database import Base
+from xagent.web.models.task import Task
 
 MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
@@ -70,6 +71,25 @@ _CHECK_CLAUSE = re.compile(
 
 def _operations(connection: sa.Connection) -> Operations:
     return Operations(MigrationContext.configure(connection))
+
+
+# ---- backend-free: the model and the migration agree on the CHECK text ----
+
+
+def test_model_and_migration_constraint_texts_are_identical() -> None:
+    """The model's CheckConstraint and the migration's CONSTRAINT_CONDITION
+    are two copies of one contract; today they agree purely by discipline.
+    This needs no backend: a one-character divergence fails here before any
+    database ever sees either copy."""
+    model_conditions = {
+        item.name: str(item.sqltext)
+        for item in Task.__table_args__
+        if type(item).__name__ == "CheckConstraint"
+    }
+
+    migration = load_migration_module(MIGRATION_PATH)
+
+    assert model_conditions[CONSTRAINT_NAME] == migration.CONSTRAINT_CONDITION
 
 
 def _column_names(connection) -> set[str]:


### PR DESCRIPTION
## Summary

Adds `tasks.interaction_protocol_version` (nullable Integer) plus a CHECK
constraint pinning it to NULL or 1, a matching Alembic revision, and
schema-parity coverage between the model and the migration. This is the first PR of the wiring
batch that connects `task_interaction_requests` to the rest of the task
lifecycle; it has no writers and no readers of the new column yet -- it only
lays down the column and its constraint for the PRs that follow.

## The four existing-table pairing groups, recorded in one place

AC bullet 6 of the original interaction-schema design called for four
existing-table columns paired against `task_interaction_requests`, each
serving a different consumer. All four hit the same SQLite/offline conflict
(P7): adding a FK, CHECK, or UNIQUE constraint to an *existing* table raises
`NotImplementedError` on SQLite (both online and offline), and the
`batch_alter_table` workaround cannot run in `--sql` mode either, which the
offline-SQL requirement rules out. Only `op.create_table` for a brand-new
table avoids this. Because of that conflict, three of the four groups were
scoped out of the delivery series entirely and left for a follow-up issue (#1292) to
decide, pair by pair, once each has a real consumer. This PR is the first to
land one of the four (the `tasks` marker); the other three remain
undelivered. All four are recorded here, not just the `tasks` one, so the
remaining scope stays visible in one place.

1. **`tasks`** -- Task-level protocol marker (this PR). One column,
   `interaction_protocol_version Integer NULL`, and one CHECK,
   `ck_tasks_interaction_protocol_version`: `IS NULL OR = 1`. Consumer: the
   three wait finalizers and the three legacy-resume injection sites landing
   in later PRs of this batch.

2. **`task_chat_messages`** -- transcript link. One column,
   `interaction_request_id Integer NULL`, FK to
   `task_interaction_requests.id` with `ON DELETE SET NULL`. Deliberately
   left unpaired (no CHECK): the column is nullable by design, and pairing
   it against another column was never part of the original AC. Undelivered.

3. **`uploaded_files`** -- upload intent. Two columns,
   `interaction_request_id Integer NULL` (FK, `ON DELETE SET NULL`) and
   `upload_intent_token String(64) NULL`; one one-directional CHECK,
   `ck_uploaded_files_interaction_intent`:
   `interaction_request_id IS NULL OR upload_intent_token IS NOT NULL`; one
   unique index, `uq_uploaded_files_interaction_intent`, over both columns.
   The one-directional shape (rather than a two-way biconditional) is
   deliberate: `ON DELETE SET NULL` clearing `interaction_request_id` must
   not itself violate the constraint. Undelivered -- and blocked on a prior
   product question, since the tree has no upload-intent surface today (no
   presign/intent flow, only a synchronous upload endpoint).

4. **`task_execution_commands`** -- command association. Two columns,
   `interaction_request_id Integer NULL` (FK, `ON DELETE SET NULL`) and
   `interaction_protocol_version Integer NULL`; two CHECKs,
   `ck_task_commands_interaction_pair` (one-directional pairing, same
   SET-NULL reasoning as above) and
   `ck_task_commands_interaction_protocol_version`; one unique index,
   `uq_task_commands_interaction_request`. Undelivered.

Disposition principle for all three undelivered groups: each is decided
independently, at the point its real consumer lands, whether to accept an
Alembic-upgraded SQLite database with the constraint missing (matching this
PR's precedent) or to give up that group's offline-SQL support instead.

## Registered, not done

- **`tasks` constraint-name-length guard.** The existing guard
  (`test_no_constraint_name_exceeds_the_postgres_identifier_limit`-style
  scan) only walks `TaskInteractionRequest.__table__`; nothing scans
  `tasks`. `ck_tasks_interaction_protocol_version` is 37 characters, well
  under PostgreSQL's 63-character identifier limit, so this is not an
  immediate risk, but the table has no guard watching it. Registered as a
  candidate extension, not implemented in this PR.
- **Paired-guard scanning blind spots** (existing, unrelated to this PR's
  own diff, noted alongside the item above as the same class of backlog):
  the carrier set for the existing pairing guards needs an `ast.Attribute`
  assignment-target case added, and `SUBJECT_MODULES` needs `websocket` and
  `managed_task_lease` added.

## SQLite asymmetry

The CHECK constraint only reaches PostgreSQL and `create_all`-built test
databases. On SQLite, plain `ALTER TABLE ADD CONSTRAINT` is unsupported;
an online `batch_alter_table` rebuild could add it, but that convergence
is deliberately deferred to the change that lands this column's first
production writer, and the offline (`--sql`) path cannot render a batch
rebuild at all. So a SQLite database maintained through the Alembic
revision chain does not carry this CHECK; a SQLite database built via
`Base.metadata.create_all()` (as most tests are) has it, straight from
the model. Both suites assert this asymmetry explicitly rather than
leaving it as an unexplained gap.

Two consequences of that split are pinned by tests rather than left to
be discovered. First, `downgrade()` succeeds on both SQLite shapes: the
online branch rebuilds the table via `batch_alter_table`, which drops
the column and, on a `create_all`-built database, the CHECK along with
it. Second — and this is the sharp edge — a rollback/reapply cycle on a
`create_all`-built SQLite database is one-way: `upgrade()` deliberately
does not re-add the CHECK on SQLite, so after `downgrade()` then
`upgrade()` the column is back but the constraint is gone for good, and
an insert the database used to reject is then accepted. A dedicated
round-trip test pins that transition so the first-writer change cannot
miss it.

## Migration-chain handoff

#1218 (`task_interaction_requests` table) merged first, as
`20260809_add_task_interaction_requests` chained onto
`20260806_seed_chrome_mcp_app`. This branch has been rebased onto that
merge and this PR's revision (`20260810_add_task_interaction_protocol_version`)
now chains onto `20260809_add_task_interaction_requests` instead, keeping
the graph at a single head. `alembic heads` and `scripts/check_alembic_heads.sh`
both confirm one head on the rebased tree; the alembic and parity suites for
this migration pass on SQLite and PostgreSQL, and `alembic upgrade`/`downgrade`
with `--sql` render correctly for both dialects across the
`20260809_add_task_interaction_requests` -> `20260810_add_task_interaction_protocol_version`
step.

The rebase also surfaced an add/add conflict on
`tests/shared/postgres_disposable.py`: this branch and #1218 had
independently written the same disposable-PostgreSQL-database factory
(identical code, different module docstring). #1218's version is now the
one on `main`, so this branch's commit that introduced the file became a
byte-for-byte duplicate and was dropped during the rebase rather than kept
as a no-op modification.


