### PR TITLE
fix(browser): stop hardcoding zh-CN for browser automation locale

### DIFF
--- a/example.env
+++ b/example.env
@@ -426,9 +426,12 @@ XAGENT_WEB_SEARCH_PROVIDER="auto"
 # XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS="2000"
 
 # Fallback locale/timezone for browser_use (Playwright) sessions, used when a
-# task carries no account-derived locale (the app_locale cookie set by the web
-# UI's language switcher). Locale defaults to "en-US"; timezone defaults to
-# the host's own system timezone when unset.
+# task carries no resolvable locale of its own (the app_locale cookie set by
+# the web UI's language switcher). Locale defaults to "en-US"; timezone
+# defaults to the host's own system timezone when unset. An invalid value
+# raises on first browser-tool use (not at process startup, and not silently
+# ignored) -- check the error against the tool call that triggered it, since
+# the validation itself lives in src/xagent/config.py, not here.
 # XAGENT_BROWSER_TOOL_DEFAULT_LOCALE="en-US"
 # XAGENT_BROWSER_TOOL_DEFAULT_TIMEZONE=""
 

--- a/example.env
+++ b/example.env
@@ -425,6 +425,13 @@ XAGENT_WEB_SEARCH_PROVIDER="auto"
 # menus without sending the full accessibility tree to the model.
 # XAGENT_BROWSER_CUA_DRIVER_MAX_ELEMENTS="2000"
 
+# Fallback locale/timezone for browser_use (Playwright) sessions, used when a
+# task carries no account-derived locale (the app_locale cookie set by the web
+# UI's language switcher). Locale defaults to "en-US"; timezone defaults to
+# the host's own system timezone when unset.
+# XAGENT_BROWSER_TOOL_DEFAULT_LOCALE="en-US"
+# XAGENT_BROWSER_TOOL_DEFAULT_TIMEZONE=""
+
 # Context compaction: the conversation is compacted when the estimated context
 # size reaches (model context window * ratio). Set a model's context window in
 # the model config; models without one fall back to the default below.

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -687,6 +687,9 @@ def get_native_browser_app_name() -> str:
     return canonical
 
 
+_BCP47_LOCALE_RE = re.compile(r"^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})*$")
+
+
 def get_browser_tool_default_locale() -> str:
     """Get the fallback Playwright context locale for the browser_use tool.
 
@@ -699,8 +702,21 @@ def get_browser_tool_default_locale() -> str:
     Priority:
         1. XAGENT_BROWSER_TOOL_DEFAULT_LOCALE environment variable
         2. "en-US"
+
+    Raises:
+        ValueError: if the env var is set but isn't a plausible BCP-47 tag
+            (e.g. "en-US"), so a typo fails loudly at read time instead of
+            surfacing as an opaque Playwright error at session creation.
     """
-    return os.getenv(BROWSER_TOOL_DEFAULT_LOCALE, "").strip() or "en-US"
+    configured = os.getenv(BROWSER_TOOL_DEFAULT_LOCALE, "").strip()
+    if not configured:
+        return "en-US"
+    if not _BCP47_LOCALE_RE.match(configured):
+        raise ValueError(
+            f"{BROWSER_TOOL_DEFAULT_LOCALE} must be a BCP-47 locale tag "
+            f"(e.g. 'en-US', 'zh-CN'), got {configured!r}"
+        )
+    return configured
 
 
 def get_browser_tool_default_timezone() -> str | None:
@@ -709,8 +725,26 @@ def get_browser_tool_default_timezone() -> str | None:
     Priority:
         1. XAGENT_BROWSER_TOOL_DEFAULT_TIMEZONE environment variable
         2. None (Playwright falls back to the host's own system timezone)
+
+    Raises:
+        ValueError: if the env var is set but isn't a recognized IANA
+            timezone name (e.g. "Asia/Shanghai"), so a typo fails loudly at
+            read time instead of surfacing as an opaque Playwright error at
+            session creation.
     """
-    return os.getenv(BROWSER_TOOL_DEFAULT_TIMEZONE, "").strip() or None
+    configured = os.getenv(BROWSER_TOOL_DEFAULT_TIMEZONE, "").strip()
+    if not configured:
+        return None
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    try:
+        ZoneInfo(configured)
+    except (ZoneInfoNotFoundError, ValueError, KeyError) as exc:
+        raise ValueError(
+            f"{BROWSER_TOOL_DEFAULT_TIMEZONE} must be a valid IANA timezone "
+            f"name (e.g. 'Asia/Shanghai'), got {configured!r}"
+        ) from exc
+    return configured
 
 
 def get_browser_cua_driver_command() -> str:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -705,8 +705,10 @@ def get_browser_tool_default_locale() -> str:
 
     Raises:
         ValueError: if the env var is set but isn't a plausible BCP-47 tag
-            (e.g. "en-US"), so a typo fails loudly at read time instead of
-            surfacing as an opaque Playwright error at session creation.
+            (e.g. "en-US"). This getter is called lazily, from
+            BrowserSession.__init__ on first browser tool use rather than at
+            process startup, so a typo still fails as a clean tool-call
+            error instead of an opaque Playwright error at session creation.
     """
     configured = os.getenv(BROWSER_TOOL_DEFAULT_LOCALE, "").strip()
     if not configured:
@@ -728,9 +730,9 @@ def get_browser_tool_default_timezone() -> str | None:
 
     Raises:
         ValueError: if the env var is set but isn't a recognized IANA
-            timezone name (e.g. "Asia/Shanghai"), so a typo fails loudly at
-            read time instead of surfacing as an opaque Playwright error at
-            session creation.
+            timezone name (e.g. "Asia/Shanghai"). Like
+            get_browser_tool_default_locale, this is read lazily on first
+            browser tool use, not at process startup.
     """
     configured = os.getenv(BROWSER_TOOL_DEFAULT_TIMEZONE, "").strip()
     if not configured:

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -52,6 +52,8 @@ UPLOADED_FILE_RECOVERY_BATCH_SIZE = "XAGENT_UPLOADED_FILE_RECOVERY_BATCH_SIZE"
 STORAGE_ROOT = "XAGENT_STORAGE_ROOT"
 NATIVE_BROWSER_ENABLED = "XAGENT_NATIVE_BROWSER_ENABLED"
 NATIVE_BROWSER_APP_NAME = "XAGENT_NATIVE_BROWSER_APP_NAME"
+BROWSER_TOOL_DEFAULT_LOCALE = "XAGENT_BROWSER_TOOL_DEFAULT_LOCALE"
+BROWSER_TOOL_DEFAULT_TIMEZONE = "XAGENT_BROWSER_TOOL_DEFAULT_TIMEZONE"
 BROWSER_CUA_DRIVER_COMMAND = "XAGENT_BROWSER_CUA_DRIVER_COMMAND"
 BROWSER_CUA_DRIVER_SOCKET = "XAGENT_BROWSER_CUA_DRIVER_SOCKET"
 BROWSER_CUA_DRIVER_TIMEOUT_SECONDS = "XAGENT_BROWSER_CUA_DRIVER_TIMEOUT_SECONDS"
@@ -683,6 +685,32 @@ def get_native_browser_app_name() -> str:
             f"{NATIVE_BROWSER_APP_NAME} must name a supported browser: {supported}"
         )
     return canonical
+
+
+def get_browser_tool_default_locale() -> str:
+    """Get the fallback Playwright context locale for the browser_use tool.
+
+    Used when a task/request carries no resolvable locale of its own (see
+    ``WebToolConfig.get_browser_locale``). Was previously hardcoded to
+    ``"zh-CN"``, which forced every automated browser session -- regardless
+    of the requesting user's own language -- to request and render
+    Chinese-localized pages.
+
+    Priority:
+        1. XAGENT_BROWSER_TOOL_DEFAULT_LOCALE environment variable
+        2. "en-US"
+    """
+    return os.getenv(BROWSER_TOOL_DEFAULT_LOCALE, "").strip() or "en-US"
+
+
+def get_browser_tool_default_timezone() -> str | None:
+    """Get the fallback Playwright context timezone for the browser_use tool.
+
+    Priority:
+        1. XAGENT_BROWSER_TOOL_DEFAULT_TIMEZONE environment variable
+        2. None (Playwright falls back to the host's own system timezone)
+    """
+    return os.getenv(BROWSER_TOOL_DEFAULT_TIMEZONE, "").strip() or None
 
 
 def get_browser_cua_driver_command() -> str:

--- a/src/xagent/core/computer/browser.py
+++ b/src/xagent/core/computer/browser.py
@@ -154,6 +154,7 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         headless: bool = True,
         viewport_width: int = 1280,
         viewport_height: int = 720,
+        locale: str | None = None,
     ) -> None:
         super().__init__(session_id)
         if viewport_width <= 0 or viewport_height <= 0:
@@ -164,6 +165,7 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         self.headless = headless
         self.viewport_width = viewport_width
         self.viewport_height = viewport_height
+        self.locale = locale
         self._manager_session_id = f"{self.session_id}:computer"
         self._browser_session: Any | None = None
 
@@ -171,6 +173,7 @@ class BrowserComputerEnvironment(ComputerEnvironment):
         session = await self.manager.get_or_create(
             self._manager_session_id,
             headless=self.headless,
+            locale=self.locale,
         )
         recreated = (
             self._browser_session is not None and session is not self._browser_session

--- a/src/xagent/core/tools/adapters/vibe/browser_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_tools.py
@@ -49,7 +49,9 @@ async def create_browser_tools(config: "BaseToolConfig") -> list[Any]:
     try:
         from .browser_use import create_browser_tools
 
-        return create_browser_tools(task_id=task_id, workspace=workspace)
+        return create_browser_tools(
+            task_id=task_id, workspace=workspace, locale=config.get_browser_locale()
+        )
     except Exception as e:
         logger.warning(f"Failed to create browser tools: {e}")
         return []

--- a/src/xagent/core/tools/adapters/vibe/browser_use.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_use.py
@@ -334,11 +334,15 @@ class BrowserNavigateTool(BrowserTaskSessionMixin, AbstractBaseTool):
     """Navigate to a URL in a browser session."""
 
     def __init__(
-        self, task_id: Optional[str] = None, workspace: Optional["TaskWorkspace"] = None
+        self,
+        task_id: Optional[str] = None,
+        workspace: Optional["TaskWorkspace"] = None,
+        locale: Optional[str] = None,
     ):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
         self._workspace = workspace
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -500,9 +504,10 @@ class BrowserClickTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Click an element on the current page."""
 
-    def __init__(self, task_id: Optional[str] = None):
+    def __init__(self, task_id: Optional[str] = None, locale: Optional[str] = None):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -548,9 +553,10 @@ class BrowserFillTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Fill an input field with text."""
 
-    def __init__(self, task_id: Optional[str] = None):
+    def __init__(self, task_id: Optional[str] = None, locale: Optional[str] = None):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -597,11 +603,15 @@ class BrowserScreenshotTool(BrowserTaskSessionMixin, AbstractBaseTool):
     """Take a screenshot of the current page."""
 
     def __init__(
-        self, task_id: Optional[str] = None, workspace: Optional["TaskWorkspace"] = None
+        self,
+        task_id: Optional[str] = None,
+        workspace: Optional["TaskWorkspace"] = None,
+        locale: Optional[str] = None,
     ):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
         self._workspace = workspace
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -716,9 +726,10 @@ class BrowserExtractTextTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Extract text content from the page."""
 
-    def __init__(self, task_id: Optional[str] = None):
+    def __init__(self, task_id: Optional[str] = None, locale: Optional[str] = None):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -763,9 +774,10 @@ class BrowserEvaluateTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Execute JavaScript code in the browser."""
 
-    def __init__(self, task_id: Optional[str] = None):
+    def __init__(self, task_id: Optional[str] = None, locale: Optional[str] = None):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -870,9 +882,10 @@ class BrowserSelectOptionTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Select an option from a dropdown."""
 
-    def __init__(self, task_id: Optional[str] = None):
+    def __init__(self, task_id: Optional[str] = None, locale: Optional[str] = None):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -919,9 +932,10 @@ class BrowserWaitForSelectorTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Wait for an element to appear on the page."""
 
-    def __init__(self, task_id: Optional[str] = None):
+    def __init__(self, task_id: Optional[str] = None, locale: Optional[str] = None):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -967,9 +981,10 @@ class BrowserCloseTool(BrowserTaskSessionMixin, AbstractBaseTool):
     category = ToolCategory.BROWSER
     """Close a browser session and free resources."""
 
-    def __init__(self, task_id: Optional[str] = None):
+    def __init__(self, task_id: Optional[str] = None, locale: Optional[str] = None):
         self._visibility = ToolVisibility.PRIVATE  # Internal tool
         self._task_id = task_id
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -1011,11 +1026,15 @@ class BrowserPdfTool(BrowserTaskSessionMixin, AbstractBaseTool):
     """Save current page as PDF."""
 
     def __init__(
-        self, task_id: Optional[str] = None, workspace: Optional["TaskWorkspace"] = None
+        self,
+        task_id: Optional[str] = None,
+        workspace: Optional["TaskWorkspace"] = None,
+        locale: Optional[str] = None,
     ):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
         self._workspace = workspace
+        self._locale = locale
 
     @property
     def name(self) -> str:
@@ -1148,25 +1167,23 @@ def create_browser_tools(
     """
     from .computer import ComputerTool
 
+    # A browser session is created by the FIRST tool call that touches it
+    # (navigate is typical, but nothing guarantees it), so every tool needs
+    # locale passed explicitly rather than relying on just one of them
+    # (e.g. navigate) to carry it.
     tools = [
-        ComputerTool(task_id=task_id, workspace=workspace),
-        BrowserNavigateTool(task_id=task_id, workspace=workspace),
-        BrowserClickTool(task_id=task_id),
-        BrowserFillTool(task_id=task_id),
-        BrowserScreenshotTool(task_id=task_id, workspace=workspace),
-        BrowserExtractTextTool(task_id=task_id),
-        BrowserPdfTool(task_id=task_id, workspace=workspace),
-        BrowserEvaluateTool(task_id=task_id),
-        BrowserSelectOptionTool(task_id=task_id),
-        BrowserWaitForSelectorTool(task_id=task_id),
-        BrowserCloseTool(task_id=task_id),
+        ComputerTool(task_id=task_id, workspace=workspace, locale=locale),
+        BrowserNavigateTool(task_id=task_id, workspace=workspace, locale=locale),
+        BrowserClickTool(task_id=task_id, locale=locale),
+        BrowserFillTool(task_id=task_id, locale=locale),
+        BrowserScreenshotTool(task_id=task_id, workspace=workspace, locale=locale),
+        BrowserExtractTextTool(task_id=task_id, locale=locale),
+        BrowserPdfTool(task_id=task_id, workspace=workspace, locale=locale),
+        BrowserEvaluateTool(task_id=task_id, locale=locale),
+        BrowserSelectOptionTool(task_id=task_id, locale=locale),
+        BrowserWaitForSelectorTool(task_id=task_id, locale=locale),
+        BrowserCloseTool(task_id=task_id, locale=locale),
     ]
     if include_debug_tools:
         tools.append(BrowserListSessionsTool())
-    # A browser session is created by the FIRST tool call that touches it
-    # (navigate is typical, but nothing guarantees it), so every tool must
-    # carry the locale for _with_default_session to inject.
-    for tool in tools:
-        if isinstance(tool, BrowserTaskSessionMixin):
-            tool._locale = locale
     return tools

--- a/src/xagent/core/tools/adapters/vibe/browser_use.py
+++ b/src/xagent/core/tools/adapters/vibe/browser_use.py
@@ -38,6 +38,11 @@ class BrowserTaskSessionMixin:
     """Keeps browser tool default sessions aligned during task setup."""
 
     _task_id: Optional[str] = None
+    # Playwright context locale for sessions this task creates. Set once by
+    # ``create_browser_tools`` on every browser tool (not just navigate):
+    # a session springs into existence on the FIRST tool call that touches
+    # it, whichever tool that is, and the locale is frozen at that moment.
+    _locale: Optional[str] = None
 
     async def setup(self, task_id: Optional[str] = None) -> None:
         if task_id:
@@ -51,6 +56,8 @@ class BrowserTaskSessionMixin:
         step_id = updated.pop(_STEP_SESSION_ARG, None)
         if not updated.get("session_id") and self._task_id:
             updated["session_id"] = self._default_session_id(step_id)
+        if self._locale and "locale" not in updated:
+            updated["locale"] = self._locale
         return updated
 
     def _default_session_id(self, step_id: Any = None) -> str:
@@ -1122,6 +1129,7 @@ def create_browser_tools(
     workspace: Optional["TaskWorkspace"] = None,
     *,
     include_debug_tools: bool = False,
+    locale: Optional[str] = None,
 ) -> list:
     """
     Create all browser automation tools for a task.
@@ -1131,6 +1139,9 @@ def create_browser_tools(
         workspace: Optional workspace for saving screenshots
         include_debug_tools: Include browser session diagnostics. Disabled for
             normal agent runs so debug schemas do not consume model context.
+        locale: Playwright context locale for sessions this task creates
+            (e.g. derived from the requesting account's app_locale setting).
+            Falls back to the deployment default when not supplied.
 
     Returns:
         List of browser tool instances
@@ -1152,4 +1163,10 @@ def create_browser_tools(
     ]
     if include_debug_tools:
         tools.append(BrowserListSessionsTool())
+    # A browser session is created by the FIRST tool call that touches it
+    # (navigate is typical, but nothing guarantees it), so every tool must
+    # carry the locale for _with_default_session to inject.
+    for tool in tools:
+        if isinstance(tool, BrowserTaskSessionMixin):
+            tool._locale = locale
     return tools

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -341,11 +341,23 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         environment = self._environments.get(session_id)
         try:
             if environment is None:
-                environment = self._environment_factory(
-                    session_id=session_id,
-                    workspace=self._workspace,
-                    headless=self._headless,
-                )
+                factory_kwargs: dict[str, Any] = {
+                    "session_id": session_id,
+                    "workspace": self._workspace,
+                    "headless": self._headless,
+                }
+                # Only the default Playwright-backed factory understands
+                # `locale` -- the native-local-browser factory (a functools.partial
+                # around _authorized_native_browser_environment /
+                # NativeBrowserEnvironment) drives the user's own already-running
+                # browser and has no `locale`/`**kwargs` parameter, so passing it
+                # there would raise TypeError instead of silently doing nothing.
+                if (
+                    self._locale
+                    and self._environment_factory is BrowserComputerEnvironment
+                ):
+                    factory_kwargs["locale"] = self._locale
+                environment = self._environment_factory(**factory_kwargs)
                 self._environments[session_id] = environment
             current = environment.current_observation
             if current is None:

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -352,11 +352,18 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
                 # NativeBrowserEnvironment) drives the user's own already-running
                 # browser and has no `locale`/`**kwargs` parameter, so passing it
                 # there would raise TypeError instead of silently doing nothing.
-                if (
-                    self._locale
-                    and self._environment_factory is BrowserComputerEnvironment
-                ):
-                    factory_kwargs["locale"] = self._locale
+                if self._locale:
+                    if self._environment_factory is BrowserComputerEnvironment:
+                        factory_kwargs["locale"] = self._locale
+                    else:
+                        logger.debug(
+                            "Dropping resolved locale %r for computer tool "
+                            "session %r: environment factory %r doesn't accept "
+                            "a locale kwarg",
+                            self._locale,
+                            session_id,
+                            self._environment_factory,
+                        )
                 environment = self._environment_factory(**factory_kwargs)
                 self._environments[session_id] = environment
             current = environment.current_observation

--- a/src/xagent/core/tools/adapters/vibe/computer.py
+++ b/src/xagent/core/tools/adapters/vibe/computer.py
@@ -196,6 +196,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         *,
         task_id: str | None = None,
         workspace: TaskWorkspace | None = None,
+        locale: str | None = None,
         environment_factory: ComputerEnvironmentFactory = BrowserComputerEnvironment,
         environment_instructions: str | None = None,
         environment_label: str = "browser",
@@ -208,6 +209,7 @@ class ComputerTool(BrowserTaskSessionMixin, AbstractBaseTool):
         self._visibility = ToolVisibility.PUBLIC
         self._task_id = task_id
         self._workspace = workspace
+        self._locale = locale
         self._environment_factory = environment_factory
         self._environment_label = environment_label.strip() or "computer"
         self._perception_mode = ComputerPerceptionMode(perception_mode)

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -284,6 +284,17 @@ class BaseToolConfig(ABC):
         configs without a DB session.
         """
 
+    def get_browser_locale(self) -> Optional[str]:
+        """Locale for browser automation sessions this config's tasks create.
+
+        ``None`` means "no request-derived locale available" -- the browser
+        tool then falls back to its own deployment default (see
+        ``get_browser_tool_default_locale`` in config.py) rather than a
+        single language being hardcoded for every task regardless of who
+        asked.
+        """
+        return None
+
     @abstractmethod
     def get_file_tools_enabled(self) -> bool:
         """Whether to include file tools."""

--- a/src/xagent/core/tools/core/browser_use.py
+++ b/src/xagent/core/tools/core/browser_use.py
@@ -286,6 +286,12 @@ class BrowserSessionManager:
                         f"{existing.locale!r}; requested locale {locale!r} ignored "
                         "(a session's locale is frozen at creation)"
                     )
+                if timezone_id and existing.timezone_id != timezone_id:
+                    logger.warning(
+                        f"Browser session {session_id!r} already exists with timezone "
+                        f"{existing.timezone_id!r}; requested timezone {timezone_id!r} "
+                        "ignored (a session's timezone is frozen at creation)"
+                    )
                 existing._last_used = datetime.now()
                 return existing
 

--- a/src/xagent/core/tools/core/browser_use.py
+++ b/src/xagent/core/tools/core/browser_use.py
@@ -290,13 +290,18 @@ class BrowserSessionManager:
             if self._cleanup_task is None:
                 self._cleanup_task = asyncio.create_task(self._cleanup_loop())
 
-            logger.info(f"Creating browser session {session_id!r} (locale={locale!r})")
             # Create new session with specified settings
-            self._sessions[session_id] = BrowserSession(
-                session_id, headless, locale=locale
+            new_session = BrowserSession(session_id, headless, locale=locale)
+            self._sessions[session_id] = new_session
+            new_session._last_used = datetime.now()
+            # Log the resolved locale (falls back to the deployment default
+            # when `locale` is None), not the raw argument -- otherwise the
+            # one case an operator most wants visible here, the deployment
+            # default kicking in, would read as "locale=None".
+            logger.info(
+                f"Creating browser session {session_id!r} (locale={new_session.locale!r})"
             )
-            self._sessions[session_id]._last_used = datetime.now()
-            return self._sessions[session_id]
+            return new_session
 
     async def close(self, session_id: str) -> None:
         """

--- a/src/xagent/core/tools/core/browser_use.py
+++ b/src/xagent/core/tools/core/browser_use.py
@@ -280,18 +280,17 @@ class BrowserSessionManager:
                 # Ignore headless/locale/timezone_id for existing sessions
                 # (none of these can change after creation)
                 existing = self._sessions[session_id]
-                if locale and existing.locale != locale:
-                    logger.warning(
-                        f"Browser session {session_id!r} already exists with locale "
-                        f"{existing.locale!r}; requested locale {locale!r} ignored "
-                        "(a session's locale is frozen at creation)"
-                    )
-                if timezone_id and existing.timezone_id != timezone_id:
-                    logger.warning(
-                        f"Browser session {session_id!r} already exists with timezone "
-                        f"{existing.timezone_id!r}; requested timezone {timezone_id!r} "
-                        "ignored (a session's timezone is frozen at creation)"
-                    )
+                for attr_name, requested, current in (
+                    ("locale", locale, existing.locale),
+                    ("timezone_id", timezone_id, existing.timezone_id),
+                ):
+                    if requested and current != requested:
+                        logger.warning(
+                            f"Browser session {session_id!r} already exists with "
+                            f"{attr_name} {current!r}; requested {attr_name} "
+                            f"{requested!r} ignored (a session's {attr_name} is "
+                            "frozen at creation)"
+                        )
                 existing._last_used = datetime.now()
                 return existing
 
@@ -1135,12 +1134,16 @@ async def browser_wait_for_selector(**kwargs: Any) -> Dict[str, Any]:
         }
 
 
-async def browser_close(session_id: str) -> Dict[str, Any]:
+async def browser_close(session_id: str, **_kwargs: Any) -> Dict[str, Any]:
     """
     Explicitly close a browser session and free resources.
 
     Args:
         session_id: Session ID to close
+        **_kwargs: Accepted and ignored. ``BrowserTaskSessionMixin._with_default_session``
+            injects a ``locale`` kwarg into every tool call once a task locale is
+            resolved, regardless of which tool happens to create the session first;
+            every sibling browser_* function already tolerates that via **kwargs.
 
     Returns:
         Dictionary with close result

--- a/src/xagent/core/tools/core/browser_use.py
+++ b/src/xagent/core/tools/core/browser_use.py
@@ -66,7 +66,6 @@ class BrowserSession:
         session_id: str,
         headless: bool = True,
         locale: Optional[str] = None,
-        timezone_id: Optional[str] = None,
     ):
         """
         Initialize a browser session.
@@ -77,14 +76,14 @@ class BrowserSession:
             locale: Playwright context locale (e.g. "en-US"). Falls back to
                 the deployment default (see get_browser_tool_default_locale)
                 when not supplied by the caller.
-            timezone_id: Playwright context timezone (e.g. "America/New_York").
-                Falls back to the deployment default, or the host's own
-                system timezone when neither is configured.
         """
         self.session_id = session_id
         self.headless = headless
         self.locale = locale or get_browser_tool_default_locale()
-        self.timezone_id = timezone_id or get_browser_tool_default_timezone()
+        # No caller ever supplies a per-request timezone (no tool schema
+        # exposes it, and _with_default_session only injects locale) -- this
+        # is deployment-configured only, unlike locale.
+        self.timezone_id = get_browser_tool_default_timezone()
         self._browser: Optional[Browser] = None
         self._context: Optional[BrowserContext] = None
         self._page: Optional[Page] = None
@@ -124,12 +123,12 @@ class BrowserSession:
                 ],
             )
 
-            # Create context with realistic settings. locale/timezone_id come
-            # from the caller (ultimately the requesting user/task's own
-            # language), falling back to the deployment default -- previously
-            # this was hardcoded to zh-CN/Asia/Shanghai, which forced every
-            # automated session to request Chinese-localized pages regardless
-            # of who asked.
+            # Create context with realistic settings. locale comes from the
+            # caller (ultimately the requesting user/task's own language);
+            # timezone_id is deployment-configured only. Both fall back to
+            # the deployment default -- previously hardcoded to
+            # zh-CN/Asia/Shanghai, which forced every automated session to
+            # request Chinese-localized pages regardless of who asked.
             self._context = await self._browser.new_context(
                 viewport={"width": 1920, "height": 1080},
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -255,7 +254,6 @@ class BrowserSessionManager:
         session_id: str,
         headless: bool = False,
         locale: Optional[str] = None,
-        timezone_id: Optional[str] = None,
     ) -> BrowserSession:
         """
         Get or create a browser session (async-safe).
@@ -264,7 +262,6 @@ class BrowserSessionManager:
             session_id: Unique session identifier
             headless: Whether to use headless mode (only used when creating new session)
             locale: Playwright context locale (only used when creating new session)
-            timezone_id: Playwright context timezone (only used when creating new session)
 
         Returns:
             BrowserSession instance
@@ -277,20 +274,15 @@ class BrowserSessionManager:
             # Check if session already exists
             if session_id in self._sessions:
                 # Update last used time and return existing session
-                # Ignore headless/locale/timezone_id for existing sessions
-                # (none of these can change after creation)
+                # Ignore headless/locale for existing sessions (can't change
+                # after creation)
                 existing = self._sessions[session_id]
-                for attr_name, requested, current in (
-                    ("locale", locale, existing.locale),
-                    ("timezone_id", timezone_id, existing.timezone_id),
-                ):
-                    if requested and current != requested:
-                        logger.warning(
-                            f"Browser session {session_id!r} already exists with "
-                            f"{attr_name} {current!r}; requested {attr_name} "
-                            f"{requested!r} ignored (a session's {attr_name} is "
-                            "frozen at creation)"
-                        )
+                if locale and existing.locale != locale:
+                    logger.warning(
+                        f"Browser session {session_id!r} already exists with locale "
+                        f"{existing.locale!r}; requested locale {locale!r} ignored "
+                        "(a session's locale is frozen at creation)"
+                    )
                 existing._last_used = datetime.now()
                 return existing
 
@@ -298,13 +290,10 @@ class BrowserSessionManager:
             if self._cleanup_task is None:
                 self._cleanup_task = asyncio.create_task(self._cleanup_loop())
 
-            logger.info(
-                f"Creating browser session {session_id!r} "
-                f"(locale={locale!r}, timezone_id={timezone_id!r})"
-            )
+            logger.info(f"Creating browser session {session_id!r} (locale={locale!r})")
             # Create new session with specified settings
             self._sessions[session_id] = BrowserSession(
-                session_id, headless, locale=locale, timezone_id=timezone_id
+                session_id, headless, locale=locale
             )
             self._sessions[session_id]._last_used = datetime.now()
             return self._sessions[session_id]
@@ -398,8 +387,6 @@ async def browser_navigate(**kwargs: Any) -> Dict[str, Any]:
         wait_until: Wait condition (default: "networkidle")
         locale: Playwright context locale (only applied when the session is
             first created); falls back to the deployment default
-        timezone_id: Playwright context timezone (only applied when the
-            session is first created); falls back to the deployment default
 
     Returns:
         Dictionary with navigation result including URL, page title, and success status
@@ -419,7 +406,6 @@ async def browser_navigate(**kwargs: Any) -> Dict[str, Any]:
     headless = kwargs.get("headless", False)
     wait_until = kwargs.get("wait_until", "networkidle")
     locale = kwargs.get("locale")
-    timezone_id = kwargs.get("timezone_id")
 
     if not PLAYWRIGHT_AVAILABLE:
         return {
@@ -432,9 +418,7 @@ async def browser_navigate(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(
-        session_id, headless, locale=locale, timezone_id=timezone_id
-    )
+    session = await manager.get_or_create(session_id, headless, locale=locale)
     page = await session.get_page()
 
     try:

--- a/src/xagent/core/tools/core/browser_use.py
+++ b/src/xagent/core/tools/core/browser_use.py
@@ -7,8 +7,14 @@ automatically cleaned up after a timeout period.
 """
 
 import asyncio
+import json
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from ....config import (
+    get_browser_tool_default_locale,
+    get_browser_tool_default_timezone,
+)
 
 if TYPE_CHECKING:
     from playwright.async_api import Browser, BrowserContext, Page, async_playwright
@@ -55,16 +61,30 @@ def _format_error_with_traceback(error: Exception, context: str = "") -> str:
 class BrowserSession:
     """Browser session with lazy initialization."""
 
-    def __init__(self, session_id: str, headless: bool = True):
+    def __init__(
+        self,
+        session_id: str,
+        headless: bool = True,
+        locale: Optional[str] = None,
+        timezone_id: Optional[str] = None,
+    ):
         """
         Initialize a browser session.
 
         Args:
             session_id: Unique identifier for this session
             headless: Whether to run browser in headless mode
+            locale: Playwright context locale (e.g. "en-US"). Falls back to
+                the deployment default (see get_browser_tool_default_locale)
+                when not supplied by the caller.
+            timezone_id: Playwright context timezone (e.g. "America/New_York").
+                Falls back to the deployment default, or the host's own
+                system timezone when neither is configured.
         """
         self.session_id = session_id
         self.headless = headless
+        self.locale = locale or get_browser_tool_default_locale()
+        self.timezone_id = timezone_id or get_browser_tool_default_timezone()
         self._browser: Optional[Browser] = None
         self._context: Optional[BrowserContext] = None
         self._page: Optional[Page] = None
@@ -104,20 +124,35 @@ class BrowserSession:
                 ],
             )
 
-            # Create context with realistic settings
+            # Create context with realistic settings. locale/timezone_id come
+            # from the caller (ultimately the requesting user/task's own
+            # language), falling back to the deployment default -- previously
+            # this was hardcoded to zh-CN/Asia/Shanghai, which forced every
+            # automated session to request Chinese-localized pages regardless
+            # of who asked.
             self._context = await self._browser.new_context(
                 viewport={"width": 1920, "height": 1080},
                 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                # Set locale and timezone
-                locale="zh-CN",
-                timezone_id="Asia/Shanghai",
+                locale=self.locale,
+                timezone_id=self.timezone_id,
             )
 
             self._page = await self._context.new_page()
 
+            # Languages mirror the context's own locale instead of a fixed
+            # list, so the spoofed navigator.languages stays consistent with
+            # what the locale/Accept-Language header already imply. Built via
+            # plain string substitution (not an f-string) since the rest of
+            # this script is full of literal JS braces that an f-string would
+            # require escaping.
+            base_language = self.locale.split("-")[0]
+            spoofed_languages = json.dumps(
+                list(dict.fromkeys([self.locale, base_language, "en-US", "en"]))
+            )
+
             # Inject script to hide webdriver property
-            await self._page.add_init_script("""
+            init_script = """
                 // Override webdriver detection
                 Object.defineProperty(navigator, 'webdriver', {
                     get: () => undefined
@@ -143,9 +178,10 @@ class BrowserSession:
 
                 // Override languages
                 Object.defineProperty(navigator, 'languages', {
-                    get: () => ['zh-CN', 'zh', 'en-US', 'en']
+                    get: () => __XAGENT_LANGUAGES__
                 });
-            """)
+            """.replace("__XAGENT_LANGUAGES__", spoofed_languages)
+            await self._page.add_init_script(init_script)
 
             self._initialized = True
 
@@ -215,7 +251,11 @@ class BrowserSessionManager:
         self._cleanup_task: Optional[asyncio.Task[None]] = None  # Track cleanup task
 
     async def get_or_create(
-        self, session_id: str, headless: bool = False
+        self,
+        session_id: str,
+        headless: bool = False,
+        locale: Optional[str] = None,
+        timezone_id: Optional[str] = None,
     ) -> BrowserSession:
         """
         Get or create a browser session (async-safe).
@@ -223,24 +263,44 @@ class BrowserSessionManager:
         Args:
             session_id: Unique session identifier
             headless: Whether to use headless mode (only used when creating new session)
+            locale: Playwright context locale (only used when creating new session)
+            timezone_id: Playwright context timezone (only used when creating new session)
 
         Returns:
             BrowserSession instance
         """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
         async with self._lock:
             # Check if session already exists
             if session_id in self._sessions:
                 # Update last used time and return existing session
-                # Ignore headless parameter for existing sessions (can't change mode after creation)
-                self._sessions[session_id]._last_used = datetime.now()
-                return self._sessions[session_id]
+                # Ignore headless/locale/timezone_id for existing sessions
+                # (none of these can change after creation)
+                existing = self._sessions[session_id]
+                if locale and existing.locale != locale:
+                    logger.warning(
+                        f"Browser session {session_id!r} already exists with locale "
+                        f"{existing.locale!r}; requested locale {locale!r} ignored "
+                        "(a session's locale is frozen at creation)"
+                    )
+                existing._last_used = datetime.now()
+                return existing
 
             # Start cleanup task on first session creation
             if self._cleanup_task is None:
                 self._cleanup_task = asyncio.create_task(self._cleanup_loop())
 
-            # Create new session with specified headless mode
-            self._sessions[session_id] = BrowserSession(session_id, headless)
+            logger.info(
+                f"Creating browser session {session_id!r} "
+                f"(locale={locale!r}, timezone_id={timezone_id!r})"
+            )
+            # Create new session with specified settings
+            self._sessions[session_id] = BrowserSession(
+                session_id, headless, locale=locale, timezone_id=timezone_id
+            )
             self._sessions[session_id]._last_used = datetime.now()
             return self._sessions[session_id]
 
@@ -331,6 +391,10 @@ async def browser_navigate(**kwargs: Any) -> Dict[str, Any]:
         url: Target URL to navigate to
         headless: Whether to run browser in headless mode (default: True)
         wait_until: Wait condition (default: "networkidle")
+        locale: Playwright context locale (only applied when the session is
+            first created); falls back to the deployment default
+        timezone_id: Playwright context timezone (only applied when the
+            session is first created); falls back to the deployment default
 
     Returns:
         Dictionary with navigation result including URL, page title, and success status
@@ -349,6 +413,8 @@ async def browser_navigate(**kwargs: Any) -> Dict[str, Any]:
         }
     headless = kwargs.get("headless", False)
     wait_until = kwargs.get("wait_until", "networkidle")
+    locale = kwargs.get("locale")
+    timezone_id = kwargs.get("timezone_id")
 
     if not PLAYWRIGHT_AVAILABLE:
         return {
@@ -361,7 +427,9 @@ async def browser_navigate(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(session_id, headless)
+    session = await manager.get_or_create(
+        session_id, headless, locale=locale, timezone_id=timezone_id
+    )
     page = await session.get_page()
 
     try:
@@ -465,7 +533,7 @@ async def browser_click(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(session_id)
+    session = await manager.get_or_create(session_id, locale=kwargs.get("locale"))
     page = await session.get_page()
 
     try:
@@ -526,7 +594,7 @@ async def browser_fill(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(session_id)
+    session = await manager.get_or_create(session_id, locale=kwargs.get("locale"))
     page = await session.get_page()
 
     try:
@@ -622,7 +690,7 @@ async def browser_screenshot(**kwargs: Any) -> Dict[str, Any]:
     manager = get_browser_manager()
     logger.info(f"[browser_screenshot] Got browser manager (session={session_id})")
 
-    session = await manager.get_or_create(session_id)
+    session = await manager.get_or_create(session_id, locale=kwargs.get("locale"))
     logger.info(f"[browser_screenshot] Got/created session (session={session_id})")
 
     page = await session.get_page()
@@ -800,7 +868,7 @@ async def browser_extract_text(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(session_id)
+    session = await manager.get_or_create(session_id, locale=kwargs.get("locale"))
     page = await session.get_page()
 
     try:
@@ -880,7 +948,7 @@ async def browser_evaluate(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(session_id)
+    session = await manager.get_or_create(session_id, locale=kwargs.get("locale"))
     page = await session.get_page()
 
     try:
@@ -954,7 +1022,7 @@ async def browser_select_option(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(session_id)
+    session = await manager.get_or_create(session_id, locale=kwargs.get("locale"))
     page = await session.get_page()
 
     try:
@@ -1038,7 +1106,7 @@ async def browser_wait_for_selector(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(session_id)
+    session = await manager.get_or_create(session_id, locale=kwargs.get("locale"))
     page = await session.get_page()
 
     try:
@@ -1147,7 +1215,7 @@ async def browser_pdf(**kwargs: Any) -> Dict[str, Any]:
         }
 
     manager = get_browser_manager()
-    session = await manager.get_or_create(session_id)
+    session = await manager.get_or_create(session_id, locale=kwargs.get("locale"))
     page = await session.get_page()
 
     try:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -3651,6 +3651,9 @@ def _build_unique_workspace_target(base_dir: Path, filename: str) -> Path:
 @chat_router.post("/task/create", response_model=TaskCreateResponse)
 async def create_task(
     request: TaskCreateRequest,
+    # FastAPI always injects the real Request for HTTP calls regardless of the
+    # default; the None default keeps direct (test) callers working.
+    http_request: Request = None,  # type: ignore[assignment]
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> TaskCreateResponse:
@@ -3987,7 +3990,13 @@ async def create_task(
         logger.info(
             f"Setting LLM configuration for task {task.id} with llm_ids: {task_llm_ids_to_set}"
         )
-        get_agent_manager(request).set_task_llms(int(task.id), task_llm_ids_to_set, db)
+        # ``http_request`` (the real Starlette Request, with cookies/headers)
+        # -- not ``request`` (the parsed TaskCreateRequest body, which has
+        # neither) -- so WebToolConfig.get_browser_locale() can resolve the
+        # account's app_locale cookie once this task's tools get built.
+        get_agent_manager(http_request).set_task_llms(
+            int(task.id), task_llm_ids_to_set, db
+        )
 
         if selected_file_ids:
             from ..models.uploaded_file import UploadedFile
@@ -4046,7 +4055,7 @@ async def create_task(
                     "creation failure",
                     task_id,
                 )
-            get_agent_manager(request).remove_agent(task_id, int(user.id))
+            get_agent_manager(http_request).remove_agent(task_id, int(user.id))
             if isinstance(exc.cause, TaskRuntimeClientError):
                 status_code = exc.cause.status_code
                 detail = exc.cause.detail

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -3652,7 +3652,13 @@ def _build_unique_workspace_target(base_dir: Path, filename: str) -> Path:
 async def create_task(
     request: TaskCreateRequest,
     # FastAPI always injects the real Request for HTTP calls regardless of the
-    # default; the None default keeps direct (test) callers working.
+    # default; the None default keeps direct (test) callers working. Must stay
+    # a bare `Request` annotation, not `Optional[Request]` -- FastAPI only
+    # recognizes the special-cased injected-Request parameter with the exact
+    # bare type; wrapping it in Optional makes FastAPI try to build a Pydantic
+    # field from it instead, which fails at route-registration time since
+    # Request isn't a valid Pydantic field type (verified: this reproduces a
+    # collection-time FastAPIError in every test that imports this module).
     http_request: Request = None,  # type: ignore[assignment]
     db: Session = Depends(get_db),
     user: User = Depends(get_current_user),

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5816,7 +5816,7 @@ async def _handle_chat_message_unserialized(
                 )
                 if task_setup_snapshot is None:
                     raise ValueError(f"Task {task_id} is no longer available")
-                agent_service = await get_agent_manager().get_agent_for_task(
+                agent_service = await get_agent_manager(websocket).get_agent_for_task(
                     task_id,
                     None,
                     user=task_setup_snapshot.runtime_user,
@@ -7427,7 +7427,7 @@ async def _handle_pause_task_unserialized(
 
         # Get agent service (as the task owner)
         logger.info(f"Getting agent service for task {task_id}")
-        agent_service = await get_agent_manager().get_agent_for_task(
+        agent_service = await get_agent_manager(websocket).get_agent_for_task(
             task_id,
             None,
             user=task_setup_snapshot.runtime_user,
@@ -7651,7 +7651,7 @@ async def _handle_resume_task_unserialized(
             status=task_status,
         ).as_dict()
 
-        agent_service = await get_agent_manager().get_agent_for_task(
+        agent_service = await get_agent_manager(websocket).get_agent_for_task(
             task_id,
             None,
             user=task_setup_snapshot.runtime_user,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5816,7 +5816,7 @@ async def _handle_chat_message_unserialized(
                 )
                 if task_setup_snapshot is None:
                     raise ValueError(f"Task {task_id} is no longer available")
-                agent_service = await get_agent_manager(websocket).get_agent_for_task(
+                agent_service = await get_agent_manager().get_agent_for_task(
                     task_id,
                     None,
                     user=task_setup_snapshot.runtime_user,
@@ -7427,7 +7427,7 @@ async def _handle_pause_task_unserialized(
 
         # Get agent service (as the task owner)
         logger.info(f"Getting agent service for task {task_id}")
-        agent_service = await get_agent_manager(websocket).get_agent_for_task(
+        agent_service = await get_agent_manager().get_agent_for_task(
             task_id,
             None,
             user=task_setup_snapshot.runtime_user,
@@ -7651,7 +7651,7 @@ async def _handle_resume_task_unserialized(
             status=task_status,
         ).as_dict()
 
-        agent_service = await get_agent_manager(websocket).get_agent_for_task(
+        agent_service = await get_agent_manager().get_agent_for_task(
             task_id,
             None,
             user=task_setup_snapshot.runtime_user,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -9,6 +9,7 @@ import copy
 import inspect
 import logging
 import os
+import re
 import shlex
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -1289,6 +1290,13 @@ class WebToolConfig(BaseToolConfig):
         self._retained_factory_model_state: _RetainedFactoryModelState | None = None
         self._factory_runtime_handed_off = False
         self._pending_runtime_policy: _ToolRuntimePolicySnapshot | None = None
+        # get_browser_locale() memoizes on first call: _detach_factory_runtime_resources()
+        # nulls self.request once tools are built, but AgentService can rebuild tools on
+        # this same config instance later (_ensure_tools_initialized), at which point
+        # re-deriving from self.request would silently lose the already-resolved locale
+        # to the deployment default rather than reusing what was actually resolved.
+        self._browser_locale_resolved = False
+        self._cached_browser_locale: Optional[str] = None
 
     def _build_mcp_file_allowed_dirs(self) -> str:
         """Build comma-separated file roots that local MCP tools may read."""
@@ -1778,15 +1786,37 @@ class WebToolConfig(BaseToolConfig):
         deliberate account choice, and does not necessarily match what
         language the account works in).
 
-        ``None`` (no request, no cookie, or a value the frontend doesn't
-        emit) lets the browser tool fall back to its own deployment
-        default.
+        ``None`` (no request, no cookie, or an unrecognized value) lets the
+        browser tool fall back to its own deployment default.
+
+        Memoized on first call: ``_detach_factory_runtime_resources`` nulls
+        ``self.request`` once tools are built, but ``AgentService`` can
+        rebuild tools on this same config instance later
+        (``_ensure_tools_initialized``) -- re-deriving at that point would
+        silently lose the already-resolved locale to the deployment default
+        instead of reusing what this task actually resolved.
         """
-        cookies = getattr(self.request, "cookies", None)
-        app_locale = getattr(cookies, "get", lambda _key: None)("app_locale")
-        if not isinstance(app_locale, str):
+        if not self._browser_locale_resolved:
+            cookies = getattr(self.request, "cookies", None)
+            app_locale = getattr(cookies, "get", lambda _key: None)("app_locale")
+            self._cached_browser_locale = self._normalize_app_locale_cookie(app_locale)
+            self._browser_locale_resolved = True
+        return self._cached_browser_locale
+
+    @staticmethod
+    def _normalize_app_locale_cookie(app_locale: Any) -> Optional[str]:
+        """Map an ``app_locale`` cookie value to a Playwright locale tag.
+
+        Matches on the primary language subtag so an already-valid BCP-47-ish
+        variant (``zh-CN``, ``zh_CN``, ``EN``, ...) resolves the same as the
+        exact ``"en"``/``"zh"`` the frontend writes today (see
+        ``frontend/src/contexts/i18n-context.tsx``), instead of only matching
+        those two literal strings.
+        """
+        if not isinstance(app_locale, str) or not app_locale:
             return None
-        return _APP_LOCALE_TO_BROWSER_LOCALE.get(app_locale)
+        primary = re.split(r"[-_]", app_locale, maxsplit=1)[0].lower()
+        return _APP_LOCALE_TO_BROWSER_LOCALE.get(primary)
 
     def set_task_runtime_contribution(self, contribution: Any) -> None:
         """Attach the detached contribution built for this task."""

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1122,6 +1122,11 @@ def _load_tool_runtime_policy_snapshot(
     )
 
 
+# Maps the frontend's `app_locale` cookie (see i18n-context.tsx, which only
+# ever sets "en" or "zh") to a Playwright-compatible locale tag.
+_APP_LOCALE_TO_BROWSER_LOCALE = {"en": "en-US", "zh": "zh-CN"}
+
+
 class WebToolConfig(BaseToolConfig):
     """Web-specific tool configuration that loads from database."""
 
@@ -1761,6 +1766,27 @@ class WebToolConfig(BaseToolConfig):
     def get_browser_tools_enabled(self) -> bool:
         """Whether to include browser automation tools."""
         return self._browser_tools_enabled
+
+    def get_browser_locale(self) -> Optional[str]:
+        """Derive a browser-automation locale from the account's own
+        ``app_locale`` setting (the language picked via xagent's UI
+        language switcher; see frontend/src/contexts/i18n-context.tsx),
+        so a task's Playwright sessions request pages in the language the
+        account actually chose to work in, rather than a single locale
+        hardcoded for every deployment or the browser's own
+        Accept-Language header (which reflects OS/browser settings, not a
+        deliberate account choice, and does not necessarily match what
+        language the account works in).
+
+        ``None`` (no request, no cookie, or a value the frontend doesn't
+        emit) lets the browser tool fall back to its own deployment
+        default.
+        """
+        cookies = getattr(self.request, "cookies", None)
+        app_locale = getattr(cookies, "get", lambda _key: None)("app_locale")
+        if not isinstance(app_locale, str):
+            return None
+        return _APP_LOCALE_TO_BROWSER_LOCALE.get(app_locale)
 
     def set_task_runtime_contribution(self, contribution: Any) -> None:
         """Attach the detached contribution built for this task."""

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1322,6 +1322,16 @@ class WebToolConfig(BaseToolConfig):
 
         Uses ``getattr`` so a minimal request object (e.g. one carrying only a
         user id) doesn't trip the broad ``except`` and log a spurious warning.
+
+        Only safe as long as ``request`` never reaches here as a real
+        Starlette ``Request``/``HTTPConnection`` without ``AuthenticationMiddleware``
+        installed (which this app never installs): accessing ``.user`` on one
+        raises ``AssertionError``, not ``AttributeError``, so ``getattr``'s
+        default would not save it. Currently unreachable because
+        ``create_default_tools`` always passes an explicit ``user=``/``is_admin=``
+        (this path only runs when ``is_admin`` is left unset), but a future
+        caller that omits both and passes a real ``Request`` here would crash
+        instead of defaulting to ``False``.
         """
         user = getattr(request, "user", None)
         return bool(getattr(user, "is_admin", False)) if user is not None else False
@@ -1812,6 +1822,13 @@ class WebToolConfig(BaseToolConfig):
         exact ``"en"``/``"zh"`` the frontend writes today (see
         ``frontend/src/contexts/i18n-context.tsx``), instead of only matching
         those two literal strings.
+
+        Primary-subtag-only means ``zh-TW``/``zh-HK`` would also map to the
+        Simplified ``zh-CN`` in ``_APP_LOCALE_TO_BROWSER_LOCALE`` rather than
+        a Traditional-Chinese locale -- harmless today since the frontend's
+        ``Locale`` type is a hard ``"en" | "zh"`` union with no way to write
+        those values, but revisit this if a Traditional-Chinese UI locale is
+        ever added.
         """
         if not isinstance(app_locale, str) or not app_locale:
             return None

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1786,15 +1786,19 @@ class WebToolConfig(BaseToolConfig):
         return self._browser_tools_enabled
 
     def get_browser_locale(self) -> Optional[str]:
-        """Derive a browser-automation locale from the account's own
-        ``app_locale`` setting (the language picked via xagent's UI
-        language switcher; see frontend/src/contexts/i18n-context.tsx),
-        so a task's Playwright sessions request pages in the language the
-        account actually chose to work in, rather than a single locale
-        hardcoded for every deployment or the browser's own
-        Accept-Language header (which reflects OS/browser settings, not a
-        deliberate account choice, and does not necessarily match what
-        language the account works in).
+        """Derive a browser-automation locale from the ``app_locale``
+        cookie the web UI's language switcher sets (see
+        frontend/src/contexts/i18n-context.tsx), so a task's Playwright
+        sessions request pages in the language the browser is currently
+        set to, rather than a single locale hardcoded for every
+        deployment or the browser's own Accept-Language header (which
+        reflects OS/browser settings, not a deliberate in-app choice, and
+        does not necessarily match the language the UI is displaying).
+
+        This is a browser cookie, not a persisted account attribute: there
+        is no ``locale`` column on ``User`` and no ``locale`` field on
+        ``TaskCreateRequest``. It's device- and browser-scoped, lost when
+        cookies are cleared, and not synced across a user's sessions.
 
         ``None`` (no request, no cookie, or an unrecognized value) lets the
         browser tool fall back to its own deployment default.

--- a/tests/core/computer/test_browser_environment.py
+++ b/tests/core/computer/test_browser_environment.py
@@ -149,11 +149,17 @@ class FakeManager:
     def __init__(self, page: FakePage) -> None:
         self.page = page
         self.session = FakeSession(page)
-        self.calls: list[tuple[str, bool]] = []
+        self.calls: list[tuple[str, bool, str | None]] = []
         self.closed: list[str] = []
 
-    async def get_or_create(self, session_id: str, headless: bool) -> FakeSession:
-        self.calls.append((session_id, headless))
+    async def get_or_create(
+        self,
+        session_id: str,
+        headless: bool,
+        locale: str | None = None,
+        timezone_id: str | None = None,
+    ) -> FakeSession:
+        self.calls.append((session_id, headless, locale))
         return self.session
 
     async def close(self, session_id: str) -> None:
@@ -199,7 +205,7 @@ async def test_browser_observation_captures_screenshot_and_dom_elements(
     assert observation.metadata["browser_runtime_kind"] == "ephemeral_playwright"
     assert environment.current_observation == observation
     assert environment.manager.calls == [  # type: ignore[attr-defined]
-        ("browser-1:computer", True)
+        ("browser-1:computer", True, None)
     ]
 
 

--- a/tests/core/computer/test_browser_environment.py
+++ b/tests/core/computer/test_browser_environment.py
@@ -157,7 +157,6 @@ class FakeManager:
         session_id: str,
         headless: bool,
         locale: str | None = None,
-        timezone_id: str | None = None,
     ) -> FakeSession:
         self.calls.append((session_id, headless, locale))
         return self.session

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1749,6 +1749,31 @@ class TestLocalBrowserConfig:
             get_native_browser_app_name()
 
 
+class TestBrowserToolDefaultLocaleConfig:
+    """Fallback locale/timezone for browser_use (Playwright) sessions."""
+
+    def test_defaults(self, monkeypatch):
+        monkeypatch.delenv(config.BROWSER_TOOL_DEFAULT_LOCALE, raising=False)
+        monkeypatch.delenv(config.BROWSER_TOOL_DEFAULT_TIMEZONE, raising=False)
+
+        assert config.get_browser_tool_default_locale() == "en-US"
+        assert config.get_browser_tool_default_timezone() is None
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv(config.BROWSER_TOOL_DEFAULT_LOCALE, "ja-JP")
+        monkeypatch.setenv(config.BROWSER_TOOL_DEFAULT_TIMEZONE, "Asia/Tokyo")
+
+        assert config.get_browser_tool_default_locale() == "ja-JP"
+        assert config.get_browser_tool_default_timezone() == "Asia/Tokyo"
+
+    def test_blank_values_fall_back(self, monkeypatch):
+        monkeypatch.setenv(config.BROWSER_TOOL_DEFAULT_LOCALE, "   ")
+        monkeypatch.setenv(config.BROWSER_TOOL_DEFAULT_TIMEZONE, "")
+
+        assert config.get_browser_tool_default_locale() == "en-US"
+        assert config.get_browser_tool_default_timezone() is None
+
+
 class TestCheckpointStorageConfig:
     """Config for checkpoint trace-event storage encoding and retention."""
 


### PR DESCRIPTION
## Summary
- Playwright browser automation sessions were hardcoded to `locale="zh-CN"` / `timezone_id="Asia/Shanghai"` and spoofed `navigator.languages` as Chinese-first, so every task's browser tool requested Chinese-localized pages regardless of who was asking (many sites auto-localize based on this). Combined with a sandbox image missing Chinese fonts, this rendered as garbled tofu characters in screenshots.
- Locale is now derived from the account's own `app_locale` cookie (set by the frontend's language switcher), threaded through `WebToolConfig.get_browser_locale()` into `BrowserTaskSessionMixin` so whichever browser tool call happens to create the session carries it. Falls back to a deployment-level default (`XAGENT_BROWSER_TOOL_DEFAULT_LOCALE`, default `en-US`) when unresolvable.
- Also fixes `create_task()` passing the parsed `TaskCreateRequest` body (no cookies) into `get_agent_manager()` instead of the real `Request` — the cookie could never have been read otherwise. The three WebSocket call sites now pass their live connection object for the same reason.

## Test plan
- [x] `pytest tests/core/tools/test_browser_use.py tests/core/test_config.py::TestBrowserToolDefaultLocaleConfig tests/web/api/test_task_runtime_delete_bindings.py` — 29 passed
- [x] `ruff format` / `ruff check` / `mypy` all pass (pre-commit hook)
- [x] Local end-to-end verification: built `frontend/out` and served it same-origin from the backend, switched the UI language to Chinese, created a new task opening the HubSpot login page — logs confirmed `Creating browser session ... locale='zh-CN'` and the screenshot rendered correctly in Chinese; repeated after switching back to English and got `locale='en-US'`