### PR TITLE
Resolve custom API connector visibility from the governing agent's team

### DIFF
--- a/src/xagent/web/services/connector_runtime.py
+++ b/src/xagent/web/services/connector_runtime.py
@@ -276,17 +276,15 @@ def load_connector_runtime_view(
     for ref in selected_refs:
         connector = visible.get(ref)
         if connector is None:
-            # Tool loading applies the same visibility filter before
-            # instantiating a tool, so a now-hidden historical ref has no
-            # runtime tool to receive values on this turn. This holds for
-            # MCP on both the new-hook and legacy-hook branches, and for
-            # Custom API on the new-hook branch too (narrowed to the
-            # junction-only set until a follow-up team-keys the Custom API
-            # tool loaders and this branch's Custom API set to match). On
-            # the legacy-hook branch the filters diverge for Custom API: a
-            # legacy user-keyed hook can grant a team-shared Custom API
-            # here while the Custom API tool loader resolves junction-only,
-            # so such a ref stays visible without a runtime tool.
+            # Tool loading applies the same visibility filter when the
+            # team-scope hook is installed, for both connector kinds, so a
+            # ref absent here has no runtime tool either way. With only the
+            # legacy hook installed, this view is user-keyed and unions a
+            # legacy-granted team-shared custom API, while both tool
+            # loaders resolve personal-only -- they consult the team-keyed
+            # hook exclusively, never the legacy one -- so such a ref is
+            # selectable and persistable into a task's connector selection
+            # but builds no runtime tool.
             continue
         raw_ephemeral = (
             ephemeral_by_ref.get(ref.storage_key, {})
@@ -403,11 +401,11 @@ def prepare_connector_runtime_selection_snapshot(
     the agent's tool-selection policy, while ``connector_user_id`` supplies the
     same connector visibility scope used by normal web tool loading:
     ``connector_user_id``'s personal MCP/Custom API links, unioned with
-    ``agent``'s owning team's connectors for MCP when a team-keyed hook is
-    installed (Custom API stays junction-only for now). For published-agent
-    chats, personal visibility still follows the task owner rather than the
-    published agent's owner; team visibility follows the agent regardless of
-    who is running it.
+    ``agent``'s owning team's connectors for both connector kinds when a
+    team-keyed hook is installed. For published-agent chats, personal
+    visibility still follows the task owner rather than the published
+    agent's owner; team visibility follows the agent regardless of who is
+    running it.
     """
 
     if agent is None or connector_user_id is None:
@@ -593,8 +591,8 @@ def _load_visible_runtime_connectors(
     db: Session, *, user_id: int, agent_team_id: int | None = None
 ) -> dict[ConnectorRef, Any]:
     from .connector_team_scope import (
+        resolve_team_connector_ids_or_raise,
         team_connector_hook_installed,
-        team_connector_ids,
         visible_team_connector_ids,
     )
 
@@ -602,31 +600,17 @@ def _load_visible_runtime_connectors(
     if team_connector_hook_installed():
         # Team ownership is resolved from the team that owns the governing
         # agent. A run with no governing agent resolves personal links only.
-        try:
-            team_ids = team_connector_ids(db, team_id=agent_team_id)
-        except ConnectorRuntimeError:
-            raise
-        except Exception as exc:
-            logger.warning(
-                "Failed to resolve team connector scope for user %s",
-                user_id,
-                exc_info=True,
-            )
-            raise ConnectorRuntimeError(
-                ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
-                "Connector team scope is unavailable.",
-                details={"reason": "team_scope_resolution_failed"},
-                status_code=503,
-            ) from exc
-        # Custom API is not team-keyed on either side of this seam yet: the
-        # tool-build loaders (WebToolConfig's custom-API paths) stay
-        # junction-only until a follow-up team-keys them too. Consuming the
-        # "custom_api" half here without a matching consumer would let a
-        # team-owned custom API be selected into a task's runtime snapshot
-        # and then fail at runtime-view resolution (no personal link to
-        # satisfy it) while never building a tool either -- so this side
-        # stays MCP-only until both halves move together.
-        team_ids = {"mcp": team_ids["mcp"], "custom_api": set()}
+        team_ids = resolve_team_connector_ids_or_raise(
+            db, team_id=agent_team_id, log_subject=user_id
+        )
+        # Both connector kinds are team-keyed together: the tool-build
+        # loaders (WebToolConfig's MCP and custom-API paths) both consult
+        # the same team scope now, so a team-owned custom API selected into
+        # a task's runtime snapshot here always has a matching tool-loader
+        # consumer to build it. Consuming the "custom_api" half without a
+        # matching consumer would let a selected connector fail at
+        # runtime-view resolution while never building a tool either --
+        # that hazard is why the two sides move together, not separately.
     else:
         # No team-keyed hook: keep the legacy user-keyed overlay exactly as
         # it is, so an installation that adopts this revision without

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -7,11 +7,19 @@ the application's team tables.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 from sqlalchemy.sql.elements import ColumnElement
+
+from ...core.tools.adapters.vibe.connector_runtime import (
+    ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+    ConnectorRuntimeError,
+)
+
+logger = logging.getLogger(__name__)
 
 ConnectorType = Literal["mcp", "custom_api"]
 ConnectorRenamedHook = Callable[[Any, int, ConnectorType, int, str, str], None]
@@ -61,10 +69,16 @@ class TeamConnectorVisibilityHook(Protocol):
 
     Every connector id a hook returns becomes executable by *any* runner of
     that team's agents, not only members: for stdio and other static-auth
-    transports, a team-owned server with no personal link for the running
-    user executes using the shared definition row's own stored credentials,
-    not the runner's. (OAuth transports fail closed instead, for lack of a
-    token to resolve.)
+    MCP transports, a team-owned server with no personal link for the
+    running user executes using the shared definition row's own stored
+    credentials, not the runner's. (OAuth transports fail closed instead,
+    for lack of a token to resolve.) Custom APIs are starker: there is no
+    per-member credential override layer at all, and no transport-level
+    exception either -- every custom API always executes with whatever is
+    stored on its shared definition row (headers, a static API key, and so
+    on), for every runner, member or not. Sharing a custom API with a team
+    means sharing whatever credential it holds with everyone who can run
+    the team's agents.
     """
 
     def __call__(self, db: Any, *, team_id: int) -> dict[str, set[int]]: ...
@@ -176,6 +190,50 @@ def team_connector_hook_installed() -> bool:
     return _team_connector_visibility_hook is not None
 
 
+def resolve_team_connector_ids_or_raise(
+    db: Any, *, team_id: int | None, log_subject: int | None
+) -> dict[str, set[int]]:
+    """``team_connector_ids(db, team_id=team_id)``, with every non-typed
+    failure converted into the seam's one typed 503.
+
+    Every team-scope resolution call site -- both of ``WebToolConfig``'s
+    custom-API read points, its MCP read point, and the runtime-context
+    view loader -- wraps ``team_connector_ids`` the same way: a
+    ``ConnectorRuntimeError`` passes through unchanged, and any other
+    exception is logged at ``WARNING`` and converted into
+    ``ConnectorRuntimeError(ERROR_CONNECTOR_RUNTIME_UNAVAILABLE, "Connector
+    team scope is unavailable.", details={"reason":
+    "team_scope_resolution_failed"}, status_code=503)``. This function is
+    that wrap, written once. Returns the full ``{"mcp": ..., "custom_api":
+    ...}`` dict unmodified -- callers that need one connector kind extract
+    it themselves (e.g. ``result["mcp"]``); the runtime-context view loader
+    needs both and takes the dict as-is.
+
+    ``log_subject`` is the user id that identifies the caller in the
+    warning log line -- ``None`` at any call site whose own identity guard
+    the caller has not yet reached (the MCP read point's private loader has
+    no identity guard of its own; production only reaches it through its
+    guarded public wrapper). It is only ever formatted into the log
+    message, never interpreted.
+    """
+    try:
+        return team_connector_ids(db, team_id=team_id)
+    except ConnectorRuntimeError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve team connector scope for user %s",
+            log_subject,
+            exc_info=True,
+        )
+        raise ConnectorRuntimeError(
+            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+            "Connector team scope is unavailable.",
+            details={"reason": "team_scope_resolution_failed"},
+            status_code=503,
+        ) from exc
+
+
 def visible_mcp_server_clause(
     owner_user_id: int | None, team_mcp_ids: Collection[int]
 ) -> ColumnElement[bool]:
@@ -207,6 +265,39 @@ def visible_mcp_server_clause(
     if not team_mcp_ids or owner_user_id is None:
         return personal
     return or_(personal, MCPServer.id.in_(set(team_mcp_ids)))
+
+
+def visible_custom_api_clause(
+    owner_user_id: int | None, team_api_ids: Collection[int]
+) -> ColumnElement[bool]:
+    """Predicate selecting the custom APIs visible to ``owner_user_id``.
+
+    Personal custom APIs (an active ``UserCustomApi`` link) unioned with the
+    team-owned APIs named in ``team_api_ids``. ``is_active`` gates only the
+    personal arm -- a team-owned API is visible regardless of the member's
+    own personal link state, which is intentional (see the module's callers
+    for the credential consequence). Pure function over ORM constructs -- no
+    I/O. An empty ``team_api_ids`` reduces to exactly the personal
+    semi-join, so a deployment with no team overlay compiles the same query
+    shape it always has. A ``None`` owner also reduces to the personal arm
+    regardless of ``team_api_ids`` -- defense in depth so this function is
+    fail-closed on its own terms, not only because of how its callers
+    happen to be gated today.
+    """
+
+    from sqlalchemy import or_, select
+
+    from ..models.custom_api import CustomApi, UserCustomApi
+
+    personal = CustomApi.id.in_(
+        select(UserCustomApi.custom_api_id).where(
+            UserCustomApi.user_id == owner_user_id,
+            UserCustomApi.is_active,
+        )
+    )
+    if not team_api_ids or owner_user_id is None:
+        return personal
+    return or_(personal, CustomApi.id.in_(set(team_api_ids)))
 
 
 def delete_team_connector(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -728,6 +728,28 @@ def _load_custom_api_runtime_view_sync(
         ) from exc
 
 
+def _visible_custom_api_query(
+    db: Any, *, owner_user_id: int | None, team_api_ids: frozenset[int]
+) -> Any:
+    """Production custom-API visibility query, shared by both read points.
+
+    Module-level, not a ``WebToolConfig`` method: ``_load_custom_api_factory_inputs``
+    below is a module-level function that never sees a ``WebToolConfig``
+    instance (the detached-plan contract documented on
+    ``_load_tool_factory_runtime_snapshot``'s docstring, this module: "never
+    receives the caller's ``WebToolConfig``, request Session, or ORM user"),
+    so a method could serve only one of the two read points.
+    """
+    from ..models.custom_api import CustomApi
+    from ..services.connector_team_scope import visible_custom_api_clause
+
+    return (
+        db.query(CustomApi)
+        .filter(visible_custom_api_clause(owner_user_id, team_api_ids))
+        .order_by(CustomApi.id)
+    )
+
+
 def _load_custom_api_factory_inputs(
     db: Any,
     *,
@@ -739,17 +761,23 @@ def _load_custom_api_factory_inputs(
     if user_id is None:
         return []
 
-    from ..models.custom_api import UserCustomApi
+    # Resolved before the caller's guarded region (this helper carries no
+    # try/except of its own): that region reports "every selected API is
+    # unavailable", which is the wrong answer for "the scope could not be
+    # resolved". The typed error is what survives the tool-creator frame --
+    # an untyped one is dropped there with an ERROR and no tool set at all.
+    from ..services.connector_team_scope import resolve_team_connector_ids_or_raise
 
-    user_apis = (
-        db.query(UserCustomApi)
-        .filter(
-            UserCustomApi.user_id == user_id,
-            UserCustomApi.is_active,
-        )
-        .all()
+    team_api_ids = frozenset(
+        resolve_team_connector_ids_or_raise(
+            db, team_id=connector_team_id, log_subject=user_id
+        )["custom_api"]
     )
-    if not user_apis:
+
+    rows = _visible_custom_api_query(
+        db, owner_user_id=user_id, team_api_ids=team_api_ids
+    ).all()
+    if not rows:
         return []
 
     runtime_view = _load_custom_api_runtime_view_sync(
@@ -760,10 +788,7 @@ def _load_custom_api_factory_inputs(
         agent_team_id=connector_team_id,
     )
     configs: list[dict[str, Any]] = []
-    for user_api in user_apis:
-        api = user_api.custom_api
-        if api is None:
-            continue
+    for api in rows:
         runtime_values = runtime_view.get(f"custom_api:{int(api.id)}")
         configs.append(
             _custom_api_config_from_model(
@@ -3391,26 +3416,13 @@ class WebToolConfig(BaseToolConfig):
         # for "the scope could not be resolved". The typed error is what
         # survives the tool-creator frame -- an untyped one is dropped there
         # with a WARNING and no tool set at all.
-        try:
-            from ..services.connector_team_scope import team_connector_ids
+        from ..services.connector_team_scope import resolve_team_connector_ids_or_raise
 
-            team_mcp_ids = frozenset(
-                team_connector_ids(self.db, team_id=self._connector_team_id)["mcp"]
-            )
-        except ConnectorRuntimeError:
-            raise
-        except Exception as exc:
-            logger.warning(
-                "Failed to resolve team connector scope for user %s",
-                self._user_id,
-                exc_info=True,
-            )
-            raise ConnectorRuntimeError(
-                ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
-                "Connector team scope is unavailable.",
-                details={"reason": "team_scope_resolution_failed"},
-                status_code=503,
-            ) from exc
+        team_mcp_ids = frozenset(
+            resolve_team_connector_ids_or_raise(
+                self.db, team_id=self._connector_team_id, log_subject=self._user_id
+            )["mcp"]
+        )
 
         try:
             from ..services.mcp_runtime import (
@@ -3461,26 +3473,60 @@ class WebToolConfig(BaseToolConfig):
         if not self._user_id:
             return []
 
+        # Resolved before the guarded region below: that region reports
+        # "every selected API is unavailable", which is the wrong answer
+        # for "the scope could not be resolved". The typed error is what
+        # survives the tool-creator frame -- an untyped one is dropped there
+        # with an ERROR and no tool set at all.
+        from ..services.connector_team_scope import resolve_team_connector_ids_or_raise
+
+        team_api_ids = frozenset(
+            resolve_team_connector_ids_or_raise(
+                self.db, team_id=self._connector_team_id, log_subject=self._user_id
+            )["custom_api"]
+        )
+
+        # Fails closed on the query itself, matching the MCP twin
+        # (_load_mcp_server_configs): a genuine DB/query failure here is not
+        # "the caller selected zero custom APIs", so it must not degrade to
+        # an empty list. The MCP twin raises its own MCPConfigLoadError,
+        # whose summaries/failure-policy machinery (enforce_mcp_failure_policy)
+        # has no custom-API equivalent and would be new surface to build for
+        # this fix; ConnectorRuntimeError is the typed error this same
+        # function already raises for the team-scope-resolution failure
+        # above, is already propagated by every frame between here and the
+        # tool creator (create_db_custom_api_tools's own
+        # ``except ConnectorRuntimeError: raise``, then the registry loop's),
+        # and needs no new plumbing. Per-row config-building below keeps its
+        # existing swallow behavior unchanged -- neither side treats an
+        # individual row's build failure as fatal -- but the granularity
+        # still differs and is a remaining difference, out of scope here:
+        # the MCP twin isolates a failed row into an "unavailable" config
+        # and keeps loading the others, while this loop's guard spans the
+        # whole loop, so one bad row still discards every row.
         try:
-            from ..models.custom_api import UserCustomApi
-
-            user_apis = (
-                self.db.query(UserCustomApi)
-                .filter(
-                    UserCustomApi.user_id == int(self._user_id),
-                    UserCustomApi.is_active,
-                )
-                .all()
+            apis = _visible_custom_api_query(
+                self.db,
+                owner_user_id=int(self._user_id),
+                team_api_ids=team_api_ids,
+            ).all()
+        except ConnectorRuntimeError:
+            raise
+        except Exception as error:
+            logger.warning(
+                "Failed to scan Custom API configs with %s",
+                type(error).__name__,
             )
+            raise ConnectorRuntimeError(
+                ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+                "Custom API configurations could not be loaded.",
+                details={"reason": "custom_api_config_load_failed"},
+                status_code=503,
+            ) from error
 
-            if not user_apis:
-                return []
-
+        try:
             custom_api_configs = []
-            for user_api in user_apis:
-                api = user_api.custom_api
-                if api is None:
-                    continue
+            for api in apis:
                 custom_api_configs.append(
                     _custom_api_config_from_model(
                         api,

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -1201,6 +1201,7 @@ class TestWebToolConfigCustomApi:
 
         # Mirror of production custom_apis row (id=5, name=Post_HelloAPI)
         api = MagicMock()
+        api.id = 5
         api.name = "Post_HelloAPI"
         api.description = None
         api.url = "https://helloapi-u6nc.onrender.com/"
@@ -1209,11 +1210,10 @@ class TestWebToolConfigCustomApi:
         api.body = '{\n  "message": "example message"\n}'
         api.env = None
 
-        user_api = MagicMock()
-        user_api.custom_api = api
-
         db = MagicMock()
-        db.query.return_value.filter.return_value.all.return_value = [user_api]
+        db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+            api
+        ]
 
         cfg = WebToolConfig(
             db=db,
@@ -1239,6 +1239,7 @@ class TestWebToolConfigCustomApi:
         from xagent.web.tools.config import WebToolConfig
 
         api = MagicMock()
+        api.id = 6
         api.name = "Get_HiAPI"
         api.description = None
         api.url = "https://helloapi-u6nc.onrender.com/"
@@ -1247,11 +1248,10 @@ class TestWebToolConfigCustomApi:
         api.body = None
         api.env = None
 
-        user_api = MagicMock()
-        user_api.custom_api = api
-
         db = MagicMock()
-        db.query.return_value.filter.return_value.all.return_value = [user_api]
+        db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+            api
+        ]
 
         cfg = WebToolConfig(
             db=db,

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -417,21 +417,20 @@ def test_installed_hook_with_no_governing_agent_supersedes_legacy_overlay(
 
 
 # ---------------------------------------------------------------------------
-# The new-hook branch narrows to MCP only: a team hook's "custom_api" grant
-# is not consumed at this seam. Custom API is not team-keyed on either side
-# yet -- the tool-build loaders (WebToolConfig's custom-API paths) stay
-# junction-only until a follow-up change team-keys them too. Unioning the
-# custom_api set here without a matching consumer would let a team-owned
-# custom API enter a task's runtime selection snapshot with no personal
-# link to satisfy its runtime-view resolution, and no tool loader able to
-# build it either -- selectable and persistable, never executable. This is
-# distinct from the legacy branch above (test_legacy_visibility_hook_alone_
-# is_unchanged), which keeps granting team custom APIs through the legacy
-# user-keyed hook -- the narrowing applies only to the new team-keyed hook.
+# The new-hook branch unions both connector kinds: a team hook's
+# "custom_api" grant is consumed at this seam exactly like its "mcp" grant.
+# Custom API is now team-keyed on both sides of this seam -- the tool-build
+# loaders (WebToolConfig's custom-API paths) are team-keyed too, so a
+# team-owned custom API entering a task's runtime selection snapshot always
+# has a personal-or-team-satisfied runtime-view resolution and a tool
+# loader able to build it. This is the same shape as the legacy branch
+# above (test_legacy_visibility_hook_alone_is_unchanged), which already
+# grants team custom APIs through the legacy user-keyed hook -- the two
+# branches now agree on custom API instead of diverging.
 # ---------------------------------------------------------------------------
 
 
-def test_new_hook_branch_does_not_union_team_custom_api(db_session, seed):
+def test_new_hook_branch_unions_team_custom_api_too(db_session, seed):
     connector_team_scope.set_connector_team_hooks(team_visibility=_team_hook(seed))
     try:
         visible = _load_visible_runtime_connectors(
@@ -440,10 +439,9 @@ def test_new_hook_branch_does_not_union_team_custom_api(db_session, seed):
         mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
         capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
         # T1's hook (see _team_hook above) grants both seed.team_s (mcp) and
-        # seed.a_capi (custom_api). The mcp grant still unions in; the
-        # custom_api grant does not -- that is the narrowing under test.
+        # seed.a_capi (custom_api). Both grants union in now.
         assert mcp_ids == {int(seed.active_own.id), int(seed.team_s.id)}
-        assert capi_ids == {int(seed.capi_own.id)}
+        assert capi_ids == {int(seed.capi_own.id), int(seed.a_capi.id)}
     finally:
         connector_team_scope.set_connector_team_hooks()
 
@@ -579,5 +577,32 @@ def test_runtime_view_seam_retypes_malformed_hook_answer(db_session, seed):
             )
         assert excinfo.value.status_code == 503
         assert isinstance(excinfo.value.__cause__, ValueError)
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+def test_resolve_or_raise_passes_a_typed_error_through_unchanged():
+    """The shared wrap's ``except ConnectorRuntimeError: raise`` arm: a hook
+    that already raises the typed error must reach the caller as that exact
+    object -- not re-wrapped, not given a new cause -- so an inner seam's
+    more specific reason survives to whatever renders the failure."""
+    planted = ConnectorRuntimeError(
+        "planted_code",
+        "planted typed failure",
+        details={"reason": "planted_inner_reason"},
+        status_code=503,
+    )
+
+    def _raising_hook(db, *, team_id):
+        raise planted
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_raising_hook)
+    try:
+        with pytest.raises(ConnectorRuntimeError) as excinfo:
+            connector_team_scope.resolve_team_connector_ids_or_raise(
+                None, team_id=T1, log_subject="passthrough-probe"
+            )
+        assert excinfo.value is planted
+        assert excinfo.value.details["reason"] == "planted_inner_reason"
     finally:
         connector_team_scope.set_connector_team_hooks()

--- a/tests/web/services/test_connector_visibility_parity.py
+++ b/tests/web/services/test_connector_visibility_parity.py
@@ -1,21 +1,25 @@
-"""The runtime-context view and the tool loader agree on MCP visibility.
+"""The runtime-context view and the tool loaders agree on visibility, for
+both connector kinds.
 
 One fixture seeded with all four connector categories (owner-active,
-owner-inactive, team-only, stranger) simultaneously, plus one
-OAuth-without-grant row so the ``config["server_id"]`` fallback below is
-actually exercised (the tool loader's "unavailable" shape has no top-level
-``id``). The matrix varies the team parameter over ``{T1, None}`` on the run
-owner, plus one ``T2`` cell -- trimmed to the cells that each discriminate a
-distinct case rather than repeating one already covered.
+owner-inactive, team-only, stranger) simultaneously per kind, plus one
+OAuth-without-grant MCP row so the ``config["server_id"]`` fallback below is
+actually exercised (the MCP tool loader's "unavailable" shape has no
+top-level ``id``; the custom-API loader always emits one, so no such
+fallback is needed on that half). The matrix varies the team parameter over
+``{T1, None}`` on the run owner, plus one ``T2`` cell (so the agent's team
+differs from the run owner's own team, per the run owner's
+agent-team-scope mapping below) -- trimmed to the cells that each
+discriminate a distinct case rather than repeating one already covered.
 
-Scope note: this asserts ``connector_type == "mcp"`` parity only. The
-custom-API half is deliberately NOT team-keyed on either side: the new-hook
-branch of ``_load_visible_runtime_connectors`` narrows its custom-API set
-to the junction-only view (pinned by
-``test_new_hook_branch_does_not_union_team_custom_api``), matching the
-custom-API tool loaders in ``config.py``, until both sides are team-keyed
-together. Custom-API parity therefore holds trivially today; the cells
-here pin the MCP half, where the union is live.
+Scope note: this asserts parity on the **live** path only, for both
+connector kinds. ``_load_visible_runtime_connectors`` and the custom-API
+tool loaders in ``config.py`` are now team-keyed together (see
+``test_new_hook_branch_unions_team_custom_api_too`` in
+``test_connector_team_scope.py``), so the custom-API half of this parity
+check is live, not trivial, the same way the MCP half always was. The
+custom-API snapshot/prefetch path is covered separately, by its own
+``test_snapshot_and_live_custom_api_paths_agree``.
 """
 
 from __future__ import annotations
@@ -29,6 +33,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from xagent.web.models import Base, MCPServer, User, UserMCPServer
+from xagent.web.models.custom_api import CustomApi, UserCustomApi
 from xagent.web.services import agent_team_scope, connector_team_scope
 from xagent.web.services.connector_runtime import _load_visible_runtime_connectors
 from xagent.web.tools.config import WebToolConfig
@@ -101,10 +106,42 @@ def _create_mcp(
     return server
 
 
+def _create_custom_api(
+    db: Session, name: str, *, owner: User | None = None, active: bool = True
+) -> CustomApi:
+    api = CustomApi(
+        name=name,
+        description=f"{name} description",
+        url="https://api.example.test",
+        method="GET",
+        headers={},
+        body=None,
+        env={},
+    )
+    db.add(api)
+    db.flush()
+    if owner is not None:
+        db.add(
+            UserCustomApi(
+                user_id=owner.id,
+                custom_api_id=api.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=active,
+            )
+        )
+        db.flush()
+    return api
+
+
 @pytest.fixture()
 def seed(db_session: Session):
     c = _create_user(db_session, "run-owner")
     stranger_owner = _create_user(db_session, "stranger-owner")
+    team_a_owner = _create_user(db_session, "team-a-owner")
+    team_b_owner = _create_user(db_session, "team-b-owner")
+
     active_own = _create_mcp(db_session, "active-own", owner=c, active=True)
     inactive_own = _create_mcp(db_session, "inactive-own", owner=c, active=False)
     stranger = _create_mcp(db_session, "stranger", owner=stranger_owner)
@@ -115,17 +152,34 @@ def seed(db_session: Session):
     oauth_no_grant = _create_mcp(
         db_session, "oauth-no-grant", owner=c, transport="oauth"
     )
+
+    active_own_api = _create_custom_api(
+        db_session, "active-own-api", owner=c, active=True
+    )
+    inactive_own_api = _create_custom_api(
+        db_session, "inactive-own-api", owner=c, active=False
+    )
+    stranger_api = _create_custom_api(db_session, "stranger-api", owner=stranger_owner)
+    team_a_api = _create_custom_api(db_session, "team-a-api", owner=team_a_owner)
+    team_b_api = _create_custom_api(db_session, "team-b-api", owner=team_b_owner)
+
     connector_team_scope.set_connector_team_hooks(
-        # inactive_own also carries a live T1 team grant here, pinning the
-        # deliberate "no is_active veto" decision: a member's deactivated
-        # personal link must not silently hide a connector the team still
-        # shares. Without this, ``inactive_own`` only ever pinned "inactive
-        # personal link alone -> not visible", never the combination that
-        # actually matters.
+        # inactive_own/inactive_own_api also carry a live T1 team grant here,
+        # pinning the deliberate "no is_active veto" decision: a member's
+        # deactivated personal link must not silently hide a connector the
+        # team still shares. Without this, the inactive rows would only
+        # ever pin "inactive personal link alone -> not visible", never the
+        # combination that actually matters.
         team_visibility=lambda db, *, team_id: (
-            {"mcp": {int(team_s.id), int(inactive_own.id)}, "custom_api": set()}
+            {
+                "mcp": {int(team_s.id), int(inactive_own.id)},
+                "custom_api": {int(team_a_api.id), int(inactive_own_api.id)},
+            }
             if team_id == T1
-            else {"mcp": {int(team_x.id)}, "custom_api": set()}
+            else {
+                "mcp": {int(team_x.id)},
+                "custom_api": {int(team_b_api.id)},
+            }
             if team_id == T2
             else {"mcp": set(), "custom_api": set()}
         )
@@ -135,11 +189,11 @@ def seed(db_session: Session):
     # runner-keyed misimplementation is distinguishable from the correct
     # agent-keyed one on the ``team=None`` cell.
     agent_team_scope.set_agent_team_scope_hook(
-        lambda db, user_id: agent_team_scope.AgentTeamScope(
-            team_id=T1, is_team_admin=False
+        lambda db, user_id: (
+            agent_team_scope.AgentTeamScope(team_id=T1, is_team_admin=False)
+            if user_id == int(c.id)
+            else None
         )
-        if user_id == int(c.id)
-        else None
     )
     return SimpleNamespace(
         c=c,
@@ -149,16 +203,23 @@ def seed(db_session: Session):
         team_s=team_s,
         team_x=team_x,
         oauth_no_grant=oauth_no_grant,
+        active_own_api=active_own_api,
+        inactive_own_api=inactive_own_api,
+        stranger_api=stranger_api,
+        team_a_api=team_a_api,
+        team_b_api=team_b_api,
     )
 
 
 async def _parity_ids(
-    db_session: Session, seed, *, team: int | None
+    db_session: Session, seed, *, team: int | None, connector_type: str
 ) -> tuple[set[int], set[int]]:
     visible = _load_visible_runtime_connectors(
         db_session, user_id=int(seed.c.id), agent_team_id=team
     )
-    runtime_ids = {ref.connector_id for ref in visible if ref.connector_type == "mcp"}
+    runtime_ids = {
+        ref.connector_id for ref in visible if ref.connector_type == connector_type
+    }
 
     cfg = WebToolConfig(
         db=db_session,
@@ -167,15 +228,27 @@ async def _parity_ids(
         connector_team_id=team,
         include_mcp_tools=True,
     )
-    configs = await cfg._load_mcp_server_configs()
-    loader_ids = {c.get("id") or c.get("config", {}).get("server_id") for c in configs}
+    if connector_type == "mcp":
+        configs = await cfg._load_mcp_server_configs()
+        loader_ids = {
+            c.get("id") or c.get("config", {}).get("server_id") for c in configs
+        }
+    else:
+        # The custom-API loader always emits a top-level "id"
+        # (_custom_api_config_from_model, config.py:781), so no
+        # _build_unavailable_mcp_config-style fallback is needed here --
+        # that fallback stays on the MCP half above.
+        configs = cfg.get_custom_api_configs()
+        loader_ids = {c["id"] for c in configs}
     return runtime_ids, loader_ids
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("team", [T1, None, T2])
-async def test_runtime_view_and_tool_config_agree(db_session, seed, team):
-    runtime_ids, loader_ids = await _parity_ids(db_session, seed, team=team)
+async def test_runtime_view_and_tool_config_agree_mcp(db_session, seed, team):
+    runtime_ids, loader_ids = await _parity_ids(
+        db_session, seed, team=team, connector_type="mcp"
+    )
     assert runtime_ids == loader_ids
 
     # Every seeded category is represented in the agreed-on set so the
@@ -186,10 +259,10 @@ async def test_runtime_view_and_tool_config_agree(db_session, seed, team):
     if team == T1:
         assert int(seed.team_s.id) in loader_ids
         assert int(seed.team_x.id) not in loader_ids
-        # Plan §6's "no is_active veto": a deactivated personal link plus a
-        # live T1 team grant still resolves visible, in parity on both
-        # read points -- the team grant is not blocked by the member's own
-        # inactive association.
+        # No is_active veto: a deactivated personal link plus a live T1
+        # team grant still resolves visible, in parity on both read points
+        # -- the team grant is not blocked by the member's own inactive
+        # association.
         assert int(seed.inactive_own.id) in loader_ids
     elif team == T2:
         assert int(seed.team_x.id) in loader_ids
@@ -201,3 +274,28 @@ async def test_runtime_view_and_tool_config_agree(db_session, seed, team):
         assert int(seed.team_s.id) not in loader_ids
         assert int(seed.team_x.id) not in loader_ids
         assert int(seed.inactive_own.id) not in loader_ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("team", [T1, None, T2])
+async def test_runtime_view_and_tool_config_agree_custom_api(db_session, seed, team):
+    runtime_ids, loader_ids = await _parity_ids(
+        db_session, seed, team=team, connector_type="custom_api"
+    )
+    assert runtime_ids == loader_ids
+
+    assert int(seed.active_own_api.id) in loader_ids
+    assert int(seed.stranger_api.id) not in loader_ids
+    if team == T1:
+        assert int(seed.team_a_api.id) in loader_ids
+        assert int(seed.team_b_api.id) not in loader_ids
+        # No is_active veto, on the custom-API half too.
+        assert int(seed.inactive_own_api.id) in loader_ids
+    elif team == T2:
+        assert int(seed.team_b_api.id) in loader_ids
+        assert int(seed.team_a_api.id) not in loader_ids
+        assert int(seed.inactive_own_api.id) not in loader_ids
+    else:
+        assert int(seed.team_a_api.id) not in loader_ids
+        assert int(seed.team_b_api.id) not in loader_ids
+        assert int(seed.inactive_own_api.id) not in loader_ids

--- a/tests/web/tools/test_custom_api_team_visibility.py
+++ b/tests/web/tools/test_custom_api_team_visibility.py
@@ -1,0 +1,708 @@
+"""Team-scope connector visibility at the custom-API tool-load boundary.
+
+The mirror of ``test_mcp_team_visibility.py``, extended for the two things
+that only exist on this side: two read points instead of one (a live path,
+``WebToolConfig.get_custom_api_configs``, and an off-loop snapshot prefetch,
+``_load_custom_api_factory_inputs``, selected by
+``snapshot is not None and snapshot.plan.load_custom_api``), and no
+per-member credential layer (``CustomApi.env`` lives on the shared
+definition row; ``UserCustomApi`` carries no ``env`` column at all).
+
+Fixture seed (six custom-API rows, run owner ``C`` throughout unless noted):
+
+    active_own            -- C holds an active personal link
+    inactive_own           -- C holds an inactive personal link
+    stranger                -- owned by a third user, no link to anything
+    a                        -- another user's, reachable only through a
+                                team hook keyed on T1
+    b                        -- another user's, reachable only through a
+                                team hook keyed on T2
+    inactive_own_shared     -- C holds an inactive personal link AND it is
+                                in T1's team-owned set -- the one cell where
+                                "personal ∪ team" is not a strict widening
+                                of C's own list (a member's personal
+                                deactivate does not hide a team-shared API)
+
+The deterministic-ordering contract (``ORDER BY custom_apis.id``) is pinned
+by the compiled-SQL assertion in ``test_production_custom_api_query_shape``,
+not by any list-order assertion in this file -- no test here asserts the
+order of a multi-row-visible result, so the seed's insertion order carries
+no test-discrimination weight and is left natural.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Reused verbatim from the MCP sibling: same probe exception, same team ids,
+# same hook install/teardown factory. ``db_session`` and the autouse hook
+# reset are declared locally below rather than imported -- both are cheap
+# and self-contained, and importing a ``@pytest.fixture`` for use as a test
+# parameter name collides with the parameter of the same name in every
+# consuming test.
+from tests.web.tools.test_mcp_team_visibility import (
+    T1,
+    T2,
+    _create_user,
+    _ProbeError,
+    install_team_hooks,
+)
+from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from xagent.core.tools.adapters.vibe.custom_api_factory import (
+    create_db_custom_api_tools,
+)
+from xagent.web.models import Base
+from xagent.web.models.custom_api import CustomApi, UserCustomApi
+from xagent.web.services import agent_team_scope, connector_team_scope
+from xagent.web.services.connector_runtime import _load_visible_runtime_connectors
+from xagent.web.tools.config import (
+    WebToolConfig,
+    _load_custom_api_factory_inputs,
+    _load_tool_factory_runtime_snapshot,
+    _visible_custom_api_query,
+)
+
+
+@pytest.fixture()
+def db_session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks() -> Iterator[None]:
+    yield
+    connector_team_scope.set_connector_team_hooks()
+    agent_team_scope.set_agent_team_scope_hook(None)
+
+
+def _create_custom_api(
+    db: Session,
+    name: str,
+    *,
+    owner=None,
+    active: bool = True,
+    env: dict | None = None,
+) -> CustomApi:
+    api = CustomApi(
+        name=name,
+        description=f"{name} description",
+        url="https://api.example.test",
+        method="GET",
+        headers={},
+        body=None,
+        env=env if env is not None else {},
+    )
+    db.add(api)
+    db.flush()
+    if owner is not None:
+        db.add(
+            UserCustomApi(
+                user_id=owner.id,
+                custom_api_id=api.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=active,
+            )
+        )
+        db.flush()
+    return api
+
+
+def _build_seed(db: Session) -> SimpleNamespace:
+    c = _create_user(db, "run-owner")
+    z = _create_user(db, "stranger-owner")
+    w = _create_user(db, "team-a-owner")
+    v = _create_user(db, "team-b-owner")
+
+    # Creation order fixes custom_apis.id ascending in this sequence.
+    stranger = _create_custom_api(db, "stranger-api", owner=z)
+    a = _create_custom_api(db, "team-a-api", owner=w, env={"API_KEY": "team-a-secret"})
+    b = _create_custom_api(db, "team-b-api", owner=v)
+    active_own = _create_custom_api(db, "active-own-api")
+    inactive_own_shared = _create_custom_api(db, "inactive-own-shared-api")
+    inactive_own = _create_custom_api(db, "inactive-own-api")
+
+    db.add(
+        UserCustomApi(
+            user_id=c.id,
+            custom_api_id=active_own.id,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+            is_active=True,
+        )
+    )
+    db.add(
+        UserCustomApi(
+            user_id=c.id,
+            custom_api_id=inactive_own_shared.id,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+            is_active=False,
+        )
+    )
+    db.add(
+        UserCustomApi(
+            user_id=c.id,
+            custom_api_id=inactive_own.id,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+            is_active=False,
+        )
+    )
+    db.flush()
+
+    return SimpleNamespace(
+        c=c,
+        z=z,
+        w=w,
+        v=v,
+        active_own=active_own,
+        inactive_own=inactive_own,
+        stranger=stranger,
+        a=a,
+        b=b,
+        inactive_own_shared=inactive_own_shared,
+    )
+
+
+@pytest.fixture()
+def seed(db_session: Session) -> SimpleNamespace:
+    return _build_seed(db_session)
+
+
+def _team_visibility_hook(seed):
+    """ENV-T's team_visibility hook: disjoint per-team custom_api sets."""
+
+    def _hook(db, *, team_id):
+        if team_id == T1:
+            return {
+                "mcp": set(),
+                "custom_api": {int(seed.a.id), int(seed.inactive_own_shared.id)},
+            }
+        if team_id == T2:
+            return {"mcp": set(), "custom_api": {int(seed.b.id)}}
+        return {"mcp": set(), "custom_api": set()}
+
+    return _hook
+
+
+def _install_env_t(seed) -> None:
+    install_team_hooks(
+        team_visibility=_team_visibility_hook(seed), agent_owner_id=int(seed.c.id)
+    )
+
+
+def _install_env_legacy(seed) -> None:
+    """ENV-LEGACY's user-keyed ``visibility=`` hook, custom_api-only for C."""
+
+    connector_team_scope.set_connector_team_hooks(
+        visibility=lambda db, user_id: (
+            {"mcp": set(), "custom_api": {int(seed.a.id)}}
+            if user_id == int(seed.c.id)
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+
+
+def _cfg(db_session: Session, seed, *, connector_team_id: int | None) -> WebToolConfig:
+    return WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        connector_team_id=connector_team_id,
+    )
+
+
+def _file_engine(tmp_path, name: str):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / name}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# A team agent loads its group's custom API for a run owner with no
+# junction row.
+# ---------------------------------------------------------------------------
+
+
+def test_team_agent_loads_team_custom_api(db_session, seed):
+    _install_env_t(seed)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+    configs = cfg.get_custom_api_configs()
+
+    assert {c["name"] for c in configs} == {
+        seed.active_own.name,
+        seed.a.name,
+        seed.inactive_own_shared.name,
+    }
+    # Correction A: there is no per-member env layer to be missing -- a
+    # team-only API's env comes straight off the definition row.
+    a_config = next(c for c in configs if c["name"] == seed.a.name)
+    assert a_config["env"] == {"API_KEY": "team-a-secret"}
+
+
+# ---------------------------------------------------------------------------
+# A personal agent gets nothing from any team, and writes nothing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("env", ["env_t", "env_legacy"])
+def test_personal_agent_gets_no_team_custom_api(db_session, seed, env):
+    if env == "env_t":
+        _install_env_t(seed)
+    else:
+        _install_env_legacy(seed)
+
+    cfg = _cfg(db_session, seed, connector_team_id=None)
+
+    before = db_session.query(UserCustomApi).filter_by(user_id=int(seed.c.id)).count()
+    assert before == 3  # active_own + inactive_own + inactive_own_shared, seeded
+
+    configs = cfg.get_custom_api_configs()
+    names = {c["name"] for c in configs}
+    # Positive control: the probe actually ran and returned the caller's own
+    # row, so the two negatives below aren't vacuously true of an
+    # unconditional [].
+    assert seed.active_own.name in names
+    assert seed.a.name not in names
+    assert seed.b.name not in names
+
+    after = db_session.query(UserCustomApi).filter_by(user_id=int(seed.c.id)).count()
+    assert after == before
+
+
+# ---------------------------------------------------------------------------
+# A known, deliberately-pinned divergence in a legacy-hook-only deployment
+# that also names a governing team: the runtime-context view is user-keyed
+# and unions a legacy-granted team-shared custom API, while the tool loader
+# resolves personal-only -- it consults the team-keyed hook exclusively and
+# never the legacy one. This asserts the actual divergent behavior, not an
+# endorsement of it; connector_runtime.py's comment documents the same gap.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_hook_with_governing_team_diverges_from_runtime_view(db_session, seed):
+    _install_env_legacy(seed)
+
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=T1
+    )
+    capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+    # The legacy hook grants seed.a to C regardless of connector_team_id --
+    # it is user-keyed, not team-keyed -- so the runtime view sees it here.
+    assert int(seed.a.id) in capi_ids
+
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+    configs = cfg.get_custom_api_configs()
+    names = {c["name"] for c in configs}
+    # But no team_visibility hook is installed, so the loader's team
+    # resolution stays empty regardless of connector_team_id, and it never
+    # builds a runtime tool for seed.a -- selectable and persistable via the
+    # runtime view above, but toolless.
+    assert seed.a.name not in names
+
+
+# ---------------------------------------------------------------------------
+# The snapshot prefetch and the live path return the same ordered list,
+# for every governing-team parameter.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("connector_team_id", [T1, None, T2])
+def test_snapshot_and_live_custom_api_paths_agree(tmp_path, connector_team_id):
+    engine = _file_engine(tmp_path, "j3.db")
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    db = factory()
+    try:
+        seed = _build_seed(db)
+        _install_env_t(seed)
+        db.commit()
+
+        live_cfg = _cfg(db, seed, connector_team_id=connector_team_id)
+        live_ids = [c["id"] for c in live_cfg.get_custom_api_configs()]
+        # Positive control: the comparison below isn't vacuously satisfied
+        # by a defect that empties both sides identically.
+        assert live_ids
+
+        snapshot_cfg = WebToolConfig(
+            db=None,
+            request=None,
+            db_factory=factory,
+            user_id=int(seed.c.id),
+            connector_team_id=connector_team_id,
+        )
+        # Plan-field wiring pin: the plan must actually be built through
+        # production, not hand-constructed, or a dropped
+        # `connector_team_id=` at the plan-construction call site would
+        # silently resolve custom APIs personal-only while this test still
+        # passed.
+        plan = snapshot_cfg._build_factory_runtime_load_plan()
+        assert plan.connector_team_id == snapshot_cfg._connector_team_id
+        assert plan.load_custom_api is True
+
+        snapshot = _load_tool_factory_runtime_snapshot(factory, plan)
+        assert snapshot.plan.load_custom_api is True
+        snapshot_cfg._factory_runtime_snapshot = snapshot
+        snapshot_ids = [c["id"] for c in snapshot_cfg.get_custom_api_configs()]
+
+        assert snapshot_ids == live_ids
+    finally:
+        db.close()
+        connector_team_scope.set_connector_team_hooks()
+        agent_team_scope.set_agent_team_scope_hook(None)
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# The production custom-API *builder* drives off custom_apis, with a
+# deterministic order. Compiled on the production module-level builder.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("team_ids_present", [False, True])
+def test_production_custom_api_query_shape(db_session, seed, team_ids_present):
+    team_api_ids = frozenset({int(seed.a.id)}) if team_ids_present else frozenset()
+    sql = str(
+        _visible_custom_api_query(
+            db_session, owner_user_id=int(seed.c.id), team_api_ids=team_api_ids
+        ).statement.compile(dialect=postgresql.dialect())
+    )
+    norm = " ".join(sql.split()).upper()
+    assert norm.startswith("SELECT")  # positive control
+    assert re.search(r"\bFROM CUSTOM_APIS\b", norm)  # driving table
+    assert "JOIN USER_CUSTOM_APIS" not in norm  # misuse guard
+    assert norm.endswith("ORDER BY CUSTOM_APIS.ID")  # exact ordering column
+
+
+# ---------------------------------------------------------------------------
+# visible_custom_api_clause is fail-closed on its own terms, not only
+# because of how its two production callers happen to be gated today (both
+# already refuse to call it with a None owner). Mirrors the same guard the
+# MCP predicate carries.
+# ---------------------------------------------------------------------------
+
+
+def test_visible_custom_api_clause_matches_nothing_for_none_owner_even_with_team_ids(
+    db_session, seed
+):
+    """With ``owner_user_id=None``, the clause reduces to the personal arm
+    regardless of ``team_api_ids`` -- it never matches a team-owned row even
+    when one is named, rather than relying on a caller to have already
+    checked identity first."""
+    from xagent.web.services.connector_team_scope import visible_custom_api_clause
+
+    clause = visible_custom_api_clause(None, {int(seed.a.id)})
+    matches = db_session.query(CustomApi).filter(clause).all()
+    assert matches == []
+
+
+# ---------------------------------------------------------------------------
+# No identity means no custom-API configs, even when a team grant exists
+# and connector_team_id names it -- both read points' identity guards sit
+# before the team-scope resolution entirely, so a team grant cannot leak
+# through, and cannot turn into a 503 either, for an unauthenticated build.
+# Mirrors the MCP suite's equivalent pair.
+# ---------------------------------------------------------------------------
+
+
+def test_unidentified_live_call_resolves_no_custom_api_configs_regardless_of_team(
+    db_session,
+):
+    team_api = _create_custom_api(db_session, "team-only-unidentified-probe")
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: (
+            {"mcp": set(), "custom_api": {int(team_api.id)}}
+            if team_id == T1
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+    try:
+        cfg = WebToolConfig(
+            db=db_session,
+            request=None,
+            user_id=None,
+            connector_team_id=T1,
+        )
+        assert cfg._user_id is None
+
+        configs = cfg.get_custom_api_configs()
+        assert configs == []
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+def test_unidentified_prefetch_call_resolves_no_custom_api_configs_regardless_of_team(
+    db_session,
+):
+    team_api = _create_custom_api(db_session, "team-only-prefetch-probe")
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: (
+            {"mcp": set(), "custom_api": {int(team_api.id)}}
+            if team_id == T1
+            else {"mcp": set(), "custom_api": set()}
+        )
+    )
+    try:
+        configs = _load_custom_api_factory_inputs(
+            db_session,
+            user_id=None,
+            task_id=None,
+            connector_runtime_turn_id=None,
+            connector_team_id=T1,
+        )
+        assert configs == []
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+
+# ---------------------------------------------------------------------------
+# A team-hook failure surfaces as a typed ConnectorRuntimeError at the
+# tool-creator boundary, not as an empty tool set. Both read points.
+# ---------------------------------------------------------------------------
+
+
+def test_team_hook_failure_surfaces_as_connector_runtime_error(db_session, seed):
+    def _boom(db, *, team_id):
+        raise _ProbeError("boom")
+
+    connector_team_scope.set_connector_team_hooks(team_visibility=_boom)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+
+    with pytest.raises(ConnectorRuntimeError) as exc_info:
+        cfg.get_custom_api_configs()
+    assert exc_info.value.details["reason"] == "team_scope_resolution_failed"
+
+    # One frame up, where the user-visible outcome is decided.
+    with pytest.raises(ConnectorRuntimeError):
+        asyncio.run(create_db_custom_api_tools(cfg))
+
+
+# ---------------------------------------------------------------------------
+# A genuine DB/query failure while loading custom APIs fails the turn,
+# matching the MCP twin (_load_mcp_server_configs, which raises
+# MCPConfigLoadError on the same class of failure), instead of silently
+# degrading to an empty tool set.
+# ---------------------------------------------------------------------------
+
+
+class _FailingCustomApiQuery:
+    def filter(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def all(self):
+        raise RuntimeError("database unavailable")
+
+
+class _FailingCustomApiQuerySession:
+    def query(self, *a, **k):
+        return _FailingCustomApiQuery()
+
+
+def test_query_failure_fails_closed_instead_of_returning_empty():
+    cfg = WebToolConfig(
+        db=_FailingCustomApiQuerySession(),
+        request=None,
+        user_id=1,
+    )
+
+    with pytest.raises(ConnectorRuntimeError) as exc_info:
+        cfg.get_custom_api_configs()
+    assert exc_info.value.details["reason"] == "custom_api_config_load_failed"
+
+    # One frame up, where the user-visible outcome is decided.
+    with pytest.raises(ConnectorRuntimeError):
+        asyncio.run(create_db_custom_api_tools(cfg))
+
+
+def test_team_hook_failure_surfaces_in_prefetch_snapshot(tmp_path):
+    """Prefetch twin: the same failure escapes ``_load_tool_factory_runtime_snapshot``
+    because ``propagated_exceptions=(ConnectorRuntimeError,)`` names it."""
+
+    engine = _file_engine(tmp_path, "j5.db")
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    db = factory()
+    try:
+        seed = _build_seed(db)
+        db.commit()
+
+        def _boom(db, *, team_id):
+            raise _ProbeError("boom")
+
+        connector_team_scope.set_connector_team_hooks(team_visibility=_boom)
+
+        cfg = WebToolConfig(
+            db=None,
+            request=None,
+            db_factory=factory,
+            user_id=int(seed.c.id),
+            connector_team_id=T1,
+        )
+        plan = cfg._build_factory_runtime_load_plan()
+        assert plan.load_custom_api is True
+
+        with pytest.raises(ConnectorRuntimeError) as exc_info:
+            _load_tool_factory_runtime_snapshot(factory, plan)
+        assert exc_info.value.details["reason"] == "team_scope_resolution_failed"
+    finally:
+        db.close()
+        connector_team_scope.set_connector_team_hooks()
+        agent_team_scope.set_agent_team_scope_hook(None)
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Standalone (no hooks installed) is result-identical to today as a set,
+# and the new order is custom_apis.id. Control: every revert in the suite
+# must leave the set-equality half of this test green.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", ["live", "snapshot"])
+@pytest.mark.parametrize("connector_team_id", [None, 7])
+def test_no_hooks_matches_legacy_custom_api_result_set(
+    tmp_path, connector_team_id, path
+):
+    engine = _file_engine(tmp_path, f"j6-{connector_team_id}-{path}.db")
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    db = factory()
+    try:
+        seed = _build_seed(db)
+        db.commit()
+
+        if path == "live":
+            cfg = _cfg(db, seed, connector_team_id=connector_team_id)
+            configs = cfg.get_custom_api_configs()
+        else:
+            cfg = WebToolConfig(
+                db=None,
+                request=None,
+                db_factory=factory,
+                user_id=int(seed.c.id),
+                connector_team_id=connector_team_id,
+            )
+            plan = cfg._build_factory_runtime_load_plan()
+            snapshot = _load_tool_factory_runtime_snapshot(factory, plan)
+            cfg._factory_runtime_snapshot = snapshot
+            configs = cfg.get_custom_api_configs()
+
+        loaded_names = [c["name"] for c in configs]
+        # Inertness, as a set: with no hooks installed, only the one active
+        # personal row is visible regardless of the connector_team_id param.
+        assert set(loaded_names) == {seed.active_own.name}
+
+        # No ordering assertion here: ENV-0 has exactly one visible row for
+        # the run owner, so a list comparison against that single row is a
+        # tautology (measured -- SQLite resolves the legacy junction loop
+        # through sqlite_autoindex_user_custom_apis_1 on
+        # (user_id, custom_api_id), so its order coincides with
+        # custom_apis.id order regardless of insertion order; seeding a
+        # second visible row would not change that). The ordering contract
+        # (`ORDER BY custom_apis.id`) is pinned at the SQL level by
+        # test_production_custom_api_query_shape.
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def test_no_hooks_zero_row_owner_never_reaches_runtime_view(tmp_path, monkeypatch):
+    """The zero-row guard (config.py §4.5) runs before
+    ``_load_custom_api_runtime_view_sync`` on the snapshot path: an owner
+    with no visible custom APIs gets ``[]`` and never resolves the runtime
+    view, so a broken runtime-view hook does not turn a "nothing to load"
+    run into a 503.
+    """
+
+    engine = _file_engine(tmp_path, "j6-zero-row.db")
+    factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    db = factory()
+    try:
+        owner = _create_user(db, "no-apis-owner")
+        db.commit()
+
+        def _explode(**_kwargs):
+            raise AssertionError(
+                "runtime view must not be resolved when there are zero rows"
+            )
+
+        monkeypatch.setattr(
+            "xagent.web.services.connector_runtime.load_connector_runtime_view",
+            _explode,
+        )
+
+        cfg = WebToolConfig(
+            db=None,
+            request=None,
+            db_factory=factory,
+            user_id=int(owner.id),
+            task_id="web_task_1",
+            connector_runtime_turn_id="turn-1",
+        )
+        plan = cfg._build_factory_runtime_load_plan()
+        snapshot = _load_tool_factory_runtime_snapshot(factory, plan)
+        assert snapshot.custom_api_configs == []
+    finally:
+        db.close()
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_query_failure_survives_tool_registry_boundary():
+    """Companion to the direct-creator assertion above, mirroring the MCP
+    suite's registry-boundary test: without this frame the test proves only
+    that the loader raises, not that anybody downstream is left to hear it.
+    ``factory.py``'s registry loop re-raises ``ConnectorRuntimeError``
+    specifically and would swallow an untyped exception into a WARNING and
+    an empty tool list."""
+    from xagent.core.tools.adapters.vibe.factory import ToolRegistry
+
+    cfg = WebToolConfig(
+        db=_FailingCustomApiQuerySession(),
+        request=None,
+        user_id=1,
+    )
+
+    saved_creators = list(ToolRegistry._tool_creators)
+    saved_imported = ToolRegistry._modules_imported
+    ToolRegistry._tool_creators = []
+    ToolRegistry._modules_imported = True
+    try:
+        ToolRegistry.register(create_db_custom_api_tools)
+        with pytest.raises(ConnectorRuntimeError) as excinfo:
+            await ToolRegistry.create_registered_tools(cfg)
+    finally:
+        ToolRegistry._tool_creators = saved_creators
+        ToolRegistry._modules_imported = saved_imported
+
+    assert excinfo.value.details["reason"] == "custom_api_config_load_failed"

--- a/tests/web/tools/test_mcp_team_visibility.py
+++ b/tests/web/tools/test_mcp_team_visibility.py
@@ -122,6 +122,33 @@ def seed(db_session: Session):
     )
 
 
+def install_team_hooks(*, team_visibility, agent_owner_id: int) -> None:
+    """Install a ``team_visibility`` hook *and* the agent-team-scope hook
+    mapping ``agent_owner_id`` -> T1.
+
+    Shared by the MCP and custom-API team-visibility suites so the
+    hook-*install* pattern is written once; each suite's own autouse
+    ``_reset_hooks`` undoes both hooks after every test -- this module's
+    copy and the custom-API suite's separate copy are two independent
+    fixtures, not one shared teardown.
+
+    The scope-hook mapping is a negative-control fixture, not something
+    production code consults for this decision (both tool loaders key on
+    ``self._connector_team_id``, never on ``get_agent_team_scope(db, owner)``)
+    -- but without it installed, a runner-keyed misimplementation would be
+    indistinguishable from the correct one on these fixtures, since
+    ``get_agent_team_scope`` would resolve ``None`` for everybody either way.
+    """
+    connector_team_scope.set_connector_team_hooks(team_visibility=team_visibility)
+    agent_team_scope.set_agent_team_scope_hook(
+        lambda db, user_id: (
+            agent_team_scope.AgentTeamScope(team_id=T1, is_team_admin=False)
+            if user_id == agent_owner_id
+            else None
+        )
+    )
+
+
 def _team_visibility_hook(seed):
     """A team_visibility hook whose answer is disjoint per team, empty otherwise."""
 
@@ -137,24 +164,9 @@ def _team_visibility_hook(seed):
 
 def _install_env_t(seed) -> None:
     """Install the team_visibility hook *and* the agent-team-scope hook
-    mapping the run owner C -> T1 (the team that owns ``team_s``).
-
-    The scope-hook mapping is a negative-control fixture, not something
-    production code consults for this decision (the MCP loader keys on
-    ``self._connector_team_id``, never on ``get_agent_team_scope(db, owner)``)
-    -- but without it installed, a runner-keyed misimplementation would be
-    indistinguishable from the correct one on these fixtures, since
-    ``get_agent_team_scope`` would resolve ``None`` for everybody either way.
-    """
-    connector_team_scope.set_connector_team_hooks(
-        team_visibility=_team_visibility_hook(seed)
-    )
-    agent_team_scope.set_agent_team_scope_hook(
-        lambda db, user_id: agent_team_scope.AgentTeamScope(
-            team_id=T1, is_team_admin=False
-        )
-        if user_id == int(seed.c.id)
-        else None
+    mapping the run owner C -> T1 (the team that owns ``team_s``)."""
+    install_team_hooks(
+        team_visibility=_team_visibility_hook(seed), agent_owner_id=int(seed.c.id)
     )
 
 
@@ -247,7 +259,7 @@ def test_production_mcp_query_shape(db_session, seed):
     assert norm.startswith("SELECT")
     assert "MCP_SERVERS" in norm
     assert "JOIN USER_MCPSERVERS" not in norm
-    assert "ORDER BY" in norm
+    assert norm.endswith("ORDER BY MCP_SERVERS.ID")  # exact ordering column
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -2862,7 +2862,7 @@ def test_custom_api_config_loader_propagates_runtime_view_resolution_error(monke
         allow_delegated_authorization=False,
     )
     cfg = WebToolConfig(
-        db=_StaticRowsSession([SimpleNamespace(custom_api=api)]),
+        db=_StaticRowsSession([api]),
         request=None,
         task_id="web_task_123",
         user_id=1,


### PR DESCRIPTION
## Summary

Custom API tool loading resolved visibility by iterating a user's personal
junction rows only, so a custom API shared with a team never loaded for a
team-governed agent, even though the equivalent MCP path already resolved
team-shared servers.

This change applies the same rule to custom APIs: a run's visible custom
APIs are the run owner's own active personal links, unioned with whatever
the governing agent's owning team holds, through the same optional
application hook the MCP path already uses.

- Both of `WebToolConfig`'s custom-API read points -- the live call used
  during normal tool building, and the off-loop snapshot prefetch used by
  the tool factory -- now query through one shared, module-level query
  builder instead of iterating personal junction rows. A deterministic
  `ORDER BY` keeps config order reproducible now that the underlying query
  shape changed.
- A team-scope resolution failure raises the same typed error -- same
  code, same message, same failure reason -- that the MCP loader already
  raises, so a broken team hook fails the turn instead of silently
  dropping the custom-API tool set.
- The runtime-context view's custom-API half, previously narrowed to
  personal-only because the tool loaders could not yet back it up, is
  widened back to match now that both sides resolve team ownership
  together. Selecting a team-owned custom API into a task's runtime
  snapshot always has a tool loader able to build it now.
- The team-scope resolution wrap above -- resolve the team's connector ids,
  re-raise a typed error unchanged, convert anything else into the same
  503 -- existed as two near-identical copies before this change (the MCP
  read point and the runtime-context view loader; the custom-API read
  points did no team resolution at all before this PR, since they were
  still junction-only). This PR's own two new custom-API call sites would
  otherwise have made four copies; instead, all four now share one
  function. Three call sites reduce to naming the connector kind they need;
  the runtime-context view loader consumes the whole answer. No behavior
  changed; verified by running every existing test that pins any of the
  four sites' failure behavior, unchanged before and after.

## Behavior and compatibility

| Deployment state | Custom API visibility |
|---|---|
| No team-scope hook installed | Unchanged: personal active links only, same result set as before this change |
| Team-scope hook installed, agent has no governing team | Personal-only, unchanged |
| Team-scope hook installed, agent has a governing team | Personal active links, unioned with the team's custom APIs -- now matches the existing MCP behavior |
| Only the legacy user-keyed visibility hook installed (no team-keyed hook) | Unchanged fallback behavior for both connector kinds |

A custom API shared with a team executes using the shared definition row's
own stored credentials -- there is no per-member credential layer for
custom APIs to lose, unlike MCP's per-member environment overrides.

A genuine database failure while loading custom APIs now fails the turn,
matching the existing MCP behavior, instead of silently producing no
custom-API tools for that turn.

## Measured evidence

Each row below was verified by reverting the specific change as a literal
source edit, confirming the listed tests go red, then restoring the change
and confirming green again.

| Change reverted | Tests that catch it |
|---|---|
| Restore the personal-junction-row loop in the live read point | the team-agent-loads-its-team's-custom-API test; the snapshot/live agreement test (team parameter set); the runtime-view/tool-loader parity test (team cells) |
| Restore the personal-junction-row loop in the snapshot prefetch | the snapshot/live agreement test (team parameter set) |
| Fall back to the legacy user-keyed hook when the governing team id is unset | the personal-agent test's legacy-hook variant |
| Key the lookup on the runner's own team instead of the governing agent's team | the runtime-view/tool-loader parity test (team cells); the personal-agent test; the snapshot/live agreement test; the hook-failure test |
| Drop the governing-team id from the prefetch's detached load plan | the snapshot/live agreement test; the hook-failure test's snapshot twin |
| Fold the team-scope resolution into the same guarded region as the query, dropping its own error wrap | the hook-failure test |
| Remove the typed-error wrap entirely, letting a raw hook exception propagate | the hook-failure test (both its live and tool-creator assertions) |
| Drop the zero-row short-circuit ahead of the runtime-view resolution | the dedicated zero-row test |
| Point the deterministic ordering clause at the wrong column | the compiled-query-shape test's exact ordering assertion (same fix applied to the pre-existing MCP sibling test) |
| Reintroduce the narrowing that discarded the runtime-view's custom-API half | the runtime-view union test; the runtime-view/tool-loader parity test (team cells) |
| Drop the `None`-owner guard on the visibility predicate | the predicate's own dedicated test |
| Revert the query-failure fail-closed change back to the swallow-to-empty-list behavior | the dedicated DB-failure test |

## Test totals

- The six files this change touches directly (`WebToolConfig` custom-API
  loading, the visibility-clause seam and its dedicated tests, the parity
  check, and the two rewritten regression tests): 172 passed, 0 failed.
- `tests/web/tools/` (the whole directory): 529 passed, 0 failed.
- `tests/web/services/` (the whole directory): 1009 passed, 79 skipped
  (skips are pre-existing environment gates -- a Postgres test URL not
  being set locally -- unrelated to this change), 0 failed.

Pre-commit (formatting, linting, type checking) passes on every changed
file.
