### PR TITLE
fix: resolve mcp: tool selectors against the real connected server row

### DIFF
--- a/frontend/src/components/build/agent-builder-mcp-selector-resolution.test.tsx
+++ b/frontend/src/components/build/agent-builder-mcp-selector-resolution.test.tsx
@@ -2,10 +2,10 @@ import React from "react"
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-// #1280 round-3 review, Major finding 2: the pure resolveMcpToolSelector unit
-// tests cover the helper in isolation, but nothing exercised the two things
-// this PR's fix actually depends on end to end: (a) the outbound save
-// request's tool_categories carries the *resolved* selector, not whatever
+// The pure resolveMcpToolSelector unit tests (mcp-lookup.test.ts) cover the
+// helper in isolation, but nothing exercised the two things this fix
+// actually depends on end to end: (a) the outbound save request's
+// tool_categories carries the *resolved* selector, not whatever
 // selectedMcpServers holds, and (b) isDirty returns to false after a
 // successful save instead of staying permanently true because
 // selectedMcpServers was never re-seeded to match. This drives both through
@@ -229,7 +229,8 @@ describe("AgentBuilder mcp: selector resolution on save", () => {
     // The Update button starts disabled: nothing has changed yet, and
     // selectedMcpServers/originalData's MCP extraction agree on the loaded
     // (still-unresolved) "Chrome" -- loading an already-broken agent
-    // doesn't self-heal it without an edit, by design (round-1 review).
+    // doesn't self-heal it without an edit, by design (a plain save does
+    // not re-resolve a selector that was already persisted unresolved).
     const updateButton = screen.getByRole("button", {
       name: "builds.editor.header.update",
     })

--- a/frontend/src/components/build/agent-builder-mcp-selector-resolution.test.tsx
+++ b/frontend/src/components/build/agent-builder-mcp-selector-resolution.test.tsx
@@ -1,0 +1,260 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// #1280 round-3 review, Major finding 2: the pure resolveMcpToolSelector unit
+// tests cover the helper in isolation, but nothing exercised the two things
+// this PR's fix actually depends on end to end: (a) the outbound save
+// request's tool_categories carries the *resolved* selector, not whatever
+// selectedMcpServers holds, and (b) isDirty returns to false after a
+// successful save instead of staying permanently true because
+// selectedMcpServers was never re-seeded to match. This drives both through
+// the real AgentBuilder component and a mocked PUT /api/agents/{id}.
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper"
+  )
+  return { ...actual, apiRequest: apiRequestMock }
+})
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return {
+    ...actual,
+    getApiUrl: () => "http://api.local",
+    getUploadApiUrl: () => "http://api.local",
+    getWsUrl: () => "ws://api.local",
+  }
+})
+
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({
+    state: {
+      messages: [],
+      traceEvents: [],
+      currentTask: null,
+      isProcessing: false,
+      isHistoryLoading: false,
+      taskId: null,
+      filePreview: { isOpen: false },
+      dagExecution: null,
+      steps: [],
+    },
+    setTaskId: vi.fn(),
+    sendMessage: vi.fn(),
+    dispatch: vi.fn(),
+    closeFilePreview: vi.fn(),
+    pauseTask: vi.fn(),
+    resumeTask: vi.fn(),
+    openFilePreview: vi.fn(),
+    requestStatus: vi.fn(),
+  }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ token: "token", user: { id: "1", is_admin: false } }),
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({
+    locale: "en",
+    t: (key: string, vars?: Record<string, string>) =>
+      vars?.appName ? `${key}:${vars.appName}` : key,
+  }),
+}))
+
+// The catalog app: display name "Chrome" deliberately diverging from its
+// real connected server row's name "chrome-devtools" (installApi below) --
+// the exact divergence this whole fix exists for.
+vi.mock("@/contexts/mcp-apps-context", () => ({
+  useMcpApps: () => ({
+    apps: [
+      {
+        id: "chrome-devtools",
+        name: "Chrome",
+        description: "",
+        icon: "",
+        users: "",
+        transport: "stdio",
+        provider: "",
+        category: "Productivity",
+        is_connected: true,
+      },
+    ],
+    getAppIcon: () => null,
+  }),
+}))
+
+vi.mock("@/lib/branding", () => ({
+  getBrandingFromEnv: () => ({ appName: "Xagent" }),
+}))
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock("@/components/layout/resizable-three-column-layout", () => ({
+  ResizableThreeColumnLayout: ({ middlePanel }: { middlePanel: React.ReactNode }) => (
+    <div>{middlePanel}</div>
+  ),
+}))
+
+vi.mock("@/components/task/task-conversation-panel", () => ({
+  TaskConversationPanel: () => null,
+}))
+
+vi.mock("@/components/build/agent-builder-chat", () => ({ AgentBuilderChat: () => null }))
+vi.mock("@/components/kb/knowledge-base-creation-dialog", () => ({
+  KnowledgeBaseCreationDialog: () => null,
+}))
+vi.mock("@/components/mcp/connect-mcp-dialog", () => ({
+  ConnectMcpDialog: () => null,
+}))
+vi.mock("@/components/chat/FileMentionDropdown", () => ({ FileMentionDropdown: () => null }))
+vi.mock("@/hooks/use-file-mention", () => ({
+  useFileMention: () => ({
+    checkTrigger: vi.fn(),
+    isOpen: false,
+    items: [],
+    selectedIndex: 0,
+    selectItem: vi.fn(),
+    close: vi.fn(),
+  }),
+}))
+vi.mock("@/components/ui/multi-select", () => ({ MultiSelect: () => null }))
+vi.mock("@/components/ui/select", () => ({ Select: () => null }))
+vi.mock("@/components/build/build-file-preview-sheet", () => ({
+  BuildFilePreviewSheet: () => null,
+}))
+
+import { AgentBuilder } from "./agent-builder"
+
+const AGENT_ID = "5"
+
+function agentResponse(toolCategories: string[]) {
+  return {
+    id: Number(AGENT_ID),
+    user_id: 1,
+    team_id: null,
+    name: "Some Agent",
+    description: "",
+    instructions: "Do the thing",
+    execution_mode: "balanced",
+    // handleCreate's save validation requires a general model to be set.
+    models: { general: 1, small_fast: null, visual: null, compact: null },
+    knowledge_bases: [],
+    skills: [],
+    tool_categories: toolCategories,
+    suggested_prompts: [],
+    logo_url: null,
+    status: "draft",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    widget_enabled: false,
+    allowed_domains: [],
+    share_enabled: false,
+    share_updated_at: null,
+    readonly: false,
+    can_edit: true,
+  }
+}
+
+// The agent was saved before this fix landed, with the unresolved display
+// name -- exactly the shape the original Chrome bug produced.
+const INITIAL_TOOL_CATEGORIES = ["mcp:Chrome"]
+
+let putBody: Record<string, unknown> | undefined
+
+function installApi() {
+  putBody = undefined
+  apiRequestMock.mockImplementation((url: string, init?: RequestInit) => {
+    if (url.endsWith("/api/kb/collections"))
+      return Promise.resolve(new Response(JSON.stringify({ collections: [] }), { status: 200 }))
+    if (url.endsWith("/api/skills/"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/tools/available"))
+      return Promise.resolve(new Response(JSON.stringify({ tools: [] }), { status: 200 }))
+    if (url.endsWith("/api/models/?category=llm"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.endsWith("/api/models/user-default"))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    if (url.includes(`/api/agents/${AGENT_ID}/triggers`))
+      return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }))
+    // The real connected MCPServer row: named after the app_id
+    // ("chrome-devtools"), not the display name -- Chrome's actual
+    // shared-server-catalog convention (_ensure_catalog_app_server).
+    if (url.includes("/api/mcp/servers"))
+      return Promise.resolve(
+        new Response(JSON.stringify([{ id: 1, name: "chrome-devtools" }]), { status: 200 })
+      )
+    if (url.endsWith(`/api/agents/${AGENT_ID}`) && init?.method === "PUT") {
+      putBody = JSON.parse(init.body as string)
+      return Promise.resolve(
+        new Response(JSON.stringify(agentResponse(putBody!.tool_categories as string[])), {
+          status: 200,
+        })
+      )
+    }
+    if (url.endsWith(`/api/agents/${AGENT_ID}`))
+      return Promise.resolve(
+        new Response(JSON.stringify(agentResponse(INITIAL_TOOL_CATEGORIES)), { status: 200 })
+      )
+    return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+  })
+}
+
+describe("AgentBuilder mcp: selector resolution on save", () => {
+  beforeEach(() => {
+    apiRequestMock.mockReset()
+    installApi()
+    ;(globalThis as unknown as { WebSocket: unknown }).WebSocket = vi.fn()
+  })
+
+  afterEach(() => cleanup())
+
+  it("saves the resolved server-row name, not the unresolved display name, and clears isDirty afterward", async () => {
+    render(<AgentBuilder agentId={AGENT_ID} />)
+
+    const nameInput = await screen.findByPlaceholderText(
+      "builds.configForm.name.placeholder"
+    )
+    await waitFor(() => expect(nameInput).toHaveValue("Some Agent"))
+
+    // The Update button starts disabled: nothing has changed yet, and
+    // selectedMcpServers/originalData's MCP extraction agree on the loaded
+    // (still-unresolved) "Chrome" -- loading an already-broken agent
+    // doesn't self-heal it without an edit, by design (round-1 review).
+    const updateButton = screen.getByRole("button", {
+      name: "builds.editor.header.update",
+    })
+    expect(updateButton).toBeDisabled()
+
+    // A trivial, unrelated edit is enough to make isDirty true and reach
+    // the save path -- this test isn't about the name change itself.
+    fireEvent.change(nameInput, { target: { value: "Some Agent Renamed" } })
+    await waitFor(() => expect(updateButton).not.toBeDisabled())
+
+    fireEvent.click(updateButton)
+
+    await waitFor(() => expect(putBody).toBeDefined())
+
+    // (a) The outbound PUT resolved "Chrome" to the real connected row's
+    // name, not the display name that was actually in selectedMcpServers.
+    expect(putBody?.tool_categories).toContain("mcp:chrome-devtools")
+    expect(putBody?.tool_categories).not.toContain("mcp:Chrome")
+
+    // (b) isDirty clears back to false once the save succeeds, observed via
+    // the Update button re-disabling with no further edits. Before the
+    // selectedMcpServers re-seed fix, this stayed enabled forever: the PUT
+    // response's tool_categories rewrote originalData to hold
+    // "chrome-devtools" while selectedMcpServers kept holding "Chrome",
+    // and isDirty's plain string comparison of the two never matched again.
+    await waitFor(() => expect(updateButton).toBeDisabled())
+  })
+})

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -148,17 +148,12 @@ interface TemplateRequirements {
 // instead (issue #802), and `other` is an internal fallback bucket.
 const isAssignableToolCategory = (c: string) => c !== 'agent' && c !== 'other'
 
-// Round-2 review of #1280: selectedMcpServers must be re-seeded from a
-// save's resolved tool_categories the same way loadAgent seeds it from a
-// fetched agent's tool_categories -- otherwise it keeps holding whatever
-// (often unresolved, e.g. a display name) value the user picked, while
-// originalData.tool_categories now holds resolveMcpToolSelector's
-// authoritative resolved name. isDirty's comparison of the two is a plain
-// string compare with no name/id normalization, so a resolved value that
-// differs from the display name (Chrome: "chrome-devtools" vs. "Chrome")
-// left isDirty permanently true after a successful save, with no further
-// action from the user, until a full page reload re-seeded it correctly
-// via loadAgent.
+// The single extraction every tool_categories -> selectedMcpServers site
+// must share: isDirty compares selectedMcpServers against this same
+// extraction applied to originalData.tool_categories with a plain string
+// compare, no name/id normalization -- so a caller that inlines its own
+// copy and drifts from this one silently reintroduces a permanently-dirty
+// isDirty state.
 function mcpServerNamesFromToolCategories(categories: string[]): string[] {
   return categories
     .filter((c) => c.startsWith('mcp:'))
@@ -876,7 +871,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           // never show or round-trip it.
           const rawToolCategories = agent.tool_categories || []
           setSelectedToolCategories(rawToolCategories.filter((c: string) => !c.startsWith('mcp:') && isAssignableToolCategory(c)))
-          setSelectedMcpServers(rawToolCategories.filter((c: string) => c.startsWith('mcp:')).map((c: string) => c.replace('mcp:', '')))
+          setSelectedMcpServers(mcpServerNamesFromToolCategories(rawToolCategories))
           // Seed the SSH auto-category from the saved config so a failed
           // bindings-load (which never fires onCount) can't leave "ssh" unset
           // at save time. A successful load overwrites this with the live count.
@@ -963,9 +958,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           const allCategories = template.agent_config?.tool_categories || []
           setSelectedToolCategories(allCategories.filter((c: string) => !c.startsWith('mcp:') && isAssignableToolCategory(c)))
 
-          const explicitlyConfiguredMcps = allCategories
-            .filter((c: string) => c.startsWith('mcp:'))
-            .map((c: string) => c.replace('mcp:', ''))
+          const explicitlyConfiguredMcps = mcpServerNamesFromToolCategories(allCategories)
 
           // _enrich_template merges connections into tool_categories as mcp: entries, so
           // iterating both explicitlyConfiguredMcps and connections would add each
@@ -1142,16 +1135,24 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       }
 
       const finalToolCategories = [...selectedToolCategories]
+      // Match handleCreate below: a preview session with a knowledge base
+      // selected must include "knowledge" too, or it runs with different
+      // categories than the agent it's a preview of.
+      if (selectedKbs.length > 0 && !finalToolCategories.includes("knowledge")) {
+        finalToolCategories.push("knowledge")
+      }
       // Resolve each selection to the real, connected MCPServer row's name
       // (see resolveMcpToolSelector for why a name/id fallback alone isn't
       // enough -- the backend uses either convention depending on app
       // type). Depends on mcpServers/officialApps having loaded; if a
       // preview message is sent before they do, this falls back to the raw
       // selector for every MCP tool (matching pre-existing behavior for
-      // this call site, not just this connector).
-      selectedMcpServers.forEach(server => {
-        finalToolCategories.push(`mcp:${resolveMcpToolSelector(server, mcpServers, officialApps)}`)
-      })
+      // this call site, not just this connector). Deduped: two distinct
+      // selectedMcpServers entries can resolve to the same real row.
+      const resolvedMcpSelectors = new Set(
+        selectedMcpServers.map(server => resolveMcpToolSelector(server, mcpServers, officialApps))
+      )
+      resolvedMcpSelectors.forEach(selector => finalToolCategories.push(`mcp:${selector}`))
       if (hasSshBindings && !finalToolCategories.includes("ssh")) {
         finalToolCategories.push("ssh")
       }
@@ -1300,9 +1301,7 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     if (normalize(selectedSkills) !== normalize(originalData.skills)) return true
 
     // Check MCP servers by extracting them from originalData.tool_categories
-    const originalMcpServers = (originalData.tool_categories || [])
-      .filter((c: string) => c.startsWith('mcp:'))
-      .map((c: string) => c.replace('mcp:', ''))
+    const originalMcpServers = mcpServerNamesFromToolCategories(originalData.tool_categories || [])
     if (normalize(selectedMcpServers) !== normalize(originalMcpServers)) return true
 
     // Check non-MCP tool categories
@@ -1473,10 +1472,14 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
     // Add selected MCP servers back into tool_categories, resolved to the
     // real connected MCPServer row's name -- see resolveMcpToolSelector for
-    // why a hard-coded id/name fallback can't work for every app.
-    selectedMcpServers.forEach(server => {
-      finalToolCategories.push(`mcp:${resolveMcpToolSelector(server, mcpServers, officialApps)}`)
-    })
+    // why a hard-coded id/name fallback can't work for every app. Deduped:
+    // two distinct selectedMcpServers entries can resolve to the same real
+    // row, and the backend persists tool_categories verbatim (agents.py),
+    // so an unresolved duplicate here lands in the DB and stays there.
+    const resolvedMcpSelectors = new Set(
+      selectedMcpServers.map(server => resolveMcpToolSelector(server, mcpServers, officialApps))
+    )
+    resolvedMcpSelectors.forEach(selector => finalToolCategories.push(`mcp:${selector}`))
 
     setIsCreating(true)
 
@@ -1593,11 +1596,16 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
 
           // Newly created agents are always personal; promote if the user chose Team.
           const ownershipResult = await reconcileOwnership(newAgent.id.toString(), newAgent.team_id)
-          setOriginalData({ ...newAgent, ...(ownershipResult ?? {}) })
+          // tool_categories: finalToolCategories explicitly, not whatever
+          // newAgent.tool_categories echoes back -- matches the edit-mode
+          // branch above, which sources both originalData and the reseed
+          // below from the same local value rather than mixing a server
+          // response with a local one.
+          setOriginalData({ ...newAgent, tool_categories: finalToolCategories, ...(ownershipResult ?? {}) })
           // Same re-seed as the edit-mode branch above, and for the same
-          // reason: newAgent.tool_categories echoes back the resolved
-          // selectors this request submitted (finalToolCategories), not
-          // the possibly-unresolved values selectedMcpServers still holds.
+          // reason: selectedMcpServers must hold the resolved selectors
+          // this request submitted, not the possibly-unresolved values it
+          // still held from before save.
           setSelectedMcpServers(mcpServerNamesFromToolCategories(finalToolCategories))
           // Only confirm success once ownership resolved. If a promote was blocked
           // (the share-connectors dialog opened, ownershipResult is null), don't
@@ -1891,7 +1899,13 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       selectedMcpServers.map((serverName) => {
         const connectedServer = findMatchingMcpServer(mcpServers, serverName)
         const matchingApp = findMatchingMcpApp(officialApps, serverName)
-        return connectedServer?.name || matchingApp?.name || serverName
+        // matchingApp?.name (the catalog display name, e.g. "Chrome") first,
+        // not connectedServer?.name (the real MCPServer row name, e.g.
+        // "chrome-devtools"): this is a *display* label. Preferring the row
+        // name here made the chip flip from "Chrome" to "chrome-devtools"
+        // the instant selectedMcpServers gets re-seeded with the resolved
+        // name after a save (see mcpServerNamesFromToolCategories).
+        return matchingApp?.name || connectedServer?.name || serverName
       }),
     [selectedMcpServers, mcpServers, officialApps],
   )
@@ -2656,7 +2670,9 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
                 statusDesc = t("tools.mcp.notSupported")
               }
 
-              const server = { name: connectedServer?.name || matchingApp?.name || serverName, description: statusDesc }
+              // Display label: matchingApp?.name first, same reasoning as
+              // connectorDisplayNames above.
+              const server = { name: matchingApp?.name || connectedServer?.name || serverName, description: statusDesc }
               const icon = getAppIcon(server.name)
               return (
                 <div key={index} className={cn("flex items-center gap-3 p-2 rounded-md border", !isConnected && "opacity-50 bg-muted/50")}>

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -50,7 +50,7 @@ import { KnowledgeBaseCreationDialog } from "@/components/kb/knowledge-base-crea
 import { toast } from "@/components/ui/sonner"
 import { cn } from "@/lib/utils"
 import { getBrandingFromEnv } from "@/lib/branding"
-import { findMatchingMcpApp, findMatchingMcpServer, mcpNameMatches } from "@/lib/mcp-lookup"
+import { findMatchingMcpApp, findMatchingMcpServer, mcpNameMatches, resolveMcpToolSelector } from "@/lib/mcp-lookup"
 import { BuildFilePreviewSheet } from "./build-file-preview-sheet"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
 import { AgentTriggersDialog } from "./agent-triggers-dialog"
@@ -1125,17 +1125,15 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       }
 
       const finalToolCategories = [...selectedToolCategories]
-      // Same resolution as handleCreate below: selectedMcpServers holds
-      // whatever string the connect flow stored (often the app's display
-      // name), but the backend matches mcp:<selector> against the actual
-      // MCP server row name, which is the catalog app_id for a
-      // shared-server catalog app -- not its display name. Pushing the raw
-      // value broke Chrome (app_id "chrome-devtools" vs. display name
-      // "Chrome"), the first app where the two deliberately differ.
+      // Resolve each selection to the real, connected MCPServer row's name
+      // (see resolveMcpToolSelector for why a name/id fallback alone isn't
+      // enough -- the backend uses either convention depending on app
+      // type). Depends on mcpServers/officialApps having loaded; if a
+      // preview message is sent before they do, this falls back to the raw
+      // selector for every MCP tool (matching pre-existing behavior for
+      // this call site, not just this connector).
       selectedMcpServers.forEach(server => {
-        const connectedServer = findMatchingMcpServer(mcpServers, server)
-        const connectedApp = findMatchingMcpApp(officialApps, server)
-        finalToolCategories.push(`mcp:${connectedServer?.name || connectedApp?.id || server}`)
+        finalToolCategories.push(`mcp:${resolveMcpToolSelector(server, mcpServers, officialApps)}`)
       })
       if (hasSshBindings && !finalToolCategories.includes("ssh")) {
         finalToolCategories.push("ssh")
@@ -1456,22 +1454,16 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       finalToolCategories.push("ssh")
     }
 
-    // Add selected MCP servers back into tool_categories
+    // Add selected MCP servers back into tool_categories. See
+    // resolveMcpToolSelector: the backend names a catalog app's MCPServer
+    // row after either its app_id or its display name depending on app
+    // type, so this resolves the real connected row rather than guessing
+    // at a single fallback (a guess broke Chrome, app_id "chrome-devtools"
+    // vs. display name "Chrome", with the pre-existing "prefer name"
+    // fallback; the reverse "prefer id" fallback breaks Facebook, app_id
+    // "facebook" vs. display name "Facebook Pages", the other direction).
     selectedMcpServers.forEach(server => {
-      const connectedServer = findMatchingMcpServer(mcpServers, server)
-      const connectedApp = findMatchingMcpApp(officialApps, server)
-      // connectedApp?.id (the catalog app_id), not connectedApp?.name (its
-      // display name): for a shared-server catalog app, the backend names
-      // the actual MCP server row after the app_id
-      // (_ensure_catalog_app_server / _ensure_catalog_mcp_oauth_server), not
-      // the display name. Every pre-existing app's id and name normalize to
-      // the same backend key, so this was previously masked -- Chrome is
-      // the first app where they deliberately differ (app_id
-      // "chrome-devtools" vs. display name "Chrome"), and pushing the name
-      // here sent the backend an mcp:Chrome selector matching no loaded
-      // server, silently loading zero tools (backend log:
-      // reason="no_tools_returned").
-      finalToolCategories.push(`mcp:${connectedServer?.name || connectedApp?.id || server}`)
+      finalToolCategories.push(`mcp:${resolveMcpToolSelector(server, mcpServers, officialApps)}`)
     })
 
     setIsCreating(true)

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -1125,8 +1125,17 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       }
 
       const finalToolCategories = [...selectedToolCategories]
+      // Same resolution as handleCreate below: selectedMcpServers holds
+      // whatever string the connect flow stored (often the app's display
+      // name), but the backend matches mcp:<selector> against the actual
+      // MCP server row name, which is the catalog app_id for a
+      // shared-server catalog app -- not its display name. Pushing the raw
+      // value broke Chrome (app_id "chrome-devtools" vs. display name
+      // "Chrome"), the first app where the two deliberately differ.
       selectedMcpServers.forEach(server => {
-        finalToolCategories.push(`mcp:${server}`)
+        const connectedServer = findMatchingMcpServer(mcpServers, server)
+        const connectedApp = findMatchingMcpApp(officialApps, server)
+        finalToolCategories.push(`mcp:${connectedServer?.name || connectedApp?.id || server}`)
       })
       if (hasSshBindings && !finalToolCategories.includes("ssh")) {
         finalToolCategories.push("ssh")
@@ -1451,7 +1460,18 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
     selectedMcpServers.forEach(server => {
       const connectedServer = findMatchingMcpServer(mcpServers, server)
       const connectedApp = findMatchingMcpApp(officialApps, server)
-      finalToolCategories.push(`mcp:${connectedServer?.name || connectedApp?.name || server}`)
+      // connectedApp?.id (the catalog app_id), not connectedApp?.name (its
+      // display name): for a shared-server catalog app, the backend names
+      // the actual MCP server row after the app_id
+      // (_ensure_catalog_app_server / _ensure_catalog_mcp_oauth_server), not
+      // the display name. Every pre-existing app's id and name normalize to
+      // the same backend key, so this was previously masked -- Chrome is
+      // the first app where they deliberately differ (app_id
+      // "chrome-devtools" vs. display name "Chrome"), and pushing the name
+      // here sent the backend an mcp:Chrome selector matching no loaded
+      // server, silently loading zero tools (backend log:
+      // reason="no_tools_returned").
+      finalToolCategories.push(`mcp:${connectedServer?.name || connectedApp?.id || server}`)
     })
 
     setIsCreating(true)

--- a/frontend/src/components/build/agent-builder.tsx
+++ b/frontend/src/components/build/agent-builder.tsx
@@ -148,6 +148,23 @@ interface TemplateRequirements {
 // instead (issue #802), and `other` is an internal fallback bucket.
 const isAssignableToolCategory = (c: string) => c !== 'agent' && c !== 'other'
 
+// Round-2 review of #1280: selectedMcpServers must be re-seeded from a
+// save's resolved tool_categories the same way loadAgent seeds it from a
+// fetched agent's tool_categories -- otherwise it keeps holding whatever
+// (often unresolved, e.g. a display name) value the user picked, while
+// originalData.tool_categories now holds resolveMcpToolSelector's
+// authoritative resolved name. isDirty's comparison of the two is a plain
+// string compare with no name/id normalization, so a resolved value that
+// differs from the display name (Chrome: "chrome-devtools" vs. "Chrome")
+// left isDirty permanently true after a successful save, with no further
+// action from the user, until a full page reload re-seeded it correctly
+// via loadAgent.
+function mcpServerNamesFromToolCategories(categories: string[]): string[] {
+  return categories
+    .filter((c) => c.startsWith('mcp:'))
+    .map((c) => c.replace('mcp:', ''))
+}
+
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null
 }
@@ -1454,14 +1471,9 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
       finalToolCategories.push("ssh")
     }
 
-    // Add selected MCP servers back into tool_categories. See
-    // resolveMcpToolSelector: the backend names a catalog app's MCPServer
-    // row after either its app_id or its display name depending on app
-    // type, so this resolves the real connected row rather than guessing
-    // at a single fallback (a guess broke Chrome, app_id "chrome-devtools"
-    // vs. display name "Chrome", with the pre-existing "prefer name"
-    // fallback; the reverse "prefer id" fallback breaks Facebook, app_id
-    // "facebook" vs. display name "Facebook Pages", the other direction).
+    // Add selected MCP servers back into tool_categories, resolved to the
+    // real connected MCPServer row's name -- see resolveMcpToolSelector for
+    // why a hard-coded id/name fallback can't work for every app.
     selectedMcpServers.forEach(server => {
       finalToolCategories.push(`mcp:${resolveMcpToolSelector(server, mcpServers, officialApps)}`)
     })
@@ -1541,6 +1553,11 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
             logo_url: updatedAgent.logo_url,
             ...(ownershipResult ?? {}),
           })
+          // Re-seed selectedMcpServers to match: see
+          // mcpServerNamesFromToolCategories's comment for why (isDirty
+          // would otherwise compare a resolved name against the
+          // display name the user picked, forever).
+          setSelectedMcpServers(mcpServerNamesFromToolCategories(finalToolCategories))
           // Sync the saved logo URL so the preview doesn't fall back to the
           // stale URL captured at initial load once logoFile is cleared below.
           setLogoUrl(updatedAgent.logo_url || null)
@@ -1577,6 +1594,11 @@ export function AgentBuilder({ agentId }: AgentBuilderProps) {
           // Newly created agents are always personal; promote if the user chose Team.
           const ownershipResult = await reconcileOwnership(newAgent.id.toString(), newAgent.team_id)
           setOriginalData({ ...newAgent, ...(ownershipResult ?? {}) })
+          // Same re-seed as the edit-mode branch above, and for the same
+          // reason: newAgent.tool_categories echoes back the resolved
+          // selectors this request submitted (finalToolCategories), not
+          // the possibly-unresolved values selectedMcpServers still holds.
+          setSelectedMcpServers(mcpServerNamesFromToolCategories(finalToolCategories))
           // Only confirm success once ownership resolved. If a promote was blocked
           // (the share-connectors dialog opened, ownershipResult is null), don't
           // stack a "created" dialog on top of it — but remember to show it when

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -1411,4 +1411,54 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       expect(new URLSearchParams(url.split("?")[1]).get("category")).toBe("Operations")
     })
   })
+
+  it("cleanly deselects a card whose stored selection is an id, instead of duplicating it", async () => {
+    // Regression test for a Major finding on #1280: a consumer (e.g.
+    // agent-builder.tsx, which re-seeds selectedMcpServers with a
+    // connector's resolved server-row name after a save) can pass this
+    // component a selection that names the connector by id
+    // ("chrome-devtools") rather than display name ("Chrome"). isSelected
+    // matches by id OR name, so the card renders selected either way -- but
+    // the toggle previously removed only by name, so clicking a
+    // visually-selected id-only entry appended the name instead of
+    // removing the id: both ended up present, the card stayed selected,
+    // and further clicks just oscillated between duplicated and
+    // stuck-selected, never reaching "deselected".
+    const onConnectSelected = vi.fn()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            {
+              id: "chrome-devtools",
+              name: "Chrome",
+              description: "",
+              icon: "",
+              is_connected: true,
+              transport: "stdio",
+              auth_type: "keyless",
+            },
+          ],
+        })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    render(
+      <ConnectMcpDialog
+        open
+        onOpenChange={vi.fn()}
+        selectedMcpServers={["chrome-devtools"]}
+        onConnectSelected={onConnectSelected}
+      />,
+    )
+    await screen.findByText("Chrome")
+
+    // One click on the visually-selected card must deselect it outright.
+    fireEvent.click(screen.getByText("Chrome"))
+
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenCalledWith([])
+  })
 })

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -914,9 +914,18 @@ export function ConnectMcpDialog({
 
   const handleCardClick = (app: AppIntegration, isGloballyConnected: boolean) => {
     if (isSelectMode && isGloballyConnected) {
+      // Match isSelected's own check (id OR name) below, not just name: a
+      // consumer (e.g. agent-builder.tsx re-seeding after save) can store
+      // this connector's id instead of its display name once resolved to
+      // its real server row. Toggling off by name only left an id-only
+      // selection un-removable -- the card looked selected, clicking it
+      // matched neither branch's name-only check, so it appended the name
+      // instead of removing the id, leaving both present (duplicated,
+      // still selected, and clicking again just oscillated between the two
+      // states without ever reaching "deselected").
       setLocalSelectedServers(prev =>
-        prev.includes(app.name)
-          ? prev.filter(name => name !== app.name)
+        prev.some(name => name === app.id || name === app.name)
+          ? prev.filter(name => name !== app.id && name !== app.name)
           : [...prev, app.name]
       );
     } else {

--- a/frontend/src/lib/mcp-lookup.test.ts
+++ b/frontend/src/lib/mcp-lookup.test.ts
@@ -94,16 +94,27 @@ describe("resolveMcpToolSelector", () => {
     ).toBe("chrome-devtools")
   })
 
-  it("preserves the raw selector unchanged when the app is known but no server row is connected yet", () => {
-    // Round-2 review: guessing connectedApp.id here was itself a
-    // wrong-convention guess for builtin_oauth apps (facebook), and,
-    // regardless of app type, risked overwriting an already-correct
-    // selector for a row this viewer simply can't currently see (a stale
-    // fetch, or a row query-restricted to this viewer) with a guessed one.
-    // Preserving the input unchanged is strictly safer than guessing.
+  it("preserves the raw selector unchanged -- never a guessed id or name -- when the app is known but no server row is connected yet", () => {
+    // Locks in the invariant: whatever the app type or naming convention,
+    // an unresolvable selector always comes back exactly as given, never
+    // substituted with a guess. That's what makes it safe to call on a
+    // selector that may already be correct for a row this viewer simply
+    // can't currently see.
     expect(resolveMcpToolSelector("Chrome", [], [chromeApp])).toBe("Chrome")
     expect(resolveMcpToolSelector("Facebook Pages", [], [facebookApp])).toBe(
       "Facebook Pages"
+    )
+  })
+
+  it("preserves the raw selector unchanged when a matched row's name is blank", () => {
+    // A row *is* found here (by app_id) -- unlike the no-row-at-all case
+    // above, this exercises the other unresolved path: a found row with
+    // nothing usable to return. Whitespace-only is deliberately included:
+    // "   " is truthy in JS, so this also pins that it's rejected by an
+    // explicit trim-and-check, not just a falsy check.
+    const mcpServers = [{ name: "   ", app_id: "facebook" }]
+    expect(resolveMcpToolSelector("facebook", mcpServers, [facebookApp])).toBe(
+      "facebook"
     )
   })
 

--- a/frontend/src/lib/mcp-lookup.test.ts
+++ b/frontend/src/lib/mcp-lookup.test.ts
@@ -35,32 +35,89 @@ describe("resolveMcpToolSelector", () => {
   // display name (_ensure_user_mcp_server) for builtin_oauth apps. A single
   // hard-coded fallback can only satisfy one -- these two apps diverge in
   // opposite directions and must both resolve correctly.
+  //
+  // Chrome is stdio transport: _enrich_oauth_server_info short-circuits on
+  // non-oauth transports, so its real connected row never carries an
+  // app_id -- just { name: "chrome-devtools" }, as used below.
   const chromeApp = { id: "chrome-devtools", name: "Chrome" }
+  // Facebook is oauth transport: GET /api/mcp/servers enriches oauth rows
+  // with app_id via _enrich_oauth_server_info, so its real row shape is
+  // { name: "Facebook Pages", app_id: "facebook" } -- carrying both.
   const facebookApp = { id: "facebook", name: "Facebook Pages" }
 
-  it("resolves a connected app-id-named server row (chrome-devtools convention)", () => {
+  it("resolves a connected app-id-named server row (chrome-devtools convention, no app_id on the row)", () => {
     const mcpServers = [{ name: "chrome-devtools" }]
     expect(resolveMcpToolSelector("Chrome", mcpServers, [chromeApp])).toBe(
       "chrome-devtools"
     )
   })
 
-  it("resolves a connected name-named server row (facebook builtin_oauth convention)", () => {
+  it("resolves a real oauth row carrying app_id (facebook, via step 1's direct app_id match)", () => {
+    const mcpServers = [{ name: "Facebook Pages", app_id: "facebook" }]
+    expect(resolveMcpToolSelector("facebook", mcpServers, [facebookApp])).toBe(
+      "Facebook Pages"
+    )
+  })
+
+  it("resolves a name-named row with no id at all (isolates the builtin_oauth name-fallback step)", () => {
+    // A row shaped like _ensure_user_mcp_server's convention with no app_id
+    // present at all -- unlike the case above, this can only resolve via
+    // resolveMcpToolSelector's app-name fallback step, not a direct id
+    // match, so it exercises that step independently.
     const mcpServers = [{ name: "Facebook Pages" }]
     expect(resolveMcpToolSelector("facebook", mcpServers, [facebookApp])).toBe(
       "Facebook Pages"
     )
   })
 
-  it("falls back to the app id when the app is known but no server row is connected yet", () => {
-    expect(resolveMcpToolSelector("Chrome", [], [chromeApp])).toBe(
-      "chrome-devtools"
+  it("picks the one matching row out of several connected servers", () => {
+    const mcpServers = [
+      { name: "Zoom" },
+      { name: "chrome-devtools" },
+      { name: "Facebook Pages", app_id: "facebook" },
+    ]
+    expect(
+      resolveMcpToolSelector("Chrome", mcpServers, [chromeApp, facebookApp])
+    ).toBe("chrome-devtools")
+    expect(
+      resolveMcpToolSelector("facebook", mcpServers, [chromeApp, facebookApp])
+    ).toBe("Facebook Pages")
+  })
+
+  it("round-trips an already-resolved real server name unchanged (loadAgent -> re-save)", () => {
+    // loadAgent seeds selectedMcpServers straight from a saved
+    // tool_categories entry, which after any save already holds the
+    // resolved real name -- the very next save must not perturb it.
+    const mcpServers = [{ name: "chrome-devtools" }]
+    expect(
+      resolveMcpToolSelector("chrome-devtools", mcpServers, [chromeApp])
+    ).toBe("chrome-devtools")
+  })
+
+  it("preserves the raw selector unchanged when the app is known but no server row is connected yet", () => {
+    // Round-2 review: guessing connectedApp.id here was itself a
+    // wrong-convention guess for builtin_oauth apps (facebook), and,
+    // regardless of app type, risked overwriting an already-correct
+    // selector for a row this viewer simply can't currently see (a stale
+    // fetch, or a row query-restricted to this viewer) with a guessed one.
+    // Preserving the input unchanged is strictly safer than guessing.
+    expect(resolveMcpToolSelector("Chrome", [], [chromeApp])).toBe("Chrome")
+    expect(resolveMcpToolSelector("Facebook Pages", [], [facebookApp])).toBe(
+      "Facebook Pages"
     )
   })
 
-  it("falls back to the raw selector when nothing matches at all", () => {
+  it("preserves the raw selector unchanged when nothing matches at all", () => {
     expect(resolveMcpToolSelector("some-custom-server", [], [])).toBe(
       "some-custom-server"
     )
+  })
+
+  it("preserves an empty selector unchanged rather than guessing", () => {
+    // Documents current behavior rather than asserting it's the ideal
+    // outcome: an empty selector never resolves to anything, so it passes
+    // through as "" (becoming the tool category "mcp:", handled downstream
+    // by selection_spec.py as an unmatchable scope entry).
+    expect(resolveMcpToolSelector("", [], [])).toBe("")
   })
 })

--- a/frontend/src/lib/mcp-lookup.test.ts
+++ b/frontend/src/lib/mcp-lookup.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
 
-import { findMatchingMcpApp, findMatchingMcpServer, mcpNameMatches } from "./mcp-lookup"
+import {
+  findMatchingMcpApp,
+  findMatchingMcpServer,
+  mcpNameMatches,
+  resolveMcpToolSelector,
+} from "./mcp-lookup"
 
 describe("MCP lookup helpers", () => {
   it("matches saved app ids to connected server names", () => {
@@ -20,5 +25,42 @@ describe("MCP lookup helpers", () => {
 
     expect(app?.id).toBe("google-drive")
     expect(mcpNameMatches("google-drive", "Google Drive")).toBe(true)
+  })
+})
+
+describe("resolveMcpToolSelector", () => {
+  // The backend has two contradictory conventions for a catalog app's real
+  // MCPServer row name: app_id (_ensure_catalog_app_server /
+  // _ensure_catalog_mcp_oauth_server) for shared-server apps, or the
+  // display name (_ensure_user_mcp_server) for builtin_oauth apps. A single
+  // hard-coded fallback can only satisfy one -- these two apps diverge in
+  // opposite directions and must both resolve correctly.
+  const chromeApp = { id: "chrome-devtools", name: "Chrome" }
+  const facebookApp = { id: "facebook", name: "Facebook Pages" }
+
+  it("resolves a connected app-id-named server row (chrome-devtools convention)", () => {
+    const mcpServers = [{ name: "chrome-devtools" }]
+    expect(resolveMcpToolSelector("Chrome", mcpServers, [chromeApp])).toBe(
+      "chrome-devtools"
+    )
+  })
+
+  it("resolves a connected name-named server row (facebook builtin_oauth convention)", () => {
+    const mcpServers = [{ name: "Facebook Pages" }]
+    expect(resolveMcpToolSelector("facebook", mcpServers, [facebookApp])).toBe(
+      "Facebook Pages"
+    )
+  })
+
+  it("falls back to the app id when the app is known but no server row is connected yet", () => {
+    expect(resolveMcpToolSelector("Chrome", [], [chromeApp])).toBe(
+      "chrome-devtools"
+    )
+  })
+
+  it("falls back to the raw selector when nothing matches at all", () => {
+    expect(resolveMcpToolSelector("some-custom-server", [], [])).toBe(
+      "some-custom-server"
+    )
   })
 })

--- a/frontend/src/lib/mcp-lookup.ts
+++ b/frontend/src/lib/mcp-lookup.ts
@@ -76,11 +76,20 @@ export const findMatchingMcpApp = <T extends McpLookupReference>(
 // So: resolve the actual connected MCPServer row and use its real name --
 // find the catalog app the selector refers to, then look up a server row
 // by that app's id, then by its name, covering both conventions regardless
-// of which one applies to this app. Only when no server row can be found
-// at all does this return the incoming selector completely unchanged
-// (never a guessed id or name) -- if it was already correct, it stays
-// correct; if the app genuinely isn't connected, there's nothing better to
-// substitute.
+// of which one applies to this app. This falls through to returning the
+// incoming selector completely unchanged (never a guessed id or name) in
+// two cases: no server row can be found at all, or a matched row's `name`
+// is empty/whitespace -- narrow (every known write path already requires a
+// non-blank name), but a row *was* found there, it just had nothing usable
+// to return. Either way, if the incoming selector was already correct, it
+// stays correct; if the app genuinely isn't connected, there's nothing
+// better to substitute.
+//
+// A caller that gets the unresolved input back has no signal of *why* --
+// only that this selector may load zero tools once persisted. Logged here
+// rather than surfaced as a user-facing warning: deciding the right UX for
+// that (a toast? which flows?) is a separate, larger call than this helper
+// should make on its own.
 export const resolveMcpToolSelector = <
   S extends McpLookupReference,
   A extends McpLookupReference
@@ -100,8 +109,13 @@ export const resolveMcpToolSelector = <
       ? findMatchingMcpServer(mcpServers, connectedApp.name)
       : undefined)
 
-  if (typeof connectedServer?.name === "string" && connectedServer.name) {
+  if (typeof connectedServer?.name === "string" && connectedServer.name.trim()) {
     return connectedServer.name
+  }
+  if (server) {
+    console.warn(
+      `resolveMcpToolSelector: could not resolve "${server}" to a connected MCP server row; persisting it unchanged, which may load zero tools for this connector.`
+    )
   }
   return server
 }

--- a/frontend/src/lib/mcp-lookup.ts
+++ b/frontend/src/lib/mcp-lookup.ts
@@ -52,3 +52,51 @@ export const findMatchingMcpApp = <T extends McpLookupReference>(
     hasSharedMcpLookupKey(getMcpLookupKeys(app.name, app.id), targetKeys)
   )
 }
+
+// Turns a selected connector (identified by whatever string the UI is
+// currently holding for it -- historically a mix of display names and ids)
+// into the string that should follow "mcp:" when building a tool-category
+// selector for the backend.
+//
+// The backend has two contradictory conventions for what a catalog app's
+// MCPServer row is actually named:
+//   - _ensure_catalog_app_server / _ensure_catalog_mcp_oauth_server
+//     (src/xagent/web/api/mcp.py) name the row after the app_id.
+//   - _ensure_user_mcp_server (src/xagent/web/api/auth.py), used for
+//     builtin_oauth apps, names the row after the display name.
+// Guessing a single fallback (id, or name) can only ever satisfy one
+// convention -- e.g. "chrome-devtools" (app_id) vs. "Chrome" (name) diverge
+// one way, "facebook" (app_id) vs. "Facebook Pages" (name) diverge the
+// other way, and a hard-coded id-first or name-first fallback silently
+// breaks whichever app uses the other convention.
+//
+// So this resolves the *real* server row instead of guessing at its name:
+// find the catalog app the selector refers to, then look up an actual
+// MCPServer row by that app's id, then by its name -- whichever convention
+// created the row, this finds it and returns its authoritative real name.
+// Only when no server row exists at all (not yet connected) does this fall
+// back to the app's id, then to the raw selector unchanged.
+export const resolveMcpToolSelector = <T extends McpLookupReference>(
+  server: string,
+  mcpServers: T[],
+  officialApps: T[]
+): string => {
+  const connectedApp = findMatchingMcpApp(officialApps, server)
+
+  const connectedServer =
+    findMatchingMcpServer(mcpServers, server) ||
+    (typeof connectedApp?.id === "string" && connectedApp.id
+      ? findMatchingMcpServer(mcpServers, connectedApp.id)
+      : undefined) ||
+    (typeof connectedApp?.name === "string" && connectedApp.name
+      ? findMatchingMcpServer(mcpServers, connectedApp.name)
+      : undefined)
+
+  if (typeof connectedServer?.name === "string" && connectedServer.name) {
+    return connectedServer.name
+  }
+  if (typeof connectedApp?.id === "string" && connectedApp.id) {
+    return connectedApp.id
+  }
+  return server
+}

--- a/frontend/src/lib/mcp-lookup.ts
+++ b/frontend/src/lib/mcp-lookup.ts
@@ -56,30 +56,38 @@ export const findMatchingMcpApp = <T extends McpLookupReference>(
 // Turns a selected connector (identified by whatever string the UI is
 // currently holding for it -- historically a mix of display names and ids)
 // into the string that should follow "mcp:" when building a tool-category
-// selector for the backend.
+// selector for the backend. The backend matches that selector by name only,
+// with no id fallback (src/xagent/core/tools/adapters/vibe/mcp_tools.py),
+// so an unresolved or wrongly-guessed selector silently loads zero tools
+// for that connector -- no error, just an agent that can't use it.
 //
-// The backend has two contradictory conventions for what a catalog app's
-// MCPServer row is actually named:
-//   - _ensure_catalog_app_server / _ensure_catalog_mcp_oauth_server
-//     (src/xagent/web/api/mcp.py) name the row after the app_id.
-//   - _ensure_user_mcp_server (src/xagent/web/api/auth.py), used for
-//     builtin_oauth apps, names the row after the display name.
-// Guessing a single fallback (id, or name) can only ever satisfy one
-// convention -- e.g. "chrome-devtools" (app_id) vs. "Chrome" (name) diverge
-// one way, "facebook" (app_id) vs. "Facebook Pages" (name) diverge the
-// other way, and a hard-coded id-first or name-first fallback silently
-// breaks whichever app uses the other convention.
+// Why this can't be "prefer id" or "prefer name": the backend has two
+// different conventions for what a catalog app's MCPServer row is actually
+// named -- _ensure_catalog_app_server / _ensure_catalog_mcp_oauth_server
+// (src/xagent/web/api/mcp.py) name shared-server rows after the app_id,
+// while _ensure_user_mcp_server (src/xagent/web/api/auth.py), used for
+// builtin_oauth apps, names the row after the display name. A single
+// hard-coded fallback direction can only ever match one convention, and
+// guessing wrong doesn't just fail to help -- it can *overwrite* a selector
+// that was already correct (e.g. because the app just isn't visible in
+// mcpServers yet: a stale fetch, or a row this viewer genuinely can't
+// query) with a wrong one, corrupting a previously-working selection.
 //
-// So this resolves the *real* server row instead of guessing at its name:
-// find the catalog app the selector refers to, then look up an actual
-// MCPServer row by that app's id, then by its name -- whichever convention
-// created the row, this finds it and returns its authoritative real name.
-// Only when no server row exists at all (not yet connected) does this fall
-// back to the app's id, then to the raw selector unchanged.
-export const resolveMcpToolSelector = <T extends McpLookupReference>(
+// So: resolve the actual connected MCPServer row and use its real name --
+// find the catalog app the selector refers to, then look up a server row
+// by that app's id, then by its name, covering both conventions regardless
+// of which one applies to this app. Only when no server row can be found
+// at all does this return the incoming selector completely unchanged
+// (never a guessed id or name) -- if it was already correct, it stays
+// correct; if the app genuinely isn't connected, there's nothing better to
+// substitute.
+export const resolveMcpToolSelector = <
+  S extends McpLookupReference,
+  A extends McpLookupReference
+>(
   server: string,
-  mcpServers: T[],
-  officialApps: T[]
+  mcpServers: S[],
+  officialApps: A[]
 ): string => {
   const connectedApp = findMatchingMcpApp(officialApps, server)
 
@@ -94,9 +102,6 @@ export const resolveMcpToolSelector = <T extends McpLookupReference>(
 
   if (typeof connectedServer?.name === "string" && connectedServer.name) {
     return connectedServer.name
-  }
-  if (typeof connectedApp?.id === "string" && connectedApp.id) {
-    return connectedApp.id
   }
   return server
 }


### PR DESCRIPTION
## Summary

Task/agent creation builds `mcp:<selector>` category strings for each
connected MCP connector the user selects. Both call sites in
`agent-builder.tsx` guessed at that selector instead of resolving it against
the actually-connected `MCPServer` row.

The backend has **two contradictory conventions** for what that row is
actually named:

- `_ensure_catalog_app_server` / `_ensure_catalog_mcp_oauth_server`
  (`src/xagent/web/api/mcp.py`) name the row after the catalog **app_id**.
- `_ensure_user_mcp_server` (`src/xagent/web/api/auth.py`), used for
  `builtin_oauth` apps, names the row after the display **name**.

`normalize_mcp_server_name`'s hyphen/space/case folding is deterministic, so
every previously-working connector's app_id and display name happened to
fold to the same key (Zoom → `zoom`, Google Maps → `google-maps`) — until
**Chrome** (#1179) diverged by a whole word: `app_id="chrome-devtools"`,
name `"Chrome"`. A name-first guess builds `mcp:Chrome`, matching no server
row, silently loading zero tools
(`mcp_load_summary: reason=no_tools_returned`) — the agent falls back to a
text-only answer with no visible error, even though connecting the app
looked successful.

## Fix

Added `resolveMcpToolSelector(server, mcpServers, officialApps)` to
`frontend/src/lib/mcp-lookup.ts`. Instead of guessing a fallback, it:

1. Finds the catalog app the current selection refers to.
2. Looks up a real, connected `MCPServer` row by that app's `id`, then by
   its `name` — covering both backend conventions regardless of which one
   applies to a given app.
3. Returns that row's authoritative real name.
4. Falls through to returning the incoming selector **completely
   unchanged** — never a guessed id or name — in two cases: no server row
   is connected at all, or a matched row's `name` is empty/whitespace. If
   the selector was already correct (e.g. the row just isn't in this
   viewer's current `mcpServers` snapshot yet), it stays correct; if the
   app genuinely isn't connected, there's nothing better to substitute.
   Logs a `console.warn` when this happens — dev-visible only; a
   user-facing signal is a separate, deferred design decision (see Review
   history).

Both call sites in `agent-builder.tsx` (the publish/create handler and the
builder-preview chat handler) call this shared helper instead of each
inlining its own resolution logic, dedup the resolved values with a `Set`
before building `tool_categories`, and both now push the `"knowledge"`
category when a knowledge base is selected (the preview-chat path was
missing it, diverging from what the agent would run with once actually
saved).

`selectedMcpServers` is also re-seeded from the resolved selectors
immediately after both save paths succeed (edit-mode update and initial
create), matching how `loadAgent` seeds it on a fresh load — otherwise it
keeps holding the pre-resolution value (e.g. a display name) while
`originalData.tool_categories` now holds the resolved real name, making the
editor's "unsaved changes" check compare the two and return true forever
after a successful save. The three other places that filtered/stripped
`mcp:` prefixes from `tool_categories` (`loadAgent`, template-requirements
loading, `isDirty`'s own extraction) now share the same
`mcpServerNamesFromToolCategories` helper the re-seed uses, so a future edit
to one can't silently drift out of sync with the others.

A connector's `connect-mcp-dialog.tsx` selection card is also fixed to
match `isSelected`'s own id-or-name check when toggling a card off — the
re-seed above can leave `selectedMcpServers` holding a connector's id
instead of its display name, and the toggle previously removed only by
name, so clicking a visually-selected id-only entry appended the name
instead of removing the id: the card stayed selected and duplicated no
matter how many more times it was clicked.

## Testing

- `frontend/src/lib/mcp-lookup.test.ts`: covers the app-id-named convention
  (Chrome), the app-id-carrying oauth-row convention and the isolated
  name-only-fallback convention (Facebook), disambiguating among several
  connected rows, an already-resolved-name round trip, the not-yet-connected
  fallback (preserves the input, never guesses), a matched-row-with-blank-name
  fallback, and the no-match/empty-string fallback.
- `frontend/src/components/build/agent-builder-mcp-selector-resolution.test.tsx`
  (new): mounts the real `AgentBuilder` component end to end and asserts (a)
  the outbound PUT body's `tool_categories` carries the resolved server name,
  not the unresolved display name held in `selectedMcpServers`, and (b)
  `isDirty` (observed via the Update button re-disabling) returns to false
  once the save succeeds. Verified this test actually catches the regression
  by reverting the `selectedMcpServers` re-seed and confirming it fails.
- `frontend/src/components/mcp/connect-mcp-dialog.test.tsx` (new case):
  mounts `ConnectMcpDialog` in select mode with an id-only initial selection
  and asserts one click on the visually-selected card deselects it outright,
  rather than duplicating it. Verified this test fails against the
  pre-fix toggle logic.
- `npx vitest run src/lib/mcp-lookup.test.ts src/components/build/agent-builder src/components/mcp/connect-mcp-dialog.test.tsx` — 106 passed.
- `npx tsc --noEmit` — clean.

**Known gaps (non-blocking, left for a follow-up):** the create-mode POST
branch's resolution/dedup, the preview-chat path's resolution/dedup/knowledge
push, and the async-load race noted in `agent-builder.tsx` (where a preview
message sent before `mcpServers`/`officialApps` have loaded falls back to the
raw selector) have no dedicated automated coverage yet — the edit-mode save
path and the connect-dialog toggle are the two covered end to end.

## Review history

- **Round 1** caught that the initial version hard-coded an app_id-first
  fallback, which fixed Chrome but risked breaking any app using the other
  naming convention the other way, and flagged zero test coverage on the
  original diff (both addressed by `resolveMcpToolSelector`).
- **Round 2** caught two further issues in that fix: (1) the
  not-yet-connected fallback still guessed `connectedApp.id`, which is the
  wrong convention for `builtin_oauth` apps and could overwrite an
  already-correct selector — removed; it now preserves the input unchanged
  instead of guessing. (2) `selectedMcpServers` was never re-seeded after a
  save, leaving `isDirty` permanently true — fixed at both save call sites.
  Round 2 also corrected an inaccuracy in round 1's own reasoning: Facebook's
  real connected server row does carry `app_id` (`_enrich_oauth_server_info`
  enriches oauth-transport rows), so an id-first guess would not actually
  have broken it the way round 1's comments claimed — the doc comment and
  test fixtures now reflect the real API shape.
- **Round 3** caught that the round-2 re-seed fix is directly reachable from
  `connect-mcp-dialog.tsx` (not touched by rounds 1-2), where the
  selection-card toggle only removed entries by display name — fixed as
  described above. Also flagged that the actual behavioral fix (outbound
  payload + `isDirty` clearing) had no test beyond the pure-helper unit
  tests — addressed by the new `agent-builder-mcp-selector-resolution.test.tsx`.
  Additional round-3 minors: a matched-row-with-blank-name edge case in the
  doc comment/behavior, missing dedup at both call sites, the missing
  `"knowledge"` category in the preview path, inconsistent create-mode
  seeding, and consolidating the three inlined `mcp:`-stripping copies onto
  one helper — all fixed.
- **Round 4 (approved)**: no blocking findings. Remaining minors, left
  as follow-ups: broader test coverage for the create-mode/preview-path/
  async-race branches (see "Known gaps" above), and a user-facing (not just
  `console.warn`) signal when a selector can't be resolved at save time.
