### PR TITLE
feat(interactions): resolve the interaction anchor and open the handoff surface

### DIFF
--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -43,7 +43,10 @@ from ...web.services.task_lease_service import (
     TASK_RUN_ID_TRACE_FIELD,
     current_task_lease,
 )
-from ...web.services.trace_event_staging import stage_trace_event_row
+from ...web.services.trace_event_staging import (
+    checkpoint_run_partition_filter,
+    stage_trace_event_row,
+)
 from ...web.services.trace_message_storage import (
     SQL_IN_CLAUSE_CHUNK_SIZE,
     CheckpointMessageDecodeError,
@@ -470,8 +473,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
 
     @staticmethod
     def _checkpoint_run_partition_filter(run_id: str | None) -> Any:
-        run_field = DatabaseTraceEvent.data[TASK_RUN_ID_TRACE_FIELD].as_string()
-        return run_field == run_id if run_id is not None else run_field.is_(None)
+        return checkpoint_run_partition_filter(run_id)
 
     def _load_pk_anchored_checkpoint(
         self,

--- a/src/xagent/web/services/interaction_rollout.py
+++ b/src/xagent/web/services/interaction_rollout.py
@@ -142,12 +142,15 @@ def gating_key(task: "Task") -> str | None:
 # constants -- even the families this PR does not increment -- so that later
 # producers (materialization, response handling, repair, command staging)
 # reuse this one registry instead of standing up a second counter parser.
-# This mirrors ops_signals's own "one owner, many producers" shape. Only the
-# rollout.decision.* family is incremented in this PR; every other constant
-# below is a placeholder naming its future owner. The nine placeholder
-# constants below are intentionally dead code until the producer named in
-# each one's comment lands and starts incrementing it -- not an oversight
-# to flag.
+# This mirrors ops_signals's own "one owner, many producers" shape. Two
+# families are actively incremented: rollout.decision.* by the publication
+# gate below, and anchor.* by resolve_interaction_anchor
+# (services/task_interaction_anchor.py) -- that resolver imports this
+# module's increment_counter rather than standing up a second registry, the
+# exact reuse this comment exists to encourage. Every other constant below
+# is a placeholder naming its future owner, intentionally dead code until
+# the producer named in each one's comment lands and starts incrementing it
+# -- not an oversight to flag.
 # ---------------------------------------------------------------------------
 COUNTER_ROLLOUT_DECISION_ALLOWED = "rollout.decision.allowed"
 COUNTER_ROLLOUT_DECISION_BLOCKED_MODE = "rollout.decision.blocked_mode"
@@ -158,6 +161,17 @@ COUNTER_ROLLOUT_DECISION_BLOCKED_UNKNOWN_SOURCE = (
 COUNTER_ROLLOUT_DECISION_BLOCKED_SCHEMA_ABSENT = (
     "rollout.decision.blocked_schema_absent"
 )
+
+# Incremented by resolve_interaction_anchor (task_interaction_anchor.py),
+# not by anything in this module -- named here because this registry is the
+# one counter namespace, not because the rollout gate produces them. There
+# is deliberately no anchor.corrupt counter alongside these three: the
+# corrupt outcome registers an ops_signals degradation instead (see that
+# resolver's own docstring for why the two observability surfaces diverge
+# there).
+COUNTER_ANCHOR_ABSENT_NO_RUN = "anchor.absent_no_run"
+COUNTER_ANCHOR_UNAVAILABLE_DANGLING_POINTER = "anchor.unavailable_dangling_pointer"
+COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE = "anchor.absent_legacy_checkpoint_type"
 
 # Not incremented by this PR -- placeholders for later owners sharing this
 # registry.

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -30,10 +30,11 @@ CHECKPOINT_PRUNE_FAILED = "checkpoint_prune_failed"
 INTERACTION_ROLLOUT_SCHEMA_ABSENT = "interaction_rollout_schema_absent"
 # Set when the interaction rollout gate sees a Task.source value that does
 # not normalize to a known origin. Deliberately not paired with a clear
-# site, unlike every other signal in this module: an unrecognized source is
-# a property of persisted data, and no in-process signal can observe that
-# data being fixed. Auto-clearing would assert "the data got fixed" without
-# evidence for it.
+# site: an unrecognized source is a property of persisted data, and no
+# in-process signal can observe that data being fixed. Auto-clearing would
+# assert "the data got fixed" without evidence for it. See
+# INTERACTION_ANCHOR_CORRUPT below for the same reasoning applied to a
+# different persisted-data corruption.
 INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE = "interaction_rollout_unknown_task_source"
 # interaction_handoff (task_interaction_staging.py) degrades instead of
 # losing a caller's turn on five expected failures, sharing this signal.
@@ -46,6 +47,14 @@ INTERACTION_HANDOFF_DEGRADED = "interaction_handoff_degraded"
 INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED = (
     "interaction_run_partition_mismatch_degraded"
 )
+# Set by resolve_interaction_anchor (task_interaction_anchor.py) when the
+# trace_events row its pointer names fails the ownership/type/partition/
+# identity checks that make it a valid anchor. Deliberately not paired with
+# a clear site, the same reasoning as INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE
+# above: a corrupt anchor is a property of a persisted trace_events row, and
+# no in-process registry can observe that row being fixed. Auto-clearing
+# would assert "the data got fixed" without evidence for it.
+INTERACTION_ANCHOR_CORRUPT = "interaction_anchor_corrupt"
 
 _signals: dict[str, str] = {}
 _lock = threading.Lock()

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -1,0 +1,227 @@
+"""Resolve one task's interaction anchor from its checkpoint pointer.
+
+This is the "other half" of anchor resolution ``InteractionAnchor``'s own
+docstring (``task_interaction_staging.py``) names: a primary-key read
+against ``trace_events``, performed here entirely outside any savepoint
+either staging primitive opens, before a caller ever builds an anchor to
+hand to ``stage_interaction_request`` or ``interaction_handoff``.
+
+Six-outcome judgment table, evaluated in order -- the order is the contract,
+not an implementation detail (see the corrupt-before-legacy note below):
+
+1. ``task.run_id IS NULL`` -> absence.
+2. ``task.last_checkpoint_trace_event_id IS NULL`` -> absence.
+3. the pointer names no live ``trace_events`` row -> unavailable, reported
+   to the caller as absence (see below for why).
+4. the row exists but fails any of six self-consistency conditions ->
+   corrupt.
+5. the row passes all six conditions but its ``checkpoint_type`` is a
+   legacy type -> absence, not corrupt.
+6. the row passes all six conditions and its ``checkpoint_type`` is the
+   current one -> a resolved ``InteractionAnchor``.
+
+Step 4 must run before step 5: a row belonging to a *different* task, even
+one whose ``checkpoint_type`` is legacy, must still be reported corrupt.
+Folding the two steps into one (checking legacy-type first) would let a
+cross-task row slip through as an ordinary absence instead -- see
+``test_task_interaction_anchor.py``'s mutation test for that ordering.
+
+``run_id IS NULL`` handling deliberately does not match
+``trace_event_staging.checkpoint_run_partition_filter``. That predicate
+treats ``run_id IS NULL`` as a legitimate partition (the root-checkpoint
+read path it was written for can genuinely have no run id yet) and matches
+rows whose own run field is also NULL. This function instead treats
+``task.run_id IS NULL`` as absence outright, at step 1, before any row is
+even read: ``InteractionAnchor.resume_run_partition`` is typed ``str``, and
+``_validate_anchor_fields`` (``task_interaction_staging.py``) raises
+``InteractionAnchorCorrupt`` for an empty string -- protocol v1 has no way
+to represent a NULL partition inside an anchor at all. Do not "align" this
+with the legacy predicate by matching a NULL run field or by reclassifying
+it as corrupt; the two functions are answering different questions about
+NULL on purpose.
+
+Step 3, the dangling pointer, is reported to the caller as absence, not as
+a distinct outcome, and this function does not scan the legacy
+``last_checkpoint_event_id`` column the way the trace-read side's fallback
+does (``_AnchorFallback``, ``trace_handlers.py``) -- unavailable and absence
+get different log levels (``logger.warning`` versus ``logger.info``) and
+only the former is counted, but both return ``None`` and both mean the same
+thing to this function's caller: there is no anchor to stage against.
+Folding them into one legacy-style scan is exactly the shape this function
+is built not to reproduce.
+
+``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED`` (``ops_signals.py``) is a
+signal owned by ``interaction_handoff``, not by this function: it is
+registered when that context manager swallows
+``InteractionRunPartitionMismatch``, an exception this function never
+raises. It is a pure data-corruption alarm, not an expected degradation
+channel the way the other five signals ``interaction_handoff`` registers
+are -- a resolved anchor's ``resume_run_partition`` always equals the
+``run_id`` this function read it against (step 4's partition-match
+condition enforces that), so a caller that passes this function's own
+output straight through to ``stage_interaction_request`` should see that
+signal at an expected frequency of zero in normal operation. A nonzero rate
+means the anchor a caller staged did not come from this function, or the
+run identity changed between resolution and staging.
+
+Zero production callers as of this module's introduction: a static test
+(``tests/web/services/test_task_interaction_anchor.py``) asserts that no
+production module calls ``resolve_interaction_anchor``, mirroring the
+existing gate for ``task_interaction_staging.py``'s two entry points
+without extending that gate itself -- this module is not one of the two
+names it scans for. See that test's own docstring for the removal
+condition.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ...core.agent.checkpoint import (
+    LEGACY_CHECKPOINT_TYPES,
+    READABLE_CHECKPOINT_TYPES,
+    checkpoint_execution_id,
+)
+from ..models.task import Task
+from ..models.task import TraceEvent as DatabaseTraceEvent
+from .interaction_rollout import (
+    COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE,
+    COUNTER_ANCHOR_ABSENT_NO_RUN,
+    COUNTER_ANCHOR_UNAVAILABLE_DANGLING_POINTER,
+    increment_counter,
+)
+from .ops_signals import INTERACTION_ANCHOR_CORRUPT, register_degradation
+from .task_interaction_staging import InteractionAnchor
+from .task_lease_service import TASK_RUN_ID_TRACE_FIELD
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_interaction_anchor(db: Session, task: Task) -> InteractionAnchor | None:
+    """Resolve ``task``'s interaction anchor from its checkpoint pointer, or
+    ``None`` if none applies -- see the module docstring for the six-outcome
+    table this function implements, in the order it must run.
+
+    Six self-consistency conditions are checked once a pointed-to row is
+    found (step 4); any one failing classifies the row as corrupt, copied
+    verbatim from ``_load_pk_anchored_checkpoint``'s own six conditions
+    (``trace_handlers.py``) rather than re-derived:
+
+    1. ``row.task_id != task.id`` -- ownership.
+    2. ``row.event_type != "system_update_general"`` -- not a checkpoint
+       row's event type.
+    3. ``row.build_id is not None`` -- must not be a build-partition row.
+    4. ``row_data.get("checkpoint_type") not in READABLE_CHECKPOINT_TYPES``
+       -- not a checkpoint row at all.
+    5. the row's run field does not match ``task.run_id`` -- the row
+       belongs to another run. Checked in Python against the fetched row's
+       own data, not via ``trace_event_staging.checkpoint_run_partition_filter``
+       (that predicate compiles to SQL for a query's ``WHERE`` clause; this
+       function already has the one candidate row in hand), but the same
+       equality semantics.
+    6. ``row_execution_id and row_execution_id != execution_id`` --
+       execution identity mismatch. An empty ``row_execution_id`` (a legacy
+       row with no identity field) short-circuits past this condition on
+       purpose -- this leniency is copied from the source condition, not a
+       gap to close.
+
+    ``InteractionAnchor`` carries no task id (see its own field list in
+    ``task_interaction_staging.py``). Once this function returns an anchor,
+    nothing downstream re-checks which task the anchored ``trace_events``
+    row belongs to -- ``_validate_anchor_fields`` only checks the dataclass
+    against itself, and the staging primitive's run-partition comparison is
+    about ``run_id``, not ownership. **This function is therefore the
+    single execution point of the ownership check.** Condition 1 below
+    (``row.task_id != task.id``) is not a redundant sanity assert; it is
+    the only one there is.
+
+    The anchor's ``resume_execution_id`` and the condition-6 ``execution_id``
+    it is checked against are both ``str(task.id)``: this function takes no
+    separate execution-identity argument the way
+    ``_load_pk_anchored_checkpoint`` does, because the web read path that
+    function serves passes it the task id already (see that function's own
+    docstring: "web's execution_id is the task id"). Using anything else
+    here (e.g. the row's own, possibly-empty ``row_execution_id``) could
+    persist an empty string into a column
+    (``ck_task_interaction_requests_resume_execution_id_nonempty``,
+    ``models/task_interaction.py``) that must never be empty.
+    """
+
+    if task.run_id is None:
+        logger.info("task %s has no run_id; no interaction anchor to resolve", task.id)
+        increment_counter(COUNTER_ANCHOR_ABSENT_NO_RUN)
+        return None
+
+    pointer_id = task.last_checkpoint_trace_event_id
+    if pointer_id is None:
+        logger.info(
+            "task %s has no checkpoint pointer; no interaction anchor to resolve",
+            task.id,
+        )
+        return None
+
+    row = db.get(DatabaseTraceEvent, pointer_id)
+    if row is None:
+        logger.warning(
+            "task %s's checkpoint pointer %s has no matching trace_events row",
+            task.id,
+            pointer_id,
+        )
+        increment_counter(COUNTER_ANCHOR_UNAVAILABLE_DANGLING_POINTER)
+        return None
+
+    row_data: dict[str, Any] = row.data if isinstance(row.data, dict) else {}
+    run_field = row_data.get(TASK_RUN_ID_TRACE_FIELD)
+    partition_matches = run_field == task.run_id
+    execution_id = str(task.id)
+    row_execution_id = checkpoint_execution_id(row_data)
+    if (
+        row.task_id != task.id
+        or row.event_type != "system_update_general"
+        or row.build_id is not None
+        or row_data.get("checkpoint_type") not in READABLE_CHECKPOINT_TYPES
+        or not partition_matches
+        or (row_execution_id and row_execution_id != execution_id)
+    ):
+        register_degradation(
+            INTERACTION_ANCHOR_CORRUPT,
+            f"task {task.id}: checkpoint pointer {pointer_id} does not "
+            "match the row it anchors",
+        )
+        logger.error(
+            "task %s's checkpoint pointer %s failed anchor validation",
+            task.id,
+            pointer_id,
+        )
+        return None
+
+    # Every row that survives the six conditions above has a
+    # checkpoint_type in READABLE_CHECKPOINT_TYPES (condition 4), which is
+    # exactly {CHECKPOINT_TYPE} | LEGACY_CHECKPOINT_TYPES -- so the branch
+    # below is exhaustive between steps 5 and 6, with nothing left over.
+    checkpoint_type = row_data.get("checkpoint_type")
+    if checkpoint_type in LEGACY_CHECKPOINT_TYPES:
+        logger.info(
+            "task %s's checkpoint pointer %s names a legacy checkpoint "
+            "type %r; no interaction anchor to resolve",
+            task.id,
+            pointer_id,
+            checkpoint_type,
+        )
+        increment_counter(COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE)
+        return None
+
+    logger.debug(
+        "task %s's checkpoint pointer %s resolved to an interaction anchor",
+        task.id,
+        pointer_id,
+    )
+    return InteractionAnchor(
+        trace_event_id=int(row.id),
+        resume_event_id=str(row.event_id),
+        resume_execution_id=execution_id,
+        resume_run_partition=task.run_id,
+    )

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -71,6 +71,29 @@ existing gate for ``task_interaction_staging.py``'s two entry points
 without extending that gate itself -- this module is not one of the two
 names it scans for. See that test's own docstring for the removal
 condition.
+
+Two kinds of pre-existing row fail the run-partition self-consistency
+check today and classify as corrupt rather than as absence, even though
+neither one represents actual data corruption. The first is a row whose
+checkpoint pointer was filled in by the migration that added
+``last_checkpoint_trace_event_id`` (2026-08): that migration backfills the
+pointer by matching a task's legacy event-id column against an existing
+``trace_events`` row, and that row was written before the run-partition
+field existed, so it never carries one. The second is any legacy-type
+checkpoint row, on any task, because the function that writes this field
+(``stage_trace_event_row``, ``trace_event_staging.py``) only ever writes
+it for current-type checkpoints -- a legacy-type row cannot carry the
+field regardless of when it was written. Both kinds of row are missing
+the field, fail the partition check before the legacy-type check ever
+runs, and register the corrupt-anchor degradation signal
+(``INTERACTION_ANCHOR_CORRUPT``, ``ops_signals.py``). That signal has no
+clearing point by design, so once one of these rows triggers it, it stays
+active until the process restarts. The change that wires this function's
+first production caller has to decide, before that caller ships, how a
+pre-existing row like this should be classified -- as corrupt, as
+absence, or some other way -- because the classification these rows get
+today is a side effect of when and how they were written, not a decision
+anyone made about what a caller should see for them.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/task_interaction_anchor.py
+++ b/src/xagent/web/services/task_interaction_anchor.py
@@ -24,7 +24,8 @@ Step 4 must run before step 5: a row belonging to a *different* task, even
 one whose ``checkpoint_type`` is legacy, must still be reported corrupt.
 Folding the two steps into one (checking legacy-type first) would let a
 cross-task row slip through as an ordinary absence instead -- see
-``test_task_interaction_anchor.py``'s mutation test for that ordering.
+``test_task_interaction_anchor.py``'s cross-task legacy-type cell for that
+ordering.
 
 ``run_id IS NULL`` handling deliberately does not match
 ``trace_event_staging.checkpoint_run_partition_filter``. That predicate
@@ -78,8 +79,8 @@ neither one represents actual data corruption. The first is a row whose
 checkpoint pointer was filled in by the migration that added
 ``last_checkpoint_trace_event_id`` (2026-08): that migration backfills the
 pointer by matching a task's legacy event-id column against an existing
-``trace_events`` row, and that row was written before the run-partition
-field existed, so it never carries one. The second is any legacy-type
+``trace_events`` row, and if that row predates the run-partition field
+(added before this migration), it carries none. The second is any legacy-type
 checkpoint row, on any task, because the function that writes this field
 (``stage_trace_event_row``, ``trace_event_staging.py``) only ever writes
 it for current-type checkpoints -- a legacy-type row cannot carry the

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -160,6 +160,29 @@ from .task_lease_service import TaskLease
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    # Entry points.
+    "interaction_handoff",
+    "stage_interaction_request",
+    # The object interaction_handoff yields.
+    "InteractionHandoff",
+    # Data carriers.
+    "InteractionAnchor",
+    "StagedInteractionRequest",
+    # Exceptions -- InteractionHandoffError is the common base every other
+    # one subclasses; see _SWALLOWED below for which six of these eight
+    # subclasses interaction_handoff degrades instead of propagating.
+    "InteractionHandoffError",
+    "InteractionAnchorCorrupt",
+    "InteractionAttemptMismatch",
+    "InteractionHandoffMisuse",
+    "InteractionOriginUnknown",
+    "InteractionOwnerStateError",
+    "InteractionRequestClosed",
+    "InteractionRunPartitionMismatch",
+    "InteractionSlotTaken",
+]
+
 _KIND_VOCABULARY = frozenset({"clarification"})
 # Derived from the model's own INTERACTION_ORIGIN_VOCABULARY (the merged
 # rollout-controls change owns the vocabulary now), not a second
@@ -273,7 +296,7 @@ class InteractionAnchorCorrupt(InteractionHandoffError):
 class InteractionAttemptMismatch(InteractionHandoffError):
     """The caller's lease no longer names the task's current attempt.
 
-    Raised by ``_InteractionHandoff.stage()``, at the start of the call,
+    Raised by ``InteractionHandoff.stage()``, at the start of the call,
     before any staging SQL is issued -- not by ``interaction_handoff``'s
     ``__enter__`` (see ``stage()``'s own docstring for why this
     precondition has to live there). Raised when
@@ -343,7 +366,7 @@ class InteractionHandoffMisuse(InteractionHandoffError):
       ``with`` block -- violating ``interaction_handoff``'s "no I/O in
       between" obligation -- whether or not ``stage()`` had already
       succeeded (zero calls is otherwise legal on its own -- see
-      ``_InteractionHandoff``'s own docstring). Both operations end the
+      ``InteractionHandoff``'s own docstring). Both operations end the
       whole transaction, deactivating this context manager's own outer
       savepoint along with it; by the time the block exits normally, that
       savepoint no longer exists to commit. Raising here instead of
@@ -449,10 +472,15 @@ class InteractionAnchor:
 
     Represents only half of anchor resolution. The other half -- a database
     read against ``trace_events`` by primary key, layered into
-    absence/unavailable/corrupt outcomes with a legacy-column fallback -- is
-    a caller obligation that belongs to the change that wires a production
-    reader, because it is a DB read that must happen outside any savepoint
-    this module opens. What this dataclass carries is the *result* of that
+    absence/unavailable/corrupt outcomes -- is a caller obligation that
+    belongs to the change that wires a production reader, because it is a DB
+    read that must happen outside any savepoint this module opens. That
+    resolution (``resolve_interaction_anchor``,
+    ``task_interaction_anchor.py``) reports an unavailable pointer as
+    absence uniformly, with no fallback scan of the legacy
+    ``last_checkpoint_event_id`` column -- see that function's own docstring
+    for why the two are not folded together. What this dataclass carries is
+    the *result* of that
     read once the caller already has one in hand: the fields both
     ``stage_interaction_request`` and ``interaction_handoff`` validate for
     self-consistency (non-empty strings, the two closed vocabularies, and a
@@ -509,7 +537,7 @@ class StagedInteractionRequest:
 def _validate_anchor_fields(anchor: InteractionAnchor) -> None:
     """The plain-Python half of anchor validation, shared by
     ``stage_interaction_request``'s own pre-INSERT check and
-    ``_InteractionHandoff.stage()``'s own precondition check -- both now run
+    ``InteractionHandoff.stage()``'s own precondition check -- both now run
     at the start of their respective calls, not in ``__enter__`` -- so the
     two never drift into checking different things for the same dataclass.
 
@@ -1078,10 +1106,16 @@ def stage_interaction_request(
 # ---------------------------------------------------------------------------
 
 
-class _InteractionHandoff:
+class InteractionHandoff:
     """The object ``interaction_handoff`` yields. Constructed once per
     ``with`` block; ``stage`` may be called exactly once (zero calls is
     legal: a caller may decide not to ask).
+
+    This class is constructed only by ``interaction_handoff``. Constructing
+    it directly bypasses the savepoint that function owns, so a row a direct
+    construction stages has none of the handoff's containment guarantees --
+    nothing rolls it back on a swallowed failure, because nothing opened the
+    savepoint that rollback would target.
     """
 
     def __init__(
@@ -1098,14 +1132,22 @@ class _InteractionHandoff:
         self.task = task
         self.anchor = anchor
         self.now = now
+        # Call count, for the one-call-per-handoff reentry rule -- True the
+        # instant stage() is entered, before it is known whether a call
+        # actually produced a row. Distinct from self.staged, set below,
+        # which records the row: a stage() call that raises before
+        # stage_interaction_request returns leaves _staged True (it was
+        # called) but self.staged None (nothing was produced). The misuse
+        # handler in interaction_handoff reads self.staged, not this flag,
+        # to tell the two apart.
         self._staged = False
-        # Whether a call to stage() actually returned a staged row, as
-        # opposed to _staged, which only counts that stage() was called at
-        # all (the one-call-per-handoff reentry rule) regardless of whether
-        # that call raised before ever staging anything. See stage()'s own
-        # assignment of this flag, and the misuse handler below that reads
-        # it, for why the two must not be conflated.
-        self._staged_row = False
+        # The row stage() actually produced, or None if stage() was never
+        # called, or was called but raised before stage_interaction_request
+        # returned. This is the object's public degradation surface: a
+        # caller can check `handoff.staged is None` after the `with` block
+        # to know whether this round staged an interaction row, without
+        # consulting the ops_signals registry.
+        self.staged: StagedInteractionRequest | None = None
 
     def _assert_current_attempt(self) -> None:
         """``lease.attempt_id is None`` is a fail-open sentinel (a
@@ -1229,11 +1271,12 @@ class _InteractionHandoff:
             expires_at=expires_at,
             now=self.now,
         )
-        # Only set once stage_interaction_request has actually returned a
-        # row -- an exception from any of it (the misclassification funnel,
-        # a DataError, ...) leaves this False, which is what the misuse
-        # handler below relies on to keep its message accurate.
-        self._staged_row = True
+        # Only assigned once stage_interaction_request has actually returned
+        # a row -- an exception from any of it (the misclassification
+        # funnel, a DataError, ...) leaves self.staged at its __init__
+        # default of None, which is what the misuse handler below relies on
+        # to keep its message accurate.
+        self.staged = result
         return result
 
 
@@ -1265,7 +1308,7 @@ def interaction_handoff(
     task: Task,
     anchor: InteractionAnchor,
     now: datetime,
-) -> Iterator[_InteractionHandoff]:
+) -> Iterator[InteractionHandoff]:
     """Open the savepoint one interaction handoff lives in and degrade --
     instead of losing the caller's turn -- on a closed set of expected
     failures, including the caller's lease no longer owning the task's
@@ -1521,7 +1564,7 @@ def interaction_handoff(
     # function is a @contextmanager generator, would fire from __enter__ --
     # before `with` ever runs its body, and before this savepoint could be
     # unwound the way every other exit path below unwinds it.
-    handoff = _InteractionHandoff(db, lease, task=task, anchor=anchor, now=now)
+    handoff = InteractionHandoff(db, lease, task=task, anchor=anchor, now=now)
     try:
         yield handoff
     except _SWALLOWED as exc:
@@ -1584,14 +1627,14 @@ def interaction_handoff(
         raise
     else:
         if not savepoint.is_active:
-            # handoff._staged_row tells the two ways this misuse can happen
+            # handoff.staged tells the two ways this misuse can happen
             # apart: a caller can violate the no-I/O-in-between obligation
             # either after a successful stage() (there is a real staged row
             # whose containment just vanished) or without ever calling
             # stage() at all, or calling it but never reaching a staged row
-            # (zero calls is otherwise legal -- see _InteractionHandoff's
-            # own docstring -- and a stage() call that raised before
-            # returning also leaves nothing staged), so the caller's own
+            # (zero calls is otherwise legal -- see InteractionHandoff's own
+            # docstring -- and a stage() call that raised before returning
+            # also leaves nothing staged), so the caller's own
             # commit/rollback still deactivated this savepoint the same way
             # with no row behind it. Same exception type either way; only
             # the message should claim a staged row exists when one does.
@@ -1600,7 +1643,7 @@ def interaction_handoff(
             # stage() is entered, before it is known whether a row was ever
             # staged, which would make this message claim a row exists even
             # when stage() raised before staging anything.
-            if handoff._staged_row:
+            if handoff.staged is not None:
                 raise InteractionHandoffMisuse(
                     "the caller committed or rolled back inside the "
                     "interaction_handoff block; the savepoint that contains "

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -679,7 +679,7 @@ def _validate_request_fields(
     # own json.loads but is not valid JSON text. The two backends then
     # diverge on what a real INSERT does with it -- SQLite has no native
     # JSON type and stores the column as TEXT, so it stores that invalid
-    # JSON verbatim with no complaint at all; PostgreSQL's jsonb parser
+    # JSON verbatim with no complaint at all; PostgreSQL's JSON parser
     # rejects it, raising DataError, not StatementError. Passing
     # allow_nan=False makes this probe raise ValueError for NaN/Infinity
     # before either of those divergent, backend-specific outcomes is ever

--- a/src/xagent/web/services/trace_event_staging.py
+++ b/src/xagent/web/services/trace_event_staging.py
@@ -156,5 +156,33 @@ def stage_trace_event_row(
                 trace_event_id=row_id,
             ),
         )
-
     return StagedTraceRow(row_id=None, stored_data=data, anchor=None)
+
+
+def checkpoint_run_partition_filter(run_id: str | None) -> Any:
+    """The run-partition predicate the legacy checkpoint scan uses to filter
+    ``trace_events`` rows by run partition
+    (``DatabaseTraceHandler._checkpoint_run_partition_filter``,
+    ``web/api/trace_handlers.py``).
+
+    Moved here, unchanged, from that ``trace_handlers.py`` staticmethod: this
+    module already imports every name the predicate needs
+    (``DatabaseTraceEvent``, ``TASK_RUN_ID_TRACE_FIELD``), and services must
+    not import from api, so the move means a future services-layer consumer
+    of this predicate never has to reverse-import the api layer to get it.
+
+    The interaction anchor resolver (``resolve_interaction_anchor``,
+    ``services/task_interaction_anchor.py``) is not such a consumer -- it
+    never calls this function. It does its own plain-Python equality check
+    against a single already-fetched row instead of building a SQL predicate
+    for a query's ``WHERE`` clause, and is mentioned here only as this
+    function's semantic sibling: the two answer the same run-partition-match
+    question, but disagree on what ``run_id IS NULL`` means. ``run_id is
+    None`` is a legitimate partition here -- the root-checkpoint read path
+    this predicate was written for can genuinely have no run id yet --
+    which is why it compiles to ``IS NULL`` rather than being rejected. The
+    resolver instead treats ``task.run_id IS NULL`` as absence outright,
+    before any row is even read (see that module's own docstring for why).
+    """
+    run_field = DatabaseTraceEvent.data[TASK_RUN_ID_TRACE_FIELD].as_string()
+    return run_field == run_id if run_id is not None else run_field.is_(None)

--- a/src/xagent/web/services/trace_event_staging.py
+++ b/src/xagent/web/services/trace_event_staging.py
@@ -156,6 +156,7 @@ def stage_trace_event_row(
                 trace_event_id=row_id,
             ),
         )
+
     return StagedTraceRow(row_id=None, stored_data=data, anchor=None)
 
 

--- a/tests/web/services/test_interaction_handoff_surface.py
+++ b/tests/web/services/test_interaction_handoff_surface.py
@@ -1,0 +1,341 @@
+"""Contract tests for ``InteractionHandoff``'s public surface: the
+``staged`` observability field, the ``__all__`` public boundary, and the
+zero-direct-construction guard the public rename makes necessary (T-A-12).
+
+This is a companion to ``test_interaction_staging.py``, not a replacement
+for any of it -- the six-swallowed-exception degrade matrix, the savepoint
+containment group, and every other primitive-level behavior stay pinned
+there. This file isolates the surface that changed here: the renamed
+public class, the field that replaced ``_staged_row``, and the explicit
+``__all__`` list -- kept separate so a reviewer looking for "what did this
+change touch" does not have to diff a 2000-line file to find it.
+"""
+
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timedelta, timezone
+from itertools import count
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import xagent
+from tests.web.services.task_interaction_schema_shared import (
+    make_task,
+    make_trace_event,
+    make_user,
+)
+from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task
+from xagent.web.services import ops_signals
+from xagent.web.services import task_interaction_staging as staging
+from xagent.web.services.task_interaction_staging import (
+    InteractionAnchor,
+    StagedInteractionRequest,
+    interaction_handoff,
+    stage_interaction_request,
+)
+from xagent.web.services.task_lease_service import TaskLease
+
+_key_counter = count()
+
+
+def _engine(tmp_path: Path):
+    db_path = tmp_path / "interaction_handoff_surface.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    apply_sqlite_concurrency_pragmas(engine)
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def _session_factory(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _seed(session_factory) -> tuple[int, int]:
+    db = session_factory()
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    anchor_id = make_trace_event(db, task_id=task_id)
+    db.close()
+    return task_id, anchor_id
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _anchor(trace_event_id: int, **overrides: Any) -> InteractionAnchor:
+    values: dict[str, Any] = {
+        "trace_event_id": trace_event_id,
+        "resume_event_id": "resume-event-1",
+        "resume_execution_id": "resume-exec-1",
+        "resume_run_partition": "run-a",
+    }
+    values.update(overrides)
+    return InteractionAnchor(**values)
+
+
+def _lease(task_id: int, *, run_id: str = "run-a") -> TaskLease:
+    return TaskLease(
+        task_id=task_id, runner_id="runner-1", run_id=run_id, attempt_id=None
+    )
+
+
+def _next_key() -> str:
+    return f"key-{next(_key_counter)}"
+
+
+def _stage_kwargs(**overrides: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "kind": "clarification",
+        "protocol_version": 1,
+        "request_payload": {"prompt": "example"},
+        "request_idempotency_key": _next_key(),
+        "expires_at": _now() + timedelta(minutes=15),
+    }
+    values.update(overrides)
+    return values
+
+
+@pytest.fixture(autouse=True)
+def _reset_ops_signals():
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+    yield
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+
+
+# ---------------------------------------------------------------------------
+# T-H-1: success -- handoff.staged is stage()'s own return value, the same
+# object, not merely an equal one.
+# ---------------------------------------------------------------------------
+
+
+def test_th1_staged_holds_the_row_stage_returned(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        result = h.stage(**_stage_kwargs())
+        # Asserted *inside* the with-block, before the savepoint commits, so
+        # this pins the object identity stage() itself hands back -- not
+        # some later re-derivation after commit.
+        assert h.staged is result
+        assert isinstance(h.staged, StagedInteractionRequest)
+
+    db.commit()
+    assert h.staged is result
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-H-2: zero stage() calls is legal -- documented, not an error path.
+# ---------------------------------------------------------------------------
+
+
+def test_th2_zero_stage_calls_leaves_staged_none(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        pass
+
+    db.commit()
+    assert h.staged is None
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-H-3: degraded -- staged stays None, and the caller's code after the
+# with-block runs normally (the with-block itself never raises).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", ["slot-taken", "run-partition-mismatch"])
+def test_th3_degraded_stage_leaves_staged_none(tmp_path: Path, case: str) -> None:
+    """Two of the six swallowed types, not all six -- test_interaction_staging.py's
+    T-CM-1 already parametrizes the full six-plus-replay matrix for
+    degrade-vs-signal-vs-caller-write behavior; this only needs enough
+    cells to prove ``staged`` behaves the same way regardless of which
+    signal fired, per the module's own dispatch table
+    (``_DEGRADATION_SIGNALS``). ``InteractionRunPartitionMismatch`` is
+    included specifically because it registers the *other* signal
+    (``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED``), not
+    ``INTERACTION_HANDOFF_DEGRADED`` -- proving ``staged`` does not depend
+    on which signal a given swallowed type maps to.
+    """
+
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+
+    if case == "slot-taken":
+        stage_interaction_request(
+            db,
+            task_id=task_id,
+            run_id=lease.run_id,
+            anchor=anchor,
+            origin="internal",
+            now=_now(),
+            **_stage_kwargs(),
+        )
+        db.commit()
+    else:
+        assert case == "run-partition-mismatch"
+        anchor = _anchor(anchor_id, resume_run_partition="some-other-run")
+
+    task = db.get(Task, task_id)
+    with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+        h.stage(**_stage_kwargs())
+    db.commit()
+
+    assert h.staged is None
+    # The with-block above completed without raising -- reaching this line
+    # at all is part of the assertion; a caller's code after the block runs
+    # exactly the way it does on a clean exit.
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-H-5: equivalence -- the two misuse messages must still tell "a row was
+# staged" apart from "no row was staged" after _staged_row's removal.
+# ---------------------------------------------------------------------------
+
+
+def test_th5a_misuse_message_after_a_successful_stage_names_a_row(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with pytest.raises(
+        staging.InteractionHandoffMisuse,
+        match="the staged interaction row no longer exists",
+    ):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
+            h.stage(**_stage_kwargs())
+            db.commit()
+
+    db.close()
+
+
+def test_th5b_misuse_message_after_zero_stage_calls_names_no_row(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    task_id, anchor_id = _seed(session_factory)
+    db = session_factory()
+    anchor = _anchor(anchor_id)
+    lease = _lease(task_id)
+    task = db.get(Task, task_id)
+
+    with pytest.raises(
+        staging.InteractionHandoffMisuse,
+        match="no interaction row was staged",
+    ):
+        with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()):
+            db.commit()
+
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-H-6: __all__ -- every name resolves, none are private, InteractionHandoff
+# is in it.
+# ---------------------------------------------------------------------------
+
+
+def test_th6_all_names_resolve_and_are_public() -> None:
+    assert staging.__all__, "task_interaction_staging.__all__ must not be empty"
+    for name in staging.__all__:
+        assert not name.startswith("_"), (
+            f"{name!r} in __all__ starts with an underscore"
+        )
+        assert hasattr(staging, name), (
+            f"{name!r} is in __all__ but not defined on the module"
+        )
+    assert "InteractionHandoff" in staging.__all__
+    assert len(staging.__all__) == len(set(staging.__all__)), (
+        "duplicate name in __all__"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T-A-12: InteractionHandoff has zero direct-construction points in src/
+# outside its own defining module (task_interaction_staging.py). Publicizing
+# the class (F-3(a), this module's own rename) makes direct construction
+# syntactically possible for the first time -- this guard depends on that
+# rename having already landed, which is why it lives here rather than in
+# test_task_interaction_anchor.py, whose own dependencies do not carry it.
+# ---------------------------------------------------------------------------
+
+_HANDOFF_CLASS_NAME = "InteractionHandoff"
+_STAGING_MODULE_STEM = "task_interaction_staging"
+
+
+def _direct_construction_uses(source: str) -> bool:
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == _HANDOFF_CLASS_NAME:
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == _HANDOFF_CLASS_NAME:
+                return True
+    return False
+
+
+def _scan_root(exclude_stem: str) -> list[Path]:
+    root = Path(next(iter(xagent.__path__)))
+    modules = [p for p in root.rglob("*.py") if p.stem != exclude_stem]
+    assert modules, "production scan set is empty"
+    return modules
+
+
+def test_ta12_interaction_handoff_has_zero_direct_construction_points() -> None:
+    """A direct ``InteractionHandoff(...)`` call anywhere else in ``src/``
+    would build an object whose ``stage()`` runs with no containment at
+    all: ``interaction_handoff`` is the only place that owns the savepoint
+    a constructed instance needs to mean anything.
+    """
+
+    offenders: dict[str, bool] = {}
+    for path in _scan_root(_STAGING_MODULE_STEM):
+        source = path.read_text(encoding="utf-8")
+        if _direct_construction_uses(source):
+            offenders[str(path)] = True
+    assert offenders == {}
+    # Positive control: the module's own defining source, scanned directly,
+    # does contain exactly this construction (interaction_handoff's own
+    # `handoff = InteractionHandoff(...)`) -- proving the stem exclusion is
+    # doing real work, not vacuously passing because nothing in the tree
+    # constructs this class at all.
+    import xagent.web.services.task_interaction_staging as staging_module
+
+    own_source = Path(staging_module.__file__).read_text(encoding="utf-8")
+    assert _direct_construction_uses(own_source)

--- a/tests/web/services/test_interaction_handoff_surface.py
+++ b/tests/web/services/test_interaction_handoff_surface.py
@@ -1,6 +1,6 @@
 """Contract tests for ``InteractionHandoff``'s public surface: the
 ``staged`` observability field, the ``__all__`` public boundary, and the
-zero-direct-construction guard the public rename makes necessary (T-A-12).
+zero-direct-construction guard the public rename makes necessary.
 
 This is a companion to ``test_interaction_staging.py``, not a replacement
 for any of it -- the six-swallowed-exception degrade matrix, the savepoint
@@ -287,11 +287,11 @@ def test_th6_all_names_resolve_and_are_public() -> None:
 
 
 # ---------------------------------------------------------------------------
-# T-A-12: InteractionHandoff has zero direct-construction points in src/
-# outside its own defining module (task_interaction_staging.py). Publicizing
-# the class (F-3(a), this module's own rename) makes direct construction
-# syntactically possible for the first time -- this guard depends on that
-# rename having already landed, which is why it lives here rather than in
+# InteractionHandoff has zero direct-construction points in src/ outside
+# its own defining module (task_interaction_staging.py). Publicizing the
+# class (this module's own rename) makes direct construction syntactically
+# possible for the first time -- this guard depends on that rename having
+# already landed, which is why it lives here rather than in
 # test_task_interaction_anchor.py, whose own dependencies do not carry it.
 # ---------------------------------------------------------------------------
 

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -2075,8 +2075,8 @@ def test_cm3_attempt_assertion_gates_on_not_none(tmp_path: Path) -> None:
 
 
 def test_cm3b_zero_stage_calls_is_legal(tmp_path: Path) -> None:
-    """F-11: zero stage() calls is legal (see _InteractionHandoff's own
-    docstring, task_interaction_staging.py :1038-1042) -- a caller may open
+    """F-11: zero stage() calls is legal (see InteractionHandoff's own
+    docstring, task_interaction_staging.py) -- a caller may open
     interaction_handoff, decide not to ask, and exit normally with nothing
     staged."""
 
@@ -2381,9 +2381,8 @@ def test_cm8c_normal_exit_after_deactivation_without_a_stage_call_names_no_row(
     savepoint the same way T-CM-8b's does -- the misuse detection does not
     require a prior ``stage()`` call to fire. The two variants must not
     share a message that claims a staged row exists when
-    ``handoff._staged_row`` is still ``False``: this pins the "no
-    interaction row was staged" wording for that case, while T-CM-8b pins
-    the other."""
+    ``handoff.staged`` is still ``None``: this pins the "no interaction row
+    was staged" wording for that case, while T-CM-8b pins the other."""
 
     engine = _engine(tmp_path)
     session_factory = _session_factory(engine)
@@ -2407,13 +2406,13 @@ def test_cm8c_normal_exit_after_deactivation_without_a_stage_call_names_no_row(
 def test_cm8d_stage_call_that_raises_before_staging_names_no_row(
     tmp_path: Path,
 ) -> None:
-    """The case the ``_staged`` / ``_staged_row`` split exists for:
+    """The case the ``_staged`` / ``staged`` split exists for:
     ``h.stage()`` is called (so ``_staged`` -- the one-call-per-handoff
     reentry counter -- is ``True`` from the first line of ``stage()``,
     before any of its own checks run), but this call's ``lease`` has no
     ``run_id``, so ``stage()`` raises ``ValueError`` before it ever calls
-    ``stage_interaction_request`` -- no row was staged, so ``_staged_row``
-    stays ``False``. The caller here catches that ``ValueError`` itself,
+    ``stage_interaction_request`` -- no row was staged, so ``staged``
+    stays ``None``. The caller here catches that ``ValueError`` itself,
     inside the ``with`` block, and then commits from inside it -- the same
     no-I/O-in-between violation T-CM-8b/T-CM-8c construct, deactivating
     this handoff's own savepoint. The misuse message that follows must

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -43,10 +43,11 @@ from typing import Any
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import event
-from sqlalchemy.exc import IntegrityError, InternalError
+from sqlalchemy.exc import DataError, IntegrityError, InternalError
 from sqlalchemy.orm import Session, sessionmaker
 
 from tests.web.services.task_interaction_schema_shared import (
+    make_row,
     make_task,
     make_trace_event,
     make_user,
@@ -254,6 +255,94 @@ def test_p_over_length_run_id_rejected_before_sql_via_handoff(
         s.strip().upper().startswith(("INSERT", "UPDATE")) for s in issued
     ), issued
     db.rollback()
+
+
+# ---------------------------------------------------------------------------
+# T-PG group: two backend facts that, until now, lived only in comments
+# (``_MAX_LENGTHS``'s and the ``allow_nan=False`` probe's), with no test
+# actually exercising the PostgreSQL behavior those comments predict. Both
+# cells bypass ``stage_interaction_request``'s Python-side validation
+# entirely -- a direct Core INSERT against the table, not the primitive --
+# because that validation is exactly what ordinarily preempts the backend
+# outcome each cell is pinning: the test above this one
+# (T-P, ``test_p_over_length_run_id_rejected_before_sql_via_handoff``)
+# already proves the Python guard fires first, not what happens if it
+# didn't. Both must raise DataError specifically, not IntegrityError or its
+# base -- that distinction is the entire reason
+# ``_MAX_LENGTHS``/``allow_nan=False`` exist as *Python* guards rather than
+# relying on the database's own CHECK/conflict-classification machinery
+# (see the module docstring of task_interaction_staging.py's own
+# misclassification-funnel paragraph). If either assertion below observes
+# the opposite of what its guard's comment predicts, that is a defect in
+# the guard's own justification, not in this test -- do not loosen the
+# assertion to match.
+# ---------------------------------------------------------------------------
+
+
+def test_pg1_over_length_run_id_rejected_by_backend_as_data_error(
+    db_session, fixtures
+) -> None:
+    """``run_id`` is ``String(64)``; a direct 65-character INSERT must raise
+    ``DataError`` on PostgreSQL, not ``IntegrityError`` -- the fact
+    ``_MAX_LENGTHS``'s comment (``task_interaction_staging.py``) predicts to
+    justify deriving those caps from the model instead of trusting a CHECK
+    constraint to catch an over-length value."""
+
+    task_id, anchor_id = fixtures
+    row = make_row(
+        task_id=task_id,
+        resume_trace_event_id=anchor_id,
+        run_id="x" * 65,
+    )
+    db = db_session
+    try:
+        with pytest.raises(DataError) as excinfo:
+            db.execute(sa.insert(TaskInteractionRequest.__table__).values(**row))
+        # pytest.raises(DataError) already does the real pinning (accepts
+        # DataError or a subclass); "not IntegrityError" would be a
+        # tautology (the two are siblings under DBAPIError, never
+        # overlapping) and "not StatementError" is unassertable here --
+        # DataError is itself a StatementError subclass. Exact-type instead,
+        # ruling out DataError's own subclasses too.
+        assert type(excinfo.value) is DataError
+    finally:
+        db.rollback()
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")], ids=["nan", "inf"])
+def test_pg2_non_finite_json_payload_rejected_by_backend_as_data_error(
+    db_session, fixtures, value: float
+) -> None:
+    """A direct INSERT whose ``request_payload`` contains a non-finite float
+    must raise ``DataError`` on PostgreSQL, not ``StatementError`` -- the
+    fact the ``allow_nan=False`` probe's comment
+    (``task_interaction_staging.py``) predicts to justify rejecting NaN/
+    Infinity in Python before the INSERT is issued, rather than trusting
+    the database's own JSON parser to catch it. This bypasses that probe by
+    using the default SQLAlchemy JSON binder (``json.dumps`` with its
+    default ``allow_nan=True``), which renders the bare, non-JSON tokens
+    ``NaN`` / ``Infinity`` the probe exists to catch. The column's
+    PostgreSQL type is ``JSON`` here, not ``jsonb`` (see the corrected
+    comment this cell pins alongside itself) -- the JSON input function
+    that rejects these tokens is the same one either type name would use.
+    """
+
+    task_id, anchor_id = fixtures
+    row = make_row(
+        task_id=task_id,
+        resume_trace_event_id=anchor_id,
+        request_payload={"v": value},
+    )
+    db = db_session
+    try:
+        with pytest.raises(DataError) as excinfo:
+            db.execute(sa.insert(TaskInteractionRequest.__table__).values(**row))
+        # Same reasoning as test_pg1's own comment: pytest.raises(DataError)
+        # already pins the real fact; exact-type here is the non-tautological
+        # assertion left to make.
+        assert type(excinfo.value) is DataError
+    finally:
+        db.rollback()
 
 
 def test_sp1_slot_taken_rolls_back_cleanly(db_session, fixtures) -> None:

--- a/tests/web/services/test_interaction_staging_production_gate.py
+++ b/tests/web/services/test_interaction_staging_production_gate.py
@@ -234,7 +234,7 @@ def test_test_module_consumers_are_not_flagged() -> None:
 
 def test_primitive_module_itself_is_not_flagged() -> None:
     """The primitive module's own body -- definitions, its one internal call
-    from ``_InteractionHandoff.stage()`` to ``stage_interaction_request``,
+    from ``InteractionHandoff.stage()`` to ``stage_interaction_request``,
     and its docstrings mentioning both names in prose -- must not trip the
     gate. ``_production_modules()`` excludes it by filename; this test pins
     that exclusion rather than re-deriving it."""
@@ -245,7 +245,7 @@ def test_primitive_module_itself_is_not_flagged() -> None:
     assert all(path.stem != "task_interaction_staging" for path in modules)
     # Also confirm the module's own source, scanned directly, DOES contain a
     # gated name (stage_interaction_request, called by name from
-    # _InteractionHandoff.stage()) -- proving the filename exclusion is
+    # InteractionHandoff.stage()) -- proving the filename exclusion is
     # doing real work, not vacuously passing because the file has nothing
     # for the scanner to find. interaction_handoff itself is never called
     # from within its own module (only entered via a caller's `with`), so

--- a/tests/web/services/test_task_interaction_anchor.py
+++ b/tests/web/services/test_task_interaction_anchor.py
@@ -294,6 +294,55 @@ def test_ta3_corrupt_conditions(
 
 
 # ---------------------------------------------------------------------------
+# The row's data column holds something other than a dict -- the shape
+# resolve_interaction_anchor's isinstance(row.data, dict) guard exists to
+# handle without raising. A list payload coerces to an empty dict inside
+# the resolver, which has no checkpoint_type key, so it fails the
+# checkpoint-type self-consistency condition immediately and lands on
+# corrupt, the same outcome the six-condition table above produces. A None
+# payload would exercise the same guard, but trace_events.data is a
+# NOT NULL column, so committing a row with data=None raises an
+# IntegrityError before this function ever runs -- that shape cannot be
+# built through a committed row at all, so it is not covered here.
+# ---------------------------------------------------------------------------
+
+
+def test_non_dict_row_data_classifies_corrupt(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(
+        logging.ERROR, logger="xagent.web.services.task_interaction_anchor"
+    )
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    task = _make_task(db, run_id="run-a")
+    # Built directly rather than through _make_row, which always writes a
+    # dict -- this is the one caller that needs a non-dict payload.
+    row = TraceEvent(
+        task_id=task.id,
+        build_id=None,
+        event_id=f"anchor-event-{next(_event_counter)}",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        data=["not", "a", "dict"],
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    _point(db, task, row.id)
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.INTERACTION_ANCHOR_CORRUPT in ops_signals.active_degradations()
+    assert ir.counters_snapshot() == {}
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1, caplog.records
+    assert errors[0].msg == "task %s's checkpoint pointer %s failed anchor validation"
+    db.close()
+
+
+# ---------------------------------------------------------------------------
 # task.run_id IS NULL classifies as absence even when the pointer names a
 # row that would otherwise fail a corrupt condition -- proving step 1
 # short-circuits before the row is ever evaluated, not merely that its own

--- a/tests/web/services/test_task_interaction_anchor.py
+++ b/tests/web/services/test_task_interaction_anchor.py
@@ -1,19 +1,18 @@
 """Contract tests for ``resolve_interaction_anchor``
 (``task_interaction_anchor.py``) and the static zero-production-caller
-assertion this module introduces for the resolver itself (T-A-11).
+assertion this module introduces for the resolver itself.
 
-Two cells the task book groups with this test group live elsewhere: T-A-10
-(the checkpoint run-partition predicate's move into
-``trace_event_staging.py``) is not about the resolver at all and lives in
-``test_trace_event_staging.py``, alongside the predicate itself. T-A-12
-(the zero-direct-construction guard for the public ``InteractionHandoff``
-class) depends on that class's public rename, which this module's own
-dependencies do not carry -- it lives in
+Two related cases live in other test files rather than here. The checkpoint
+run-partition predicate's move into ``trace_event_staging.py`` is not about
+the resolver at all and is tested in ``test_trace_event_staging.py``,
+alongside the predicate itself. The zero-direct-construction guard for the
+public ``InteractionHandoff`` class depends on that class's public rename,
+which this module's own dependencies do not carry -- it is tested in
 ``test_interaction_handoff_surface.py``, where the rename is pinned.
 
-All nine judgment-table cells run on a private, file-backed SQLite database
-per test, following ``test_interaction_staging.py``'s own convention (see
-that file's module docstring for why file-backed rather than in-memory).
+All judgment-table cells run on a private, file-backed SQLite database per
+test, following ``test_interaction_staging.py``'s own convention (see that
+file's module docstring for why file-backed rather than in-memory).
 """
 
 from __future__ import annotations
@@ -164,10 +163,10 @@ def _reset_state():
 
 def _count_anchor_constructions(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
     """Instruments ``InteractionAnchor.__init__`` itself, not the return
-    value of ``resolve_interaction_anchor`` -- T-A-6a/T-A-6b need to prove
-    the dataclass was never *built* on the corrupt path, which "the
-    function returned None" alone does not distinguish from "it built one
-    and then discarded it"."""
+    value of ``resolve_interaction_anchor`` -- the cross-task-row corrupt
+    tests below need to prove the dataclass was never *built* on the
+    corrupt path, which "the function returned None" alone does not
+    distinguish from "it built one and then discarded it"."""
 
     calls = {"n": 0}
     original_init = InteractionAnchor.__init__
@@ -181,10 +180,10 @@ def _count_anchor_constructions(monkeypatch: pytest.MonkeyPatch) -> dict[str, in
 
 
 # ---------------------------------------------------------------------------
-# T-A-1: task.run_id is NOT NULL but task.last_checkpoint_trace_event_id IS
-# NULL -> absence. Distinct from T-A-4 (task.run_id IS NULL): this cell
-# exercises step 2 of the judgment table specifically, with step 1 passed,
-# so a pointer-NULL misclassification (e.g. falling into step 3's
+# task.run_id is NOT NULL but task.last_checkpoint_trace_event_id IS NULL ->
+# absence. Distinct from the no-run-id case below: this cell exercises step
+# 2 of the judgment table specifically, with step 1 passed, so a
+# pointer-NULL misclassification (e.g. falling into step 3's
 # dangling-pointer branch) cannot hide behind step 1 short-circuiting first.
 # ---------------------------------------------------------------------------
 
@@ -206,7 +205,7 @@ def test_ta1_no_checkpoint_pointer_is_absence(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# T-A-2: pointer names no live trace_events row -> unavailable, reported as
+# The pointer names no live trace_events row -> unavailable, reported as
 # absence, counted separately from a NULL pointer.
 # ---------------------------------------------------------------------------
 
@@ -243,7 +242,7 @@ def test_ta2_dangling_pointer_is_absence_and_counted(
 
 
 # ---------------------------------------------------------------------------
-# T-A-3: the row exists but fails one of six self-consistency conditions ->
+# The row exists but fails one of six self-consistency conditions ->
 # corrupt. Six parametrized cells, one broken condition each.
 # ---------------------------------------------------------------------------
 
@@ -285,8 +284,9 @@ def test_ta3_corrupt_conditions(
     # ops_signals, not the counter registry).
     assert ir.counters_snapshot() == {}
     # Step 4's judgment-table entry is a logger.error call -- same rationale
-    # as T-A-2's warning pin, applied uniformly across all six parametrized
-    # conditions since they all fall through the same log call site.
+    # as the dangling-pointer case's warning pin above, applied uniformly
+    # across all six parametrized conditions since they all fall through
+    # the same log call site.
     errors = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert len(errors) == 1, caplog.records
     assert errors[0].msg == "task %s's checkpoint pointer %s failed anchor validation"
@@ -294,10 +294,10 @@ def test_ta3_corrupt_conditions(
 
 
 # ---------------------------------------------------------------------------
-# T-A-4: task.run_id IS NULL classifies as absence even when the pointer
-# names a row that would otherwise fail a corrupt condition -- proving step
-# 1 short-circuits before the row is ever evaluated, not merely that its
-# own outcome happens to be absence.
+# task.run_id IS NULL classifies as absence even when the pointer names a
+# row that would otherwise fail a corrupt condition -- proving step 1
+# short-circuits before the row is ever evaluated, not merely that its own
+# outcome happens to be absence.
 # ---------------------------------------------------------------------------
 
 
@@ -396,9 +396,9 @@ def test_legacy_type_row_with_matching_run_partition_field_is_absence(
 
 
 # ---------------------------------------------------------------------------
-# T-A-6a / T-A-6b: a row belonging to another task is corrupt regardless of
-# checkpoint_type -- ownership is checked (step 4) before the legacy-type
-# absence classification (step 5), never bypassed by it. Both cells assert
+# A row belonging to another task is corrupt regardless of checkpoint_type
+# -- ownership is checked (step 4) before the legacy-type absence
+# classification (step 5), never bypassed by it. Both cells assert
 # InteractionAnchor's constructor was never even called, not merely that
 # the return value was None.
 # ---------------------------------------------------------------------------
@@ -426,12 +426,11 @@ def test_ta6a_cross_task_row_modern_type_is_corrupt(
 def test_ta6b_cross_task_row_legacy_type_is_still_corrupt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Differs from T-A-6a in exactly one field: this row's owning task_id
-    is the *other* task's, same as 6a, but here checkpoint_type is legacy.
-    If step 5 (legacy -> absence) ran before step 4 (the six conditions,
-    including ownership), this row would wrongly classify as absence
-    instead of corrupt -- see T-A-9 for the mutation that pins this
-    ordering directly."""
+    """Differs from the previous test in exactly one field: this row's
+    owning task_id is the *other* task's, same as before, but here
+    checkpoint_type is legacy. If step 5 (legacy -> absence) ran before
+    step 4 (the six conditions, including ownership), this row would
+    wrongly classify as absence instead of corrupt."""
 
     calls = _count_anchor_constructions(monkeypatch)
     engine = _engine(tmp_path)
@@ -449,8 +448,8 @@ def test_ta6b_cross_task_row_legacy_type_is_still_corrupt(
 
 
 # ---------------------------------------------------------------------------
-# T-A-7: happy path -- all six conditions pass, checkpoint_type is current
-# -> a resolved InteractionAnchor, every field asserted individually.
+# Happy path -- all six conditions pass, checkpoint_type is current -> a
+# resolved InteractionAnchor, every field asserted individually.
 # ---------------------------------------------------------------------------
 
 
@@ -481,8 +480,8 @@ def test_ta7_happy_path_resolves_anchor(tmp_path: Path) -> None:
 # comparison before it ever runs. This cell builds the row directly (rather
 # than through _build_scenario, which cannot take the task's own id before
 # the task exists) so the row's execution id can be set to the task's id
-# after creation, exercising the right-hand side of that comparison for the
-# first time: two non-empty, equal execution ids should resolve, not corrupt.
+# after creation -- the first cell where that comparison runs and comes out
+# equal: two non-empty, equal execution ids should resolve, not corrupt.
 # ---------------------------------------------------------------------------
 
 
@@ -509,7 +508,7 @@ def test_matching_non_empty_execution_identity_resolves_anchor(
 
 
 # ---------------------------------------------------------------------------
-# T-A-11: resolve_interaction_anchor ships with zero production callers.
+# resolve_interaction_anchor ships with zero production callers.
 # ---------------------------------------------------------------------------
 
 _ANCHOR_GATED_NAME = "resolve_interaction_anchor"

--- a/tests/web/services/test_task_interaction_anchor.py
+++ b/tests/web/services/test_task_interaction_anchor.py
@@ -322,11 +322,51 @@ def test_ta4_no_run_id_short_circuits_before_corrupt_row_is_read(
 
 
 # ---------------------------------------------------------------------------
-# T-A-5: legacy checkpoint type, same task -> absence, not corrupt.
+# A legacy-type row, same task, with no run-partition field at all -- the
+# only shape a real legacy checkpoint row can have, since
+# stage_trace_event_row (trace_event_staging.py) only ever writes that
+# field for current-type checkpoints. Missing the field fails the
+# run-partition self-consistency condition before the legacy-type check is
+# even reached, so this classifies corrupt, not absent.
 # ---------------------------------------------------------------------------
 
 
-def test_ta5_legacy_type_same_task_is_absence(
+def test_legacy_type_row_without_run_partition_field_classifies_corrupt(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(
+        logging.ERROR, logger="xagent.web.services.task_interaction_anchor"
+    )
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    legacy_type = next(iter(LEGACY_CHECKPOINT_TYPES))
+    task, _row = _build_scenario(db, checkpoint_type=legacy_type, run_partition=None)
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.INTERACTION_ANCHOR_CORRUPT in ops_signals.active_degradations()
+    # Corrupt registers no counter -- the legacy-absence counter this row
+    # might look like it should reach is never incremented, because the
+    # run-partition condition fails first.
+    assert ir.counters_snapshot() == {}
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1, caplog.records
+    assert errors[0].msg == "task %s's checkpoint pointer %s failed anchor validation"
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# The one shape that does reach the legacy-absence outcome: a legacy-type
+# row whose run-partition field is present and matches the task's run id.
+# No current writer produces this shape -- stage_trace_event_row only ever
+# writes the run-partition field for current-type checkpoints -- so this
+# cell pins what the outcome does for a row shaped this way, rather than
+# covering a path production data can take today.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_type_row_with_matching_run_partition_field_is_absence(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     caplog.set_level(logging.INFO, logger="xagent.web.services.task_interaction_anchor")
@@ -430,6 +470,40 @@ def test_ta7_happy_path_resolves_anchor(tmp_path: Path) -> None:
     assert result.resume_run_partition == "run-a"
     assert result.resume_locator_format == "trace_event_pk_v1"
     assert result.resume_checkpoint_type == "agent_execution_checkpoint"
+    assert ops_signals.active_degradations() == {}
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# Happy path with a non-empty execution identity on both sides, matching --
+# every other non-corrupt cell in this file leaves execution_id unset, which
+# leaves the row's execution id empty and short-circuits condition 6's
+# comparison before it ever runs. This cell builds the row directly (rather
+# than through _build_scenario, which cannot take the task's own id before
+# the task exists) so the row's execution id can be set to the task's id
+# after creation, exercising the right-hand side of that comparison for the
+# first time: two non-empty, equal execution ids should resolve, not corrupt.
+# ---------------------------------------------------------------------------
+
+
+def test_matching_non_empty_execution_identity_resolves_anchor(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    task = _make_task(db, run_id="run-a")
+    row = _make_row(
+        db,
+        task_id=task.id,
+        run_partition="run-a",
+        execution_id=str(task.id),
+    )
+    _point(db, task, row.id)
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is not None
+    assert result.resume_execution_id == str(task.id)
     assert ops_signals.active_degradations() == {}
     db.close()
 

--- a/tests/web/services/test_task_interaction_anchor.py
+++ b/tests/web/services/test_task_interaction_anchor.py
@@ -1,0 +1,491 @@
+"""Contract tests for ``resolve_interaction_anchor``
+(``task_interaction_anchor.py``) and the static zero-production-caller
+assertion this module introduces for the resolver itself (T-A-11).
+
+Two cells the task book groups with this test group live elsewhere: T-A-10
+(the checkpoint run-partition predicate's move into
+``trace_event_staging.py``) is not about the resolver at all and lives in
+``test_trace_event_staging.py``, alongside the predicate itself. T-A-12
+(the zero-direct-construction guard for the public ``InteractionHandoff``
+class) depends on that class's public rename, which this module's own
+dependencies do not carry -- it lives in
+``test_interaction_handoff_surface.py``, where the rename is pinned.
+
+All nine judgment-table cells run on a private, file-backed SQLite database
+per test, following ``test_interaction_staging.py``'s own convention (see
+that file's module docstring for why file-backed rather than in-memory).
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from datetime import datetime, timezone
+from itertools import count
+from pathlib import Path
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+import xagent
+from tests.web.services.task_interaction_schema_shared import make_user
+from xagent.core.agent.checkpoint import CHECKPOINT_TYPE, LEGACY_CHECKPOINT_TYPES
+from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TraceEvent
+from xagent.web.services import interaction_rollout as ir
+from xagent.web.services import ops_signals
+from xagent.web.services.task_interaction_anchor import resolve_interaction_anchor
+from xagent.web.services.task_interaction_staging import InteractionAnchor
+from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD
+
+_event_counter = count()
+
+
+def _engine(tmp_path: Path):
+    db_path = tmp_path / "task_interaction_anchor.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    apply_sqlite_concurrency_pragmas(engine)
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def _session_factory(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _make_task(db: Session, *, run_id: str | None) -> Task:
+    user_id = make_user(db)
+    task = Task(user_id=user_id, title="anchor resolver fixture task", run_id=run_id)
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def _make_row(
+    db: Session,
+    *,
+    task_id: int,
+    build_id: str | None = None,
+    event_type: str = "system_update_general",
+    checkpoint_type: str | None = CHECKPOINT_TYPE,
+    run_partition: str | None = "run-a",
+    execution_id: str | None = None,
+) -> TraceEvent:
+    data: dict[str, Any] = {}
+    if checkpoint_type is not None:
+        data["checkpoint_type"] = checkpoint_type
+    if run_partition is not None:
+        data[TASK_RUN_ID_TRACE_FIELD] = run_partition
+    if execution_id is not None:
+        data["execution_id"] = execution_id
+    row = TraceEvent(
+        task_id=task_id,
+        build_id=build_id,
+        event_id=f"anchor-event-{next(_event_counter)}",
+        event_type=event_type,
+        timestamp=datetime.now(timezone.utc),
+        data=data,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _point(db: Session, task: Task, trace_event_id: int | None) -> None:
+    task.last_checkpoint_trace_event_id = trace_event_id
+    db.commit()
+    db.refresh(task)
+
+
+def _point_dangling(db: Session, task: Task, trace_event_id: int) -> None:
+    """Points ``task`` at a ``trace_events`` row id that does not exist.
+
+    ``trace_handlers.py``'s own docstring says this is only reachable on a
+    database upgraded through Alembic rather than created fresh, because
+    that path has no DB-level FK on this column. This fixture's schema is
+    built fresh via ``create_all``, which does enforce the FK -- so
+    foreign-key checking is switched off for this one write, reproducing
+    the no-FK production shape directly rather than fighting the stronger
+    guarantee ``create_all`` happens to give a test schema.
+    """
+    db.execute(sa.text("PRAGMA foreign_keys=OFF"))
+    task.last_checkpoint_trace_event_id = trace_event_id
+    db.commit()
+    db.execute(sa.text("PRAGMA foreign_keys=ON"))
+    db.refresh(task)
+
+
+def _build_scenario(
+    db: Session,
+    *,
+    task_run_id: str | None = "run-a",
+    row_task_id: int | None = None,
+    build_id: str | None = None,
+    event_type: str = "system_update_general",
+    checkpoint_type: str | None = CHECKPOINT_TYPE,
+    run_partition: str | None = "run-a",
+    execution_id: str | None = None,
+) -> tuple[Task, TraceEvent]:
+    """A task whose checkpoint pointer names a row satisfying every one of
+    the six corrupt-check conditions by default -- callers pass one
+    ``overrides``-style kwarg to break exactly one condition."""
+
+    task = _make_task(db, run_id=task_run_id)
+    target_task_id = row_task_id if row_task_id is not None else task.id
+    row = _make_row(
+        db,
+        task_id=target_task_id,
+        build_id=build_id,
+        event_type=event_type,
+        checkpoint_type=checkpoint_type,
+        run_partition=run_partition,
+        execution_id=execution_id,
+    )
+    _point(db, task, row.id)
+    return task, row
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+    ir._counters.clear()
+    yield
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+    ir._counters.clear()
+
+
+def _count_anchor_constructions(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Instruments ``InteractionAnchor.__init__`` itself, not the return
+    value of ``resolve_interaction_anchor`` -- T-A-6a/T-A-6b need to prove
+    the dataclass was never *built* on the corrupt path, which "the
+    function returned None" alone does not distinguish from "it built one
+    and then discarded it"."""
+
+    calls = {"n": 0}
+    original_init = InteractionAnchor.__init__
+
+    def _wrapped(self: InteractionAnchor, *args: Any, **kwargs: Any) -> None:
+        calls["n"] += 1
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(InteractionAnchor, "__init__", _wrapped)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# T-A-1: task.run_id is NOT NULL but task.last_checkpoint_trace_event_id IS
+# NULL -> absence. Distinct from T-A-4 (task.run_id IS NULL): this cell
+# exercises step 2 of the judgment table specifically, with step 1 passed,
+# so a pointer-NULL misclassification (e.g. falling into step 3's
+# dangling-pointer branch) cannot hide behind step 1 short-circuiting first.
+# ---------------------------------------------------------------------------
+
+
+def test_ta1_no_checkpoint_pointer_is_absence(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    task = _make_task(db, run_id="run-a")
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.active_degradations() == {}
+    # Step 2 registers no counter -- only step 1 (anchor_absent_no_run) and
+    # step 3 (anchor_unavailable_dangling_pointer) do; see the resolver's
+    # own judgment table.
+    assert ir.counters_snapshot() == {}
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-A-2: pointer names no live trace_events row -> unavailable, reported as
+# absence, counted separately from a NULL pointer.
+# ---------------------------------------------------------------------------
+
+
+def test_ta2_dangling_pointer_is_absence_and_counted(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(
+        logging.WARNING, logger="xagent.web.services.task_interaction_anchor"
+    )
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    task = _make_task(db, run_id="run-a")
+    # A pointer naming a row id that was never inserted -- the same shape
+    # an Alembic-upgraded database with no DB-level FK on this column can
+    # produce (see trace_handlers.py's own docstring on this exact case).
+    _point_dangling(db, task, 999_999)
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.active_degradations() == {}
+    assert ir.counters_snapshot() == {ir.COUNTER_ANCHOR_UNAVAILABLE_DANGLING_POINTER: 1}
+    # Step 3's judgment-table entry is a logger.warning call, not info or
+    # error -- pinned directly, since the judgment table's log levels are
+    # contract, not incidental. Matched on the raw format string (not the
+    # rendered message), so this stays exact even if the %-args change.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, caplog.records
+    assert warnings[0].msg == (
+        "task %s's checkpoint pointer %s has no matching trace_events row"
+    )
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-A-3: the row exists but fails one of six self-consistency conditions ->
+# corrupt. Six parametrized cells, one broken condition each.
+# ---------------------------------------------------------------------------
+
+_CONDITION_BREAKS: dict[str, dict[str, Any]] = {
+    "ownership": {"cross_task": True},
+    "event_type": {"event_type": "system_update_partial"},
+    "build_partition": {"build_id": "build-x"},
+    "checkpoint_type": {"checkpoint_type": "not_a_checkpoint_type"},
+    "run_partition": {"run_partition": "run-b"},
+    "execution_identity": {"execution_id": "execution-mismatch"},
+}
+
+
+@pytest.mark.parametrize("condition", sorted(_CONDITION_BREAKS))
+def test_ta3_corrupt_conditions(
+    tmp_path: Path, condition: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(
+        logging.ERROR, logger="xagent.web.services.task_interaction_anchor"
+    )
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    overrides = dict(_CONDITION_BREAKS[condition])
+
+    kwargs: dict[str, Any] = {}
+    if overrides.pop("cross_task", False):
+        other = _make_task(db, run_id=None)
+        kwargs["row_task_id"] = other.id
+    kwargs.update(overrides)
+
+    task, _row = _build_scenario(db, **kwargs)
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.INTERACTION_ANCHOR_CORRUPT in ops_signals.active_degradations()
+    # Corrupt registers no counter -- only the three absence/unavailable
+    # outcomes do (see the resolver's own docstring: corrupt uses
+    # ops_signals, not the counter registry).
+    assert ir.counters_snapshot() == {}
+    # Step 4's judgment-table entry is a logger.error call -- same rationale
+    # as T-A-2's warning pin, applied uniformly across all six parametrized
+    # conditions since they all fall through the same log call site.
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1, caplog.records
+    assert errors[0].msg == "task %s's checkpoint pointer %s failed anchor validation"
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-A-4: task.run_id IS NULL classifies as absence even when the pointer
+# names a row that would otherwise fail a corrupt condition -- proving step
+# 1 short-circuits before the row is ever evaluated, not merely that its
+# own outcome happens to be absence.
+# ---------------------------------------------------------------------------
+
+
+def test_ta4_no_run_id_short_circuits_before_corrupt_row_is_read(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    other = _make_task(db, run_id=None)
+    task, _row = _build_scenario(
+        db,
+        task_run_id=None,
+        row_task_id=other.id,  # ownership condition would fail
+    )
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.active_degradations() == {}
+    assert ir.counters_snapshot() == {ir.COUNTER_ANCHOR_ABSENT_NO_RUN: 1}
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-A-5: legacy checkpoint type, same task -> absence, not corrupt.
+# ---------------------------------------------------------------------------
+
+
+def test_ta5_legacy_type_same_task_is_absence(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger="xagent.web.services.task_interaction_anchor")
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    legacy_type = next(iter(LEGACY_CHECKPOINT_TYPES))
+    task, _row = _build_scenario(db, checkpoint_type=legacy_type)
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert ops_signals.active_degradations() == {}
+    assert ir.counters_snapshot() == {
+        ir.COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE: 1
+    }
+    # Step 5's judgment-table entry is a logger.info call, distinct from
+    # step 1's and step 2's own info-level messages (different format
+    # strings) -- matched exactly, not just "any info record", so this
+    # cell cannot pass on the strength of some other step's log call.
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 1, caplog.records
+    assert infos[0].msg == (
+        "task %s's checkpoint pointer %s names a legacy checkpoint "
+        "type %r; no interaction anchor to resolve"
+    )
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-A-6a / T-A-6b: a row belonging to another task is corrupt regardless of
+# checkpoint_type -- ownership is checked (step 4) before the legacy-type
+# absence classification (step 5), never bypassed by it. Both cells assert
+# InteractionAnchor's constructor was never even called, not merely that
+# the return value was None.
+# ---------------------------------------------------------------------------
+
+
+def test_ta6a_cross_task_row_modern_type_is_corrupt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _count_anchor_constructions(monkeypatch)
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    other = _make_task(db, run_id=None)
+    task, _row = _build_scenario(
+        db, row_task_id=other.id, checkpoint_type=CHECKPOINT_TYPE
+    )
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert calls["n"] == 0
+    assert ops_signals.INTERACTION_ANCHOR_CORRUPT in ops_signals.active_degradations()
+    db.close()
+
+
+def test_ta6b_cross_task_row_legacy_type_is_still_corrupt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Differs from T-A-6a in exactly one field: this row's owning task_id
+    is the *other* task's, same as 6a, but here checkpoint_type is legacy.
+    If step 5 (legacy -> absence) ran before step 4 (the six conditions,
+    including ownership), this row would wrongly classify as absence
+    instead of corrupt -- see T-A-9 for the mutation that pins this
+    ordering directly."""
+
+    calls = _count_anchor_constructions(monkeypatch)
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    other = _make_task(db, run_id=None)
+    legacy_type = next(iter(LEGACY_CHECKPOINT_TYPES))
+    task, _row = _build_scenario(db, row_task_id=other.id, checkpoint_type=legacy_type)
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is None
+    assert calls["n"] == 0
+    assert ops_signals.INTERACTION_ANCHOR_CORRUPT in ops_signals.active_degradations()
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-A-7: happy path -- all six conditions pass, checkpoint_type is current
+# -> a resolved InteractionAnchor, every field asserted individually.
+# ---------------------------------------------------------------------------
+
+
+def test_ta7_happy_path_resolves_anchor(tmp_path: Path) -> None:
+    engine = _engine(tmp_path)
+    db = _session_factory(engine)()
+    task, row = _build_scenario(
+        db, task_run_id="run-a", run_partition="run-a", checkpoint_type=CHECKPOINT_TYPE
+    )
+
+    result = resolve_interaction_anchor(db, task)
+
+    assert result is not None
+    assert result.trace_event_id == row.id
+    assert result.resume_event_id == row.event_id
+    assert result.resume_execution_id == str(task.id)
+    assert result.resume_run_partition == "run-a"
+    assert result.resume_locator_format == "trace_event_pk_v1"
+    assert result.resume_checkpoint_type == "agent_execution_checkpoint"
+    assert ops_signals.active_degradations() == {}
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# T-A-11: resolve_interaction_anchor ships with zero production callers.
+# ---------------------------------------------------------------------------
+
+_ANCHOR_GATED_NAME = "resolve_interaction_anchor"
+_ANCHOR_MODULE_STEM = "task_interaction_anchor"
+
+
+def _anchor_production_uses(source: str) -> bool:
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.ImportFrom):
+            if any(a.name == _ANCHOR_GATED_NAME for a in node.names):
+                return True
+            if (
+                any(a.name == "*" for a in node.names)
+                and (node.module or "").split(".")[-1] == _ANCHOR_MODULE_STEM
+            ):
+                return True
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == _ANCHOR_GATED_NAME:
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == _ANCHOR_GATED_NAME:
+                return True
+    return False
+
+
+def _scan_root(exclude_stem: str) -> list[Path]:
+    root = Path(next(iter(xagent.__path__)))
+    modules = [p for p in root.rglob("*.py") if p.stem != exclude_stem]
+    assert modules, "production scan set is empty"
+    return modules
+
+
+def test_ta11_resolve_interaction_anchor_has_zero_production_callers() -> None:
+    """This is a fresh assertion, not an extension of
+    ``test_interaction_staging_production_gate.py``'s gate: that gate scans
+    only for ``stage_interaction_request`` and ``interaction_handoff`` by
+    name (``GATED_NAMES``), and this function is not one of them.
+
+    The zero here is scoped to this module's introduction, not a permanent
+    invariant to preserve by construction: the change that wires the first
+    production caller changes this number to 3 (the three finalizers named
+    in ``task_interaction_staging.py``'s own module docstring) and updates
+    this test alongside that wiring, deliberately -- it is not a constant a
+    later change edits in isolation without also reasoning about the wiring
+    itself.
+    """
+
+    offenders: dict[str, bool] = {}
+    for path in _scan_root(_ANCHOR_MODULE_STEM):
+        source = path.read_text(encoding="utf-8")
+        if _anchor_production_uses(source):
+            offenders[str(path)] = True
+    assert offenders == {}

--- a/tests/web/services/test_trace_event_staging.py
+++ b/tests/web/services/test_trace_event_staging.py
@@ -27,6 +27,8 @@ does not give.
 from __future__ import annotations
 
 import ast
+import inspect
+import textwrap
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -49,7 +51,10 @@ from xagent.web.services.task_lease_service import (
     TaskLease,
     bind_task_lease_context,
 )
-from xagent.web.services.trace_event_staging import stage_trace_event_row
+from xagent.web.services.trace_event_staging import (
+    checkpoint_run_partition_filter,
+    stage_trace_event_row,
+)
 
 
 def _engine(tmp_path: Path):
@@ -584,3 +589,52 @@ def test_prune_checkpoint_history_guard_allows_a_clean_session(
     )
 
     db.close()
+
+
+# ---------------------------------------------------------------------------
+# checkpoint_run_partition_filter's move from a trace_handlers.py
+# staticmethod into this module must leave the old staticmethod delegating,
+# not reimplementing. An earlier draft of the cell below compiled both
+# callables' SQL to a string and compared -- that stays green even if the
+# old path grew its own copy of the predicate body instead of calling this
+# module's function (a real mutation, tried directly), so the cell pins the
+# structural fact instead: the staticmethod's body is exactly one `return`
+# statement calling checkpoint_run_partition_filter.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_staticmethod_delegates_to_the_shared_predicate() -> None:
+    source = textwrap.dedent(
+        inspect.getsource(DatabaseTraceHandler._checkpoint_run_partition_filter)
+    )
+    func_def = ast.parse(source).body[0]
+    assert isinstance(func_def, ast.FunctionDef)
+    assert len(func_def.body) == 1, (
+        "_checkpoint_run_partition_filter must be exactly one statement "
+        "(a delegating return), not a reimplementation"
+    )
+    stmt = func_def.body[0]
+    assert isinstance(stmt, ast.Return)
+    call = stmt.value
+    assert isinstance(call, ast.Call)
+    assert isinstance(call.func, ast.Name)
+    assert call.func.id == "checkpoint_run_partition_filter"
+
+
+def test_positive_control_both_run_partition_predicates_compile_identical_sql() -> None:
+    """Not the cell above's own guard (see its docstring for why), but a
+    positive control that the two still agree on output today, for both a
+    real run_id and None."""
+
+    for run_id in ("run-a", None):
+        old = str(
+            DatabaseTraceHandler._checkpoint_run_partition_filter(run_id).compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+        new = str(
+            checkpoint_run_partition_filter(run_id).compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+        assert old == new


### PR DESCRIPTION
## Summary

Adds `resolve_interaction_anchor`, the primary-key read against `trace_events` that resolves a task's interaction anchor from its checkpoint pointer, with zero production callers. Moves the checkpoint run-partition predicate into the services layer so future services-side consumers need not reverse-import the api layer; the new resolver checks the same condition with its own in-Python comparison and does not call the predicate. Gives the interaction handoff primitive a public produced-object type and a `staged` observability field. Adds two PostgreSQL-only tests pinning backend behavior that previously lived only in comments.

## Anchor resolution

`resolve_interaction_anchor(db, task)` reads `task.last_checkpoint_trace_event_id` and classifies the result into one of six outcomes, in a fixed order: no `run_id` (absence), no pointer (absence), a dangling pointer (unavailable, reported as absence), a row that fails one of six self-consistency conditions (corrupt), a row with a legacy `checkpoint_type` (absence, not corrupt), or a row that passes everything (a resolved anchor). The corrupt-before-legacy ordering matters: a row belonging to a different task must be reported corrupt even when its `checkpoint_type` is legacy, never silently absorbed into the legacy-absence branch.

An unavailable pointer is reported to the caller as absence and does not fall back to scanning the legacy `last_checkpoint_event_id` column the way the trace-read side's fallback does — the two paths are deliberately not the same shape.

The resolver ships with zero production callers, guarded by its own static AST assertion scoped to this function specifically (not an extension of the existing zero-production-caller gate for `stage_interaction_request` / `interaction_handoff`, which does not scan for this name). A companion guard pins zero direct-construction points for the now-public `InteractionHandoff` class outside its own defining module.

Three counters (`anchor.absent_no_run`, `anchor.unavailable_dangling_pointer`, `anchor.absent_legacy_checkpoint_type`) are incremented in `interaction_rollout`'s existing counter registry rather than a new one. The corrupt outcome instead registers a new `ops_signals` constant, `INTERACTION_ANCHOR_CORRUPT`, deliberately left without a paired `clear_degradation` call: a corrupt anchor is a property of a persisted row, and no in-process registry can observe that row being fixed.

## Predicate move

`checkpoint_run_partition_filter` moves from a `trace_handlers.py` staticmethod into `trace_event_staging.py`, unchanged, so future services-layer consumers can use it without importing from the api layer. The new anchor resolver is not such a consumer: it checks the same run-partition condition with its own in-Python comparison on the already-fetched row, and its docstring names the predicate as the semantic sibling of that check. The old staticmethod now delegates in one line. Neither file needed a new import statement — both already imported everything the predicate uses.

## Public handoff surface

`_InteractionHandoff` is renamed to `InteractionHandoff`, and `interaction_handoff`'s return annotation changes to match — the object a public context manager yields is now a public type. No test imports the old name, so this changes no test's behavior.

A public `staged: StagedInteractionRequest | None` attribute replaces the private `_staged_row` flag. It is assigned in `stage()` at the exact point `stage_interaction_request` has actually returned a row, and the misuse handler that used to read `_staged_row` now reads this field instead — an equivalent substitution, since `stage_interaction_request`'s return value is never `None`. A caller can now tell whether a handoff round staged a row by reading this field after the `with` block, without consulting the `ops_signals` registry.

`__all__` now lists both entry points, the public type, both dataclasses, and every exception class the module defines.

## PostgreSQL backend assertions

Two facts that previously lived only in code comments now have tests: an over-length locator column raises `DataError` (not `IntegrityError`) on PostgreSQL, and a non-finite float in a JSON payload raises `DataError` (not `StatementError`) once it reaches the database's own parser. Both cells bypass `stage_interaction_request`'s Python-side validation with a direct Core `INSERT`, since that validation is exactly what ordinarily prevents either outcome from reaching SQL at all. Also corrects a comment that named the `request_payload` column's PostgreSQL type as `jsonb`; it compiles to `JSON`.

Both land in the existing `test_interaction_staging_postgresql.py`, reusing its disposable-schema fixture. No CI workflow changes: this file's path is already listed in both `test-migrations.yml`'s trigger paths and its explicit pytest step.

## Notes on two deliberate choices

- The resolver imports `InteractionAnchor` only as `from .task_interaction_staging import InteractionAnchor`. Importing the module itself and referencing `task_interaction_staging.InteractionAnchor` would trip the zero-production-caller gate for `stage_interaction_request` / `interaction_handoff`, which matches on that module-path form.
- The predicate move is a pure position change: same body, same signature, same behavior. It moves because services code must not import from api, and because one run-partition predicate should have one definition.
