### PR TITLE
fix: import Google Slides from Drive into knowledge bases

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -325,6 +325,15 @@ backend cannot see v2 containers and otherwise double-provisions sandboxes.
 - `nginx.conf` - Frontend nginx configuration
 - `entrypoint.sh` - Backend startup script
 
+## Cloud Ingest Timeouts
+
+`nginx.conf` gives `/api/kb/ingest-cloud` a 900-second read timeout.
+The backend polls Google Drive for 600 seconds by default. The final file transfer uses additional request time.
+
+If you use a custom reverse proxy, set its read timeout to cover the polling and transfer phases.
+If you increase `XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS`, also increase the reverse-proxy timeout.
+A closed client request does not stop the active worker thread.
+
 ## Building Individual Images
 
 ### Backend

--- a/docker/README.md
+++ b/docker/README.md
@@ -325,14 +325,18 @@ backend cannot see v2 containers and otherwise double-provisions sandboxes.
 - `nginx.conf` - Frontend nginx configuration
 - `entrypoint.sh` - Backend startup script
 
-## Cloud Ingest Timeouts
+## Cloud Ingest Limits and Timeouts
 
-`nginx.conf` gives `/api/kb/ingest-cloud` a 900-second read timeout.
-The backend polls Google Drive for 600 seconds by default. The final file transfer uses additional request time.
+`POST /api/kb/ingest-cloud` accepts one to five files per request. The bundled
+`nginx.conf` gives this route a 900-second read timeout. For native Google
+Workspace files, Drive polling has a 600-second default application deadline.
+The final transfer, parsing, chunking, and embedding all continue within the
+same HTTP request.
 
-If you use a custom reverse proxy, set its read timeout to cover the polling and transfer phases.
-If you increase `XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS`, also increase the reverse-proxy timeout.
-A closed client request does not stop the active worker thread.
+Custom reverse proxies must allow for the full end-to-end request. Increase the
+proxy timeout when you increase
+`XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS`. A closed client request does
+not stop the active worker thread.
 
 ## Building Individual Images
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -36,6 +36,23 @@ server {
         proxy_connect_timeout 75s;
     }
 
+    # Native Google Slides downloads can poll Drive for up to 600 seconds and
+    # then stream the exported file. Keep this route above the generic API limit.
+    location = /api/kb/ingest-cloud {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 900s;
+        proxy_send_timeout 900s;
+        proxy_connect_timeout 75s;
+    }
+
     # Proxy to backend API
     location /api/ {
         proxy_pass http://backend;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -41,13 +41,10 @@ server {
     location = /api/kb/ingest-cloud {
         proxy_pass http://backend;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 900s;
         proxy_send_timeout 900s;
         proxy_connect_timeout 75s;

--- a/example.env
+++ b/example.env
@@ -650,6 +650,11 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 # to the whole request. Raise it for very large collections; exceeding it returns 503.
 # XAGENT_KB_COLLECTIONS_TIMEOUT_SECONDS="30"
 
+# Maximum time in seconds to poll a Google Drive long-running export during
+# POST /api/kb/ingest-cloud. The final file transfer can extend the request beyond
+# this value, so reverse-proxy timeouts must also allow for transfer time.
+# XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS="600"
+
 # Database encryption key
 # Generate one with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ENCRYPTION_KEY="RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="

--- a/frontend/src/components/kb/cloud-connect-dialog.test.tsx
+++ b/frontend/src/components/kb/cloud-connect-dialog.test.tsx
@@ -124,6 +124,7 @@ describe("CloudConnectDialog", () => {
             id: `file-${index + 1}`,
             name: `File ${index + 1}.pdf`,
             type: "file",
+            ...(index === 0 ? { resourceKey: "resource-key-1" } : {}),
           }))
         ))
       }
@@ -134,6 +135,38 @@ describe("CloudConnectDialog", () => {
   afterEach(() => {
     cleanup()
     vi.unstubAllGlobals()
+  })
+
+  it("preserves a Drive resource key through file selection", async () => {
+    const onConfirm = vi.fn()
+    const onOpenChange = vi.fn()
+
+    render(
+      <CloudConnectDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        provider={{
+          id: "google-drive",
+          name: "Google Drive",
+          hasDrives: false,
+          authPath: "google",
+          logo: "drive",
+        }}
+        onConfirm={onConfirm}
+      />
+    )
+
+    fireEvent.click(await screen.findByTestId("select-user@example.com"))
+    fireEvent.click(await screen.findByText("File 1.pdf"))
+    fireEvent.click(screen.getByText("kb.dialog.cloudConnect.select.confirm"))
+
+    expect(onConfirm).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: "file-1",
+        resourceKey: "resource-key-1",
+      }),
+    ])
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it("prevents selecting more than five files", async () => {

--- a/frontend/src/components/kb/cloud-connect-dialog.test.tsx
+++ b/frontend/src/components/kb/cloud-connect-dialog.test.tsx
@@ -1,0 +1,170 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ token: "token" }),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("@/lib/api-wrapper", () => ({
+  apiRequest: apiRequestMock,
+}))
+
+vi.mock("@/lib/utils", () => ({
+  getApiUrl: () => "http://api.local",
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+    success: vi.fn(),
+  },
+}))
+
+vi.mock("lucide-react", () => {
+  const Icon = (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />
+  return {
+    Check: Icon,
+    ChevronRight: Icon,
+    Folder: Icon,
+    File: Icon,
+    Loader2: Icon,
+    Search: Icon,
+    RefreshCw: Icon,
+    Trash2: Icon,
+  }
+})
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    options,
+    onValueChange,
+  }: {
+    options: Array<{ value: string; label: string }>
+    onValueChange: (value: string) => void
+  }) => (
+    <div>
+      {options.map(option => (
+        <button
+          key={option.value}
+          data-testid={`select-${option.value}`}
+          onClick={() => onValueChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock("@/components/ui/confirm-dialog", () => ({
+  ConfirmDialog: () => null,
+}))
+
+import { CloudConnectDialog } from "./cloud-connect-dialog"
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+  }
+}
+
+describe("CloudConnectDialog", () => {
+  beforeEach(() => {
+    vi.stubGlobal("React", React)
+    apiRequestMock.mockReset()
+    toastErrorMock.mockReset()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/cloud/accounts?provider=google-drive") {
+        return Promise.resolve(jsonResponse([
+          { id: 1, provider: "google-drive", email: "user@example.com", created_at: "now" },
+        ]))
+      }
+      if (url === "http://api.local/api/cloud/google-drive/files?folder_id=root&account_id=1") {
+        return Promise.resolve(jsonResponse(
+          Array.from({ length: 6 }, (_, index) => ({
+            id: `file-${index + 1}`,
+            name: `File ${index + 1}.pdf`,
+            type: "file",
+          }))
+        ))
+      }
+      throw new Error(`Unhandled apiRequest: ${url}`)
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it("prevents selecting more than five files", async () => {
+    render(
+      <CloudConnectDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        provider={{
+          id: "google-drive",
+          name: "Google Drive",
+          hasDrives: false,
+          authPath: "google",
+          logo: "drive",
+        }}
+        onConfirm={vi.fn()}
+      />
+    )
+
+    fireEvent.click(await screen.findByTestId("select-user@example.com"))
+    await screen.findByText("File 6.pdf")
+
+    for (let index = 1; index <= 6; index += 1) {
+      fireEvent.click(screen.getByText(`File ${index}.pdf`))
+    }
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "kb.dialog.cloudConnect.selectedFiles.limitReached"
+    )
+    await waitFor(() => {
+      expect(screen.getAllByText(/^File [1-5]\.pdf$/)).toHaveLength(10)
+    })
+    expect(screen.getAllByText("File 6.pdf")).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/kb/cloud-connect-dialog.test.tsx
+++ b/frontend/src/components/kb/cloud-connect-dialog.test.tsx
@@ -4,15 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
+const translateMock = vi.hoisted(() => vi.fn((key: string) => key))
 
 vi.mock("@/contexts/auth-context", () => ({
   useAuth: () => ({ token: "token" }),
 }))
 
 vi.mock("@/contexts/i18n-context", () => ({
-  useI18n: () => ({
-    t: (key: string) => key,
-  }),
+  useI18n: () => ({ t: translateMock }),
 }))
 
 vi.mock("@/lib/api-wrapper", () => ({
@@ -112,6 +111,7 @@ describe("CloudConnectDialog", () => {
     vi.stubGlobal("React", React)
     apiRequestMock.mockReset()
     toastErrorMock.mockReset()
+    translateMock.mockClear()
     apiRequestMock.mockImplementation((url: string) => {
       if (url === "http://api.local/api/cloud/accounts?provider=google-drive") {
         return Promise.resolve(jsonResponse([
@@ -192,6 +192,10 @@ describe("CloudConnectDialog", () => {
       fireEvent.click(screen.getByText(`File ${index}.pdf`))
     }
 
+    expect(translateMock).toHaveBeenCalledWith(
+      "kb.dialog.cloudConnect.selectedFiles.limitReached",
+      { count: 5 },
+    )
     expect(toastErrorMock).toHaveBeenCalledWith(
       "kb.dialog.cloudConnect.selectedFiles.limitReached"
     )

--- a/frontend/src/components/kb/cloud-connect-dialog.tsx
+++ b/frontend/src/components/kb/cloud-connect-dialog.tsx
@@ -38,6 +38,8 @@ interface ConnectedAccount {
   created_at: string
 }
 
+const MAX_CLOUD_INGEST_FILES = 5
+
 interface CloudConnectDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -133,6 +135,12 @@ export function CloudConnectDialog({
     if (isSelected(file.id)) {
       setSelectedFiles(prev => prev.filter(f => f.id !== file.id))
     } else {
+      if (selectedFiles.length >= MAX_CLOUD_INGEST_FILES) {
+        toast.error(t("kb.dialog.cloudConnect.selectedFiles.limitReached", {
+          count: MAX_CLOUD_INGEST_FILES,
+        }))
+        return
+      }
       setSelectedFiles(prev => [...prev, file])
     }
   }

--- a/frontend/src/components/kb/cloud-connect-dialog.tsx
+++ b/frontend/src/components/kb/cloud-connect-dialog.tsx
@@ -38,6 +38,7 @@ interface ConnectedAccount {
   created_at: string
 }
 
+// Keep in sync with CloudIngestRequest.files max_length in src/xagent/web/api/kb.py.
 const MAX_CLOUD_INGEST_FILES = 5
 
 interface CloudConnectDialogProps {

--- a/frontend/src/components/kb/cloud-connect-dialog.tsx
+++ b/frontend/src/components/kb/cloud-connect-dialog.tsx
@@ -28,6 +28,7 @@ export interface CloudFile {
   type: 'file' | 'folder'
   size?: string
   updatedAt?: string
+  resourceKey?: string
 }
 
 interface ConnectedAccount {

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.test.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.test.tsx
@@ -143,17 +143,29 @@ vi.mock("./cloud-connect-dialog", () => ({
     onConfirm: (files: Array<{ id: string; name: string; size?: string; resourceKey?: string }>) => void
   }) => (
     open && provider ? (
-      <button
-        data-testid="mock-cloud-confirm"
-        onClick={() => onConfirm([{
-          id: `${provider.id}-file-1`,
-          name: "alpha.pdf",
-          size: "1 KB",
-          resourceKey: "resource-secret",
-        }])}
-      >
-        mock cloud confirm
-      </button>
+      <>
+        <button
+          data-testid="mock-cloud-confirm"
+          onClick={() => onConfirm([{
+            id: `${provider.id}-file-1`,
+            name: "alpha.pdf",
+            size: "1 KB",
+            resourceKey: "resource-secret",
+          }])}
+        >
+          mock cloud confirm
+        </button>
+        <button
+          data-testid="mock-cloud-confirm-no-key"
+          onClick={() => onConfirm([{
+            id: `${provider.id}-file-2`,
+            name: "beta.pdf",
+            size: "1 KB",
+          }])}
+        >
+          mock cloud confirm without resource key
+        </button>
+      </>
     ) : null
   ),
 }))
@@ -220,7 +232,12 @@ const IMPORT_TABS = ["file", "web", "cloud"] as const
 type ImportTab = (typeof IMPORT_TABS)[number]
 
 /** Walk the wizard to step 3 (where the create button lives) for one import tab. */
-async function goToStep3(container: HTMLElement, tab: ImportTab, fileCount = 1) {
+async function goToStep3(
+  container: HTMLElement,
+  tab: ImportTab,
+  fileCount = 1,
+  cloudFileHasResourceKey = true,
+) {
   fireEvent.click(screen.getByText("common.next"))
 
   if (tab === "file") {
@@ -240,9 +257,13 @@ async function goToStep3(container: HTMLElement, tab: ImportTab, fileCount = 1) 
   } else {
     fireEvent.click(screen.getByText("kb.dialog.tabs.cloud"))
     fireEvent.click(screen.getByText("kb.dialog.cloudConnect.googleDrive"))
-    fireEvent.click(await screen.findByTestId("mock-cloud-confirm"))
+    fireEvent.click(await screen.findByTestId(
+      cloudFileHasResourceKey ? "mock-cloud-confirm" : "mock-cloud-confirm-no-key"
+    ))
     await waitFor(() => {
-      expect(screen.getByText("alpha.pdf")).toBeInTheDocument()
+      expect(
+        screen.getByText(cloudFileHasResourceKey ? "alpha.pdf" : "beta.pdf")
+      ).toBeInTheDocument()
     })
   }
 
@@ -566,6 +587,52 @@ describe("KnowledgeBaseCreationDialog collection naming", () => {
     } finally {
       consoleErrorSpy.mockRestore()
     }
+  })
+
+  it("omits an absent cloud resource key from the ingest request", async () => {
+    const baseApiRequest = apiRequestMock.getMockImplementation()
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "http://api.local/api/kb/ingest-cloud") {
+        return Promise.resolve(createJsonResponse([{
+          status: "success",
+          message: "ok",
+          doc_id: "doc-1",
+          chunk_count: 1,
+          embedding_count: 1,
+        }]))
+      }
+      if (!baseApiRequest) {
+        throw new Error(`Unhandled apiRequest: ${url}`)
+      }
+      return baseApiRequest(url, options)
+    })
+
+    const { container } = render(
+      <KnowledgeBaseCreationDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+    )
+    fireEvent.change(container.querySelector("#collection_name") as HTMLInputElement, {
+      target: { value: "cloud-docs" },
+    })
+
+    await goToStep3(container, "cloud", 1, false)
+    fireEvent.click(screen.getByText("kb.dialog.createButton"))
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/kb/ingest-cloud",
+        expect.any(Object),
+      )
+    })
+    const cloudCall = apiRequestMock.mock.calls.find(
+      ([url]) => url === "http://api.local/api/kb/ingest-cloud"
+    )
+    expect(JSON.parse(cloudCall?.[1]?.body as string).files).toEqual([
+      {
+        provider: "google-drive",
+        fileId: "google-drive-file-2",
+        fileName: "beta.pdf",
+      },
+    ])
   })
 
   it("keeps the dialog open for web partial failures and surfaces the failure message", async () => {

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.test.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.test.tsx
@@ -140,12 +140,17 @@ vi.mock("./cloud-connect-dialog", () => ({
   }: {
     open: boolean
     provider: { id: string } | null
-    onConfirm: (files: Array<{ id: string; name: string; size?: string }>) => void
+    onConfirm: (files: Array<{ id: string; name: string; size?: string; resourceKey?: string }>) => void
   }) => (
     open && provider ? (
       <button
         data-testid="mock-cloud-confirm"
-        onClick={() => onConfirm([{ id: `${provider.id}-file-1`, name: "alpha.pdf", size: "1 KB" }])}
+        onClick={() => onConfirm([{
+          id: `${provider.id}-file-1`,
+          name: "alpha.pdf",
+          size: "1 KB",
+          resourceKey: "resource-secret",
+        }])}
       >
         mock cloud confirm
       </button>
@@ -541,6 +546,18 @@ describe("KnowledgeBaseCreationDialog collection naming", () => {
           })
         )
       })
+
+      const cloudCall = apiRequestMock.mock.calls.find(
+        ([url]) => url === "http://api.local/api/kb/ingest-cloud"
+      )
+      expect(JSON.parse(cloudCall?.[1]?.body as string).files).toEqual([
+        {
+          provider: "google-drive",
+          fileId: "google-drive-file-1",
+          fileName: "alpha.pdf",
+          resourceKey: "resource-secret",
+        },
+      ])
 
       expect(toastSuccessMock).not.toHaveBeenCalled()
       expect(onOpenChange).not.toHaveBeenCalledWith(false)

--- a/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
+++ b/frontend/src/components/kb/knowledge-base-creation-dialog.tsx
@@ -820,7 +820,12 @@ export function KnowledgeBaseCreationDialog({ open, onOpenChange, onSuccess }: K
     try {
       // Aggregate all selected files from all providers
       const filesToIngest = Object.entries(cloudSelections).flatMap(([provider, files]) =>
-        files.map(file => ({ provider, fileId: file.id, fileName: file.name }))
+        files.map(file => ({
+          provider,
+          fileId: file.id,
+          fileName: file.name,
+          resourceKey: file.resourceKey,
+        }))
       )
 
       await reserveTeamName(collectionName, teamClaimed)

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2072,6 +2072,7 @@ Build when you need.`,
           title: "Selected Files",
           empty: "No files selected",
           clearAll: "Clear All",
+          limitReached: "You can select up to {count} files per import.",
         },
         select: {
           driveLabel: "Select Drive",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2072,6 +2072,7 @@ const zh = {
           title: "已选文件",
           empty: "未选择文件",
           clearAll: "清除全部",
+          limitReached: "每次最多可选择 {count} 个文件。",
         },
         select: {
           driveLabel: "选择硬盘",

--- a/frontend/src/lib/api-wrapper.test.ts
+++ b/frontend/src/lib/api-wrapper.test.ts
@@ -161,6 +161,22 @@ describe("api-wrapper upload helpers", () => {
     expect(message).toBe("explicit detail")
   })
 
+  it("renders FastAPI validation detail arrays as readable messages", () => {
+    const response = new Response(null, { status: 422 })
+    const message = getUploadErrorMessage(response, {
+      data: {
+        detail: [
+          { type: "too_long", loc: ["body", "files"], msg: "List should have at most 5 items", input: [] },
+          { type: "string_pattern_mismatch", loc: ["body", "files", 0, "fileId"], msg: "String should match pattern" },
+        ],
+      },
+      text: null,
+      isHtml: false,
+    }, MESSAGES)
+
+    expect(message).toBe("List should have at most 5 items; String should match pattern")
+  })
+
   it("returns truncated raw text for non-413 non-html responses", () => {
     const response = new Response(null, { status: 500 })
     const rawText = "x".repeat(240)

--- a/frontend/src/lib/api-wrapper.ts
+++ b/frontend/src/lib/api-wrapper.ts
@@ -197,6 +197,12 @@ export async function parseApiResponse(response: Response): Promise<ParsedApiRes
 export const UPLOAD_ERROR_MESSAGES = { tooLarge: "File is too large. Please reduce the upload size and try again.", proxy: "Upload failed before reaching the application. Please check the server upload limit." }
 export function getUploadErrorMessage(response: Response, parsed: ParsedApiResponse, messages: { generic: string; tooLarge: string; proxy: string }): string {
   if (isJsonRecord(parsed.data) && typeof parsed.data.detail === "string" && parsed.data.detail.trim()) return parsed.data.detail
+  if (isJsonRecord(parsed.data) && Array.isArray(parsed.data.detail)) {
+    const validationMessages = parsed.data.detail
+      .map(item => isJsonRecord(item) && typeof item.msg === "string" ? item.msg.trim() : "")
+      .filter(Boolean)
+    if (validationMessages.length) return validationMessages.join("; ")
+  }
   if (isJsonRecord(parsed.data) && typeof parsed.data.message === "string" && parsed.data.message.trim()) return parsed.data.message
   if (response.status === 413) return messages.tooLarge
   if (parsed.isHtml) return messages.proxy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "beartype>=0.18.5",
   "matplotlib>=3.5.0",
   "google-auth-oauthlib>=1.2.0",
-  "google-api-python-client>=2.111.0",
+  "google-api-python-client>=2.145.0",
   "boxlite>=0.6.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "boxlite>=0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "filelock>=3.0.0",

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -81,6 +81,7 @@ SANDBOX_IMAGE = "SANDBOX_IMAGE"
 LANCEDB_PATH = "LANCEDB_PATH"
 KB_COLLECTIONS_TIMEOUT_SECONDS = "XAGENT_KB_COLLECTIONS_TIMEOUT_SECONDS"
 KB_SEARCH_TIMEOUT_SECONDS = "XAGENT_KB_SEARCH_TIMEOUT_SECONDS"
+GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS = "XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS"
 DATABASE_URL = "DATABASE_URL"
 DB_POOL_SIZE = "XAGENT_DB_POOL_SIZE"
 DB_MAX_OVERFLOW = "XAGENT_DB_MAX_OVERFLOW"
@@ -2024,6 +2025,23 @@ def get_lancedb_path() -> Path:
 
     # Default: storage_root/data/lancedb
     return get_storage_root() / "data" / "lancedb"
+
+
+def get_google_drive_download_timeout_seconds() -> int:
+    """Get the maximum wait for a Google Drive long-running download.
+
+    Native Google Workspace exports can return a pending Drive operation. This
+    timeout bounds polling inside the cloud-ingest HTTP request. External proxy
+    timeouts must also allow time for the final file transfer.
+
+    Priority:
+        1. XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS environment variable
+        2. Default of 600 seconds
+
+    Returns:
+        Maximum operation wait in seconds.
+    """
+    return _get_positive_int_env(GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS, 600)
 
 
 def get_kb_collections_timeout_seconds() -> int:

--- a/src/xagent/web/api/cloud_storage.py
+++ b/src/xagent/web/api/cloud_storage.py
@@ -209,7 +209,10 @@ async def list_google_drive_files(
             .list(
                 q=query,
                 pageSize=100,
-                fields="nextPageToken, files(id, name, mimeType, size, modifiedTime)",
+                fields=(
+                    "nextPageToken, "
+                    "files(id, name, mimeType, size, modifiedTime, resourceKey)"
+                ),
                 orderBy="folder,name",
                 supportsAllDrives=supports_all_drives,
                 includeItemsFromAllDrives=include_items_from_all_drives,
@@ -255,6 +258,7 @@ async def list_google_drive_files(
                     "size": size_str,
                     "updatedAt": updated_at,
                     "mimeType": mime_type,  # Optional, helpful for debugging
+                    "resourceKey": file.get("resourceKey"),
                 }
             )
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3364,8 +3364,9 @@ class CloudFile(BaseModel):
 
 
 class CloudIngestRequest(BaseModel):
-    # An empty batch ingests nothing, so it must not reach the handler at all.
-    files: List[CloudFile] = Field(..., min_length=1)
+    # Reject empty work and keep each request within one five-file concurrency
+    # wave so Drive polling cannot add a second full timeout interval.
+    files: List[CloudFile] = Field(..., min_length=1, max_length=5)
     collection: str
     parse_method: Optional[ParseMethod] = None
     chunk_strategy: Optional[ChunkStrategy] = None

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -180,6 +180,7 @@ T = TypeVar("T", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
 _GOOGLE_SLIDES_MIME_TYPE = "application/vnd.google-apps.presentation"
+_GOOGLE_DRIVE_SHORTCUT_MIME_TYPE = "application/vnd.google-apps.shortcut"
 _POWERPOINT_EXPORT_MIME_TYPE = (
     "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 )
@@ -4673,6 +4674,10 @@ async def ingest_cloud(
                     metadata_name = metadata.get("name")
                     metadata_mime_type = metadata.get("mimeType")
                     metadata_size = metadata.get("size")
+                    if metadata_name:
+                        source_filename = Path(str(metadata_name)).name
+                    if metadata_mime_type == _GOOGLE_DRIVE_SHORTCUT_MIME_TYPE:
+                        raise ValueError("Google Drive shortcuts are not supported")
                     if (
                         not metadata_name
                         or not metadata_mime_type
@@ -4682,7 +4687,6 @@ async def ingest_cloud(
                             "Google Drive returned incomplete file metadata"
                         )
 
-                    source_filename = Path(str(metadata_name)).name
                     if not source_filename:
                         raise ValueError("Google Drive returned an invalid file name")
                     if int(str(metadata_size)) > MAX_FILE_SIZE:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4626,8 +4626,13 @@ async def ingest_cloud(
             is_native_google_slides = False
             service: Any = None
             creds: Any = None
+            drive_request_headers: dict[str, str] = {}
 
             if file_info.provider == "google-drive":
+                if file_info.resourceKey:
+                    drive_request_headers["X-Goog-Drive-Resource-Keys"] = (
+                        f"{file_info.fileId}/{file_info.resourceKey}"
+                    )
                 try:
                     creds = await asyncio.to_thread(
                         get_google_credentials, int(actor_user.id), db
@@ -4657,14 +4662,8 @@ async def ingest_cloud(
                             fields="id,name,mimeType",
                             supportsAllDrives=True,
                         )
-                        if file_info.resourceKey:
-                            metadata_request.headers.update(
-                                {
-                                    "X-Goog-Drive-Resource-Keys": (
-                                        f"{file_info.fileId}/{file_info.resourceKey}"
-                                    )
-                                }
-                            )
+                        if drive_request_headers:
+                            metadata_request.headers.update(drive_request_headers)
                         return cast(dict[str, Any], metadata_request.execute())
 
                     metadata = await asyncio.to_thread(_get_file_metadata)
@@ -4757,6 +4756,8 @@ async def ingest_cloud(
                                 fileId=file_info.fileId,
                                 supportsAllDrives=True,
                             )
+                            if drive_request_headers:
+                                request_file.headers.update(drive_request_headers)
                             with open(file_path, "wb") as fh:
                                 downloader = MediaIoBaseDownload(fh, request_file)
                                 done = False

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4659,7 +4659,7 @@ async def ingest_cloud(
                         """Read current metadata before deriving the local file format."""
                         metadata_request = service.files().get(
                             fileId=file_info.fileId,
-                            fields="id,name,mimeType",
+                            fields="id,name,mimeType,size",
                             supportsAllDrives=True,
                         )
                         if drive_request_headers:
@@ -4671,7 +4671,12 @@ async def ingest_cloud(
                     metadata = await asyncio.to_thread(_get_file_metadata)
                     metadata_name = metadata.get("name")
                     metadata_mime_type = metadata.get("mimeType")
-                    if not metadata_name or not metadata_mime_type:
+                    metadata_size = metadata.get("size")
+                    if (
+                        not metadata_name
+                        or not metadata_mime_type
+                        or metadata_size is None
+                    ):
                         raise ValueError(
                             "Google Drive returned incomplete file metadata"
                         )
@@ -4679,6 +4684,17 @@ async def ingest_cloud(
                     source_filename = Path(str(metadata_name)).name
                     if not source_filename:
                         raise ValueError("Google Drive returned an invalid file name")
+                    if int(str(metadata_size)) > MAX_FILE_SIZE:
+                        return KBApiOperationResult(
+                            result=IngestionResult(
+                                status="error",
+                                message=(
+                                    "File size exceeds maximum limit of "
+                                    f"{MAX_FILE_SIZE_LABEL}"
+                                ),
+                                doc_id=source_filename,
+                            )
+                        )
 
                     drive_mime_type = str(metadata_mime_type)
                     is_native_google_slides = (

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3360,6 +3360,7 @@ class CloudFile(BaseModel):
     provider: str
     fileId: str
     fileName: str
+    resourceKey: Optional[str] = None
 
 
 class CloudIngestRequest(BaseModel):
@@ -4651,16 +4652,20 @@ async def ingest_cloud(
 
                     def _get_file_metadata() -> dict[str, Any]:
                         """Read current metadata before deriving the local file format."""
-                        return cast(
-                            dict[str, Any],
-                            service.files()
-                            .get(
-                                fileId=file_info.fileId,
-                                fields="id,name,mimeType",
-                                supportsAllDrives=True,
-                            )
-                            .execute(),
+                        metadata_request = service.files().get(
+                            fileId=file_info.fileId,
+                            fields="id,name,mimeType",
+                            supportsAllDrives=True,
                         )
+                        if file_info.resourceKey:
+                            metadata_request.headers.update(
+                                {
+                                    "X-Goog-Drive-Resource-Keys": (
+                                        f"{file_info.fileId}/{file_info.resourceKey}"
+                                    )
+                                }
+                            )
+                        return cast(dict[str, Any], metadata_request.execute())
 
                     metadata = await asyncio.to_thread(_get_file_metadata)
                     metadata_name = metadata.get("name")
@@ -4744,6 +4749,7 @@ async def ingest_cloud(
                                     mime_type=_POWERPOINT_EXPORT_MIME_TYPE,
                                     destination=file_path,
                                     timeout_seconds=get_google_drive_download_timeout_seconds(),
+                                    resource_key=file_info.resourceKey,
                                 )
                                 return
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4623,7 +4623,6 @@ async def ingest_cloud(
                 mimetypes.guess_type(safe_filename)[0] or "application/octet-stream"
             )
             is_native_google_slides = False
-            drive_resource_key: str | None = None
             service: Any = None
             creds: Any = None
 
@@ -4657,7 +4656,7 @@ async def ingest_cloud(
                             service.files()
                             .get(
                                 fileId=file_info.fileId,
-                                fields="id,name,mimeType,resourceKey",
+                                fields="id,name,mimeType",
                                 supportsAllDrives=True,
                             )
                             .execute(),
@@ -4676,10 +4675,6 @@ async def ingest_cloud(
                         raise ValueError("Google Drive returned an invalid file name")
 
                     drive_mime_type = str(metadata_mime_type)
-                    metadata_resource_key = metadata.get("resourceKey")
-                    drive_resource_key = (
-                        str(metadata_resource_key) if metadata_resource_key else None
-                    )
                     is_native_google_slides = (
                         drive_mime_type == _GOOGLE_SLIDES_MIME_TYPE
                     )
@@ -4749,7 +4744,6 @@ async def ingest_cloud(
                                     mime_type=_POWERPOINT_EXPORT_MIME_TYPE,
                                     destination=file_path,
                                     timeout_seconds=get_google_drive_download_timeout_seconds(),
-                                    resource_key=drive_resource_key,
                                 )
                                 return
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4721,7 +4721,7 @@ async def ingest_cloud(
                         result=IngestionResult(
                             status="error",
                             message=f"Metadata lookup failed: {str(e)}",
-                            doc_id=file_info.fileName,
+                            doc_id=source_filename,
                         )
                     )
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4797,6 +4797,7 @@ async def ingest_cloud(
                             file_info.fileId,
                             int(actor_user.id),
                             e,
+                            exc_info=True,
                         )
                         rollback_api_result = KBApiOperationResult(
                             result=IngestionResult(

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4824,7 +4824,7 @@ async def ingest_cloud(
                                         f"{safe_collection}/{file_info.fileName}: "
                                         f"{rollback_execution.error}"
                                     ),
-                                    doc_id=file_info.fileName,
+                                    doc_id=source_filename,
                                 ),
                             )
                         return rollback_execution.operation_result
@@ -4897,7 +4897,7 @@ async def ingest_cloud(
                                     IngestionResult(
                                         status="error",
                                         message=str(rollback_execution.error),
-                                        doc_id=file_info.fileName,
+                                        doc_id=source_filename,
                                     ),
                                 )
                         elif file_backup_path is not None:
@@ -4911,7 +4911,7 @@ async def ingest_cloud(
                             result=IngestionResult(
                                 status="error",
                                 message=str(rollback_exc),
-                                doc_id=file_info.fileName,
+                                doc_id=source_filename,
                             ),
                             operation_outcome=api_result.operation_outcome
                             if "api_result" in locals()
@@ -4921,7 +4921,7 @@ async def ingest_cloud(
                     except Exception as e:
                         rollback_result = IngestionResult(
                             status="error",
-                            doc_id=file_info.fileName,
+                            doc_id=source_filename,
                             message=f"Ingestion failed: {str(e)}",
                         )
                         rollback_api_result = KBApiOperationResult(
@@ -4952,7 +4952,7 @@ async def ingest_cloud(
                                 IngestionResult(
                                     status="error",
                                     message=str(rollback_execution.error),
-                                    doc_id=file_info.fileName,
+                                    doc_id=source_filename,
                                 ),
                             )
                         return rollback_execution.operation_result
@@ -4962,7 +4962,7 @@ async def ingest_cloud(
                         result=IngestionResult(
                             status="error",
                             message=f"Unsupported provider: {file_info.provider}",
-                            doc_id=file_info.fileName,
+                            doc_id=source_filename,
                         )
                     )
 
@@ -4972,7 +4972,7 @@ async def ingest_cloud(
                     result=IngestionResult(
                         status="error",
                         message=str(e),
-                        doc_id=file_info.fileName,
+                        doc_id=source_filename,
                     ),
                     rollback_complete=False,
                 )
@@ -4981,7 +4981,7 @@ async def ingest_cloud(
                     result=IngestionResult(
                         status="error",
                         message=f"Unexpected error: {str(e)}",
-                        doc_id=file_info.fileName,
+                        doc_id=source_filename,
                     )
                 )
                 rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
@@ -5007,7 +5007,7 @@ async def ingest_cloud(
                                 f"{safe_collection}/{file_info.fileName}: "
                                 f"{rollback_execution.error}"
                             ),
-                            doc_id=file_info.fileName,
+                            doc_id=source_filename,
                         ),
                     )
                 logger.exception(

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -46,7 +46,10 @@ from googleapiclient.http import MediaIoBaseDownload  # type: ignore
 from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy.orm import Session
 
-from ...config import get_kb_collections_timeout_seconds
+from ...config import (
+    get_google_drive_download_timeout_seconds,
+    get_kb_collections_timeout_seconds,
+)
 from ...core.file_storage.keys import build_upload_storage_key
 from ...core.tools.core.RAG_tools.core.config import DEFAULT_VECTOR_STORE_SCAN_LIMIT
 from ...core.tools.core.RAG_tools.core.parser_registry import (
@@ -113,6 +116,7 @@ from ..services.background_jobs import (
     is_background_job_enqueue_available,
     mark_job_failed,
 )
+from ..services.google_drive_download import download_google_workspace_file
 from ..services.kb_collection_service import (
     delete_collection_physical_dir,
     delete_collection_uploaded_files,
@@ -4619,7 +4623,9 @@ async def ingest_cloud(
                 mimetypes.guess_type(safe_filename)[0] or "application/octet-stream"
             )
             is_native_google_slides = False
+            drive_resource_key: str | None = None
             service: Any = None
+            creds: Any = None
 
             if file_info.provider == "google-drive":
                 try:
@@ -4651,7 +4657,7 @@ async def ingest_cloud(
                             service.files()
                             .get(
                                 fileId=file_info.fileId,
-                                fields="id,name,mimeType",
+                                fields="id,name,mimeType,resourceKey",
                                 supportsAllDrives=True,
                             )
                             .execute(),
@@ -4670,6 +4676,10 @@ async def ingest_cloud(
                         raise ValueError("Google Drive returned an invalid file name")
 
                     drive_mime_type = str(metadata_mime_type)
+                    metadata_resource_key = metadata.get("resourceKey")
+                    drive_resource_key = (
+                        str(metadata_resource_key) if metadata_resource_key else None
+                    )
                     is_native_google_slides = (
                         drive_mime_type == _GOOGLE_SLIDES_MIME_TYPE
                     )
@@ -4732,24 +4742,30 @@ async def ingest_cloud(
 
                         def _download_file() -> None:
                             if is_native_google_slides:
-                                request_file = service.files().export_media(
-                                    fileId=file_info.fileId,
-                                    mimeType=_POWERPOINT_EXPORT_MIME_TYPE,
+                                download_google_workspace_file(
+                                    service=service,
+                                    credentials=creds,
+                                    file_id=file_info.fileId,
+                                    mime_type=_POWERPOINT_EXPORT_MIME_TYPE,
+                                    destination=file_path,
+                                    timeout_seconds=get_google_drive_download_timeout_seconds(),
+                                    resource_key=drive_resource_key,
                                 )
-                            else:
-                                request_file = service.files().get_media(
-                                    fileId=file_info.fileId,
-                                    supportsAllDrives=True,
-                                )
+                                return
+
+                            request_file = service.files().get_media(
+                                fileId=file_info.fileId,
+                                supportsAllDrives=True,
+                            )
                             with open(file_path, "wb") as fh:
                                 downloader = MediaIoBaseDownload(fh, request_file)
                                 done = False
                                 while done is False:
-                                    status, done = downloader.next_chunk()
+                                    _status, done = downloader.next_chunk()
 
                         if is_native_google_slides:
                             logger.info(
-                                "Exporting native Google Slides file_id=%s user_id=%s mime_type=%s",
+                                "Downloading native Google Slides file_id=%s user_id=%s mime_type=%s",
                                 file_info.fileId,
                                 int(actor_user.id),
                                 _POWERPOINT_EXPORT_MIME_TYPE,
@@ -4757,9 +4773,7 @@ async def ingest_cloud(
                         await asyncio.to_thread(_download_file)
 
                     except Exception as e:
-                        transfer_action = (
-                            "Export" if is_native_google_slides else "Download"
-                        )
+                        transfer_action = "Download"
                         logger.warning(
                             "Google Drive %s failed for file_id=%s user_id=%s: %s",
                             transfer_action.lower(),

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -175,6 +175,11 @@ from .cloud_storage import get_google_credentials
 T = TypeVar("T", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
+_GOOGLE_SLIDES_MIME_TYPE = "application/vnd.google-apps.presentation"
+_POWERPOINT_EXPORT_MIME_TYPE = (
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+)
+
 
 def _create_file_compensation_delete(
     *,
@@ -4608,7 +4613,91 @@ async def ingest_cloud(
             file_backup_path: Optional[Path] = None
             had_existing_file = False
             uploaded_file_existed_before = False
-            safe_filename = Path(file_info.fileName).name
+            source_filename = Path(file_info.fileName).name
+            safe_filename = source_filename
+            stored_mime_type = (
+                mimetypes.guess_type(safe_filename)[0] or "application/octet-stream"
+            )
+            is_native_google_slides = False
+            service: Any = None
+
+            if file_info.provider == "google-drive":
+                try:
+                    creds = await asyncio.to_thread(
+                        get_google_credentials, int(actor_user.id), db
+                    )
+                except HTTPException as e:
+                    return KBApiOperationResult(
+                        result=IngestionResult(
+                            status="error",
+                            message=f"Authentication error: {e.detail}",
+                            doc_id=file_info.fileName,
+                        )
+                    )
+
+                try:
+                    service = await asyncio.to_thread(
+                        build,
+                        "drive",
+                        "v3",
+                        credentials=creds,
+                        cache_discovery=False,
+                    )
+
+                    def _get_file_metadata() -> dict[str, Any]:
+                        """Read current metadata before deriving the local file format."""
+                        return cast(
+                            dict[str, Any],
+                            service.files()
+                            .get(
+                                fileId=file_info.fileId,
+                                fields="id,name,mimeType",
+                                supportsAllDrives=True,
+                            )
+                            .execute(),
+                        )
+
+                    metadata = await asyncio.to_thread(_get_file_metadata)
+                    metadata_name = metadata.get("name")
+                    metadata_mime_type = metadata.get("mimeType")
+                    if not metadata_name or not metadata_mime_type:
+                        raise ValueError(
+                            "Google Drive returned incomplete file metadata"
+                        )
+
+                    source_filename = Path(str(metadata_name)).name
+                    if not source_filename:
+                        raise ValueError("Google Drive returned an invalid file name")
+
+                    drive_mime_type = str(metadata_mime_type)
+                    is_native_google_slides = (
+                        drive_mime_type == _GOOGLE_SLIDES_MIME_TYPE
+                    )
+                    safe_filename = source_filename
+                    if is_native_google_slides and not safe_filename.lower().endswith(
+                        ".pptx"
+                    ):
+                        safe_filename = f"{safe_filename}.pptx"
+                    stored_mime_type = (
+                        _POWERPOINT_EXPORT_MIME_TYPE
+                        if is_native_google_slides
+                        else drive_mime_type
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Google Drive metadata lookup failed for file_id=%s user_id=%s: %s",
+                        file_info.fileId,
+                        int(actor_user.id),
+                        e,
+                    )
+                    return KBApiOperationResult(
+                        result=IngestionResult(
+                            status="error",
+                            message=f"Metadata lookup failed: {str(e)}",
+                            doc_id=file_info.fileName,
+                        )
+                    )
+
             storage_filename = _build_cloud_storage_filename(
                 safe_filename,
                 file_info.fileId,
@@ -4625,30 +4714,11 @@ async def ingest_cloud(
                     result=IngestionResult(
                         status="error",
                         message=ve.detail,
-                        doc_id=file_info.fileName,
+                        doc_id=source_filename,
                     )
                 )
             try:
                 if file_info.provider == "google-drive":
-                    # Get credentials (run in thread to avoid blocking)
-                    try:
-                        creds = await asyncio.to_thread(
-                            get_google_credentials, int(actor_user.id), db
-                        )
-                    except HTTPException as e:
-                        return KBApiOperationResult(
-                            result=IngestionResult(
-                                status="error",
-                                message=f"Authentication error: {e.detail}",
-                                doc_id=file_info.fileName,
-                            )
-                        )
-
-                    # Build service (blocking)
-                    service = await asyncio.to_thread(
-                        build, "drive", "v3", credentials=creds, cache_discovery=False
-                    )
-
                     # Save to local path
                     had_existing_file = file_path.exists()
                     if had_existing_file:
@@ -4661,23 +4731,47 @@ async def ingest_cloud(
                     try:
 
                         def _download_file() -> None:
-                            request_file = service.files().get_media(
-                                fileId=file_info.fileId
-                            )
+                            if is_native_google_slides:
+                                request_file = service.files().export_media(
+                                    fileId=file_info.fileId,
+                                    mimeType=_POWERPOINT_EXPORT_MIME_TYPE,
+                                )
+                            else:
+                                request_file = service.files().get_media(
+                                    fileId=file_info.fileId,
+                                    supportsAllDrives=True,
+                                )
                             with open(file_path, "wb") as fh:
                                 downloader = MediaIoBaseDownload(fh, request_file)
                                 done = False
                                 while done is False:
                                     status, done = downloader.next_chunk()
 
+                        if is_native_google_slides:
+                            logger.info(
+                                "Exporting native Google Slides file_id=%s user_id=%s mime_type=%s",
+                                file_info.fileId,
+                                int(actor_user.id),
+                                _POWERPOINT_EXPORT_MIME_TYPE,
+                            )
                         await asyncio.to_thread(_download_file)
 
                     except Exception as e:
+                        transfer_action = (
+                            "Export" if is_native_google_slides else "Download"
+                        )
+                        logger.warning(
+                            "Google Drive %s failed for file_id=%s user_id=%s: %s",
+                            transfer_action.lower(),
+                            file_info.fileId,
+                            int(actor_user.id),
+                            e,
+                        )
                         rollback_api_result = KBApiOperationResult(
                             result=IngestionResult(
                                 status="error",
-                                message=f"Download failed: {str(e)}",
-                                doc_id=file_info.fileName,
+                                message=f"{transfer_action} failed: {str(e)}",
+                                doc_id=source_filename,
                             )
                         )
                         rollback_execution = await _get_api_compatibility_facade().run_failed_ingest_rollback_async(
@@ -4715,10 +4809,7 @@ async def ingest_cloud(
                         user_id=int(_user.id),
                         filename=safe_filename,
                         storage_path=file_path,
-                        mime_type=(
-                            mimetypes.guess_type(safe_filename)[0]
-                            or "application/octet-stream"
-                        ),
+                        mime_type=stored_mime_type,
                         file_size=int(file_path.stat().st_size),
                     )
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3359,9 +3359,9 @@ def _effective_knowledge_base_user(
 
 class CloudFile(BaseModel):
     provider: str
-    fileId: str
+    fileId: str = Field(pattern=r"^[^\r\n]*$")
     fileName: str
-    resourceKey: Optional[str] = None
+    resourceKey: Optional[str] = Field(default=None, pattern=r"^[^\r\n]*$")
 
 
 class CloudIngestRequest(BaseModel):
@@ -3572,12 +3572,17 @@ async def _save_collection_config_after_ingest(
 
 
 def _build_cloud_storage_filename(original_filename: str, file_id: str) -> str:
-    """Generate a collision-resistant local filename for cloud ingests."""
+    """Generate a collision-resistant filename within filesystem byte limits."""
     original_path = Path(original_filename)
     suffix = original_path.suffix
-    stem = original_path.stem or "cloud-file"
     digest = hashlib.sha256(file_id.encode("utf-8")).hexdigest()[:12]
-    return f"{stem}__{digest}{suffix}"
+    trailer = f"__{digest}{suffix}"
+    max_stem_bytes = _MAX_FILESYSTEM_FILENAME_BYTES - len(trailer.encode("utf-8"))
+    stem = _truncate_utf8_bytes(
+        original_path.stem or "cloud-file",
+        max_stem_bytes,
+    )
+    return f"{stem}{trailer}"
 
 
 def _raise_if_list_collections_failed(
@@ -4703,7 +4708,14 @@ async def ingest_cloud(
                         raise GoogleDriveMetadataValidationError(
                             "Google Drive returned an invalid file size"
                         ) from exc
-                    if file_size > MAX_FILE_SIZE:
+                    drive_mime_type = str(metadata_mime_type)
+                    is_native_google_slides = (
+                        drive_mime_type == _GOOGLE_SLIDES_MIME_TYPE
+                    )
+                    # Drive reports the native editor-file size here, not the
+                    # generated PPTX size. The export stream enforces its own
+                    # byte limit while it is written.
+                    if not is_native_google_slides and file_size > MAX_FILE_SIZE:
                         return KBApiOperationResult(
                             result=IngestionResult(
                                 status="error",
@@ -4715,10 +4727,6 @@ async def ingest_cloud(
                             )
                         )
 
-                    drive_mime_type = str(metadata_mime_type)
-                    is_native_google_slides = (
-                        drive_mime_type == _GOOGLE_SLIDES_MIME_TYPE
-                    )
                     safe_filename = source_filename
                     if is_native_google_slides and not safe_filename.lower().endswith(
                         ".pptx"

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -3396,6 +3396,10 @@ class CollectionConfigSaveError(RuntimeError):
         self.file_id = file_id
 
 
+class GoogleDriveMetadataValidationError(ValueError):
+    """Report a client-safe validation failure in trusted Drive metadata fields."""
+
+
 async def _maybe_await(value: Any) -> Any:
     if inspect.isawaitable(value):
         return await value
@@ -4644,7 +4648,7 @@ async def ingest_cloud(
                         result=IngestionResult(
                             status="error",
                             message=f"Authentication error: {e.detail}",
-                            doc_id=file_info.fileName,
+                            doc_id=source_filename,
                         )
                     )
 
@@ -4677,19 +4681,29 @@ async def ingest_cloud(
                     if metadata_name:
                         source_filename = Path(str(metadata_name)).name
                     if metadata_mime_type == _GOOGLE_DRIVE_SHORTCUT_MIME_TYPE:
-                        raise ValueError("Google Drive shortcuts are not supported")
+                        raise GoogleDriveMetadataValidationError(
+                            "Google Drive shortcuts are not supported"
+                        )
                     if (
                         not metadata_name
                         or not metadata_mime_type
                         or metadata_size is None
                     ):
-                        raise ValueError(
+                        raise GoogleDriveMetadataValidationError(
                             "Google Drive returned incomplete file metadata"
                         )
 
                     if not source_filename:
-                        raise ValueError("Google Drive returned an invalid file name")
-                    if int(str(metadata_size)) > MAX_FILE_SIZE:
+                        raise GoogleDriveMetadataValidationError(
+                            "Google Drive returned an invalid file name"
+                        )
+                    try:
+                        file_size = int(str(metadata_size))
+                    except (TypeError, ValueError) as exc:
+                        raise GoogleDriveMetadataValidationError(
+                            "Google Drive returned an invalid file size"
+                        ) from exc
+                    if file_size > MAX_FILE_SIZE:
                         return KBApiOperationResult(
                             result=IngestionResult(
                                 status="error",
@@ -4715,18 +4729,26 @@ async def ingest_cloud(
                         if is_native_google_slides
                         else drive_mime_type
                     )
-                except Exception as e:
+                except GoogleDriveMetadataValidationError as e:
+                    return KBApiOperationResult(
+                        result=IngestionResult(
+                            status="error",
+                            message=f"Metadata lookup failed: {e}",
+                            doc_id=source_filename or file_info.fileId,
+                        )
+                    )
+                except Exception:
                     logger.warning(
-                        "Google Drive metadata lookup failed for file_id=%s user_id=%s: %s",
+                        "Google Drive metadata lookup failed for file_id=%s user_id=%s",
                         file_info.fileId,
                         int(actor_user.id),
-                        e,
+                        exc_info=True,
                     )
                     return KBApiOperationResult(
                         result=IngestionResult(
                             status="error",
-                            message=f"Metadata lookup failed: {str(e)}",
-                            doc_id=source_filename,
+                            message="Google Drive metadata lookup failed",
+                            doc_id=source_filename or file_info.fileId,
                         )
                     )
 
@@ -4827,7 +4849,7 @@ async def ingest_cloud(
                                     status="error",
                                     message=(
                                         "Failed to fully roll back cloud ingest for "
-                                        f"{safe_collection}/{file_info.fileName}: "
+                                        f"{safe_collection}/{source_filename}: "
                                         f"{rollback_execution.error}"
                                     ),
                                     doc_id=source_filename,
@@ -5010,7 +5032,7 @@ async def ingest_cloud(
                             status="error",
                             message=(
                                 "Failed to fully roll back cloud ingest for "
-                                f"{safe_collection}/{file_info.fileName}: "
+                                f"{safe_collection}/{source_filename}: "
                                 f"{rollback_execution.error}"
                             ),
                             doc_id=source_filename,

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4768,6 +4768,7 @@ async def ingest_cloud(
                                     destination=file_path,
                                     timeout_seconds=get_google_drive_download_timeout_seconds(),
                                     resource_key=file_info.resourceKey,
+                                    max_bytes=MAX_FILE_SIZE,
                                 )
                                 return
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4664,7 +4664,9 @@ async def ingest_cloud(
                         )
                         if drive_request_headers:
                             metadata_request.headers.update(drive_request_headers)
-                        return cast(dict[str, Any], metadata_request.execute())
+                        return cast(
+                            dict[str, Any], metadata_request.execute(num_retries=3)
+                        )
 
                     metadata = await asyncio.to_thread(_get_file_metadata)
                     metadata_name = metadata.get("name")

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4,6 +4,7 @@ import asyncio
 import functools
 import hashlib
 import inspect
+import io
 import json
 import logging
 import mimetypes
@@ -659,6 +660,24 @@ _BACKGROUND_INGEST_STAGING_DIR = ".background-ingest"
 class UploadCopyResult:
     total_size: int
     sha256: str
+
+
+class _LimitedWriter(io.BufferedWriter):
+    """Reject a write before a cloud download can exceed its byte limit."""
+
+    def __init__(self, raw: io.FileIO, *, max_bytes: int) -> None:
+        super().__init__(raw)
+        self._max_bytes = max_bytes
+        self._written = 0
+
+    def write(self, data: Any) -> int:
+        if self._written + len(data) > self._max_bytes:
+            raise ValueError(
+                f"File size exceeds maximum limit of {MAX_FILE_SIZE_LABEL}"
+            )
+        written = super().write(data)
+        self._written += written
+        return written
 
 
 def _like_contains_pattern(value: str) -> str:
@@ -4812,11 +4831,18 @@ async def ingest_cloud(
                             )
                             if drive_request_headers:
                                 request_file.headers.update(drive_request_headers)
-                            with open(file_path, "wb") as fh:
-                                downloader = MediaIoBaseDownload(fh, request_file)
-                                done = False
-                                while done is False:
-                                    _status, done = downloader.next_chunk()
+                            with open(file_path, "wb", buffering=0) as raw_file:
+                                with _LimitedWriter(
+                                    raw_file,
+                                    max_bytes=MAX_FILE_SIZE,
+                                ) as output_file:
+                                    downloader = MediaIoBaseDownload(
+                                        output_file,
+                                        request_file,
+                                    )
+                                    done = False
+                                    while done is False:
+                                        _status, done = downloader.next_chunk()
 
                         if is_native_google_slides:
                             logger.info(

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4773,10 +4773,8 @@ async def ingest_cloud(
                         await asyncio.to_thread(_download_file)
 
                     except Exception as e:
-                        transfer_action = "Download"
                         logger.warning(
-                            "Google Drive %s failed for file_id=%s user_id=%s: %s",
-                            transfer_action.lower(),
+                            "Google Drive download failed for file_id=%s user_id=%s: %s",
                             file_info.fileId,
                             int(actor_user.id),
                             e,
@@ -4784,7 +4782,7 @@ async def ingest_cloud(
                         rollback_api_result = KBApiOperationResult(
                             result=IngestionResult(
                                 status="error",
-                                message=f"{transfer_action} failed: {str(e)}",
+                                message=f"Download failed: {str(e)}",
                                 doc_id=source_filename,
                             )
                         )

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -171,6 +171,8 @@ def download_google_workspace_file(
                             raise GoogleDriveDownloadError(
                                 f"Failed to write Drive download: {reason}"
                             ) from exc
+                if written == 0:
+                    raise GoogleDriveDownloadError("Drive export produced no content")
     except GoogleDriveDownloadError:
         raise
     except Exception as exc:

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -93,9 +93,13 @@ def download_google_workspace_file(
         poll_delay_seconds = min(poll_delay_seconds * 2, 60.0)
 
     if "error" in operation:
-        error = cast(dict[str, Any], operation["error"])
-        code = error.get("code", "unknown")
-        message = error.get("message", "Unknown Drive operation error")
+        error = operation["error"]
+        if not error or not isinstance(error, dict):
+            code = "unknown"
+            message = str(error) if error else "Unknown Drive operation error"
+        else:
+            code = error.get("code", "unknown")
+            message = error.get("message", "Unknown Drive operation error")
         raise GoogleDriveDownloadError(f"Drive operation failed ({code}): {message}")
 
     logger.info(

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -84,7 +84,9 @@ def download_google_workspace_file(
                 f"{timeout_seconds:g} seconds"
             )
         sleep(min(poll_delay_seconds, remaining_seconds))
-        poll_request = service.operations().get(name=str(operation_name))
+        poll_request = service.operations().get(
+            name=str(operation_name).removeprefix("operations/")
+        )
         poll_request.headers.update(headers)
         operation = cast(dict[str, Any], poll_request.execute())
         _update_resource_key_header(headers, file_id=file_id, operation=operation)

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -1,0 +1,121 @@
+"""Download exported Google Workspace files through the Drive LRO API."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from time import monotonic, sleep
+from typing import Any, cast
+
+from google.auth.credentials import Credentials
+from google.auth.transport.requests import AuthorizedSession
+
+logger = logging.getLogger(__name__)
+
+_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+_DOWNLOAD_HTTP_TIMEOUT_SECONDS = 60
+
+
+class GoogleDriveDownloadError(RuntimeError):
+    """Report a failed or invalid Drive download operation."""
+
+
+class GoogleDriveDownloadTimeout(GoogleDriveDownloadError):
+    """Report a Drive operation that exceeded the caller's wait limit."""
+
+
+def download_google_workspace_file(
+    *,
+    service: Any,
+    credentials: Credentials,
+    file_id: str,
+    mime_type: str,
+    destination: Path,
+    timeout_seconds: float,
+    resource_key: str | None = None,
+) -> None:
+    """Export a Google Workspace file and stream it to ``destination``.
+
+    Drive returns an operation instead of file bytes. This synchronous helper
+    owns that protocol so callers can move the complete blocking operation to a
+    worker thread.
+    """
+    headers: dict[str, str] = {}
+    if resource_key:
+        headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
+
+    request = service.files().download(fileId=file_id, mimeType=mime_type)
+    request.headers.update(headers)
+    operation = cast(dict[str, Any], request.execute())
+    started_at = monotonic()
+    deadline = started_at + timeout_seconds
+    logger.info(
+        "Drive download operation started file_id=%s operation_name=%s",
+        file_id,
+        operation.get("name", "completed-inline"),
+    )
+    poll_delay_seconds = 10.0
+    while operation.get("done") is not True:
+        operation_name = operation.get("name")
+        if not operation_name:
+            raise GoogleDriveDownloadError(
+                "Drive returned a pending operation without a name"
+            )
+        remaining_seconds = deadline - monotonic()
+        if remaining_seconds <= 0:
+            raise GoogleDriveDownloadTimeout(
+                f"Drive download for {file_id} did not finish within "
+                f"{timeout_seconds:g} seconds"
+            )
+        sleep(min(poll_delay_seconds, remaining_seconds))
+        poll_request = service.operations().get(name=str(operation_name))
+        poll_request.headers.update(headers)
+        operation = cast(dict[str, Any], poll_request.execute())
+        poll_delay_seconds = min(poll_delay_seconds * 2, 60.0)
+
+    if "error" in operation:
+        error = cast(dict[str, Any], operation["error"])
+        code = error.get("code", "unknown")
+        message = error.get("message", "Unknown Drive operation error")
+        raise GoogleDriveDownloadError(f"Drive operation failed ({code}): {message}")
+
+    logger.info(
+        "Drive download operation completed file_id=%s elapsed_seconds=%.3f",
+        file_id,
+        monotonic() - started_at,
+    )
+
+    response_metadata = operation.get("response")
+    if not isinstance(response_metadata, dict):
+        raise GoogleDriveDownloadError(
+            "Drive completed the operation without a response"
+        )
+    download_uri = response_metadata.get("downloadUri")
+    if not download_uri:
+        raise GoogleDriveDownloadError(
+            "Drive completed the operation without a download URI"
+        )
+
+    try:
+        with AuthorizedSession(credentials) as session:
+            with session.get(
+                download_uri,
+                stream=True,
+                timeout=_DOWNLOAD_HTTP_TIMEOUT_SECONDS,
+                headers=headers,
+            ) as response:
+                try:
+                    response.raise_for_status()
+                except Exception as exc:
+                    status_code = getattr(response, "status_code", "unknown")
+                    raise GoogleDriveDownloadError(
+                        f"Final Drive download failed with HTTP status {status_code}"
+                    ) from exc
+                with destination.open("wb") as output:
+                    for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
+                        if chunk:
+                            output.write(chunk)
+    except GoogleDriveDownloadError:
+        raise
+    except Exception as exc:
+        raise GoogleDriveDownloadError("Final Drive download request failed") from exc

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -47,6 +47,7 @@ def download_google_workspace_file(
     mime_type: str,
     destination: Path,
     timeout_seconds: float,
+    resource_key: str | None = None,
 ) -> None:
     """Export a Google Workspace file and stream it to ``destination``.
 
@@ -55,6 +56,8 @@ def download_google_workspace_file(
     worker thread.
     """
     headers: dict[str, str] = {}
+    if resource_key:
+        headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
 
     request = service.files().download(fileId=file_id, mimeType=mime_type)
     request.headers.update(headers)

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -76,7 +76,7 @@ def download_google_workspace_file(
         file_id,
         operation.get("name", "completed-inline"),
     )
-    poll_delay_seconds = 10.0
+    poll_delay_seconds = 2.0
     while operation.get("done") is not True:
         operation_name = operation.get("name")
         if not operation_name:

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -111,10 +111,25 @@ def download_google_workspace_file(
                     raise GoogleDriveDownloadError(
                         f"Final Drive download failed with HTTP status {status_code}"
                     ) from exc
-                with destination.open("wb") as output:
+                try:
+                    output_file = destination.open("wb")
+                except OSError as exc:
+                    reason = exc.strerror or "local filesystem error"
+                    raise GoogleDriveDownloadError(
+                        f"Failed to write Drive download: {reason}"
+                    ) from exc
+
+                with output_file as output:
                     for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
-                        if chunk:
+                        if not chunk:
+                            continue
+                        try:
                             output.write(chunk)
+                        except OSError as exc:
+                            reason = exc.strerror or "local filesystem error"
+                            raise GoogleDriveDownloadError(
+                                f"Failed to write Drive download: {reason}"
+                            ) from exc
     except GoogleDriveDownloadError:
         raise
     except Exception as exc:

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -53,7 +53,8 @@ def download_google_workspace_file(
 
     Drive returns an operation instead of file bytes. This synchronous helper
     owns that protocol so callers can move the complete blocking operation to a
-    worker thread.
+    worker thread. On mid-stream failure, ``destination`` may contain a partial
+    write; callers are responsible for cleanup.
     """
     headers: dict[str, str] = {}
     if resource_key:

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -85,11 +85,14 @@ def download_google_workspace_file(
                 f"{timeout_seconds:g} seconds"
             )
         sleep(min(poll_delay_seconds, remaining_seconds))
-        poll_request = service.operations().get(
-            name=str(operation_name).removeprefix("operations/")
-        )
-        poll_request.headers.update(headers)
-        operation = cast(dict[str, Any], poll_request.execute())
+        try:
+            poll_request = service.operations().get(
+                name=str(operation_name).removeprefix("operations/")
+            )
+            poll_request.headers.update(headers)
+            operation = cast(dict[str, Any], poll_request.execute())
+        except Exception as exc:
+            raise GoogleDriveDownloadError("Drive operation polling failed") from exc
         _update_resource_key_header(headers, file_id=file_id, operation=operation)
         poll_delay_seconds = min(poll_delay_seconds * 2, 60.0)
 

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -24,6 +24,21 @@ class GoogleDriveDownloadTimeout(GoogleDriveDownloadError):
     """Report a Drive operation that exceeded the caller's wait limit."""
 
 
+def _update_resource_key_header(
+    headers: dict[str, str],
+    *,
+    file_id: str,
+    operation: dict[str, Any],
+) -> None:
+    """Apply the resource key returned in Drive operation metadata."""
+    metadata = operation.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+    resource_key = metadata.get("resourceKey")
+    if resource_key:
+        headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
+
+
 def download_google_workspace_file(
     *,
     service: Any,
@@ -32,7 +47,6 @@ def download_google_workspace_file(
     mime_type: str,
     destination: Path,
     timeout_seconds: float,
-    resource_key: str | None = None,
 ) -> None:
     """Export a Google Workspace file and stream it to ``destination``.
 
@@ -41,12 +55,11 @@ def download_google_workspace_file(
     worker thread.
     """
     headers: dict[str, str] = {}
-    if resource_key:
-        headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
 
     request = service.files().download(fileId=file_id, mimeType=mime_type)
     request.headers.update(headers)
     operation = cast(dict[str, Any], request.execute())
+    _update_resource_key_header(headers, file_id=file_id, operation=operation)
     started_at = monotonic()
     deadline = started_at + timeout_seconds
     logger.info(
@@ -71,6 +84,7 @@ def download_google_workspace_file(
         poll_request = service.operations().get(name=str(operation_name))
         poll_request.headers.update(headers)
         operation = cast(dict[str, Any], poll_request.execute())
+        _update_resource_key_header(headers, file_id=file_id, operation=operation)
         poll_delay_seconds = min(poll_delay_seconds * 2, 60.0)
 
     if "error" in operation:

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -48,13 +48,15 @@ def download_google_workspace_file(
     destination: Path,
     timeout_seconds: float,
     resource_key: str | None = None,
+    max_bytes: int | None = None,
 ) -> None:
     """Export a Google Workspace file and stream it to ``destination``.
 
     Drive returns an operation instead of file bytes. This synchronous helper
     owns that protocol so callers can move the complete blocking operation to a
-    worker thread. On mid-stream failure, ``destination`` may contain a partial
-    write; callers are responsible for cleanup.
+    worker thread. When ``max_bytes`` is set, the stream aborts before writing
+    a chunk that would cross the limit. On mid-stream failure, ``destination``
+    may contain a partial write; callers are responsible for cleanup.
     """
     headers: dict[str, str] = {}
     if resource_key:
@@ -146,12 +148,18 @@ def download_google_workspace_file(
                         f"Failed to write Drive download: {reason}"
                     ) from exc
 
+                written = 0
                 with output_file as output:
                     for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
                         if not chunk:
                             continue
+                        if max_bytes is not None and written + len(chunk) > max_bytes:
+                            raise GoogleDriveDownloadError(
+                                "Exported file exceeds the maximum allowed size"
+                            )
                         try:
                             output.write(chunk)
+                            written += len(chunk)
                         except OSError as exc:
                             reason = exc.strerror or "local filesystem error"
                             raise GoogleDriveDownloadError(

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 _DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 _DOWNLOAD_HTTP_TIMEOUT_SECONDS = 60
+_GOOGLE_API_NUM_RETRIES = 3
 
 
 class GoogleDriveDownloadError(RuntimeError):
@@ -64,7 +65,9 @@ def download_google_workspace_file(
 
     request = service.files().download(fileId=file_id, mimeType=mime_type)
     request.headers.update(headers)
-    operation = cast(dict[str, Any], request.execute())
+    operation = cast(
+        dict[str, Any], request.execute(num_retries=_GOOGLE_API_NUM_RETRIES)
+    )
     _update_resource_key_header(headers, file_id=file_id, operation=operation)
     started_at = monotonic()
     deadline = started_at + timeout_seconds
@@ -92,7 +95,10 @@ def download_google_workspace_file(
                 name=str(operation_name).removeprefix("operations/")
             )
             poll_request.headers.update(headers)
-            operation = cast(dict[str, Any], poll_request.execute())
+            operation = cast(
+                dict[str, Any],
+                poll_request.execute(num_retries=_GOOGLE_API_NUM_RETRIES),
+            )
         except Exception as exc:
             raise GoogleDriveDownloadError("Drive operation polling failed") from exc
         _update_resource_key_header(headers, file_id=file_id, operation=operation)

--- a/src/xagent/web/services/google_drive_download.py
+++ b/src/xagent/web/services/google_drive_download.py
@@ -25,21 +25,6 @@ class GoogleDriveDownloadTimeout(GoogleDriveDownloadError):
     """Report a Drive operation that exceeded the caller's wait limit."""
 
 
-def _update_resource_key_header(
-    headers: dict[str, str],
-    *,
-    file_id: str,
-    operation: dict[str, Any],
-) -> None:
-    """Apply the resource key returned in Drive operation metadata."""
-    metadata = operation.get("metadata")
-    if not isinstance(metadata, dict):
-        return
-    resource_key = metadata.get("resourceKey")
-    if resource_key:
-        headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
-
-
 def download_google_workspace_file(
     *,
     service: Any,
@@ -56,8 +41,9 @@ def download_google_workspace_file(
     Drive returns an operation instead of file bytes. This synchronous helper
     owns that protocol so callers can move the complete blocking operation to a
     worker thread. When ``max_bytes`` is set, the stream aborts before writing
-    a chunk that would cross the limit. On mid-stream failure, ``destination``
-    may contain a partial write; callers are responsible for cleanup.
+    a chunk that would cross the limit. Any failure after opening
+    ``destination`` may leave an empty or partially written file; callers are
+    responsible for cleanup.
     """
     headers: dict[str, str] = {}
     if resource_key:
@@ -68,7 +54,6 @@ def download_google_workspace_file(
     operation = cast(
         dict[str, Any], request.execute(num_retries=_GOOGLE_API_NUM_RETRIES)
     )
-    _update_resource_key_header(headers, file_id=file_id, operation=operation)
     started_at = monotonic()
     deadline = started_at + timeout_seconds
     logger.info(
@@ -101,7 +86,6 @@ def download_google_workspace_file(
             )
         except Exception as exc:
             raise GoogleDriveDownloadError("Drive operation polling failed") from exc
-        _update_resource_key_header(headers, file_id=file_id, operation=operation)
         poll_delay_seconds = min(poll_delay_seconds * 2, 60.0)
 
     if "error" in operation:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1222,6 +1222,31 @@ class TestGetLancedbPath:
         assert result == Path("/custom/lancedb")
 
 
+class TestGoogleDriveDownloadTimeout:
+    """Test the Google Drive LRO timeout configuration."""
+
+    def test_constant_name(self):
+        assert (
+            config.GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS
+            == "XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS"
+        )
+
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv(
+            "XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS", raising=False
+        )
+        assert config.get_google_drive_download_timeout_seconds() == 600
+
+    def test_environment_override(self, monkeypatch):
+        monkeypatch.setenv("XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS", "120")
+        assert config.get_google_drive_download_timeout_seconds() == 120
+
+    @pytest.mark.parametrize("value", ["0", "-1", "not-a-number"])
+    def test_invalid_value_uses_default(self, monkeypatch, value):
+        monkeypatch.setenv("XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS", value)
+        assert config.get_google_drive_download_timeout_seconds() == 600
+
+
 class TestGetKbCollectionsTimeoutSeconds:
     """Test get_kb_collections_timeout_seconds() function."""
 

--- a/tests/web/api/test_cloud_storage.py
+++ b/tests/web/api/test_cloud_storage.py
@@ -21,7 +21,12 @@ async def test_google_drive_listing_preserves_resource_keys() -> None:
                         "name": "Linked Slides",
                         "mimeType": "application/vnd.google-apps.presentation",
                         "resourceKey": "link-resource-key",
-                    }
+                    },
+                    {
+                        "id": "slides-unlinked",
+                        "name": "Unlinked Slides",
+                        "mimeType": "application/vnd.google-apps.presentation",
+                    },
                 ]
             }
 
@@ -49,5 +54,8 @@ async def test_google_drive_listing_preserves_resource_keys() -> None:
             user=SimpleNamespace(id=1),
         )
 
-    assert "resourceKey" in str(list_calls[0]["fields"])
+    assert list_calls[0]["fields"] == (
+        "nextPageToken, files(id, name, mimeType, size, modifiedTime, resourceKey)"
+    )
     assert files[0]["resourceKey"] == "link-resource-key"
+    assert files[1]["resourceKey"] is None

--- a/tests/web/api/test_cloud_storage.py
+++ b/tests/web/api/test_cloud_storage.py
@@ -1,0 +1,53 @@
+"""Tests for cloud-storage API metadata contracts."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from xagent.web.api.cloud_storage import list_google_drive_files
+
+
+@pytest.mark.asyncio
+async def test_google_drive_listing_preserves_resource_keys() -> None:
+    list_calls: list[dict[str, object]] = []
+
+    class _ListRequest:
+        def execute(self):
+            return {
+                "files": [
+                    {
+                        "id": "slides-linked",
+                        "name": "Linked Slides",
+                        "mimeType": "application/vnd.google-apps.presentation",
+                        "resourceKey": "link-resource-key",
+                    }
+                ]
+            }
+
+    class _FilesResource:
+        def list(self, **kwargs):
+            list_calls.append(kwargs)
+            return _ListRequest()
+
+    class _DriveService:
+        def files(self):
+            return _FilesResource()
+
+    with (
+        patch(
+            "xagent.web.api.cloud_storage.get_google_credentials",
+            return_value=object(),
+        ),
+        patch(
+            "xagent.web.api.cloud_storage.build",
+            return_value=_DriveService(),
+        ),
+    ):
+        files = await list_google_drive_files(
+            db=MagicMock(),
+            user=SimpleNamespace(id=1),
+        )
+
+    assert "resourceKey" in str(list_calls[0]["fields"])
+    assert files[0]["resourceKey"] == "link-resource-key"

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -5641,6 +5641,31 @@ def test_kb_ingest_cloud_empty_batch_is_rejected(test_env) -> None:
     metadata_store.save_collection_config.assert_not_awaited()
 
 
+def test_kb_ingest_cloud_batch_over_five_files_is_rejected(test_env) -> None:
+    """A cloud batch must fit the endpoint's single five-file worker wave."""
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/kb/ingest-cloud",
+        json={
+            "collection": "cloud_oversized_batch",
+            "files": [
+                {
+                    "provider": "google-drive",
+                    "fileId": f"drive-file-{index}",
+                    "fileName": f"document-{index}.pdf",
+                }
+                for index in range(6)
+            ],
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"][-1] == "files"
+
+
 def test_kb_ingest_cloud_config_save_failure_keeps_per_file_results(
     test_env, temp_uploads
 ) -> None:

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3090,21 +3090,29 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
     app, headers, _user, TestingSessionLocal = test_env
     client = TestClient(app)
     metadata_calls: list[dict[str, object]] = []
+    metadata_requests: list[MagicMock] = []
     download_calls: list[dict[str, object]] = []
+    download_requests: list[MagicMock] = []
     captured_source_paths: list[str] = []
 
     class _FakeFilesService:
         def get(self, **kwargs):
             metadata_calls.append(kwargs)
-            return _fake_drive_metadata_request(
+            request = _fake_drive_metadata_request(
                 "drive-pptx-1",
                 "Current Deck.pptx",
                 "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             )
+            request.headers = {}
+            metadata_requests.append(request)
+            return request
 
         def get_media(self, **kwargs):
             download_calls.append(kwargs)
-            return kwargs
+            request = MagicMock()
+            request.headers = {}
+            download_requests.append(request)
+            return request
 
         def export_media(self, **_kwargs):
             raise AssertionError("binary PPTX files must use get_media")
@@ -3147,6 +3155,7 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
                         "provider": "google-drive",
                         "fileId": "drive-pptx-1",
                         "fileName": "stale-name.txt",
+                        "resourceKey": "binary-resource-key",
                     }
                 ],
             },
@@ -3162,7 +3171,12 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
             "supportsAllDrives": True,
         }
     ]
+    expected_resource_key_headers = {
+        "X-Goog-Drive-Resource-Keys": "drive-pptx-1/binary-resource-key"
+    }
+    assert metadata_requests[0].headers == expected_resource_key_headers
     assert download_calls == [{"fileId": "drive-pptx-1", "supportsAllDrives": True}]
+    assert download_requests[0].headers == expected_resource_key_headers
     assert len(captured_source_paths) == 1
     assert Path(captured_source_paths[0]).suffix == ".pptx"
 

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3330,7 +3330,12 @@ def test_kb_ingest_cloud_reports_unsupported_drive_shortcut(
         (
             {"name": "/"},
             "Google Drive returned an invalid file name",
-            "",
+            "drive-invalid-metadata",
+        ),
+        (
+            {"size": None},
+            "Google Drive returned incomplete file metadata",
+            "current.pdf",
         ),
     ],
 )
@@ -3489,9 +3494,7 @@ def test_kb_ingest_cloud_metadata_failure_has_no_file_side_effects(
         )
 
     assert response.status_code == 200
-    assert response.json()[0]["message"] == (
-        "Metadata lookup failed: metadata unavailable"
-    )
+    assert response.json()[0]["message"] == "Google Drive metadata lookup failed"
     downloader.assert_not_called()
     run_ingestion.assert_not_called()
     restore_backup.assert_not_called()
@@ -3502,6 +3505,41 @@ def test_kb_ingest_cloud_metadata_failure_has_no_file_side_effects(
         assert session.query(UploadedFile).count() == 0
     finally:
         session.close()
+
+
+def test_kb_ingest_cloud_authentication_error_uses_normalized_filename(
+    test_env,
+):
+    """Authentication failures should identify files by normalized basenames."""
+    from fastapi import HTTPException
+
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+
+    with patch(
+        "xagent.web.api.kb.get_google_credentials",
+        side_effect=HTTPException(status_code=401, detail="Reconnect Drive"),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_auth_failure",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-file-1",
+                        "fileName": "folder/current.pdf",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    result = response.json()[0]
+    assert result["status"] == "error"
+    assert result["message"] == "Authentication error: Reconnect Drive"
+    assert result["doc_id"] == "current.pdf"
 
 
 def test_kb_ingest_cloud_rejects_extensionless_binary_file(test_env, temp_uploads):
@@ -3965,7 +4003,11 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_download_error(
     data = response.json()
     assert data[0]["status"] == "error"
     assert data[0]["doc_id"] == "cloud.csv"
-    assert "Failed to fully roll back cloud ingest" in data[0]["message"]
+    assert (
+        "Failed to fully roll back cloud ingest for cloud_coll/cloud.csv"
+        in data[0]["message"]
+    )
+    assert "stale.csv" not in data[0]["message"]
 
 
 def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
@@ -3979,31 +4021,31 @@ def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
 
     class _FakeFilesService:
         def get(self, fileId: str, **_kwargs):
-            return _fake_drive_metadata_request(fileId, "cloud.csv", "text/csv")
-
-        def get_media(self, fileId: str, **_kwargs):
-            return {"fileId": fileId}
+            return _fake_drive_metadata_request(
+                fileId,
+                "Quarterly Review",
+                "application/vnd.google-apps.presentation",
+            )
 
     class _FakeDriveService:
         def files(self):
             return _FakeFilesService()
 
-    class _FailingDownloader:
-        def __init__(self, fh, request_file):
-            self._fh = fh
-
-        def next_chunk(self):
-            try:
-                raise RuntimeError("socket reset")
-            except RuntimeError as cause:
-                raise GoogleDriveDownloadError(
-                    "Final Drive download request failed"
-                ) from cause
+    def _fail_workspace_download(**_kwargs):
+        try:
+            raise RuntimeError("socket reset")
+        except RuntimeError as cause:
+            raise GoogleDriveDownloadError(
+                "Final Drive download request failed"
+            ) from cause
 
     with (
         patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
         patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
-        patch("xagent.web.api.kb.MediaIoBaseDownload", _FailingDownloader),
+        patch(
+            "xagent.web.api.kb.download_google_workspace_file",
+            side_effect=_fail_workspace_download,
+        ),
         patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
     ):
         response = client.post(
@@ -4014,7 +4056,7 @@ def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
                     {
                         "provider": "google-drive",
                         "fileId": "drive-file-1",
-                        "fileName": "cloud.csv",
+                        "fileName": "Quarterly Review",
                     }
                 ],
             },
@@ -4077,7 +4119,7 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_unexpected_error(
                     {
                         "provider": "google-drive",
                         "fileId": "drive-file-2",
-                        "fileName": "cloud.csv",
+                        "fileName": "stale.csv",
                     }
                 ],
             },
@@ -4087,7 +4129,11 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_unexpected_error(
     assert response.status_code == 200
     data = response.json()
     assert data[0]["status"] == "error"
-    assert "Failed to fully roll back cloud ingest" in data[0]["message"]
+    assert (
+        "Failed to fully roll back cloud ingest for cloud_coll/cloud.csv"
+        in data[0]["message"]
+    )
+    assert "stale.csv" not in data[0]["message"]
 
 
 def test_restore_ingest_file_backup_raises_when_existing_backup_is_missing(

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2958,14 +2958,16 @@ def test_kb_ingest_cloud_denied_request_does_not_persist_collection_config(
     metadata_store.save_collection_config.assert_not_awaited()
 
 
-def test_kb_ingest_cloud_exports_native_google_slides_as_pptx(test_env, temp_uploads):
-    """Native Google Slides should use Drive export and the PPTX parser path."""
+def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(test_env, temp_uploads):
+    """Native Google Slides should use the Drive LRO and the PPTX parser path."""
     from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
 
     app, headers, user, TestingSessionLocal = test_env
     client = TestClient(app)
+    credentials = object()
+    drive_service = MagicMock()
     metadata_calls: list[dict[str, object]] = []
-    export_calls: list[dict[str, str]] = []
+    lro_calls: list[dict[str, object]] = []
     captured_source_paths: list[str] = []
 
     class _FakeMetadataRequest:
@@ -2974,6 +2976,7 @@ def test_kb_ingest_cloud_exports_native_google_slides_as_pptx(test_env, temp_upl
                 "id": "drive-slides-1",
                 "name": "Quarterly.review",
                 "mimeType": "application/vnd.google-apps.presentation",
+                "resourceKey": "shared-resource-key",
             }
 
     class _FakeFilesService:
@@ -2981,26 +2984,19 @@ def test_kb_ingest_cloud_exports_native_google_slides_as_pptx(test_env, temp_upl
             metadata_calls.append(kwargs)
             return _FakeMetadataRequest()
 
-        def export_media(self, **kwargs):
-            export_calls.append(kwargs)
-            return kwargs
+        def export_media(self, **_kwargs):
+            raise AssertionError("native Google Slides must not use export_media")
 
-        def get_media(self, **kwargs):
-            raise AssertionError("native Google Slides must use export_media")
+        def get_media(self, **_kwargs):
+            raise AssertionError("native Google Slides must not use get_media")
 
-    class _FakeDriveService:
-        def files(self):
-            return _FakeFilesService()
+    drive_service.files.return_value = _FakeFilesService()
 
-    class _FakeDownloader:
-        def __init__(self, fh, request_file):
-            self._fh = fh
+    def _download_with_lro(**kwargs):
+        lro_calls.append(kwargs)
+        Path(kwargs["destination"]).write_bytes(b"downloaded-pptx")
 
-        def next_chunk(self):
-            self._fh.write(b"exported-pptx")
-            return None, True
-
-    def _capture_ingest(*, source_path=None, **kwargs):
+    def _capture_ingest(*, source_path=None, **_kwargs):
         assert source_path is not None
         captured_source_paths.append(str(source_path))
         return IngestionResult(
@@ -3012,9 +3008,12 @@ def test_kb_ingest_cloud_exports_native_google_slides_as_pptx(test_env, temp_upl
         )
 
     with (
-        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
-        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
-        patch("xagent.web.api.kb.MediaIoBaseDownload", _FakeDownloader),
+        patch("xagent.web.api.kb.get_google_credentials", return_value=credentials),
+        patch("xagent.web.api.kb.build", return_value=drive_service),
+        patch(
+            "xagent.web.api.kb.download_google_workspace_file",
+            side_effect=_download_with_lro,
+        ),
         patch("xagent.web.api.kb.run_document_ingestion", side_effect=_capture_ingest),
     ):
         response = client.post(
@@ -3037,14 +3036,19 @@ def test_kb_ingest_cloud_exports_native_google_slides_as_pptx(test_env, temp_upl
     assert metadata_calls == [
         {
             "fileId": "drive-slides-1",
-            "fields": "id,name,mimeType",
+            "fields": "id,name,mimeType,resourceKey",
             "supportsAllDrives": True,
         }
     ]
-    assert export_calls == [
+    assert lro_calls == [
         {
-            "fileId": "drive-slides-1",
-            "mimeType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "service": drive_service,
+            "credentials": credentials,
+            "file_id": "drive-slides-1",
+            "mime_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "destination": Path(captured_source_paths[0]),
+            "timeout_seconds": 600,
+            "resource_key": "shared-resource-key",
         }
     ]
     assert len(captured_source_paths) == 1
@@ -3140,7 +3144,7 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
     assert metadata_calls == [
         {
             "fileId": "drive-pptx-1",
-            "fields": "id,name,mimeType",
+            "fields": "id,name,mimeType,resourceKey",
             "supportsAllDrives": True,
         }
     ]
@@ -3266,8 +3270,8 @@ def test_kb_ingest_cloud_rejects_extensionless_binary_file(test_env, temp_upload
     assert not [path for path in temp_uploads.rglob("*") if path.is_file()]
 
 
-def test_kb_ingest_cloud_export_failure_removes_partial_file(test_env, temp_uploads):
-    """Failed native Slides exports should remove partial local state."""
+def test_kb_ingest_cloud_download_failure_removes_partial_file(test_env, temp_uploads):
+    """Failed native Slides downloads should remove partial local state."""
     app, headers, _user, TestingSessionLocal = test_env
     client = TestClient(app)
 
@@ -3279,35 +3283,27 @@ def test_kb_ingest_cloud_export_failure_removes_partial_file(test_env, temp_uplo
                 "application/vnd.google-apps.presentation",
             )
 
-        def export_media(self, **kwargs):
-            return kwargs
-
     class _FakeDriveService:
         def files(self):
             return _FakeFilesService()
 
-    class _FailingDownloader:
-        def __init__(self, fh, request_file):
-            self._fh = fh
-            self._calls = 0
-
-        def next_chunk(self):
-            self._calls += 1
-            if self._calls == 1:
-                self._fh.write(b"partial-pptx")
-                return None, False
-            raise RuntimeError("export interrupted")
+    def _fail_download(**kwargs):
+        Path(kwargs["destination"]).write_bytes(b"partial-pptx")
+        raise RuntimeError("download interrupted")
 
     with (
         patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
         patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
-        patch("xagent.web.api.kb.MediaIoBaseDownload", _FailingDownloader),
+        patch(
+            "xagent.web.api.kb.download_google_workspace_file",
+            side_effect=_fail_download,
+        ),
         patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
     ):
         response = client.post(
             "/api/kb/ingest-cloud",
             json={
-                "collection": "cloud_export_failure",
+                "collection": "cloud_download_failure",
                 "files": [
                     {
                         "provider": "google-drive",
@@ -3320,7 +3316,7 @@ def test_kb_ingest_cloud_export_failure_removes_partial_file(test_env, temp_uplo
         )
 
     assert response.status_code == 200
-    assert response.json()[0]["message"] == "Export failed: export interrupted"
+    assert response.json()[0]["message"] == "Download failed: download interrupted"
     run_ingestion.assert_not_called()
     assert not [path for path in temp_uploads.rglob("*") if path.is_file()]
 
@@ -3331,7 +3327,9 @@ def test_kb_ingest_cloud_export_failure_removes_partial_file(test_env, temp_uplo
         session.close()
 
 
-def test_kb_ingest_cloud_export_failure_restores_existing_file(test_env, temp_uploads):
+def test_kb_ingest_cloud_download_failure_restores_existing_file(
+    test_env, temp_uploads
+):
     """A failed native Slides refresh should restore the previous local file."""
     from xagent.web.api.kb import _build_cloud_storage_filename
 
@@ -3353,31 +3351,27 @@ def test_kb_ingest_cloud_export_failure_restores_existing_file(test_env, temp_up
                 "application/vnd.google-apps.presentation",
             )
 
-        def export_media(self, **kwargs):
-            return kwargs
-
     class _FakeDriveService:
         def files(self):
             return _FakeFilesService()
 
-    class _FailingDownloader:
-        def __init__(self, fh, request_file):
-            self._fh = fh
-
-        def next_chunk(self):
-            self._fh.write(b"replacement-partial")
-            raise RuntimeError("export interrupted")
+    def _fail_download(**kwargs):
+        Path(kwargs["destination"]).write_bytes(b"replacement-partial")
+        raise RuntimeError("download interrupted")
 
     with (
         patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
         patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
-        patch("xagent.web.api.kb.MediaIoBaseDownload", _FailingDownloader),
+        patch(
+            "xagent.web.api.kb.download_google_workspace_file",
+            side_effect=_fail_download,
+        ),
         patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
     ):
         response = client.post(
             "/api/kb/ingest-cloud",
             json={
-                "collection": "cloud_export_restore",
+                "collection": "cloud_download_restore",
                 "files": [
                     {
                         "provider": "google-drive",
@@ -3390,7 +3384,7 @@ def test_kb_ingest_cloud_export_failure_restores_existing_file(test_env, temp_up
         )
 
     assert response.status_code == 200
-    assert response.json()[0]["message"] == "Export failed: export interrupted"
+    assert response.json()[0]["message"] == "Download failed: download interrupted"
     run_ingestion.assert_not_called()
     assert file_path.read_bytes() == b"previous-pptx"
     assert list(file_path.parent.glob("*.rollback-*")) == []

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2976,7 +2976,6 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(test_env, temp_u
                 "id": "drive-slides-1",
                 "name": "Quarterly.review",
                 "mimeType": "application/vnd.google-apps.presentation",
-                "resourceKey": "shared-resource-key",
             }
 
     class _FakeFilesService:
@@ -3036,7 +3035,7 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(test_env, temp_u
     assert metadata_calls == [
         {
             "fileId": "drive-slides-1",
-            "fields": "id,name,mimeType,resourceKey",
+            "fields": "id,name,mimeType",
             "supportsAllDrives": True,
         }
     ]
@@ -3048,7 +3047,6 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(test_env, temp_u
             "mime_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             "destination": Path(captured_source_paths[0]),
             "timeout_seconds": 600,
-            "resource_key": "shared-resource-key",
         }
     ]
     assert len(captured_source_paths) == 1
@@ -3144,7 +3142,7 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
     assert metadata_calls == [
         {
             "fileId": "drive-pptx-1",
-            "fields": "id,name,mimeType,resourceKey",
+            "fields": "id,name,mimeType",
             "supportsAllDrives": True,
         }
     ]

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2972,10 +2972,14 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
     credentials = object()
     drive_service = MagicMock()
     metadata_calls: list[dict[str, object]] = []
+    metadata_requests: list[object] = []
     lro_calls: list[dict[str, object]] = []
     captured_source_paths: list[str] = []
 
     class _FakeMetadataRequest:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def execute(self):
             return {
                 "id": "drive-slides-1",
@@ -2986,7 +2990,9 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
     class _FakeFilesService:
         def get(self, **kwargs):
             metadata_calls.append(kwargs)
-            return _FakeMetadataRequest()
+            request = _FakeMetadataRequest()
+            metadata_requests.append(request)
+            return request
 
         def export_media(self, **_kwargs):
             raise AssertionError("native Google Slides must not use export_media")
@@ -3029,6 +3035,7 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
                         "provider": "google-drive",
                         "fileId": "drive-slides-1",
                         "fileName": "Quarterly Review",
+                        "resourceKey": "link-resource-key",
                     }
                 ],
             },
@@ -3044,6 +3051,9 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
             "supportsAllDrives": True,
         }
     ]
+    assert metadata_requests[0].headers == {
+        "X-Goog-Drive-Resource-Keys": "drive-slides-1/link-resource-key"
+    }
     assert lro_calls == [
         {
             "service": drive_service,
@@ -3052,6 +3062,7 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
             "mime_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             "destination": Path(captured_source_paths[0]),
             "timeout_seconds": 600,
+            "resource_key": "link-resource-key",
         }
     ]
     assert len(captured_source_paths) == 1

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3319,6 +3319,77 @@ def test_kb_ingest_cloud_reports_unsupported_drive_shortcut(
     assert list(temp_uploads.iterdir()) == []
 
 
+@pytest.mark.parametrize(
+    ("metadata_updates", "expected_message", "expected_doc_id"),
+    [
+        (
+            {"mimeType": None},
+            "Google Drive returned incomplete file metadata",
+            "current.pdf",
+        ),
+        (
+            {"name": "/"},
+            "Google Drive returned an invalid file name",
+            "",
+        ),
+    ],
+)
+def test_kb_ingest_cloud_rejects_invalid_drive_metadata(
+    metadata_updates,
+    expected_message,
+    expected_doc_id,
+    test_env,
+    temp_uploads,
+):
+    """Untrusted Drive metadata must fail before download or ingestion."""
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+    metadata_request = _fake_drive_metadata_request(
+        "drive-invalid-metadata",
+        "current.pdf",
+        "application/pdf",
+    )
+    metadata_request.execute.return_value.update(metadata_updates)
+
+    class _FakeFilesService:
+        def get(self, **_kwargs):
+            return metadata_request
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload") as downloader,
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_invalid_metadata",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-invalid-metadata",
+                        "fileName": "stale.pdf",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    result = response.json()[0]
+    assert result["status"] == "error"
+    assert result["doc_id"] == expected_doc_id
+    assert result["message"] == f"Metadata lookup failed: {expected_message}"
+    downloader.assert_not_called()
+    run_ingestion.assert_not_called()
+    assert list(temp_uploads.iterdir()) == []
+
+
 def test_kb_ingest_cloud_metadata_validation_uses_current_drive_filename(
     test_env,
     temp_uploads,

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2958,11 +2958,16 @@ def test_kb_ingest_cloud_denied_request_does_not_persist_collection_config(
     metadata_store.save_collection_config.assert_not_awaited()
 
 
-def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(test_env, temp_uploads):
+def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
+    test_env,
+    temp_uploads,
+    monkeypatch,
+):
     """Native Google Slides should use the Drive LRO and the PPTX parser path."""
     from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
 
     app, headers, user, TestingSessionLocal = test_env
+    monkeypatch.delenv("XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS", raising=False)
     client = TestClient(app)
     credentials = object()
     drive_service = MagicMock()

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3767,7 +3767,7 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_download_error(
                     {
                         "provider": "google-drive",
                         "fileId": "drive-file-1",
-                        "fileName": "cloud.csv",
+                        "fileName": "stale.csv",
                     }
                 ],
             },
@@ -3777,6 +3777,7 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_download_error(
     assert response.status_code == 200
     data = response.json()
     assert data[0]["status"] == "error"
+    assert data[0]["doc_id"] == "cloud.csv"
     assert "Failed to fully roll back cloud ingest" in data[0]["message"]
 
 

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2699,6 +2699,7 @@ def _fake_drive_metadata_request(
         "id": file_id,
         "name": name,
         "mimeType": mime_type,
+        "size": "1",
     }
     return request
 
@@ -2980,11 +2981,12 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
         def __init__(self):
             self.headers: dict[str, str] = {}
 
-        def execute(self):
+        def execute(self, **_kwargs):
             return {
                 "id": "drive-slides-1",
                 "name": "Quarterly.review",
                 "mimeType": "application/vnd.google-apps.presentation",
+                "size": "1",
             }
 
     class _FakeFilesService:
@@ -3047,7 +3049,7 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
     assert metadata_calls == [
         {
             "fileId": "drive-slides-1",
-            "fields": "id,name,mimeType",
+            "fields": "id,name,mimeType,size",
             "supportsAllDrives": True,
         }
     ]
@@ -3167,7 +3169,7 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
     assert metadata_calls == [
         {
             "fileId": "drive-pptx-1",
-            "fields": "id,name,mimeType",
+            "fields": "id,name,mimeType,size",
             "supportsAllDrives": True,
         }
     ]
@@ -3192,6 +3194,70 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
             file_record.mime_type
             == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
         )
+    finally:
+        session.close()
+
+
+def test_kb_ingest_cloud_rejects_oversized_drive_file_before_download(
+    test_env,
+    temp_uploads,
+    monkeypatch,
+):
+    """Drive imports should enforce the same file-size limit as uploads."""
+    app, headers, _user, TestingSessionLocal = test_env
+    client = TestClient(app)
+    get_media = MagicMock()
+    metadata_request = _fake_drive_metadata_request(
+        "drive-large-1",
+        "large.pdf",
+        "application/pdf",
+    )
+    metadata_request.execute.return_value["size"] = "5"
+
+    class _FakeFilesService:
+        def get(self, **_kwargs):
+            return metadata_request
+
+        def get_media(self, **kwargs):
+            return get_media(**kwargs)
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    monkeypatch.setattr("xagent.web.api.kb.MAX_FILE_SIZE", 4)
+    monkeypatch.setattr("xagent.web.api.kb.MAX_FILE_SIZE_LABEL", "4B")
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_oversized",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-large-1",
+                        "fileName": "large.pdf",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["message"] == "File size exceeds maximum limit of 4B"
+    metadata_request.execute.assert_called_once_with(num_retries=3)
+    get_media.assert_not_called()
+    run_ingestion.assert_not_called()
+    assert list(temp_uploads.iterdir()) == []
+
+    session = TestingSessionLocal()
+    try:
+        assert session.query(UploadedFile).count() == 0
     finally:
         session.close()
 
@@ -5530,11 +5596,12 @@ def test_kb_ingest_cloud_config_save_failure_keeps_per_file_results(
         def __init__(self):
             self.headers: dict[str, str] = {}
 
-        def execute(self):
+        def execute(self, **_kwargs):
             return {
                 "id": "drive-file-1",
                 "name": "doc.txt",
                 "mimeType": "text/plain",
+                "size": "1",
             }
 
     class _FakeFilesService:

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2966,6 +2966,7 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
 ):
     """Native Google Slides should use the Drive LRO and the PPTX parser path."""
     from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+    from xagent.web.config import MAX_FILE_SIZE
 
     app, headers, user, TestingSessionLocal = test_env
     monkeypatch.delenv("XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS", raising=False)
@@ -3065,6 +3066,7 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
             "destination": Path(captured_source_paths[0]),
             "timeout_seconds": 600,
             "resource_key": "link-resource-key",
+            "max_bytes": MAX_FILE_SIZE,
         }
     ]
     assert len(captured_source_paths) == 1

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -2688,6 +2688,21 @@ async def test_kb_ingest_cloud_rollback_passes_admin_scope() -> None:
     )
 
 
+def _fake_drive_metadata_request(
+    file_id: str,
+    name: str,
+    mime_type: str,
+) -> MagicMock:
+    """Build the executable metadata request returned by the Drive client."""
+    request = MagicMock()
+    request.execute.return_value = {
+        "id": file_id,
+        "name": name,
+        "mimeType": mime_type,
+    }
+    return request
+
+
 def test_kb_ingest_cloud_all_failures_clean_new_collection_config(test_env) -> None:
     """Cloud ingest should remove saved config when a brand-new collection never ingests anything."""
     app, headers, _user, _ = test_env
@@ -2833,7 +2848,10 @@ def test_kb_ingest_cloud_mixed_failure_still_publishes_config(
     metadata_store.delete_collection_metadata = AsyncMock()
 
     class _FakeFilesService:
-        def get_media(self, fileId: str):
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(fileId, "doc.txt", "text/plain")
+
+        def get_media(self, fileId: str, **_kwargs):
             return {"fileId": fileId}
 
     class _FakeDriveService:
@@ -2940,6 +2958,444 @@ def test_kb_ingest_cloud_denied_request_does_not_persist_collection_config(
     metadata_store.save_collection_config.assert_not_awaited()
 
 
+def test_kb_ingest_cloud_exports_native_google_slides_as_pptx(test_env, temp_uploads):
+    """Native Google Slides should use Drive export and the PPTX parser path."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+    metadata_calls: list[dict[str, object]] = []
+    export_calls: list[dict[str, str]] = []
+    captured_source_paths: list[str] = []
+
+    class _FakeMetadataRequest:
+        def execute(self):
+            return {
+                "id": "drive-slides-1",
+                "name": "Quarterly.review",
+                "mimeType": "application/vnd.google-apps.presentation",
+            }
+
+    class _FakeFilesService:
+        def get(self, **kwargs):
+            metadata_calls.append(kwargs)
+            return _FakeMetadataRequest()
+
+        def export_media(self, **kwargs):
+            export_calls.append(kwargs)
+            return kwargs
+
+        def get_media(self, **kwargs):
+            raise AssertionError("native Google Slides must use export_media")
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    class _FakeDownloader:
+        def __init__(self, fh, request_file):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"exported-pptx")
+            return None, True
+
+    def _capture_ingest(*, source_path=None, **kwargs):
+        assert source_path is not None
+        captured_source_paths.append(str(source_path))
+        return IngestionResult(
+            status="success",
+            doc_id="slides-doc-id",
+            parse_hash="hash",
+            failed_step="",
+            message="success",
+        )
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload", _FakeDownloader),
+        patch("xagent.web.api.kb.run_document_ingestion", side_effect=_capture_ingest),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_slides",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-slides-1",
+                        "fileName": "Quarterly Review",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "success"
+    assert metadata_calls == [
+        {
+            "fileId": "drive-slides-1",
+            "fields": "id,name,mimeType",
+            "supportsAllDrives": True,
+        }
+    ]
+    assert export_calls == [
+        {
+            "fileId": "drive-slides-1",
+            "mimeType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        }
+    ]
+    assert len(captured_source_paths) == 1
+    assert Path(captured_source_paths[0]).suffix == ".pptx"
+
+    session = TestingSessionLocal()
+    try:
+        file_record = (
+            session.query(UploadedFile)
+            .filter(UploadedFile.filename == "Quarterly.review.pptx")
+            .one()
+        )
+        assert (
+            file_record.mime_type
+            == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        )
+    finally:
+        session.close()
+
+
+def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uploads):
+    """Binary imports should trust Drive metadata and support shared drives."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+    app, headers, _user, TestingSessionLocal = test_env
+    client = TestClient(app)
+    metadata_calls: list[dict[str, object]] = []
+    download_calls: list[dict[str, object]] = []
+    captured_source_paths: list[str] = []
+
+    class _FakeFilesService:
+        def get(self, **kwargs):
+            metadata_calls.append(kwargs)
+            return _fake_drive_metadata_request(
+                "drive-pptx-1",
+                "Current Deck.pptx",
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            )
+
+        def get_media(self, **kwargs):
+            download_calls.append(kwargs)
+            return kwargs
+
+        def export_media(self, **_kwargs):
+            raise AssertionError("binary PPTX files must use get_media")
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    class _FakeDownloader:
+        def __init__(self, fh, request_file):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"binary-pptx")
+            return None, True
+
+    def _capture_ingest(*, source_path=None, **_kwargs):
+        assert source_path is not None
+        captured_source_paths.append(str(source_path))
+        return IngestionResult(
+            status="success",
+            doc_id="binary-pptx-doc-id",
+            parse_hash="hash",
+            failed_step="",
+            message="success",
+        )
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload", _FakeDownloader),
+        patch("xagent.web.api.kb.run_document_ingestion", side_effect=_capture_ingest),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_binary_pptx",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-pptx-1",
+                        "fileName": "stale-name.txt",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "success"
+    assert metadata_calls == [
+        {
+            "fileId": "drive-pptx-1",
+            "fields": "id,name,mimeType",
+            "supportsAllDrives": True,
+        }
+    ]
+    assert download_calls == [{"fileId": "drive-pptx-1", "supportsAllDrives": True}]
+    assert len(captured_source_paths) == 1
+    assert Path(captured_source_paths[0]).suffix == ".pptx"
+
+    session = TestingSessionLocal()
+    try:
+        file_record = (
+            session.query(UploadedFile)
+            .filter(UploadedFile.filename == "Current Deck.pptx")
+            .one()
+        )
+        assert (
+            file_record.mime_type
+            == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        )
+    finally:
+        session.close()
+
+
+def test_kb_ingest_cloud_metadata_failure_has_no_file_side_effects(
+    test_env, temp_uploads
+):
+    """Metadata failures should stop before local file mutation."""
+    app, headers, _user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    class _FakeFilesService:
+        def get(self, **_kwargs):
+            request = MagicMock()
+            request.execute.side_effect = RuntimeError("metadata unavailable")
+            return request
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload") as downloader,
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+        patch("xagent.web.api.kb._restore_ingest_file_backup") as restore_backup,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_metadata_failure",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-file-1",
+                        "fileName": "stale-name.txt",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["message"] == (
+        "Metadata lookup failed: metadata unavailable"
+    )
+    downloader.assert_not_called()
+    run_ingestion.assert_not_called()
+    restore_backup.assert_not_called()
+    assert list(temp_uploads.iterdir()) == []
+
+    session = TestingSessionLocal()
+    try:
+        assert session.query(UploadedFile).count() == 0
+    finally:
+        session.close()
+
+
+def test_kb_ingest_cloud_rejects_extensionless_binary_file(test_env, temp_uploads):
+    """An extensionless binary file must not be guessed as native Slides."""
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+
+    class _FakeFilesService:
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(
+                fileId,
+                "No Extension",
+                "application/octet-stream",
+            )
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload") as downloader,
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_unsupported_binary",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-file-1",
+                        "fileName": "misleading.txt",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["message"] == (
+        "Unsupported file type '' for ingestion. "
+        "No available parser supports this format."
+    )
+    downloader.assert_not_called()
+    run_ingestion.assert_not_called()
+    assert not [path for path in temp_uploads.rglob("*") if path.is_file()]
+
+
+def test_kb_ingest_cloud_export_failure_removes_partial_file(test_env, temp_uploads):
+    """Failed native Slides exports should remove partial local state."""
+    app, headers, _user, TestingSessionLocal = test_env
+    client = TestClient(app)
+
+    class _FakeFilesService:
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(
+                fileId,
+                "Quarterly Review",
+                "application/vnd.google-apps.presentation",
+            )
+
+        def export_media(self, **kwargs):
+            return kwargs
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    class _FailingDownloader:
+        def __init__(self, fh, request_file):
+            self._fh = fh
+            self._calls = 0
+
+        def next_chunk(self):
+            self._calls += 1
+            if self._calls == 1:
+                self._fh.write(b"partial-pptx")
+                return None, False
+            raise RuntimeError("export interrupted")
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload", _FailingDownloader),
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_export_failure",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-slides-1",
+                        "fileName": "Quarterly Review",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["message"] == "Export failed: export interrupted"
+    run_ingestion.assert_not_called()
+    assert not [path for path in temp_uploads.rglob("*") if path.is_file()]
+
+    session = TestingSessionLocal()
+    try:
+        assert session.query(UploadedFile).count() == 0
+    finally:
+        session.close()
+
+
+def test_kb_ingest_cloud_export_failure_restores_existing_file(test_env, temp_uploads):
+    """A failed native Slides refresh should restore the previous local file."""
+    from xagent.web.api.kb import _build_cloud_storage_filename
+
+    app, headers, user, _ = test_env
+    client = TestClient(app)
+    storage_filename = _build_cloud_storage_filename(
+        "Quarterly Review.pptx",
+        "drive-slides-1",
+    )
+    file_path = temp_uploads / f"user_{user.id}" / storage_filename
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(b"previous-pptx")
+
+    class _FakeFilesService:
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(
+                fileId,
+                "Quarterly Review",
+                "application/vnd.google-apps.presentation",
+            )
+
+        def export_media(self, **kwargs):
+            return kwargs
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    class _FailingDownloader:
+        def __init__(self, fh, request_file):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"replacement-partial")
+            raise RuntimeError("export interrupted")
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload", _FailingDownloader),
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_export_restore",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-slides-1",
+                        "fileName": "Quarterly Review",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["message"] == "Export failed: export interrupted"
+    run_ingestion.assert_not_called()
+    assert file_path.read_bytes() == b"previous-pptx"
+    assert list(file_path.parent.glob("*.rollback-*")) == []
+
+
 def test_kb_ingest_cloud_passes_file_id_to_pipeline(test_env, temp_uploads):
     """Cloud ingest should also register UploadedFile before pipeline execution."""
     app, headers, user, TestingSessionLocal = test_env
@@ -2947,7 +3403,10 @@ def test_kb_ingest_cloud_passes_file_id_to_pipeline(test_env, temp_uploads):
     captured_file_ids: list[str] = []
 
     class _FakeFilesService:
-        def get_media(self, fileId: str):
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(fileId, "cloud.txt", "text/plain")
+
+        def get_media(self, fileId: str, **_kwargs):
             return {"fileId": fileId}
 
     class _FakeDriveService:
@@ -3028,7 +3487,10 @@ def test_kb_ingest_cloud_normalizes_parser_and_rolls_back_partial_failure(
     captured_parse_methods = []
 
     class _FakeFilesService:
-        def get_media(self, fileId: str):
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(fileId, "cloud.csv", "text/csv")
+
+        def get_media(self, fileId: str, **_kwargs):
             return {"fileId": fileId}
 
     class _FakeDriveService:
@@ -3105,7 +3567,10 @@ def test_kb_ingest_cloud_returns_rollback_failure_message(test_env, temp_uploads
     client = TestClient(app)
 
     class _FakeFilesService:
-        def get_media(self, fileId: str):
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(fileId, "cloud.csv", "text/csv")
+
+        def get_media(self, fileId: str, **_kwargs):
             return {"fileId": fileId}
 
     class _FakeDriveService:
@@ -3179,7 +3644,10 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_download_error(
     client = TestClient(app)
 
     class _FakeFilesService:
-        def get_media(self, fileId: str):
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(fileId, "cloud.csv", "text/csv")
+
+        def get_media(self, fileId: str, **_kwargs):
             return {"fileId": fileId}
 
     class _FakeDriveService:
@@ -3232,7 +3700,10 @@ def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
     client = TestClient(app)
 
     class _FakeFilesService:
-        def get_media(self, fileId: str):
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(fileId, "cloud.csv", "text/csv")
+
+        def get_media(self, fileId: str, **_kwargs):
             return {"fileId": fileId}
 
     class _FakeDriveService:
@@ -3283,7 +3754,10 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_unexpected_error(
     client = TestClient(app)
 
     class _FakeFilesService:
-        def get_media(self, fileId: str):
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(fileId, "cloud.csv", "text/csv")
+
+        def get_media(self, fileId: str, **_kwargs):
             return {"fileId": fileId}
 
     class _FakeDriveService:
@@ -3362,7 +3836,10 @@ def test_kb_ingest_cloud_uses_unique_storage_paths_for_duplicate_filenames(
     captured_paths: list[str] = []
 
     class _FakeFilesService:
-        def get_media(self, fileId: str):
+        def get(self, fileId: str, **_kwargs):
+            return _fake_drive_metadata_request(fileId, "same-name.csv", "text/csv")
+
+        def get_media(self, fileId: str, **_kwargs):
             return {"fileId": fileId}
 
     class _FakeDriveService:

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3262,6 +3262,65 @@ def test_kb_ingest_cloud_rejects_oversized_drive_file_before_download(
         session.close()
 
 
+def test_kb_ingest_cloud_metadata_validation_uses_current_drive_filename(
+    test_env,
+    temp_uploads,
+):
+    """Metadata validation errors should identify Drive's current file name."""
+    app, headers, _user, TestingSessionLocal = test_env
+    client = TestClient(app)
+    metadata_request = _fake_drive_metadata_request(
+        "drive-invalid-size",
+        "current.pdf",
+        "application/pdf",
+    )
+    metadata_request.execute.return_value["size"] = "invalid"
+
+    class _FakeFilesService:
+        def get(self, **_kwargs):
+            return metadata_request
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload") as downloader,
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_invalid_size",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-invalid-size",
+                        "fileName": "stale.pdf",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    result = response.json()[0]
+    assert result["status"] == "error"
+    assert result["doc_id"] == "current.pdf"
+    assert result["message"].startswith("Metadata lookup failed:")
+    downloader.assert_not_called()
+    run_ingestion.assert_not_called()
+    assert list(temp_uploads.iterdir()) == []
+
+    session = TestingSessionLocal()
+    try:
+        assert session.query(UploadedFile).count() == 0
+    finally:
+        session.close()
+
+
 def test_kb_ingest_cloud_metadata_failure_has_no_file_side_effects(
     test_env, temp_uploads
 ):

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3338,6 +3338,94 @@ def test_kb_ingest_cloud_accepts_drive_file_at_exact_size_limit(
     assert response.json()[0]["status"] == "success"
 
 
+@pytest.mark.parametrize("had_existing_file", [False, True])
+def test_kb_ingest_cloud_rejects_binary_download_that_grows_over_limit(
+    had_existing_file,
+    test_env,
+    temp_uploads,
+    monkeypatch,
+):
+    """Actual binary bytes must remain bounded after the metadata size check."""
+    app, headers, user, TestingSessionLocal = test_env
+    client = TestClient(app)
+    metadata_request = _fake_drive_metadata_request(
+        "drive-growing-file",
+        "growing.pdf",
+        "application/pdf",
+    )
+    metadata_request.execute.return_value["size"] = "4"
+
+    class _FakeFilesService:
+        def get(self, **_kwargs):
+            return metadata_request
+
+        def get_media(self, **_kwargs):
+            return object()
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    class _GrowingDownloader:
+        def __init__(self, fh, _request_file):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"12345")
+            return None, True
+
+    monkeypatch.setattr("xagent.web.api.kb.MAX_FILE_SIZE", 4)
+    monkeypatch.setattr("xagent.web.api.kb.MAX_FILE_SIZE_LABEL", "4B")
+    from xagent.web.api.kb import _build_cloud_storage_filename
+
+    file_path = (
+        temp_uploads
+        / f"user_{user.id}"
+        / _build_cloud_storage_filename("growing.pdf", "drive-growing-file")
+    )
+    if had_existing_file:
+        file_path.parent.mkdir(parents=True)
+        file_path.write_bytes(b"previous")
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload", _GrowingDownloader),
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_growing_binary",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-growing-file",
+                        "fileName": "stale.pdf",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["message"] == (
+        "Download failed: File size exceeds maximum limit of 4B"
+    )
+    run_ingestion.assert_not_called()
+    if had_existing_file:
+        assert file_path.read_bytes() == b"previous"
+        assert list(file_path.parent.glob("*.rollback-*")) == []
+    else:
+        assert not [path for path in temp_uploads.rglob("*") if path.is_file()]
+
+    session = TestingSessionLocal()
+    try:
+        assert session.query(UploadedFile).count() == 0
+    finally:
+        session.close()
+
+
 def test_kb_ingest_cloud_rejects_oversized_drive_file_before_download(
     test_env,
     temp_uploads,

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -5511,9 +5511,23 @@ def test_kb_ingest_cloud_config_save_failure_keeps_per_file_results(
     )
     metadata_store.delete_collection_metadata = AsyncMock()
 
+    class _FakeMetadataRequest:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
+        def execute(self):
+            return {
+                "id": "drive-file-1",
+                "name": "doc.txt",
+                "mimeType": "text/plain",
+            }
+
     class _FakeFilesService:
-        def get_media(self, fileId: str):
-            return {"fileId": fileId}
+        def get(self, **_kwargs):
+            return _FakeMetadataRequest()
+
+        def get_media(self, fileId: str, supportsAllDrives: bool):
+            return {"fileId": fileId, "supportsAllDrives": supportsAllDrives}
 
     class _FakeDriveService:
         def files(self):

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3175,6 +3175,7 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
         "X-Goog-Drive-Resource-Keys": "drive-pptx-1/binary-resource-key"
     }
     assert metadata_requests[0].headers == expected_resource_key_headers
+    metadata_requests[0].execute.assert_called_once_with(num_retries=3)
     assert download_calls == [{"fileId": "drive-pptx-1", "supportsAllDrives": True}]
     assert download_requests[0].headers == expected_resource_key_headers
     assert len(captured_source_paths) == 1

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3264,6 +3264,61 @@ def test_kb_ingest_cloud_rejects_oversized_drive_file_before_download(
         session.close()
 
 
+def test_kb_ingest_cloud_reports_unsupported_drive_shortcut(
+    test_env,
+    temp_uploads,
+):
+    """Drive shortcuts should fail with a specific unsupported-type message."""
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+    metadata_request = _fake_drive_metadata_request(
+        "drive-shortcut-1",
+        "Linked presentation",
+        "application/vnd.google-apps.shortcut",
+    )
+    metadata_request.execute.return_value.pop("size")
+
+    class _FakeFilesService:
+        def get(self, **_kwargs):
+            return metadata_request
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload") as downloader,
+        patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_shortcut",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-shortcut-1",
+                        "fileName": "stale-name",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    result = response.json()[0]
+    assert result["status"] == "error"
+    assert result["doc_id"] == "Linked presentation"
+    assert result["message"] == (
+        "Metadata lookup failed: Google Drive shortcuts are not supported"
+    )
+    downloader.assert_not_called()
+    run_ingestion.assert_not_called()
+    assert list(temp_uploads.iterdir()) == []
+
+
 def test_kb_ingest_cloud_metadata_validation_uses_current_drive_filename(
     test_env,
     temp_uploads,

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3781,9 +3781,10 @@ def test_kb_ingest_cloud_surfaces_restore_failure_on_download_error(
 
 
 def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
-    test_env, temp_uploads
+    test_env, temp_uploads, caplog
 ):
     """Cloud download failures should stop after restoring the local backup."""
+    from xagent.web.services.google_drive_download import GoogleDriveDownloadError
 
     app, headers, _user, _ = test_env
     client = TestClient(app)
@@ -3804,7 +3805,12 @@ def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
             self._fh = fh
 
         def next_chunk(self):
-            raise RuntimeError("download blew up")
+            try:
+                raise RuntimeError("socket reset")
+            except RuntimeError as cause:
+                raise GoogleDriveDownloadError(
+                    "Final Drive download request failed"
+                ) from cause
 
     with (
         patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
@@ -3830,7 +3836,8 @@ def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
     assert response.status_code == 200
     data = response.json()
     assert data[0]["status"] == "error"
-    assert "Download failed: download blew up" in data[0]["message"]
+    assert "Download failed: Final Drive download request failed" in data[0]["message"]
+    assert "socket reset" in caplog.text
     run_ingestion.assert_not_called()
 
 

--- a/tests/web/api/test_kb_dir.py
+++ b/tests/web/api/test_kb_dir.py
@@ -3025,6 +3025,7 @@ def test_kb_ingest_cloud_downloads_native_google_slides_as_pptx(
         patch("xagent.web.api.kb.build", return_value=drive_service),
         patch(
             "xagent.web.api.kb.download_google_workspace_file",
+            autospec=True,
             side_effect=_download_with_lro,
         ),
         patch("xagent.web.api.kb.run_document_ingestion", side_effect=_capture_ingest),
@@ -3198,6 +3199,143 @@ def test_kb_ingest_cloud_uses_drive_metadata_for_binary_file(test_env, temp_uplo
         )
     finally:
         session.close()
+
+
+def test_kb_ingest_cloud_downloads_native_slides_when_native_size_exceeds_limit(
+    test_env,
+    temp_uploads,
+    monkeypatch,
+):
+    """Native editor size must not reject a smaller exported PPTX artifact."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+    metadata_request = _fake_drive_metadata_request(
+        "drive-large-native",
+        "Large Native Deck",
+        "application/vnd.google-apps.presentation",
+    )
+    metadata_request.execute.return_value["size"] = "5"
+    drive_service = MagicMock()
+    drive_service.files.return_value.get.return_value = metadata_request
+
+    def _download(**kwargs):
+        Path(kwargs["destination"]).write_bytes(b"pptx")
+
+    monkeypatch.setattr("xagent.web.api.kb.MAX_FILE_SIZE", 4)
+    monkeypatch.setattr("xagent.web.api.kb.MAX_FILE_SIZE_LABEL", "4B")
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=drive_service),
+        patch(
+            "xagent.web.api.kb.download_google_workspace_file",
+            autospec=True,
+            side_effect=_download,
+        ) as download,
+        patch(
+            "xagent.web.api.kb.run_document_ingestion",
+            return_value=IngestionResult(
+                status="success",
+                doc_id="slides-doc-id",
+                parse_hash="hash",
+                failed_step="",
+                message="success",
+            ),
+        ),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_large_native",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-large-native",
+                        "fileName": "stale-name",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "success"
+    download.assert_called_once()
+
+
+def test_kb_ingest_cloud_accepts_drive_file_at_exact_size_limit(
+    test_env,
+    temp_uploads,
+    monkeypatch,
+):
+    """A blob whose metadata size equals the limit remains valid."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+    metadata_request = _fake_drive_metadata_request(
+        "drive-exact-size",
+        "exact.pdf",
+        "application/pdf",
+    )
+    metadata_request.execute.return_value["size"] = "4"
+
+    class _FakeFilesService:
+        def get(self, **_kwargs):
+            return metadata_request
+
+        def get_media(self, **_kwargs):
+            return object()
+
+    class _FakeDriveService:
+        def files(self):
+            return _FakeFilesService()
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request_file):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"1234")
+            return None, True
+
+    monkeypatch.setattr("xagent.web.api.kb.MAX_FILE_SIZE", 4)
+    monkeypatch.setattr("xagent.web.api.kb.MAX_FILE_SIZE_LABEL", "4B")
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
+        patch("xagent.web.api.kb.MediaIoBaseDownload", _FakeDownloader),
+        patch(
+            "xagent.web.api.kb.run_document_ingestion",
+            return_value=IngestionResult(
+                status="success",
+                doc_id="exact-doc-id",
+                parse_hash="hash",
+                failed_step="",
+                message="success",
+            ),
+        ),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_exact_size",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-exact-size",
+                        "fileName": "stale.pdf",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "success"
 
 
 def test_kb_ingest_cloud_rejects_oversized_drive_file_before_download(
@@ -3590,6 +3728,72 @@ def test_kb_ingest_cloud_rejects_extensionless_binary_file(test_env, temp_upload
     assert not [path for path in temp_uploads.rglob("*") if path.is_file()]
 
 
+@pytest.mark.parametrize(
+    "metadata_name", ["Quarterly Review.pptx", "Quarterly Review.PPTX"]
+)
+def test_kb_ingest_cloud_native_slides_preserves_existing_pptx_suffix(
+    metadata_name,
+    test_env,
+    temp_uploads,
+):
+    """Native Slides names that already end in PPTX must not gain a second suffix."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import IngestionResult
+
+    app, headers, _user, TestingSessionLocal = test_env
+    client = TestClient(app)
+    drive_service = MagicMock()
+    drive_service.files.return_value.get.return_value = _fake_drive_metadata_request(
+        "drive-slides-suffixed",
+        metadata_name,
+        "application/vnd.google-apps.presentation",
+    )
+
+    def _download(**kwargs):
+        Path(kwargs["destination"]).write_bytes(b"pptx")
+
+    with (
+        patch("xagent.web.api.kb.get_google_credentials", return_value=object()),
+        patch("xagent.web.api.kb.build", return_value=drive_service),
+        patch(
+            "xagent.web.api.kb.download_google_workspace_file",
+            autospec=True,
+            side_effect=_download,
+        ),
+        patch(
+            "xagent.web.api.kb.run_document_ingestion",
+            return_value=IngestionResult(
+                status="success",
+                doc_id="slides-doc-id",
+                parse_hash="hash",
+                failed_step="",
+                message="success",
+            ),
+        ),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_slides_suffix",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive-slides-suffixed",
+                        "fileName": "stale-name",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["status"] == "success"
+    session = TestingSessionLocal()
+    try:
+        assert session.query(UploadedFile).one().filename == metadata_name
+    finally:
+        session.close()
+
+
 def test_kb_ingest_cloud_download_failure_removes_partial_file(test_env, temp_uploads):
     """Failed native Slides downloads should remove partial local state."""
     app, headers, _user, TestingSessionLocal = test_env
@@ -3616,6 +3820,7 @@ def test_kb_ingest_cloud_download_failure_removes_partial_file(test_env, temp_up
         patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
         patch(
             "xagent.web.api.kb.download_google_workspace_file",
+            autospec=True,
             side_effect=_fail_download,
         ),
         patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
@@ -3684,6 +3889,7 @@ def test_kb_ingest_cloud_download_failure_restores_existing_file(
         patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
         patch(
             "xagent.web.api.kb.download_google_workspace_file",
+            autospec=True,
             side_effect=_fail_download,
         ),
         patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
@@ -3708,6 +3914,37 @@ def test_kb_ingest_cloud_download_failure_restores_existing_file(
     run_ingestion.assert_not_called()
     assert file_path.read_bytes() == b"previous-pptx"
     assert list(file_path.parent.glob("*.rollback-*")) == []
+
+
+@pytest.mark.parametrize(
+    "original_filename",
+    ["a" * 255 + ".pptx", "資料" * 100 + ".pptx"],
+)
+def test_build_cloud_storage_filename_respects_utf8_filesystem_limit(
+    original_filename,
+    temp_uploads,
+) -> None:
+    """Cloud filename truncation must preserve its digest and extension."""
+    from xagent.web.api.kb import _build_cloud_storage_filename
+
+    storage_filename = _build_cloud_storage_filename(original_filename, "drive-file-1")
+
+    assert len(storage_filename.encode("utf-8")) <= 255
+    assert storage_filename.endswith("__30b487d9d8d6.pptx")
+    destination = temp_uploads / storage_filename
+    destination.write_bytes(b"content")
+    assert destination.read_bytes() == b"content"
+
+
+def test_build_cloud_storage_filename_is_deterministic_after_truncation() -> None:
+    """Truncating a stem must not discard the file-ID collision guard."""
+    from xagent.web.api.kb import _build_cloud_storage_filename
+
+    original_filename = "資料" * 100 + ".pptx"
+
+    first = _build_cloud_storage_filename(original_filename, "drive-file-1")
+    assert first == _build_cloud_storage_filename(original_filename, "drive-file-1")
+    assert first != _build_cloud_storage_filename(original_filename, "drive-file-2")
 
 
 def test_kb_ingest_cloud_passes_file_id_to_pipeline(test_env, temp_uploads):
@@ -4044,6 +4281,7 @@ def test_kb_ingest_cloud_returns_download_failure_after_restore_success(
         patch("xagent.web.api.kb.build", return_value=_FakeDriveService()),
         patch(
             "xagent.web.api.kb.download_google_workspace_file",
+            autospec=True,
             side_effect=_fail_workspace_download,
         ),
         patch("xagent.web.api.kb.run_document_ingestion") as run_ingestion,
@@ -5793,6 +6031,65 @@ def test_list_collections_skips_document_scan_when_duplicate_names_have_metadata
     assert len(payload["collections"][0]["document_metadata"]) == 2
 
 
+@pytest.mark.parametrize("field", ["fileId", "resourceKey"])
+@pytest.mark.parametrize("line_break", ["\r", "\n"])
+def test_kb_ingest_cloud_rejects_line_breaks_in_drive_header_values(
+    field,
+    line_break,
+    test_env,
+) -> None:
+    """Drive identifiers must not permit HTTP header line breaks."""
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+    file_payload = {
+        "provider": "google-drive",
+        "fileId": "drive:file_1-2",
+        "fileName": "document.pdf",
+        "resourceKey": "resource:key_1-2",
+    }
+    file_payload[field] = f"valid{line_break}injected"
+
+    response = client.post(
+        "/api/kb/ingest-cloud",
+        json={"collection": "cloud_header_validation", "files": [file_payload]},
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"][-1] == field
+
+
+def test_kb_ingest_cloud_accepts_punctuation_in_drive_identifiers(test_env) -> None:
+    """Header safety validation must not invent a narrower Drive identifier grammar."""
+    from fastapi import HTTPException
+
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+
+    with patch(
+        "xagent.web.api.kb.get_google_credentials",
+        side_effect=HTTPException(status_code=401, detail="validation passed"),
+    ):
+        response = client.post(
+            "/api/kb/ingest-cloud",
+            json={
+                "collection": "cloud_identifier_punctuation",
+                "files": [
+                    {
+                        "provider": "google-drive",
+                        "fileId": "drive:file_1-2",
+                        "fileName": "document.pdf",
+                        "resourceKey": "resource:key_1-2",
+                    }
+                ],
+            },
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()[0]["message"] == "Authentication error: validation passed"
+
+
 def test_kb_ingest_cloud_empty_batch_is_rejected(test_env) -> None:
     """An empty batch publishes nothing, so it must not report success."""
     app, headers, _user, _ = test_env
@@ -5813,6 +6110,31 @@ def test_kb_ingest_cloud_empty_batch_is_rejected(test_env) -> None:
 
     assert response.status_code == 422
     metadata_store.save_collection_config.assert_not_awaited()
+
+
+def test_kb_ingest_cloud_batch_of_exactly_five_files_is_accepted(test_env) -> None:
+    """The request boundary includes one complete five-worker wave."""
+    app, headers, _user, _ = test_env
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/kb/ingest-cloud",
+        json={
+            "collection": "cloud_full_wave",
+            "files": [
+                {
+                    "provider": "unsupported",
+                    "fileId": f"file-{index}",
+                    "fileName": f"document-{index}.pdf",
+                }
+                for index in range(5)
+            ],
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 5
 
 
 def test_kb_ingest_cloud_batch_over_five_files_is_rejected(test_env) -> None:

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 from google.auth.credentials import AnonymousCredentials
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 
 
 class _Request:
@@ -189,6 +190,48 @@ def test_download_google_workspace_file_polls_pending_operation(
     assert destination.read_bytes() == b"complete"
     assert service.operations_resource.get_calls == ["download-2"]
     assert sleep_calls == [10]
+
+
+def test_download_google_workspace_file_wraps_poll_http_error(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService({"name": "operations/download-poll-error"})
+
+    class _HttpResponse(dict):
+        status = 503
+        reason = "Service Unavailable"
+
+    poll_error = HttpError(_HttpResponse(), b"Drive unavailable")
+
+    class _FailingPollRequest:
+        headers: dict[str, str] = {}
+
+        def execute(self) -> dict[str, Any]:
+            raise poll_error
+
+    monkeypatch.setattr(module, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        service.operations_resource,
+        "get",
+        lambda *, name: _FailingPollRequest(),
+    )
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match="Drive operation polling failed",
+    ) as exc_info:
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-poll-error",
+            mime_type="application/vnd.test.presentation",
+            destination=tmp_path / "slides.pptx",
+            timeout_seconds=600,
+        )
+
+    assert exc_info.value.__cause__ is poll_error
 
 
 def test_download_google_workspace_file_raises_completed_operation_error(

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -187,7 +187,7 @@ def test_download_google_workspace_file_polls_pending_operation(
     )
 
     assert destination.read_bytes() == b"complete"
-    assert service.operations_resource.get_calls == ["operations/download-2"]
+    assert service.operations_resource.get_calls == ["download-2"]
     assert sleep_calls == [10]
 
 
@@ -246,7 +246,7 @@ def test_download_google_workspace_file_stops_at_operation_timeout(
             timeout_seconds=10,
         )
 
-    assert service.operations_resource.get_calls == ["operations/download-4"]
+    assert service.operations_resource.get_calls == ["download-4"]
     assert sleep_calls == [10]
     assert not (tmp_path / "slides.pptx").exists()
 

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -18,8 +18,10 @@ class _Request:
     def __init__(self, response: dict[str, Any]) -> None:
         self.response = response
         self.headers: dict[str, str] = {}
+        self.execute_calls: list[int] = []
 
-    def execute(self) -> dict[str, Any]:
+    def execute(self, *, num_retries: int = 0) -> dict[str, Any]:
+        self.execute_calls.append(num_retries)
         return self.response
 
 
@@ -190,6 +192,8 @@ def test_download_google_workspace_file_polls_pending_operation(
 
     assert destination.read_bytes() == b"complete"
     assert service.operations_resource.get_calls == ["download-2"]
+    assert service.files_resource.request.execute_calls == [3]
+    assert service.operations_resource.requests[0].execute_calls == [3]
     assert sleep_calls == [10]
 
 
@@ -209,7 +213,8 @@ def test_download_google_workspace_file_wraps_poll_http_error(
     class _FailingPollRequest:
         headers: dict[str, str] = {}
 
-        def execute(self) -> dict[str, Any]:
+        def execute(self, *, num_retries: int = 0) -> dict[str, Any]:
+            assert num_retries == 3
             raise poll_error
 
     monkeypatch.setattr(module, "sleep", lambda _seconds: None)

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import importlib
 import logging
 from pathlib import Path
@@ -613,6 +614,60 @@ def test_download_google_workspace_file_reports_local_write_failure(
             destination=tmp_path / "missing" / "slides.pptx",
             timeout_seconds=600,
         )
+
+
+def test_download_google_workspace_file_reports_midstream_write_failure(
+    monkeypatch: Any,
+) -> None:
+    """A disk failure after a partial write must use the service error contract."""
+    module = _module()
+    service = _DriveService(
+        {
+            "done": True,
+            "response": {"downloadUri": "https://drive.example/download/disk-full"},
+        }
+    )
+    session = _AuthorizedSession(_Response([b"first", b"second"]))
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+
+    class _FailingOutput:
+        def __init__(self) -> None:
+            self.writes: list[bytes] = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def write(self, chunk: bytes) -> None:
+            if self.writes:
+                raise OSError(errno.ENOSPC, "No space left on device")
+            self.writes.append(chunk)
+
+    output = _FailingOutput()
+
+    class _Destination:
+        def open(self, mode: str) -> _FailingOutput:
+            assert mode == "wb"
+            return output
+
+    destination: Any = _Destination()
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match="Failed to write Drive download: No space left on device",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-disk-full",
+            mime_type="application/vnd.test.presentation",
+            destination=destination,
+            timeout_seconds=600,
+        )
+
+    assert output.writes == [b"first"]
 
 
 def test_download_google_workspace_file_wraps_final_http_failure(

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -516,6 +516,39 @@ def test_download_google_workspace_file_caps_poll_backoff(
     assert sleep_calls == [10, 20, 40, 60, 60]
 
 
+def test_download_google_workspace_file_rejects_export_over_max_bytes(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """The exported artifact must not exceed the caller's byte limit."""
+    module = _module()
+    service = _DriveService(
+        {
+            "done": True,
+            "response": {"downloadUri": "https://drive.example/download/large"},
+        }
+    )
+    session = _AuthorizedSession(_Response([b"123", b"45"]))
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    destination = tmp_path / "slides.pptx"
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match="Exported file exceeds the maximum allowed size",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-large-export",
+            mime_type="application/vnd.test.presentation",
+            destination=destination,
+            timeout_seconds=600,
+            max_bytes=4,
+        )
+
+    assert destination.read_bytes() == b"123"
+
+
 def test_download_google_workspace_file_preserves_partial_file_on_stream_failure(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -297,6 +297,41 @@ def test_download_google_workspace_file_wraps_malformed_operation_error(
         )
 
 
+def test_download_google_workspace_file_clamps_sleep_to_remaining_deadline(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """The poll sleep must not overshoot a shorter remaining deadline."""
+    module = _module()
+    service = _DriveService(
+        {"name": "operations/download-clamped"},
+        poll_responses=[
+            {
+                "name": "operations/download-clamped",
+                "done": True,
+                "response": {"downloadUri": "https://drive.example/download/clamped"},
+            }
+        ],
+    )
+    session = _AuthorizedSession(_Response([b"complete"]))
+    times = iter([0.0, 3.0, 4.0])
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    monkeypatch.setattr(module, "monotonic", lambda: next(times))
+    monkeypatch.setattr(module, "sleep", sleep_calls.append)
+
+    module.download_google_workspace_file(
+        service=service,
+        credentials=object(),
+        file_id="slides-clamped",
+        mime_type="application/vnd.test.presentation",
+        destination=tmp_path / "slides.pptx",
+        timeout_seconds=5,
+    )
+
+    assert sleep_calls == [2]
+
+
 def test_download_google_workspace_file_stops_at_operation_timeout(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -194,7 +194,7 @@ def test_download_google_workspace_file_polls_pending_operation(
     assert service.operations_resource.get_calls == ["download-2"]
     assert service.files_resource.request.execute_calls == [3]
     assert service.operations_resource.requests[0].execute_calls == [3]
-    assert sleep_calls == [10]
+    assert sleep_calls == [2]
 
 
 def test_download_google_workspace_file_wraps_poll_http_error(
@@ -314,7 +314,7 @@ def test_download_google_workspace_file_clamps_sleep_to_remaining_deadline(
         ],
     )
     session = _AuthorizedSession(_Response([b"complete"]))
-    times = iter([0.0, 3.0, 4.0])
+    times = iter([0.0, 4.0, 5.0])
     sleep_calls: list[float] = []
     monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
     monkeypatch.setattr(module, "monotonic", lambda: next(times))
@@ -329,7 +329,7 @@ def test_download_google_workspace_file_clamps_sleep_to_remaining_deadline(
         timeout_seconds=5,
     )
 
-    assert sleep_calls == [2]
+    assert sleep_calls == [1]
 
 
 def test_download_google_workspace_file_stops_at_operation_timeout(
@@ -360,7 +360,7 @@ def test_download_google_workspace_file_stops_at_operation_timeout(
         )
 
     assert service.operations_resource.get_calls == ["download-4"]
-    assert sleep_calls == [10]
+    assert sleep_calls == [2]
     assert not (tmp_path / "slides.pptx").exists()
 
 
@@ -533,6 +533,8 @@ def test_download_google_workspace_file_caps_poll_backoff(
             {"name": "operations/download-backoff", "done": False},
             {"name": "operations/download-backoff"},
             {"name": "operations/download-backoff", "done": False},
+            {"name": "operations/download-backoff"},
+            {"name": "operations/download-backoff", "done": False},
             {
                 "name": "operations/download-backoff",
                 "done": True,
@@ -554,7 +556,7 @@ def test_download_google_workspace_file_caps_poll_backoff(
         timeout_seconds=600,
     )
 
-    assert sleep_calls == [10, 20, 40, 60, 60]
+    assert sleep_calls == [2, 4, 8, 16, 32, 60, 60]
 
 
 def test_download_google_workspace_file_rejects_export_over_max_bytes(

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -1,0 +1,354 @@
+"""Tests for Google Drive long-running Workspace downloads."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+class _Request:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        self.headers: dict[str, str] = {}
+
+    def execute(self) -> dict[str, Any]:
+        return self.response
+
+
+class _FilesResource:
+    def __init__(self, operation: dict[str, Any]) -> None:
+        self.request = _Request(operation)
+        self.download_calls: list[dict[str, str]] = []
+
+    def download(self, **kwargs: str) -> _Request:
+        self.download_calls.append(kwargs)
+        return self.request
+
+
+class _OperationsResource:
+    def __init__(self, responses: list[dict[str, Any]] | None = None) -> None:
+        self.responses = list(responses or [])
+        self.get_calls: list[str] = []
+        self.requests: list[_Request] = []
+
+    def get(self, *, name: str) -> _Request:
+        self.get_calls.append(name)
+        if not self.responses:
+            raise AssertionError(f"Unexpected poll for operation {name}")
+        request = _Request(self.responses.pop(0))
+        self.requests.append(request)
+        return request
+
+
+class _DriveService:
+    def __init__(
+        self,
+        operation: dict[str, Any],
+        *,
+        poll_responses: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.files_resource = _FilesResource(operation)
+        self.operations_resource = _OperationsResource(poll_responses)
+
+    def files(self) -> _FilesResource:
+        return self.files_resource
+
+    def operations(self) -> _OperationsResource:
+        return self.operations_resource
+
+
+class _Response:
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        error: Exception | None = None,
+        status_code: int = 200,
+    ) -> None:
+        self.chunks = chunks
+        self.error = error
+        self.status_code = status_code
+        self.raise_for_status_called = False
+
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        self.raise_for_status_called = True
+        if self.error is not None:
+            raise self.error
+
+    def iter_content(self, *, chunk_size: int) -> list[bytes]:
+        assert chunk_size == 1024 * 1024
+        return self.chunks
+
+
+class _AuthorizedSession:
+    def __init__(self, response: _Response) -> None:
+        self.response = response
+        self.get_calls: list[dict[str, Any]] = []
+
+    def __enter__(self) -> _AuthorizedSession:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def get(self, url: str, **kwargs: Any) -> _Response:
+        self.get_calls.append({"url": url, **kwargs})
+        return self.response
+
+
+def _module() -> Any:
+    return importlib.import_module("xagent.web.services.google_drive_download")
+
+
+def test_download_google_workspace_file_writes_completed_operation(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {
+            "name": "operations/download-1",
+            "done": True,
+            "response": {"downloadUri": "https://drive.example/download/1"},
+        }
+    )
+    response = _Response([b"first", b"", b"second"])
+    session = _AuthorizedSession(response)
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    destination = tmp_path / "slides.pptx"
+
+    module.download_google_workspace_file(
+        service=service,
+        credentials=object(),
+        file_id="slides-1",
+        mime_type="application/vnd.test.presentation",
+        destination=destination,
+        timeout_seconds=600,
+    )
+
+    assert destination.read_bytes() == b"firstsecond"
+    assert service.files_resource.download_calls == [
+        {
+            "fileId": "slides-1",
+            "mimeType": "application/vnd.test.presentation",
+        }
+    ]
+    assert response.raise_for_status_called is True
+    assert session.get_calls == [
+        {
+            "url": "https://drive.example/download/1",
+            "stream": True,
+            "timeout": 60,
+            "headers": {},
+        }
+    ]
+
+
+def test_download_google_workspace_file_polls_pending_operation(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {"name": "operations/download-2"},
+        poll_responses=[
+            {
+                "name": "operations/download-2",
+                "done": True,
+                "response": {"downloadUri": "https://drive.example/download/2"},
+            }
+        ],
+    )
+    session = _AuthorizedSession(_Response([b"complete"]))
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    monkeypatch.setattr(module, "sleep", sleep_calls.append)
+    destination = tmp_path / "slides.pptx"
+
+    module.download_google_workspace_file(
+        service=service,
+        credentials=object(),
+        file_id="slides-2",
+        mime_type="application/vnd.test.presentation",
+        destination=destination,
+        timeout_seconds=600,
+    )
+
+    assert destination.read_bytes() == b"complete"
+    assert service.operations_resource.get_calls == ["operations/download-2"]
+    assert sleep_calls == [10]
+
+
+def test_download_google_workspace_file_raises_completed_operation_error(
+    tmp_path: Path,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {
+            "name": "operations/download-3",
+            "done": True,
+            "error": {"code": 13, "message": "Drive could not create the export"},
+        }
+    )
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match=r"Drive operation failed \(13\): Drive could not create the export",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-3",
+            mime_type="application/vnd.test.presentation",
+            destination=tmp_path / "slides.pptx",
+            timeout_seconds=600,
+        )
+
+    assert not (tmp_path / "slides.pptx").exists()
+
+
+def test_download_google_workspace_file_stops_at_operation_timeout(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {"name": "operations/download-4"},
+        poll_responses=[{"name": "operations/download-4"}],
+    )
+    times = iter([0.0, 0.0, 10.0])
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(module, "monotonic", lambda: next(times), raising=False)
+    monkeypatch.setattr(module, "sleep", sleep_calls.append)
+
+    with pytest.raises(
+        module.GoogleDriveDownloadTimeout,
+        match="Drive download for slides-4 did not finish within 10 seconds",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-4",
+            mime_type="application/vnd.test.presentation",
+            destination=tmp_path / "slides.pptx",
+            timeout_seconds=10,
+        )
+
+    assert service.operations_resource.get_calls == ["operations/download-4"]
+    assert sleep_calls == [10]
+    assert not (tmp_path / "slides.pptx").exists()
+
+
+@pytest.mark.parametrize(
+    ("operation", "expected_message"),
+    [
+        ({}, "Drive returned a pending operation without a name"),
+        ({"done": True}, "Drive completed the operation without a response"),
+        (
+            {"done": True, "response": {}},
+            "Drive completed the operation without a download URI",
+        ),
+    ],
+)
+def test_download_google_workspace_file_rejects_malformed_operation(
+    operation: dict[str, Any],
+    expected_message: str,
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(operation)
+    monkeypatch.setattr(module, "sleep", lambda _seconds: None)
+
+    with pytest.raises(module.GoogleDriveDownloadError, match=expected_message):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-invalid",
+            mime_type="application/vnd.test.presentation",
+            destination=tmp_path / "slides.pptx",
+            timeout_seconds=600,
+        )
+
+
+def test_download_google_workspace_file_sends_resource_key_without_logging_secrets(
+    tmp_path: Path,
+    monkeypatch: Any,
+    caplog: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {"name": "operations/download-shared"},
+        poll_responses=[
+            {
+                "name": "operations/download-shared",
+                "done": True,
+                "response": {"downloadUri": "https://drive.example/download/shared"},
+            }
+        ],
+    )
+    session = _AuthorizedSession(_Response([b"shared"]))
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    monkeypatch.setattr(module, "sleep", lambda _seconds: None)
+    caplog.set_level(logging.INFO, logger=module.__name__)
+
+    module.download_google_workspace_file(
+        service=service,
+        credentials=object(),
+        file_id="slides-shared",
+        mime_type="application/vnd.test.presentation",
+        destination=tmp_path / "slides.pptx",
+        timeout_seconds=600,
+        resource_key="resource-secret",
+    )
+
+    expected_headers = {"X-Goog-Drive-Resource-Keys": "slides-shared/resource-secret"}
+    assert service.files_resource.request.headers == expected_headers
+    assert service.operations_resource.requests[0].headers == expected_headers
+    assert session.get_calls[0]["headers"] == expected_headers
+    assert "Drive download operation started file_id=slides-shared" in caplog.text
+    assert "Drive download operation completed file_id=slides-shared" in caplog.text
+    assert "resource-secret" not in caplog.text
+    assert "drive.example" not in caplog.text
+
+
+def test_download_google_workspace_file_wraps_final_http_failure(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {
+            "done": True,
+            "response": {"downloadUri": "https://drive.example/download/failure"},
+        }
+    )
+    response = _Response([], error=RuntimeError("signed URI"), status_code=503)
+    session = _AuthorizedSession(response)
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    destination = tmp_path / "slides.pptx"
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match="Final Drive download failed with HTTP status 503",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-failure",
+            mime_type="application/vnd.test.presentation",
+            destination=destination,
+            timeout_seconds=600,
+        )
+
+    assert not destination.exists()

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -417,6 +417,34 @@ def test_download_google_workspace_file_preserves_partial_file_on_stream_failure
     assert destination.read_bytes() == b"partial"
 
 
+def test_download_google_workspace_file_reports_local_write_failure(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {
+            "done": True,
+            "response": {"downloadUri": "https://drive.example/download/write"},
+        }
+    )
+    session = _AuthorizedSession(_Response([b"content"]))
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match="Failed to write Drive download: No such file or directory",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-write-failure",
+            mime_type="application/vnd.test.presentation",
+            destination=tmp_path / "missing" / "slides.pptx",
+            timeout_seconds=600,
+        )
+
+
 def test_download_google_workspace_file_wraps_final_http_failure(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -257,9 +257,9 @@ def test_download_google_workspace_file_stops_at_operation_timeout(
         {"name": "operations/download-4"},
         poll_responses=[{"name": "operations/download-4"}],
     )
-    times = iter([0.0, 0.0, 10.0])
+    times = iter([0.0, 0.0, 10.0, 10.0])
     sleep_calls: list[float] = []
-    monkeypatch.setattr(module, "monotonic", lambda: next(times), raising=False)
+    monkeypatch.setattr(module, "monotonic", lambda: next(times))
     monkeypatch.setattr(module, "sleep", sleep_calls.append)
 
     with pytest.raises(

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -384,6 +384,40 @@ def test_download_google_workspace_file_sends_supplied_resource_key_on_start(
     assert session.get_calls[0]["headers"] == expected_headers
 
 
+def test_download_google_workspace_file_prefers_operation_resource_key(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """Drive operation metadata should replace a stale caller resource key."""
+    module = _module()
+    service = _DriveService(
+        {
+            "done": True,
+            "metadata": {"resourceKey": "operation-resource-key"},
+            "response": {"downloadUri": "https://drive.example/download/updated-key"},
+        }
+    )
+    session = _AuthorizedSession(_Response([b"updated-key"]))
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+
+    module.download_google_workspace_file(
+        service=service,
+        credentials=object(),
+        file_id="slides-updated-key",
+        mime_type="application/vnd.test.presentation",
+        destination=tmp_path / "slides.pptx",
+        timeout_seconds=600,
+        resource_key="caller-resource-key",
+    )
+
+    assert service.files_resource.request.headers == {
+        "X-Goog-Drive-Resource-Keys": "slides-updated-key/caller-resource-key"
+    }
+    assert session.get_calls[0]["headers"] == {
+        "X-Goog-Drive-Resource-Keys": "slides-updated-key/operation-resource-key"
+    }
+
+
 def test_download_google_workspace_file_sends_resource_key_without_logging_secrets(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -283,6 +283,35 @@ def test_download_google_workspace_file_rejects_malformed_operation(
         )
 
 
+def test_download_google_workspace_file_sends_supplied_resource_key_on_start(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {
+            "done": True,
+            "response": {"downloadUri": "https://drive.example/download/linked"},
+        }
+    )
+    session = _AuthorizedSession(_Response([b"linked"]))
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+
+    module.download_google_workspace_file(
+        service=service,
+        credentials=object(),
+        file_id="slides-linked",
+        mime_type="application/vnd.test.presentation",
+        destination=tmp_path / "slides.pptx",
+        timeout_seconds=600,
+        resource_key="link-resource-key",
+    )
+
+    expected_headers = {"X-Goog-Drive-Resource-Keys": "slides-linked/link-resource-key"}
+    assert service.files_resource.request.headers == expected_headers
+    assert session.get_calls[0]["headers"] == expected_headers
+
+
 def test_download_google_workspace_file_sends_resource_key_without_logging_secrets(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -290,7 +290,10 @@ def test_download_google_workspace_file_sends_resource_key_without_logging_secre
 ) -> None:
     module = _module()
     service = _DriveService(
-        {"name": "operations/download-shared"},
+        {
+            "name": "operations/download-shared",
+            "metadata": {"resourceKey": "resource-secret"},
+        },
         poll_responses=[
             {
                 "name": "operations/download-shared",
@@ -311,11 +314,10 @@ def test_download_google_workspace_file_sends_resource_key_without_logging_secre
         mime_type="application/vnd.test.presentation",
         destination=tmp_path / "slides.pptx",
         timeout_seconds=600,
-        resource_key="resource-secret",
     )
 
     expected_headers = {"X-Goog-Drive-Resource-Keys": "slides-shared/resource-secret"}
-    assert service.files_resource.request.headers == expected_headers
+    assert service.files_resource.request.headers == {}
     assert service.operations_resource.requests[0].headers == expected_headers
     assert session.get_calls[0]["headers"] == expected_headers
     assert "Drive download operation started file_id=slides-shared" in caplog.text

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -219,6 +219,35 @@ def test_download_google_workspace_file_raises_completed_operation_error(
     assert not (tmp_path / "slides.pptx").exists()
 
 
+@pytest.mark.parametrize(
+    ("error", "expected_message"),
+    [
+        (None, "Unknown Drive operation error"),
+        ("malformed error", "malformed error"),
+    ],
+)
+def test_download_google_workspace_file_wraps_malformed_operation_error(
+    error: object,
+    expected_message: str,
+    tmp_path: Path,
+) -> None:
+    module = _module()
+    service = _DriveService({"done": True, "error": error})
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match=f"Drive operation failed \\(unknown\\): {expected_message}",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-malformed-error",
+            mime_type="application/vnd.test.presentation",
+            destination=tmp_path / "slides.pptx",
+            timeout_seconds=600,
+        )
+
+
 def test_download_google_workspace_file_stops_at_operation_timeout(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -555,6 +555,38 @@ def test_download_google_workspace_file_rejects_export_over_max_bytes(
     assert destination.read_bytes() == b"123"
 
 
+def test_download_google_workspace_file_rejects_zero_byte_export(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """An empty Drive export should fail before the parser sees it."""
+    module = _module()
+    service = _DriveService(
+        {
+            "done": True,
+            "response": {"downloadUri": "https://drive.example/download/empty"},
+        }
+    )
+    session = _AuthorizedSession(_Response([b""]))
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    destination = tmp_path / "slides.pptx"
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match="Drive export produced no content",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-empty-export",
+            mime_type="application/vnd.test.presentation",
+            destination=destination,
+            timeout_seconds=600,
+        )
+
+    assert destination.read_bytes() == b""
+
+
 def test_download_google_workspace_file_preserves_partial_file_on_stream_failure(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -425,40 +425,6 @@ def test_download_google_workspace_file_sends_supplied_resource_key_on_start(
     assert session.get_calls[0]["headers"] == expected_headers
 
 
-def test_download_google_workspace_file_prefers_operation_resource_key(
-    tmp_path: Path,
-    monkeypatch: Any,
-) -> None:
-    """Drive operation metadata should replace a stale caller resource key."""
-    module = _module()
-    service = _DriveService(
-        {
-            "done": True,
-            "metadata": {"resourceKey": "operation-resource-key"},
-            "response": {"downloadUri": "https://drive.example/download/updated-key"},
-        }
-    )
-    session = _AuthorizedSession(_Response([b"updated-key"]))
-    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
-
-    module.download_google_workspace_file(
-        service=service,
-        credentials=object(),
-        file_id="slides-updated-key",
-        mime_type="application/vnd.test.presentation",
-        destination=tmp_path / "slides.pptx",
-        timeout_seconds=600,
-        resource_key="caller-resource-key",
-    )
-
-    assert service.files_resource.request.headers == {
-        "X-Goog-Drive-Resource-Keys": "slides-updated-key/caller-resource-key"
-    }
-    assert session.get_calls[0]["headers"] == {
-        "X-Goog-Drive-Resource-Keys": "slides-updated-key/operation-resource-key"
-    }
-
-
 def test_download_google_workspace_file_sends_resource_key_without_logging_secrets(
     tmp_path: Path,
     monkeypatch: Any,
@@ -466,10 +432,7 @@ def test_download_google_workspace_file_sends_resource_key_without_logging_secre
 ) -> None:
     module = _module()
     service = _DriveService(
-        {
-            "name": "operations/download-shared",
-            "metadata": {"resourceKey": "resource-secret"},
-        },
+        {"name": "operations/download-shared"},
         poll_responses=[
             {
                 "name": "operations/download-shared",
@@ -490,10 +453,11 @@ def test_download_google_workspace_file_sends_resource_key_without_logging_secre
         mime_type="application/vnd.test.presentation",
         destination=tmp_path / "slides.pptx",
         timeout_seconds=600,
+        resource_key="resource-secret",
     )
 
     expected_headers = {"X-Goog-Drive-Resource-Keys": "slides-shared/resource-secret"}
-    assert service.files_resource.request.headers == {}
+    assert service.files_resource.request.headers == expected_headers
     assert service.operations_resource.requests[0].headers == expected_headers
     assert session.get_calls[0]["headers"] == expected_headers
     assert "Drive download operation started file_id=slides-shared" in caplog.text

--- a/tests/web/services/test_google_drive_download.py
+++ b/tests/web/services/test_google_drive_download.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from google.auth.credentials import AnonymousCredentials
+from googleapiclient.discovery import build
 
 
 class _Request:
@@ -320,6 +322,99 @@ def test_download_google_workspace_file_sends_resource_key_without_logging_secre
     assert "Drive download operation completed file_id=slides-shared" in caplog.text
     assert "resource-secret" not in caplog.text
     assert "drive.example" not in caplog.text
+
+
+def test_drive_discovery_exposes_long_running_download_contract() -> None:
+    """The minimum client contract includes Drive download and polling methods."""
+    service = build(
+        "drive",
+        "v3",
+        credentials=AnonymousCredentials(),
+        cache_discovery=False,
+    )
+
+    download_request = service.files().download(
+        fileId="slides-contract",
+        mimeType="application/vnd.test.presentation",
+    )
+    poll_request = service.operations().get(name="download-contract")
+
+    assert isinstance(download_request.headers, dict)
+    assert isinstance(poll_request.headers, dict)
+
+
+def test_download_google_workspace_file_caps_poll_backoff(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {"name": "operations/download-backoff"},
+        poll_responses=[
+            {"name": "operations/download-backoff"},
+            {"name": "operations/download-backoff", "done": False},
+            {"name": "operations/download-backoff"},
+            {"name": "operations/download-backoff", "done": False},
+            {
+                "name": "operations/download-backoff",
+                "done": True,
+                "response": {"downloadUri": "https://drive.example/download/backoff"},
+            },
+        ],
+    )
+    session = _AuthorizedSession(_Response([b"complete"]))
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    monkeypatch.setattr(module, "sleep", sleep_calls.append)
+
+    module.download_google_workspace_file(
+        service=service,
+        credentials=object(),
+        file_id="slides-backoff",
+        mime_type="application/vnd.test.presentation",
+        destination=tmp_path / "slides.pptx",
+        timeout_seconds=600,
+    )
+
+    assert sleep_calls == [10, 20, 40, 60, 60]
+
+
+def test_download_google_workspace_file_preserves_partial_file_on_stream_failure(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    module = _module()
+    service = _DriveService(
+        {
+            "done": True,
+            "response": {"downloadUri": "https://drive.example/download/partial"},
+        }
+    )
+
+    class _MidstreamFailureResponse(_Response):
+        def iter_content(self, *, chunk_size: int):
+            assert chunk_size == 1024 * 1024
+            yield b"partial"
+            raise RuntimeError("connection reset")
+
+    session = _AuthorizedSession(_MidstreamFailureResponse([]))
+    monkeypatch.setattr(module, "AuthorizedSession", lambda _credentials: session)
+    destination = tmp_path / "slides.pptx"
+
+    with pytest.raises(
+        module.GoogleDriveDownloadError,
+        match="Final Drive download request failed",
+    ):
+        module.download_google_workspace_file(
+            service=service,
+            credentials=object(),
+            file_id="slides-partial",
+            mime_type="application/vnd.test.presentation",
+            destination=destination,
+            timeout_seconds=600,
+        )
+
+    assert destination.read_bytes() == b"partial"
 
 
 def test_download_google_workspace_file_wraps_final_http_failure(

--- a/uv.lock
+++ b/uv.lock
@@ -8007,7 +8007,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.35.0" },
     { name = "filelock", specifier = ">=3.0.0" },
     { name = "fsspec", specifier = ">=2024.0.0" },
-    { name = "google-api-python-client", specifier = ">=2.111.0" },
+    { name = "google-api-python-client", specifier = ">=2.145.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
     { name = "google-cloud-pubsub", specifier = ">=2.21.0" },
     { name = "google-genai", specifier = ">=1.65.0" },


### PR DESCRIPTION
## Summary

- import native Google Slides into knowledge bases as PowerPoint files
- use the Drive `files.download` long-running operation with bounded polling, streamed transfer, rollback, and resource-key support
- align the Google API client requirement and reverse-proxy timeout with the new download path

## Testing

- affected backend test suites
- frontend knowledge-base dialog tests
- Ruff and mypy
- frontend lint and type-check
- nginx configuration validation
- `uv lock --check`
- all pre-commit hooks

## Deployment notes

`POST /api/kb/ingest-cloud` accepts one to five files per request. The bundled nginx configuration gives this route a 900-second read timeout. For native Google Workspace files, Drive polling has a 600-second default application deadline; final transfer, parsing, chunking, and embedding all continue within the same HTTP request. Custom reverse proxies must allow for the full end-to-end request, and their timeout must also be increased when `XAGENT_GOOGLE_DRIVE_DOWNLOAD_TIMEOUT_SECONDS` is increased.
