### PR TITLE
fix: prefer task runtime computer tool

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/browser_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_tools.py
@@ -1,7 +1,7 @@
 """Browser automation tools registration using @register_tool decorator."""
 
 import logging
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any
 
 from .factory import ToolFactory, register_tool
 
@@ -11,10 +11,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _has_local_browser_runtime(contribution: Any) -> bool:
-    from ....computer.native_browser import (
-        LOCAL_BROWSER_TASK_EXTENSION,
-    )
+def _has_computer_runtime(contribution: Any) -> bool:
+    """Return whether the full pre-policy contribution declares ``computer``."""
     from ....task_runtime import (
         TaskRuntimeContribution,
         full_task_runtime_contribution,
@@ -24,29 +22,25 @@ def _has_local_browser_runtime(contribution: Any) -> bool:
         return False
     full_contribution = full_task_runtime_contribution(contribution)
     return any(
-        provider_name == LOCAL_BROWSER_TASK_EXTENSION
-        and any(
-            getattr(tool, "name", None) == "computer"
-            for tool in provider_contribution.tools
-        )
-        for provider_name, provider_contribution in (
-            full_contribution.provider_contributions
-        )
+        isinstance((name := getattr(tool, "name", None)), str)
+        and name.strip() == "computer"
+        for tool in full_contribution.tools
     )
 
 
 @register_tool(categories={"browser"})
-async def create_browser_tools(config: "BaseToolConfig") -> List[Any]:
+async def create_browser_tools(config: "BaseToolConfig") -> list[Any]:
     """Create browser automation tools."""
     if not config.get_browser_tools_enabled():
         return []
 
-    # A bound Local browser task contributes its own ``computer`` instance.
-    # Suppress the Playwright browser family as one unit so the runtime tool
-    # does not collide with the core tool or accidentally expose a second,
-    # unrelated browser to the model.
+    # A task runtime may contribute its own ``computer`` instance. Suppress the
+    # Playwright browser family as one unit so an out-of-tree runtime does not
+    # collide with the core tool or silently fall back to an unrelated browser.
+    # This is deliberately capability-based rather than provider-name-based:
+    # the extension hook is public and core cannot enumerate its providers.
     contribution = config.get_task_runtime_contribution()
-    if _has_local_browser_runtime(contribution):
+    if _has_computer_runtime(contribution):
         return []
 
     task_id = config.get_task_id()

--- a/tests/web/services/test_local_browser_runtime.py
+++ b/tests/web/services/test_local_browser_runtime.py
@@ -15,7 +15,7 @@ from xagent.core.task_runtime import (
     merge_task_runtime_contributions,
 )
 from xagent.core.tools.adapters.vibe.browser_tools import (
-    _has_local_browser_runtime,
+    _has_computer_runtime,
     create_browser_tools,
 )
 from xagent.web.models.task import Task
@@ -41,11 +41,11 @@ class FakeSession:
         self.closed = False
         self.committed = False
 
-    def query(self, model: Any) -> "FakeSession":
+    def query(self, model: Any) -> FakeSession:
         self.model = model
         return self
 
-    def filter(self, *_args: Any) -> "FakeSession":
+    def filter(self, *_args: Any) -> FakeSession:
         return self
 
     def first(self) -> Any:
@@ -339,7 +339,37 @@ def test_unbound_local_browser_provider_does_not_suppress_playwright() -> None:
         {LOCAL_BROWSER_TASK_EXTENSION: None}
     )
 
-    assert _has_local_browser_runtime(contribution) is False
+    assert _has_computer_runtime(contribution) is False
+
+
+def test_whitespace_padded_computer_name_suppresses_playwright() -> None:
+    contribution = merge_task_runtime_contributions(
+        {
+            "out_of_tree_browser": TaskRuntimeContribution(
+                tools=(SimpleNamespace(name=" computer "),)
+            )
+        }
+    )
+
+    assert _has_computer_runtime(contribution) is True
+
+
+@pytest.mark.asyncio
+async def test_out_of_tree_computer_runtime_suppresses_playwright_family() -> None:
+    contribution = merge_task_runtime_contributions(
+        {
+            "out_of_tree_browser": TaskRuntimeContribution(
+                tools=(SimpleNamespace(name="computer"),)
+            )
+        }
+    )
+    config = SimpleNamespace(
+        get_browser_tools_enabled=lambda: True,
+        get_task_runtime_contribution=lambda: contribution,
+    )
+
+    assert _has_computer_runtime(contribution) is True
+    assert await create_browser_tools(config) == []
 
 
 def test_local_browser_public_metadata_is_bound_task_only(

--- a/tests/web/tools/test_runtime_computer_precedence.py
+++ b/tests/web/tools/test_runtime_computer_precedence.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+
+import pytest
+
+import xagent.web.api.chat as chat_module
+from xagent.core.task_runtime import (
+    TaskRuntimeContext,
+    TaskRuntimeContribution,
+    merge_task_runtime_contributions,
+)
+from xagent.core.tools.adapters.vibe import browser_tools as browser_tools_module
+from xagent.core.tools.adapters.vibe.base import ToolCategory
+from xagent.core.tools.adapters.vibe.config import ToolConfig
+from xagent.core.tools.adapters.vibe.factory import ToolFactory, ToolRegistry
+from xagent.web.api.chat import create_default_tools
+
+
+@pytest.mark.asyncio
+async def test_create_default_tools_prefers_out_of_tree_computer_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runtime_tool = SimpleNamespace(
+        name="computer",
+        metadata=SimpleNamespace(category=ToolCategory.OTHER),
+    )
+    conflicting_runtime_tool = SimpleNamespace(
+        name="computer",
+        metadata=SimpleNamespace(category=ToolCategory.OTHER),
+    )
+
+    class _FakeToolConfig(ToolConfig):
+        def __init__(self, **_kwargs):
+            super().__init__({})
+            self.runtime_contribution = TaskRuntimeContribution()
+            self.runtime_workspace = None
+
+        def get_workspace_config(self):
+            return {"task_id": "web_task_11"}
+
+        def set_task_runtime_contribution(self, contribution) -> None:
+            self.runtime_contribution = contribution
+
+        def get_task_runtime_contribution(self):
+            return self.runtime_contribution
+
+        def set_task_runtime_workspace(self, workspace) -> None:
+            self.runtime_workspace = workspace
+
+        def get_task_runtime_workspace(self):
+            return self.runtime_workspace
+
+        def get_browser_tools_enabled(self) -> bool:
+            return True
+
+    async def create_registered_tools(config):
+        return await browser_tools_module.create_browser_tools(config)
+
+    async def build_runtime(_context):
+        return merge_task_runtime_contributions(
+            {
+                "out_of_tree_browser": TaskRuntimeContribution(
+                    tools=(runtime_tool,),
+                    environment="Control the selected browser.",
+                    preferred_input_modalities=("image",),
+                ),
+                "second_browser": TaskRuntimeContribution(
+                    tools=(conflicting_runtime_tool,),
+                    environment="Control a different browser.",
+                ),
+            }
+        )
+
+    monkeypatch.setattr("xagent.web.tools.config.WebToolConfig", _FakeToolConfig)
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        ToolRegistry,
+        "create_registered_tools",
+        create_registered_tools,
+    )
+    monkeypatch.setattr(
+        ToolFactory,
+        "create_workspace",
+        lambda _config: SimpleNamespace(id="workspace"),
+    )
+    monkeypatch.setattr(chat_module, "build_task_runtime", build_runtime)
+    monkeypatch.setattr(
+        chat_module,
+        "registered_task_extensions",
+        lambda: ("out_of_tree_browser",),
+    )
+
+    tools, config = await create_default_tools(
+        None,
+        user=SimpleNamespace(id=7, is_admin=False),
+        task_id="web_task_11",
+        task_runtime_context=TaskRuntimeContext(
+            task_id=11,
+            user_id=7,
+            source="internal",
+            session_factory=lambda: object(),
+        ),
+    )
+
+    assert tools == [runtime_tool]
+    assert config.runtime_contribution.tools == (runtime_tool,)
+    assert config.runtime_contribution.environment == "Control the selected browser."
+    assert "Dropping task runtime extension 'second_browser'" in caplog.text


### PR DESCRIPTION
## What this PR does

- suppresses the default Playwright browser family whenever a task-runtime provider contributes its own `computer` tool
- detects the capability from the normalized full provider contribution instead of hard-coding the built-in `local_browser` provider name
- normalizes contributed tool names consistently with runtime conflict reconciliation
- adds `create_default_tools` regression coverage proving Playwright is suppressed, the first out-of-tree `computer` provider is retained, and a second colliding provider is dropped as one unit with its environment contribution

## Why

The task-runtime extension hook is public, but the browser tool creator previously recognized only `local_browser`. An out-of-tree runtime that contributed `computer` therefore collided with the default Playwright tool and was silently removed as one provider unit. The task then controlled an unrelated ephemeral browser.

## Explicit boundary

This PR does not:

- add knowledge of any closed-source provider or runtime kind
- weaken duplicate-name isolation for arbitrary extension tools
- change tool policy, user overrides, or task selection semantics
- suppress Playwright for tasks with no contributed `computer` tool

A bound computer runtime owns that capability; if policy later filters it, Xagent must not silently substitute a different browser.

## Validation

- `PYTHONPATH=src uv run pytest -q -n 0 tests/web/services/test_local_browser_runtime.py tests/web/tools/test_runtime_computer_precedence.py tests/core/tools/adapters/vibe/test_factory_runtime_tools.py` — 38 passed
- Ruff 0.12.3 check and format validation using the standalone OSS repository settings — passed
