### PR TITLE
fix(monitor): divide model calls by the fleet total, not by themselves

### DIFF
--- a/src/xagent/web/api/monitor.py
+++ b/src/xagent/web/api/monitor.py
@@ -571,25 +571,39 @@ async def get_model_stats(
             logger.error(f"Failed to query model stats: {e}")
             model_stats = []
 
-        # Get total call count for calculating usage rate
-        total_calls = sum(stat.total_calls for stat in model_stats)
+        # Rows the response will carry. Filtered here rather than inside the
+        # loop so a dropped row stays out of the denominator too: the query
+        # rejects a NULL model name but not an empty one, and counting calls
+        # that are never reported would deflate every rate that is.
+        counted_models = [
+            (model_name, model_calls)
+            for model_name, model_calls in model_stats
+            if model_name and model_calls > 0
+        ]
+
+        # Denominator for each model's share of the traffic. Deliberately not
+        # named ``total_calls``: the loop below used to bind that same name to
+        # the per-model count, so the rate divided a model's calls by itself
+        # and every model reported 100% (#1245).
+        all_model_calls = sum(model_calls for _, model_calls in counted_models)
 
         result = []
-        for model_name, total_calls in model_stats:
-            if model_name and total_calls > 0:
-                usage_rate = (total_calls / total_calls * 100) if total_calls > 0 else 0
+        for model_name, model_calls in counted_models:
+            # No zero-guard needed: the sum runs over these same rows, each of
+            # which the comprehension above established is positive.
+            usage_rate = model_calls / all_model_calls * 100
 
-                result.append(
-                    {
-                        "name": model_name,
-                        "status": "running",
-                        "usage_rate": round(usage_rate, 1),
-                        "success_rate": None,  # Simplified, do not calculate success rate
-                        "total_tasks": total_calls,
-                        "successful_tasks": None,
-                        "failed_tasks": None,
-                    }
-                )
+            result.append(
+                {
+                    "name": model_name,
+                    "status": "running",
+                    "usage_rate": round(usage_rate, 1),
+                    "success_rate": None,  # Simplified, do not calculate success rate
+                    "total_tasks": model_calls,
+                    "successful_tasks": None,
+                    "failed_tasks": None,
+                }
+            )
 
         # If no real data, return empty list
         if not result:

--- a/src/xagent/web/api/monitor.py
+++ b/src/xagent/web/api/monitor.py
@@ -581,10 +581,10 @@ async def get_model_stats(
             if model_name and model_calls > 0
         ]
 
-        # Denominator for each model's share of the traffic. Deliberately not
-        # named ``total_calls``: the loop below used to bind that same name to
-        # the per-model count, so the rate divided a model's calls by itself
-        # and every model reported 100% (#1245).
+        # Denominator for each model's share of the traffic. Must stay distinct
+        # from the loop's per-model variable: while the two shared a name the
+        # rate divided a model's calls by itself and every model reported 100%
+        # (#1245).
         all_model_calls = sum(model_calls for _, model_calls in counted_models)
 
         result = []
@@ -604,10 +604,6 @@ async def get_model_stats(
                     "failed_tasks": None,
                 }
             )
-
-        # If no real data, return empty list
-        if not result:
-            return []
 
         return result
     except Exception as e:

--- a/tests/web/api/test_monitor_model_stats.py
+++ b/tests/web/api/test_monitor_model_stats.py
@@ -1,0 +1,133 @@
+"""``/monitor/model-stats`` usage-rate arithmetic.
+
+``get_model_stats`` reported ``usage_rate: 100.0`` for every model no matter
+how the calls were actually distributed (#1245). The grand total was summed
+into ``total_calls`` and then shadowed by the loop variable of the same name,
+so the rate divided a model's own call count by itself -- ``n / n * 100``, a
+constant 100 for every row with any traffic at all. The dashboard renders the
+field directly as a percentage, so the distribution it exists to show was
+replaced by a column of identical numbers.
+
+Nothing here is dialect-specific: the shadowing is plain Python downstream of
+the query, so the SQLite path exercises it. The sibling PostgreSQL suite
+covers the dialect-dependent JSON extraction feeding it and asserts only
+per-model call counts.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.orm import Session
+
+from xagent.web.api.monitor import get_model_stats
+from xagent.web.models.task import Task, TraceEvent
+from xagent.web.models.user import User
+
+from .conftest import _direct_db_session
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+def _seed_model_calls(db: Session, model_names: list[str], *, owner: str) -> User:
+    """One admin with one ``llm_call_start`` event per name in ``model_names``.
+
+    Repeat a name to give that model more calls. ``owner`` keeps usernames
+    distinct so a test never depends on another test's rows surviving.
+    """
+    admin = User(username=owner, password_hash="hash", is_admin=True)
+    db.add(admin)
+    db.commit()
+    db.refresh(admin)
+
+    task = Task(user_id=admin.id, title=f"{owner}-task")
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+
+    now = datetime.now()
+    for index, model_name in enumerate(model_names):
+        db.add(
+            TraceEvent(
+                task_id=task.id,
+                event_id=f"{owner}-{index}",
+                event_type="llm_call_start",
+                timestamp=now,
+                data={"model_name": model_name},
+            )
+        )
+    db.commit()
+    return admin
+
+
+async def test_usage_rate_is_each_model_share_of_all_calls() -> None:
+    """Each rate is the model's share of the total, not a constant 100.
+
+    A lopsided split is the point: with equal counts every candidate formula
+    agrees, so only an uneven distribution tells a real share of the total
+    apart from the constant the handler used to return.
+    """
+    db = _direct_db_session()
+    try:
+        admin = _seed_model_calls(
+            db,
+            ["gpt-4o", "gpt-4o", "gpt-4o", "claude-opus"],
+            owner="lopsided-admin",
+        )
+
+        stats = await get_model_stats(db=db, current_user=admin)
+
+        assert {entry["name"]: entry["usage_rate"] for entry in stats} == {
+            "gpt-4o": 75.0,
+            "claude-opus": 25.0,
+        }
+        # The call counts the rates are derived from, so a regression that
+        # fixed the ratio by miscounting cannot hide here.
+        assert {entry["name"]: entry["total_tasks"] for entry in stats} == {
+            "gpt-4o": 3,
+            "claude-opus": 1,
+        }
+    finally:
+        db.close()
+
+
+async def test_single_model_uses_the_whole_budget() -> None:
+    """One model with all the traffic really is at 100%.
+
+    Kept alongside the lopsided case so the fix is pinned from both sides: the
+    old code returned 100.0 here too, and a fix that merely stopped returning
+    100.0 would be just as wrong.
+    """
+    db = _direct_db_session()
+    try:
+        admin = _seed_model_calls(db, ["gpt-4o"], owner="solo-admin")
+
+        stats = await get_model_stats(db=db, current_user=admin)
+
+        assert [(entry["name"], entry["usage_rate"]) for entry in stats] == [
+            ("gpt-4o", 100.0)
+        ]
+    finally:
+        db.close()
+
+
+async def test_nameless_calls_stay_out_of_the_denominator() -> None:
+    """Calls the response omits must not shrink the rates it reports.
+
+    The query filters a NULL model name but not an empty one, so an empty name
+    reaches Python and is dropped there. Once the total became a real
+    denominator, dropping such a row from the output while still counting it
+    would leave the reported rates summing to less than 100.
+    """
+    db = _direct_db_session()
+    try:
+        admin = _seed_model_calls(db, ["gpt-4o", "", ""], owner="nameless-calls-admin")
+
+        stats = await get_model_stats(db=db, current_user=admin)
+
+        assert [(entry["name"], entry["usage_rate"]) for entry in stats] == [
+            ("gpt-4o", 100.0)
+        ]
+    finally:
+        db.close()

--- a/tests/web/api/test_monitor_model_stats.py
+++ b/tests/web/api/test_monitor_model_stats.py
@@ -30,18 +30,21 @@ from .conftest import _direct_db_session
 pytestmark = pytest.mark.usefixtures("_test_db")
 
 
-def _seed_model_calls(db: Session, model_names: list[str], *, owner: str) -> User:
-    """One admin with one ``llm_call_start`` event per name in ``model_names``.
+def _seed_model_calls(
+    db: Session, model_names: list[str], *, owner: str, is_admin: bool = True
+) -> User:
+    """One user with one ``llm_call_start`` event per name in ``model_names``.
 
-    Repeat a name to give that model more calls. ``owner`` keeps usernames
-    distinct so a test never depends on another test's rows surviving.
+    Repeat a name to give that model more calls. ``owner`` must differ between
+    calls within a test -- ``User.username`` is ``unique=True``, so reusing one
+    raises rather than merely mixing two users' traffic together.
     """
-    admin = User(username=owner, password_hash="hash", is_admin=True)
-    db.add(admin)
+    user = User(username=owner, password_hash="hash", is_admin=is_admin)
+    db.add(user)
     db.commit()
-    db.refresh(admin)
+    db.refresh(user)
 
-    task = Task(user_id=admin.id, title=f"{owner}-task")
+    task = Task(user_id=user.id, title=f"{owner}-task")
     db.add(task)
     db.commit()
     db.refresh(task)
@@ -62,7 +65,7 @@ def _seed_model_calls(db: Session, model_names: list[str], *, owner: str) -> Use
             )
         )
     db.commit()
-    return admin
+    return user
 
 
 async def test_usage_rate_is_each_model_share_of_all_calls() -> None:
@@ -133,5 +136,57 @@ async def test_nameless_calls_stay_out_of_the_denominator() -> None:
         assert [(entry["name"], entry["usage_rate"]) for entry in stats] == [
             ("gpt-4o", 100.0)
         ]
+    finally:
+        db.close()
+
+
+async def test_no_calls_yields_an_empty_list() -> None:
+    """No traffic returns ``[]`` rather than raising or reporting a zero row.
+
+    The handler used to end with ``if not result: return []`` ahead of
+    ``return result``, which could not be told apart from it -- both arms
+    returned an equal empty list. That branch is gone; this pins the behaviour
+    it was there to express.
+    """
+    db = _direct_db_session()
+    try:
+        member = _seed_model_calls(db, [], owner="no-traffic-user")
+
+        assert await get_model_stats(db=db, current_user=member) == []
+    finally:
+        db.close()
+
+
+async def test_non_admin_shares_are_scoped_to_their_own_calls() -> None:
+    """A regular user's denominator is their own traffic, not the fleet's.
+
+    Non-admins get a ``task_id`` subquery restricting the scan to their own
+    tasks, so both the numerator and the denominator shrink to what they can
+    see. Now that the denominator is read, a leak would not just add rows the
+    caller should not see -- it would silently restate the rates for the rows
+    they should. The other user's traffic is sized so the two readings cannot
+    be confused: fleet-wide would be 90.0/10.0, own-traffic 75.0/25.0.
+    """
+    db = _direct_db_session()
+    try:
+        _seed_model_calls(db, ["gpt-4o"] * 6, owner="other-tenant")
+        member = _seed_model_calls(
+            db,
+            ["gpt-4o", "gpt-4o", "gpt-4o", "claude-opus"],
+            owner="member",
+            is_admin=False,
+        )
+
+        stats = await get_model_stats(db=db, current_user=member)
+
+        assert {entry["name"]: entry["usage_rate"] for entry in stats} == {
+            "gpt-4o": 75.0,
+            "claude-opus": 25.0,
+        }
+        # The counts too, so a leak cannot hide behind a coincidental ratio.
+        assert {entry["name"]: entry["total_tasks"] for entry in stats} == {
+            "gpt-4o": 3,
+            "claude-opus": 1,
+        }
     finally:
         db.close()

--- a/tests/web/api/test_monitor_model_stats.py
+++ b/tests/web/api/test_monitor_model_stats.py
@@ -16,7 +16,7 @@ per-model call counts.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy.orm import Session
@@ -46,7 +46,11 @@ def _seed_model_calls(db: Session, model_names: list[str], *, owner: str) -> Use
     db.commit()
     db.refresh(task)
 
-    now = datetime.now()
+    # Aware UTC, matching what production writes into this tz-aware column
+    # (``websocket.py`` persists ``datetime.now(timezone.utc)``). No assertion
+    # here depends on it -- ``get_model_stats`` never reads ``timestamp``, and
+    # the column is only populated because it is ``nullable=False``.
+    now = datetime.now(timezone.utc)
     for index, model_name in enumerate(model_names):
         db.add(
             TraceEvent(


### PR DESCRIPTION
Closes #1245

## Problem

`GET /monitor/model-stats` reported `usage_rate: 100.0` for every model regardless of how the calls were distributed. Two models with 3 and 1 calls both came back as 100%.

`get_model_stats` summed the grand total into `total_calls`, then the loop header rebound the same name to the per-model count:

```python
total_calls = sum(stat.total_calls for stat in model_stats)

for model_name, total_calls in model_stats:      # rebinds total_calls
    if model_name and total_calls > 0:
        usage_rate = (total_calls / total_calls * 100) if total_calls > 0 else 0
```

By the time the rate was computed both sides of the division were the same value — `n / n * 100`, a constant 100 for every row with any traffic. The aggregate was never read, and the `else 0` arm was unreachable because the enclosing `if` already required a positive count.

The frontend renders the field straight through as a percentage (`frontend/src/components/pages/monitoring.tsx:191`), so the call distribution the monitoring page exists to show was replaced by a column of identical numbers.

## Fix

Rename the aggregate to `all_model_calls` so a loop variable cannot shadow it, name the loop variable `model_calls`, and divide one by the other. The zero-guard is dropped rather than rewritten: the denominator sums the same rows the loop walks, each already established to be positive.

Beyond the report, the rows are now selected *before* the sum rather than skipped inside the loop. The query rejects a NULL model name but not an empty one, so an empty name reaches Python and is dropped there. That was free while the aggregate went unread; now that it is the denominator, counting calls the response never reports would deflate every rate it does report — one nameless call beside two real ones drops a sole model from 100% to 66.7%. Confirmed by reverting just that filter: the new test goes from 100.0 to 33.3.

## Tests

New `tests/web/api/test_monitor_model_stats.py` on the SQLite path — the shadowing was plain Python downstream of the query, with nothing dialect-specific about it. The sibling PostgreSQL suite covers the dialect-dependent JSON extraction feeding this handler and asserts only per-model call counts, so it passed before this fix and keeps passing after.

- Two models splitting traffic 3-to-1 report 75.0 and 25.0. Verified red before the fix (both 100.0).
- A single model holding all the traffic still reports 100.0, so a fix that merely stopped returning 100.0 everywhere would not pass.
- A model sharing a task with nameless calls still reports 100.0.

`tests/web/api` passes in full; `ruff check`/`ruff format` clean; `mypy` reports nothing new for `monitor.py`.

## Out of scope

The response key `total_tasks` holds LLM call counts, not task counts. Renaming it is a wire-contract change touching the frontend type, its usage, and the i18n strings, so it is left for a follow-up rather than folded into this fix.
