### PR TITLE
fix(auth): keep post-commit OAuth side effects out of the failure handler

### DIFF
--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -75,13 +75,19 @@ def _best_effort_ensure_gmail_watches_for_user(db: Session, *, user_id: int) -> 
 
 
 def _run_post_commit_oauth_side_effects(
-    db: Session, *, user_id: int, connector_key: str
+    db: Session, *, user_id: Any, connector_key: str
 ) -> None:
     """Run the OAuth callback's post-commit work; never raise.
 
     ``connector_key`` is the value persisted as ``UserOAuth.provider``: the app
     id when the connect is app-scoped (``"gmail"``), otherwise the provider
     name (``"google"``).
+
+    ``user_id`` is the raw ``oauth_state`` claim rather than an ``int`` so that
+    its coercion happens inside the guard below. Coercing it into the argument
+    would put that conversion post-commit but outside the guard, which is the
+    one thing this helper exists to prevent, and would lose the offending value
+    to a 500 instead of logging it.
 
     Everything here runs once ``db.commit()`` has persisted the OAuth token, so
     the connect has already succeeded as far as the user is concerned. The
@@ -112,7 +118,7 @@ def _run_post_commit_oauth_side_effects(
     """
     try:
         if connector_key == "gmail":
-            _best_effort_ensure_gmail_watches_for_user(db, user_id=user_id)
+            _best_effort_ensure_gmail_watches_for_user(db, user_id=int(user_id))
     except Exception:
         logger.warning(
             "Post-commit OAuth side effects failed for user %s on connector %s; "
@@ -1538,7 +1544,7 @@ def generic_oauth_callback(
             # change what this callback returns. Add new post-commit work
             # there, not here.
             _run_post_commit_oauth_side_effects(
-                db, user_id=int(user_id), connector_key=(app_id or provider)
+                db, user_id=user_id, connector_key=(app_id or provider)
             )
 
         import json

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -74,6 +74,55 @@ def _best_effort_ensure_gmail_watches_for_user(db: Session, *, user_id: int) -> 
         )
 
 
+def _run_post_commit_oauth_side_effects(
+    db: Session, *, user_id: int, connector_key: str
+) -> None:
+    """Run the OAuth callback's post-commit work; never raise.
+
+    ``connector_key`` is the value persisted as ``UserOAuth.provider``: the app
+    id when the connect is app-scoped (``"gmail"``), otherwise the provider
+    name (``"google"``).
+
+    Everything here runs once ``db.commit()`` has persisted the OAuth token, so
+    the connect has already succeeded as far as the user is concerned. The
+    callback's outer ``except Exception`` would render anything raised here as
+    an ``Authentication Failed`` 500, reporting a failure for a connector that
+    is in fact connected. That is the bug #1150 reproduced on staging.
+
+    Guarding the region rather than each individual call is what makes that
+    property structural: a side effect added here inherits it, instead of
+    reintroducing #1150 whenever someone forgets to wrap their own call. The
+    inner guards each side effect carries are kept as well, deliberately, so
+    that neither layer is load-bearing on its own.
+
+    One guard over the whole region does couple the side effects to each other:
+    a raiser aborts the ones after it. That is why the inner guards matter and
+    are worth keeping per side effect. Anything added here that must run even
+    when an earlier entry fails needs its own guard, exactly as Gmail
+    provisioning has.
+
+    Response construction stays outside this region on purpose. It also runs
+    after the commit, but a failure there leaves no response to return, so it
+    must keep reaching the outer handler rather than being swallowed here.
+
+    Failures are logged only. That is acceptable while every side effect in
+    this region has its own recovery path: Gmail watches are re-provisioned by
+    ``scan_due_gmail_watch_renewals``. A side effect that a swallowed failure
+    would strand needs a user-visible signal instead.
+    """
+    try:
+        if connector_key == "gmail":
+            _best_effort_ensure_gmail_watches_for_user(db, user_id=user_id)
+    except Exception:
+        logger.warning(
+            "Post-commit OAuth side effects failed for user %s on connector %s; "
+            "the connect itself succeeded",
+            user_id,
+            connector_key,
+            exc_info=True,
+        )
+
+
 def _oauth_env_name(provider: str, suffix: str) -> str:
     return f"{provider.upper()}_{suffix}"
 
@@ -1485,8 +1534,12 @@ def generic_oauth_callback(
                         )
 
             db.commit()
-            if (app_id or provider) == "gmail":
-                _best_effort_ensure_gmail_watches_for_user(db, user_id=int(user_id))
+            # Everything past the commit belongs in the helper, which cannot
+            # change what this callback returns. Add new post-commit work
+            # there, not here.
+            _run_post_commit_oauth_side_effects(
+                db, user_id=int(user_id), connector_key=(app_id or provider)
+            )
 
         import json
         from urllib.parse import urlparse

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -312,6 +312,142 @@ def test_gmail_callback_survives_a_raising_account_lookup_during_provisioning(
     assert "Failed to resolve Gmail accounts for user" in caplog.text
 
 
+def test_oauth_callback_survives_a_raising_post_commit_side_effect(
+    db_session, monkeypatch, caplog
+):
+    """The post-commit region is guarded as a region, not per side effect.
+
+    The tests above all raise from inside Gmail provisioning, which carries its
+    own guard, so they cannot tell a per-call guard apart from a regional one.
+    Here the guarded wrapper itself raises, which is what a newly added
+    post-commit side effect would do before anyone remembers to guard it.
+    """
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "google",
+            "app_id": "gmail",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "gmail-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "access_token": "gmail-token",
+                    "refresh_token": "gmail-refresh",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": "https://www.googleapis.com/auth/gmail.modify",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"sub": "google-user-1", "email": "alice@gmail.com"}
+            )
+        ),
+    )
+
+    def raising_side_effect(_db, *, user_id: int):
+        raise RuntimeError("an unguarded post-commit side effect blew up")
+
+    monkeypatch.setattr(
+        auth_api, "_best_effort_ensure_gmail_watches_for_user", raising_side_effect
+    )
+
+    caplog.set_level(logging.WARNING, logger=auth_api.__name__)
+
+    response = generic_oauth_callback("google", request, db, _google_provider())
+
+    assert response.status_code == 200
+    assert "Authentication Failed" not in response.body.decode()
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "gmail")
+        .one()
+    )
+    assert oauth_account.email == "alice@gmail.com"
+    assert "Post-commit OAuth side effects failed" in caplog.text
+
+
+def test_oauth_callback_still_fails_when_the_success_page_cannot_be_rendered(
+    db_session, monkeypatch
+):
+    """The swallow covers post-commit side effects only, not response building.
+
+    Rendering runs after the commit too, but a failure there leaves nothing to
+    return, so it must keep reaching the outer handler instead of being
+    swallowed into a response that does not exist.
+    """
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "google",
+            "app_id": "gmail",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "gmail-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "access_token": "gmail-token",
+                    "refresh_token": "gmail-refresh",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": "https://www.googleapis.com/auth/gmail.modify",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"sub": "google-user-1", "email": "alice@gmail.com"}
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_provisioning."
+        "best_effort_provision_gmail_watches_for_user",
+        lambda _db, *, user_id, context: None,
+    )
+
+    real_html_response = auth_api.HTMLResponse
+
+    def failing_success_page(*args, **kwargs):
+        # Fail only the success page; the outer handler's own error page has to
+        # keep rendering, otherwise the test could not observe the 500.
+        content = kwargs.get("content", args[0] if args else "")
+        if "Connected Successfully" in str(content):
+            raise RuntimeError("template rendering failed")
+        return real_html_response(*args, **kwargs)
+
+    monkeypatch.setattr(auth_api, "HTMLResponse", failing_success_page)
+
+    response = generic_oauth_callback("google", request, db, _google_provider())
+
+    assert response.status_code == 500
+    assert "Authentication Failed" in response.body.decode()
+
+
 def test_meta_callback_exchanges_short_lived_token_and_connects_selected_app(
     db_session, monkeypatch
 ):

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -448,6 +448,69 @@ def test_oauth_callback_still_fails_when_the_success_page_cannot_be_rendered(
     assert "Authentication Failed" in response.body.decode()
 
 
+def test_oauth_callback_survives_a_non_integer_user_id_claim(
+    db_session, monkeypatch, caplog
+):
+    """Coercing the state claim is post-commit work, so it belongs in the guard.
+
+    A ``user_id`` claim that is not an integer only becomes observable once the
+    OAuth row is committed, so failing the coercion has to behave like any
+    other post-commit failure rather than rendering a 500 for a connect that
+    already succeeded. Reachable if a deployment is still running on the
+    default ``XAGENT_JWT_SECRET``, which makes the state token forgeable.
+    """
+    db, _user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": "7abc",
+            "provider": "google",
+            "app_id": "gmail",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "gmail-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "access_token": "gmail-token",
+                    "refresh_token": "gmail-refresh",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": "https://www.googleapis.com/auth/gmail.modify",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"sub": "google-user-1", "email": "alice@gmail.com"}
+            )
+        ),
+    )
+    provision = Mock()
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_provisioning."
+        "best_effort_provision_gmail_watches_for_user",
+        provision,
+    )
+
+    caplog.set_level(logging.WARNING, logger=auth_api.__name__)
+
+    response = generic_oauth_callback("google", request, db, _google_provider())
+
+    assert response.status_code == 200
+    assert "Authentication Failed" not in response.body.decode()
+    provision.assert_not_called()
+    assert "Post-commit OAuth side effects failed" in caplog.text
+
+
 def test_meta_callback_exchanges_short_lived_token_and_connects_selected_app(
     db_session, monkeypatch
 ):


### PR DESCRIPTION
Closes #1233.

## Problem

`generic_oauth_callback` wraps its entire body in a single `except Exception` that renders an HTTP 500 as `Authentication Failed`. That handler spans `db.commit()`, so anything raised after the OAuth token is persisted turns a successful connect into a misleading hard failure — the bug #1150 reproduced on staging.

#1223 guarded `_best_effort_ensure_gmail_watches_for_user` at its call site, so today's post-commit region is safe. The region itself is still inside the blanket handler, though, so the next post-commit addition reintroduces the same bug by default rather than by mistake.

## Changes

The post-commit region moves into `_run_post_commit_oauth_side_effects`, which logs and swallows its own failures. The call site becomes one unconditional call, so new post-commit work inherits the property instead of having to remember it:

```python
db.commit()
_run_post_commit_oauth_side_effects(
    db, user_id=int(user_id), connector_key=(app_id or provider)
)
```

The inner guard on Gmail provisioning is kept as well. The redundancy is deliberate, for the same reason #1223 gave: neither layer should be load-bearing on its own.

## The three points the issue left open

**Where the boundary sits.** At the side effects, not at `db.commit()`. The issue's own reservation is right: response construction (`json.dumps`, `urlparse`, `HTMLResponse`) also runs post-commit, but a failure there leaves no response to return, so it must keep reaching the outer handler. A regression test pins that.

**Whether other callbacks in the module need the same split.** No. `generic_oauth_callback` is the only implementation — `oauth_callback` just delegates. `google_oidc_callback` in `oidc_google.py` does run `_create_exchange_code` after its commit, but the failure semantics differ: without an exchange code there is no way to complete the login, so the error redirect is correct, and a retry succeeds through the existing-identity branch of `_get_or_create_google_user`. It is not the #1150 bug class.

**Whether swallowed failures need a user-visible signal.** Keeping #1150's log-only decision, with its precondition now written down: it holds while every side effect in the region has a recovery path — Gmail watches are re-provisioned by `scan_due_gmail_watch_renewals`, which outer-joins `GmailWatchState` and selects rows where `GmailWatchState.id IS NULL`. A side effect that a swallowed failure would strand needs a signal instead.

## One property worth flagging

A single guard over the whole region couples its entries: a raiser aborts the ones after it, which per-call guards did not do. That is the substantive reason to keep the inner guards, and the docstring says so — anything added there that must run even when an earlier entry fails needs its own guard, exactly as Gmail provisioning has.

## Testing

Two regression tests in `tests/web/test_meta_oauth.py`:

- a raising post-commit side effect leaves the callback at 200. This patches the guarded *wrapper*, not the service beneath it, which is what distinguishes a regional guard from the per-call one #1223 added — the existing tests all raise from inside Gmail provisioning and so cannot tell them apart. Verified to fail without the fix as `assert 500 == 200`, rendering `Authentication Failed`.
- a success page that cannot be rendered still surfaces as 500, pinning the boundary against being widened later.

`tests/web/test_meta_oauth.py`, `test_slack_oauth.py`, `test_zoom_oauth.py`, `test_oidc_google_auth.py`, `test_auth_api.py`, `services/test_gmail_provisioning.py`, `api/test_gmail_auto_triggers.py`: 181 passed, 4 skipped (the skips are the PostgreSQL-only cases). `ruff check`, `ruff format --check` and `mypy src/xagent/web/api/auth.py` are clean.

The wider `pytest tests/web` leg was also run locally: 11 failures, all reproduced identically on a clean tree at the merge-base. 5 are SVG rasterization tests that need `libcairo`, which is absent on this machine; the other 6 are the sandbox reconcile e2e suite.
