### PR TITLE
ref(share): make the ShareChatAccessContext exactly-one-entity invariant structural (#1225)

### DIFF
--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -88,6 +88,8 @@ class PublicChatAccessContext:
     widget_agent_id: int | None = None
     # Set instead of ``widget_agent_id`` when the widget key exposes a
     # workforce. Exactly one of the two is populated for a widget guest.
+    # Structural enforcement is tracked in #1288 (the share twin is already
+    # enforced below, #1225).
     widget_workforce_id: int | None = None
 
 

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -119,9 +119,11 @@ class ShareChatAccessContext:
         # workforce bucket; a neither-set one has no billing bucket at all.
         # Compared against None, not truthiness — tests construct the context
         # with arbitrary stand-in objects. A violation is a programming
-        # defect, never a bad credential, so ValueError deliberately does NOT
-        # map to a 401: get_share_chat_user only projects _PublicTokenRejected
-        # / HTTPException to 401 and lets defects propagate loudly (#1214).
+        # defect, never a bad credential: get_share_chat_user only rewrites
+        # _PublicTokenRejected into a 401 and passes HTTPException through
+        # unchanged (e.g. the 403s from ensure_share_*_available), so this
+        # ValueError propagates loudly (#1214). Both production construction
+        # sites set exactly one entity; the guard defends future call sites.
         if (self.agent is None) == (self.workforce is None):
             raise ValueError(
                 "ShareChatAccessContext requires exactly one of 'agent' or 'workforce'"

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -95,7 +95,8 @@ class PublicChatAccessContext:
 class ShareChatAccessContext:
     """Validated share-guest identity: exactly one of ``agent`` /
     ``workforce`` is set, depending on which kind of share token the guest
-    presented. ``user`` is always the owner the shared entity runs as.
+    presented — enforced at construction by ``__post_init__`` (#1225).
+    ``user`` is always the owner the shared entity runs as.
 
     ``guest_id`` is the per-guest isolation credential (#973): a share link is
     public, so many anonymous visitors share the same owner + entity id, and
@@ -110,6 +111,21 @@ class ShareChatAccessContext:
     guest_id: str
     agent: Agent | None = None
     workforce: Workforce | None = None
+
+    def __post_init__(self) -> None:
+        # Exactly-one guard (#1225): the run quota keys off these markers and
+        # entity_rate_limit_key prefers workforce when both ids are set, so a
+        # both-set context would silently charge an agent-share run to a
+        # workforce bucket; a neither-set one has no billing bucket at all.
+        # Compared against None, not truthiness — tests construct the context
+        # with arbitrary stand-in objects. A violation is a programming
+        # defect, never a bad credential, so ValueError deliberately does NOT
+        # map to a 401: get_share_chat_user only projects _PublicTokenRejected
+        # / HTTPException to 401 and lets defects propagate loudly (#1214).
+        if (self.agent is None) == (self.workforce is None):
+            raise ValueError(
+                "ShareChatAccessContext requires exactly one of 'agent' or 'workforce'"
+            )
 
 
 def mint_share_guest_id() -> str:
@@ -1154,11 +1170,13 @@ async def _create_workforce_share_chat_task(
             # Null the agent marker for symmetry with the agent path (#1132),
             # mirroring the widget workforce branch: entity_rate_limit_key
             # prefers workforce, so a stray agent id would be ignored anyway,
-            # but stamping both keeps the run-quota key unambiguous. Safe
-            # because the snapshot-built config never sets either marker --
-            # not because merge order is irrelevant: _merge_agent_config
-            # returns {**extra_agent_config, **task_config}, so the built
-            # config wins every collision and this dict loses.
+            # but stamping both keeps the run-quota key unambiguous. The None
+            # is a literal by the context's exactly-one invariant, enforced in
+            # ShareChatAccessContext.__post_init__ (#1225). Safe also because
+            # the snapshot-built config never sets either marker -- not
+            # because merge order is irrelevant: _merge_agent_config returns
+            # {**extra_agent_config, **task_config}, so the built config wins
+            # every collision and this dict loses.
             "share_agent_id": None,
             # Per-guest isolation (#973). extra_agent_config is overlaid under
             # the snapshot-built config, which never sets guest_id, so this is
@@ -1222,18 +1240,9 @@ async def create_share_chat_task(
     # workforce, so a client-injected share_workforce_id must never survive to
     # redirect an agent-share task's bucket onto a workforce. The sanitizer
     # already strips both, but stamping explicitly keeps this correct
-    # independent of the sanitizer's reserved-key set.
-    #
-    # The workforce marker is a literal None because the dispatch above forces
-    # it: this branch runs only after the early return into
-    # _create_workforce_share_chat_task, so access_context.workforce is None
-    # here and a context read would yield the same value today. Preserving that
-    # guard is what keeps the literal honest. If it were ever removed, a
-    # context read would not be the safe fallback it looks like: this branch
-    # builds an *agent* task (agent_id=share_agent_id below), and
-    # entity_rate_limit_key prefers workforce whenever both markers are set, so
-    # a non-None workforce id here would charge an agent-share run to a
-    # workforce bucket — the misattribution this stamping exists to prevent.
+    # independent of the sanitizer's reserved-key set. The workforce marker is
+    # a literal None by the context's exactly-one invariant, enforced in
+    # ShareChatAccessContext.__post_init__ (#1225).
     agent_config["share_agent_id"] = share_agent_id
     agent_config["share_workforce_id"] = None
 

--- a/src/xagent/web/services/share_rate_limit.py
+++ b/src/xagent/web/services/share_rate_limit.py
@@ -77,7 +77,9 @@ def entity_rate_limit_key(agent_id: int | None, workforce_id: int | None) -> str
     The single formatter behind every entity-keyed bucket (``"agent:<id>"``
     / ``"workforce:<id>"``), shared by the widget upload/turn gates and the
     share run quota so the shape can never drift between call sites.
-    Workforce wins when both ids are set (callers guarantee at most one is).
+    Workforce wins when both ids are set (callers guarantee at most one is;
+    on the share path ``ShareChatAccessContext.__post_init__`` enforces that
+    structurally, #1225).
     Returns ``None`` when neither id is set; the request-throttle ``allow_*``
     gates degrade that to their shared ``"unknown"`` bucket rather than
     admitting freely, while the run-quota chokepoint (chat.py) instead admits

--- a/tests/web/api/test_public_chat_websocket_db_boundary.py
+++ b/tests/web/api/test_public_chat_websocket_db_boundary.py
@@ -529,6 +529,18 @@ def test_public_token_failure_projection_preserves_http_exception_identity() -> 
     )
 
 
+def test_public_token_failure_projection_leaves_defects_unprojected() -> None:
+    """A non-credential exception (e.g. the ShareChatAccessContext invariant
+    ValueError, #1225) must NOT be laundered into a 401: the projection
+    returns None so the caller re-raises the defect loudly (#1214)."""
+    assert (
+        public_chat_access._project_public_token_failure(
+            ValueError("boom"), invalid_detail="Invalid share token"
+        )
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     ("resolver_kind", "claim", "value", "expected_bind_count"),
     (

--- a/tests/web/api/test_share_access_context_invariant.py
+++ b/tests/web/api/test_share_access_context_invariant.py
@@ -11,13 +11,14 @@ unconstructible instead of merely narrated in docstrings.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from xagent.web.api.public_chat_access import ShareChatAccessContext
 
 
-def _context_kwargs(**entity: object) -> dict[str, object]:
+def _context_kwargs(**entity: Any) -> dict[str, Any]:
     return {
         "user": SimpleNamespace(id=1),
         "share_token": "tok",
@@ -27,28 +28,24 @@ def _context_kwargs(**entity: object) -> dict[str, object]:
 
 
 def test_agent_only_context_constructs() -> None:
-    context = ShareChatAccessContext(
-        **_context_kwargs(agent=SimpleNamespace(id=7))  # type: ignore[arg-type]
-    )
+    context = ShareChatAccessContext(**_context_kwargs(agent=SimpleNamespace(id=7)))
     assert context.workforce is None
 
 
 def test_workforce_only_context_constructs() -> None:
-    context = ShareChatAccessContext(
-        **_context_kwargs(workforce=SimpleNamespace(id=7))  # type: ignore[arg-type]
-    )
+    context = ShareChatAccessContext(**_context_kwargs(workforce=SimpleNamespace(id=7)))
     assert context.agent is None
 
 
 def test_neither_entity_set_is_rejected() -> None:
     with pytest.raises(ValueError, match="exactly one"):
-        ShareChatAccessContext(**_context_kwargs())  # type: ignore[arg-type]
+        ShareChatAccessContext(**_context_kwargs())
 
 
 def test_both_entities_set_is_rejected() -> None:
     with pytest.raises(ValueError, match="exactly one"):
         ShareChatAccessContext(
-            **_context_kwargs(  # type: ignore[arg-type]
+            **_context_kwargs(
                 agent=SimpleNamespace(id=7),
                 workforce=SimpleNamespace(id=9),
             )
@@ -67,14 +64,12 @@ class _FalsyEntity:
 
 
 def test_falsy_entity_object_counts_as_set() -> None:
-    context = ShareChatAccessContext(
-        **_context_kwargs(agent=_FalsyEntity())  # type: ignore[arg-type]
-    )
+    context = ShareChatAccessContext(**_context_kwargs(agent=_FalsyEntity()))
     assert context.agent is not None
 
     with pytest.raises(ValueError, match="exactly one"):
         ShareChatAccessContext(
-            **_context_kwargs(  # type: ignore[arg-type]
+            **_context_kwargs(
                 agent=_FalsyEntity(),
                 workforce=_FalsyEntity(),
             )

--- a/tests/web/api/test_share_access_context_invariant.py
+++ b/tests/web/api/test_share_access_context_invariant.py
@@ -1,0 +1,81 @@
+"""Structural exactly-one-entity invariant on ``ShareChatAccessContext`` (#1225).
+
+The context documents that exactly one of ``agent`` / ``workforce`` is set.
+That guarantee is load-bearing for run-quota attribution: the entity
+rate-limit key prefers workforce when both ids are present, so a both-set
+context would silently charge an agent-share run to a workforce bucket.
+These tests pin the ``__post_init__`` guard that makes the illegal states
+unconstructible instead of merely narrated in docstrings.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from xagent.web.api.public_chat_access import ShareChatAccessContext
+
+
+def _context_kwargs(**entity: object) -> dict[str, object]:
+    return {
+        "user": SimpleNamespace(id=1),
+        "share_token": "tok",
+        "guest_id": "guest",
+        **entity,
+    }
+
+
+def test_agent_only_context_constructs() -> None:
+    context = ShareChatAccessContext(
+        **_context_kwargs(agent=SimpleNamespace(id=7))  # type: ignore[arg-type]
+    )
+    assert context.workforce is None
+
+
+def test_workforce_only_context_constructs() -> None:
+    context = ShareChatAccessContext(
+        **_context_kwargs(workforce=SimpleNamespace(id=7))  # type: ignore[arg-type]
+    )
+    assert context.agent is None
+
+
+def test_neither_entity_set_is_rejected() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        ShareChatAccessContext(**_context_kwargs())  # type: ignore[arg-type]
+
+
+def test_both_entities_set_is_rejected() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        ShareChatAccessContext(
+            **_context_kwargs(  # type: ignore[arg-type]
+                agent=SimpleNamespace(id=7),
+                workforce=SimpleNamespace(id=9),
+            )
+        )
+
+
+class _FalsyEntity:
+    """Truthy-ness must not matter: the guard must compare against ``None``.
+
+    Tests elsewhere construct the context with ``MagicMock()`` / ``object()``
+    stand-ins; a stand-in whose ``__bool__`` is falsy is still a *set* entity.
+    """
+
+    def __bool__(self) -> bool:
+        return False
+
+
+def test_falsy_entity_object_counts_as_set() -> None:
+    context = ShareChatAccessContext(
+        **_context_kwargs(agent=_FalsyEntity())  # type: ignore[arg-type]
+    )
+    assert context.agent is not None
+
+    with pytest.raises(ValueError, match="exactly one"):
+        ShareChatAccessContext(
+            **_context_kwargs(  # type: ignore[arg-type]
+                agent=_FalsyEntity(),
+                workforce=_FalsyEntity(),
+            )
+        )

--- a/tests/web/api/test_share_access_context_invariant.py
+++ b/tests/web/api/test_share_access_context_invariant.py
@@ -28,12 +28,16 @@ def _context_kwargs(**entity: Any) -> dict[str, Any]:
 
 
 def test_agent_only_context_constructs() -> None:
-    context = ShareChatAccessContext(**_context_kwargs(agent=SimpleNamespace(id=7)))
+    agent = SimpleNamespace(id=7)
+    context = ShareChatAccessContext(**_context_kwargs(agent=agent))
+    assert context.agent is agent
     assert context.workforce is None
 
 
 def test_workforce_only_context_constructs() -> None:
-    context = ShareChatAccessContext(**_context_kwargs(workforce=SimpleNamespace(id=7)))
+    workforce = SimpleNamespace(id=7)
+    context = ShareChatAccessContext(**_context_kwargs(workforce=workforce))
+    assert context.workforce is workforce
     assert context.agent is None
 
 
@@ -64,13 +68,7 @@ class _FalsyEntity:
 
 
 def test_falsy_entity_object_counts_as_set() -> None:
-    context = ShareChatAccessContext(**_context_kwargs(agent=_FalsyEntity()))
-    assert context.agent is not None
-
-    with pytest.raises(ValueError, match="exactly one"):
-        ShareChatAccessContext(
-            **_context_kwargs(
-                agent=_FalsyEntity(),
-                workforce=_FalsyEntity(),
-            )
-        )
+    agent = _FalsyEntity()
+    context = ShareChatAccessContext(**_context_kwargs(agent=agent))
+    assert context.agent is agent
+    assert context.workforce is None


### PR DESCRIPTION
Closes #1225. Spun out of review feedback on #1221 (the fix for #1132).

## What

Make the `ShareChatAccessContext` exactly-one-entity invariant structural: `__post_init__` on the frozen dataclass now rejects both-set and neither-set `agent` / `workforce`, so the illegal states the docstring used to merely narrate are unconstructible.

## Why

The invariant is load-bearing for run-quota attribution: `entity_rate_limit_key` prefers workforce when both ids are set, so a future refactor that let both fields be populated would silently charge an agent-share run to a workforce bucket, with nothing failing loudly. Until now the only thing enforcing it was the shape of `get_share_chat_user`'s two branches, plus prose — and prose does not fail a build.

## Design decisions

- **Guard compares against `None`, not truthiness.** Tests construct the context with `MagicMock()` / `object()` / `SimpleNamespace` stand-ins; a stand-in whose `__bool__` is falsy is still a *set* entity. A dedicated test pins this.
- **A violation raises `ValueError` and is deliberately NOT mapped to a 401.** An invariant violation is a programming defect, never a bad credential. `get_share_chat_user` only projects `_PublicTokenRejected` / `HTTPException` into 401 and lets defects propagate loudly, matching the #1214 boundary policy (this PR is based on top of that refactor; the guard's comment documents the interaction).
- **`__post_init__` over the tagged-union split.** Roughly ten call sites dispatch on `workforce is not None` / `agent is None` fail-closed guards; splitting the type would touch all of them plus the FastAPI dependency typing for disproportionate gain. The guard already makes the illegal state fail at construction. The union remains open as a future deepening if the type grows more variant-specific behavior.

## Comment shrinkage (the issue's "Ask")

- The ~12-line defensive comment in `create_share_chat_task` justifying the literal `share_workforce_id = None` now cites the enforced invariant in one line instead of re-deriving it from the dispatch guard.
- The workforce-side stamping site (`_create_workforce_share_chat_task`) cites it too.
- The `entity_rate_limit_key` docstring notes the share path's "callers guarantee at most one is" is now structural. (The widget path's identical guarantee on `PublicChatAccessContext` is still caller-maintained — see follow-up note below.)

## Tests

New `tests/web/api/test_share_access_context_invariant.py`:

- agent-only and workforce-only construction passes;
- both-set and neither-set raise `ValueError`;
- a falsy-but-set entity object still counts as set.

The issue's caveat about the four existing direct constructions (`test_share_rate_limit_endpoints.py:437`/`:490`, `test_upload_connection_boundary.py:707`, `test_public_runtime_extensions.py:47` — all under `tests/web/api/`, the issue's paths were missing the `api/` segment) is verified by execution, not assumption: each sets exactly one field and all pass unchanged.

Full `tests/web` suite run: green except three pre-existing SVG preview rasterization failures (`test_svg_preview_cache.py`, `test_file_upload.py::TestSvgPreviewSecurity`) that reproduce identically on a clean `main` baseline worktree — environmental, unrelated to this change. `ruff format --check`, `ruff check`, and `mypy` are clean on the touched files.

## Follow-up

`PublicChatAccessContext` (the widget twin directly above) documents the same exactly-one shape for `widget_agent_id` / `widget_workforce_id` and remains narration-only. Out of scope here per the issue; worth a sibling issue if this approach is accepted.
