### PR TITLE
ops(interactions): add default-off mixed-version rollout controls

### DIFF
--- a/example.env
+++ b/example.env
@@ -846,3 +846,17 @@ ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
 #
 # Example: Set PYTHONPATH to include mounted site-packages
 # SANDBOX_ENV="PYTHONPATH=/home/user/my-python-app:/opt/my-python-app"
+
+# ===========================================
+# Interaction Rollout Configuration
+# ===========================================
+# Default-off gate controlling whether tasks may publish native interaction
+# rows. One of: legacy, read, native. Stays "legacy" (no native rows
+# produced) unless explicitly switched.
+# XAGENT_INTERACTION_PROTOCOL_MODE="legacy"
+
+# Comma-separated list of task sources allowed to publish native rows when
+# mode is "native" (ignored otherwise). Each entry must be one of: internal,
+# sdk, a2a, trigger, widget, shared_link, channel. Native mode requires at
+# least one entry here.
+# XAGENT_INTERACTION_NATIVE_SOURCES=""

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -38,6 +38,8 @@ FRONTEND_DIST_DIR = "XAGENT_FRONTEND_DIST_DIR"
 EXTERNAL_UPLOAD_DIRS = "XAGENT_EXTERNAL_UPLOAD_DIRS"
 EXTERNAL_SKILLS_LIBRARY_DIRS = "XAGENT_EXTERNAL_SKILLS_LIBRARY_DIRS"
 AGENT_RUNTIME = "XAGENT_AGENT_RUNTIME"
+INTERACTION_PROTOCOL_MODE = "XAGENT_INTERACTION_PROTOCOL_MODE"
+INTERACTION_NATIVE_SOURCES = "XAGENT_INTERACTION_NATIVE_SOURCES"
 TASK_LEASE_TTL_SECONDS = "XAGENT_TASK_LEASE_TTL_SECONDS"
 TASK_LEASE_HEARTBEAT_SECONDS = "XAGENT_TASK_LEASE_HEARTBEAT_SECONDS"
 TASK_LEASE_RECOVERY_INTERVAL_SECONDS = "XAGENT_TASK_LEASE_RECOVERY_INTERVAL_SECONDS"
@@ -221,6 +223,46 @@ def get_agent_runtime() -> Literal["v1", "v2"]:
         return "v2"
     logger.warning("Invalid %s=%r; falling back to v1", AGENT_RUNTIME, runtime)
     return "v1"
+
+
+def get_interaction_protocol_mode() -> str:
+    """Raw XAGENT_INTERACTION_PROTOCOL_MODE reading: stripped and lowercased.
+
+    Returns the env value normalized for whitespace and case, or "legacy" if
+    the variable is unset or blank. Does not check that the result is one
+    of the three valid modes -- validating the parsed value and building a
+    policy out of it belongs to the interaction rollout policy owner
+    (``web/services/interaction_rollout.py``), not to this module. Unlike
+    ``get_agent_runtime`` above, an unrecognized value is not this
+    function's problem to warn about or fall back from.
+    """
+    value = os.getenv(INTERACTION_PROTOCOL_MODE)
+    if value is None or not value.strip():
+        return "legacy"
+    return value.strip().lower()
+
+
+def get_interaction_native_sources() -> list[str]:
+    """Raw XAGENT_INTERACTION_NATIVE_SOURCES reading: a normalized token list.
+
+    Comma-splits the env value, strips and lowercases each token, and skips
+    blank tokens -- the same shape ``get_external_upload_dirs`` below uses
+    for its own comma-separated list. Duplicate tokens are preserved and
+    tokens are not checked against any vocabulary here: deduplication and
+    vocabulary validation need to raise two distinguishable errors, and
+    producing those belongs to the interaction rollout policy owner, not to
+    this module.
+    """
+    raw = os.getenv(INTERACTION_NATIVE_SOURCES, "")
+    if not raw:
+        return []
+
+    result: list[str] = []
+    for token in raw.split(","):
+        token = token.strip().lower()
+        if token:
+            result.append(token)
+    return result
 
 
 def get_agent_pattern_for_execution_mode(execution_mode: str | None) -> str:

--- a/src/xagent/web/api/admin_interaction_rollout.py
+++ b/src/xagent/web/api/admin_interaction_rollout.py
@@ -74,21 +74,29 @@ async def get_interaction_rollout_diagnostics(
                 "WHERE status = 'active' AND active_slot IS NOT NULL"
             )
         ).one()
+
+        # Result-type marshaling for the raw column value differs by
+        # backend: PostgreSQL hands back a tz-aware datetime, SQLite hands
+        # back a plain str (its DATETIME type has no native temporal type).
+        # Both shapes -- and any further marshaling surprise -- are handled
+        # in this same try so they land in the deliberate 503 branch below,
+        # never as an unhandled 500.
+        oldest_created_at = row.oldest_created_at
+        oldest_age_seconds: float | None = None
+        if oldest_created_at is not None:
+            if isinstance(oldest_created_at, str):
+                oldest_created_at = datetime.fromisoformat(oldest_created_at)
+            if oldest_created_at.tzinfo is None:
+                oldest_created_at = oldest_created_at.replace(tzinfo=timezone.utc)
+            oldest_age_seconds = (
+                datetime.now(timezone.utc) - oldest_created_at
+            ).total_seconds()
     except Exception as exc:
         logger.exception("Interaction rollout diagnostics stats query failed")
         raise HTTPException(
             status_code=503,
             detail="Interaction rollout diagnostics stats query failed",
         ) from exc
-
-    oldest_created_at = row.oldest_created_at
-    oldest_age_seconds: float | None = None
-    if oldest_created_at is not None:
-        if oldest_created_at.tzinfo is None:
-            oldest_created_at = oldest_created_at.replace(tzinfo=timezone.utc)
-        oldest_age_seconds = (
-            datetime.now(timezone.utc) - oldest_created_at
-        ).total_seconds()
 
     response["active_count"] = row.active_count
     response["oldest_age_seconds"] = oldest_age_seconds

--- a/src/xagent/web/api/admin_interaction_rollout.py
+++ b/src/xagent/web/api/admin_interaction_rollout.py
@@ -1,0 +1,95 @@
+"""Admin diagnostic endpoint for the interaction rollout policy and gate state.
+
+Read-only, admin-authenticated. This is a diagnostic surface, not part of
+the gate itself: it queries active-row stats on demand rather than caching
+them, so a stale reading is never possible, at the cost of a query per
+request.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..auth_dependencies import get_current_user
+from ..models.database import get_db
+from ..models.user import User
+from ..services.interaction_rollout import (
+    counters_snapshot,
+    get_interaction_rollout_policy,
+)
+from ..services.ops_signals import active_degradations
+from ..services.task_interaction_schema import interaction_requests_table_exists
+
+router = APIRouter(
+    prefix="/api/admin/interaction-rollout", tags=["admin-interaction-rollout"]
+)
+logger = logging.getLogger(__name__)
+
+
+@router.get("")
+async def get_interaction_rollout_diagnostics(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict[str, object]:
+    """Resolved policy, active-row stats, gate counters, and degradations.
+
+    Failure shape is three-way, not the usual two: table absent is a normal
+    pre-migration deployment state and returns 200 with ``schema_absent``
+    true and no count fields (an empty allow list read as "0 active rows"
+    would be misleading -- there is no table to have rows). A stats query
+    that raises (a transient DB error) returns 503, not a fabricated
+    ``active_count: 0`` -- a 0 here is the specific number operators watch
+    to confirm a rollback has drained, and a fake 0 during an outage would
+    read as "drained" when the truth is "unknown."
+    """
+    if not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    policy = get_interaction_rollout_policy()
+    response: dict[str, object] = {
+        "policy": {
+            "mode": policy.mode,
+            "native_sources": sorted(policy.native_sources),
+            "native_protocol_version": policy.native_protocol_version,
+        },
+        "counters": counters_snapshot(),
+        "degradations": active_degradations(),
+    }
+
+    if not interaction_requests_table_exists(db):
+        response["schema_absent"] = True
+        return response
+
+    try:
+        row = db.execute(
+            text(
+                "SELECT count(*) AS active_count, "
+                "min(created_at) AS oldest_created_at "
+                "FROM task_interaction_requests "
+                "WHERE status = 'active' AND active_slot IS NOT NULL"
+            )
+        ).one()
+    except Exception as exc:
+        logger.exception("Interaction rollout diagnostics stats query failed")
+        raise HTTPException(
+            status_code=503,
+            detail="Interaction rollout diagnostics stats query failed",
+        ) from exc
+
+    oldest_created_at = row.oldest_created_at
+    oldest_age_seconds: float | None = None
+    if oldest_created_at is not None:
+        if oldest_created_at.tzinfo is None:
+            oldest_created_at = oldest_created_at.replace(tzinfo=timezone.utc)
+        oldest_age_seconds = (
+            datetime.now(timezone.utc) - oldest_created_at
+        ).total_seconds()
+
+    response["active_count"] = row.active_count
+    response["oldest_age_seconds"] = oldest_age_seconds
+    return response

--- a/src/xagent/web/api/admin_interaction_rollout.py
+++ b/src/xagent/web/api/admin_interaction_rollout.py
@@ -61,11 +61,11 @@ async def get_interaction_rollout_diagnostics(
         "degradations": active_degradations(),
     }
 
-    if not interaction_requests_table_exists(db):
-        response["schema_absent"] = True
-        return response
-
     try:
+        if not interaction_requests_table_exists(db):
+            response["schema_absent"] = True
+            return response
+
         row = db.execute(
             text(
                 "SELECT count(*) AS active_count, "

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -78,16 +78,27 @@ from .dynamic_memory_store import get_memory_store
 from .logging_config import setup_logging
 from .models.database import init_db
 from .services.a2a_protocol import A2AApiError, a2a_api_error_handler, a2a_error
-from .services.interaction_rollout import validate_interaction_rollout_at_startup
+from .services.interaction_rollout import (
+    get_interaction_rollout_policy,
+    is_native_schema_ready,
+    mark_native_schema_ready,
+    validate_interaction_rollout_at_startup,
+)
 from .services.local_browser_runtime import (
     register_local_browser_runtime,
     unregister_local_browser_runtime,
+)
+from .services.ops_signals import (
+    INTERACTION_ROLLOUT_SCHEMA_ABSENT,
+    clear_degradation,
+    register_degradation,
 )
 from .services.orphan_upload_gc import run_orphan_upload_gc_loop
 from .services.skill_runtime import (
     SkillRuntimeSessionBoundaryError,
     skill_runtime_session_boundary_error_handler,
 )
+from .services.task_interaction_schema import interaction_requests_table_exists
 from .services.task_lease_recovery import run_task_lease_recovery_loop
 from .services.uploaded_file_recovery import (
     run_uploaded_file_compensation_recovery_loop,
@@ -704,9 +715,12 @@ async def readiness_check() -> JSONResponse:
     schema has been observed present, this endpoint never queries for it
     again for the lifetime of the process (the table is only ever added,
     never dropped, so a stale "present" reading cannot happen). In legacy
-    or read mode the whole segment is skipped -- zero added behavior, zero
-    added query -- so the default deployment stance is unaffected byte for
-    byte.
+    or read mode the schema check and the database query it would trigger
+    are skipped entirely -- zero added query. The frozen policy read
+    above the mode check always runs regardless of mode, including its
+    RuntimeError-if-uninitialized contract (see
+    ``get_interaction_rollout_policy``'s docstring); that read is cheap
+    (no I/O once the policy is frozen at startup) but it is not skipped.
     """
     task = getattr(app.state, "file_storage_startup_sync_task", None)
     error = getattr(app.state, "file_storage_startup_sync_error", None)
@@ -725,19 +739,6 @@ async def readiness_check() -> JSONResponse:
             },
         )
 
-    from .models.database import get_session_local
-    from .services.interaction_rollout import (
-        get_interaction_rollout_policy,
-        is_native_schema_ready,
-        mark_native_schema_ready,
-    )
-    from .services.ops_signals import (
-        INTERACTION_ROLLOUT_SCHEMA_ABSENT,
-        clear_degradation,
-        register_degradation,
-    )
-    from .services.task_interaction_schema import interaction_requests_table_exists
-
     policy = get_interaction_rollout_policy()
     if policy.mode == "native" and not is_native_schema_ready():
         # If the database itself is unreachable here (connection refused,
@@ -748,6 +749,18 @@ async def readiness_check() -> JSONResponse:
         # 503 would, and folding "database unreachable" into that same
         # typed 503 would misreport a connectivity outage as a pending
         # migration.
+        #
+        # get_session_local is imported here rather than hoisted with the
+        # policy/schema imports above: tests replace
+        # database_module.get_session_local itself with a stub session
+        # factory (see tests/web/test_interaction_rollout_observability.py),
+        # and this import must re-resolve that name from the module on
+        # every call for the replacement to take effect. A module-level
+        # import would bind the original function once at process start
+        # and keep calling it through that binding, silently defeating the
+        # test's monkeypatch.
+        from .models.database import get_session_local
+
         SessionLocal = get_session_local()
         db = SessionLocal()
         try:

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -740,6 +740,14 @@ async def readiness_check() -> JSONResponse:
 
     policy = get_interaction_rollout_policy()
     if policy.mode == "native" and not is_native_schema_ready():
+        # If the database itself is unreachable here (connection refused,
+        # timeout), that exception propagates out of this route unhandled
+        # and FastAPI turns it into a 500 -- asymmetric with the deliberate
+        # 503 below for "database reachable, schema not yet migrated".
+        # Accepted: a 500 still fails the readiness probe the same way a
+        # 503 would, and folding "database unreachable" into that same
+        # typed 503 would misreport a connectivity outage as a pending
+        # migration.
         SessionLocal = get_session_local()
         db = SessionLocal()
         try:

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -39,6 +39,7 @@ from ..core.execution_scope import (
 from ..core.file_storage import StorageKeyScopeError
 from ..core.tracing.langfuse import flush_langfuse, initialize_langfuse
 from .api.a2a import router as a2a_router
+from .api.admin_interaction_rollout import router as admin_interaction_rollout_router
 from .api.admin_mcp import admin_mcp_router
 from .api.admin_users import router as admin_users_router
 from .api.agent_api_keys import router as agent_api_keys_router
@@ -77,6 +78,7 @@ from .dynamic_memory_store import get_memory_store
 from .logging_config import setup_logging
 from .models.database import init_db
 from .services.a2a_protocol import A2AApiError, a2a_api_error_handler, a2a_error
+from .services.interaction_rollout import validate_interaction_rollout_at_startup
 from .services.local_browser_runtime import (
     register_local_browser_runtime,
     unregister_local_browser_runtime,
@@ -695,7 +697,17 @@ async def health_check() -> dict[str, Any]:
 
 @app.get("/ready")
 async def readiness_check() -> JSONResponse:
-    """Readiness check that reflects startup file storage sync status."""
+    """Readiness check for startup file storage sync and, in native
+    interaction-rollout mode, task_interaction_requests schema presence.
+
+    The interaction-rollout segment below is a one-way latch: once the
+    schema has been observed present, this endpoint never queries for it
+    again for the lifetime of the process (the table is only ever added,
+    never dropped, so a stale "present" reading cannot happen). In legacy
+    or read mode the whole segment is skipped -- zero added behavior, zero
+    added query -- so the default deployment stance is unaffected byte for
+    byte.
+    """
     task = getattr(app.state, "file_storage_startup_sync_task", None)
     error = getattr(app.state, "file_storage_startup_sync_error", None)
 
@@ -712,6 +724,47 @@ async def readiness_check() -> JSONResponse:
                 "detail": "Startup file storage sync running",
             },
         )
+
+    from .models.database import get_session_local
+    from .services.interaction_rollout import (
+        get_interaction_rollout_policy,
+        is_native_schema_ready,
+        mark_native_schema_ready,
+    )
+    from .services.ops_signals import (
+        INTERACTION_ROLLOUT_SCHEMA_ABSENT,
+        clear_degradation,
+        register_degradation,
+    )
+    from .services.task_interaction_schema import interaction_requests_table_exists
+
+    policy = get_interaction_rollout_policy()
+    if policy.mode == "native" and not is_native_schema_ready():
+        SessionLocal = get_session_local()
+        db = SessionLocal()
+        try:
+            schema_present = interaction_requests_table_exists(db)
+        finally:
+            db.close()
+
+        if not schema_present:
+            # This endpoint is unauthenticated -- the detail below
+            # deliberately does not name the missing table.
+            register_degradation(
+                INTERACTION_ROLLOUT_SCHEMA_ABSENT,
+                "task_interaction_requests table not present",
+            )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "status": "error",
+                    "detail": "Interaction rollout schema not ready",
+                },
+            )
+
+        mark_native_schema_ready()
+        clear_degradation(INTERACTION_ROLLOUT_SCHEMA_ABSENT)
+
     return JSONResponse(status_code=200, content={"status": "ready"})
 
 
@@ -994,6 +1047,7 @@ app.include_router(custom_api_router)
 app.include_router(deployment_config_router)
 app.include_router(tools_router)
 app.include_router(admin_users_router)
+app.include_router(admin_interaction_rollout_router)
 app.include_router(admin_mcp_router)
 app.include_router(skills_router)
 app.include_router(skill_hub_router)
@@ -1017,6 +1071,7 @@ app.include_router(v1_router)
 async def startup_event() -> None:
     global _migration_task
     logger.info("Agent runtime configured: %s", get_agent_runtime())
+    validate_interaction_rollout_at_startup()
     logger.info("Initializing database...")
     init_db()
     logger.info("Database initialized successfully")

--- a/src/xagent/web/models/task_interaction.py
+++ b/src/xagent/web/models/task_interaction.py
@@ -15,6 +15,75 @@ from sqlalchemy.sql import func
 
 from .database import Base
 
+# ---------------------------------------------------------------------------
+# Column-domain constants for this table's `origin` and `protocol_version`
+# columns.
+#
+# Attribution: these four names -- the vocabulary, the protocol version, the
+# normalizer, and the literal-subset constant -- live here rather than in an
+# interaction-rollout gate module or anywhere else, because they define what
+# a row in ``task_interaction_requests`` *means*, not whether some rollout
+# gate currently lets a new native row through. ``origin`` and
+# ``protocol_version`` are columns on this table; ``INTERACTION_ORIGIN_VOCABULARY``
+# mirrors the ``ck_task_interaction_requests_origin`` CHECK a few lines
+# below, and ``INTERACTION_PROTOCOL_VERSION`` mirrors
+# ``ck_task_interaction_requests_active_protocol``. A rollout gate built on
+# top of these names can be deleted outright and this table's column-domain
+# mapping still has to exist for whatever reads or writes rows here -- so
+# the mapping is owned by the table, not by whichever gate happens to
+# consume it today.
+#
+# Two call surfaces, two normalization rules, by design: ``Task.source`` is
+# a value written by application code and persisted, so an unexpected
+# reading of it (extra whitespace, wrong case) is itself a fact worth
+# surfacing -- ``normalize_interaction_origin`` below does not strip or
+# lowercase, so a stray ``" SDK "`` reads back as unknown instead of being
+# silently folded into the known ``"sdk"`` bucket. The
+# ``XAGENT_INTERACTION_NATIVE_SOURCES`` environment variable parsed in
+# ``config.py`` is a human-typed operator input and *is* stripped and
+# lowercased there. Do not unify the two -- each rule is pinned by its own
+# tests and guards a different kind of input.
+# ---------------------------------------------------------------------------
+INTERACTION_ORIGIN_VOCABULARY = frozenset(
+    {"internal", "sdk", "a2a", "trigger", "widget", "shared_link"}
+)
+INTERACTION_PROTOCOL_VERSION = 1
+
+# ``Task.source`` literals actually written by producers today -- a proper
+# subset of INTERACTION_ORIGIN_VOCABULARY, never an alias for it. The
+# vocabulary can (and does, via "internal") contain a value no call site
+# ever passes explicitly, produced instead by the column default and by
+# normalize_interaction_origin's falsy fallback below. Retiring a
+# ``Task.source`` value -- stop producing it, keep reading rows that
+# already carry it -- is a legitimate, expected move, and doing so narrows
+# this constant without narrowing INTERACTION_ORIGIN_VOCABULARY or the
+# origin CHECK. Because of that this constant must only ever be asserted as
+# a subset of the vocabulary, never as equal to it.
+TASK_SOURCE_LITERALS = frozenset({"a2a", "sdk", "shared_link", "trigger", "widget"})
+
+
+def normalize_interaction_origin(source: str | None) -> str | None:
+    """Map a ``Task.source`` reading to an origin vocabulary member.
+
+    Returns ``None`` for anything not recognized -- callers must treat that
+    as "unknown", not silently fall back to ``"internal"`` or any other
+    bucket. Deliberately does not ``strip()`` or ``.lower()`` the input (see
+    the module-level comment above): a value that only matches after
+    normalization is exactly the signal this function exists to preserve.
+
+    - ``None`` or ``""`` (falsy) -> ``"internal"``, matching this column's
+      default for rows that predate this vocabulary.
+    - An exact (byte-for-byte) match against
+      :data:`INTERACTION_ORIGIN_VOCABULARY` -> that value.
+    - Anything else, including whitespace-only strings and near-matches
+      that only differ in case or surrounding whitespace -> ``None``.
+    """
+    if not source:
+        return "internal"
+    if source in INTERACTION_ORIGIN_VOCABULARY:
+        return source
+    return None
+
 
 class TaskInteractionRequest(Base):  # type: ignore
     """One blocking interaction request raised by a task and its lifecycle to answer or expiry.

--- a/src/xagent/web/services/interaction_rollout.py
+++ b/src/xagent/web/services/interaction_rollout.py
@@ -113,6 +113,15 @@ def gating_key(task: "Task") -> str | None:
     widget task's synthetic key would collapse to ``"channel"`` even though
     its actual origin is ``"widget"``, silently pulling widget traffic into
     whatever rollout batch was meant only for IM channels.
+
+    The ``"channel"`` key is persisted but not stable over a task's
+    lifetime: ``Task.channel_id`` has ``ondelete=SET NULL``, so deleting
+    the channel a task belongs to nulls that column on the task row that
+    survives the deletion. A task gated as ``"channel"`` today can be
+    re-read later, after its channel is deleted, and gate as
+    ``"internal"`` instead -- the same task, two different answers,
+    neither of them wrong for the state of the data at the time each was
+    computed.
     """
     # Task.source is a legacy Column-typed attribute (not Mapped[str | None]),
     # so mypy sees it as opaque; cast rather than loosen
@@ -135,7 +144,10 @@ def gating_key(task: "Task") -> str | None:
 # reuse this one registry instead of standing up a second counter parser.
 # This mirrors ops_signals's own "one owner, many producers" shape. Only the
 # rollout.decision.* family is incremented in this PR; every other constant
-# below is a placeholder naming its future owner.
+# below is a placeholder naming its future owner. The nine placeholder
+# constants below are intentionally dead code until the producer named in
+# each one's comment lands and starts incrementing it -- not an oversight
+# to flag.
 # ---------------------------------------------------------------------------
 COUNTER_ROLLOUT_DECISION_ALLOWED = "rollout.decision.allowed"
 COUNTER_ROLLOUT_DECISION_BLOCKED_MODE = "rollout.decision.blocked_mode"
@@ -250,15 +262,23 @@ def validate_interaction_rollout_at_startup() -> InteractionRolloutPolicy:
 
         raw_sources_env = os.getenv(INTERACTION_NATIVE_SOURCES)
         tokens = get_interaction_native_sources()
+        # Same split and blank-filter as get_interaction_native_sources(),
+        # but without its case/whitespace normalization, so the duplicate
+        # check below can quote what the operator actually typed. Without
+        # this, "SDK,sdk" would report the collision as "'sdk' is listed
+        # more than once" with no indication that the two entries were
+        # spelled differently in the first place.
+        raw_tokens = [t for t in (raw_sources_env or "").split(",") if t.strip()]
 
-        seen: set[str] = set()
-        for token in tokens:
+        seen: dict[str, str] = {}
+        for token, raw_token in zip(tokens, raw_tokens):
             if token in seen:
                 raise InteractionRolloutConfigError(
-                    f"Invalid {INTERACTION_NATIVE_SOURCES}: entry {token!r} "
-                    "is listed more than once."
+                    f"Invalid {INTERACTION_NATIVE_SOURCES}: entry {raw_token!r} "
+                    f"is listed more than once (already present as "
+                    f"{seen[token]!r}; both normalize to {token!r})."
                 )
-            seen.add(token)
+            seen[token] = raw_token
             if token not in INTERACTION_GATING_SOURCES:
                 raise InteractionRolloutConfigError(
                     f"Invalid {INTERACTION_NATIVE_SOURCES} entry {token!r}: "

--- a/src/xagent/web/services/interaction_rollout.py
+++ b/src/xagent/web/services/interaction_rollout.py
@@ -1,0 +1,490 @@
+"""Owner of the default-off interaction rollout policy and its publication gate.
+
+This module answers exactly one question for the rest of the codebase: "is
+a task allowed to publish a native interaction row right now." It owns the
+env-derived policy (parsed once, frozen, fail-fast at startup), the
+publication gate that answers the question, an in-process counter registry
+for the gate's outcomes, and a one-way readiness latch consumed by
+``/ready``. It does not read interaction rows, answer them, close them, or
+decide what a reader sees -- those stay untouched by every mode this
+module can be configured into (see the module-level invariant below).
+
+Gating vocabulary vs. origin vocabulary
+    ``INTERACTION_GATING_SOURCES`` (seven entries) is a proper superset of
+    ``INTERACTION_ORIGIN_VOCABULARY`` (six entries, defined on
+    ``task_interaction.py`` next to the ``origin`` column it constrains).
+    The extra entry, ``"channel"``, is a synthetic split of the
+    ``"internal"`` bucket by ``task.channel_id`` -- it exists only to pick a
+    rollout batch and must never be written into the ``origin`` column or
+    added to that column's CHECK constraint. Any change that merges the two
+    vocabularies, or adds ``"channel"`` to the origin CHECK, needs to justify
+    why a temporary rollout-axis split is worth a database migration.
+
+Retired sources stay in the vocabulary
+    A gating source that has stopped producing new tasks is "legitimate but
+    dead," not invalid. Retiring a ``Task.source`` value means "no new tasks
+    of this kind," not "no task of this kind will ever reach a finalizer
+    again" -- historical rows keep flowing through the same finalizers.
+    Seeing a gating entry with zero current traffic is not a reason to
+    remove it from an allow list.
+
+Suppression markers never ride the read-side key
+    (Applies once a write-side suppression mechanism exists; there is none
+    in this PR, but the constraint is pinned here because it binds whatever
+    key this gate produces.) A suppression marker must never be written into
+    any column the read-side decision key already consumes. The read-side
+    key answers "what has been published;" a suppression marker answers
+    "what the write side intends to do next." Letting the marker share the
+    read side's column would let a write-side intention masquerade as a
+    published fact.
+
+Hard invariant enforced by this module and by the static guards that check
+it: the interaction rollout mode can only decide whether a *new* native row
+gets produced. It can never decide how an already-published row is read,
+answered, or closed.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, cast
+
+from ...config import (
+    INTERACTION_NATIVE_SOURCES,
+    INTERACTION_PROTOCOL_MODE,
+    get_interaction_native_sources,
+    get_interaction_protocol_mode,
+)
+from ..models.task_interaction import (
+    INTERACTION_ORIGIN_VOCABULARY,
+    INTERACTION_PROTOCOL_VERSION,
+    normalize_interaction_origin,
+)
+from .ops_signals import (
+    INTERACTION_ROLLOUT_SCHEMA_ABSENT,
+    INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE,
+    clear_degradation,
+    register_degradation,
+)
+from .task_interaction_schema import interaction_requests_table_exists
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from ..models.task import Task
+
+logger = logging.getLogger(__name__)
+
+_VALID_MODES = ("legacy", "read", "native")
+
+
+class InteractionRolloutConfigError(ValueError):
+    """Raised at startup when the interaction rollout configuration is invalid."""
+
+
+# ---------------------------------------------------------------------------
+# Gating vocabulary and the synthetic "channel" split.
+# ---------------------------------------------------------------------------
+
+# The right-hand operand here must stay INTERACTION_ORIGIN_VOCABULARY, not
+# TASK_SOURCE_LITERALS: the latter is missing "internal" today (nothing in
+# the codebase constructs a Task with source="internal" as a literal -- it
+# only ever arrives via the column default or normalize_interaction_origin's
+# falsy fallback), and deriving the gating vocabulary from it would silently
+# drop the single most important gating source.
+INTERACTION_GATING_SOURCES = INTERACTION_ORIGIN_VOCABULARY | {"channel"}
+
+
+def gating_key(task: "Task") -> str | None:
+    """Map a task to the gating vocabulary entry that governs its publication.
+
+    Returns ``None`` for a task whose ``Task.source`` does not normalize to
+    a known origin -- callers must treat that as "unknown," not fall back to
+    any bucket.
+
+    The ``origin == "internal"`` guard below is required, not incidental:
+    Web UI, WebSocket, and IM-channel tasks all land in the ``"internal"``
+    origin bucket, but a ``widget`` task can also carry a non-null
+    ``channel_id`` (public chat access sets one). Without the guard, that
+    widget task's synthetic key would collapse to ``"channel"`` even though
+    its actual origin is ``"widget"``, silently pulling widget traffic into
+    whatever rollout batch was meant only for IM channels.
+    """
+    # Task.source is a legacy Column-typed attribute (not Mapped[str | None]),
+    # so mypy sees it as opaque; cast rather than loosen
+    # normalize_interaction_origin's own signature, which is a documented
+    # public contract (see task_interaction.py) independent of this cast.
+    origin = normalize_interaction_origin(cast("str | None", task.source))
+    if origin is None:
+        return None
+    if origin == "internal" and task.channel_id is not None:
+        return "channel"
+    return origin
+
+
+# ---------------------------------------------------------------------------
+# In-process counter registry.
+#
+# The full counter namespace for the mixed-version rollout is pinned here as
+# constants -- even the families this PR does not increment -- so that later
+# producers (materialization, response handling, repair, command staging)
+# reuse this one registry instead of standing up a second counter parser.
+# This mirrors ops_signals's own "one owner, many producers" shape. Only the
+# rollout.decision.* family is incremented in this PR; every other constant
+# below is a placeholder naming its future owner.
+# ---------------------------------------------------------------------------
+COUNTER_ROLLOUT_DECISION_ALLOWED = "rollout.decision.allowed"
+COUNTER_ROLLOUT_DECISION_BLOCKED_MODE = "rollout.decision.blocked_mode"
+COUNTER_ROLLOUT_DECISION_BLOCKED_SOURCE = "rollout.decision.blocked_source"
+COUNTER_ROLLOUT_DECISION_BLOCKED_UNKNOWN_SOURCE = (
+    "rollout.decision.blocked_unknown_source"
+)
+COUNTER_ROLLOUT_DECISION_BLOCKED_SCHEMA_ABSENT = (
+    "rollout.decision.blocked_schema_absent"
+)
+
+# Not incremented by this PR -- placeholders for later owners sharing this
+# registry.
+COUNTER_COMPAT_READ_FALLBACK = "compat.read_fallback"  # owner: read-path wiring
+COUNTER_LIFECYCLE_RESPONSE_CONFLICT = "lifecycle.response_conflict"  # owner: #1075
+COUNTER_MATERIALIZE_SUCCESS = "materialize.success"  # owner: #1078
+COUNTER_MATERIALIZE_TRANSIENT = "materialize.transient"  # owner: #1078
+COUNTER_MATERIALIZE_PERMANENT = "materialize.permanent"  # owner: #1078
+COUNTER_MATERIALIZE_AMBIGUOUS = "materialize.ambiguous"  # owner: #1078
+COUNTER_REPAIR_COUNT = "repair.count"  # owner: #1082
+COUNTER_REPAIR_TERMINAL = "repair.terminal"  # owner: #1082
+COUNTER_COMMAND_LAG_SECONDS_MAX = "command.lag_seconds_max"  # owner: #1073 / #1075
+
+_counters: dict[str, int] = {}
+_counters_lock = threading.Lock()
+
+
+def increment_counter(name: str) -> None:
+    """Increment one named counter by one. Process-local, like ops_signals."""
+    with _counters_lock:
+        _counters[name] = _counters.get(name, 0) + 1
+
+
+def counters_snapshot() -> dict[str, int]:
+    """Point-in-time copy of every counter's current value.
+
+    Returns a copy, not the live registry -- mutating the returned dict
+    never affects what a later call to this function returns. Counters are
+    per-process, the same limitation ``ops_signals`` documents for its own
+    registry: a diagnostic reader behind a load balancer only ever sees its
+    own process's counts.
+    """
+    with _counters_lock:
+        return dict(_counters)
+
+
+# ---------------------------------------------------------------------------
+# Policy: parsed once at startup, frozen, and fail-fast.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InteractionRolloutPolicy:
+    """The frozen, fully-validated interaction rollout configuration."""
+
+    mode: Literal["legacy", "read", "native"]
+    native_sources: frozenset[str]
+    native_protocol_version: int
+
+
+_policy: InteractionRolloutPolicy | None = None
+_policy_lock = threading.Lock()
+
+# One-way readiness latch for /ready's native-mode schema check. Lives here,
+# alongside the policy singleton, rather than on app.state: cache True
+# forever (the table is only ever added, never dropped, so a stale True
+# cannot occur) and let False re-query every time (the table may not exist
+# yet during a legitimate "service rolled before migration ran" window).
+# This latch is consumed only by /ready -- the gate's own schema check
+# (evaluate_native_publication step 5) always queries fresh.
+_native_schema_ready = False
+
+
+def is_native_schema_ready() -> bool:
+    """Current state of the one-way /ready schema latch."""
+    return _native_schema_ready
+
+
+def mark_native_schema_ready() -> None:
+    """Flip the one-way /ready schema latch. Idempotent; never unflips."""
+    global _native_schema_ready
+    _native_schema_ready = True
+
+
+def validate_interaction_rollout_at_startup() -> InteractionRolloutPolicy:
+    """Parse, validate, and freeze the interaction rollout policy.
+
+    Idempotent: the first call parses env and freezes the result; every
+    later call returns that same object (``is``-identical), without
+    re-reading env. Raises :class:`InteractionRolloutConfigError` (a
+    ``ValueError`` subclass) for anything invalid enough to make the
+    process refuse to start -- deliberately, a departure from this
+    codebase's more common three-state warn-and-fall-back pattern (see
+    ``get_agent_runtime`` in ``config.py``). A rollout switch that silently
+    falls back to legacy on a typo would defeat the entire purpose of this
+    module: it exists so a misconfigured deployment fails loudly at
+    startup instead of quietly staying in legacy while an operator
+    believes they enabled native mode.
+    """
+    global _policy
+    with _policy_lock:
+        if _policy is not None:
+            return _policy
+
+        raw_mode = os.getenv(INTERACTION_PROTOCOL_MODE)
+        mode = get_interaction_protocol_mode()
+        if mode not in _VALID_MODES:
+            raise InteractionRolloutConfigError(
+                f"Invalid {INTERACTION_PROTOCOL_MODE} value: {raw_mode!r}. "
+                f"Expected one of: {', '.join(_VALID_MODES)}."
+            )
+
+        raw_sources_env = os.getenv(INTERACTION_NATIVE_SOURCES)
+        tokens = get_interaction_native_sources()
+
+        seen: set[str] = set()
+        for token in tokens:
+            if token in seen:
+                raise InteractionRolloutConfigError(
+                    f"Invalid {INTERACTION_NATIVE_SOURCES}: entry {token!r} "
+                    "is listed more than once."
+                )
+            seen.add(token)
+            if token not in INTERACTION_GATING_SOURCES:
+                raise InteractionRolloutConfigError(
+                    f"Invalid {INTERACTION_NATIVE_SOURCES} entry {token!r}: "
+                    "not a member of the gating source vocabulary "
+                    f"{sorted(INTERACTION_GATING_SOURCES)}. A retired "
+                    "Task.source value is a legitimate but dead entry -- it "
+                    "stays in the gating vocabulary even after it stops "
+                    "producing new rows, so if this entry used to be valid "
+                    "check whether it was removed from the vocabulary in "
+                    "error before assuming this configuration is wrong."
+                )
+
+        if mode == "native" and not tokens:
+            raise InteractionRolloutConfigError(
+                f"{INTERACTION_PROTOCOL_MODE}=native requires at least one "
+                f"entry in {INTERACTION_NATIVE_SOURCES}."
+            )
+
+        native_sources = frozenset(tokens)
+
+        # legacy/read with a non-empty source list is normal --
+        # operators pre-stage the source list before flipping the mode
+        # switch. Not a failure, just worth an INFO line.
+        if mode != "native" and native_sources:
+            logger.info(
+                "%s is set while %s=%s; it has no effect until mode is "
+                "switched to native.",
+                INTERACTION_NATIVE_SOURCES,
+                INTERACTION_PROTOCOL_MODE,
+                mode,
+            )
+
+        # "trigger" tasks are hidden tasks with no interactive responder --
+        # allowing them is never wrong on its own, but it can never be
+        # answered, so operators get a WARNING instead of silence.
+        if "trigger" in native_sources:
+            logger.warning(
+                "%s includes 'trigger': trigger-originated tasks are "
+                "hidden tasks with no interactive responder, so native "
+                "publication for them will never be answered.",
+                INTERACTION_NATIVE_SOURCES,
+            )
+
+        # Normalization (case/whitespace) changing the raw value is by
+        # design, not a fault -- INFO only, so operators can see it happened.
+        normalized_sources = ",".join(tokens)
+        if (raw_mode is not None and raw_mode != mode) or (
+            raw_sources_env is not None and raw_sources_env != normalized_sources
+        ):
+            logger.info(
+                "Interaction rollout config normalized: %s=%r->%r %s=%r->%r",
+                INTERACTION_PROTOCOL_MODE,
+                raw_mode,
+                mode,
+                INTERACTION_NATIVE_SOURCES,
+                raw_sources_env,
+                normalized_sources,
+            )
+
+        # mode was already checked against _VALID_MODES above; mypy cannot
+        # narrow a plain str to the Literal from that membership check, so
+        # the cast documents an invariant already enforced by the raise.
+        policy = InteractionRolloutPolicy(
+            mode=cast('Literal["legacy", "read", "native"]', mode),
+            native_sources=native_sources,
+            native_protocol_version=INTERACTION_PROTOCOL_VERSION,
+        )
+
+        # Unconditional, same shape as app.py's "Agent runtime configured:"
+        # startup line -- this is the one line an operator can grep for to
+        # know what a given process actually resolved, every time, not just
+        # on failure.
+        logger.info(
+            "Interaction rollout policy configured: mode=%s native_sources=%s "
+            "native_protocol_version=%s",
+            policy.mode,
+            sorted(policy.native_sources),
+            policy.native_protocol_version,
+        )
+
+        _policy = policy
+        return policy
+
+
+def _require_policy() -> InteractionRolloutPolicy:
+    """Shared uninitialized-singleton guard.
+
+    Not itself a tracked consumer-facing symbol -- both the public
+    accessor below and the gate's own internal read go through this, so
+    the gate reading its own owner module's state does not inflate the
+    call-site count the ``get_interaction_rollout_policy`` guard tracks
+    for *external* consumers.
+    """
+    if _policy is None:
+        raise RuntimeError(
+            "get_interaction_rollout_policy() called before "
+            "validate_interaction_rollout_at_startup() initialized the "
+            "interaction rollout policy singleton."
+        )
+    return _policy
+
+
+def get_interaction_rollout_policy() -> InteractionRolloutPolicy:
+    """Return the frozen policy singleton.
+
+    Raises ``RuntimeError`` if called before
+    ``validate_interaction_rollout_at_startup()`` -- this accessor never
+    lazily parses env itself. In production this path is unreachable: the
+    startup event calls the validator before the process accepts traffic.
+    A caller that hits this is a programming error (a new process entry
+    point that forgot to call the validator), not a runtime condition to
+    recover from, so it is treated as one.
+    """
+    return _require_policy()
+
+
+# ---------------------------------------------------------------------------
+# The publication gate.
+# ---------------------------------------------------------------------------
+
+
+def _truncated_repr(value: object, *, limit: int = 64) -> str:
+    """``repr()`` a value and cap the result to ``limit`` characters.
+
+    ``Task.source`` is a ``String(20)`` column with no CHECK constraint, and
+    SQLite does not enforce column length at all, so it can hold arbitrary-
+    length text. ``repr()`` (not plain ``str()``) makes whitespace and other
+    invisible characters visible -- the most common shape of an unknown
+    source once normalization stops stripping/lowercasing -- and the length
+    cap keeps a pathological value out of logs and degradation detail.
+    """
+    text = repr(value)
+    if len(text) > limit:
+        return text[:limit] + "..."
+    return text
+
+
+class NativePublicationDecision(enum.Enum):
+    """The five possible outcomes of :func:`evaluate_native_publication`.
+
+    ``ALLOWED`` is the only member carrying a payload:
+    :attr:`protocol_version`, which mirrors ``INTERACTION_PROTOCOL_VERSION``
+    (``task_interaction.py``) rather than defining its own value. No member
+    carries an ``origin`` field -- the normalized origin value computed
+    during evaluation is used only inside the gate, for vocabulary lookups
+    and logging. It never becomes part of what the gate returns, because the
+    gate answers "may a native row be published," and letting a write-side
+    input ride along on that answer invites a future caller to treat the
+    gate's return value as if it were an authoritative reading of already-
+    published data.
+    """
+
+    ALLOWED = "allowed"
+    BLOCKED_MODE = "blocked_mode"
+    BLOCKED_UNKNOWN_SOURCE = "blocked_unknown_source"
+    BLOCKED_SOURCE = "blocked_source"
+    BLOCKED_SCHEMA_ABSENT = "blocked_schema_absent"
+
+    @property
+    def protocol_version(self) -> int | None:
+        if self is NativePublicationDecision.ALLOWED:
+            return INTERACTION_PROTOCOL_VERSION
+        return None
+
+
+def evaluate_native_publication(
+    db: "Session", task: "Task"
+) -> NativePublicationDecision:
+    """Decide whether ``task`` may publish a native interaction row now.
+
+    Call this only when a finalizer is about to transition a task into
+    ``WAITING_FOR_USER`` -- this function does not check task status
+    itself, it assumes that precondition already gated the call.
+
+    Guard order is the contract, not an implementation detail:
+
+    1. The mode check runs first. The default deployment carries 100% of
+       traffic in legacy mode, so putting the cheapest possible check first
+       (one attribute read off the frozen policy singleton, one string
+       compare -- no environment read happens here, unlike in earlier,
+       unfrozen designs) drives the gate's total cost to zero queries for
+       the common case.
+    2. The schema-existence check is the only step that issues a query, so
+       it runs last among the blocking checks -- after every check capable
+       of rejecting for free has had its turn.
+    3. Unknown source is checked before allow-list membership, not after:
+       an unrecognized ``Task.source`` value is a data anomaly worth a
+       human's attention, while a recognized-but-not-yet-allowed source is
+       ordinary rollout progress. Merging the two into one outcome would
+       bury the anomaly inside the routine case.
+
+    Never opens a transaction, writes a row, resolves a resume anchor, or
+    takes a lock -- it only answers the yes/no question, never acts on the
+    answer. That boundary is what lets this gate exist with zero production
+    callers and full unit coverage.
+    """
+    policy = _require_policy()
+
+    if policy.mode != "native":
+        logger.debug("Native publication blocked: mode=%s", policy.mode)
+        increment_counter(COUNTER_ROLLOUT_DECISION_BLOCKED_MODE)
+        return NativePublicationDecision.BLOCKED_MODE
+
+    key = gating_key(task)
+    if key is None:
+        detail = (
+            f"task {task.id}: unrecognized Task.source {_truncated_repr(task.source)}"
+        )
+        logger.info("Native publication blocked: %s", detail)
+        register_degradation(INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE, detail)
+        increment_counter(COUNTER_ROLLOUT_DECISION_BLOCKED_UNKNOWN_SOURCE)
+        return NativePublicationDecision.BLOCKED_UNKNOWN_SOURCE
+
+    if key not in policy.native_sources:
+        logger.info("Native publication blocked: source %r not in allowed sources", key)
+        increment_counter(COUNTER_ROLLOUT_DECISION_BLOCKED_SOURCE)
+        return NativePublicationDecision.BLOCKED_SOURCE
+
+    if not interaction_requests_table_exists(db):
+        detail = "task_interaction_requests table not present"
+        logger.info("Native publication blocked: %s", detail)
+        register_degradation(INTERACTION_ROLLOUT_SCHEMA_ABSENT, detail)
+        increment_counter(COUNTER_ROLLOUT_DECISION_BLOCKED_SCHEMA_ABSENT)
+        return NativePublicationDecision.BLOCKED_SCHEMA_ABSENT
+
+    clear_degradation(INTERACTION_ROLLOUT_SCHEMA_ABSENT)
+    logger.info("Native publication allowed: source %r", key)
+    increment_counter(COUNTER_ROLLOUT_DECISION_ALLOWED)
+    return NativePublicationDecision.ALLOWED

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -24,6 +24,17 @@ CHECKPOINT_LEGACY_POINTER_AMBIGUOUS = "checkpoint_legacy_pointer_ambiguous"
 CHECKPOINT_LOAD_UNAVAILABLE = "checkpoint_load_unavailable"
 CHECKPOINT_PK_ANCHOR_DANGLING = "checkpoint_pk_anchor_dangling"
 CHECKPOINT_PRUNE_FAILED = "checkpoint_prune_failed"
+# Set when the interaction rollout gate (or /ready, in native mode) finds
+# task_interaction_requests missing; cleared at either site once the table
+# is observed to exist.
+INTERACTION_ROLLOUT_SCHEMA_ABSENT = "interaction_rollout_schema_absent"
+# Set when the interaction rollout gate sees a Task.source value that does
+# not normalize to a known origin. Deliberately not paired with a clear
+# site, unlike every other signal in this module: an unrecognized source is
+# a property of persisted data, and no in-process signal can observe that
+# data being fixed. Auto-clearing would assert "the data got fixed" without
+# evidence for it.
+INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE = "interaction_rollout_unknown_task_source"
 
 _signals: dict[str, str] = {}
 _lock = threading.Lock()

--- a/tests/web/services/test_interaction_rollout_config.py
+++ b/tests/web/services/test_interaction_rollout_config.py
@@ -1,0 +1,215 @@
+"""Startup configuration parsing and fail-fast validation.
+
+Covers env parsing, startup validation, and vocabulary pairings, plus
+``Task.source`` normalization -- the current no-strip/no-lower spec.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+
+import pytest
+
+import xagent.config as config
+import xagent.web.services.interaction_rollout as ir
+from xagent.web.models.task_interaction import (
+    INTERACTION_ORIGIN_VOCABULARY,
+    TASK_SOURCE_LITERALS,
+    TaskInteractionRequest,
+    normalize_interaction_origin,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    monkeypatch.delenv(config.INTERACTION_PROTOCOL_MODE, raising=False)
+    monkeypatch.delenv(config.INTERACTION_NATIVE_SOURCES, raising=False)
+    monkeypatch.setattr(ir, "_policy", None)
+    ir._counters.clear()
+    yield
+    monkeypatch.setattr(ir, "_policy", None)
+    ir._counters.clear()
+
+
+# ---------------------------------------------------------------------------
+# T-C: config parsing + startup validation
+# ---------------------------------------------------------------------------
+
+
+def test_tc1_defaults_to_legacy_with_empty_sources_and_version_1():
+    policy = ir.validate_interaction_rollout_at_startup()
+    assert policy.mode == "legacy"
+    assert policy.native_sources == frozenset()
+    assert policy.native_protocol_version == 1
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("legacy", "legacy"), (" READ ", "read"), ("Native", "native")],
+)
+def test_tc2_valid_modes_parse_with_whitespace_and_case(monkeypatch, raw, expected):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, raw)
+    if expected == "native":
+        monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, "sdk")
+    policy = ir.validate_interaction_rollout_at_startup()
+    assert policy.mode == expected
+
+
+def test_tc3_invalid_mode_raises_with_original_value_and_legal_values(monkeypatch):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "prod")
+    with pytest.raises(ir.InteractionRolloutConfigError) as exc:
+        ir.validate_interaction_rollout_at_startup()
+    message = str(exc.value)
+    assert "prod" in message
+    assert "legacy" in message
+    assert "read" in message
+    assert "native" in message
+
+
+def test_tc4_all_seven_gating_sources_parse_with_case_and_whitespace(monkeypatch):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "native")
+    monkeypatch.setenv(
+        config.INTERACTION_NATIVE_SOURCES,
+        " Internal, SDK ,a2a,TRIGGER,widget,Shared_Link,Channel",
+    )
+    policy = ir.validate_interaction_rollout_at_startup()
+    assert policy.native_sources == frozenset(
+        {"internal", "sdk", "a2a", "trigger", "widget", "shared_link", "channel"}
+    )
+
+
+def test_tc5_unknown_source_and_duplicate_source_raise_distinct_messages(monkeypatch):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "native")
+    monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, "sdk,bogus")
+    with pytest.raises(ir.InteractionRolloutConfigError) as exc_unknown:
+        ir.validate_interaction_rollout_at_startup()
+    unknown_message = str(exc_unknown.value)
+
+    monkeypatch.setattr(ir, "_policy", None)
+    monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, "sdk,sdk")
+    with pytest.raises(ir.InteractionRolloutConfigError) as exc_dup:
+        ir.validate_interaction_rollout_at_startup()
+    dup_message = str(exc_dup.value)
+
+    assert "bogus" in unknown_message
+    assert "sdk" in dup_message
+    assert unknown_message != dup_message
+    assert "more than once" in dup_message
+    assert "more than once" not in unknown_message
+
+
+def test_tc6_native_mode_with_empty_sources_raises(monkeypatch):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "native")
+    with pytest.raises(ir.InteractionRolloutConfigError):
+        ir.validate_interaction_rollout_at_startup()
+
+
+def test_tc7_legacy_with_nonempty_sources_does_not_raise_but_logs_info(
+    monkeypatch, caplog
+):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "legacy")
+    monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, "sdk")
+    with caplog.at_level(
+        logging.INFO, logger="xagent.web.services.interaction_rollout"
+    ):
+        policy = ir.validate_interaction_rollout_at_startup()
+    assert policy.mode == "legacy"
+    assert policy.native_sources == frozenset({"sdk"})
+    assert any(
+        "no effect until mode is switched to native" in r.message
+        for r in caplog.records
+    )
+
+
+def test_tc8_blank_entries_are_skipped_not_raised(monkeypatch):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "native")
+    monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, "sdk,,a2a")
+    policy = ir.validate_interaction_rollout_at_startup()
+    assert policy.native_sources == frozenset({"sdk", "a2a"})
+
+
+def test_tc9_policy_is_frozen():
+    policy = ir.validate_interaction_rollout_at_startup()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        policy.mode = "native"  # type: ignore[misc]
+
+
+def test_tc12_idempotent_returns_same_object_identity(monkeypatch):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "read")
+    first = ir.validate_interaction_rollout_at_startup()
+    second = ir.validate_interaction_rollout_at_startup()
+    assert first is second
+
+
+def test_tc13_uninitialized_singleton_raises_runtime_error_not_lazy_parse():
+    with pytest.raises(RuntimeError):
+        ir.get_interaction_rollout_policy()
+
+
+def test_tc14_trigger_in_allowlist_warns_but_does_not_raise(monkeypatch, caplog):
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "native")
+    monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, "trigger")
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.web.services.interaction_rollout"
+    ):
+        policy = ir.validate_interaction_rollout_at_startup()
+    assert policy.native_sources == frozenset({"trigger"})
+    assert any("no interactive responder" in r.message for r in caplog.records)
+
+
+def test_tc10a_origin_vocabulary_equals_check_constraint_in_list():
+    check = next(
+        c
+        for c in TaskInteractionRequest.__table__.constraints
+        if getattr(c, "name", None) == "ck_task_interaction_requests_origin"
+    )
+    values = frozenset(re.findall(r"'([^']+)'", check.sqltext.text))
+    assert INTERACTION_ORIGIN_VOCABULARY == values
+
+
+def test_tc10b_task_source_literals_is_a_strict_subset_of_vocabulary():
+    assert TASK_SOURCE_LITERALS <= INTERACTION_ORIGIN_VOCABULARY
+    assert TASK_SOURCE_LITERALS != INTERACTION_ORIGIN_VOCABULARY
+    assert INTERACTION_ORIGIN_VOCABULARY - TASK_SOURCE_LITERALS == {"internal"}
+
+
+def test_tc10c_gating_sources_is_origin_vocabulary_plus_channel_only():
+    assert ir.INTERACTION_GATING_SOURCES >= INTERACTION_ORIGIN_VOCABULARY
+    assert ir.INTERACTION_GATING_SOURCES - INTERACTION_ORIGIN_VOCABULARY == {"channel"}
+
+
+# ---------------------------------------------------------------------------
+# T-S: Task.source normalization -- LIVE spec, no strip/lower
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_ts1_falsy_normalizes_to_internal(value):
+    assert normalize_interaction_origin(value) == "internal"
+
+
+def test_ts2_whitespace_only_is_unknown_not_internal():
+    assert normalize_interaction_origin("   ") is None
+
+
+@pytest.mark.parametrize(
+    "value", ["internal", "sdk", "a2a", "trigger", "widget", "shared_link"]
+)
+def test_ts3_exact_vocabulary_matches_pass_through(value):
+    assert normalize_interaction_origin(value) == value
+
+
+@pytest.mark.parametrize("value", [" sdk", "SDK", "sdk "])
+def test_ts4_near_matches_are_unknown_not_coerced(value):
+    assert normalize_interaction_origin(value) is None
+
+
+def test_ts5_unrecognized_free_text_is_unknown_not_internal():
+    assert normalize_interaction_origin("something-else") is None
+
+
+def test_ts6_env_side_source_list_still_strips_and_lowers(monkeypatch):
+    monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, " SDK , a2a")
+    assert config.get_interaction_native_sources() == ["sdk", "a2a"]

--- a/tests/web/services/test_interaction_rollout_gate.py
+++ b/tests/web/services/test_interaction_rollout_gate.py
@@ -1,0 +1,205 @@
+"""Publication gate decision logic: guard order is the contract."""
+
+from __future__ import annotations
+
+import ast
+import inspect as pyinspect
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import xagent.web.services.interaction_rollout as ir
+from tests.web.services.task_interaction_schema_shared import (
+    tables_excluding_interaction_requests,
+)
+from xagent.web.models.database import Base
+from xagent.web.services.ops_signals import (
+    INTERACTION_ROLLOUT_SCHEMA_ABSENT,
+    INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE,
+    active_degradations,
+    clear_degradation,
+)
+
+
+class _FakeTask:
+    """Duck-typed stand-in: the gate only ever reads .source/.channel_id/.id."""
+
+    def __init__(self, source, channel_id=None, id=1):  # noqa: A002 - matches Task.id
+        self.source = source
+        self.channel_id = channel_id
+        self.id = id
+
+
+class _PoisonSession:
+    """Raises on any DB access -- proves the gate never reached the query step."""
+
+    def connection(self):
+        raise AssertionError("gate must not touch the database at this step")
+
+    def execute(self, *args, **kwargs):
+        raise AssertionError("gate must not touch the database at this step")
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    monkeypatch.setattr(ir, "_policy", None)
+    ir._counters.clear()
+    clear_degradation(INTERACTION_ROLLOUT_SCHEMA_ABSENT)
+    clear_degradation(INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE)
+    yield
+    monkeypatch.setattr(ir, "_policy", None)
+    ir._counters.clear()
+    clear_degradation(INTERACTION_ROLLOUT_SCHEMA_ABSENT)
+    clear_degradation(INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE)
+
+
+def _set_policy(monkeypatch, *, mode="native", native_sources=frozenset()):
+    monkeypatch.setattr(
+        ir,
+        "_policy",
+        ir.InteractionRolloutPolicy(
+            mode=mode,
+            native_sources=frozenset(native_sources),
+            native_protocol_version=1,
+        ),
+    )
+
+
+@pytest.fixture()
+def sqlite_session_with_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'with_table.db'}")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture()
+def sqlite_session_without_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'without_table.db'}")
+    Base.metadata.create_all(
+        bind=engine, tables=tables_excluding_interaction_requests()
+    )
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.mark.parametrize("non_native_mode", ["legacy", "read"])
+def test_tg1_tg2_non_native_modes_block_with_zero_queries(monkeypatch, non_native_mode):
+    _set_policy(monkeypatch, mode=non_native_mode)
+    decision = ir.evaluate_native_publication(_PoisonSession(), _FakeTask("sdk"))
+    assert decision is ir.NativePublicationDecision.BLOCKED_MODE
+
+
+def test_tg3_native_mode_unknown_source_blocks_zero_queries_registers_degradation(
+    monkeypatch,
+):
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    decision = ir.evaluate_native_publication(_PoisonSession(), _FakeTask("bogus"))
+    assert decision is ir.NativePublicationDecision.BLOCKED_UNKNOWN_SOURCE
+    assert INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE in active_degradations()
+
+
+def test_tg4_native_mode_disallowed_known_source_blocks_zero_queries_no_unknown_degradation(
+    monkeypatch,
+):
+    _set_policy(monkeypatch, mode="native", native_sources={"a2a"})
+    decision = ir.evaluate_native_publication(_PoisonSession(), _FakeTask("sdk"))
+    assert decision is ir.NativePublicationDecision.BLOCKED_SOURCE
+    assert INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE not in active_degradations()
+
+
+def test_tg5_native_mode_allowed_source_table_absent_blocks_with_degradation(
+    monkeypatch, sqlite_session_without_table
+):
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    decision = ir.evaluate_native_publication(
+        sqlite_session_without_table, _FakeTask("sdk")
+    )
+    assert decision is ir.NativePublicationDecision.BLOCKED_SCHEMA_ABSENT
+    assert INTERACTION_ROLLOUT_SCHEMA_ABSENT in active_degradations()
+
+
+def test_tg6_native_mode_allowed_source_table_present_is_allowed_no_origin_field(
+    monkeypatch, sqlite_session_with_table
+):
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    decision = ir.evaluate_native_publication(
+        sqlite_session_with_table, _FakeTask("sdk")
+    )
+    assert decision is ir.NativePublicationDecision.ALLOWED
+    assert decision.protocol_version == 1
+    assert not hasattr(decision, "origin")
+
+
+def test_tg7_none_source_with_no_channel_allowed_as_internal(
+    monkeypatch, sqlite_session_with_table
+):
+    _set_policy(monkeypatch, mode="native", native_sources={"internal"})
+    decision = ir.evaluate_native_publication(
+        sqlite_session_with_table, _FakeTask(None, channel_id=None)
+    )
+    assert decision is ir.NativePublicationDecision.ALLOWED
+
+
+def test_tg8_policy_singleton_identity_stable_after_env_mutated(monkeypatch):
+    import xagent.config as config
+
+    monkeypatch.delenv(config.INTERACTION_NATIVE_SOURCES, raising=False)
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "legacy")
+    ir.validate_interaction_rollout_at_startup()
+    policy_before = ir.get_interaction_rollout_policy()
+
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "native")
+    monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, "sdk")
+
+    policy_after = ir.get_interaction_rollout_policy()
+    assert policy_after is policy_before
+    assert policy_after.mode == "legacy"
+
+    decision = ir.evaluate_native_publication(_PoisonSession(), _FakeTask("sdk"))
+    assert decision is ir.NativePublicationDecision.BLOCKED_MODE
+
+
+def test_tg10_counters_increment_only_the_matching_outcome(
+    monkeypatch, sqlite_session_with_table, sqlite_session_without_table
+):
+    _set_policy(monkeypatch, mode="legacy")
+    ir.evaluate_native_publication(_PoisonSession(), _FakeTask("sdk"))
+    assert ir.counters_snapshot() == {ir.COUNTER_ROLLOUT_DECISION_BLOCKED_MODE: 1}
+    ir._counters.clear()
+
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    ir.evaluate_native_publication(_PoisonSession(), _FakeTask("bogus"))
+    assert ir.counters_snapshot() == {
+        ir.COUNTER_ROLLOUT_DECISION_BLOCKED_UNKNOWN_SOURCE: 1
+    }
+    ir._counters.clear()
+
+    ir.evaluate_native_publication(_PoisonSession(), _FakeTask("a2a"))
+    assert ir.counters_snapshot() == {ir.COUNTER_ROLLOUT_DECISION_BLOCKED_SOURCE: 1}
+    ir._counters.clear()
+
+    ir.evaluate_native_publication(sqlite_session_without_table, _FakeTask("sdk"))
+    assert ir.counters_snapshot() == {
+        ir.COUNTER_ROLLOUT_DECISION_BLOCKED_SCHEMA_ABSENT: 1
+    }
+    ir._counters.clear()
+
+    ir.evaluate_native_publication(sqlite_session_with_table, _FakeTask("sdk"))
+    assert ir.counters_snapshot() == {ir.COUNTER_ROLLOUT_DECISION_ALLOWED: 1}
+
+
+def test_tg11_gate_function_body_has_no_try_except():
+    source = pyinspect.getsource(ir.evaluate_native_publication)
+    tree = ast.parse(source)
+    func = tree.body[0]
+    assert isinstance(func, ast.FunctionDef)
+    for node in ast.walk(func):
+        assert not isinstance(node, ast.Try), (
+            "gate must not silently degrade via try/except"
+        )

--- a/tests/web/services/test_interaction_rollout_gate.py
+++ b/tests/web/services/test_interaction_rollout_gate.py
@@ -136,6 +136,26 @@ def test_tg6_native_mode_allowed_source_table_present_is_allowed_no_origin_field
     assert not hasattr(decision, "origin")
 
 
+def test_tg6b_unknown_source_degradation_survives_a_later_allowed_decision(
+    monkeypatch, sqlite_session_with_table
+):
+    """Pins the deliberate no-auto-clear deviation: SCHEMA_ABSENT is cleared
+    on every ALLOWED decision (test_tg6 exercises that path directly), but
+    UNKNOWN_TASK_SOURCE is never touched by any decision other than the one
+    that raised it -- an unrelated task later clearing to ALLOWED must not
+    erase a still-unexplained unrecognized source on a different task.
+    """
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    ir.evaluate_native_publication(sqlite_session_with_table, _FakeTask("bogus", id=1))
+    assert INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE in active_degradations()
+
+    decision = ir.evaluate_native_publication(
+        sqlite_session_with_table, _FakeTask("sdk", id=2)
+    )
+    assert decision is ir.NativePublicationDecision.ALLOWED
+    assert INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE in active_degradations()
+
+
 def test_tg7_none_source_with_no_channel_allowed_as_internal(
     monkeypatch, sqlite_session_with_table
 ):

--- a/tests/web/services/test_interaction_rollout_guards.py
+++ b/tests/web/services/test_interaction_rollout_guards.py
@@ -381,8 +381,8 @@ def test_tw3a_source_literals_are_a_subset_of_task_source_literals():
 
 # Named, exact -- not a wildcard rule. Each is a bot/handler setting its
 # *own* instance attribute (self.channel_id), unrelated to any Task ORM
-# row; audited as the complete set at the pinned baseline (see the task
-# book's fact audit). Paths are relative to src/xagent/web.
+# row; audited as the complete set at the pinned baseline. Paths are
+# relative to src/xagent/web.
 _TASK_ATTRIBUTE_MUTATION_EXEMPT_SITES = frozenset(
     {
         ("channels/feishu/bot.py", "channel_id"),
@@ -435,7 +435,15 @@ def test_tw3b_no_post_construction_mutation_outside_the_named_self_exemption():
         for path, _lineno, attr, is_self in hits
         if is_self
     }
+    added = self_sites - _TASK_ATTRIBUTE_MUTATION_EXEMPT_SITES
+    removed = _TASK_ATTRIBUTE_MUTATION_EXEMPT_SITES - self_sites
     assert self_sites == _TASK_ATTRIBUTE_MUTATION_EXEMPT_SITES, (
-        f"the self-attribute exemption set drifted from the audited 4 "
-        f"sites: found {self_sites}"
+        "self-attribute exemption set drifted from the audited baseline. "
+        f"New site(s) found that are not yet exempted: {added or '{}'} -- "
+        "this is expected when a new bot class assigns its own "
+        "self.source/self.channel_id; after confirming the receiver is not "
+        "a Task row, add the file to "
+        "_TASK_ATTRIBUTE_MUTATION_EXEMPT_SITES. "
+        f"Previously-exempted site(s) no longer found: {removed or '{}'} -- "
+        "the exemption set must shrink to drop them."
     )

--- a/tests/web/services/test_interaction_rollout_guards.py
+++ b/tests/web/services/test_interaction_rollout_guards.py
@@ -1,0 +1,441 @@
+"""Static AST guards enforcing the hard invariant: the interaction rollout
+mode can decide whether a NEW native row gets produced, and nothing else.
+It can never affect how an already-published row is read, answered, or
+closed. Covers the import/reference guards on read-side consumers, the
+counted-call-site guards on the module's own public symbols, and the
+guard machinery's own self-check.
+
+Everything here parses real source files with the standard library ``ast``
+module under whatever interpreter runs pytest. This suite must run under
+Python >= 3.11: the codebase uses ``match`` statements elsewhere, which an
+older stdlib ``ast`` cannot parse, and a parse failure in this suite must
+fail loudly (see test_tw4 below), never silently skip a file.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+import xagent.web.api.a2a as a2a_module
+import xagent.web.api.chat as chat_module
+import xagent.web.api.websocket as websocket_module
+import xagent.web.models.task_interaction as task_interaction_module
+import xagent.web.services.chat_history_service as chat_history_service_module
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="AST guards require Python >= 3.11 to parse this codebase's syntax",
+)
+
+# ---------------------------------------------------------------------------
+# Import guard: the module half (three modules, zero import expected)
+# ---------------------------------------------------------------------------
+
+_IMPORT_GUARD_MODULES = {
+    "chat.py": chat_module,
+    "chat_history_service.py": chat_history_service_module,
+    "a2a.py": a2a_module,
+}
+
+# websocket.py is explicitly, by name, exempted from the module-half check:
+# it hosts both a read-side consumer (_load_historical_stream_snapshot_sync)
+# and two finalizers that will eventually need to import interaction_rollout
+# once the gate is wired into task finalization. A guard that would be
+# deleted the day that wiring lands is not a guard worth having at the
+# module level -- see the function-half check below, which covers this
+# module with an assertion that survives that wiring.
+_WEBSOCKET_IMPORT_EXEMPTION = frozenset({"websocket.py"})
+
+
+def _module_source_path(module) -> Path:
+    return Path(module.__file__)
+
+
+def _imports_interaction_rollout(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any("interaction_rollout" in alias.name for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and "interaction_rollout" in node.module:
+                return True
+            if any("interaction_rollout" in alias.name for alias in node.names):
+                return True
+    return False
+
+
+def _parse(path: Path) -> ast.Module:
+    source = path.read_text()
+    try:
+        return ast.parse(source, filename=str(path))
+    except SyntaxError as exc:  # pragma: no cover - guard self-check below
+        raise AssertionError(f"failed to parse {path}: {exc}") from exc
+
+
+@pytest.mark.parametrize("label", sorted(_IMPORT_GUARD_MODULES))
+def test_tw1a_import_guard_modules_do_not_import_interaction_rollout(label):
+    module = _IMPORT_GUARD_MODULES[label]
+    tree = _parse(_module_source_path(module))
+    assert not _imports_interaction_rollout(tree), (
+        f"{label} must not import interaction_rollout: read-side consumers "
+        "and close-side statements must stay unaware of the rollout mode "
+        "(see the module docstring's hard invariant)"
+    )
+
+
+def test_tw1c_websocket_module_half_exemption_is_named_and_exactly_one_module():
+    assert _WEBSOCKET_IMPORT_EXEMPTION == {"websocket.py"}
+
+
+# ---------------------------------------------------------------------------
+# Reference guard: the function half (websocket.py's replacement for
+# module-level zero-import: 5 closure seeds, own-scope-only banned-name scan)
+# ---------------------------------------------------------------------------
+
+_BANNED_NAMES = frozenset(
+    {
+        "interaction_rollout",
+        "evaluate_native_publication",
+        "get_interaction_rollout_policy",
+        # Included even though the production call-count guard below would
+        # also catch a read-side consumer calling this: a fail-closed guard
+        # should never depend on a second guard to notice the same
+        # violation.
+        "validate_interaction_rollout_at_startup",
+        "InteractionRolloutPolicy",
+    }
+)
+
+# The 5 closure seeds are not 3: get_task and get_task_status's own bodies
+# (the code outside their nested _get_task_sync / _get_task_status_sync
+# definitions) are themselves part of the read path -- they are the
+# *callers* of the nested sync functions, not reachable *from* them, so a
+# scan that only checked the 3 innermost functions would miss a banned name
+# referenced directly in the outer function body.
+_CLOSURE_SEEDS = [
+    ("chat.py", "get_task"),
+    ("chat.py", "get_task._get_task_sync"),
+    ("chat.py", "get_task_status"),
+    ("chat.py", "get_task_status._get_task_status_sync"),
+    ("websocket.py", "_load_historical_stream_snapshot_sync"),
+]
+
+_SOURCE_BY_LABEL = {
+    "chat.py": chat_module,
+    "websocket.py": websocket_module,
+}
+
+
+def _direct_scope_functions(scope) -> list:
+    """Function/async-function defs belonging to ``scope``'s own scope.
+
+    Walks through control-flow wrappers (``try``/``if``/``with``/loops --
+    none of which introduce a new Python scope) but does not descend into a
+    further-nested function or class body. ``_get_task_sync`` sits inside a
+    ``try:`` block directly in ``get_task``'s body, so a check that only
+    looked at immediate AST children (``ast.iter_child_nodes(scope)``, no
+    deeper) would silently never find it -- exactly the failure mode this
+    helper (and the ast.walk-based approach in general) exists to avoid.
+    """
+    results = []
+
+    def _walk(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                results.append(child)
+                # A new scope -- do not look inside it for *this* scope's
+                # functions; it gets scanned separately under its own name.
+            elif isinstance(child, ast.ClassDef):
+                pass  # a new scope; irrelevant to this codebase's shape here
+            else:
+                _walk(child)
+
+    _walk(scope)
+    return results
+
+
+def _find_qualified_function(tree: ast.Module, qualname: str):
+    """Resolve a dotted qualname (``outer.inner``) to its FunctionDef node.
+
+    Not a Module.body-only lookup: ``_get_task_sync`` and
+    ``_get_task_status_sync`` are nested one level deep inside a ``try:``
+    block, and a shallow walk would silently never find them.
+    """
+    parts = qualname.split(".")
+    scope = tree
+    found = None
+    for index, name in enumerate(parts):
+        candidates = _direct_scope_functions(scope)
+        found = next((c for c in candidates if c.name == name), None)
+        if found is None:
+            raise AssertionError(
+                f"function {qualname!r} not found (stuck resolving "
+                f"part {index} = {name!r})"
+            )
+        scope = found
+    return found
+
+
+def _own_scope_identifiers(func_node) -> set[str]:
+    """Every Name id / Attribute attr referenced in this function's own
+    body -- not descending into further-nested function definitions, which
+    get scanned separately under their own qualified name. Without this
+    exclusion, an outer function would be flagged for merely *containing*
+    a banned reference inside an inner definition, turning a real guard
+    into noise on the first unrelated nested helper."""
+    identifiers: set[str] = set()
+
+    class _Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node):  # noqa: N802 - ast visitor API
+            if node is func_node:
+                self.generic_visit(node)
+            # else: a deeper nested def -- belongs to its own scope, skip.
+
+        def visit_AsyncFunctionDef(self, node):  # noqa: N802
+            self.visit_FunctionDef(node)
+
+        def visit_Name(self, node):  # noqa: N802
+            identifiers.add(node.id)
+
+        def visit_Attribute(self, node):  # noqa: N802
+            identifiers.add(node.attr)
+            self.generic_visit(node)
+
+    _Visitor().visit(func_node)
+    return identifiers
+
+
+def _scan_closure_for_banned_names() -> dict[str, set[str]]:
+    """For each of the 5 closure seeds, the banned names (if any) found in
+    its own scope. Real production files, always re-parsed from disk."""
+    hits: dict[str, set[str]] = {}
+    trees = {
+        label: _parse(_module_source_path(module))
+        for label, module in _SOURCE_BY_LABEL.items()
+    }
+    for label, qualname in _CLOSURE_SEEDS:
+        func_node = _find_qualified_function(trees[label], qualname)
+        found = _own_scope_identifiers(func_node) & _BANNED_NAMES
+        if found:
+            hits[f"{label}::{qualname}"] = found
+    return hits
+
+
+def test_tw1b_closure_seeds_reference_no_banned_names():
+    # _get_task_sync / _get_task_status_sync sit one level inside a `try:`
+    # block in get_task / get_task_status, not as direct ast.Module.body
+    # children -- a scanner that only checked Module.body would silently
+    # never find either one, turning this into an always-green false guard.
+    # _find_qualified_function (used above to resolve the 5 closure seeds)
+    # walks through control-flow wrappers for exactly this reason.
+    hits = _scan_closure_for_banned_names()
+    assert hits == {}, f"read-side consumer(s) reference the rollout module: {hits}"
+
+
+# ---------------------------------------------------------------------------
+# The guard machinery's own self-check -- a parse failure must fail loudly
+# ---------------------------------------------------------------------------
+
+
+def test_tw4_syntax_error_in_a_scanned_file_fails_loudly(tmp_path):
+    broken = tmp_path / "broken.py"
+    broken.write_text("def f(:\n    pass\n")
+    with pytest.raises(AssertionError):
+        _parse(broken)
+
+
+# ---------------------------------------------------------------------------
+# Counted-call-site guards: production symbols (src/, excluding tests/)
+# ---------------------------------------------------------------------------
+
+
+def _src_root() -> Path:
+    # xagent.web.api.chat is .../src/xagent/web/api/chat.py
+    return _module_source_path(chat_module).parents[2]
+
+
+def _iter_src_files():
+    root = _src_root()
+    for path in sorted(root.rglob("*.py")):
+        yield path
+
+
+def _count_calls(symbol: str) -> list[tuple[Path, int]]:
+    hits: list[tuple[Path, int]] = []
+    for path in _iter_src_files():
+        tree = _parse(path)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == symbol:
+                hits.append((path, node.lineno))
+            elif isinstance(func, ast.Attribute) and func.attr == symbol:
+                hits.append((path, node.lineno))
+    return hits
+
+
+def test_tw2a_evaluate_native_publication_has_zero_production_callers():
+    hits = _count_calls("evaluate_native_publication")
+    assert hits == [], f"unexpected production caller(s): {hits}"
+
+
+_GET_POLICY_SITE_WHITELIST = {
+    ("app.py", "readiness_check"),
+    ("admin_interaction_rollout.py", "get_interaction_rollout_diagnostics"),
+}
+
+
+def _enclosing_function_name(tree: ast.Module, lineno: int) -> str | None:
+    best = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start = node.lineno
+            end = max(
+                (getattr(n, "lineno", start) for n in ast.walk(node)), default=start
+            )
+            if start <= lineno <= end:
+                if best is None or start > best.lineno:
+                    best = node
+    return best.name if best is not None else None
+
+
+def test_tw2c_get_interaction_rollout_policy_has_at_most_two_whitelisted_sites():
+    hits = _count_calls("get_interaction_rollout_policy")
+    seen = set()
+    for path, lineno in hits:
+        tree = _parse(path)
+        func_name = _enclosing_function_name(tree, lineno)
+        seen.add((path.name, func_name))
+
+    assert len(hits) <= 2, f"more than 2 call sites: {hits}"
+    for site in seen:
+        assert site in _GET_POLICY_SITE_WHITELIST, f"unlisted call site: {site}"
+
+
+def test_tw2c_ii_fewer_than_two_sites_is_allowed_and_only_informational():
+    """A count of 1 (e.g. if the admin diagnostics endpoint were split into
+    its own PR) must not fail this guard -- only a site outside the
+    whitelist, or more than 2 sites total, may fail it."""
+    hits = _count_calls("get_interaction_rollout_policy")
+    # This branch ships both whitelisted sites, so today's count is 2 --
+    # this assertion documents that a future count of 1 remains valid too,
+    # for whenever one of the two call sites moves to a later change.
+    assert len(hits) in (1, 2)
+
+
+def test_tw2d_validate_interaction_rollout_at_startup_has_exactly_one_caller():
+    hits = _count_calls("validate_interaction_rollout_at_startup")
+    assert len(hits) == 1, f"expected exactly 1 production caller, got: {hits}"
+    path, _ = hits[0]
+    assert path.name == "app.py"
+
+
+# ---------------------------------------------------------------------------
+# Task.source construction literals and post-construction mutation
+# ---------------------------------------------------------------------------
+
+
+def _source_literal_call_sites() -> list[tuple[Path, int, str]]:
+    """Every ``source=`` / ``task_source=`` keyword whose value is a string
+    literal, scoped to ``src/xagent/web`` (the audited scope -- scanning by
+    keyword name rather than by callee, since Task.source is written
+    through several different call targets, not just ``Task(...)``; a
+    callee-restricted scan would silently miss most of them). The
+    migrations directory is excluded even though it is part of that
+    audited scope: historical backfills are allowed to write retired
+    literals current code no longer produces, and a scan that is not
+    kwarg-name-scoped elsewhere in the tree would pick up unrelated APIs
+    that happen to share the same keyword name (e.g. a "source" kwarg on
+    an entirely unrelated personal-database helper)."""
+    hits: list[tuple[Path, int, str]] = []
+    root = _src_root() / "web"
+    for path in sorted(root.rglob("*.py")):
+        if "migrations" in path.parts:
+            continue
+        tree = _parse(path)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for kw in node.keywords:
+                if kw.arg in ("source", "task_source") and isinstance(
+                    kw.value, ast.Constant
+                ):
+                    if isinstance(kw.value.value, str):
+                        hits.append((path, node.lineno, kw.value.value))
+    return hits
+
+
+def test_tw3a_source_literals_are_a_subset_of_task_source_literals():
+    hits = _source_literal_call_sites()
+    literals = {value for _, _, value in hits}
+    assert literals <= task_interaction_module.TASK_SOURCE_LITERALS, (
+        f"literal(s) outside TASK_SOURCE_LITERALS: "
+        f"{literals - task_interaction_module.TASK_SOURCE_LITERALS}"
+    )
+
+
+# Named, exact -- not a wildcard rule. Each is a bot/handler setting its
+# *own* instance attribute (self.channel_id), unrelated to any Task ORM
+# row; audited as the complete set at the pinned baseline (see the task
+# book's fact audit). Paths are relative to src/xagent/web.
+_TASK_ATTRIBUTE_MUTATION_EXEMPT_SITES = frozenset(
+    {
+        ("channels/feishu/bot.py", "channel_id"),
+        ("channels/slack/bot.py", "channel_id"),
+        ("channels/slack/trace_handler.py", "channel_id"),
+        ("channels/telegram/bot.py", "channel_id"),
+    }
+)
+
+
+def _attribute_assignments(
+    attr_names: tuple[str, ...],
+) -> list[tuple[Path, int, str, bool]]:
+    """Every assignment to ``x.<attr> = ...`` / ``x.<attr> += ...`` in
+    src/xagent/web where ``<attr>`` is one of ``attr_names``, tagged with
+    whether the receiver ``x`` is ``self``. Receiver is not filtered out at
+    collection time -- the self/non-self split is the test's job, so a
+    drift in which sites are self-only is visible instead of silently
+    never collected."""
+    hits: list[tuple[Path, int, str, bool]] = []
+    web_root = _src_root() / "web"
+    for path in sorted(web_root.rglob("*.py")):
+        tree = _parse(path)
+        for node in ast.walk(tree):
+            targets = []
+            if isinstance(node, ast.Assign):
+                targets = node.targets
+            elif isinstance(node, ast.AugAssign):
+                targets = [node.target]
+            for target in targets:
+                if isinstance(target, ast.Attribute) and target.attr in attr_names:
+                    is_self = (
+                        isinstance(target.value, ast.Name) and target.value.id == "self"
+                    )
+                    hits.append((path, node.lineno, target.attr, is_self))
+    return hits
+
+
+def test_tw3b_no_post_construction_mutation_outside_the_named_self_exemption():
+    hits = _attribute_assignments(("source", "channel_id"))
+    web_root = _src_root() / "web"
+
+    non_self = [
+        (path, lineno, attr) for path, lineno, attr, is_self in hits if not is_self
+    ]
+    assert non_self == [], f"non-self post-construction mutation(s) found: {non_self}"
+
+    self_sites = {
+        (str(path.relative_to(web_root)), attr)
+        for path, _lineno, attr, is_self in hits
+        if is_self
+    }
+    assert self_sites == _TASK_ATTRIBUTE_MUTATION_EXEMPT_SITES, (
+        f"the self-attribute exemption set drifted from the audited 4 "
+        f"sites: found {self_sites}"
+    )

--- a/tests/web/services/test_interaction_rollout_guards.py
+++ b/tests/web/services/test_interaction_rollout_guards.py
@@ -107,6 +107,13 @@ _BANNED_NAMES = frozenset(
         # violation.
         "validate_interaction_rollout_at_startup",
         "InteractionRolloutPolicy",
+        # The module-private accessor and its backing singleton: a
+        # read-side consumer reaching for either one bypasses the public
+        # accessor (and its own fail-fast check) entirely, so both must be
+        # banned directly rather than relying on the public name alone to
+        # catch it.
+        "_require_policy",
+        "_policy",
     }
 )
 
@@ -305,6 +312,10 @@ def _enclosing_function_name(tree: ast.Module, lineno: int) -> str | None:
 
 
 def test_tw2c_get_interaction_rollout_policy_has_at_most_two_whitelisted_sites():
+    # The bound is <=2, not ==2, on purpose: a count of 1 (e.g. if the admin
+    # diagnostics endpoint moved into its own later change) must stay valid
+    # too -- only a site outside the whitelist, or more than 2 sites total,
+    # may fail this guard.
     hits = _count_calls("get_interaction_rollout_policy")
     seen = set()
     for path, lineno in hits:
@@ -315,17 +326,6 @@ def test_tw2c_get_interaction_rollout_policy_has_at_most_two_whitelisted_sites()
     assert len(hits) <= 2, f"more than 2 call sites: {hits}"
     for site in seen:
         assert site in _GET_POLICY_SITE_WHITELIST, f"unlisted call site: {site}"
-
-
-def test_tw2c_ii_fewer_than_two_sites_is_allowed_and_only_informational():
-    """A count of 1 (e.g. if the admin diagnostics endpoint were split into
-    its own PR) must not fail this guard -- only a site outside the
-    whitelist, or more than 2 sites total, may fail it."""
-    hits = _count_calls("get_interaction_rollout_policy")
-    # This branch ships both whitelisted sites, so today's count is 2 --
-    # this assertion documents that a future count of 1 remains valid too,
-    # for whenever one of the two call sites moves to a later change.
-    assert len(hits) in (1, 2)
 
 
 def test_tw2d_validate_interaction_rollout_at_startup_has_exactly_one_caller():

--- a/tests/web/services/test_interaction_rollout_vocabulary.py
+++ b/tests/web/services/test_interaction_rollout_vocabulary.py
@@ -1,0 +1,154 @@
+"""Vocabulary pairings and the synthetic "channel" gating key.
+
+Two related checks are intentionally not implemented here: verifying how
+a sibling staging module binds against this vocabulary, and its
+behavior when gated on the synthetic "channel" key. That module does not
+exist yet on this branch, so there is nothing to test against --
+whichever change introduces it is responsible for adding that coverage
+alongside its own guards.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import xagent.web.services.interaction_rollout as ir
+from xagent.web.models.database import Base
+from xagent.web.models.task_interaction import (
+    INTERACTION_ORIGIN_VOCABULARY,
+    TaskInteractionRequest,
+)
+
+
+class _FakeTask:
+    def __init__(self, source, channel_id=None):
+        self.source = source
+        self.channel_id = channel_id
+
+
+def test_tv1_gating_sources_superset_with_channel_as_the_only_addition():
+    assert ir.INTERACTION_GATING_SOURCES >= INTERACTION_ORIGIN_VOCABULARY
+    assert ir.INTERACTION_GATING_SOURCES - INTERACTION_ORIGIN_VOCABULARY == {"channel"}
+
+
+def test_tv2a_channel_is_not_in_origin_vocabulary_or_the_origin_check():
+    assert "channel" not in INTERACTION_ORIGIN_VOCABULARY
+
+    check = next(
+        c
+        for c in TaskInteractionRequest.__table__.constraints
+        if getattr(c, "name", None) == "ck_task_interaction_requests_origin"
+    )
+    import re
+
+    values = set(re.findall(r"'([^']+)'", check.sqltext.text))
+    assert "channel" not in values
+
+
+@pytest.mark.parametrize(
+    "source,channel_id,expected",
+    [
+        (None, 7, "channel"),
+        (None, None, "internal"),
+        ("shared_link", None, "shared_link"),
+    ],
+)
+def test_tv3_tv5_tv6_gating_key_direct_lookups(source, channel_id, expected):
+    assert ir.gating_key(_FakeTask(source, channel_id=channel_id)) == expected
+
+
+def test_tv4_widget_source_with_channel_id_keeps_widget_key_not_channel():
+    """An explicit non-internal origin must never be swallowed into the
+    synthetic 'channel' bucket just because channel_id happens to be set --
+    a widget task can carry a non-null channel_id too. Kept as its own
+    test (not folded into the parametrized lookup table above): this is
+    the core regression this rollout's design exists to guard, not a
+    routine lookup."""
+    assert ir.gating_key(_FakeTask("widget", channel_id=7)) == "widget"
+
+
+@pytest.fixture()
+def sqlite_session_with_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'with_table.db'}")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    monkeypatch.setattr(ir, "_policy", None)
+    ir._counters.clear()
+    yield
+    monkeypatch.setattr(ir, "_policy", None)
+    ir._counters.clear()
+
+
+def test_tv7_internal_only_allowlist_does_not_let_channel_traffic_through(
+    monkeypatch, sqlite_session_with_table
+):
+    """The core regression this rollout exists to prevent: allowing
+    "internal" must not silently open the door for IM-channel traffic --
+    that traffic must be gated by its own "channel" entry."""
+    monkeypatch.setattr(
+        ir,
+        "_policy",
+        ir.InteractionRolloutPolicy(
+            mode="native",
+            native_sources=frozenset({"internal"}),
+            native_protocol_version=1,
+        ),
+    )
+    decision = ir.evaluate_native_publication(
+        sqlite_session_with_table, _FakeTask(None, channel_id=42)
+    )
+    assert decision is ir.NativePublicationDecision.BLOCKED_SOURCE
+
+
+def test_tv8_channel_gated_decision_has_internal_origin_not_leaked_into_audit_column():
+    """The gating key ("channel") must never leak out as if it were the
+    origin value that would be written to the origin column -- the
+    normalized origin underneath a channel-gated task is still
+    "internal"."""
+    from xagent.web.models.task_interaction import normalize_interaction_origin
+
+    task = _FakeTask(None, channel_id=42)
+    assert ir.gating_key(task) == "channel"
+    assert normalize_interaction_origin(task.source) == "internal"
+
+
+def test_tv9_gating_sources_definition_derives_from_origin_vocabulary_not_literals():
+    """AST assertion: the right-hand operand of the INTERACTION_GATING_SOURCES
+    assignment must name INTERACTION_ORIGIN_VOCABULARY, not
+    TASK_SOURCE_LITERALS -- deriving from the literals constant would drop
+    "internal" (absent from that constant today) from the gating vocabulary
+    entirely.
+    """
+    source = inspect.getsource(ir)
+    tree = ast.parse(source)
+
+    assign = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "INTERACTION_GATING_SOURCES"
+        ):
+            assign = node
+            break
+    assert assign is not None, "INTERACTION_GATING_SOURCES definition not found"
+
+    names_used = {n.id for n in ast.walk(assign.value) if isinstance(n, ast.Name)}
+    assert "INTERACTION_ORIGIN_VOCABULARY" in names_used, (
+        "retired sources are legitimate but dead entries -- they stay in the "
+        "gating vocabulary even after they stop producing new rows"
+    )
+    assert "TASK_SOURCE_LITERALS" not in names_used

--- a/tests/web/test_interaction_rollout_observability.py
+++ b/tests/web/test_interaction_rollout_observability.py
@@ -23,6 +23,11 @@ from sqlalchemy.orm import sessionmaker
 import xagent.web.models.database as database_module
 import xagent.web.services.interaction_rollout as ir
 from tests.web.services.task_interaction_schema_shared import (
+    assert_accepted,
+    make_row,
+    make_task,
+    make_trace_event,
+    make_user,
     tables_excluding_interaction_requests,
 )
 from xagent.web.api.admin_interaction_rollout import (
@@ -210,13 +215,18 @@ async def test_to4c_latch_negative_rechecks_every_probe(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 # Admin diagnostics endpoint
 #
-# SQLite only, deliberately: the active-row stats query
+# SQLite only, deliberately: the query itself
 # (SELECT count(*), min(created_at) FROM task_interaction_requests WHERE
 # status = 'active' AND active_slot IS NOT NULL) uses no PostgreSQL-specific
 # syntax -- no JSON operators, no ::casts, no RETURNING, nothing beyond
-# ANSI count()/min()/WHERE -- so its behavior does not vary by backend and
-# a PostgreSQL run would exercise nothing this SQLite run does not already
-# cover.
+# ANSI count()/min()/WHERE -- so the SQL dialect itself does not vary by
+# backend. What *does* vary is how each driver marshals the min(created_at)
+# result back into Python: PostgreSQL hands back a tz-aware datetime,
+# SQLite hands back a plain str. That difference is exactly why this suite
+# includes a non-empty-table cell (test_to6b below) in addition to the
+# empty-table cell (test_to6) -- an empty table never puts a value through
+# min(created_at) at all, so it cannot catch a mismatch between what the
+# query returns and what the age computation expects.
 # ---------------------------------------------------------------------------
 
 
@@ -253,6 +263,16 @@ def _regular_user() -> User:
 async def test_to5_non_admin_gets_403_with_exact_detail(
     monkeypatch, sqlite_session_with_table
 ):
+    # No 401 (missing/invalid/expired credentials) cell here: this suite
+    # calls the route function directly with a hand-built User, bypassing
+    # the get_current_user dependency entirely (see the module docstring),
+    # so there is no request to reject with 401 in the first place. That
+    # dependency is shared by every admin-authenticated endpoint in this
+    # codebase and its own 401 paths (missing, malformed, expired, and
+    # invalid tokens) are already covered by tests/web/test_auth_dependencies.py --
+    # this endpoint adds nothing to that behavior, so re-deriving it through
+    # a second TestClient + JWT harness here would test the shared
+    # dependency a second time, not this endpoint.
     _set_policy(monkeypatch, mode="legacy")
     with pytest.raises(HTTPException) as exc:
         await get_interaction_rollout_diagnostics(
@@ -280,6 +300,32 @@ async def test_to6_empty_table_returns_zero_active_count_and_no_oldest_age(
     assert response["active_count"] == 0
     assert response["oldest_age_seconds"] is None
     assert "schema_absent" not in response
+
+
+async def test_to6b_active_row_present_yields_positive_count_and_age(
+    monkeypatch, sqlite_session_with_table
+):
+    """Regression cell for the SQLite str-vs-datetime marshaling gap: SQLite
+    returns min(created_at) as a plain str, not a datetime, so the age
+    computation must accept both shapes (see the comment above this
+    section). An empty table never exercises this path.
+    """
+    _set_policy(monkeypatch, mode="legacy")
+    user_id = make_user(sqlite_session_with_table)
+    task_id = make_task(sqlite_session_with_table, user_id=user_id)
+    anchor_id = make_trace_event(sqlite_session_with_table, task_id=task_id)
+    assert_accepted(
+        sqlite_session_with_table,
+        make_row(task_id=task_id, resume_trace_event_id=anchor_id),
+    )
+
+    response = await get_interaction_rollout_diagnostics(
+        current_user=_admin_user(), db=sqlite_session_with_table
+    )
+
+    assert response["active_count"] == 1
+    assert isinstance(response["oldest_age_seconds"], float)
+    assert response["oldest_age_seconds"] > 0
 
 
 async def test_to7_table_absent_returns_schema_absent_without_count_fields(

--- a/tests/web/test_interaction_rollout_observability.py
+++ b/tests/web/test_interaction_rollout_observability.py
@@ -1,0 +1,396 @@
+"""Observability surfaces for the interaction rollout gate: /health,
+/ready, and the admin diagnostics endpoint.
+
+/health and /ready are exercised by calling the route functions directly
+(``asyncio.run`` / ``await``), the same pattern
+``tests/web/test_health_degradations.py`` uses -- it avoids booting the
+full ASGI lifespan (and the real startup event) just to reach two plain
+async functions. The admin diagnostics endpoint is exercised the same way
+``tests/web/api/test_admin_users_hidden.py`` calls its own admin routes:
+directly, with a hand-built ``User``/``Session`` pair, rather than through
+TestClient + JWT headers.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import xagent.web.models.database as database_module
+import xagent.web.services.interaction_rollout as ir
+from tests.web.services.task_interaction_schema_shared import (
+    tables_excluding_interaction_requests,
+)
+from xagent.web.api.admin_interaction_rollout import (
+    get_interaction_rollout_diagnostics,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.user import User
+from xagent.web.services.ops_signals import (
+    INTERACTION_ROLLOUT_SCHEMA_ABSENT,
+    INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE,
+    active_degradations,
+    clear_degradation,
+)
+
+app_module = import_module("xagent.web.app")
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    monkeypatch.setattr(ir, "_policy", None)
+    monkeypatch.setattr(ir, "_native_schema_ready", False)
+    ir._counters.clear()
+    clear_degradation(INTERACTION_ROLLOUT_SCHEMA_ABSENT)
+    clear_degradation(INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE)
+    yield
+    monkeypatch.setattr(ir, "_policy", None)
+    monkeypatch.setattr(ir, "_native_schema_ready", False)
+    ir._counters.clear()
+    clear_degradation(INTERACTION_ROLLOUT_SCHEMA_ABSENT)
+    clear_degradation(INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE)
+
+
+def _set_policy(monkeypatch, *, mode="legacy", native_sources=frozenset()):
+    monkeypatch.setattr(
+        ir,
+        "_policy",
+        ir.InteractionRolloutPolicy(
+            mode=mode,
+            native_sources=frozenset(native_sources),
+            native_protocol_version=1,
+        ),
+    )
+
+
+class _PoisonSessionLocal:
+    def __call__(self):
+        raise AssertionError("must not open a DB session at this step")
+
+
+# ---------------------------------------------------------------------------
+# /health surfaces the two new signal names, never their detail
+# ---------------------------------------------------------------------------
+
+
+async def test_to1_health_surfaces_new_signal_names_but_not_detail():
+    import xagent.web.services.ops_signals as ops_signals
+
+    ops_signals.register_degradation(
+        INTERACTION_ROLLOUT_SCHEMA_ABSENT, "task_interaction_requests table absent"
+    )
+    ops_signals.register_degradation(
+        INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE, "task 42: unrecognized source"
+    )
+
+    payload = await app_module.health_check()
+
+    assert payload["status"] == "ok"
+    assert INTERACTION_ROLLOUT_SCHEMA_ABSENT in payload["degradations"]
+    assert INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE in payload["degradations"]
+    assert "task 42" not in str(payload)
+    assert "table absent" not in str(payload)
+
+
+# ---------------------------------------------------------------------------
+# /ready: default-mode passthrough, the native-mode schema check, and its
+# one-way latch in both directions
+# ---------------------------------------------------------------------------
+
+
+async def test_to2_default_mode_ready_behavior_is_unchanged_zero_queries(
+    monkeypatch,
+):
+    _set_policy(monkeypatch, mode="legacy")
+    monkeypatch.setattr(database_module, "get_session_local", _PoisonSessionLocal())
+    app_module.app.state.file_storage_startup_sync_task = None
+    app_module.app.state.file_storage_startup_sync_error = None
+
+    response = await app_module.readiness_check()
+
+    assert response.status_code == 200
+
+
+async def test_to3_native_mode_table_absent_returns_503_without_table_name(
+    monkeypatch, tmp_path
+):
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    app_module.app.state.file_storage_startup_sync_task = None
+    app_module.app.state.file_storage_startup_sync_error = None
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'no_table.db'}")
+    Base.metadata.create_all(
+        bind=engine, tables=tables_excluding_interaction_requests()
+    )
+    session_local = sessionmaker(bind=engine)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: session_local)
+
+    response = await app_module.readiness_check()
+
+    assert response.status_code == 503
+    body = response.body.decode()
+    assert "Interaction rollout schema not ready" in body
+    assert "task_interaction_requests" not in body
+
+
+async def test_to4_native_mode_table_present_returns_200_and_clears_degradation(
+    monkeypatch, tmp_path
+):
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    app_module.app.state.file_storage_startup_sync_task = None
+    app_module.app.state.file_storage_startup_sync_error = None
+    import xagent.web.services.ops_signals as ops_signals
+
+    ops_signals.register_degradation(
+        INTERACTION_ROLLOUT_SCHEMA_ABSENT, "task_interaction_requests table absent"
+    )
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'with_table.db'}")
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(bind=engine)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: session_local)
+
+    response = await app_module.readiness_check()
+
+    assert response.status_code == 200
+    assert INTERACTION_ROLLOUT_SCHEMA_ABSENT not in active_degradations()
+
+
+async def test_to4b_latch_positive_means_zero_queries_on_next_probe(
+    monkeypatch, tmp_path
+):
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    app_module.app.state.file_storage_startup_sync_task = None
+    app_module.app.state.file_storage_startup_sync_error = None
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'with_table.db'}")
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(bind=engine)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: session_local)
+
+    first = await app_module.readiness_check()
+    assert first.status_code == 200
+    assert ir.is_native_schema_ready() is True
+
+    # Second probe: swap in a poison session-factory. If the latch were not
+    # honored, this would raise instead of returning 200.
+    monkeypatch.setattr(database_module, "get_session_local", _PoisonSessionLocal())
+    second = await app_module.readiness_check()
+    assert second.status_code == 200
+
+
+async def test_to4c_latch_negative_rechecks_every_probe(monkeypatch, tmp_path):
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    app_module.app.state.file_storage_startup_sync_task = None
+    app_module.app.state.file_storage_startup_sync_error = None
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'absent.db'}")
+    Base.metadata.create_all(
+        bind=engine, tables=tables_excluding_interaction_requests()
+    )
+    session_local = sessionmaker(bind=engine)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: session_local)
+
+    first = await app_module.readiness_check()
+    assert first.status_code == 503
+    assert ir.is_native_schema_ready() is False
+
+    # Table shows up between probes (a migration applied while the process
+    # is running) -- the negative latch must re-query and see it.
+    Base.metadata.create_all(bind=engine)
+    second = await app_module.readiness_check()
+    assert second.status_code == 200
+    assert ir.is_native_schema_ready() is True
+
+
+# ---------------------------------------------------------------------------
+# Admin diagnostics endpoint
+#
+# SQLite only, deliberately: the active-row stats query
+# (SELECT count(*), min(created_at) FROM task_interaction_requests WHERE
+# status = 'active' AND active_slot IS NOT NULL) uses no PostgreSQL-specific
+# syntax -- no JSON operators, no ::casts, no RETURNING, nothing beyond
+# ANSI count()/min()/WHERE -- so its behavior does not vary by backend and
+# a PostgreSQL run would exercise nothing this SQLite run does not already
+# cover.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sqlite_session_with_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'diag_with_table.db'}")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture()
+def sqlite_session_without_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'diag_without_table.db'}")
+    Base.metadata.create_all(
+        bind=engine, tables=tables_excluding_interaction_requests()
+    )
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+def _admin_user() -> User:
+    return User(id=1, username="admin", password_hash="x", is_admin=True)
+
+
+def _regular_user() -> User:
+    return User(id=2, username="regular", password_hash="x", is_admin=False)
+
+
+async def test_to5_non_admin_gets_403_with_exact_detail(
+    monkeypatch, sqlite_session_with_table
+):
+    _set_policy(monkeypatch, mode="legacy")
+    with pytest.raises(HTTPException) as exc:
+        await get_interaction_rollout_diagnostics(
+            current_user=_regular_user(), db=sqlite_session_with_table
+        )
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Admin access required"
+
+
+async def test_to5_admin_gets_200(monkeypatch, sqlite_session_with_table):
+    _set_policy(monkeypatch, mode="legacy")
+    response = await get_interaction_rollout_diagnostics(
+        current_user=_admin_user(), db=sqlite_session_with_table
+    )
+    assert response["policy"]["mode"] == "legacy"
+
+
+async def test_to6_empty_table_returns_zero_active_count_and_no_oldest_age(
+    monkeypatch, sqlite_session_with_table
+):
+    _set_policy(monkeypatch, mode="legacy")
+    response = await get_interaction_rollout_diagnostics(
+        current_user=_admin_user(), db=sqlite_session_with_table
+    )
+    assert response["active_count"] == 0
+    assert response["oldest_age_seconds"] is None
+    assert "schema_absent" not in response
+
+
+async def test_to7_table_absent_returns_schema_absent_without_count_fields(
+    monkeypatch, sqlite_session_without_table
+):
+    _set_policy(monkeypatch, mode="legacy")
+    response = await get_interaction_rollout_diagnostics(
+        current_user=_admin_user(), db=sqlite_session_without_table
+    )
+    assert response["schema_absent"] is True
+    assert "active_count" not in response
+    assert "oldest_age_seconds" not in response
+
+
+async def test_to8_stats_query_exception_returns_503_not_a_fake_zero(
+    monkeypatch, sqlite_session_with_table
+):
+    _set_policy(monkeypatch, mode="legacy")
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated DB hiccup")
+
+    monkeypatch.setattr(sqlite_session_with_table, "execute", _raise)
+
+    with pytest.raises(HTTPException) as exc:
+        await get_interaction_rollout_diagnostics(
+            current_user=_admin_user(), db=sqlite_session_with_table
+        )
+    assert exc.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Counter registry snapshot isolation
+# ---------------------------------------------------------------------------
+
+
+def test_to9_counters_snapshot_is_a_copy_not_a_live_reference():
+    ir.increment_counter(ir.COUNTER_ROLLOUT_DECISION_ALLOWED)
+    snapshot = ir.counters_snapshot()
+    snapshot[ir.COUNTER_ROLLOUT_DECISION_ALLOWED] = 999
+    snapshot["bogus"] = 1
+
+    fresh = ir.counters_snapshot()
+    assert fresh[ir.COUNTER_ROLLOUT_DECISION_ALLOWED] == 1
+    assert "bogus" not in fresh
+
+
+def test_to9_counters_snapshot_concurrent_increments_total_correctly():
+    import threading
+
+    def _bump():
+        for _ in range(100):
+            ir.increment_counter(ir.COUNTER_ROLLOUT_DECISION_ALLOWED)
+
+    threads = [threading.Thread(target=_bump) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert ir.counters_snapshot()[ir.COUNTER_ROLLOUT_DECISION_ALLOWED] == 800
+
+
+# ---------------------------------------------------------------------------
+# Unconditional startup INFO log
+# ---------------------------------------------------------------------------
+
+
+def test_to10_startup_logs_resolved_policy_unconditionally(monkeypatch, caplog):
+    import logging
+
+    import xagent.config as config
+
+    monkeypatch.delenv(config.INTERACTION_PROTOCOL_MODE, raising=False)
+    monkeypatch.delenv(config.INTERACTION_NATIVE_SOURCES, raising=False)
+    monkeypatch.setattr(ir, "_policy", None)
+
+    with caplog.at_level(
+        logging.INFO, logger="xagent.web.services.interaction_rollout"
+    ):
+        ir.validate_interaction_rollout_at_startup()
+
+    assert any(
+        "Interaction rollout policy configured" in r.message for r in caplog.records
+    )
+    assert all(
+        r.levelno == logging.INFO
+        for r in caplog.records
+        if "Interaction rollout policy configured" in r.message
+    )
+
+
+# ---------------------------------------------------------------------------
+# Truncated repr of the offending Task.source in degradation detail
+# ---------------------------------------------------------------------------
+
+
+def test_to11_unknown_source_detail_is_repr_and_truncated_to_64_chars(
+    monkeypatch, sqlite_session_with_table
+):
+    class _FakeTask:
+        def __init__(self, source):
+            self.source = source
+            self.channel_id = None
+            self.id = 7
+
+    _set_policy(monkeypatch, mode="native", native_sources={"sdk"})
+    long_source = "x" * 500
+    ir.evaluate_native_publication(sqlite_session_with_table, _FakeTask(long_source))
+
+    detail = active_degradations()[INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE]
+    assert "..." in detail
+    # The embedded repr must be capped -- nowhere near the full 500 chars.
+    assert len(detail) < 200

--- a/tests/web/test_interaction_rollout_observability.py
+++ b/tests/web/test_interaction_rollout_observability.py
@@ -282,7 +282,7 @@ async def test_to5_non_admin_gets_403_with_exact_detail(
     assert exc.value.detail == "Admin access required"
 
 
-async def test_to5_admin_gets_200(monkeypatch, sqlite_session_with_table):
+async def test_to5b_admin_gets_200(monkeypatch, sqlite_session_with_table):
     _set_policy(monkeypatch, mode="legacy")
     response = await get_interaction_rollout_diagnostics(
         current_user=_admin_user(), db=sqlite_session_with_table
@@ -357,6 +357,31 @@ async def test_to8_stats_query_exception_returns_503_not_a_fake_zero(
     assert exc.value.status_code == 503
 
 
+async def test_to8b_connection_error_before_table_check_returns_503_not_500(
+    monkeypatch, sqlite_session_with_table
+):
+    """interaction_requests_table_exists() calls db.connection() before the
+    stats query runs. A transient failure there (connection refused,
+    dropped mid-request) must land in the same deliberate 503 branch as a
+    failure in the stats query itself, not escape the try block and reach
+    the caller as an unhandled 500.
+    """
+    _set_policy(monkeypatch, mode="legacy")
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated connection failure")
+
+    monkeypatch.setattr(sqlite_session_with_table, "connection", _raise)
+
+    with pytest.raises(HTTPException) as exc:
+        await get_interaction_rollout_diagnostics(
+            current_user=_admin_user(), db=sqlite_session_with_table
+        )
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "Interaction rollout diagnostics stats query failed"
+    assert "task_interaction_requests" not in exc.value.detail
+
+
 # ---------------------------------------------------------------------------
 # Counter registry snapshot isolation
 # ---------------------------------------------------------------------------
@@ -373,7 +398,7 @@ def test_to9_counters_snapshot_is_a_copy_not_a_live_reference():
     assert "bogus" not in fresh
 
 
-def test_to9_counters_snapshot_concurrent_increments_total_correctly():
+def test_to9b_counters_snapshot_concurrent_increments_total_correctly():
     import threading
 
     def _bump():


### PR DESCRIPTION
## Summary

Adds a policy-gated switch that decides whether a task may publish a
native interaction row, defaulting entirely off, plus the observability
needed to run a staged rollout safely. Nothing reads, answers, or closes
interaction rows differently based on this switch -- it only controls
whether a *new* native row can be produced. The gate has zero production
callers in this change; wiring it into a producer is a separate change.

## Default-off, verifiably

Three checkable facts back the "merged does not mean enabled" claim:

- The protocol mode defaults to `legacy`, and the gate returns a blocked
  decision unconditionally whenever the mode isn't `native` -- one
  attribute read and one string compare, no database query, no
  environment read (the policy is parsed once and frozen).
- The native-source allowlist defaults to empty, so switching only the
  mode without also configuring at least one source fails startup
  outright rather than silently doing nothing.
- The new `/ready` behavior only executes in `native` mode. In `legacy`
  or `read` mode it is skipped entirely -- zero added database query,
  zero behavior change from today.

## Why the gating key is Task.source, not the producer

The three things that currently write interaction-style state don't
carry a stable "which producer" signal by the time it would need to be
read back for gating -- that information is lost by the projection
layer. `Task.source` is: already persisted on every task, already used
in the field's own indexed queries, and shares one vocabulary with the
`origin` column's CHECK constraint, so a single normalizer serves both
concerns. Gating a rollout by producer identity was considered and
rejected because there is no reliable read-side signal to gate on.

It also lines up the rollout axis with the risk axis. Reading,
answering, and closing an interaction migrate to native handling on a
per-ingress-channel schedule -- the SDK client, the internal web/socket
path, and each IM channel move at their own pace, in their own changes.
Gating on `Task.source`, the same value that already separates those
channels, means a single allowlist entry controls exactly the traffic
whose read/respond/close path has actually been migrated -- no
broader and no narrower.

## The synthetic "channel" gating source

`Task.source == "internal"` covers three very different entry points --
the web UI, WebSocket sessions, and IM channel bots -- as one bucket.
Every task created by an IM channel integration also carries a non-null
`channel_id`, so the gate splits that traffic into its own key,
`"channel"`, computed only when `origin == "internal"` (a task whose
source is explicitly `widget` and which also happens to carry a
`channel_id` must not be misclassified as channel traffic). This key
exists purely to let operators enable IM-channel rollout independently
of the rest of `internal` traffic -- it is never written to the
`origin` column and never added to that column's CHECK constraint.

## Two departures from this codebase's usual configuration pattern

Existing three-state mode switches in this codebase warn on an invalid
value and fall back to a default. This one raises at startup instead,
and reading the resolved policy before startup validation has run
raises rather than lazily parsing the environment. Both departures
exist for the same reason: a rollout switch that silently stays in
`legacy` while an operator believes they configured `native` mode is
precisely the blind spot this change exists to close. Failing loudly at
startup turns a silent misconfiguration into an immediate, visible one.

## One degradation signal is intentionally never auto-cleared

Two new operational signals ride along on `/health`: one for a missing
`task_interaction_requests` table (clears itself once the table is
observed present) and one for an unrecognized `Task.source` value on a
task. The second is never auto-cleared. An unrecognized source value is
a property of already-persisted data; nothing in this process can
observe that data being corrected, so auto-clearing would assert
evidence that doesn't exist. There is no clearing endpoint or command for
it -- the registry that tracks it lives only in process memory, so it
stays active for the life of the process.

## Two normalization rules, on the same values, by design

`Task.source` is normalized without stripping whitespace or changing
case: it is a value written by application code, so an unexpected
reading of it -- a stray space, a wrong case -- is itself a fact worth
surfacing rather than silently coercing into a known bucket. The
operator-facing `XAGENT_INTERACTION_NATIVE_SOURCES` environment
variable, by contrast, is stripped and lowercased, because it is a
human-typed value where that kind of normalization is exactly what
operators expect. These are not the same rule applied inconsistently --
each guards a different kind of input, and neither should be changed to
match the other.

## Unauthenticated-surface tradeoffs, stated plainly

- The `/ready` native-mode check adds a request-triggered database query
  to an unauthenticated endpoint. A one-way latch (cache "present"
  forever, never cache "absent") brings the steady-state cost to zero
  once the schema exists; the residual risk is that unauthenticated
  traffic can trigger a repeated catalog query for as long as the schema
  remains absent.
- The set of active degradation *names* on `/health` is itself
  information: it tells an unauthenticated caller that this deployment
  has interaction rollout enabled and that a specific precondition
  (schema presence, or a data-quality issue) is unmet. This follows the
  same shape every existing degradation signal already uses; recorded
  here as a known tradeoff, not something newly introduced by this
  change.

## Rollback

To roll back a native-mode rollout: (1) stop producing new native
rows -- switch the mode back or remove a source from the allowlist, then
restart; (2) reading, answering, and closing existing rows keeps working
throughout, since none of that logic is mode-gated; (3) watch the admin
diagnostics endpoint's active-row count drain to zero; (4) once drained,
downgrade fully to `legacy`; (5) removing the compatibility path
entirely is a separate, later change.

Unsafe during rollback: reverting the code instead of the
configuration; rolling back a database migration while the active-row
count is still above zero; and skipping stages by jumping directly from
`legacy` to `native` without an observation window in `read` mode.

All replicas of a deployment must run the same configuration. Rolling
out by replica (some on `native`, some not) is not supported --
different replicas would answer the same task's interactions
differently depending on which replica happened to handle a given turn.
This does not lose data; it produces an inconsistent experience across
requests for the same task, which is reason enough to avoid it.

## Enablement prerequisites

Each entry in the native-source allowlist has its own readiness
requirement before it should be enabled. An entry should only move into
the allowlist once every deployment it depends on for reading, answering,
and closing that traffic's interactions is live:

- `sdk`: depends on #1079 (typed task-interaction continuation for SDK
  clients), which covers both the read path and the response path for
  this traffic in one change.
- `internal` (Web UI and WebSocket traffic that isn't split out as
  `channel`): depends on #1080 (routing clarification through task
  interactions on the internal read path), #1075 (the response/lifecycle
  service), and #1081 (front-end structured-response submission --
  without it, a clarification would render but have no way to be
  answered).
- `widget`: depends on #1075 plus a reader for the embedded-chat-window
  projection.
- `shared_link`: shares the same projection layer and #1075 dependency
  as `widget`, but needs its own verification pass since its
  authorization context differs.
- `a2a`: depends on #1075 plus a reader in the a2a protocol's own
  projection. This is the sharpest case for older-client compatibility,
  since a2a consumers are machine clients rather than a UI a human can
  just reload.
- `channel` (the synthetic IM-channel split): no reader for
  channel-originated native rows exists yet. Do not add this entry
  until one does.
- `trigger`: trigger-originated tasks are hidden tasks with no
  interactive responder. Enabling this source will never produce an
  answerable interaction, and startup logs a warning if it is present
  in the allowlist. It should not be enabled under normal operation.

## What this change does not cover

No producer writes a native interaction row yet, and no consumer reads
one differently based on this policy -- both are separate, later
changes. A full mixed-version test matrix therefore cannot be exercised
meaningfully here: the producers and consumers it would need to exist
don't exist yet on this branch. Each cell belongs to the change that
introduces the producer or consumer it needs:

| Matrix cell | Covered by |
|---|---|
| old producer / new consumer | A later change to the read path |
| new producer / new consumer | #1079, #1080 |
| lost notification | #1082 |
| producer crash mid-write | #1077 |
| route-level rollback | A later change |
| older-client compatibility | #1079, #1081 |

## Size note

This change is larger than a typical PR: 12 files, 2,274 lines added and
1 removed. Tests are the dominant share, plainly: the five test files
account for about 1,480 of those lines, versus roughly 790 across the
seven production files. The static guards that keep read-side consumers
from ever importing this module, and that bound how many production
call sites its own accessor functions may have, need to parse and walk
real production files to do that job correctly, and the
configuration/gate/observability surfaces each carry a full pass/fail
matrix. That is what accounts for the ratio -- not padding.
