### PR TITLE
feat(interactions): add typed clarification drafts to the core agent layer

### DIFF
--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -44,6 +44,15 @@ class ClarificationRequestItem:
     tool_call_id: str
     interaction_id: str
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain dict view, for ``ClarificationDraft.to_dict``."""
+
+        return {
+            "tool_name": self.tool_name,
+            "tool_call_id": self.tool_call_id,
+            "interaction_id": self.interaction_id,
+        }
+
 
 @dataclass(frozen=True)
 class ClarificationDraft:
@@ -97,6 +106,41 @@ class ClarificationDraft:
             requests=self.requests,
         )
         return replace(self, origin_step_id=step_id, turn_marker=turn_marker)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable, fully plain-data view of this draft.
+
+        This exists because the execution-result dict that carries a
+        ``ClarificationDraft`` (under ``result["clarification_draft"]``) is
+        serialized into trace events by handlers that use the ``to_dict``
+        protocol -- ``DatabaseTraceHandler._serialize_data_for_json`` and its
+        WebSocket twin call ``value.to_dict()`` whenever it is callable, and
+        then recursively re-serialize whatever that call returns. So this
+        method cannot hand back nested dataclasses: ``interactions`` becomes
+        a plain list (its entries are already plain dicts), and ``requests``
+        becomes a list of plain dicts via ``ClarificationRequestItem.to_dict``.
+        The serializers do descend into tuples on their own; the contract is
+        stricter than the mechanism requires -- only plain data may appear in
+        the returned structure -- so that a future field holding a dataclass
+        without ``to_dict`` cannot slip through unnoticed.
+
+        This method exists for those serializers, not as a general "this
+        object is always JSON-safe" promise: a consumer that calls
+        ``json.dumps`` directly on the result dict never invokes ``to_dict``
+        and still fails on the bare dataclass.
+        """
+
+        return {
+            "source": self.source,
+            "message": self.message,
+            "message_type": self.message_type,
+            "interactions": list(self.interactions),
+            "requests": [item.to_dict() for item in self.requests],
+            "origin_step_id": self.origin_step_id,
+            "origin_execution_id": self.origin_execution_id,
+            "turn_message_count": self.turn_message_count,
+            "turn_marker": self.turn_marker,
+        }
 
 
 def _marker_clean(value: str) -> str:
@@ -167,14 +211,28 @@ def draft_from_waiting_request(
       empty-form ``ask_user_question`` still has the key) -> ``"ask_user_question"``.
     - otherwise -> ``"send_message"``.
 
-    Returns ``None`` in exactly one case: ``request`` carries neither a
-    non-empty message nor an ``"interactions"`` key nor a non-empty
-    ``"requests"`` list. That case has no reachable production caller today;
-    it exists so that resuming a checkpoint written by an older schema
-    degrades to "no draft" instead of raising and blocking resume.
+    Returns ``None`` in two cases, both meaning "no typed draft could be
+    derived" rather than a raised error:
+
+    - ``request`` is not a dict (``None``, a stray ``str``, a ``list``,
+      ...) -- a type mismatch from the caller.
+    - ``request`` is a dict but carries neither a non-empty message nor an
+      ``"interactions"`` key nor a non-empty ``"requests"`` list. This is
+      reachable in production today: a ``send_message`` call with an empty
+      ``message`` and ``expect_response=True`` reaches ``waiting_for_user``
+      with no message, no ``"interactions"`` key, and no ``"requests"``
+      list (see the ``send_message`` branch of
+      ``ReActPattern._handle_control_tool`` in ``react.py``). It also
+      covers resuming a checkpoint written by an older schema, which
+      degrades to "no draft" instead of raising and blocking resume.
     """
 
     if not isinstance(request, dict):
+        logger.warning(
+            "draft_from_waiting_request: waiting request is not a dict "
+            "(got %s); skipping clarification draft",
+            type(request).__name__,
+        )
         return None
 
     message = str(request.get("message") or "")

--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -1,0 +1,253 @@
+"""Typed clarification draft derived from a ReAct waiting request.
+
+This module is pure core layer: it imports nothing from ``xagent.web`` and
+opens no database connection. Everything here is a plain function or a frozen
+dataclass over already-in-memory data.
+
+A :class:`ClarificationDraft` is a derived value, not stored state. Its only
+source of truth is ``ReActPattern.waiting_for_user_request``, which already
+travels through ``get_state()`` / ``load_state()`` on its own. The draft
+itself does not join that round trip -- it is cheap to recompute from the
+restored request every time a waiting turn is produced, so there is nothing
+to persist or reconcile a second time.
+
+``turn_marker`` is the only idempotency-relevant value this module produces,
+and it carries no persistence-format promise of its own: it is a stable,
+opaque string. Deriving a storage key (length limits, character-set
+validation, or any other on-disk contract) is a web-layer concern that reads
+this string; this module does not know what that contract looks like.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CLARIFICATION_SOURCES = frozenset({"send_message", "ask_user_question", "tool_waiting"})
+
+# Marker composition constants. ``_MARKER_KEEP`` must stay character-for-
+# character identical to the whitelist in
+# ``src/xagent/web/api/trace_handlers.py``'s ``clean_string`` (see
+# ``_marker_clean`` below for the full cross-layer contract note).
+_MARKER_KEEP = "\n\r\t"
+_MARKER_SEP = "|"
+
+
+@dataclass(frozen=True)
+class ClarificationRequestItem:
+    """One tool's pending question inside a (possibly multi-tool) draft."""
+
+    tool_name: str
+    tool_call_id: str
+    interaction_id: str
+
+
+@dataclass(frozen=True)
+class ClarificationDraft:
+    """A typed view over a waiting turn, common to all clarification sources.
+
+    ``requests`` is always non-empty: the single-source waiting points
+    (``send_message`` / ``ask_user_question``) contribute exactly one item,
+    and the multi-tool waiting point contributes one item per waiting tool.
+
+    ``turn_marker`` is a stable string built from ``turn_message_count``,
+    ``origin_step_id``, and the ordered ``(tool_call_id, interaction_id)``
+    pairs from ``requests``. Four invariants hold for it:
+
+    1. It is stable across a re-entrant resume that carries no new user
+       message: recomputing it from the same restored request yields the
+       same string.
+    2. Two drafts that differ in ``origin_step_id`` -- the same turn resolved
+       against two different DAG steps -- never produce the same marker.
+    3. It survives the trace serializer's control-character cleanup
+       (``_marker_clean`` shares that filter's domain) without changing
+       value, and re-cleaning an already-clean marker is a no-op.
+    4. Component boundaries cannot be forged by content: every component is
+       written as ``<length-after-filtering>:<value>`` before being joined,
+       so no combination of field values can make two different request
+       lists collapse onto the same marker.
+    """
+
+    source: str
+    message: str
+    message_type: str
+    interactions: tuple[dict[str, Any], ...]
+    requests: tuple[ClarificationRequestItem, ...]
+    origin_step_id: str
+    origin_execution_id: str
+    turn_message_count: int
+    turn_marker: str
+
+    def with_origin_step(self, step_id: str) -> "ClarificationDraft":
+        """Return a copy attributed to ``step_id``, with the marker redone.
+
+        A plain field replace would leave ``turn_marker`` computed against
+        the old ``origin_step_id``, silently breaking invariant 2 above.
+        """
+
+        turn_marker = _compose_turn_marker(
+            turn_message_count=self.turn_message_count,
+            origin_step_id=step_id,
+            requests=self.requests,
+        )
+        return replace(self, origin_step_id=step_id, turn_marker=turn_marker)
+
+
+def _marker_clean(value: str) -> str:
+    """Filter ``value`` to the character domain a marker may contain.
+
+    This function must stay in the same domain as ``clean_string`` in
+    ``src/xagent/web/api/trace_handlers.py:_serialize_data_for_json`` --
+    that function is a closure the core layer cannot import, so this is a
+    forced duplicate rather than a convenience one. If someone changes the
+    domain of ``clean_string``, this function must change with it. The test
+    that watches for drift is
+    ``test_marker_survives_trace_serialization_of_a_dirty_interaction_id`` in
+    ``tests/core/agent/test_react_clarification_draft.py``, which calls the
+    real ``DatabaseTraceHandler._serialize_data_for_json`` rather than a copy
+    of it.
+    """
+
+    cleaned = value.replace("\x00", "")  # Remove NULL character
+    cleaned = cleaned.replace("\u0000", "")  # Remove Unicode NULL
+    return "".join(char for char in cleaned if ord(char) >= 32 or char in _MARKER_KEEP)
+
+
+def _field(value: object) -> str:
+    """Encode one marker component as ``<filtered length>:<filtered value>``.
+
+    The length prefix is what keeps component boundaries unambiguous: two
+    request lists whose raw values differ can still be told apart even when
+    a value happens to contain the ``|`` separator, because the separator
+    carries no parsing responsibility on its own.
+    """
+
+    cleaned = _marker_clean(str(value))
+    return f"{len(cleaned)}:{cleaned}"
+
+
+def _compose_turn_marker(
+    *,
+    turn_message_count: int,
+    origin_step_id: str,
+    requests: tuple[ClarificationRequestItem, ...],
+) -> str:
+    parts = [
+        _field(turn_message_count),
+        _field(origin_step_id),
+        _field(len(requests)),
+    ]
+    for item in requests:
+        parts.append(_field(item.tool_call_id))
+        parts.append(_field(item.interaction_id))
+    return _MARKER_SEP.join(parts)
+
+
+def draft_from_waiting_request(
+    request: dict[str, Any] | None,
+    *,
+    execution_id: str | None,
+    step_id: str | None,
+) -> ClarificationDraft | None:
+    """Build a :class:`ClarificationDraft` from a ``waiting_for_user_request``.
+
+    ``request`` is classified into exactly one of three sources by checking
+    facts already present on the dict, never by re-deriving them:
+
+    - ``request["kind"] == "tool_waiting_for_user"`` -> ``"tool_waiting"``,
+      one :class:`ClarificationRequestItem` per entry in ``request["requests"]``.
+    - otherwise ``request["message_type"] == "question"`` *and* ``request``
+      has an ``"interactions"`` key (key presence, not truthiness -- an
+      empty-form ``ask_user_question`` still has the key) -> ``"ask_user_question"``.
+    - otherwise -> ``"send_message"``.
+
+    Returns ``None`` in exactly one case: ``request`` carries neither a
+    non-empty message nor an ``"interactions"`` key nor a non-empty
+    ``"requests"`` list. That case has no reachable production caller today;
+    it exists so that resuming a checkpoint written by an older schema
+    degrades to "no draft" instead of raising and blocking resume.
+    """
+
+    if not isinstance(request, dict):
+        return None
+
+    message = str(request.get("message") or "")
+    has_interactions_key = "interactions" in request
+    raw_tool_requests = request.get("requests")
+    has_tool_requests = isinstance(raw_tool_requests, list) and bool(raw_tool_requests)
+
+    if not message and not has_interactions_key and not has_tool_requests:
+        logger.warning(
+            "draft_from_waiting_request: waiting request has neither a "
+            "message nor an interactions field; skipping clarification draft"
+        )
+        return None
+
+    origin_step_id = "" if step_id is None else str(step_id)
+    origin_execution_id = "" if execution_id is None else str(execution_id)
+    turn_message_count = int(request.get("message_count", 0) or 0)
+    interactions_raw = request.get("interactions")
+    interactions = tuple(interactions_raw) if isinstance(interactions_raw, list) else ()
+
+    if request.get("kind") == "tool_waiting_for_user":
+        source = "tool_waiting"
+        message_type = str(request.get("message_type") or "question")
+        items: list[ClarificationRequestItem] = []
+        if isinstance(raw_tool_requests, list):
+            for raw_item in raw_tool_requests:
+                if not isinstance(raw_item, dict):
+                    continue
+                tool_call_id = str(raw_item.get("tool_call_id") or "")
+                items.append(
+                    ClarificationRequestItem(
+                        tool_name=str(raw_item.get("tool_name") or ""),
+                        tool_call_id=tool_call_id,
+                        interaction_id=str(
+                            raw_item.get("interaction_id") or tool_call_id
+                        ),
+                    )
+                )
+        requests = tuple(items)
+    elif request.get("message_type") == "question" and has_interactions_key:
+        source = "ask_user_question"
+        tool_call_id = str(request.get("tool_call_id") or "")
+        requests = (
+            ClarificationRequestItem(
+                tool_name=str(request.get("tool_name") or ""),
+                tool_call_id=tool_call_id,
+                interaction_id=tool_call_id,
+            ),
+        )
+        message_type = "question"
+    else:
+        source = "send_message"
+        tool_call_id = str(request.get("tool_call_id") or "")
+        requests = (
+            ClarificationRequestItem(
+                tool_name=str(request.get("tool_name") or ""),
+                tool_call_id=tool_call_id,
+                interaction_id=tool_call_id,
+            ),
+        )
+        message_type = str(request.get("message_type") or "info")
+
+    turn_marker = _compose_turn_marker(
+        turn_message_count=turn_message_count,
+        origin_step_id=origin_step_id,
+        requests=requests,
+    )
+
+    return ClarificationDraft(
+        source=source,
+        message=message,
+        message_type=message_type,
+        interactions=interactions,
+        requests=requests,
+        origin_step_id=origin_step_id,
+        origin_execution_id=origin_execution_id,
+        turn_message_count=turn_message_count,
+        turn_marker=turn_marker,
+    )

--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -49,9 +49,12 @@ class ClarificationRequestItem:
 class ClarificationDraft:
     """A typed view over a waiting turn, common to all clarification sources.
 
-    ``requests`` is always non-empty: the single-source waiting points
-    (``send_message`` / ``ask_user_question``) contribute exactly one item,
-    and the multi-tool waiting point contributes one item per waiting tool.
+    ``requests`` carries one item per pending question: the single-source
+    waiting points (``send_message`` / ``ask_user_question``) contribute
+    exactly one item, and the multi-tool waiting point contributes one item
+    per waiting tool. A malformed or legacy waiting payload can yield an
+    empty tuple; construction still succeeds and the marker stays
+    deterministic.
 
     ``turn_marker`` is a stable string built from ``turn_message_count``,
     ``origin_step_id``, and the ordered ``(tool_call_id, interaction_id)``

--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -6,16 +6,22 @@ dataclass over already-in-memory data.
 
 A :class:`ClarificationDraft` is a derived value, not stored state. Its only
 source of truth is ``ReActPattern.waiting_for_user_request``, which already
-travels through ``get_state()`` / ``load_state()`` on its own. The draft
-itself does not join that round trip -- it is cheap to recompute from the
-restored request every time a waiting turn is produced, so there is nothing
-to persist or reconcile a second time.
+travels through ``get_state()`` / ``load_state()`` on its own -- the draft
+itself never enters that particular round trip (pinned by tests). It does
+still surface, restored as a plain dict rather than this dataclass, inside a
+different snapshot: the auto coordinator pattern copies its child's whole
+result dict verbatim into ``AutoPattern.last_result`` (see
+``pattern/auto/auto.py``), and a waiting ReAct child's result carries the
+draft under ``result["clarification_draft"]``.
 
 ``turn_marker`` is the only idempotency-relevant value this module produces,
 and it carries no persistence-format promise of its own: it is a stable,
-opaque string. Deriving a storage key (length limits, character-set
-validation, or any other on-disk contract) is a web-layer concern that reads
-this string; this module does not know what that contract looks like.
+opaque string. Its idempotency scope is a single ``(task_id, run_id)``
+partition -- two different tasks or runs may legitimately produce equal
+markers, since neither identifier is a marker component. Deriving a storage
+key (length limits, character-set validation, or any other on-disk
+contract) is a web-layer concern that reads this string; this module does
+not know what that contract looks like.
 """
 
 from __future__ import annotations
@@ -114,8 +120,11 @@ class ClarificationDraft:
         ``ClarificationDraft`` (under ``result["clarification_draft"]``) is
         serialized into trace events by handlers that use the ``to_dict``
         protocol -- ``DatabaseTraceHandler._serialize_data_for_json`` and its
-        WebSocket twin call ``value.to_dict()`` whenever it is callable, and
-        then recursively re-serialize whatever that call returns. So this
+        WebSocket twins, ``WebSocketTraceHandler._serialize_data`` in
+        ``ws_trace_handlers.py`` and ``SharedWebSocketTracer._serialize_data``
+        in ``websocket.py``, call ``value.to_dict()`` whenever it is
+        callable, and then recursively re-serialize whatever that call
+        returns. So this
         method cannot hand back nested dataclasses: ``interactions`` becomes
         a plain list (its entries are already plain dicts), and ``requests``
         becomes a list of plain dicts via ``ClarificationRequestItem.to_dict``.
@@ -146,18 +155,28 @@ class ClarificationDraft:
 def _marker_clean(value: str) -> str:
     """Filter ``value`` to the character domain a marker may contain.
 
-    This function must stay in the same domain as ``clean_string`` in
-    ``src/xagent/web/api/trace_handlers.py:_serialize_data_for_json`` --
-    that function is a closure the core layer cannot import, so this is a
-    forced duplicate rather than a convenience one. If someone changes the
-    domain of ``clean_string``, this function must change with it. The test
-    that watches for drift is
+    Four independent copies of this control-character filter exist in the
+    codebase, and all four must stay in the same domain: this function,
+    plus three web-layer closures that the core layer cannot import and so
+    cannot share code with -- ``src/xagent/web/api/trace_handlers.py``'s
+    ``DatabaseTraceHandler._serialize_data_for_json`` (``clean_string``),
+    ``src/xagent/web/api/ws_trace_handlers.py``'s
+    ``WebSocketTraceHandler._serialize_data`` (``clean_string``), and
+    ``src/xagent/web/api/websocket.py``'s
+    ``SharedWebSocketTracer._serialize_data`` (``clean_string``). If
+    someone changes the domain of any one of the four, the other three must
+    change with it. The test that watches for drift between this copy and
+    the database-handler copy is
     ``test_marker_survives_trace_serialization_of_a_dirty_interaction_id`` in
     ``tests/core/agent/test_react_clarification_draft.py``, which calls the
     real ``DatabaseTraceHandler._serialize_data_for_json`` rather than a copy
     of it.
     """
 
+    # Both replaces below target the same code point, NUL (U+0000); the
+    # second is a no-op after the first and is kept only to mirror
+    # clean_string's two-line form character-for-character, per the
+    # cross-layer contract above.
     cleaned = value.replace("\x00", "")  # Remove NULL character
     cleaned = cleaned.replace("\u0000", "")  # Remove Unicode NULL
     return "".join(char for char in cleaned if ord(char) >= 32 or char in _MARKER_KEEP)

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -398,7 +398,7 @@ class AgentExecutionAdapter:
                         else [],
                     },
                     # Surfaced as its own top-level key rather than left for
-                    # callers to dig out of ``agent_result`` below:
+                    # callers to dig out of ``agent_result`` above:
                     # ``agent_result`` is a diagnostic snapshot already read
                     # by ``agent_tool.py`` and ``websocket.py`` for that
                     # purpose, and a new typed contract should not be mixed

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -397,12 +397,13 @@ class AgentExecutionAdapter:
                         if isinstance(interactions, list)
                         else [],
                     },
-                    # Surfaced as its own top-level key rather than left for
-                    # callers to dig out of ``agent_result`` above:
-                    # ``agent_result`` is a diagnostic snapshot already read
-                    # by ``agent_tool.py`` and ``websocket.py`` for that
-                    # purpose, and a new typed contract should not be mixed
-                    # into a field with different consumers and semantics.
+                    # This top-level key is the supported contract for
+                    # readers of the clarification draft. ``agent_result``
+                    # above is a diagnostic snapshot of the raw pattern
+                    # result, already read by ``agent_tool.py`` and
+                    # ``websocket.py`` for other purposes -- it happens to
+                    # carry the same draft too, but callers should not dig
+                    # it out from there.
                     "clarification_draft": result.get("clarification_draft"),
                 }
             )

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -397,6 +397,13 @@ class AgentExecutionAdapter:
                         if isinstance(interactions, list)
                         else [],
                     },
+                    # Surfaced as its own top-level key rather than left for
+                    # callers to dig out of ``agent_result`` below:
+                    # ``agent_result`` is a diagnostic snapshot already read
+                    # by ``agent_tool.py`` and ``websocket.py`` for that
+                    # purpose, and a new typed contract should not be mixed
+                    # into a field with different consumers and semantics.
+                    "clarification_draft": result.get("clarification_draft"),
                 }
             )
         return normalized

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -47,6 +47,7 @@ from ....tools.user_interaction import (
     tool_result_waits_for_user,
     user_interaction_resume_callable,
 )
+from ...clarification import draft_from_waiting_request
 from ...context.enrichment import (
     enrich_context_with_memory,
     latest_user_text,
@@ -1162,6 +1163,11 @@ class ReActPattern(AgentPattern):
                 ),
                 "interactions": self.waiting_for_user_request.get("interactions"),
                 "context": context,
+                "clarification_draft": draft_from_waiting_request(
+                    self.waiting_for_user_request,
+                    execution_id=getattr(context, "execution_id", None),
+                    step_id=None,
+                ),
             }
 
         response = self._mark_latest_user_message_as_waiting_response(
@@ -1740,6 +1746,11 @@ class ReActPattern(AgentPattern):
                     "message": message,
                     "message_type": message_type,
                     "context": context,
+                    "clarification_draft": draft_from_waiting_request(
+                        self.waiting_for_user_request,
+                        execution_id=getattr(context, "execution_id", None),
+                        step_id=None,
+                    ),
                 }
             context.add_tool_result(
                 tool_name=name,
@@ -1802,6 +1813,11 @@ class ReActPattern(AgentPattern):
                 "message_type": "question",
                 "interactions": interactions,
                 "context": context,
+                "clarification_draft": draft_from_waiting_request(
+                    self.waiting_for_user_request,
+                    execution_id=getattr(context, "execution_id", None),
+                    step_id=None,
+                ),
             }
 
         return None
@@ -1986,6 +2002,11 @@ class ReActPattern(AgentPattern):
             "message_type": message_type,
             "interactions": interactions,
             "context": context,
+            "clarification_draft": draft_from_waiting_request(
+                self.waiting_for_user_request,
+                execution_id=getattr(context, "execution_id", None),
+                step_id=None,
+            ),
         }
         await runtime.checkpoint(
             "waiting_for_user",

--- a/tests/core/agent/test_clarification_draft.py
+++ b/tests/core/agent/test_clarification_draft.py
@@ -123,10 +123,19 @@ def test_send_message_draft_classifies_and_shapes_requests() -> None:
 
     assert draft is not None
     assert draft.source == "send_message"
-    assert draft.source in CLARIFICATION_SOURCES
+    # Pins the constant's actual value rather than restating the equality
+    # assert above: ``draft.source in CLARIFICATION_SOURCES`` would pass
+    # for any of the three literals and catches nothing on its own.
+    assert CLARIFICATION_SOURCES == {
+        "send_message",
+        "ask_user_question",
+        "tool_waiting",
+    }
     assert len(draft.requests) == 1
     assert draft.requests[0].tool_call_id == "call-send"
     assert draft.requests[0].interaction_id == "call-send"
+    assert draft.requests[0].tool_name == "send_message"
+    assert draft.origin_execution_id == "exec-1"
     assert draft.interactions == ()
     assert draft.message == "Choose A or B"
 
@@ -152,6 +161,8 @@ def test_ask_user_question_draft_classifies_and_matches_normalized_interactions(
     assert len(draft.requests) == 1
     assert draft.requests[0].tool_call_id == "call-ask"
     assert draft.requests[0].interaction_id == "call-ask"
+    assert draft.requests[0].tool_name == "ask_user_question"
+    assert draft.origin_execution_id == "exec-1"
     assert draft.interactions == tuple(normalized)
 
 
@@ -167,6 +178,8 @@ def test_tool_waiting_draft_classifies_and_shapes_requests() -> None:
     assert len(draft.requests) == 1
     assert draft.requests[0].tool_call_id == "wait-a"
     assert draft.requests[0].interaction_id == "interaction-a"
+    assert draft.requests[0].tool_name == "approval_gate"
+    assert draft.origin_execution_id == "exec-1"
 
 
 def test_empty_form_ask_user_question_still_classifies_as_ask_user_question() -> None:
@@ -320,3 +333,26 @@ def test_with_origin_step_recomputes_marker_for_different_steps() -> None:
     flattened_a = draft_a.with_origin_step("").turn_marker
     flattened_b = draft_b.with_origin_step("").turn_marker
     assert flattened_a == flattened_b == base.turn_marker
+
+
+def test_distinct_nonempty_tool_call_ids_produce_distinct_markers() -> None:
+    """Two waiting requests that differ only in ``tool_call_id`` produce
+    different markers, as long as both ids are non-empty -- the guarantee
+    ``ReActPattern._normalize_tool_calls`` enforces in production by
+    falling back to ``f"tool_call_{index}"`` for any missing or empty id.
+
+    An empty-``tool_call_id`` collision is reachable only from a corrupted
+    checkpoint: ``load_state`` restores ``waiting_for_user_request``
+    verbatim from whatever dict it is given, with no re-normalization, so a
+    hand-edited or pre-normalization legacy checkpoint could still carry an
+    empty id.
+    """
+
+    request_a = _send_message_request(tool_call_id="call-a")
+    request_b = _send_message_request(tool_call_id="call-b")
+
+    draft_a = draft_from_waiting_request(request_a, execution_id="exec-1", step_id=None)
+    draft_b = draft_from_waiting_request(request_b, execution_id="exec-1", step_id=None)
+
+    assert draft_a is not None and draft_b is not None
+    assert draft_a.turn_marker != draft_b.turn_marker

--- a/tests/core/agent/test_clarification_draft.py
+++ b/tests/core/agent/test_clarification_draft.py
@@ -313,8 +313,10 @@ def test_with_origin_step_recomputes_marker_for_different_steps() -> None:
     assert draft_b.origin_step_id == "step-b"
     assert draft_a.turn_marker != draft_b.turn_marker
 
-    # Flattening origin_step_id back out leaves the two markers equal --
-    # the only encoded difference between them is that one field.
-    flattened_a = draft_a.turn_marker.replace("6:step-a", "0:")
-    flattened_b = draft_b.turn_marker.replace("6:step-b", "0:")
-    assert flattened_a == flattened_b
+    # Flattening origin_step_id back out through the same with_origin_step()
+    # method (rather than string surgery on the encoded marker) leaves the
+    # two markers equal to each other and to the original unattributed
+    # draft -- origin_step_id was the only field that varied between them.
+    flattened_a = draft_a.with_origin_step("").turn_marker
+    flattened_b = draft_b.with_origin_step("").turn_marker
+    assert flattened_a == flattened_b == base.turn_marker

--- a/tests/core/agent/test_clarification_draft.py
+++ b/tests/core/agent/test_clarification_draft.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.agent import ExecutionContext, ReActPattern
+from xagent.core.agent.checkpoint import CHECKPOINT_TYPE, TraceCheckpointStore
+from xagent.core.agent.clarification import (
+    CLARIFICATION_SOURCES,
+    ClarificationDraft,
+    draft_from_waiting_request,
+)
+from xagent.core.agent.pattern.react.react import _normalize_ask_user_interactions
+from xagent.web.api.trace_handlers import DatabaseTraceHandler
+
+
+class FakeLLM:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class RecordingTraceBackend:
+    """Fake tracer that captures the real ``_event_payload`` output.
+
+    Mirrors ``PersistentTraceBackend`` in ``tests/core/agent/test_checkpoint.py``:
+    ``TraceCheckpointStore.checkpoint`` builds the event payload with its own
+    real ``_event_payload`` method, this fake only records what it is handed.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        data: dict[str, Any] | None = None,
+        require_persisted: bool = False,
+    ) -> str:
+        del event_type, require_persisted
+        self.events.append({"task_id": task_id, "data": dict(data or {})})
+        return f"event-{len(self.events)}"
+
+
+def _send_message_request(
+    *, message_count: int = 2, tool_call_id: str = "call-send"
+) -> dict[str, Any]:
+    return {
+        "tool_call_id": tool_call_id,
+        "tool_name": "send_message",
+        "message": "Choose A or B",
+        "message_type": "question",
+        "task_text": None,
+        "message_count": message_count,
+    }
+
+
+def _ask_user_question_request(
+    *,
+    message: str = "Pick one",
+    interactions: list[dict[str, Any]] | None = None,
+    message_count: int = 3,
+    tool_call_id: str = "call-ask",
+) -> dict[str, Any]:
+    normalized = _normalize_ask_user_interactions(
+        interactions
+        if interactions is not None
+        else [{"type": "select_one", "field": "choice", "label": "Choice"}]
+    )
+    return {
+        "tool_call_id": tool_call_id,
+        "tool_name": "ask_user_question",
+        "message": message,
+        "message_type": "question",
+        "interactions": normalized,
+        "task_text": None,
+        "message_count": message_count,
+    }
+
+
+def _tool_waiting_request(
+    *,
+    requests: list[dict[str, Any]] | None = None,
+    message_count: int = 5,
+) -> dict[str, Any]:
+    default_requests = [
+        {
+            "tool_call_id": "wait-a",
+            "tool_name": "approval_gate",
+            "interaction_id": "interaction-a",
+            "message": "Continue?",
+            "message_type": "confirmation",
+            "interactions": _normalize_ask_user_interactions(
+                [{"type": "select_one", "field": "decision", "label": "Decision"}]
+            ),
+        }
+    ]
+    resolved_requests = requests if requests is not None else default_requests
+    return {
+        "kind": "tool_waiting_for_user",
+        "requests": resolved_requests,
+        "message": resolved_requests[0]["message"] if resolved_requests else "",
+        "message_type": "confirmation",
+        "interactions": [],
+        "task_text": None,
+        "message_count": message_count,
+    }
+
+
+def test_send_message_draft_classifies_and_shapes_requests() -> None:
+    """A send_message waiting request classifies as source send_message with one request item."""
+
+    request = _send_message_request()
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is not None
+    assert draft.source == "send_message"
+    assert draft.source in CLARIFICATION_SOURCES
+    assert len(draft.requests) == 1
+    assert draft.requests[0].tool_call_id == "call-send"
+    assert draft.requests[0].interaction_id == "call-send"
+    assert draft.interactions == ()
+    assert draft.message == "Choose A or B"
+
+
+def test_ask_user_question_draft_classifies_and_matches_normalized_interactions() -> (
+    None
+):
+    """An ask_user_question waiting request classifies as ask_user_question, and its
+    interactions equal the real normalizer's output for the same raw input.
+    """
+
+    raw_interactions = [
+        {"type": "select_one", "field": "choice", "label": "Choice"},
+        {"type": "text_input", "field": "note", "label": "Note"},
+    ]
+    normalized = _normalize_ask_user_interactions(raw_interactions)
+    request = _ask_user_question_request(interactions=raw_interactions)
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is not None
+    assert draft.source == "ask_user_question"
+    assert len(draft.requests) == 1
+    assert draft.requests[0].tool_call_id == "call-ask"
+    assert draft.requests[0].interaction_id == "call-ask"
+    assert draft.interactions == tuple(normalized)
+
+
+def test_tool_waiting_draft_classifies_and_shapes_requests() -> None:
+    """A tool_waiting request classifies as source tool_waiting with one request item."""
+
+    request = _tool_waiting_request()
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is not None
+    assert draft.source == "tool_waiting"
+    assert len(draft.requests) == 1
+    assert draft.requests[0].tool_call_id == "wait-a"
+    assert draft.requests[0].interaction_id == "interaction-a"
+
+
+def test_empty_form_ask_user_question_still_classifies_as_ask_user_question() -> None:
+    """An empty-form ask_user_question is still ``ask_user_question``, not send_message.
+
+    The classifier reads key presence (``"interactions" in request``), not
+    truthiness -- an empty ``interactions`` list must not fall through to the
+    ``send_message`` branch.
+    """
+
+    request = _ask_user_question_request(message="", interactions=[])
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is not None
+    assert draft.source == "ask_user_question"
+    assert draft.interactions == ()
+
+
+def test_tool_waiting_multi_tool_requests_and_interaction_id_fallback() -> None:
+    """Multiple waiting tools produce multiple requests; a missing
+    ``interaction_id`` falls back to ``tool_call_id``, mirroring react.py's
+    own fallback rule at the ``_pause_for_tool_results`` request-building site.
+    """
+
+    request = _tool_waiting_request(
+        requests=[
+            {
+                "tool_call_id": "wait-a",
+                "tool_name": "approval_gate",
+                "interaction_id": "interaction-a",
+                "message": "Continue A?",
+                "message_type": "confirmation",
+                "interactions": [],
+            },
+            {
+                "tool_call_id": "wait-b",
+                "tool_name": "second_gate",
+                "interaction_id": "",
+                "message": "Continue B?",
+                "message_type": "confirmation",
+                "interactions": [],
+            },
+        ]
+    )
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is not None
+    assert len(draft.requests) == 2
+    assert draft.requests[0].interaction_id == "interaction-a"
+    assert draft.requests[1].tool_call_id == "wait-b"
+    assert draft.requests[1].interaction_id == "wait-b"
+
+
+def test_missing_message_and_interactions_returns_none_without_raising() -> None:
+    """An old-schema waiting request with neither field degrades to no draft."""
+
+    request = {
+        "tool_call_id": "call-legacy",
+        "task_text": None,
+        "message_count": 0,
+    }
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is None
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_snapshot_survives_real_trace_serializer() -> None:
+    """A real checkpoint snapshot -- built from a real waiting run's
+    real ``pattern.get_state()`` -- round-trips through the real
+    ``DatabaseTraceHandler._serialize_data_for_json`` (not a copy of it).
+    """
+
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-checkpoint")
+    context.add_user_message("Ask")
+    llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-ask",
+                        "function": {
+                            "name": "ask_user_question",
+                            "arguments": (
+                                '{"message":"Pick one","interactions":'
+                                '[{"type":"select_one","field":"choice","label":"Choice"}]}'
+                            ),
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+
+    result = await pattern.run(context=context, tools=[], llm=llm)
+    assert result["status"] == "waiting_for_user"
+    waiting_request_before = dict(pattern.waiting_for_user_request or {})
+
+    backend = RecordingTraceBackend()
+    store = TraceCheckpointStore(backend)
+    await store.checkpoint(
+        type="checkpoint",
+        label="waiting_for_user",
+        execution_id="exec-checkpoint",
+        pattern="ReActPattern",
+        pattern_state=pattern.get_state(),
+        status="waiting_for_user",
+    )
+    event_payload = backend.events[0]["data"]
+
+    handler = DatabaseTraceHandler(1)
+    out = handler._serialize_data_for_json(event_payload)
+
+    assert out["checkpoint_type"] == CHECKPOINT_TYPE
+    assert (
+        out["snapshot"]["pattern_state"]["waiting_for_user_request"]
+        == waiting_request_before
+    )
+    assert "_serialization_error" not in out
+
+
+def test_with_origin_step_recomputes_marker_for_different_steps() -> None:
+    """``with_origin_step`` is a frozen copy that also redoes the marker.
+
+    Guards the invariant that a plain ``dataclasses.replace`` (origin_step_id
+    only) would silently violate: two different steps resolving the same
+    turn must not collapse onto the same marker.
+    """
+
+    base = draft_from_waiting_request(
+        _send_message_request(), execution_id="exec-1", step_id=None
+    )
+    assert base is not None
+
+    draft_a = base.with_origin_step("step-a")
+    draft_b = base.with_origin_step("step-b")
+
+    assert isinstance(draft_a, ClarificationDraft)
+    assert draft_a.origin_step_id == "step-a"
+    assert draft_b.origin_step_id == "step-b"
+    assert draft_a.turn_marker != draft_b.turn_marker
+
+    # Flattening origin_step_id back out leaves the two markers equal --
+    # the only encoded difference between them is that one field.
+    flattened_a = draft_a.turn_marker.replace("6:step-a", "0:")
+    flattened_b = draft_b.turn_marker.replace("6:step-b", "0:")
+    assert flattened_a == flattened_b

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -427,6 +427,68 @@ async def test_execution_adapter_preserves_waiting_for_user_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execution_adapter_surfaces_clarification_draft_at_top_level() -> None:
+    llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-ask",
+                        "function": {
+                            "name": "ask_user_question",
+                            "arguments": (
+                                '{"message":"Pick one","interactions":'
+                                '[{"type":"select_one","field":"choice","label":"Choice"}]}'
+                            ),
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="react",
+            pattern="react",
+            llm=llm,
+            tools=[],
+            service_id="react-service",
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    result = await adapter.execute(task="Ask something", task_id="react-exec")
+
+    assert result["status"] == "waiting_for_user"
+    assert result["clarification_draft"] is not None
+    assert (
+        result["clarification_draft"] is result["agent_result"]["clarification_draft"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_execution_adapter_omits_clarification_draft_key_when_not_waiting() -> (
+    None
+):
+    llm = FakeLLM(["done"])
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="lifecycle",
+            pattern="react",
+            llm=llm,
+            tools=[],
+            service_id="lifecycle-service",
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    result = await adapter.execute(task="Say done", task_id="lifecycle-exec")
+
+    assert result["status"] != "waiting_for_user"
+    assert "clarification_draft" not in result
+
+
+@pytest.mark.asyncio
 async def test_execution_adapter_includes_persisted_conversation_history() -> None:
     llm = FakeLLM(["generated"])
     adapter = AgentExecutionAdapter(

--- a/tests/core/agent/test_react_clarification_draft.py
+++ b/tests/core/agent/test_react_clarification_draft.py
@@ -229,3 +229,147 @@ async def test_reentry_without_new_message_returns_stable_draft_and_sends_nothin
     assert resumed_llm.calls == []
     assert len(resumed_runtime.outbound_messages) == 0
     assert resumed["clarification_draft"] == first["clarification_draft"]
+
+
+@pytest.mark.asyncio
+async def test_marker_survives_trace_serialization_of_a_dirty_interaction_id() -> None:
+    """A marker computed before a control-character injection matches
+    the marker recomputed after the injected request round-trips through the
+    real trace serializer and a JSON encode/decode cycle -- ``_marker_clean``
+    and ``clean_string`` share a domain, so persistence cannot desync them.
+    """
+
+    import json
+
+    from xagent.core.agent.checkpoint import TraceCheckpointStore
+    from xagent.web.api.trace_handlers import DatabaseTraceHandler
+
+    class RecordingTraceBackend:
+        def __init__(self) -> None:
+            self.events: list[dict[str, Any]] = []
+
+        async def trace_event(
+            self,
+            event_type: Any,
+            *,
+            task_id: str | None = None,
+            data: dict[str, Any] | None = None,
+            require_persisted: bool = False,
+        ) -> str:
+            del event_type, require_persisted
+            self.events.append({"task_id": task_id, "data": dict(data or {})})
+            return f"event-{len(self.events)}"
+
+    tool = ResumableTool()
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-tp4")
+    context.add_user_message("Run the gated action.")
+    llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "wait-call",
+                        "function": {
+                            "name": "approval_gate",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+    assert result["status"] == "waiting_for_user"
+
+    assert pattern.waiting_for_user_request is not None
+    pattern.waiting_for_user_request["requests"][0]["interaction_id"] += "\x01"
+
+    marker_before = draft_from_waiting_request(
+        pattern.waiting_for_user_request,
+        execution_id=context.execution_id,
+        step_id=None,
+    ).turn_marker
+
+    backend = RecordingTraceBackend()
+    store = TraceCheckpointStore(backend)
+    await store.checkpoint(
+        type="checkpoint",
+        label="waiting_for_user",
+        execution_id="exec-tp4",
+        pattern="ReActPattern",
+        pattern_state=pattern.get_state(),
+        status="waiting_for_user",
+    )
+    event_payload = backend.events[0]["data"]
+    handler = DatabaseTraceHandler(1)
+    serialized = handler._serialize_data_for_json(event_payload)
+    assert "_serialization_error" not in serialized
+
+    restored_event_payload = json.loads(json.dumps(serialized))
+    restored_state = restored_event_payload["snapshot"]["pattern_state"]
+
+    resumed_pattern = ReActPattern(max_iterations=2)
+    resumed_pattern.load_state(restored_state)
+
+    marker_after = draft_from_waiting_request(
+        resumed_pattern.waiting_for_user_request,
+        execution_id="exec-tp4",
+        step_id=None,
+    ).turn_marker
+
+    assert marker_after == marker_before
+
+
+def test_marker_distinguishes_requests_with_ambiguous_raw_concatenation() -> None:
+    """Two request sets whose raw values would collide under naive
+    ``"|"``-joining (a ``tool_call_id`` containing ``|`` vs. an
+    ``interaction_id`` containing ``|``) still produce distinct markers,
+    because every component carries its own length prefix.
+    """
+
+    request_a = {
+        "kind": "tool_waiting_for_user",
+        "requests": [
+            {
+                "tool_call_id": "a|b",
+                "tool_name": "t",
+                "interaction_id": "c\nd",
+                "message": "m",
+                "message_type": "question",
+                "interactions": [],
+            }
+        ],
+        "message": "m",
+        "message_type": "question",
+        "interactions": [],
+        "task_text": None,
+        "message_count": 1,
+    }
+    request_b = {
+        "kind": "tool_waiting_for_user",
+        "requests": [
+            {
+                "tool_call_id": "a",
+                "tool_name": "t",
+                "interaction_id": "b|c\nd",
+                "message": "m",
+                "message_type": "question",
+                "interactions": [],
+            }
+        ],
+        "message": "m",
+        "message_type": "question",
+        "interactions": [],
+        "task_text": None,
+        "message_count": 1,
+    }
+
+    draft_a = draft_from_waiting_request(request_a, execution_id="e", step_id=None)
+    draft_b = draft_from_waiting_request(request_b, execution_id="e", step_id=None)
+
+    assert draft_a is not None and draft_b is not None
+    # Naive "|"-joining without a length prefix would collapse both raw
+    # concatenations to "a|b|c\nd" -- the markers must still differ.
+    assert draft_a.turn_marker != draft_b.turn_marker

--- a/tests/core/agent/test_react_clarification_draft.py
+++ b/tests/core/agent/test_react_clarification_draft.py
@@ -7,7 +7,13 @@ import pytest
 from pydantic import BaseModel
 
 from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
-from xagent.core.agent.clarification import draft_from_waiting_request
+from xagent.core.agent.clarification import (
+    ClarificationDraft,
+    draft_from_waiting_request,
+)
+from xagent.core.agent.trace import TraceAction
+from xagent.web.api.trace_handlers import DatabaseTraceHandler
+from xagent.web.api.ws_trace_handlers import WebSocketTraceHandler
 
 
 class CalculatorArgs(BaseModel):
@@ -174,6 +180,47 @@ async def test_waiting_return_via_tool_carries_tool_waiting_draft() -> None:
     )
     assert result["clarification_draft"] == expected
     assert result["clarification_draft"].source == "tool_waiting"
+
+
+@pytest.mark.asyncio
+async def test_empty_message_send_message_reaches_waiting_with_no_draft() -> None:
+    """A ``send_message`` call with an empty ``message`` and
+    ``expect_response=True`` is schema-valid (the tool only requires the
+    ``message`` key to be present, not non-empty) and reaches
+    ``waiting_for_user`` with no derivable draft.
+
+    This is the reachable production case documented on
+    ``draft_from_waiting_request``: the waiting request carries no message,
+    no ``"interactions"`` key, and no ``"requests"`` list, so
+    ``clarification_draft`` is ``None`` rather than a typed draft.
+    """
+
+    llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-send-empty",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": (
+                                '{"message":"","message_type":"question",'
+                                '"expect_response":true}'
+                            ),
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-empty-message")
+    context.add_user_message("Ask")
+
+    result = await pattern.run(context=context, tools=[], llm=llm)
+
+    assert result["status"] == "waiting_for_user"
+    assert result["clarification_draft"] is None
 
 
 @pytest.mark.asyncio
@@ -373,3 +420,148 @@ def test_marker_distinguishes_requests_with_ambiguous_raw_concatenation() -> Non
     # Naive "|"-joining without a length prefix would collapse both raw
     # concatenations to "a|b|c\nd" -- the markers must still differ.
     assert draft_a.turn_marker != draft_b.turn_marker
+
+
+class RecordingTracer:
+    """Fake tracer that records every ``trace_event`` call verbatim.
+
+    Unlike ``RecordingTraceBackend`` in ``test_clarification_draft.py``
+    (which sits behind ``TraceCheckpointStore`` and only ever sees
+    checkpoint-shaped payloads), this attaches directly to
+    ``PatternRuntime`` so it also captures the pattern-start/pattern-end
+    trace events that ``ReActPattern.run`` emits on its own -- including
+    the ``on_pattern_end`` event, whose ``data["result"]`` is the same
+    result dict ``pattern.run`` returns, with the live
+    ``ClarificationDraft`` still attached.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        step_id: str | None = None,
+        data: dict[str, Any] | None = None,
+        require_persisted: bool = False,
+    ) -> str:
+        del require_persisted
+        self.events.append(
+            {
+                "event_type": event_type,
+                "task_id": task_id,
+                "step_id": step_id,
+                "data": dict(data or {}),
+            }
+        )
+        return f"event-{len(self.events)}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_factory", "serialize_method"),
+    [
+        (lambda: DatabaseTraceHandler(1), "_serialize_data_for_json"),
+        (lambda: WebSocketTraceHandler(1), "_serialize_data"),
+    ],
+    ids=["database_trace_handler", "websocket_trace_handler"],
+)
+async def test_pattern_end_trace_payload_with_draft_survives_real_serializer(
+    handler_factory: Any, serialize_method: str
+) -> None:
+    """The actual trace-event payload built by ``PatternRuntime.on_pattern_end``
+    (``{"pattern": ..., "result": result, "status": ...}``, see
+    ``runtime.py``'s ``on_pattern_end`` / ``_emit_pattern_trace``) round-trips
+    through the real database and WebSocket trace-handler serializers without
+    falling back to the ``_serialization_error`` stub, and ``result``/
+    ``status`` survive the round trip with their content intact.
+
+    The companion cell
+    ``test_pattern_end_trace_payload_without_to_dict_collapses_to_stub``
+    guards the failure direction: it removes ``ClarificationDraft.to_dict``
+    and asserts the payload collapses to the ``_serialization_error`` stub.
+    """
+
+    tracer = RecordingTracer()
+    runtime = PatternRuntime(execution_id="exec-trace-payload", tracer=tracer)
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-trace-payload")
+    context.add_user_message("Ask")
+
+    result = await pattern.run(
+        context=context, tools=[], llm=_send_message_llm(), runtime=runtime
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert result["clarification_draft"] is not None
+
+    end_events = [
+        event
+        for event in tracer.events
+        if event["event_type"].action == TraceAction.END and "result" in event["data"]
+    ]
+    assert len(end_events) == 1
+    payload = end_events[0]["data"]
+    assert payload["result"] is result
+
+    handler = handler_factory()
+    serialized = getattr(handler, serialize_method)(payload)
+
+    assert "_serialization_error" not in serialized
+    assert serialized["status"] == "waiting_for_user"
+    assert serialized["result"]["status"] == "waiting_for_user"
+    assert serialized["result"]["clarification_draft"]["source"] == "send_message"
+    assert serialized["result"]["clarification_draft"]["message"] == "Choose A or B"
+    requests = serialized["result"]["clarification_draft"]["requests"]
+    assert isinstance(requests, list)
+    assert requests and all(isinstance(item, dict) for item in requests)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_factory", "serialize_method"),
+    [
+        (lambda: DatabaseTraceHandler(1), "_serialize_data_for_json"),
+        (lambda: WebSocketTraceHandler(1), "_serialize_data"),
+    ],
+    ids=["database_trace_handler", "websocket_trace_handler"],
+)
+async def test_pattern_end_trace_payload_without_to_dict_collapses_to_stub(
+    handler_factory: Any, serialize_method: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Removing ``ClarificationDraft.to_dict`` collapses the whole trace
+    payload to the ``_serialization_error`` stub.
+
+    This is the failure-direction guard for the survival cell above: the
+    serializers have no branch for a bare dataclass, so without ``to_dict``
+    the draft reaches ``json.dumps`` unconverted, the dump raises, and the
+    handler replaces the ENTIRE event payload with the three-key stub.
+    """
+
+    tracer = RecordingTracer()
+    runtime = PatternRuntime(execution_id="exec-trace-stub", tracer=tracer)
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-trace-stub")
+    context.add_user_message("Ask")
+
+    result = await pattern.run(
+        context=context, tools=[], llm=_send_message_llm(), runtime=runtime
+    )
+    assert result["status"] == "waiting_for_user"
+
+    end_events = [
+        event
+        for event in tracer.events
+        if event["event_type"].action == TraceAction.END and "result" in event["data"]
+    ]
+    payload = end_events[0]["data"]
+
+    monkeypatch.delattr(ClarificationDraft, "to_dict", raising=True)
+
+    handler = handler_factory()
+    serialized = getattr(handler, serialize_method)(payload)
+
+    assert "_serialization_error" in serialized
+    assert "result" not in serialized

--- a/tests/core/agent/test_react_clarification_draft.py
+++ b/tests/core/agent/test_react_clarification_draft.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
+from xagent.core.agent.clarification import draft_from_waiting_request
+
+
+class CalculatorArgs(BaseModel):
+    expression: str
+
+
+class FakeLLM:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class ResumableTool:
+    """A tool with its own suspended interaction state, resolved by a follow-up reply."""
+
+    def __init__(self) -> None:
+        self.metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Run an action after the user responds.",
+        )
+        self.user_response: str | None = None
+
+    def args_type(self) -> type[BaseModel]:
+        return CalculatorArgs
+
+    def resume_user_interaction(self, *, interaction_id: str, response: str) -> None:
+        self.user_response = response
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        if self.user_response is None:
+            return {
+                "success": False,
+                "status": "waiting_for_user",
+                "interaction_id": "interaction-1",
+                "message": "Should the action continue?",
+                "message_type": "confirmation",
+                "interactions": [
+                    {
+                        "type": "select_one",
+                        "field": "decision",
+                        "label": "Decision",
+                        "options": [
+                            {"label": "Continue", "value": "continue"},
+                            {"label": "Stop", "value": "stop"},
+                        ],
+                    }
+                ],
+            }
+        return {"success": True, "expression": args["expression"]}
+
+
+def _send_message_llm() -> FakeLLM:
+    return FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-send",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": (
+                                '{"message":"Choose A or B",'
+                                '"message_type":"question","expect_response":true}'
+                            ),
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+
+
+def _ask_user_question_llm() -> FakeLLM:
+    return FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-ask",
+                        "function": {
+                            "name": "ask_user_question",
+                            "arguments": (
+                                '{"message":"Pick one","interactions":'
+                                '[{"type":"select_one","field":"choice","label":"Choice"}]}'
+                            ),
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("llm_factory", "tools_factory", "expected_source"),
+    [
+        (_send_message_llm, lambda: [], "send_message"),
+        (_ask_user_question_llm, lambda: [], "ask_user_question"),
+    ],
+)
+async def test_waiting_return_carries_draft_matching_recomputed_value(
+    llm_factory: Any, tools_factory: Any, expected_source: str
+) -> None:
+    """The returned ``clarification_draft`` equals the draft recomputed
+    from the same ``waiting_for_user_request`` right after the run.
+    """
+
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-tp1")
+    context.add_user_message("Ask")
+
+    result = await pattern.run(
+        context=context, tools=tools_factory(), llm=llm_factory()
+    )
+
+    assert result["status"] == "waiting_for_user"
+    expected = draft_from_waiting_request(
+        pattern.waiting_for_user_request,
+        execution_id=context.execution_id,
+        step_id=None,
+    )
+    assert result["clarification_draft"] == expected
+    assert result["clarification_draft"].source == expected_source
+
+
+@pytest.mark.asyncio
+async def test_waiting_return_via_tool_carries_tool_waiting_draft() -> None:
+    """The multi-tool waiting point also carries
+    a draft equal to the one recomputed from the same request.
+    """
+
+    tool = ResumableTool()
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-tp1-tool")
+    context.add_user_message("Run the gated action.")
+    llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "wait-call",
+                        "function": {
+                            "name": "approval_gate",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm)
+
+    assert result["status"] == "waiting_for_user"
+    expected = draft_from_waiting_request(
+        pattern.waiting_for_user_request,
+        execution_id=context.execution_id,
+        step_id=None,
+    )
+    assert result["clarification_draft"] == expected
+    assert result["clarification_draft"].source == "tool_waiting"
+
+
+@pytest.mark.asyncio
+async def test_completed_run_after_resume_carries_no_draft() -> None:
+    """Once ``waiting_for_user_request`` is cleared by
+    a real user reply, the returned result no longer carries a draft.
+    """
+
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-tp1-clear")
+    context.add_user_message("Ask")
+
+    first = await pattern.run(context=context, tools=[], llm=_send_message_llm())
+    assert first["status"] == "waiting_for_user"
+
+    context.add_user_message("B")
+    resumed_pattern = ReActPattern(max_iterations=2)
+    resumed_pattern.load_state(pattern.get_state())
+    resumed_llm = FakeLLM([{"content": "Continuing with B."}])
+
+    resumed = await resumed_pattern.run(context=context, tools=[], llm=resumed_llm)
+
+    assert resumed["success"] is True
+    assert resumed_pattern.waiting_for_user_request is None
+    assert "clarification_draft" not in resumed
+
+
+@pytest.mark.asyncio
+async def test_reentry_without_new_message_returns_stable_draft_and_sends_nothing() -> (
+    None
+):
+    """Re-entering with no new user message stays waiting, carries the
+    same draft as the first run, and sends zero new outbound messages.
+    """
+
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(execution_id="exec-tp3")
+    context.add_user_message("Ask")
+
+    first = await pattern.run(context=context, tools=[], llm=_send_message_llm())
+    assert first["status"] == "waiting_for_user"
+
+    resumed_pattern = ReActPattern(max_iterations=2)
+    resumed_pattern.load_state(pattern.get_state())
+    resumed_runtime = PatternRuntime()
+    resumed_llm = FakeLLM([{"content": "Should not run"}])
+
+    resumed = await resumed_pattern.run(
+        context=context, tools=[], llm=resumed_llm, runtime=resumed_runtime
+    )
+
+    assert resumed["status"] == "waiting_for_user"
+    assert resumed_llm.calls == []
+    assert len(resumed_runtime.outbound_messages) == 0
+    assert resumed["clarification_draft"] == first["clarification_draft"]

--- a/tests/core/agent/test_react_clarification_draft.py
+++ b/tests/core/agent/test_react_clarification_draft.py
@@ -13,6 +13,7 @@ from xagent.core.agent.clarification import (
 )
 from xagent.core.agent.trace import TraceAction
 from xagent.web.api.trace_handlers import DatabaseTraceHandler
+from xagent.web.api.websocket import SharedWebSocketTracer
 from xagent.web.api.ws_trace_handlers import WebSocketTraceHandler
 
 
@@ -284,11 +285,25 @@ async def test_marker_survives_trace_serialization_of_a_dirty_interaction_id() -
     the marker recomputed after the injected request round-trips through the
     real trace serializer and a JSON encode/decode cycle -- ``_marker_clean``
     and ``clean_string`` share a domain, so persistence cannot desync them.
+
+    The injected id carries both a byte the domain rejects (``\\x01``) and
+    one it keeps (``\\t``), so the before/after comparison actually depends
+    on the two filters agreeing on ``\\t``. That comparison alone only
+    catches a *web*-side narrowing, though: both markers finish with a call
+    to this module's own ``_marker_clean``, so a *core*-side narrowing of
+    ``_MARKER_KEEP`` would apply identically on both sides of the comparison
+    and never show up as a mismatch. The direct equality assertion below
+    closes that gap by pinning ``_MARKER_KEEP`` against the literal
+    keep-set read out of ``clean_string``'s real source.
     """
 
+    import ast
+    import inspect
     import json
+    import re
 
     from xagent.core.agent.checkpoint import TraceCheckpointStore
+    from xagent.core.agent.clarification import _MARKER_KEEP
     from xagent.web.api.trace_handlers import DatabaseTraceHandler
 
     class RecordingTraceBackend:
@@ -331,7 +346,9 @@ async def test_marker_survives_trace_serialization_of_a_dirty_interaction_id() -
     assert result["status"] == "waiting_for_user"
 
     assert pattern.waiting_for_user_request is not None
-    pattern.waiting_for_user_request["requests"][0]["interaction_id"] += "\x01"
+    pattern.waiting_for_user_request["requests"][0]["interaction_id"] = (
+        "wait\tcall\x01x"
+    )
 
     marker_before = draft_from_waiting_request(
         pattern.waiting_for_user_request,
@@ -367,6 +384,18 @@ async def test_marker_survives_trace_serialization_of_a_dirty_interaction_id() -
     ).turn_marker
 
     assert marker_after == marker_before
+
+    # Direct pin, independent of the before/after comparison above: read
+    # ``clean_string``'s keep-set literal out of the real
+    # ``DatabaseTraceHandler._serialize_data_for_json`` source and assert it
+    # matches ``_MARKER_KEEP`` character-for-character. A core-side edit
+    # that narrows or widens ``_MARKER_KEEP`` shows up here even though it
+    # cannot show up in the before/after comparison.
+    web_source = inspect.getsource(DatabaseTraceHandler._serialize_data_for_json)
+    keep_set_match = re.search(r'char in ("(?:[^"\\]|\\.)*")', web_source)
+    assert keep_set_match is not None, "clean_string keep-set literal not found"
+    web_keep_set = ast.literal_eval(keep_set_match.group(1))
+    assert _MARKER_KEEP == web_keep_set
 
 
 def test_marker_distinguishes_requests_with_ambiguous_raw_concatenation() -> None:
@@ -465,8 +494,13 @@ class RecordingTracer:
     [
         (lambda: DatabaseTraceHandler(1), "_serialize_data_for_json"),
         (lambda: WebSocketTraceHandler(1), "_serialize_data"),
+        (lambda: SharedWebSocketTracer(ws=None, task_id=1), "_serialize_data"),
     ],
-    ids=["database_trace_handler", "websocket_trace_handler"],
+    ids=[
+        "database_trace_handler",
+        "websocket_trace_handler",
+        "shared_websocket_tracer",
+    ],
 )
 async def test_pattern_end_trace_payload_with_draft_survives_real_serializer(
     handler_factory: Any, serialize_method: str
@@ -525,8 +559,13 @@ async def test_pattern_end_trace_payload_with_draft_survives_real_serializer(
     [
         (lambda: DatabaseTraceHandler(1), "_serialize_data_for_json"),
         (lambda: WebSocketTraceHandler(1), "_serialize_data"),
+        (lambda: SharedWebSocketTracer(ws=None, task_id=1), "_serialize_data"),
     ],
-    ids=["database_trace_handler", "websocket_trace_handler"],
+    ids=[
+        "database_trace_handler",
+        "websocket_trace_handler",
+        "shared_websocket_tracer",
+    ],
 )
 async def test_pattern_end_trace_payload_without_to_dict_collapses_to_stub(
     handler_factory: Any, serialize_method: str, monkeypatch: pytest.MonkeyPatch

--- a/tests/web/services/test_task_interaction_schema.py
+++ b/tests/web/services/test_task_interaction_schema.py
@@ -1215,6 +1215,13 @@ _SCAN_ROOT = _REPO_ROOT / "src" / "xagent"
 _UNRELATED_SOURCE_LITERALS = {
     ("skills/personal_db.py", "personal"),  # SkillRecord.source
     ("services/tool_credentials.py", "db"),  # local var: credential origin
+    # ClarificationDraft.source: which waiting mechanism produced the draft
+    # (send_message / ask_user_question / tool_waiting), not a Task ingress
+    # channel -- these values never reach the tasks.source column or the
+    # origin CHECK.
+    ("core/agent/clarification.py", "send_message"),
+    ("core/agent/clarification.py", "ask_user_question"),
+    ("core/agent/clarification.py", "tool_waiting"),
 }
 
 


### PR DESCRIPTION
## Summary

Adds a typed clarification draft to the core agent layer: the three
existing waiting-for-user sources (`send_message` with `expect_response`,
`ask_user_question`, and a tool's own `waiting_for_user` result) now each
attach a draft built by a single shared construction path,
`draft_from_waiting_request`. The existing waiting-return dictionaries are
untouched; the draft is a purely additive key, so downstream consumers that
want a typed view of the pending question no longer need to derive one from
the raw fields.

The draft is deliberately not part of checkpoint state. Its only source of
truth is `waiting_for_user_request`, which already round-trips through
`get_state()` / `load_state()`; the draft itself is cheap to recompute from
that restored request on every waiting turn, so there is nothing to persist
or reconcile a second time. A re-entrant resume that has not seen a new user
message returns the identical draft.

The draft carries `turn_marker`, a stable string derived from the turn's
message count, step attribution, and the ordered set of pending tool/
interaction ids. Its character domain has to match the trace event
serializer's own control-character cleanup, or a value that survives one
step and gets filtered by the other would silently produce two different
markers for what is logically the same turn. The test that guards this
overlap calls the real serializer directly rather than a copy of it.

## What's included

- `src/xagent/core/agent/clarification.py`: `ClarificationDraft`,
  `ClarificationRequestItem`, and `draft_from_waiting_request`, pure
  functions and frozen dataclasses with no web or database dependency.
- One added key at each of `ReActPattern`'s four waiting-return sites,
  attaching a `clarification_draft` built from that site's own
  `waiting_for_user_request`.
- One additional key surfaced in the execution adapter's normalized result,
  alongside the existing waiting-for-user fields, read from the same result
  dict that `agent_result` already carries.
- A `to_dict()` view on the draft, because the execution result is
  serialized into trace events: without it the serializer replaced the
  whole event payload with an error stub. One honest consequence: the
  waiting turn's trace event now stores a serialized copy of the draft
  (duplicating the question text and form fields already in the result) --
  a bounded increase in trace-row size, with no behavior change.

## Test plan

- `tests/core/agent/test_clarification_draft.py`: source classification for
  all three waiting sources, the empty-form edge case, the tool-waiting
  fallback rule, the no-draft degrade path, a real checkpoint snapshot
  through the real trace serializer, and `with_origin_step`'s marker
  recomputation.
- `tests/core/agent/test_react_clarification_draft.py`: the draft attached
  at each waiting return matches one recomputed from the same request, the
  no-new-message re-entry path returns an identical draft and sends
  nothing new, a control character injected into an interaction id survives
  a full checkpoint-serialize-restore cycle without desyncing the marker,
  and two request sets that would collide under naive separator-joining
  still produce distinct markers.
- `tests/core/agent/test_execution_adapter.py`: the top-level
  `clarification_draft` key is present and identical to the one nested
  under `agent_result` on a waiting result, and absent otherwise.

