### PR TITLE
fix(dag): resolve concurrent waiting steps deterministically

### DIFF
--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -414,6 +414,18 @@ class AgentExecutionAdapter:
                     ),
                 }
             )
+        if status == "interrupted":
+            # A losing waiting step can still be superseded in a batch whose
+            # winner is an interrupt rather than a question (the DAG ranks
+            # an interrupt ahead of a waiting result within the same
+            # wakeup), so this key must reach the top level here too --
+            # otherwise a reader has no way to tell "no sibling was
+            # superseded" apart from "this status never carries the key".
+            # Same empty-list default as the waiting branch above, for the
+            # same reason: one ``if superseded:`` check covers both.
+            normalized["clarification_superseded_step_ids"] = (
+                result.get("clarification_superseded_step_ids") or []
+            )
         return normalized
 
     def _latest_assistant_message(self, context: Any) -> str | None:

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -405,6 +405,13 @@ class AgentExecutionAdapter:
                     # carry the same draft too, but callers should not dig
                     # it out from there.
                     "clarification_draft": result.get("clarification_draft"),
+                    # Empty list rather than ``None`` so a reader only ever
+                    # needs one check (``if superseded:``) instead of also
+                    # distinguishing "key absent" from "key present but
+                    # empty".
+                    "clarification_superseded_step_ids": (
+                        result.get("clarification_superseded_step_ids") or []
+                    ),
                 }
             )
         return normalized

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -693,6 +693,18 @@ class DAGPattern(AgentPattern):
         scheduled_step_ids = set(steps_by_id)
         self._live_step_tasks = set(pending)
 
+        async def cancel_all() -> None:
+            # `pending` is rebound (not mutated) by the `asyncio.wait()`
+            # call inside the loop below; this closure reads the free
+            # variable from the enclosing scope, so it always sees whatever
+            # `pending` is currently bound to -- same mechanism
+            # `schedule_ready_steps()` already relies on.
+            await self._cancel_pending_steps(
+                pending,
+                step_ids_by_task=tasks,
+                steps_by_id=steps_by_id,
+            )
+
         def schedule_ready_steps() -> None:
             if self.plan is None:
                 return
@@ -757,11 +769,7 @@ class DAGPattern(AgentPattern):
                     None,
                 )
                 if failed_step is not None:
-                    await self._cancel_pending_steps(
-                        pending,
-                        step_ids_by_task=tasks,
-                        steps_by_id=steps_by_id,
-                    )
+                    await cancel_all()
                     return await self._fail(
                         context=root_context,
                         runtime=runtime,
@@ -772,21 +780,13 @@ class DAGPattern(AgentPattern):
                     )
 
                 if completed_results:
-                    # Deterministic winner selection: an interrupted result
-                    # always outranks a waiting one (an interrupt is a
-                    # control instruction, not a workflow question the user
-                    # can be asked to sit through), and within the same kind
-                    # the lexicographically first step id wins.
-                    completed_results.sort(
-                        key=lambda item: (
-                            0 if item[1].get("status") != "waiting_for_user" else 1,
-                            tasks[item[0]],
-                        )
+                    winner_task, winner_result = self._select_winner(
+                        completed_results,
+                        step_ids_by_task=tasks,
                     )
-                    winner_task, winner_result = completed_results[0]
                     winner_step_id = tasks[winner_task]
 
-                    # This loop invalidates losers drawn from `done`; the
+                    # This invalidates losers drawn from `done`; the
                     # cancellation below acts on `pending`. `asyncio.wait`
                     # partitions the tasks it was given into exactly these
                     # two sets, so a task can never be in both -- the two
@@ -794,23 +794,11 @@ class DAGPattern(AgentPattern):
                     # this one before or after the cancellation below
                     # cannot change which steps end up invalidated versus
                     # cancelled.
-                    superseded_step_ids: list[str] = []
-                    for loser_task, loser_result in completed_results[1:]:
-                        if loser_result.get("status") != "waiting_for_user":
-                            continue
-                        loser_step_id = tasks[loser_task]
-                        self._clear_active_step(loser_step_id)
-                        loser_step = steps_by_id.get(loser_step_id)
-                        if loser_step is not None:
-                            # Non-terminal, and not picked up by the same-
-                            # wakeup backfill in schedule_ready_steps():
-                            # _ready_steps() offers this step again once
-                            # active_step_ids drains, but
-                            # _pending_ready_steps() only collects steps
-                            # already at "pending", so it waits for the next
-                            # wakeup's readiness check before it reruns.
-                            loser_step.status = "clarification_invalidated"
-                        superseded_step_ids.append(loser_step_id)
+                    superseded_step_ids = self._invalidate_batch_siblings(
+                        completed_results[1:],
+                        step_ids_by_task=tasks,
+                        steps_by_id=steps_by_id,
+                    )
 
                     if superseded_step_ids:
                         logger.error(
@@ -832,11 +820,7 @@ class DAGPattern(AgentPattern):
                             "clarification_superseded_step_ids": superseded_step_ids,
                         }
 
-                    await self._cancel_pending_steps(
-                        pending,
-                        step_ids_by_task=tasks,
-                        steps_by_id=steps_by_id,
-                    )
+                    await cancel_all()
                     if pending or superseded_step_ids:
                         await runtime.checkpoint(
                             "dag_after_cancelled_siblings",
@@ -856,27 +840,15 @@ class DAGPattern(AgentPattern):
                     return winner_result
 
                 if self._needs_replan(root_context):
-                    await self._cancel_pending_steps(
-                        pending,
-                        step_ids_by_task=tasks,
-                        steps_by_id=steps_by_id,
-                    )
+                    await cancel_all()
                     return None
                 if self.status in {"interrupted", "waiting_for_user"}:
-                    await self._cancel_pending_steps(
-                        pending,
-                        step_ids_by_task=tasks,
-                        steps_by_id=steps_by_id,
-                    )
+                    await cancel_all()
                     return None
                 schedule_ready_steps()
         except BaseException:
             try:
-                await self._cancel_pending_steps(
-                    pending,
-                    step_ids_by_task=tasks,
-                    steps_by_id=steps_by_id,
-                )
+                await cancel_all()
             except Exception:
                 logger.exception("Failed to clean up cancelled DAG sibling steps.")
             raise
@@ -1937,6 +1909,64 @@ class DAGPattern(AgentPattern):
         if getattr(tool, "name", None):
             return str(tool.name)
         return str(tool)
+
+    def _select_winner(
+        self,
+        completed_results: list[tuple[asyncio.Task[Any], dict[str, Any]]],
+        *,
+        step_ids_by_task: dict[asyncio.Task[Any], str],
+    ) -> tuple[asyncio.Task[Any], dict[str, Any]]:
+        """Pick the one result a same-wakeup completed batch delivers.
+
+        Sorts ``completed_results`` in place and returns its new first
+        entry: an interrupted result always outranks a waiting one (an
+        interrupt is a control instruction, not a workflow question the
+        user can be asked to sit through), and within the same kind the
+        lexicographically first step id wins. Callers needing the losers
+        read ``completed_results[1:]`` after this call.
+        """
+        completed_results.sort(
+            key=lambda item: (
+                0 if item[1].get("status") != "waiting_for_user" else 1,
+                step_ids_by_task[item[0]],
+            )
+        )
+        return completed_results[0]
+
+    def _invalidate_batch_siblings(
+        self,
+        siblings: list[tuple[asyncio.Task[Any], dict[str, Any]]],
+        *,
+        step_ids_by_task: dict[asyncio.Task[Any], str],
+        steps_by_id: dict[str, PlanStep],
+    ) -> list[str]:
+        """Clear active-step bookkeeping and flip status on every
+        completed sibling result passed in that is still holding a live
+        "waiting_for_user" result -- that status is reserved for a step
+        whose question was live and never reached the user. Any other
+        sibling (e.g. one that lost an id tie-break between two
+        "interrupted" results) is left completely alone, bookkeeping
+        included: this is byte-for-byte the inline loop this method was
+        extracted from, just given a name. Returns the ids that got the
+        clarification_invalidated flip, in input order.
+        """
+        invalidated_step_ids: list[str] = []
+        for sibling_task, sibling_result in siblings:
+            if sibling_result.get("status") != "waiting_for_user":
+                continue
+            sibling_step_id = step_ids_by_task[sibling_task]
+            self._clear_active_step(sibling_step_id)
+            sibling_step = steps_by_id.get(sibling_step_id)
+            if sibling_step is not None:
+                # Non-terminal, and not picked up by the same-wakeup
+                # backfill in schedule_ready_steps(): _ready_steps() offers
+                # this step again once active_step_ids drains, but
+                # _pending_ready_steps() only collects steps already at
+                # "pending", so it waits for the next wakeup's readiness
+                # check before it reruns.
+                sibling_step.status = "clarification_invalidated"
+            invalidated_step_ids.append(sibling_step_id)
+        return invalidated_step_ids
 
     async def _cancel_pending_steps(
         self,

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1860,6 +1860,19 @@ class DAGPattern(AgentPattern):
                 None,
             )
 
+    def has_live_step_tasks(self) -> bool:
+        """Return whether a concurrent step batch is still running right now.
+
+        Only the multi-step branch of ``_execute_ready_steps`` ever
+        populates ``_live_step_tasks``; the single-step fast path never
+        creates an ``asyncio.Task`` and this is always ``False`` on that
+        path. ``_execute_ready_steps`` clears the set in a ``finally``
+        before it returns, whatever the outcome, so a caller inspecting
+        this once ``run()`` has returned always sees an accurate answer.
+        """
+
+        return bool(self._live_step_tasks)
+
     def _waiting_step_id(self) -> str | None:
         for step_id in self.active_step_ids:
             state = self.active_step_pattern_states.get(step_id)

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -817,11 +817,28 @@ class DAGPattern(AgentPattern):
                     )
 
                     if superseded_step_ids:
+                        # A superseded question always means a waiting loser,
+                        # but the winner is not always a question itself --
+                        # an interrupted winner delivers no question of its
+                        # own, so the log line must say so truthfully rather
+                        # than implying %s's question was the one delivered.
+                        if winner_result.get("status") == "waiting_for_user":
+                            log_message = (
+                                "Multiple concurrent DAG steps completed with "
+                                "a pending user question in the same batch; "
+                                "only %s's question is delivered, the rest "
+                                "are invalidated."
+                            )
+                        else:
+                            log_message = (
+                                "Multiple concurrent DAG steps completed with "
+                                "a pending user question in the same batch; "
+                                "questions from the superseded steps were "
+                                "discarded because an interrupt from %s takes "
+                                "precedence."
+                            )
                         logger.warning(
-                            "Multiple concurrent DAG steps completed with a "
-                            "pending user question in the same batch; only "
-                            "%s's question is delivered, the rest are "
-                            "invalidated.",
+                            log_message,
                             winner_step_id,
                             extra={
                                 "execution_id": getattr(

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -321,7 +321,14 @@ class _RuntimeLLMProxy:
 
 
 class DAGPattern(AgentPattern):
-    """Minimal DAG execution pattern that reuses ReActPattern for each step."""
+    """Minimal DAG execution pattern that reuses ReActPattern for each step.
+
+    A task is only ever allowed one active question outstanding at a time
+    against the user; the DAG side of that rule is exactly-one: when
+    concurrent steps in the same batch all end up waiting for a user reply
+    in the same wakeup, exactly one of them gets to keep its question, and
+    the rest are invalidated rather than left to race the user's answer.
+    """
 
     def __init__(
         self,
@@ -354,6 +361,11 @@ class DAGPattern(AgentPattern):
         self.planned_user_message_count = 0
         self.completion_feedback: str | None = None
         self.completion_replan_count = 0
+        # Live concurrent step tasks for the in-progress batch, maintained by
+        # _execute_ready_steps() and always empty once it returns (whatever
+        # the outcome). asyncio.Task objects are not JSON-serializable, so
+        # this must never be added to get_state().
+        self._live_step_tasks: set[asyncio.Task[Any]] = set()
 
     async def run(
         self,
@@ -679,6 +691,7 @@ class DAGPattern(AgentPattern):
         steps_by_id = {step.id: step for step in steps}
         pending = set(tasks)
         scheduled_step_ids = set(steps_by_id)
+        self._live_step_tasks = set(pending)
 
         def schedule_ready_steps() -> None:
             if self.plan is None:
@@ -709,6 +722,7 @@ class DAGPattern(AgentPattern):
                 tasks[task] = ready_step.id
                 steps_by_id[ready_step.id] = ready_step
                 pending.add(task)
+                self._live_step_tasks.add(task)
                 scheduled_step_ids.add(ready_step.id)
                 available_slots -= 1
                 if available_slots <= 0:
@@ -720,68 +734,124 @@ class DAGPattern(AgentPattern):
                     pending,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
+                self._live_step_tasks = set(pending)
+
+                # A single wakeup can complete more than one step; collect
+                # every non-None result instead of acting on whichever task
+                # a ``set`` happens to iterate first.
+                completed_results: list[tuple[asyncio.Task[Any], dict[str, Any]]] = []
                 for task in done:
                     result = task.result()
                     if result is not None:
-                        await self._cancel_pending_steps(
-                            pending,
-                            step_ids_by_task=tasks,
-                            steps_by_id=steps_by_id,
+                        completed_results.append((task, result))
+
+                if completed_results:
+                    # Deterministic winner selection: an interrupted result
+                    # always outranks a waiting one (an interrupt is a
+                    # control instruction, not a workflow question the user
+                    # can be asked to sit through), and within the same kind
+                    # the lexicographically first step id wins.
+                    completed_results.sort(
+                        key=lambda item: (
+                            0 if item[1].get("status") != "waiting_for_user" else 1,
+                            tasks[item[0]],
                         )
-                        if pending:
-                            await runtime.checkpoint(
-                                "dag_after_cancelled_siblings",
-                                context=root_context,
-                                pattern=self,
-                                status=self.status,
-                                metadata={
-                                    "active_step_ids": list(self.active_step_ids),
-                                    "cancelled_step_ids": [
-                                        step_id
-                                        for task, step_id in tasks.items()
-                                        if task in pending
-                                    ],
-                                },
-                            )
-                        return result
-                    failed_step = next(
-                        (
-                            step
-                            for step in steps_by_id.values()
-                            if step.status == "failed"
-                        ),
-                        None,
                     )
-                    if failed_step is not None:
-                        await self._cancel_pending_steps(
-                            pending,
-                            step_ids_by_task=tasks,
-                            steps_by_id=steps_by_id,
+                    winner_task, winner_result = completed_results[0]
+                    winner_step_id = tasks[winner_task]
+
+                    superseded_step_ids: list[str] = []
+                    for loser_task, loser_result in completed_results[1:]:
+                        if loser_result.get("status") != "waiting_for_user":
+                            continue
+                        loser_step_id = tasks[loser_task]
+                        self._clear_active_step(loser_step_id)
+                        loser_step = steps_by_id.get(loser_step_id)
+                        if loser_step is not None:
+                            # Non-terminal, and not picked up by the same-
+                            # wakeup backfill in schedule_ready_steps():
+                            # _ready_steps() offers this step again once
+                            # active_step_ids drains, but
+                            # _pending_ready_steps() only collects steps
+                            # already at "pending", so it waits for the next
+                            # wakeup's readiness check before it reruns.
+                            loser_step.status = "clarification_invalidated"
+                        superseded_step_ids.append(loser_step_id)
+
+                    if superseded_step_ids:
+                        logger.error(
+                            "Multiple concurrent DAG steps completed with a "
+                            "pending user question in the same batch; only "
+                            "%s's question is delivered, the rest are "
+                            "invalidated.",
+                            winner_step_id,
+                            extra={
+                                "execution_id": getattr(
+                                    root_context, "execution_id", None
+                                ),
+                                "superseded_step_ids": superseded_step_ids,
+                                "winner_step_id": winner_step_id,
+                            },
                         )
-                        return await self._fail(
+                        winner_result = {
+                            **winner_result,
+                            "clarification_superseded_step_ids": superseded_step_ids,
+                        }
+
+                    await self._cancel_pending_steps(
+                        pending,
+                        step_ids_by_task=tasks,
+                        steps_by_id=steps_by_id,
+                    )
+                    if pending or superseded_step_ids:
+                        await runtime.checkpoint(
+                            "dag_after_cancelled_siblings",
                             context=root_context,
-                            runtime=runtime,
-                            error=(
-                                failed_step.error or f"Step {failed_step.id} failed."
-                            ),
-                            failure_reason="step_failed",
-                            checkpoint_label="dag_failed",
-                            failed_step_id=failed_step.id,
+                            pattern=self,
+                            status=self.status,
+                            metadata={
+                                "active_step_ids": list(self.active_step_ids),
+                                "cancelled_step_ids": [
+                                    step_id
+                                    for task, step_id in tasks.items()
+                                    if task in pending
+                                ],
+                            },
                         )
-                    if self._needs_replan(root_context):
-                        await self._cancel_pending_steps(
-                            pending,
-                            step_ids_by_task=tasks,
-                            steps_by_id=steps_by_id,
-                        )
-                        return None
-                    if self.status in {"interrupted", "waiting_for_user"}:
-                        await self._cancel_pending_steps(
-                            pending,
-                            step_ids_by_task=tasks,
-                            steps_by_id=steps_by_id,
-                        )
-                        return None
+                    return winner_result
+
+                failed_step = next(
+                    (step for step in steps_by_id.values() if step.status == "failed"),
+                    None,
+                )
+                if failed_step is not None:
+                    await self._cancel_pending_steps(
+                        pending,
+                        step_ids_by_task=tasks,
+                        steps_by_id=steps_by_id,
+                    )
+                    return await self._fail(
+                        context=root_context,
+                        runtime=runtime,
+                        error=(failed_step.error or f"Step {failed_step.id} failed."),
+                        failure_reason="step_failed",
+                        checkpoint_label="dag_failed",
+                        failed_step_id=failed_step.id,
+                    )
+                if self._needs_replan(root_context):
+                    await self._cancel_pending_steps(
+                        pending,
+                        step_ids_by_task=tasks,
+                        steps_by_id=steps_by_id,
+                    )
+                    return None
+                if self.status in {"interrupted", "waiting_for_user"}:
+                    await self._cancel_pending_steps(
+                        pending,
+                        step_ids_by_task=tasks,
+                        steps_by_id=steps_by_id,
+                    )
+                    return None
                 schedule_ready_steps()
         except Exception:
             try:
@@ -793,6 +863,8 @@ class DAGPattern(AgentPattern):
             except Exception:
                 logger.exception("Failed to clean up cancelled DAG sibling steps.")
             raise
+        finally:
+            self._live_step_tasks.clear()
         return None
 
     async def _execute_step(

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -870,7 +870,7 @@ class DAGPattern(AgentPattern):
                     )
                     return None
                 schedule_ready_steps()
-        except Exception:
+        except BaseException:
             try:
                 await self._cancel_pending_steps(
                     pending,
@@ -1886,6 +1886,11 @@ class DAGPattern(AgentPattern):
         path. ``_execute_ready_steps`` clears the set in a ``finally``
         before it returns, whatever the outcome, so a caller inspecting
         this once ``run()`` has returned always sees an accurate answer.
+        This holds for cancellation too: when the task running the
+        pattern is cancelled, the sibling step tasks are cancelled and
+        awaited inside the same exception handler before the ``finally``
+        clears the set, so an empty set on return still means no step
+        task is left running.
         """
 
         return bool(self._live_step_tasks)

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1935,11 +1935,32 @@ class DAGPattern(AgentPattern):
         """Pick the one result a same-wakeup completed batch delivers.
 
         Sorts ``completed_results`` in place and returns its new first
-        entry: an interrupted result always outranks a waiting one (an
-        interrupt is a control instruction, not a workflow question the
-        user can be asked to sit through), and within the same kind the
-        lexicographically first step id wins. Callers needing the losers
-        read ``completed_results[1:]`` after this call.
+        entry. The full precedence a batch's outcome follows, from
+        highest to lowest:
+
+        1. A failed step outranks every completed result in the same
+           batch (handled by the caller before this method is even
+           reached: a doomed DAG must not ask a question or report an
+           interrupt in place of the failure).
+        2. Among completed results, an interrupted one outranks a
+           waiting one -- an interrupt is a control instruction, not a
+           workflow question the user can be asked to sit through.
+        3. Within the same kind, the lexicographically first step id
+           wins, for a deterministic pick regardless of which task an
+           ``asyncio.wait()`` wakeup or set iteration happens to surface
+           first.
+        4. Any completed result -- winner or loser -- outranks a
+           pending replan. The caller only checks ``_needs_replan()``
+           after this batch has been fully handled, so a result the
+           user has already been shown (a question, an interrupt) is
+           never discarded just because a new user message arrived
+           mid-batch. That message is not lost either: it does not
+           advance ``planned_user_message_count``, so the next
+           iteration of ``run()``'s loop still sees the replan as
+           pending and picks it up one turn later.
+
+        Callers needing the losers read ``completed_results[1:]`` after
+        this call.
         """
         completed_results.sort(
             key=lambda item: (

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1975,8 +1975,8 @@ class DAGPattern(AgentPattern):
            not a workflow question the user can be asked to sit
            through. A result status the table does not know sorts last
            instead of raising (see ``rank()`` below for why), and is
-           logged loudly since an unranked status is itself worth
-           investigating.
+           logged as a warning since an unranked status is a handled
+           anomaly worth investigating, not a failure of this method.
         3. Within the same rank, the lexicographically first step id
            wins, for a deterministic pick regardless of which task an
            ``asyncio.wait()`` wakeup or set iteration happens to surface
@@ -2012,7 +2012,7 @@ class DAGPattern(AgentPattern):
                 # the entire batch over one unrecognized status string.
                 # Sorting it last instead preserves the invariant that a
                 # question already asked is delivered whenever possible.
-                logger.error(
+                logger.warning(
                     "Completed DAG step %s has an unranked result status "
                     "%r; ranking it last in this batch instead of raising.",
                     step_ids_by_task[task],

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -760,6 +760,14 @@ class DAGPattern(AgentPattern):
                     winner_task, winner_result = completed_results[0]
                     winner_step_id = tasks[winner_task]
 
+                    # This loop invalidates losers drawn from `done`; the
+                    # cancellation below acts on `pending`. `asyncio.wait`
+                    # partitions the tasks it was given into exactly these
+                    # two sets, so a task can never be in both -- the two
+                    # cleanup passes touch disjoint task sets, and running
+                    # this one before or after the cancellation below
+                    # cannot change which steps end up invalidated versus
+                    # cancelled.
                     superseded_step_ids: list[str] = []
                     for loser_task, loser_result in completed_results[1:]:
                         if loser_result.get("status") != "waiting_for_user":
@@ -816,6 +824,7 @@ class DAGPattern(AgentPattern):
                                     for task, step_id in tasks.items()
                                     if task in pending
                                 ],
+                                "superseded_step_ids": superseded_step_ids,
                             },
                         )
                     return winner_result

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -45,6 +45,16 @@ logger = logging.getLogger(__name__)
 
 DAG_COMPLETION_TOOL_NAME = "assess_dag_completion"
 
+# Precedence for _select_winner()'s ranking of a same-wakeup completed
+# batch: lower rank wins. A status not listed here (only "interrupted"
+# and "waiting_for_user" are expected -- every other completed result
+# status the codebase produces is a terminal one that never reaches
+# this sort) ranks after both via dict.get()'s default in the sort key.
+_COMPLETED_RESULT_RANK: dict[str, int] = {
+    "interrupted": 0,
+    "waiting_for_user": 1,
+}
+
 
 @dataclass
 class DAGCompletionAssessment:
@@ -1959,10 +1969,15 @@ class DAGPattern(AgentPattern):
            batch (handled by the caller before this method is even
            reached: a doomed DAG must not ask a question or report an
            interrupt in place of the failure).
-        2. Among completed results, an interrupted one outranks a
-           waiting one -- an interrupt is a control instruction, not a
-           workflow question the user can be asked to sit through.
-        3. Within the same kind, the lexicographically first step id
+        2. Among completed results, rank comes from
+           ``_COMPLETED_RESULT_RANK``: "interrupted" outranks
+           "waiting_for_user" -- an interrupt is a control instruction,
+           not a workflow question the user can be asked to sit
+           through. A result status the table does not know sorts last
+           instead of raising (see ``rank()`` below for why), and is
+           logged loudly since an unranked status is itself worth
+           investigating.
+        3. Within the same rank, the lexicographically first step id
            wins, for a deterministic pick regardless of which task an
            ``asyncio.wait()`` wakeup or set iteration happens to surface
            first.
@@ -1979,12 +1994,36 @@ class DAGPattern(AgentPattern):
         Callers needing the losers read ``completed_results[1:]`` after
         this call.
         """
-        completed_results.sort(
-            key=lambda item: (
-                0 if item[1].get("status") != "waiting_for_user" else 1,
-                step_ids_by_task[item[0]],
+
+        def rank(
+            item: tuple[asyncio.Task[Any], dict[str, Any]],
+        ) -> tuple[int, str]:
+            task, result = item
+            status = result.get("status")
+            # dict.get()'s key must be `str`; a missing or non-string
+            # status (both otherwise valid at this untyped result-dict
+            # boundary) stringifies to something that is never a table
+            # key, which is exactly the "unranked" case below.
+            status_key = str(status)
+            if status_key not in _COMPLETED_RESULT_RANK:
+                # This runs inside the asyncio.wait() loop in
+                # _execute_ready_steps(); raising here would propagate
+                # through the BaseException cancellation handler and fail
+                # the entire batch over one unrecognized status string.
+                # Sorting it last instead preserves the invariant that a
+                # question already asked is delivered whenever possible.
+                logger.error(
+                    "Completed DAG step %s has an unranked result status "
+                    "%r; ranking it last in this batch instead of raising.",
+                    step_ids_by_task[task],
+                    status,
+                )
+            return (
+                _COMPLETED_RESULT_RANK.get(status_key, len(_COMPLETED_RESULT_RANK)),
+                step_ids_by_task[task],
             )
-        )
+
+        completed_results.sort(key=rank)
         return completed_results[0]
 
     def _invalidate_batch_siblings(
@@ -2037,7 +2076,7 @@ class DAGPattern(AgentPattern):
                 # "pending", so it waits for the next wakeup's readiness
                 # check before it reruns.
                 sibling_step.status = "clarification_invalidated"
-            invalidated_step_ids.append(sibling_step_id)
+                invalidated_step_ids.append(sibling_step_id)
         return invalidated_step_ids
 
     async def _cancel_pending_steps(

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1031,8 +1031,18 @@ class DAGPattern(AgentPattern):
                 pattern=self,
                 metadata={"active_step_id": step.id},
             )
+            # ReAct itself never knows which DAG step it is running as (its
+            # draft always carries step_id=None); attribute the draft to
+            # this step here, where that identity is known. The draft is a
+            # frozen dataclass, so this is a copy, not an in-place edit.
+            draft = result.get("clarification_draft")
+            attributed_result = dict(result)
+            if draft is not None:
+                attributed_result["clarification_draft"] = draft.with_origin_step(
+                    step.id
+                )
             return {
-                **result,
+                **attributed_result,
                 "execution_id": root_context.execution_id,
                 "context": root_context,
                 "active_step_id": step.id,

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -769,6 +769,22 @@ class DAGPattern(AgentPattern):
                     None,
                 )
                 if failed_step is not None:
+                    # A completed sibling in this same wakeup (e.g. one that
+                    # reached waiting_for_user or got interrupted) is never
+                    # coming back for its own turn -- the batch is failing
+                    # regardless -- so its active-step bookkeeping must be
+                    # cleared here too, not just the still-pending ones
+                    # cancel_all() below handles. Every completed sibling is
+                    # cleared unconditionally (clear_all_bookkeeping=True),
+                    # unlike the winner path below, which only clears a
+                    # "waiting_for_user" loser -- there is no winner here to
+                    # spare an "interrupted" sibling's bookkeeping for.
+                    self._invalidate_batch_siblings(
+                        completed_results,
+                        step_ids_by_task=tasks,
+                        steps_by_id=steps_by_id,
+                        clear_all_bookkeeping=True,
+                    )
                     await cancel_all()
                     return await self._fail(
                         context=root_context,
@@ -1939,23 +1955,41 @@ class DAGPattern(AgentPattern):
         *,
         step_ids_by_task: dict[asyncio.Task[Any], str],
         steps_by_id: dict[str, PlanStep],
+        clear_all_bookkeeping: bool = False,
     ) -> list[str]:
-        """Clear active-step bookkeeping and flip status on every
-        completed sibling result passed in that is still holding a live
-        "waiting_for_user" result -- that status is reserved for a step
-        whose question was live and never reached the user. Any other
-        sibling (e.g. one that lost an id tie-break between two
-        "interrupted" results) is left completely alone, bookkeeping
-        included: this is byte-for-byte the inline loop this method was
-        extracted from, just given a name. Returns the ids that got the
-        clarification_invalidated flip, in input order.
+        """Invalidate the losers of a same-wakeup completed batch.
+
+        By default (the winner path) a sibling is only touched at all if
+        its result is "waiting_for_user": its active-step bookkeeping is
+        cleared and its step is flipped to "clarification_invalidated".
+        Any other sibling -- e.g. one that lost an id tie-break between
+        two "interrupted" results -- is left completely alone,
+        bookkeeping included; that tie is not this method's problem to
+        solve.
+
+        Pass clear_all_bookkeeping=True (the failure fast-path) to
+        instead clear every sibling's bookkeeping unconditionally: the
+        whole batch is terminating there, so no sibling's active-step
+        registration should survive into the dag_failed checkpoint
+        regardless of what status it completed with. The
+        clarification_invalidated flip still only ever applies to a
+        "waiting_for_user" result, since that status is reserved for a
+        step whose question was live and never reached the user -- an
+        "interrupted" sibling caught up in a failure is not that step,
+        so it only loses its bookkeeping, not its status.
+
+        Returns the ids that got the clarification_invalidated flip, in
+        input order.
         """
         invalidated_step_ids: list[str] = []
         for sibling_task, sibling_result in siblings:
-            if sibling_result.get("status") != "waiting_for_user":
+            is_waiting = sibling_result.get("status") == "waiting_for_user"
+            if not is_waiting and not clear_all_bookkeeping:
                 continue
             sibling_step_id = step_ids_by_task[sibling_task]
             self._clear_active_step(sibling_step_id)
+            if not is_waiting:
+                continue
             sibling_step = steps_by_id.get(sibling_step_id)
             if sibling_step is not None:
                 # Non-terminal, and not picked up by the same-wakeup

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -890,6 +890,11 @@ class DAGPattern(AgentPattern):
                     return None
                 schedule_ready_steps()
         except BaseException:
+            # A sibling that already completed by this point is not in
+            # `pending`, so cancel_all() below never clears its active-step
+            # bookkeeping. Unobserved today: this exit writes no checkpoint,
+            # and the pattern object is discarded right after re-raising.
+            # Closing or formally waiving this gap is tracked in #1311.
             try:
                 await cancel_all()
             except Exception:

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -745,6 +745,32 @@ class DAGPattern(AgentPattern):
                     if result is not None:
                         completed_results.append((task, result))
 
+                # A batch containing a failed step fails fast, before any
+                # winner is chosen: a DAG that is already doomed must not
+                # ask the user a question or report an interrupt instead of
+                # the failure. This scan therefore runs ahead of the
+                # completed_results winner selection below, so a failure
+                # always outranks an interrupted or waiting result from a
+                # sibling that completed in the same wakeup.
+                failed_step = next(
+                    (step for step in steps_by_id.values() if step.status == "failed"),
+                    None,
+                )
+                if failed_step is not None:
+                    await self._cancel_pending_steps(
+                        pending,
+                        step_ids_by_task=tasks,
+                        steps_by_id=steps_by_id,
+                    )
+                    return await self._fail(
+                        context=root_context,
+                        runtime=runtime,
+                        error=(failed_step.error or f"Step {failed_step.id} failed."),
+                        failure_reason="step_failed",
+                        checkpoint_label="dag_failed",
+                        failed_step_id=failed_step.id,
+                    )
+
                 if completed_results:
                     # Deterministic winner selection: an interrupted result
                     # always outranks a waiting one (an interrupt is a
@@ -829,24 +855,6 @@ class DAGPattern(AgentPattern):
                         )
                     return winner_result
 
-                failed_step = next(
-                    (step for step in steps_by_id.values() if step.status == "failed"),
-                    None,
-                )
-                if failed_step is not None:
-                    await self._cancel_pending_steps(
-                        pending,
-                        step_ids_by_task=tasks,
-                        steps_by_id=steps_by_id,
-                    )
-                    return await self._fail(
-                        context=root_context,
-                        runtime=runtime,
-                        error=(failed_step.error or f"Step {failed_step.id} failed."),
-                        failure_reason="step_failed",
-                        checkpoint_label="dag_failed",
-                        failed_step_id=failed_step.id,
-                    )
                 if self._needs_replan(root_context):
                     await self._cancel_pending_steps(
                         pending,

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1888,9 +1888,9 @@ class DAGPattern(AgentPattern):
         this once ``run()`` has returned always sees an accurate answer.
         This holds for cancellation too: when the task running the
         pattern is cancelled, the sibling step tasks are cancelled and
-        awaited inside the same exception handler before the ``finally``
-        clears the set, so an empty set on return still means no step
-        task is left running.
+        awaited inside the exception handler that wraps the batch loop,
+        before the ``finally`` clears the set, so an empty set on return
+        still means no step task is left running.
         """
 
         return bool(self._live_step_tasks)

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -817,7 +817,7 @@ class DAGPattern(AgentPattern):
                     )
 
                     if superseded_step_ids:
-                        logger.error(
+                        logger.warning(
                             "Multiple concurrent DAG steps completed with a "
                             "pending user question in the same batch; only "
                             "%s's question is delivered, the rest are "

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -52,6 +52,14 @@ class PlanStep:
     termination_condition: str | None = None
     completion_evidence: str | None = None
     tool_names: list[str] = field(default_factory=list)
+    # One of: pending, running, completed, failed, interrupted,
+    # clarification_invalidated. clarification_invalidated marks a step
+    # whose question was superseded by another step's question in the
+    # same concurrent batch before it reached the user; the step is not
+    # terminal and becomes schedulable again once the batch settles.
+    # waiting_for_user is never a step status -- a step waiting on the
+    # user stays "running" here, and only the owning pattern's own
+    # status field moves to "waiting_for_user".
     status: str = "pending"
     result: Any = None
     error: str | None = None

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -255,6 +255,30 @@ class AgentRunner:
                         normalized.get("status") or "failed"
                     ).strip()
                     teardown_status = normalized_status or "failed"
+                    if (
+                        normalized_status == "waiting_for_user"
+                        and normalized.get("clarification_draft") is not None
+                    ):
+                        # A pattern that hands back a question to answer must
+                        # not still have other step tasks running -- those
+                        # would keep mutating shared state (self.status,
+                        # active step bookkeeping) after this run() call has
+                        # already told the caller it is safe to resume from
+                        # a single waiting step. Only DAGPattern implements
+                        # this today; any other pattern is read as having no
+                        # live tasks (auto.py's top-level case included --
+                        # its run() cannot return while a nested DAG child
+                        # still has tasks in flight, so that path is a known,
+                        # accepted gap rather than a real miss).
+                        has_live_step_tasks = getattr(
+                            pattern, "has_live_step_tasks", None
+                        )
+                        if callable(has_live_step_tasks) and has_live_step_tasks():
+                            raise AssertionError(
+                                f"{pattern.__class__.__name__} for execution "
+                                f"{execution_id} returned a waiting_for_user "
+                                "result while it still has live step tasks."
+                            )
                     if normalized_status in {"interrupted", "waiting_for_user"}:
                         await self._dispatch_callback(
                             "on_run_end",

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1733,12 +1733,13 @@ async def test_dag_pattern_failed_step_wins_over_waiting_sibling_in_same_batch()
     )
     pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
 
+    runtime = PatternRuntime(execution_id="dag-failed-vs-waiting")
     run_task = asyncio.create_task(
         pattern.run(
             context=ExecutionContext(execution_id="dag-failed-vs-waiting"),
             tools=[],
             llm=object(),
-            runtime=PatternRuntime(execution_id="dag-failed-vs-waiting"),
+            runtime=runtime,
         )
     )
     await asyncio.wait_for(
@@ -1756,6 +1757,19 @@ async def test_dag_pattern_failed_step_wins_over_waiting_sibling_in_same_batch()
     assert result["failed_step_id"] == "fail_step"
     assert "message" not in result
     assert "clarification_draft" not in result
+
+    # The waiting sibling never gets its own turn -- the batch is failing
+    # regardless -- so its active-step bookkeeping must not be left behind.
+    assert pattern.active_step_ids == []
+    assert pattern.active_step_pattern_states == {}
+    assert pattern.active_step_contexts == {}
+
+    checkpoint = runtime.checkpoints[-1]
+    assert checkpoint["label"] == "dag_failed"
+    checkpoint_state = checkpoint["pattern_state"]
+    assert checkpoint_state["active_step_ids"] == []
+    assert checkpoint_state["active_step_pattern_states"] == {}
+    assert checkpoint_state["active_step_contexts"] == {}
 
 
 @pytest.mark.asyncio
@@ -1802,12 +1816,13 @@ async def test_dag_pattern_failed_step_wins_over_interrupted_sibling_in_same_bat
     )
     pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
 
+    runtime = PatternRuntime(execution_id="dag-failed-vs-interrupted")
     run_task = asyncio.create_task(
         pattern.run(
             context=ExecutionContext(execution_id="dag-failed-vs-interrupted"),
             tools=[],
             llm=object(),
-            runtime=PatternRuntime(execution_id="dag-failed-vs-interrupted"),
+            runtime=runtime,
         )
     )
     await asyncio.wait_for(
@@ -1824,6 +1839,23 @@ async def test_dag_pattern_failed_step_wins_over_interrupted_sibling_in_same_bat
     assert result["status"] != "interrupted"
     assert result["failure_reason"] == "step_failed"
     assert result["failed_step_id"] == "fail_step"
+
+    # The interrupted sibling never gets its own turn -- the batch is
+    # failing regardless -- so its active-step bookkeeping must not be
+    # left behind. It is not the step whose question got superseded, so
+    # its status stays "interrupted" rather than being relabeled.
+    assert pattern.active_step_ids == []
+    assert pattern.active_step_pattern_states == {}
+    assert pattern.active_step_contexts == {}
+    steps_by_id = {step.id: step for step in pattern.plan.steps}
+    assert steps_by_id["interrupt_step"].status == "interrupted"
+
+    checkpoint = runtime.checkpoints[-1]
+    assert checkpoint["label"] == "dag_failed"
+    checkpoint_state = checkpoint["pattern_state"]
+    assert checkpoint_state["active_step_ids"] == []
+    assert checkpoint_state["active_step_pattern_states"] == {}
+    assert checkpoint_state["active_step_contexts"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -2275,6 +2275,243 @@ async def test_dag_pattern_double_waiting_invalidation_persists_across_restore()
     assert "ask_b" not in restored.active_step_contexts
 
 
+async def run_triple_waiting_dag(
+    *, step_ids: tuple[str, str, str]
+) -> tuple[DAGPattern, dict[str, Any], TracerCheckpointStore]:
+    """Run a three-step DAG where all three steps reach waiting_for_user
+    in the same wakeup; return the pattern, the DAG's returned result
+    dict, and the checkpoint tracer, for the caller to assert against."""
+
+    tracer = TracerCheckpointStore()
+    llm = ConcurrentWaitingLLM()
+    execution_id = f"dag-triple-waiting-{'-'.join(step_ids)}"
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            *(PlanStep(id=step_id, task=f"Ask {step_id}") for step_id in step_ids)
+        ),
+        max_concurrency=3,
+    )
+    runtime = PatternRuntime(tracer=tracer, execution_id=execution_id)
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id=execution_id),
+            tools=[],
+            llm=llm,
+            runtime=runtime,
+        )
+    )
+    for step_id in step_ids:
+        await llm.wait_started(f"Ask {step_id}")
+    llm.release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+    return pattern, result, tracer
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_three_way_waiting_batch_supersedes_both_losers() -> None:
+    """When three steps all reach waiting_for_user in the same wakeup,
+    exactly one draft is delivered and the other two are both
+    invalidated -- not just the first loser. The prior double-waiting
+    coverage cannot tell "invalidate every loser" apart from
+    "invalidate only the first loser", since with two results there is
+    only one loser either way; three results are the minimum that can
+    catch a completed_results[1:2] off-by-one slice."""
+
+    pattern, result, _ = await run_triple_waiting_dag(
+        step_ids=("a_step", "b_step", "c_step")
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert result["active_step_id"] == "a_step"
+    assert result["clarification_superseded_step_ids"] == ["b_step", "c_step"]
+
+    steps_by_id = {step.id: step for step in pattern.plan.steps}
+    assert steps_by_id["a_step"].status == "running"
+    assert steps_by_id["b_step"].status == "clarification_invalidated"
+    assert steps_by_id["c_step"].status == "clarification_invalidated"
+
+    assert pattern.active_step_ids == ["a_step"]
+    assert set(pattern.active_step_pattern_states.keys()) == {"a_step"}
+    assert set(pattern.active_step_contexts.keys()) == {"a_step"}
+
+
+class TwoWaitingAndSlowLLM:
+    """Two DAG steps that each reach waiting_for_user via
+    send_message(expect_response=True), synchronized on a shared release
+    event so both complete inside the same asyncio.wait() wakeup, plus a
+    third step that hangs until cancelled."""
+
+    def __init__(self) -> None:
+        self.release = asyncio.Event()
+        self.started_by_task: dict[str, asyncio.Event] = {}
+        self.slow_cancelled = asyncio.Event()
+
+    async def chat(self, **kwargs: Any) -> dict[str, Any]:
+        if has_tool(kwargs, DAG_COMPLETION_TOOL_NAME):
+            return default_completion_assessment_response(kwargs)
+        messages = list(kwargs.get("messages", []))
+        task = current_step_task(messages)
+        self.started_by_task.setdefault(task, asyncio.Event()).set()
+        if task == "Slow task":
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                self.slow_cancelled.set()
+                raise
+        await self.release.wait()
+        return {
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": f"ask-{task}",
+                    "function": {
+                        "name": "send_message",
+                        "arguments": json.dumps(
+                            {
+                                "message": f"Question for {task}",
+                                "message_type": "question",
+                                "expect_response": True,
+                            }
+                        ),
+                    },
+                }
+            ],
+            "done": False,
+        }
+
+    async def wait_started(self, task: str) -> None:
+        await asyncio.wait_for(
+            self.started_by_task.setdefault(task, asyncio.Event()).wait(),
+            timeout=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_cancelled_and_superseded_siblings_both_reported() -> None:
+    """When a batch contains two steps that both reach waiting_for_user
+    and a third that is still running (and gets cancelled as a result),
+    the dag_after_cancelled_siblings checkpoint metadata must carry both
+    outcomes at once -- cancelled_step_ids for the step that never
+    finished and superseded_step_ids for the completed loser -- since a
+    checkpoint consumer needs both to reconstruct the full batch outcome
+    from a single record."""
+
+    llm = TwoWaitingAndSlowLLM()
+    tracer = TracerCheckpointStore()
+    execution_id = "dag-two-waiting-one-slow"
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="a_ask", task="Ask a_ask"),
+            PlanStep(id="b_ask", task="Ask b_ask"),
+            PlanStep(id="slow", task="Slow task"),
+        ),
+        max_concurrency=3,
+        react_max_iterations=1,
+    )
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id=execution_id),
+            tools=[],
+            llm=llm,
+            runtime=PatternRuntime(tracer=tracer, execution_id=execution_id),
+        )
+    )
+    await llm.wait_started("Ask a_ask")
+    await llm.wait_started("Ask b_ask")
+    await llm.wait_started("Slow task")
+    llm.release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+
+    assert result["status"] == "waiting_for_user"
+    assert result["active_step_id"] == "a_ask"
+    assert result["clarification_superseded_step_ids"] == ["b_ask"]
+    assert llm.slow_cancelled.is_set()
+
+    checkpoint = tracer.checkpoints[-1]
+    assert checkpoint["label"] == "dag_after_cancelled_siblings"
+    assert checkpoint["metadata"]["cancelled_step_ids"] == ["slow"]
+    assert checkpoint["metadata"]["superseded_step_ids"] == ["b_ask"]
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_interrupted_tie_break_loser_keeps_bookkeeping() -> None:
+    """Winner-path invalidation only ever touches a "waiting_for_user"
+    loser. When two steps both complete "interrupted" in the same
+    wakeup, one wins the id tie-break and the other is a loser that is
+    not a superseded question -- unlike a waiting loser, it keeps its
+    own active-step bookkeeping (active_step_ids,
+    active_step_pattern_states, active_step_contexts) and its status
+    stays "interrupted" rather than being relabeled
+    clarification_invalidated. This pins the byte-for-byte-refactor
+    claim for _invalidate_batch_siblings(): the winner path must never
+    widen its reach to a non-waiting loser.
+    """
+
+    release = asyncio.Event()
+    started: dict[str, asyncio.Event] = {}
+
+    async def fake_execute_step(
+        self: DAGPattern, *, step: PlanStep, **kwargs: Any
+    ) -> dict[str, Any] | None:
+        started.setdefault(step.id, asyncio.Event()).set()
+        await release.wait()
+        root_context = kwargs["root_context"]
+        self.status = "interrupted"
+        step.status = "interrupted"
+        # A real interrupted step checkpoints its own context and
+        # pattern state (via the per-step child runtime) before
+        # returning; simulate that here since this test stubs
+        # _execute_step entirely and never goes through that runtime.
+        self._set_active_step_context(step.id, {"step": step.id})
+        self._set_active_step_pattern_state(step.id, {"step": step.id})
+        return {
+            "success": False,
+            "status": "interrupted",
+            "execution_id": root_context.execution_id,
+            "context": root_context,
+            "active_step_id": step.id,
+        }
+
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="a_interrupt", task="Interrupt a"),
+            PlanStep(id="b_interrupt", task="Interrupt b"),
+        ),
+        max_concurrency=2,
+    )
+    pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-interrupted-tie"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(execution_id="dag-interrupted-tie"),
+        )
+    )
+    await asyncio.wait_for(
+        started.setdefault("a_interrupt", asyncio.Event()).wait(), timeout=1
+    )
+    await asyncio.wait_for(
+        started.setdefault("b_interrupt", asyncio.Event()).wait(), timeout=1
+    )
+    release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+
+    assert result["status"] == "interrupted"
+    assert result["active_step_id"] == "a_interrupt"
+    assert "clarification_superseded_step_ids" not in result
+
+    steps_by_id = {step.id: step for step in pattern.plan.steps}
+    assert steps_by_id["b_interrupt"].status == "interrupted"
+
+    assert "b_interrupt" in pattern.active_step_ids
+    assert "b_interrupt" in pattern.active_step_pattern_states
+    assert "b_interrupt" in pattern.active_step_contexts
+
+
 @pytest.mark.asyncio
 async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
     """In a batch where one step is interrupted and another is

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -2619,6 +2619,49 @@ async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting(
     assert "'s question is delivered" not in caplog.text
 
 
+def test_dag_pattern_select_winner_orders_a_scrambled_batch() -> None:
+    """_select_winner() is a pure sort over (task, result) pairs; drive it
+    directly instead of through the full asyncio.wait() event loop.
+    completed_results is built out of id order and mixes interrupted and
+    waiting results, and the tasks are plain object() placeholders since
+    the sort never touches the task itself, only the dict it maps to in
+    step_ids_by_task."""
+
+    pattern = DAGPattern(lambda **_: None)
+
+    task_z_wait, task_m_interrupt, task_a_wait, task_b_interrupt = (
+        object(),
+        object(),
+        object(),
+        object(),
+    )
+    completed_results: list[tuple[Any, dict[str, Any]]] = [
+        (task_z_wait, {"status": "waiting_for_user"}),
+        (task_m_interrupt, {"status": "interrupted"}),
+        (task_a_wait, {"status": "waiting_for_user"}),
+        (task_b_interrupt, {"status": "interrupted"}),
+    ]
+    step_ids_by_task = {
+        task_z_wait: "z_wait",
+        task_m_interrupt: "m_interrupt",
+        task_a_wait: "a_wait",
+        task_b_interrupt: "b_interrupt",
+    }
+
+    winner_task, winner_result = pattern._select_winner(
+        completed_results, step_ids_by_task=step_ids_by_task
+    )
+
+    assert winner_task is task_b_interrupt
+    assert winner_result == {"status": "interrupted"}
+    assert [step_ids_by_task[task] for task, _ in completed_results] == [
+        "b_interrupt",
+        "m_interrupt",
+        "a_wait",
+        "z_wait",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_dag_pattern_delivered_result_outranks_pending_replan_in_same_batch() -> (
     None

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1978,10 +1978,10 @@ async def test_dag_pattern_invalidated_step_is_rescheduled_after_winner_settles(
 async def test_dag_pattern_double_waiting_invalidation_persists_across_restore() -> (
     None
 ):
-    """The §H-2 checkpoint extension: a batch that invalidates a loser
-    while ``pending`` is empty (no sibling left to cancel) still writes a
-    checkpoint, so the invalidation survives a resume instead of only
-    living in memory until the process restores from an earlier snapshot.
+    """A batch that invalidates a loser while ``pending`` is empty (no
+    sibling left to cancel) still writes a checkpoint, so the invalidation
+    survives a resume instead of only living in memory until the process
+    restores from an earlier snapshot.
     """
 
     pattern, result, tracer = await run_double_waiting_dag(
@@ -2004,7 +2004,7 @@ async def test_dag_pattern_double_waiting_invalidation_persists_across_restore()
 
 @pytest.mark.asyncio
 async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
-    """§H-3: in a batch where one step is interrupted and another is
+    """In a batch where one step is interrupted and another is
     waiting in the same wakeup, the interrupted result wins -- an
     interrupt is a control instruction, not a workflow question the user
     can be asked to sit through -- and the losing waiting step is

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -2662,6 +2662,45 @@ def test_dag_pattern_select_winner_orders_a_scrambled_batch() -> None:
     ]
 
 
+def test_dag_pattern_select_winner_ranks_an_unknown_status_last(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unrecognized result status is a bug worth surfacing, not a
+    reason to crash the whole batch: _select_winner() runs inside the
+    asyncio.wait() loop in _execute_ready_steps(), where an uncaught
+    exception would propagate through the BaseException cancellation
+    handler and fail every step in the batch over one unexpected status
+    string. It ranks last instead, behind both known ranks, and logs an
+    error so the unrecognized status does not go unnoticed."""
+
+    pattern = DAGPattern(lambda **_: None)
+
+    task_unknown, task_interrupt, task_wait = object(), object(), object()
+    completed_results: list[tuple[Any, dict[str, Any]]] = [
+        (task_unknown, {"status": "some_new_status"}),
+        (task_wait, {"status": "waiting_for_user"}),
+        (task_interrupt, {"status": "interrupted"}),
+    ]
+    step_ids_by_task = {
+        task_unknown: "c_unknown",
+        task_interrupt: "a_interrupt",
+        task_wait: "b_wait",
+    }
+
+    winner_task, _ = pattern._select_winner(
+        completed_results, step_ids_by_task=step_ids_by_task
+    )
+
+    assert winner_task is task_interrupt
+    assert [step_ids_by_task[task] for task, _ in completed_results] == [
+        "a_interrupt",
+        "b_wait",
+        "c_unknown",
+    ]
+    assert "unranked result status" in caplog.text
+    assert "c_unknown" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_dag_pattern_delivered_result_outranks_pending_replan_in_same_batch() -> (
     None

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -2795,6 +2795,112 @@ async def test_dag_pattern_delivered_result_outranks_pending_replan_in_same_batc
 
 
 @pytest.mark.asyncio
+async def test_dag_pattern_three_step_mixed_batch_interrupt_wins_waiting_supersedes_only() -> (
+    None
+):
+    """A genuinely three-way mixed batch: two interrupted steps and one
+    waiting step all complete in the same wakeup. The winner is still
+    the higher-ranked kind (interrupted), and within that kind the
+    lexicographically smaller id -- step ids are chosen so the waiting
+    step would sort first under plain lexicographic order, proving rank
+    decides this before id ever does. Only the waiting loser is a
+    superseded question and gets clarification_invalidated with its
+    bookkeeping cleared; the losing interrupted step is a plain
+    tie-break loser, not a superseded question, so it keeps its own
+    bookkeeping and status exactly like the two-interrupted-tie case.
+    """
+
+    release = asyncio.Event()
+    started: dict[str, asyncio.Event] = {}
+
+    async def fake_execute_step(
+        self: DAGPattern, *, step: PlanStep, **kwargs: Any
+    ) -> dict[str, Any] | None:
+        started.setdefault(step.id, asyncio.Event()).set()
+        await release.wait()
+        root_context = kwargs["root_context"]
+        if step.id in ("b_interrupt", "m_interrupt"):
+            self.status = "interrupted"
+            step.status = "interrupted"
+            # A real interrupted step checkpoints its own context and
+            # pattern state before returning; simulate that here since
+            # this test stubs _execute_step entirely.
+            self._set_active_step_context(step.id, {"step": step.id})
+            self._set_active_step_pattern_state(step.id, {"step": step.id})
+            return {
+                "success": False,
+                "status": "interrupted",
+                "execution_id": root_context.execution_id,
+                "context": root_context,
+                "active_step_id": step.id,
+            }
+        self.status = "waiting_for_user"
+        draft = draft_from_waiting_request(
+            {
+                "message": "Pick one",
+                "message_type": "question",
+                "interactions": [],
+                "tool_call_id": "ask-wait",
+                "tool_name": "ask_user_question",
+                "message_count": 2,
+            },
+            execution_id=root_context.execution_id,
+            step_id=None,
+        )
+        attributed_draft = draft.with_origin_step(step.id) if draft else None
+        return {
+            "success": False,
+            "status": "waiting_for_user",
+            "message": "Pick one",
+            "message_type": "question",
+            "clarification_draft": attributed_draft,
+            "execution_id": root_context.execution_id,
+            "context": root_context,
+            "active_step_id": step.id,
+        }
+
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="a_wait", task="Wait"),
+            PlanStep(id="b_interrupt", task="Interrupt b"),
+            PlanStep(id="m_interrupt", task="Interrupt m"),
+        ),
+        max_concurrency=3,
+    )
+    pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-three-way-mixed"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(execution_id="dag-three-way-mixed"),
+        )
+    )
+    for step_id in ("a_wait", "b_interrupt", "m_interrupt"):
+        await asyncio.wait_for(
+            started.setdefault(step_id, asyncio.Event()).wait(), timeout=1
+        )
+    release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+
+    assert result["status"] == "interrupted"
+    assert result["active_step_id"] == "b_interrupt"
+    assert result["clarification_superseded_step_ids"] == ["a_wait"]
+
+    steps_by_id = {step.id: step for step in pattern.plan.steps}
+    assert steps_by_id["a_wait"].status == "clarification_invalidated"
+    assert "a_wait" not in pattern.active_step_ids
+    assert "a_wait" not in pattern.active_step_pattern_states
+    assert "a_wait" not in pattern.active_step_contexts
+
+    assert steps_by_id["m_interrupt"].status == "interrupted"
+    assert "m_interrupt" in pattern.active_step_ids
+    assert "m_interrupt" in pattern.active_step_pattern_states
+    assert "m_interrupt" in pattern.active_step_contexts
+
+
+@pytest.mark.asyncio
 async def test_dag_waiting_draft_attribution_differs_only_by_step() -> None:
     """Two independently-run steps reaching an identical waiting
     turn (same message count, same tool_call_id/interaction_id) get

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1805,51 +1805,54 @@ async def test_dag_pattern_concurrent_double_waiting_delivers_to_winner() -> Non
     assert pattern._waiting_step_id() == "ask_a" == result["active_step_id"]
 
 
-@pytest.mark.asyncio
-async def test_dag_pattern_single_waiting_regression_unchanged() -> None:
-    """T-X-4: a single step reaching waiting_for_user, with an independent
-    sibling still running, is unaffected by the exactly-one machinery --
-    same result keys, same sibling cancellation, no superseded-step key."""
+class WaitingAndSlowLLM:
+    def __init__(self) -> None:
+        self.slow_started = asyncio.Event()
+        self.slow_cancelled = asyncio.Event()
 
-    class WaitingAndSlowLLM:
-        def __init__(self) -> None:
-            self.slow_started = asyncio.Event()
-            self.slow_cancelled = asyncio.Event()
+    async def chat(self, **kwargs: Any) -> dict[str, Any]:
+        if has_tool(kwargs, DAG_COMPLETION_TOOL_NAME):
+            return default_completion_assessment_response(kwargs)
+        messages = list(kwargs.get("messages", []))
+        task = current_step_task(messages)
+        if task == "Slow task":
+            self.slow_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                self.slow_cancelled.set()
+                raise
+        if task == "Ask task":
+            await self.slow_started.wait()
+            return {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "ask-only",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Pick an option",
+                                    "message_type": "question",
+                                    "expect_response": True,
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            }
+        return {"content": "done", "done": True}
 
-        async def chat(self, **kwargs: Any) -> dict[str, Any]:
-            if has_tool(kwargs, DAG_COMPLETION_TOOL_NAME):
-                return default_completion_assessment_response(kwargs)
-            messages = list(kwargs.get("messages", []))
-            task = current_step_task(messages)
-            if task == "Slow task":
-                self.slow_started.set()
-                try:
-                    await asyncio.Future()
-                except asyncio.CancelledError:
-                    self.slow_cancelled.set()
-                    raise
-            if task == "Ask task":
-                await self.slow_started.wait()
-                return {
-                    "content": "",
-                    "tool_calls": [
-                        {
-                            "id": "ask-only",
-                            "function": {
-                                "name": "send_message",
-                                "arguments": json.dumps(
-                                    {
-                                        "message": "Pick an option",
-                                        "message_type": "question",
-                                        "expect_response": True,
-                                    }
-                                ),
-                            },
-                        }
-                    ],
-                    "done": False,
-                }
-            return {"content": "done", "done": True}
+
+async def run_single_waiting_with_cancelled_sibling_dag() -> tuple[
+    DAGPattern, dict[str, Any], TracerCheckpointStore, WaitingAndSlowLLM
+]:
+    """Run a two-step DAG where one step reaches waiting_for_user while an
+    independent sibling is still in flight and gets cancelled as a result;
+    return the pattern, the result, the checkpoint tracer, and the fake
+    LLM, for the caller to assert against."""
 
     llm = WaitingAndSlowLLM()
     tracer = TracerCheckpointStore()
@@ -1870,6 +1873,16 @@ async def test_dag_pattern_single_waiting_regression_unchanged() -> None:
         ),
         timeout=1,
     )
+    return pattern, result, tracer, llm
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_single_waiting_regression_unchanged() -> None:
+    """T-X-4: a single step reaching waiting_for_user, with an independent
+    sibling still running, is unaffected by the exactly-one machinery --
+    same result keys, same sibling cancellation, no superseded-step key."""
+
+    pattern, result, tracer, llm = await run_single_waiting_with_cancelled_sibling_dag()
 
     assert result["status"] == "waiting_for_user"
     assert result["active_step_id"] == "ask"
@@ -1891,6 +1904,26 @@ async def test_dag_pattern_single_waiting_regression_unchanged() -> None:
         "slow": "pending",
     }
     assert tracer.checkpoints[-1]["label"] == "dag_after_cancelled_siblings"
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_live_step_tasks_cleared_after_cancelling_a_sibling() -> None:
+    """has_live_step_tasks() reads False once run() has returned even when
+    the winning batch left a genuinely non-empty pending set behind (here,
+    a still-running sibling that gets cancelled). The all-waiting scenario
+    cannot pin this: both of its steps complete in the same wakeup, so its
+    pending set is already empty before the batch is even processed, and
+    the finally clause that clears the live-task set has nothing left to
+    do by the time it runs. Only a scenario where pending is genuinely
+    non-empty at the point the winner is chosen -- a step cancelled
+    instead of completed -- can tell a present finally-clause clear apart
+    from a missing one.
+    """
+
+    pattern, result, _, _ = await run_single_waiting_with_cancelled_sibling_dag()
+
+    assert result["status"] == "waiting_for_user"
+    assert pattern.has_live_step_tasks() is False
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1753,7 +1753,7 @@ async def run_double_waiting_dag(
 
 @pytest.mark.asyncio
 async def test_dag_pattern_concurrent_double_waiting_invalidates_loser() -> None:
-    """T-X-1: when two steps both reach waiting_for_user in the same
+    """When two steps both reach waiting_for_user in the same
     wakeup, exactly one draft is delivered; the other is invalidated
     (status, active-step bookkeeping cleared) and its id is surfaced under
     clarification_superseded_step_ids on the winner's result. No signal is
@@ -1778,7 +1778,7 @@ async def test_dag_pattern_concurrent_double_waiting_invalidates_loser() -> None
 
 @pytest.mark.asyncio
 async def test_dag_pattern_concurrent_double_waiting_winner_is_deterministic() -> None:
-    """T-X-2: the winner is the lexicographically first step id, regardless
+    """The winner is the lexicographically first step id, regardless
     of which step's task happened to be constructed (and therefore
     scheduled) first -- not whichever task a ``set`` iterates first."""
 
@@ -1795,7 +1795,7 @@ async def test_dag_pattern_concurrent_double_waiting_winner_is_deterministic() -
 
 @pytest.mark.asyncio
 async def test_dag_pattern_concurrent_double_waiting_delivers_to_winner() -> None:
-    """T-X-3: the reply-delivery lookup resolves to the winning step, not
+    """The reply-delivery lookup resolves to the winning step, not
     an arbitrary one."""
 
     pattern, result, _ = await run_double_waiting_dag(
@@ -1878,7 +1878,7 @@ async def run_single_waiting_with_cancelled_sibling_dag() -> tuple[
 
 @pytest.mark.asyncio
 async def test_dag_pattern_single_waiting_regression_unchanged() -> None:
-    """T-X-4: a single step reaching waiting_for_user, with an independent
+    """A single step reaching waiting_for_user, with an independent
     sibling still running, is unaffected by the exactly-one machinery --
     same result keys, same sibling cancellation, no superseded-step key."""
 
@@ -1928,7 +1928,7 @@ async def test_dag_pattern_live_step_tasks_cleared_after_cancelling_a_sibling() 
 
 @pytest.mark.asyncio
 async def test_dag_pattern_has_no_live_step_tasks_at_waiting_return() -> None:
-    """T-X-5 (DAG half): has_live_step_tasks() reads False once run() has
+    """has_live_step_tasks() reads False once run() has
     handed back a waiting result -- the executable form of "no step task
     outlives the batch that produced the delivered answer"."""
 
@@ -1942,7 +1942,7 @@ async def test_dag_pattern_has_no_live_step_tasks_at_waiting_return() -> None:
 
 @pytest.mark.asyncio
 async def test_dag_pattern_live_step_tasks_excluded_from_get_state() -> None:
-    """T-X-5b: the live-task-tracking attribute never reaches get_state()
+    """The live-task-tracking attribute never reaches get_state()
     -- asyncio.Task objects are not JSON-serializable, so leaking one in
     would silently break checkpoint persistence."""
 
@@ -1961,7 +1961,7 @@ async def test_dag_pattern_live_step_tasks_excluded_from_get_state() -> None:
 async def test_dag_pattern_invalidated_step_is_rescheduled_after_winner_settles() -> (
     None
 ):
-    """T-X-6: invalidation is non-terminal. Once active_step_ids drains,
+    """Invalidation is non-terminal. Once active_step_ids drains,
     _ready_steps() offers the invalidated step again, and the next attempt
     flips its status back to "running".
 
@@ -2135,7 +2135,7 @@ async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
 
 @pytest.mark.asyncio
 async def test_dag_waiting_draft_attribution_differs_only_by_step() -> None:
-    """T-R-17: two independently-run steps reaching an identical waiting
+    """Two independently-run steps reaching an identical waiting
     turn (same message count, same tool_call_id/interaction_id) get
     distinct turn markers purely because DAG attributes each draft to its
     own step; levelling that attribution to a shared step id makes the two
@@ -2203,7 +2203,7 @@ async def test_dag_waiting_draft_attribution_differs_only_by_step() -> None:
 
 @pytest.mark.asyncio
 async def test_dag_waiting_draft_reentry_without_new_message_is_stable() -> None:
-    """T-R-18: resuming the same waiting step with no new user message
+    """Resuming the same waiting step with no new user message
     reproduces the identical origin_step_id and turn_marker -- a pure
     re-entry, not a new turn."""
 

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -3059,6 +3059,59 @@ async def test_callable_plan_generator_receives_structured_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dag_pattern_replan_treats_invalidated_step_as_pending() -> None:
+    """A step already flipped to clarification_invalidated by a
+    superseded-question batch is neither a completed result to reuse
+    nor a status that should silently carry over into a fresh plan.
+    Replan generation must still see it on previous_plan -- the replan
+    prompt is built straight from that request, so a planner can react
+    to a step whose question got superseded -- but the regenerated plan
+    comes back with every step at "pending", and any active-step
+    bookkeeping left over from before the replan is gone.
+    """
+
+    seen: list[PlanGenerationRequest] = []
+
+    def build_from_request(**kwargs: Any) -> ExecutionPlan:
+        request = kwargs["request"]
+        seen.append(request)
+        return build_plan(
+            PlanStep(id="step_1", task="Redo step 1"),
+            PlanStep(id="step_2", task="Redo step 2"),
+        )
+
+    pattern = DAGPattern(build_from_request)
+    pattern.plan = build_plan(
+        PlanStep(id="step_1", task="Do step 1", status="running"),
+        PlanStep(id="step_2", task="Do step 2", status="clarification_invalidated"),
+    )
+    pattern._set_active_step_context("step_2", {"step": "step_2"})
+    pattern._set_active_step_pattern_state("step_2", {"step": "step_2"})
+
+    context = ExecutionContext(execution_id="dag-replan-invalidated")
+
+    await pattern._generate_plan(
+        context=context,
+        tools=[],
+        llm=object(),
+        runtime=PatternRuntime(execution_id=context.execution_id),
+        replan=True,
+    )
+
+    assert len(seen) == 1
+    previous_steps_by_id = {
+        step["id"]: step for step in seen[0].previous_plan.to_dict()["steps"]
+    }
+    assert previous_steps_by_id["step_2"]["status"] == "clarification_invalidated"
+
+    assert [step.status for step in pattern.plan.steps] == ["pending", "pending"]
+
+    assert pattern.active_step_ids == []
+    assert pattern.active_step_pattern_states == {}
+    assert pattern.active_step_contexts == {}
+
+
+@pytest.mark.asyncio
 async def test_llm_plan_generator_builds_plan_from_model_json() -> None:
     generator = LLMPlanGenerator()
     context = ExecutionContext(execution_id="dag-llm-plan")

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -2513,7 +2513,9 @@ async def test_dag_pattern_interrupted_tie_break_loser_keeps_bookkeeping() -> No
 
 
 @pytest.mark.asyncio
-async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
+async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """In a batch where one step is interrupted and another is
     waiting in the same wakeup, the interrupted result wins -- an
     interrupt is a control instruction, not a workflow question the user
@@ -2529,6 +2531,10 @@ async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
     _execute_ready_steps actually schedules as asyncio.Task objects -- and
     exercises the real scheduling, sorting, and invalidation logic under
     test through genuine concurrent tasks.
+
+    The superseded-question log line must also describe an interrupted
+    winner truthfully: an interrupt delivers no question of its own, so
+    the message must not claim the winner's question was delivered.
     """
 
     release = asyncio.Event()
@@ -2608,6 +2614,9 @@ async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
     steps_by_id = {step.id: step for step in pattern.plan.steps}
     assert steps_by_id["a_wait_step"].status == "clarification_invalidated"
     assert "a_wait_step" not in pattern.active_step_ids
+
+    assert "takes precedence" in caplog.text
+    assert "'s question is delivered" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -2374,6 +2374,99 @@ async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dag_pattern_delivered_result_outranks_pending_replan_in_same_batch() -> (
+    None
+):
+    """A completed result already handed to the user is never discarded
+    just because a new user message showed up mid-batch and made
+    _needs_replan() true. The waiting step's sibling both drops out with
+    no result (as an interrupted step does) and appends a fresh user
+    message to the shared context while it runs, so by the time the
+    batch is processed self.status is "waiting_for_user" and
+    _needs_replan() would read true -- but the completed-results branch
+    returns first, so the plan is generated exactly once: no replan
+    happens, and that new message is simply picked up one turn later.
+    """
+
+    release = asyncio.Event()
+    started: dict[str, asyncio.Event] = {}
+    plan_calls: list[None] = []
+    dropout_calls: list[None] = []
+
+    def counting_plan_generator(**_: Any) -> Any:
+        plan_calls.append(None)
+        return build_plan(
+            PlanStep(id="wait_step", task="Ask me"),
+            PlanStep(id="dropout_step", task="Drop out"),
+        )
+
+    async def fake_execute_step(
+        self: DAGPattern, *, step: PlanStep, **kwargs: Any
+    ) -> dict[str, Any] | None:
+        started.setdefault(step.id, asyncio.Event()).set()
+        await release.wait()
+        root_context = kwargs["root_context"]
+        if step.id == "dropout_step":
+            # A new message arrives while this sibling is in flight, once
+            # only, so a wrongly-ordered implementation replans exactly
+            # once instead of looping forever on it; it then drops out
+            # with no result of its own, the same shape a step cancelled
+            # mid-turn produces.
+            if not dropout_calls:
+                dropout_calls.append(None)
+                root_context.add_user_message("Actually, do something else")
+            return None
+        self.status = "waiting_for_user"
+        draft = draft_from_waiting_request(
+            {
+                "message": "Pick one",
+                "message_type": "question",
+                "interactions": [],
+                "tool_call_id": "ask-wait",
+                "tool_name": "ask_user_question",
+                "message_count": 2,
+            },
+            execution_id=root_context.execution_id,
+            step_id=None,
+        )
+        attributed_draft = draft.with_origin_step(step.id) if draft else None
+        return {
+            "success": False,
+            "status": "waiting_for_user",
+            "message": "Pick one",
+            "message_type": "question",
+            "clarification_draft": attributed_draft,
+            "execution_id": root_context.execution_id,
+            "context": root_context,
+            "active_step_id": step.id,
+        }
+
+    pattern = DAGPattern(counting_plan_generator, max_concurrency=2)
+    pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-result-outranks-replan"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(execution_id="dag-result-outranks-replan"),
+        )
+    )
+    await asyncio.wait_for(
+        started.setdefault("wait_step", asyncio.Event()).wait(), timeout=1
+    )
+    await asyncio.wait_for(
+        started.setdefault("dropout_step", asyncio.Event()).wait(), timeout=1
+    )
+    release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+
+    assert result["status"] == "waiting_for_user"
+    assert result["active_step_id"] == "wait_step"
+    assert len(plan_calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_dag_waiting_draft_attribution_differs_only_by_step() -> None:
     """Two independently-run steps reaching an identical waiting
     turn (same message count, same tool_call_id/interaction_id) get

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1894,6 +1894,37 @@ async def test_dag_pattern_single_waiting_regression_unchanged() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dag_pattern_has_no_live_step_tasks_at_waiting_return() -> None:
+    """T-X-5 (DAG half): has_live_step_tasks() reads False once run() has
+    handed back a waiting result -- the executable form of "no step task
+    outlives the batch that produced the delivered answer"."""
+
+    pattern, result, _ = await run_double_waiting_dag(
+        first_step_id="ask_a", second_step_id="ask_b"
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert pattern.has_live_step_tasks() is False
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_live_step_tasks_excluded_from_get_state() -> None:
+    """T-X-5b: the live-task-tracking attribute never reaches get_state()
+    -- asyncio.Task objects are not JSON-serializable, so leaking one in
+    would silently break checkpoint persistence."""
+
+    pattern, _, _ = await run_double_waiting_dag(
+        first_step_id="ask_a", second_step_id="ask_b"
+    )
+
+    state = pattern.get_state()
+
+    assert "_live_step_tasks" not in state
+    assert not any("live_step_tasks" in key for key in state)
+    json.dumps(state)
+
+
+@pytest.mark.asyncio
 async def test_dag_pattern_invalidated_step_is_rescheduled_after_winner_settles() -> (
     None
 ):

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -21,7 +21,10 @@ from xagent.core.agent import (
     PlanStep,
     PlanValidationError,
 )
-from xagent.core.agent.clarification import draft_from_waiting_request
+from xagent.core.agent.clarification import (
+    ClarificationDraft,
+    draft_from_waiting_request,
+)
 from xagent.core.agent.pattern.base import RequiredToolCallError
 from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
 from xagent.core.agent.pattern.dag.plan_generator import (
@@ -2064,6 +2067,138 @@ async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
     steps_by_id = {step.id: step for step in pattern.plan.steps}
     assert steps_by_id["a_wait_step"].status == "clarification_invalidated"
     assert "a_wait_step" not in pattern.active_step_ids
+
+
+@pytest.mark.asyncio
+async def test_dag_waiting_draft_attribution_differs_only_by_step() -> None:
+    """T-R-17: two independently-run steps reaching an identical waiting
+    turn (same message count, same tool_call_id/interaction_id) get
+    distinct turn markers purely because DAG attributes each draft to its
+    own step; levelling that attribution to a shared step id makes the two
+    drafts fully equal, proving the inequality comes only from step
+    identity."""
+
+    class FixedAskLLM:
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "ask-fixed",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Pick an option",
+                                    "message_type": "question",
+                                    "expect_response": True,
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            }
+
+    async def run_single_step(step_id: str) -> ClarificationDraft:
+        pattern = DAGPattern(lambda **_: None)
+        root_context = ExecutionContext(execution_id=f"dag-attr-{step_id}")
+        root_context.add_user_message("Help me decide")
+        result = await pattern._execute_step(
+            step=PlanStep(id=step_id, task="Ask"),
+            root_context=root_context,
+            tools=[],
+            llm=FixedAskLLM(),
+            runtime=PatternRuntime(execution_id=f"dag-attr-{step_id}"),
+        )
+        assert result is not None
+        assert result["status"] == "waiting_for_user"
+        draft = result["clarification_draft"]
+        assert draft is not None
+        return draft
+
+    draft_a = await run_single_step("step_a")
+    draft_b = await run_single_step("step_b")
+
+    # Same turn content in every field that feeds the marker.
+    assert draft_a.turn_message_count == draft_b.turn_message_count
+    assert draft_a.requests == draft_b.requests
+    assert draft_a.origin_step_id == "step_a"
+    assert draft_b.origin_step_id == "step_b"
+    assert draft_a.turn_marker != draft_b.turn_marker
+
+    # Levelling only the step attribution (origin_execution_id is not a
+    # marker input and legitimately differs here -- each call built its own
+    # root context) makes the two markers equal, proving the earlier
+    # inequality traced to step identity alone.
+    assert (
+        draft_a.with_origin_step("shared").turn_marker
+        == draft_b.with_origin_step("shared").turn_marker
+    )
+
+
+@pytest.mark.asyncio
+async def test_dag_waiting_draft_reentry_without_new_message_is_stable() -> None:
+    """T-R-18: resuming the same waiting step with no new user message
+    reproduces the identical origin_step_id and turn_marker -- a pure
+    re-entry, not a new turn."""
+
+    class FixedAskLLM:
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "ask-fixed",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Pick an option",
+                                    "message_type": "question",
+                                    "expect_response": True,
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            }
+
+    class UnusedLLM:
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("a pure re-entry must not call the LLM again")
+
+    pattern = DAGPattern(lambda **_: None)
+    step = PlanStep(id="confirm", task="Ask")
+    root_context = ExecutionContext(execution_id="dag-reentry")
+    root_context.add_user_message("Help me decide")
+
+    first = await pattern._execute_step(
+        step=step,
+        root_context=root_context,
+        tools=[],
+        llm=FixedAskLLM(),
+        runtime=PatternRuntime(execution_id="dag-reentry"),
+    )
+    assert first is not None
+    first_draft = first["clarification_draft"]
+    assert first_draft is not None
+
+    second = await pattern._execute_step(
+        step=step,
+        root_context=root_context,
+        tools=[],
+        llm=UnusedLLM(),
+        runtime=PatternRuntime(execution_id="dag-reentry"),
+    )
+    assert second is not None
+    second_draft = second["clarification_draft"]
+    assert second_draft is not None
+
+    assert second_draft.origin_step_id == first_draft.origin_step_id == "confirm"
+    assert second_draft.turn_marker == first_draft.turn_marker
+    assert second_draft == first_draft
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -21,6 +21,7 @@ from xagent.core.agent import (
     PlanStep,
     PlanValidationError,
 )
+from xagent.core.agent.clarification import draft_from_waiting_request
 from xagent.core.agent.pattern.base import RequiredToolCallError
 from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
 from xagent.core.agent.pattern.dag.plan_generator import (
@@ -1668,6 +1669,401 @@ async def test_dag_pattern_concurrent_failure_clears_cancelled_sibling() -> None
         "fail": "failed",
         "slow": "pending",
     }
+
+
+class ConcurrentWaitingLLM:
+    """Two DAG steps that each reach waiting_for_user via
+    send_message(expect_response=True), synchronized on a shared release
+    event so both complete inside the same asyncio.wait() wakeup."""
+
+    def __init__(self) -> None:
+        self.release = asyncio.Event()
+        self.started_by_task: dict[str, asyncio.Event] = {}
+
+    async def chat(self, **kwargs: Any) -> dict[str, Any]:
+        if has_tool(kwargs, DAG_COMPLETION_TOOL_NAME):
+            return default_completion_assessment_response(kwargs)
+        messages = list(kwargs.get("messages", []))
+        task = current_step_task(messages)
+        self.started_by_task.setdefault(task, asyncio.Event()).set()
+        await self.release.wait()
+        return {
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": f"ask-{task}",
+                    "function": {
+                        "name": "send_message",
+                        "arguments": json.dumps(
+                            {
+                                "message": f"Question for {task}",
+                                "message_type": "question",
+                                "expect_response": True,
+                            }
+                        ),
+                    },
+                }
+            ],
+            "done": False,
+        }
+
+    async def wait_started(self, task: str) -> None:
+        await asyncio.wait_for(
+            self.started_by_task.setdefault(task, asyncio.Event()).wait(),
+            timeout=1,
+        )
+
+
+async def run_double_waiting_dag(
+    *, first_step_id: str, second_step_id: str
+) -> tuple[DAGPattern, dict[str, Any], TracerCheckpointStore]:
+    """Run a two-step DAG where both steps reach waiting_for_user in the
+    same wakeup; return the pattern, the DAG's returned result dict, and
+    the checkpoint tracer, for the caller to assert against."""
+
+    tracer = TracerCheckpointStore()
+    llm = ConcurrentWaitingLLM()
+    execution_id = f"dag-double-waiting-{first_step_id}-{second_step_id}"
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id=first_step_id, task=f"Ask {first_step_id}"),
+            PlanStep(id=second_step_id, task=f"Ask {second_step_id}"),
+        ),
+        max_concurrency=2,
+    )
+    runtime = PatternRuntime(tracer=tracer, execution_id=execution_id)
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id=execution_id),
+            tools=[],
+            llm=llm,
+            runtime=runtime,
+        )
+    )
+    await llm.wait_started(f"Ask {first_step_id}")
+    await llm.wait_started(f"Ask {second_step_id}")
+    llm.release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+    return pattern, result, tracer
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_concurrent_double_waiting_invalidates_loser() -> None:
+    """T-X-1: when two steps both reach waiting_for_user in the same
+    wakeup, exactly one draft is delivered; the other is invalidated
+    (status, active-step bookkeeping cleared) and its id is surfaced under
+    clarification_superseded_step_ids on the winner's result. No signal is
+    asserted here -- registering one is not this layer's job."""
+
+    pattern, result, _ = await run_double_waiting_dag(
+        first_step_id="ask_a", second_step_id="ask_b"
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert result["active_step_id"] == "ask_a"
+    assert result["clarification_superseded_step_ids"] == ["ask_b"]
+
+    steps_by_id = {step.id: step for step in pattern.plan.steps}
+    assert steps_by_id["ask_b"].status == "clarification_invalidated"
+    assert steps_by_id["ask_a"].status == "running"
+
+    assert pattern.active_step_ids == ["ask_a"]
+    assert "ask_b" not in pattern.active_step_pattern_states
+    assert "ask_b" not in pattern.active_step_contexts
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_concurrent_double_waiting_winner_is_deterministic() -> None:
+    """T-X-2: the winner is the lexicographically first step id, regardless
+    of which step's task happened to be constructed (and therefore
+    scheduled) first -- not whichever task a ``set`` iterates first."""
+
+    _, result_first_then_second, _ = await run_double_waiting_dag(
+        first_step_id="ask_a", second_step_id="ask_b"
+    )
+    _, result_second_then_first, _ = await run_double_waiting_dag(
+        first_step_id="ask_b", second_step_id="ask_a"
+    )
+
+    assert result_first_then_second["active_step_id"] == "ask_a"
+    assert result_second_then_first["active_step_id"] == "ask_a"
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_concurrent_double_waiting_delivers_to_winner() -> None:
+    """T-X-3: the reply-delivery lookup resolves to the winning step, not
+    an arbitrary one."""
+
+    pattern, result, _ = await run_double_waiting_dag(
+        first_step_id="ask_a", second_step_id="ask_b"
+    )
+
+    assert pattern._waiting_step_id() == "ask_a" == result["active_step_id"]
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_single_waiting_regression_unchanged() -> None:
+    """T-X-4: a single step reaching waiting_for_user, with an independent
+    sibling still running, is unaffected by the exactly-one machinery --
+    same result keys, same sibling cancellation, no superseded-step key."""
+
+    class WaitingAndSlowLLM:
+        def __init__(self) -> None:
+            self.slow_started = asyncio.Event()
+            self.slow_cancelled = asyncio.Event()
+
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            if has_tool(kwargs, DAG_COMPLETION_TOOL_NAME):
+                return default_completion_assessment_response(kwargs)
+            messages = list(kwargs.get("messages", []))
+            task = current_step_task(messages)
+            if task == "Slow task":
+                self.slow_started.set()
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    self.slow_cancelled.set()
+                    raise
+            if task == "Ask task":
+                await self.slow_started.wait()
+                return {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "ask-only",
+                            "function": {
+                                "name": "send_message",
+                                "arguments": json.dumps(
+                                    {
+                                        "message": "Pick an option",
+                                        "message_type": "question",
+                                        "expect_response": True,
+                                    }
+                                ),
+                            },
+                        }
+                    ],
+                    "done": False,
+                }
+            return {"content": "done", "done": True}
+
+    llm = WaitingAndSlowLLM()
+    tracer = TracerCheckpointStore()
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="ask", task="Ask task"),
+            PlanStep(id="slow", task="Slow task"),
+        ),
+        react_max_iterations=1,
+    )
+
+    result = await asyncio.wait_for(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-single-waiting"),
+            tools=[],
+            llm=llm,
+            runtime=PatternRuntime(tracer=tracer, execution_id="dag-single-waiting"),
+        ),
+        timeout=1,
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert result["active_step_id"] == "ask"
+    assert "clarification_superseded_step_ids" not in result
+    assert set(result.keys()) == {
+        "success",
+        "status",
+        "message",
+        "message_type",
+        "context",
+        "clarification_draft",
+        "execution_id",
+        "active_step_id",
+    }
+    assert llm.slow_cancelled.is_set()
+    assert pattern.active_step_ids == ["ask"]
+    assert {step.id: step.status for step in pattern.plan.steps} == {
+        "ask": "running",
+        "slow": "pending",
+    }
+    assert tracer.checkpoints[-1]["label"] == "dag_after_cancelled_siblings"
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_invalidated_step_is_rescheduled_after_winner_settles() -> (
+    None
+):
+    """T-X-6: invalidation is non-terminal. Once active_step_ids drains,
+    _ready_steps() offers the invalidated step again, and the next attempt
+    flips its status back to "running".
+
+    That next attempt is a brand-new try from the top of the step, not a
+    resume: whatever tool calls the step already made and whatever message
+    it already sent to the user before invalidation are not replayed or
+    compensated -- the step's prior context is dropped, not reused.
+    """
+
+    pattern, _, _ = await run_double_waiting_dag(
+        first_step_id="ask_a", second_step_id="ask_b"
+    )
+    loser = next(step for step in pattern.plan.steps if step.id == "ask_b")
+    assert loser.status == "clarification_invalidated"
+
+    # The winner's turn has settled and the DAG is free to schedule again.
+    pattern.active_step_ids = []
+    ready_ids = {step.id for step in pattern._ready_steps()}
+    assert "ask_b" in ready_ids
+
+    # A fresh attempt does not resume the invalidated step's prior context.
+    assert pattern.active_step_contexts.get("ask_b") is None
+
+    class CapturingStatusLLM:
+        def __init__(self, *, step: PlanStep) -> None:
+            self.step = step
+            self.status_at_call: str | None = None
+
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            self.status_at_call = self.step.status
+            return {"content": "retried", "done": True}
+
+    rerun_llm = CapturingStatusLLM(step=loser)
+    await pattern._execute_step(
+        step=loser,
+        root_context=ExecutionContext(execution_id="dag-double-waiting-rerun"),
+        tools=[],
+        llm=rerun_llm,
+        runtime=PatternRuntime(execution_id="dag-double-waiting-rerun"),
+    )
+
+    assert rerun_llm.status_at_call == "running"
+    assert loser.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_double_waiting_invalidation_persists_across_restore() -> (
+    None
+):
+    """The §H-2 checkpoint extension: a batch that invalidates a loser
+    while ``pending`` is empty (no sibling left to cancel) still writes a
+    checkpoint, so the invalidation survives a resume instead of only
+    living in memory until the process restores from an earlier snapshot.
+    """
+
+    pattern, result, tracer = await run_double_waiting_dag(
+        first_step_id="ask_a", second_step_id="ask_b"
+    )
+    assert result["clarification_superseded_step_ids"] == ["ask_b"]
+
+    checkpoint = tracer.checkpoints[-1]
+    assert checkpoint["label"] == "dag_after_cancelled_siblings"
+
+    restored = DAGPattern(lambda **_: None)
+    restored.load_state(checkpoint["pattern_state"])
+
+    restored_steps_by_id = {step.id: step for step in restored.plan.steps}
+    assert restored_steps_by_id["ask_b"].status == "clarification_invalidated"
+    assert restored.active_step_ids == ["ask_a"]
+    assert "ask_b" not in restored.active_step_pattern_states
+    assert "ask_b" not in restored.active_step_contexts
+
+
+@pytest.mark.asyncio
+async def test_dag_pattern_mixed_batch_interrupted_wins_over_waiting() -> None:
+    """§H-3: in a batch where one step is interrupted and another is
+    waiting in the same wakeup, the interrupted result wins -- an
+    interrupt is a control instruction, not a workflow question the user
+    can be asked to sit through -- and the losing waiting step is
+    invalidated exactly like a losing waiting step in an all-waiting
+    batch. Step ids are chosen so the waiting step would win under plain
+    lexicographic order, to prove the win comes from the interrupted/
+    waiting classification and not from id ordering.
+
+    Driving both a real interrupt and a real waiting_for_user through the
+    LLM/ReAct layers in the same wakeup is impractical to synchronize
+    reliably, so this stubs DAGPattern._execute_step -- the boundary
+    _execute_ready_steps actually schedules as asyncio.Task objects -- and
+    exercises the real scheduling, sorting, and invalidation logic under
+    test through genuine concurrent tasks.
+    """
+
+    release = asyncio.Event()
+    started: dict[str, asyncio.Event] = {}
+
+    async def fake_execute_step(
+        self: DAGPattern, *, step: PlanStep, **kwargs: Any
+    ) -> dict[str, Any] | None:
+        started.setdefault(step.id, asyncio.Event()).set()
+        await release.wait()
+        root_context = kwargs["root_context"]
+        if step.id == "z_interrupt_step":
+            self.status = "interrupted"
+            step.status = "interrupted"
+            return {
+                "success": False,
+                "status": "interrupted",
+                "execution_id": root_context.execution_id,
+                "context": root_context,
+                "active_step_id": step.id,
+            }
+        self.status = "waiting_for_user"
+        draft = draft_from_waiting_request(
+            {
+                "message": "Pick one",
+                "message_type": "question",
+                "interactions": [],
+                "tool_call_id": "ask-wait",
+                "tool_name": "ask_user_question",
+                "message_count": 2,
+            },
+            execution_id=root_context.execution_id,
+            step_id=None,
+        )
+        attributed_draft = draft.with_origin_step(step.id) if draft else None
+        return {
+            "success": False,
+            "status": "waiting_for_user",
+            "message": "Pick one",
+            "message_type": "question",
+            "clarification_draft": attributed_draft,
+            "execution_id": root_context.execution_id,
+            "context": root_context,
+            "active_step_id": step.id,
+        }
+
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="a_wait_step", task="Wait me"),
+            PlanStep(id="z_interrupt_step", task="Interrupt me"),
+        ),
+        max_concurrency=2,
+    )
+    pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-mixed-batch"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(execution_id="dag-mixed-batch"),
+        )
+    )
+    await asyncio.wait_for(
+        started.setdefault("a_wait_step", asyncio.Event()).wait(), timeout=1
+    )
+    await asyncio.wait_for(
+        started.setdefault("z_interrupt_step", asyncio.Event()).wait(), timeout=1
+    )
+    release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+
+    assert result["status"] == "interrupted"
+    assert result["active_step_id"] == "z_interrupt_step"
+    assert result["clarification_superseded_step_ids"] == ["a_wait_step"]
+
+    steps_by_id = {step.id: step for step in pattern.plan.steps}
+    assert steps_by_id["a_wait_step"].status == "clarification_invalidated"
+    assert "a_wait_step" not in pattern.active_step_ids
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1758,6 +1758,62 @@ async def test_dag_pattern_failed_step_wins_over_waiting_sibling_in_same_batch()
     assert "clarification_draft" not in result
 
 
+@pytest.mark.asyncio
+async def test_dag_pattern_cancelling_the_run_task_cancels_sibling_steps() -> None:
+    """Cancelling the task that is awaiting pattern.run() while two
+    independent steps are still executing must not leave their step
+    tasks running as orphans. Both step tasks are cancelled and awaited
+    before the cancellation is allowed to propagate out of run(), and
+    active_step_ids ends up empty."""
+
+    step_tasks: dict[str, asyncio.Task[Any]] = {}
+    started: dict[str, asyncio.Event] = {}
+    cancelled_ids: set[str] = set()
+
+    async def fake_execute_step(
+        self: DAGPattern, *, step: PlanStep, **kwargs: Any
+    ) -> dict[str, Any] | None:
+        step_tasks[step.id] = asyncio.current_task()
+        started.setdefault(step.id, asyncio.Event()).set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cancelled_ids.add(step.id)
+            raise
+        return None
+
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="a", task="A task"),
+            PlanStep(id="b", task="B task"),
+        ),
+        max_concurrency=2,
+    )
+    pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-cancel-outer"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(execution_id="dag-cancel-outer"),
+        )
+    )
+    await asyncio.wait_for(started.setdefault("a", asyncio.Event()).wait(), timeout=1)
+    await asyncio.wait_for(started.setdefault("b", asyncio.Event()).wait(), timeout=1)
+    await asyncio.sleep(0)  # let _execute_ready_steps park inside asyncio.wait
+
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    assert run_task.cancelled()
+    assert cancelled_ids == {"a", "b"}
+    assert step_tasks["a"].cancelled()
+    assert step_tasks["b"].cancelled()
+    assert pattern.active_step_ids == []
+
+
 class ConcurrentWaitingLLM:
     """Two DAG steps that each reach waiting_for_user via
     send_message(expect_response=True), synchronized on a shared release

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1759,6 +1759,74 @@ async def test_dag_pattern_failed_step_wins_over_waiting_sibling_in_same_batch()
 
 
 @pytest.mark.asyncio
+async def test_dag_pattern_failed_step_wins_over_interrupted_sibling_in_same_batch() -> (
+    None
+):
+    """When one step in a batch fails and its sibling is interrupted in
+    the same wakeup, the failure still wins over the interrupt. An
+    interrupt is a control instruction, but converting it to a plain
+    failure here is a deliberate choice: a batch containing a failed step
+    is already doomed, so it reports the failure rather than the
+    interrupt."""
+
+    release = asyncio.Event()
+    started: dict[str, asyncio.Event] = {}
+
+    async def fake_execute_step(
+        self: DAGPattern, *, step: PlanStep, **kwargs: Any
+    ) -> dict[str, Any] | None:
+        started.setdefault(step.id, asyncio.Event()).set()
+        await release.wait()
+        root_context = kwargs["root_context"]
+        if step.id == "fail_step":
+            step.status = "failed"
+            step.error = "boom"
+            self._clear_active_step(step.id)
+            return None
+        self.status = "interrupted"
+        step.status = "interrupted"
+        return {
+            "success": False,
+            "status": "interrupted",
+            "execution_id": root_context.execution_id,
+            "context": root_context,
+            "active_step_id": step.id,
+        }
+
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="fail_step", task="Fail me"),
+            PlanStep(id="interrupt_step", task="Interrupt me"),
+        ),
+        max_concurrency=2,
+    )
+    pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-failed-vs-interrupted"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(execution_id="dag-failed-vs-interrupted"),
+        )
+    )
+    await asyncio.wait_for(
+        started.setdefault("fail_step", asyncio.Event()).wait(), timeout=1
+    )
+    await asyncio.wait_for(
+        started.setdefault("interrupt_step", asyncio.Event()).wait(), timeout=1
+    )
+    release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["status"] != "interrupted"
+    assert result["failure_reason"] == "step_failed"
+    assert result["failed_step_id"] == "fail_step"
+
+
+@pytest.mark.asyncio
 async def test_dag_pattern_cancelling_the_run_task_cancels_sibling_steps() -> None:
     """Cancelling the task that is awaiting pattern.run() while two
     independent steps are still executing must not leave their step

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -2670,8 +2670,8 @@ def test_dag_pattern_select_winner_ranks_an_unknown_status_last(
     asyncio.wait() loop in _execute_ready_steps(), where an uncaught
     exception would propagate through the BaseException cancellation
     handler and fail every step in the batch over one unexpected status
-    string. It ranks last instead, behind both known ranks, and logs an
-    error so the unrecognized status does not go unnoticed."""
+    string. It ranks last instead, behind both known ranks, and logs a
+    warning so the unrecognized status does not go unnoticed."""
 
     pattern = DAGPattern(lambda **_: None)
 

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -1674,6 +1674,90 @@ async def test_dag_pattern_concurrent_failure_clears_cancelled_sibling() -> None
     }
 
 
+@pytest.mark.asyncio
+async def test_dag_pattern_failed_step_wins_over_waiting_sibling_in_same_batch() -> (
+    None
+):
+    """When one step in a batch fails and its sibling reaches
+    waiting_for_user in the same wakeup, the failure must win: a DAG that
+    is already doomed must not ask the user a question in place of
+    reporting the failure. The returned result is a plain failure with no
+    question or draft attached, and no clarification-related keys at
+    all."""
+
+    release = asyncio.Event()
+    started: dict[str, asyncio.Event] = {}
+
+    async def fake_execute_step(
+        self: DAGPattern, *, step: PlanStep, **kwargs: Any
+    ) -> dict[str, Any] | None:
+        started.setdefault(step.id, asyncio.Event()).set()
+        await release.wait()
+        root_context = kwargs["root_context"]
+        if step.id == "fail_step":
+            step.status = "failed"
+            step.error = "boom"
+            self._clear_active_step(step.id)
+            return None
+        self.status = "waiting_for_user"
+        draft = draft_from_waiting_request(
+            {
+                "message": "Pick one",
+                "message_type": "question",
+                "interactions": [],
+                "tool_call_id": "ask-wait",
+                "tool_name": "ask_user_question",
+                "message_count": 2,
+            },
+            execution_id=root_context.execution_id,
+            step_id=None,
+        )
+        attributed_draft = draft.with_origin_step(step.id) if draft else None
+        return {
+            "success": False,
+            "status": "waiting_for_user",
+            "message": "Pick one",
+            "message_type": "question",
+            "clarification_draft": attributed_draft,
+            "execution_id": root_context.execution_id,
+            "context": root_context,
+            "active_step_id": step.id,
+        }
+
+    pattern = DAGPattern(
+        lambda **_: build_plan(
+            PlanStep(id="fail_step", task="Fail me"),
+            PlanStep(id="wait_step", task="Ask me"),
+        ),
+        max_concurrency=2,
+    )
+    pattern._execute_step = fake_execute_step.__get__(pattern, DAGPattern)  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(
+        pattern.run(
+            context=ExecutionContext(execution_id="dag-failed-vs-waiting"),
+            tools=[],
+            llm=object(),
+            runtime=PatternRuntime(execution_id="dag-failed-vs-waiting"),
+        )
+    )
+    await asyncio.wait_for(
+        started.setdefault("fail_step", asyncio.Event()).wait(), timeout=1
+    )
+    await asyncio.wait_for(
+        started.setdefault("wait_step", asyncio.Event()).wait(), timeout=1
+    )
+    release.set()
+    result = await asyncio.wait_for(run_task, timeout=1)
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["failure_reason"] == "step_failed"
+    assert result["failed_step_id"] == "fail_step"
+    assert "message" not in result
+    assert "clarification_draft" not in result
+
+
 class ConcurrentWaitingLLM:
     """Two DAG steps that each reach waiting_for_user via
     send_message(expect_response=True), synchronized on a shared release

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -488,6 +488,51 @@ async def test_execution_adapter_omits_clarification_draft_key_when_not_waiting(
     assert "clarification_draft" not in result
 
 
+def test_execution_adapter_surfaces_superseded_step_ids_at_top_level() -> None:
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="dag",
+            pattern="react",
+            llm=FakeLLM([]),
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    with_losers = adapter._normalize_result(
+        result={
+            "status": "waiting_for_user",
+            "success": False,
+            "message": "Pick one",
+            "clarification_superseded_step_ids": ["ask_b"],
+        },
+        execution_type="agent_dag",
+        execution_id="dag-superseded-exec",
+    )
+    assert with_losers["clarification_superseded_step_ids"] == ["ask_b"]
+
+    without_losers = adapter._normalize_result(
+        result={
+            "status": "waiting_for_user",
+            "success": False,
+            "message": "Pick one",
+        },
+        execution_type="agent_dag",
+        execution_id="dag-no-superseded-exec",
+    )
+    assert without_losers["clarification_superseded_step_ids"] == []
+
+    not_waiting = adapter._normalize_result(
+        result={
+            "status": "completed",
+            "success": True,
+            "output": "done",
+        },
+        execution_type="agent_dag",
+        execution_id="dag-completed-exec",
+    )
+    assert "clarification_superseded_step_ids" not in not_waiting
+
+
 @pytest.mark.asyncio
 async def test_execution_adapter_includes_persisted_conversation_history() -> None:
     llm = FakeLLM(["generated"])

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -533,6 +533,48 @@ def test_execution_adapter_surfaces_superseded_step_ids_at_top_level() -> None:
     assert "clarification_superseded_step_ids" not in not_waiting
 
 
+def test_execution_adapter_surfaces_superseded_step_ids_for_an_interrupted_winner() -> (
+    None
+):
+    """A batch's winner can be an interrupt rather than a question -- the
+    DAG ranks an interrupt ahead of a waiting result within the same
+    wakeup -- and a losing waiting step is still superseded in that case.
+    The interrupted branch must promote the same top-level key, with the
+    same empty-list default, as the waiting branch already does; otherwise
+    a reader cannot tell "no sibling was superseded" apart from "this
+    status never carries the key"."""
+
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="dag",
+            pattern="react",
+            llm=FakeLLM([]),
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    with_losers = adapter._normalize_result(
+        result={
+            "status": "interrupted",
+            "success": False,
+            "clarification_superseded_step_ids": ["ask_b"],
+        },
+        execution_type="agent_dag",
+        execution_id="dag-interrupted-superseded-exec",
+    )
+    assert with_losers["clarification_superseded_step_ids"] == ["ask_b"]
+
+    without_losers = adapter._normalize_result(
+        result={
+            "status": "interrupted",
+            "success": False,
+        },
+        execution_type="agent_dag",
+        execution_id="dag-interrupted-no-superseded-exec",
+    )
+    assert without_losers["clarification_superseded_step_ids"] == []
+
+
 @pytest.mark.asyncio
 async def test_execution_adapter_includes_persisted_conversation_history() -> None:
     llm = FakeLLM(["generated"])

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -522,6 +522,57 @@ async def test_runner_passes_waiting_status_to_tool_teardown(tmp_path: Path) -> 
     assert tool.teardown_calls == [("interaction-task", "waiting_for_user")]
 
 
+class LiveStepTasksPattern:
+    """A pattern that reports a waiting_for_user exit while its
+    has_live_step_tasks() predicate is under test control, to pin the
+    runner-side guard independently of any real pattern implementation."""
+
+    def __init__(self, *, live_step_tasks: bool) -> None:
+        self._live_step_tasks = live_step_tasks
+
+    async def run(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "success": False,
+            "status": "waiting_for_user",
+            "message": "Pick one.",
+            "clarification_draft": {"source": "test"},
+        }
+
+    def has_live_step_tasks(self) -> bool:
+        return self._live_step_tasks
+
+
+@pytest.mark.asyncio
+async def test_runner_raises_when_waiting_exit_still_has_live_step_tasks(
+    tmp_path: Path,
+) -> None:
+    agent = Agent(
+        name="interactive",
+        patterns=[LiveStepTasksPattern(live_step_tasks=True)],
+    )
+    runner = AgentRunner(agent=agent, workspace_manager=FakeWorkspaceManager(tmp_path))
+
+    with pytest.raises(AssertionError, match="live step tasks"):
+        await runner.run(task="Run an interactive tool", execution_id="live-tasks-task")
+
+
+@pytest.mark.asyncio
+async def test_runner_allows_waiting_exit_once_step_tasks_are_clear(
+    tmp_path: Path,
+) -> None:
+    agent = Agent(
+        name="interactive",
+        patterns=[LiveStepTasksPattern(live_step_tasks=False)],
+    )
+    runner = AgentRunner(agent=agent, workspace_manager=FakeWorkspaceManager(tmp_path))
+
+    result = await runner.run(
+        task="Run an interactive tool", execution_id="no-live-tasks-task"
+    )
+
+    assert result["status"] == "waiting_for_user"
+
+
 @pytest.mark.asyncio
 async def test_runner_passes_failed_status_when_tool_setup_raises(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

When a batch of concurrently running DAG plan steps wakes up and more than
one step has reached `waiting_for_user` in that same wakeup, the DAG
pattern picks whichever result Python's `set` iteration happens to visit
first. Whichever step is picked determines which question the user's next
reply is delivered to -- the choice is not tied to which step actually
asked first, and the other step's pending question is left with no
delivery path at all.

This changes the batch-completion handling in `DAGPattern` to collect
every result produced by a wakeup, choose a winner deterministically, and
explicitly invalidate every losing waiting step: its active-step
bookkeeping is cleared, its status is set to `clarification_invalidated`,
and its id is surfaced under a new `clarification_superseded_step_ids`
key on the winning result. The full precedence is: a failed step in the
batch outranks every completed result -- the failure check now runs
before a winner is chosen, where previously whichever completed result
the loop happened to visit first was returned before the failure check
could run -- so a batch that is doomed anyway reports the failure rather
than a question or an interrupt. Among completed results, an interrupted
result outranks a waiting one, and among same-rank results the
lexicographically smaller step id wins.

Ranking an interrupt above a live question is a deliberate tradeoff: the
losing step's already-asked question is discarded and the step restarts
later from scratch, because an interrupt is a control instruction the
user issued and should not queue behind a workflow question.

This determinism holds within a single wakeup batch; which steps land in
the same batch remains scheduling-dependent, so ordering across wakeup
boundaries is unchanged.

A losing step's prior work is not compensated: whatever tool calls it
already made and whatever message it already sent to the user before
being invalidated stand as-is. This does not retract the losing step's
question from the conversation history -- it may already have been
delivered as a chat message before invalidation happened. What this
changes is which step's reply-in-flight gets delivered where, not whether
a duplicate question was ever visible.

Once the user answers the winning step's question, the invalidated step
is offered as ready work again like any other pending step, and its next
attempt starts over from the top of the step rather than resuming.
Because that attempt begins from a fresh context, tool calls the step
already executed before losing the tie-break run again -- for
non-idempotent tools (file writes, outbound API calls, messages) that
means duplicated side effects. Nothing memoizes or checkpoints completed
tool calls today; a step that loses the tie-break trades its stranded
question for a rerun, and the rerun is a full one. That attempt can ask
the same kind of question again, in the same turn the winner was just
answered in -- that is a new, honest question belonging to that step, not
the same one being delivered twice.

`clarification_superseded_step_ids` is a plain list of strings, so it is
JSON-safe on its own. It travels inside the same result dict as
everything else a step execution produces, though, so if any other value
in that dict is not serializable, the whole dict collapses into an error
payload together -- this field being safe in isolation does not guarantee
it survives to reach a trace. Nothing reads this key yet: it is
forward groundwork for a consumer on the clarification-resolution path,
and nothing user-facing surfaces "your other question was superseded"
today.

A task is only ever allowed one active question outstanding against the
user at a time. That is enforced as a persistence-layer constraint
elsewhere; this is its application-layer counterpart -- the same
invariant restated as "exactly one step's question wins a given wakeup"
at the point the DAG decides which step gets to keep its question.

## Other changes

- `DAGPattern` now attributes each waiting draft to the step that produced
  it (`with_origin_step`) at the point the draft leaves the step -- ReAct
  itself has no notion of which DAG step it is running under, so this can
  only happen on the DAG side.
- `DAGPattern.has_live_step_tasks()` exposes whether a concurrent step
  batch is still running; `AgentRunner` asserts this is false immediately
  before any `waiting_for_user` exit that carries a clarification draft,
  and raises rather than returning if a step task is still live -- that
  would mean the pattern handed back an answerable question while another
  step could still go on mutating shared state behind it.
- The execution adapter now promotes `clarification_superseded_step_ids`
  to the top level of its normalized `waiting_for_user` output, defaulting
  to an empty list so callers only need one truthiness check instead of
  also handling an absent key.
