### PR TITLE
feat: add Intercom OAuth connector

### DIFF
--- a/example.env
+++ b/example.env
@@ -627,10 +627,15 @@ ZOOM_REDIRECT_URI=""
 # conversations). Intercom does not accept a `scope` parameter on the
 # authorize URL — granted permissions come entirely from that Authentication
 # configuration, not from anything this app sends.
-# One app covers every workspace region (US/EU/AU): the authorize host
-# (app.intercom.com) and API host (api.intercom.io) both auto-route to the
-# workspace's actual region, unlike Intercom's hosted MCP server which has
-# separate per-region endpoints and does not support AU workspaces at all.
+# One app is expected to cover every workspace region (US/EU/AU): the API
+# host (api.intercom.io) auto-routing to the workspace's actual region is
+# documented in Intercom's REST API reference. The authorize host
+# (app.intercom.com) working the same way for a Public App comes from
+# Intercom's own community answer rather than primary docs, and hasn't been
+# verified against a live non-US workspace — see builtin_mcp_registry.py's
+# intercom provider row for the citation. Unlike Intercom's hosted MCP
+# server, which has separate per-region endpoints and no AU support at all,
+# this is the reason a local connector was built instead of using that.
 INTERCOM_CLIENT_ID=""
 INTERCOM_CLIENT_SECRET=""
 # Redirect URI for Intercom OAuth callback — must also be added under the

--- a/example.env
+++ b/example.env
@@ -617,6 +617,27 @@ ZOOM_CLIENT_SECRET=""
 # Example: http://localhost:8000/api/auth/zoom/callback
 ZOOM_REDIRECT_URI=""
 
+# ===========================================
+# Intercom OAuth Configuration (Optional)
+# ===========================================
+# Required for the Intercom integration in MCP (search contacts, review
+# conversations, reply to customers). Create an app at
+# https://developers.intercom.com/ and, under Authentication, enable OAuth
+# and select the permissions this connector needs (Read/write contacts and
+# conversations). Intercom does not accept a `scope` parameter on the
+# authorize URL — granted permissions come entirely from that Authentication
+# configuration, not from anything this app sends.
+# One app covers every workspace region (US/EU/AU): the authorize host
+# (app.intercom.com) and API host (api.intercom.io) both auto-route to the
+# workspace's actual region, unlike Intercom's hosted MCP server which has
+# separate per-region endpoints and does not support AU workspaces at all.
+INTERCOM_CLIENT_ID=""
+INTERCOM_CLIENT_SECRET=""
+# Redirect URI for Intercom OAuth callback — must also be added under the
+# app's Authentication > Redirect URLs.
+# Example: http://localhost:8000/api/auth/intercom/callback
+INTERCOM_REDIRECT_URI=""
+
 # Note:
 # - If embedding API keys are configured, LanceDB will be used automatically
 # - LanceDB storage path: <project_root>/memory_store/

--- a/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Intercom (OAuth) MCP connector
 
 Revision ID: 20260812_seed_intercom_mcp_app
-Revises: 20260809_add_task_interaction_requests
+Revises: 20260810_add_task_interaction_protocol_version
 Create Date: 2026-08-12 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260812_seed_intercom_mcp_app"
-down_revision: Union[str, None] = "20260809_add_task_interaction_requests"
+down_revision: Union[str, None] = "20260810_add_task_interaction_protocol_version"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
@@ -60,11 +60,17 @@ def _intercom_provider_row() -> dict[str, object]:
         "name": "Intercom",
         "client_id": os.environ.get("INTERCOM_CLIENT_ID", ""),
         "client_secret": os.environ.get("INTERCOM_CLIENT_SECRET", ""),
-        # Single global authorize host: once a public app clears Intercom App
-        # Review, Intercom replicates it across US/EU/AU automatically.
+        # Single global authorize host: per Intercom's community answer
+        # (community.intercom.com/api-webhooks-23/do-we-need-to-create
+        # -multiple-oauth-apps-per-data-region-2522), a public app is
+        # replicated across US/EU/AU automatically once it clears Intercom
+        # App Review. See builtin_mcp_registry.py's intercom provider row for
+        # the full citation and the caveat that this is a community answer,
+        # not primary docs, unverified against a live non-US workspace.
         "auth_url": "https://app.intercom.com/oauth",
         # No region prefix: api.intercom.io auto-routes to the workspace's
-        # actual hosting region (US/EU/AU), unlike Intercom's hosted MCP
+        # actual hosting region (US/EU/AU) -- this part is documented in
+        # Intercom's primary REST API reference, unlike Intercom's hosted MCP
         # server (mcp.intercom.com / mcp.eu.intercom.com) which has separate
         # per-region endpoints and does not support AU workspaces at all.
         "token_url": "https://api.intercom.io/auth/eagle/token",
@@ -89,7 +95,10 @@ def _intercom_app_row() -> dict[str, object]:
         "provider_name": "intercom",
         "category": "Support",
         "oauth_scopes": [],
-        "is_visible_in_connector": True,
+        # Hidden until manually verified against a live workspace -- see
+        # builtin_mcp_registry.py's intercom app row for the full rationale
+        # (this ships customer-facing write tools: reply/note/close).
+        "is_visible_in_connector": False,
         "launch_config": {
             "command": "python",
             "args": ["-m", "xagent.web.tools.mcp.intercom"],
@@ -159,13 +168,20 @@ def downgrade() -> None:
         if remaining_intercom_apps:
             return
 
-    # Delete unconditionally by provider_name, matching the sibling seed
-    # migrations (slack, meta, google-maps). A shape-matching guard would
-    # protect the wrong thing: an admin recreating the *real* Intercom
-    # provider enters Intercom's canonical URLs, which would match the guard
-    # and be deleted anyway -- only a differently-shaped row would survive.
+    # Only delete the provider row when it still matches the static shape this
+    # migration seeded, so an admin-created "intercom" provider (via
+    # POST /admin/mcp/providers) is preserved -- same guard as the zoom seed
+    # migration, and for the same reason: unlike slack/meta/google-maps (whose
+    # downgrades delete unconditionally), a differently-shaped custom row here
+    # must survive. client_id/client_secret are env-dependent and
+    # intentionally not part of the guard. name/auth_url/token_url are NOT
+    # NULL core columns present since the table's creation, so they can be
+    # matched unconditionally.
+    seeded_provider = _intercom_provider_row()
     bind.execute(
-        sa.delete(FULL_OAUTH_PROVIDERS_TABLE).where(
-            FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "intercom"
-        )
+        sa.delete(FULL_OAUTH_PROVIDERS_TABLE)
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "intercom")
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.name == seeded_provider["name"])
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.auth_url == seeded_provider["auth_url"])
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.token_url == seeded_provider["token_url"])
     )

--- a/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Intercom (OAuth) MCP connector
 
 Revision ID: 20260812_seed_intercom_mcp_app
-Revises: 20260810_add_hubspot_marketing_scopes
+Revises: 20260812_add_slack_history_reactions_files_scopes
 Create Date: 2026-08-12 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260812_seed_intercom_mcp_app"
-down_revision: Union[str, None] = "20260810_add_hubspot_marketing_scopes"
+down_revision: Union[str, None] = "20260812_add_slack_history_reactions_files_scopes"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Intercom (OAuth) MCP connector
 
 Revision ID: 20260812_seed_intercom_mcp_app
-Revises: 20260810_add_task_interaction_protocol_version
+Revises: 20260810_add_hubspot_marketing_scopes
 Create Date: 2026-08-12 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260812_seed_intercom_mcp_app"
-down_revision: Union[str, None] = "20260810_add_task_interaction_protocol_version"
+down_revision: Union[str, None] = "20260810_add_hubspot_marketing_scopes"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
@@ -139,6 +139,22 @@ def upgrade() -> None:
                 sa.insert(PUBLIC_MCP_APPS_TABLE),
                 [_filter_row(_intercom_app_row(), app_columns)],
             )
+        else:
+            # A row with this app_id already exists (e.g. hand-created by an
+            # operator before this migration deployed). Such a row keeps its
+            # own is_visible_in_connector, which defaults to TRUE for
+            # hand-created rows -- and the builtin registry overlays the real
+            # transport/launch_config onto ANY row sharing this app_id at read
+            # time, so a visible pre-existing row would silently become a
+            # working, one-click-connectable, unverified write-capable
+            # connector, defeating the hidden-rollout gate with no further
+            # action. Same guard, same reasoning, as the chrome seed
+            # migration's collision branch (#1143).
+            bind.execute(
+                sa.update(PUBLIC_MCP_APPS_TABLE)
+                .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+                .values(is_visible_in_connector=False)
+            )
 
 
 def downgrade() -> None:

--- a/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
+++ b/src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py
@@ -1,0 +1,171 @@
+"""seed built-in Intercom (OAuth) MCP connector
+
+Revision ID: 20260812_seed_intercom_mcp_app
+Revises: 20260809_add_task_interaction_requests
+Create Date: 2026-08-12 00:00:00.000000
+
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260812_seed_intercom_mcp_app"
+down_revision: Union[str, None] = "20260809_add_task_interaction_requests"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FULL_OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+    sa.column("name", sa.String),
+    sa.column("client_id", sa.String),
+    sa.column("client_secret", sa.String),
+    sa.column("auth_url", sa.String),
+    sa.column("token_url", sa.String),
+    sa.column("redirect_uri", sa.String),
+    sa.column("userinfo_url", sa.String),
+    sa.column("user_id_path", sa.String),
+    sa.column("email_path", sa.String),
+    sa.column("default_scopes", sa.JSON),
+)
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "intercom"
+
+
+def _filter_row(row: dict[str, object], allowed_columns: set[str]) -> dict[str, object]:
+    return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+def _intercom_provider_row() -> dict[str, object]:
+    return {
+        "provider_name": "intercom",
+        "name": "Intercom",
+        "client_id": os.environ.get("INTERCOM_CLIENT_ID", ""),
+        "client_secret": os.environ.get("INTERCOM_CLIENT_SECRET", ""),
+        # Single global authorize host: once a public app clears Intercom App
+        # Review, Intercom replicates it across US/EU/AU automatically.
+        "auth_url": "https://app.intercom.com/oauth",
+        # No region prefix: api.intercom.io auto-routes to the workspace's
+        # actual hosting region (US/EU/AU), unlike Intercom's hosted MCP
+        # server (mcp.intercom.com / mcp.eu.intercom.com) which has separate
+        # per-region endpoints and does not support AU workspaces at all.
+        "token_url": "https://api.intercom.io/auth/eagle/token",
+        "redirect_uri": os.environ.get("INTERCOM_REDIRECT_URI", ""),
+        "userinfo_url": "https://api.intercom.io/me",
+        "user_id_path": "id",
+        "email_path": "email",
+        # Intercom has no `scope` authorize-URL param; granted permissions
+        # come entirely from the app's Authentication settings in the
+        # Developer Hub, so there is nothing to list here.
+        "default_scopes": [],
+    }
+
+
+def _intercom_app_row() -> dict[str, object]:
+    return {
+        "app_id": APP_ID,
+        "name": "Intercom",
+        "description": "Connect to Intercom to search contacts, review conversations, and reply to customers.",
+        "icon": "https://www.google.com/s2/favicons?domain=intercom.com&sz=128",
+        "transport": "oauth",
+        "provider_name": "intercom",
+        "category": "Support",
+        "oauth_scopes": [],
+        "is_visible_in_connector": True,
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.intercom"],
+            "env_mapping": {"INTERCOM_ACCESS_TOKEN": "access_token"},
+        },
+    }
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "oauth_providers" in existing_tables:
+        oauth_columns = {
+            column["name"] for column in inspector.get_columns("oauth_providers")
+        }
+        existing_provider_names = set(
+            bind.execute(
+                sa.select(FULL_OAUTH_PROVIDERS_TABLE.c.provider_name)
+            ).scalars()
+        )
+        if "intercom" not in existing_provider_names:
+            bind.execute(
+                sa.insert(FULL_OAUTH_PROVIDERS_TABLE),
+                [_filter_row(_intercom_provider_row(), oauth_columns)],
+            )
+
+    if "public_mcp_apps" in existing_tables:
+        app_columns = {
+            column["name"] for column in inspector.get_columns("public_mcp_apps")
+        }
+        existing_app_ids = set(
+            bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars()
+        )
+        if APP_ID not in existing_app_ids:
+            bind.execute(
+                sa.insert(PUBLIC_MCP_APPS_TABLE),
+                [_filter_row(_intercom_app_row(), app_columns)],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "public_mcp_apps" in existing_tables:
+        # Only the catalog entry is removed. Any user OAuth connections created
+        # against this app are not owned by this migration and are cleaned up
+        # through the normal disconnect path.
+        bind.execute(
+            sa.delete(PUBLIC_MCP_APPS_TABLE).where(
+                PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID
+            )
+        )
+
+    if "oauth_providers" not in existing_tables:
+        return
+
+    if "public_mcp_apps" in existing_tables:
+        remaining_intercom_apps = bind.execute(
+            sa.select(sa.func.count())
+            .select_from(PUBLIC_MCP_APPS_TABLE)
+            .where(PUBLIC_MCP_APPS_TABLE.c.provider_name == "intercom")
+        ).scalar()
+        if remaining_intercom_apps:
+            return
+
+    # Delete unconditionally by provider_name, matching the sibling seed
+    # migrations (slack, meta, google-maps). A shape-matching guard would
+    # protect the wrong thing: an admin recreating the *real* Intercom
+    # provider enters Intercom's canonical URLs, which would match the guard
+    # and be deleted anyway -- only a differently-shaped row would survive.
+    bind.execute(
+        sa.delete(FULL_OAUTH_PROVIDERS_TABLE).where(
+            FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "intercom"
+        )
+    )

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1470,6 +1470,24 @@ def generic_oauth_callback(
         token_data = _normalize_intercom_token_response(provider, token_data)
         access_token = token_data.get("access_token")
 
+        if not access_token:
+            # Without this, a token response that slips past the "error" in
+            # token_data check above (e.g. Intercom's error.list envelope,
+            # which doesn't use that key) would fall through to the
+            # persistence block below with access_token=None, hit
+            # UserOAuth.access_token's NOT NULL constraint, and surface as a
+            # raw SQLAlchemy IntegrityError message through the generic
+            # exception handler instead of a clear, actionable error.
+            import html
+
+            return HTMLResponse(
+                content=(
+                    "<h1>Error exchanging token</h1>"
+                    f"<p>{html.escape(provider)} did not return an access token.</p>"
+                ),
+                status_code=400,
+            )
+
         provider_user_id = None
         email = None
 

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1235,6 +1235,25 @@ def generic_oauth_login(
     if app_id:
         app_info = get_app_by_id(db, app_id)
         if app_info:
+            # Reject a hidden app here too, not only at the callback --
+            # otherwise a hidden connector's consent screen is still shown at
+            # the real provider (no security bypass, since the callback
+            # still blocks the connect, but a confusing UX: the app doesn't
+            # feel hidden if you can watch it start connecting). Unlike the
+            # callback's gate, an unknown app_id is deliberately left alone
+            # here too, for the same reason (e.g. gmail's bare-app-id flows).
+            from .mcp import _reject_hidden_catalog_app
+
+            try:
+                _reject_hidden_catalog_app(app_info)
+            except HTTPException:
+                return HTMLResponse(
+                    content=(
+                        "<h1>Cannot Connect</h1>"
+                        "<p>This app is not currently available.</p>"
+                    ),
+                    status_code=404,
+                )
             if "oauth_scopes" in app_info:
                 app_scopes = app_info["oauth_scopes"]
             app_optional_scopes = app_info.get("optional_oauth_scopes") or []
@@ -1451,6 +1470,14 @@ def generic_oauth_callback(
         from ..mcp_apps import get_app_by_id
         from .mcp import _reject_hidden_catalog_app
 
+        # An app_id that resolves to no catalog row at all is left alone,
+        # deliberately not folded into this gate: several existing OAuth
+        # flows (e.g. gmail in the test suite) legitimately reach this
+        # callback with an app_id that has no PublicMCPApp row, and rely on
+        # falling through to a bare/provider-scoped grant rather than being
+        # rejected -- confirmed by running the full oauth test suite before
+        # settling on this narrower check. Only a row that exists AND is
+        # hidden is rejected here.
         target_app_info = get_app_by_id(db, app_id)
         if target_app_info:
             try:
@@ -1597,15 +1624,16 @@ def generic_oauth_callback(
                     + timedelta(seconds=int(token_data["expires_in"])),
                 )
 
-            from ..mcp_apps import get_all_mcp_apps, get_app_by_id
+            from ..mcp_apps import get_all_mcp_apps
             from .mcp import _reject_hidden_catalog_app
 
             if app_id:
-                app_info = get_app_by_id(db, app_id)
+                # Reuse target_app_info from the earlier hidden-app-gate
+                # check above rather than re-fetching by app_id: nothing
+                # mutates public_mcp_apps between there and here, so a second
+                # fetch would just be redundant, not more correct.
+                app_info = target_app_info
                 if app_info:
-                    # The hidden-app gate for this branch already ran earlier
-                    # (right after app_id was decoded from state, before the
-                    # token exchange) -- not repeated here.
                     # A stale/crafted app_id in the OAuth state can point at a
                     # non-oauth app. Fail with a clear error instead of a generic
                     # 500 after the user already completed provider consent —

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -281,6 +281,24 @@ def _normalize_intercom_token_response(
     return {**token_data, "access_token": token}
 
 
+def _extract_provider_error_message(token_data: dict[str, Any]) -> str | None:
+    """Best-effort human-readable detail for a token exchange that yielded no
+    access_token.
+
+    Standard OAuth2 providers surface `error`/`error_description`, already
+    handled by the `"error" in token_data` check earlier in the callback.
+    This covers Intercom's differently-shaped `error.list` envelope instead
+    (`{"type": "error.list", "errors": [{"message": "..."}]}`), which does
+    not use an `error` key and so slips past that earlier check.
+    """
+    errors = token_data.get("errors")
+    if isinstance(errors, list) and errors:
+        first_error = errors[0]
+        if isinstance(first_error, dict) and first_error.get("message"):
+            return str(first_error["message"])
+    return None
+
+
 def create_access_token(
     data: Dict[str, Any], expires_delta: Optional[timedelta] = None
 ) -> str:
@@ -1414,6 +1432,38 @@ def generic_oauth_callback(
     user_id = payload.get("user_id")
     app_id = payload.get("app_id")
 
+    if app_id:
+        # Reject a hidden app before spending the authorization code against
+        # the real provider, not just before persisting -- is_visible_in_
+        # connector is also used as a release gate (e.g. an unverified
+        # builtin_oauth connector shipping hidden), and this builtin_oauth
+        # provider-redirect flow used to be the one connect path
+        # _reject_hidden_catalog_app's own docstring flagged as NOT enforcing
+        # that gate (#1203): an authenticated user who knew (or guessed) the
+        # app_id could still connect a hidden connector. Checked here, ahead
+        # of the token exchange below, rather than only later next to
+        # _ensure_user_mcp_server, so a hidden app never even reaches the
+        # provider -- matching the "indistinguishable from nonexistent" intent
+        # the helper already documents for its other two call sites. The bare
+        # (app_id-less) batch branch below cannot move this early: it doesn't
+        # know which apps share the provider until it queries them, so its
+        # own per-app check stays where it is.
+        from ..mcp_apps import get_app_by_id
+        from .mcp import _reject_hidden_catalog_app
+
+        target_app_info = get_app_by_id(db, app_id)
+        if target_app_info:
+            try:
+                _reject_hidden_catalog_app(target_app_info)
+            except HTTPException:
+                return HTMLResponse(
+                    content=(
+                        "<h1>Cannot Connect</h1>"
+                        "<p>This app is not currently available.</p>"
+                    ),
+                    status_code=404,
+                )
+
     if not db_provider:
         return HTMLResponse(
             content="<h1>Error: Provider not configured</h1>", status_code=500
@@ -1480,11 +1530,12 @@ def generic_oauth_callback(
             # exception handler instead of a clear, actionable error.
             import html
 
+            message = f"{html.escape(provider)} did not return an access token."
+            detail = _extract_provider_error_message(token_data)
+            if detail:
+                message = f"{message} {html.escape(detail)}"
             return HTMLResponse(
-                content=(
-                    "<h1>Error exchanging token</h1>"
-                    f"<p>{html.escape(provider)} did not return an access token.</p>"
-                ),
+                content=f"<h1>Error exchanging token</h1><p>{message}</p>",
                 status_code=400,
             )
 
@@ -1547,10 +1598,14 @@ def generic_oauth_callback(
                 )
 
             from ..mcp_apps import get_all_mcp_apps, get_app_by_id
+            from .mcp import _reject_hidden_catalog_app
 
             if app_id:
                 app_info = get_app_by_id(db, app_id)
                 if app_info:
+                    # The hidden-app gate for this branch already ran earlier
+                    # (right after app_id was decoded from state, before the
+                    # token exchange) -- not repeated here.
                     # A stale/crafted app_id in the OAuth state can point at a
                     # non-oauth app. Fail with a clear error instead of a generic
                     # 500 after the user already completed provider consent —
@@ -1575,6 +1630,21 @@ def generic_oauth_callback(
                     if app.get("provider") == provider
                 ]
                 for app_info in apps:
+                    # Same release-gate enforcement as the single-app branch
+                    # above (same shared helper, so there is one source of
+                    # truth for this check), but a hidden app must not abort
+                    # the whole bare batch connect — skip it and keep
+                    # connecting the other visible apps under the same
+                    # provider, matching the mis-tagged-app skip below.
+                    try:
+                        _reject_hidden_catalog_app(app_info)
+                    except HTTPException:
+                        logger.info(
+                            "Skipping hidden app %s during bare %s OAuth batch connect",
+                            app_info.get("id"),
+                            provider,
+                        )
+                        continue
                     # This bare app_id-less login only ever requests
                     # db_provider.default_scopes (see the app_scopes=None
                     # branch above), never an app's own oauth_scopes. Creating

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -260,6 +260,27 @@ def _exchange_meta_long_lived_token(
     return {**token_data, **long_lived_token_data}
 
 
+def _normalize_intercom_token_response(
+    provider: str, token_data: dict[str, Any]
+) -> dict[str, Any]:
+    """Map Intercom's `{"token": ...}` token response onto `access_token`.
+
+    Intercom's token endpoint (POST /auth/eagle/token) does not follow the
+    standard OAuth2 token response shape: it returns only `{"token": "..."}`,
+    with no `access_token`, `token_type`, or `expires_in` fields. Without this,
+    generic_oauth_callback's `token_data.get("access_token")` would silently
+    resolve to None and the connection would be persisted with no token.
+    """
+    if provider.lower() != "intercom":
+        return token_data
+    if "access_token" in token_data:
+        return token_data
+    token = token_data.get("token")
+    if not token:
+        return token_data
+    return {**token_data, "access_token": token}
+
+
 def create_access_token(
     data: Dict[str, Any], expires_delta: Optional[timedelta] = None
 ) -> str:
@@ -1446,6 +1467,7 @@ def generic_oauth_callback(
         token_data = _exchange_meta_long_lived_token(
             provider, token_url, token_data, client_id, client_secret
         )
+        token_data = _normalize_intercom_token_response(provider, token_data)
         access_token = token_data.get("access_token")
 
         provider_user_id = None

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2327,16 +2327,14 @@ def _reject_hidden_catalog_app(app_info: dict) -> None:
     the connector with a direct POST. 404 (not 403) so a hidden app is
     indistinguishable from a nonexistent one.
 
-    Scope: wired into the api_key/keyless path (_ensure_catalog_app_server)
-    and the remote-MCP OAuth path (_ensure_catalog_mcp_oauth_server) only.
-    The builtin_oauth provider-redirect flow (auth.py generic_oauth_callback
-    -> _ensure_user_mcp_server) does NOT run this check. This is a config
-    action away from mattering, not just a future refactor: is_visible_in_
-    connector is freely admin-mutable via PATCH on any catalog app, so the
-    moment an operator hides an existing builtin_oauth row using this same
-    release-gate idiom, new connections reopen through this third path with
-    no code change. Tracked in #1203 — do not apply the hidden-as-release-
-    gate pattern to an oauth-transport row until that closes.
+    Scope: wired into all three connect paths — the api_key/keyless path
+    (_ensure_catalog_app_server), the remote-MCP OAuth path
+    (_ensure_catalog_mcp_oauth_server), and the builtin_oauth
+    provider-redirect flow (auth.py generic_oauth_callback, both the
+    single-app and bare-provider-batch branches). #1203 tracked exactly this
+    gap on the third path — call this same helper rather than reintroducing
+    a fourth, divergent is_visible_in_connector check if a new connect path
+    is ever added.
 
     Blast radius: this fires on every connect call, before the caller's
     existing association is looked up — so on a hidden app it also blocks

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2330,11 +2330,11 @@ def _reject_hidden_catalog_app(app_info: dict) -> None:
     Scope: wired into all three connect paths — the api_key/keyless path
     (_ensure_catalog_app_server), the remote-MCP OAuth path
     (_ensure_catalog_mcp_oauth_server), and the builtin_oauth
-    provider-redirect flow (auth.py generic_oauth_callback, both the
-    single-app and bare-provider-batch branches). #1203 tracked exactly this
-    gap on the third path — call this same helper rather than reintroducing
-    a fourth, divergent is_visible_in_connector check if a new connect path
-    is ever added.
+    provider-redirect flow (auth.py generic_oauth_login and
+    generic_oauth_callback's single-app and bare-provider-batch branches).
+    #1203 tracked exactly this gap on the third path — call this same helper
+    rather than reintroducing a fourth, divergent is_visible_in_connector
+    check if a new connect path is ever added.
 
     Blast radius: this fires on every connect call, before the caller's
     existing association is looked up — so on a hidden app it also blocks

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -165,6 +165,37 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             # kept in sync.
             "default_scopes": ["user:read:user"],
         },
+        {
+            "provider_name": "intercom",
+            "name": "Intercom",
+            "client_id": os.environ.get("INTERCOM_CLIENT_ID", ""),
+            "client_secret": os.environ.get("INTERCOM_CLIENT_SECRET", ""),
+            # The single "app.intercom.com" authorize host serves every
+            # region: once a public app clears Intercom App Review, Intercom
+            # replicates it across US/EU/AU automatically, so there is no
+            # per-region app or authorize URL to manage.
+            "auth_url": "https://app.intercom.com/oauth",
+            # "api.intercom.io" (no region prefix) auto-routes each request
+            # to the workspace's actual hosting region (US/EU/AU) based on
+            # the token/workspace being acted on -- this is what lets one
+            # provider row, unlike the hosted MCP server's separate
+            # mcp.intercom.com / mcp.eu.intercom.com endpoints (which don't
+            # support AU workspaces at all), cover all three regions.
+            "token_url": "https://api.intercom.io/auth/eagle/token",
+            "redirect_uri": os.environ.get("INTERCOM_REDIRECT_URI", ""),
+            "userinfo_url": "https://api.intercom.io/me",
+            "user_id_path": "id",
+            "email_path": "email",
+            # Intercom has no `scope` authorize-URL param at all -- granted
+            # permissions come entirely from the app's Authentication
+            # settings in the Developer Hub, the same out-of-band model as
+            # meta's config_id above. Leaving this empty means
+            # generic_oauth_login's `elif scope_str:` guard (api/auth.py)
+            # never adds a scope param for this provider, which matches
+            # Intercom's actual behavior instead of sending a param it
+            # ignores.
+            "default_scopes": [],
+        },
     ]
 
 
@@ -693,6 +724,27 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                     "--no-usage-statistics",
                     "--no-performance-crux",
                 ],
+            },
+        },
+        {
+            "app_id": "intercom",
+            "name": "Intercom",
+            "description": "Connect to Intercom to search contacts, review conversations, and reply to customers.",
+            "icon": "https://www.google.com/s2/favicons?domain=intercom.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "intercom",
+            "category": "Support",
+            "oauth_scopes": [],
+            "is_visible_in_connector": True,
+            # A local FastMCP module talking to Intercom's REST API directly,
+            # not Intercom's hosted MCP server (mcp.intercom.com) -- that
+            # hosted server does not support AU-hosted workspaces, while the
+            # underlying REST API and OAuth (api.intercom.io, auto-routed)
+            # do, which this connector needs for AU customers.
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.intercom"],
+                "env_mapping": {"INTERCOM_ACCESS_TOKEN": "access_token"},
             },
         },
     ]

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -170,17 +170,27 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "name": "Intercom",
             "client_id": os.environ.get("INTERCOM_CLIENT_ID", ""),
             "client_secret": os.environ.get("INTERCOM_CLIENT_SECRET", ""),
-            # The single "app.intercom.com" authorize host serves every
-            # region: once a public app clears Intercom App Review, Intercom
-            # replicates it across US/EU/AU automatically, so there is no
-            # per-region app or authorize URL to manage.
+            # The single "app.intercom.com" authorize host is claimed to serve
+            # every region: per Intercom's community answer to this exact
+            # question (community.intercom.com/api-webhooks-23/do-we-need-to
+            # -create-multiple-oauth-apps-per-data-region-2522), a public app
+            # is replicated across US/EU/AU automatically once it clears
+            # Intercom App Review, so there is no per-region app or authorize
+            # URL to manage. This is a community answer, not primary API
+            # reference docs, and has not been verified end-to-end against a
+            # live non-US workspace -- if it turns out to be wrong, EU/AU
+            # connects would need their own provider row instead of sharing
+            # this one.
             "auth_url": "https://app.intercom.com/oauth",
-            # "api.intercom.io" (no region prefix) auto-routes each request
-            # to the workspace's actual hosting region (US/EU/AU) based on
-            # the token/workspace being acted on -- this is what lets one
-            # provider row, unlike the hosted MCP server's separate
-            # mcp.intercom.com / mcp.eu.intercom.com endpoints (which don't
-            # support AU workspaces at all), cover all three regions.
+            # "api.intercom.io" (no region prefix) auto-routes each request to
+            # the workspace's actual hosting region (US/EU/AU) based on the
+            # token/workspace being acted on -- this part IS documented in
+            # Intercom's primary REST API reference (developers.intercom.com/
+            # docs/build-an-integration/learn-more/rest-apis, "About our REST
+            # API"). Combined with the authorize-host claim above, this is
+            # what lets one provider row, unlike the hosted MCP server's
+            # separate mcp.intercom.com / mcp.eu.intercom.com endpoints (which
+            # don't support AU workspaces at all), cover all three regions.
             "token_url": "https://api.intercom.io/auth/eagle/token",
             "redirect_uri": os.environ.get("INTERCOM_REDIRECT_URI", ""),
             "userinfo_url": "https://api.intercom.io/me",
@@ -735,12 +745,20 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "provider_name": "intercom",
             "category": "Support",
             "oauth_scopes": [],
-            "is_visible_in_connector": True,
+            # Hidden until manually verified against a live workspace (all
+            # three regions, ideally), same precedent as the chrome row
+            # above: it ships customer-facing *write* tools (reply/note/
+            # close) discoverable by every user the moment it's visible, and
+            # that hasn't happened yet. Flip to True via a follow-up once
+            # that verification is done -- no redeploy needed, per the chrome
+            # row's note (is_visible_in_connector is not builtin-protected).
+            "is_visible_in_connector": False,
             # A local FastMCP module talking to Intercom's REST API directly,
             # not Intercom's hosted MCP server (mcp.intercom.com) -- that
             # hosted server does not support AU-hosted workspaces, while the
             # underlying REST API and OAuth (api.intercom.io, auto-routed)
-            # do, which this connector needs for AU customers.
+            # do, which this connector needs for AU customers. See the
+            # oauth_providers row above for the region-coverage citation.
             "launch_config": {
                 "command": "python",
                 "args": ["-m", "xagent.web.tools.mcp.intercom"],

--- a/src/xagent/web/tools/mcp/intercom.py
+++ b/src/xagent/web/tools/mcp/intercom.py
@@ -24,7 +24,11 @@ INTERCOM_BASE_URL = "https://api.intercom.io"
 INTERCOM_API_VERSION = "2.11"
 DEFAULT_TIMEOUT_SECONDS = 30
 
-_admin_id_cache: str | None = None
+# Keyed by access token, not a single process-global value: this module is
+# imported once per subprocess, but nothing guarantees a subprocess is never
+# reused across a different user/token, and a bare global would leak one
+# user's admin identity into another user's replies in that case.
+_admin_id_cache: dict[str, str] = {}
 
 
 def _success(**payload: Any) -> str:
@@ -77,20 +81,22 @@ def _request(
 
 
 def _current_admin_id() -> str:
-    """Resolve the admin id behind the connected access token, cached per process.
+    """Resolve the admin id behind the connected access token, cached per token.
 
     Replying to a conversation as an admin requires an admin_id, but the OAuth
     connection only gives us a token -- not the identity it was created for.
     """
-    global _admin_id_cache
-    if _admin_id_cache:
-        return _admin_id_cache
+    token = os.environ.get("INTERCOM_ACCESS_TOKEN")
+    if not token:
+        raise ValueError("INTERCOM_ACCESS_TOKEN environment variable is missing")
+    if token in _admin_id_cache:
+        return _admin_id_cache[token]
     me = _request("GET", "/me")
     admin_id = me.get("id")
     if not admin_id:
         raise RuntimeError("Could not resolve the Intercom admin id for this token")
-    _admin_id_cache = str(admin_id)
-    return _admin_id_cache
+    _admin_id_cache[token] = str(admin_id)
+    return _admin_id_cache[token]
 
 
 def _contact_summary(contact: dict[str, Any]) -> dict[str, Any]:

--- a/src/xagent/web/tools/mcp/intercom.py
+++ b/src/xagent/web/tools/mcp/intercom.py
@@ -32,6 +32,10 @@ DEFAULT_TIMEOUT_SECONDS = 30
 # small Retry-After we wait once and retry rather than failing outright,
 # mirroring the same bounded-retry policy as the Slack sibling module.
 MAX_RETRY_AFTER_SECONDS = 30
+# An HTML gateway error page (or similar) landing in an unstructured error
+# body must not be forwarded to the LLM/logs verbatim and unbounded, same
+# reasoning and cap as the Zoom sibling module.
+MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
 
 # Keyed by access token, defense-in-depth rather than an active optimization:
 # every MCP tool call currently spawns and tears down a fresh subprocess
@@ -67,7 +71,6 @@ def _request(
     method: str,
     path: str,
     *,
-    params: dict[str, Any] | None = None,
     body: dict[str, Any] | None = None,
 ) -> Any:
     for attempt in (0, 1):
@@ -75,7 +78,6 @@ def _request(
             method=method,
             url=f"{INTERCOM_BASE_URL}{path}",
             headers=_headers(),
-            params=params,
             json=body,
             timeout=DEFAULT_TIMEOUT_SECONDS,
         )
@@ -93,6 +95,10 @@ def _request(
         response.raise_for_status()
     except requests.HTTPError as exc:
         response_text = response.text.strip()
+        if len(response_text) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+            response_text = response_text[:MAX_ERROR_RESPONSE_TEXT_CHARS] + (
+                "... [truncated]"
+            )
         message = str(exc)
         if response_text:
             message = f"{message} - {response_text}"
@@ -152,6 +158,8 @@ def intercom_search_contacts(query: str, limit: int = 10) -> str:
     Search Intercom contacts whose name or email contains `query`.
     """
     try:
+        if not query.strip():
+            raise ValueError("query must not be blank")
         body = {
             "query": {
                 "operator": "OR",
@@ -179,7 +187,7 @@ def intercom_get_contact(contact_id: str) -> str:
     """
     try:
         contact = _request("GET", f"/contacts/{quote(contact_id, safe='')}")
-        return _success(contact=contact)
+        return _success(contact=_contact_summary(contact))
     except Exception as e:
         logger.error(f"Error getting contact: {e}")
         return _error(str(e))
@@ -188,11 +196,13 @@ def intercom_get_contact(contact_id: str) -> str:
 @mcp.tool()
 def intercom_list_conversations(state: str = "open", limit: int = 20) -> str:
     """
-    List Intercom conversations. `state` is one of "open", "closed", or "all".
-    Returns at most `limit` conversations (max 100), most recently updated first.
+    List Intercom conversations. `state` is one of "open", "closed", "snoozed",
+    or "all". Returns at most `limit` conversations (max 100), most recently
+    updated first. `has_more` is true when the search matched more
+    conversations than were returned.
     """
     try:
-        valid_states = {"open", "closed", "all"}
+        valid_states = {"open", "closed", "snoozed", "all"}
         if state not in valid_states:
             raise ValueError(f"state must be one of {sorted(valid_states)}")
 
@@ -210,9 +220,13 @@ def intercom_list_conversations(state: str = "open", limit: int = 20) -> str:
         else:
             query = {"field": "state", "operator": "=", "value": state}
 
+        per_page = max(1, min(limit, 100))
         body: dict[str, Any] = {
             "query": query,
-            "pagination": {"per_page": max(1, min(limit, 100))},
+            "pagination": {"per_page": per_page},
+            # `sort` is a common structure documented for both
+            # /contacts/search and /conversations/search (Intercom docs,
+            # "Pagination & Sorting (Search)"), not contacts-only.
             "sort": {"field": "updated_at", "order": "descending"},
         }
 
@@ -220,7 +234,14 @@ def intercom_list_conversations(state: str = "open", limit: int = 20) -> str:
         conversations = [
             _conversation_summary(c) for c in result.get("conversations", [])
         ]
-        return _success(conversations=conversations)
+        # Intercom's search pagination carries a "next" cursor object under
+        # "pages" only when more results remain past this page.
+        has_more = bool((result.get("pages") or {}).get("next"))
+        return _success(
+            conversations=conversations,
+            total_count=result.get("total_count", len(conversations)),
+            has_more=has_more,
+        )
     except Exception as e:
         logger.error(f"Error listing conversations: {e}")
         return _error(str(e))
@@ -262,6 +283,8 @@ def intercom_reply_to_conversation(conversation_id: str, body: str) -> str:
     Reply to a customer on an Intercom conversation, as the connected admin.
     """
     try:
+        if not body.strip():
+            raise ValueError("body must not be blank")
         reply = _request(
             "POST",
             f"/conversations/{quote(conversation_id, safe='')}/reply",
@@ -285,6 +308,8 @@ def intercom_add_internal_note(conversation_id: str, body: str) -> str:
     visible to teammates, never to the customer.
     """
     try:
+        if not body.strip():
+            raise ValueError("body must not be blank")
         reply = _request(
             "POST",
             f"/conversations/{quote(conversation_id, safe='')}/reply",

--- a/src/xagent/web/tools/mcp/intercom.py
+++ b/src/xagent/web/tools/mcp/intercom.py
@@ -1,0 +1,282 @@
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("intercom-mcp")
+
+setup_proxy_env()
+
+mcp = FastMCP("intercom-mcp")
+
+# No region prefix: Intercom auto-routes each request to the workspace's
+# actual hosting region (US/EU/AU) based on the access token, so this one
+# host covers every region without per-region configuration.
+INTERCOM_BASE_URL = "https://api.intercom.io"
+# Pinned so a future default-version bump on Intercom's side can't silently
+# change response shapes underneath these tools.
+INTERCOM_API_VERSION = "2.11"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+_admin_id_cache: str | None = None
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _headers() -> dict[str, str]:
+    token = os.environ.get("INTERCOM_ACCESS_TOKEN")
+    if not token:
+        raise ValueError("INTERCOM_ACCESS_TOKEN environment variable is missing")
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Intercom-Version": INTERCOM_API_VERSION,
+    }
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+) -> Any:
+    response = requests.request(
+        method=method,
+        url=f"{INTERCOM_BASE_URL}{path}",
+        headers=_headers(),
+        params=params,
+        json=body,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        response_text = response.text.strip()
+        message = str(exc)
+        if response_text:
+            message = f"{message} - {response_text}"
+        raise RuntimeError(message) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _current_admin_id() -> str:
+    """Resolve the admin id behind the connected access token, cached per process.
+
+    Replying to a conversation as an admin requires an admin_id, but the OAuth
+    connection only gives us a token -- not the identity it was created for.
+    """
+    global _admin_id_cache
+    if _admin_id_cache:
+        return _admin_id_cache
+    me = _request("GET", "/me")
+    admin_id = me.get("id")
+    if not admin_id:
+        raise RuntimeError("Could not resolve the Intercom admin id for this token")
+    _admin_id_cache = str(admin_id)
+    return _admin_id_cache
+
+
+def _contact_summary(contact: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": contact.get("id"),
+        "name": contact.get("name"),
+        "email": contact.get("email"),
+        "phone": contact.get("phone"),
+        "role": contact.get("role"),
+        "last_seen_at": contact.get("last_seen_at"),
+    }
+
+
+def _conversation_summary(conversation: dict[str, Any]) -> dict[str, Any]:
+    source = conversation.get("source") or {}
+    return {
+        "id": conversation.get("id"),
+        "state": conversation.get("state"),
+        "title": conversation.get("title"),
+        "subject": source.get("subject"),
+        "preview": source.get("body"),
+        "created_at": conversation.get("created_at"),
+        "updated_at": conversation.get("updated_at"),
+    }
+
+
+@mcp.tool()
+def intercom_search_contacts(query: str, limit: int = 10) -> str:
+    """
+    Search Intercom contacts whose name or email contains `query`.
+    """
+    try:
+        body = {
+            "query": {
+                "operator": "OR",
+                "value": [
+                    {"field": "name", "operator": "~", "value": query},
+                    {"field": "email", "operator": "~", "value": query},
+                ],
+            },
+            "pagination": {"per_page": max(1, min(limit, 100))},
+        }
+        result = _request("POST", "/contacts/search", body=body)
+        contacts = [_contact_summary(c) for c in result.get("data", [])]
+        return _success(
+            contacts=contacts, total=result.get("total_count", len(contacts))
+        )
+    except Exception as e:
+        logger.error(f"Error searching contacts: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def intercom_get_contact(contact_id: str) -> str:
+    """
+    Get an Intercom contact by id.
+    """
+    try:
+        contact = _request("GET", f"/contacts/{contact_id}")
+        return _success(contact=contact)
+    except Exception as e:
+        logger.error(f"Error getting contact: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def intercom_list_conversations(state: str = "open", limit: int = 20) -> str:
+    """
+    List Intercom conversations. `state` is one of "open", "closed", or "all".
+    Returns at most `limit` conversations (max 100), most recently updated first.
+    """
+    try:
+        valid_states = {"open", "closed", "all"}
+        if state not in valid_states:
+            raise ValueError(f"state must be one of {sorted(valid_states)}")
+
+        body: dict[str, Any] = {
+            "pagination": {"per_page": max(1, min(limit, 100))},
+            "sort": {"field": "updated_at", "order": "descending"},
+        }
+        if state != "all":
+            body["query"] = {"field": "state", "operator": "=", "value": state}
+
+        result = _request("POST", "/conversations/search", body=body)
+        conversations = [
+            _conversation_summary(c) for c in result.get("conversations", [])
+        ]
+        return _success(conversations=conversations)
+    except Exception as e:
+        logger.error(f"Error listing conversations: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def intercom_get_conversation(conversation_id: str) -> str:
+    """
+    Get a full Intercom conversation by id, including the message thread
+    (conversation_parts).
+    """
+    try:
+        conversation = _request("GET", f"/conversations/{conversation_id}")
+        parts = (conversation.get("conversation_parts") or {}).get(
+            "conversation_parts", []
+        )
+        return _success(
+            conversation=_conversation_summary(conversation),
+            parts=[
+                {
+                    "id": part.get("id"),
+                    "author": (part.get("author") or {}).get("name"),
+                    "body": part.get("body"),
+                    "created_at": part.get("created_at"),
+                }
+                for part in parts
+            ],
+        )
+    except Exception as e:
+        logger.error(f"Error getting conversation: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def intercom_reply_to_conversation(conversation_id: str, body: str) -> str:
+    """
+    Reply to a customer on an Intercom conversation, as the connected admin.
+    """
+    try:
+        reply = _request(
+            "POST",
+            f"/conversations/{conversation_id}/reply",
+            body={
+                "message_type": "comment",
+                "type": "admin",
+                "admin_id": _current_admin_id(),
+                "body": body,
+            },
+        )
+        return _success(conversation=_conversation_summary(reply))
+    except Exception as e:
+        logger.error(f"Error replying to conversation: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def intercom_add_internal_note(conversation_id: str, body: str) -> str:
+    """
+    Add an internal note to an Intercom conversation. Internal notes are only
+    visible to teammates, never to the customer.
+    """
+    try:
+        reply = _request(
+            "POST",
+            f"/conversations/{conversation_id}/reply",
+            body={
+                "message_type": "note",
+                "type": "admin",
+                "admin_id": _current_admin_id(),
+                "body": body,
+            },
+        )
+        return _success(conversation=_conversation_summary(reply))
+    except Exception as e:
+        logger.error(f"Error adding internal note: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def intercom_close_conversation(conversation_id: str) -> str:
+    """
+    Close an Intercom conversation.
+    """
+    try:
+        conversation = _request(
+            "POST",
+            f"/conversations/{conversation_id}/parts",
+            body={
+                "message_type": "close",
+                "type": "admin",
+                "admin_id": _current_admin_id(),
+            },
+        )
+        return _success(conversation=_conversation_summary(conversation))
+    except Exception as e:
+        logger.error(f"Error closing conversation: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/intercom.py
+++ b/src/xagent/web/tools/mcp/intercom.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import os
+import time
 from typing import Any
+from urllib.parse import quote
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -20,14 +22,24 @@ mcp = FastMCP("intercom-mcp")
 # host covers every region without per-region configuration.
 INTERCOM_BASE_URL = "https://api.intercom.io"
 # Pinned so a future default-version bump on Intercom's side can't silently
-# change response shapes underneath these tools.
+# change response shapes underneath these tools. Re-check this against
+# Intercom's API changelog (developers.intercom.com/docs/references) whenever
+# 2.11 is scheduled for deprecation, and bump deliberately rather than
+# reactively once a version stops resolving.
 INTERCOM_API_VERSION = "2.11"
 DEFAULT_TIMEOUT_SECONDS = 30
+# Conversation/contact endpoints are rate-limited per-app; on a 429 with a
+# small Retry-After we wait once and retry rather than failing outright,
+# mirroring the same bounded-retry policy as the Slack sibling module.
+MAX_RETRY_AFTER_SECONDS = 30
 
-# Keyed by access token, not a single process-global value: this module is
-# imported once per subprocess, but nothing guarantees a subprocess is never
-# reused across a different user/token, and a bare global would leak one
-# user's admin identity into another user's replies in that case.
+# Keyed by access token, defense-in-depth rather than an active optimization:
+# every MCP tool call currently spawns and tears down a fresh subprocess
+# (mcp_adapter._execute_mcp_call -> create_session), so in practice a process
+# only ever sees one token and this dict never holds more than one entry.
+# Keying by token still costs nothing and keeps this safe against a future
+# pooled/reused-subprocess architecture, where a bare global would leak one
+# user's admin identity into another user's replies.
 _admin_id_cache: dict[str, str] = {}
 
 
@@ -58,14 +70,25 @@ def _request(
     params: dict[str, Any] | None = None,
     body: dict[str, Any] | None = None,
 ) -> Any:
-    response = requests.request(
-        method=method,
-        url=f"{INTERCOM_BASE_URL}{path}",
-        headers=_headers(),
-        params=params,
-        json=body,
-        timeout=DEFAULT_TIMEOUT_SECONDS,
-    )
+    for attempt in (0, 1):
+        response = requests.request(
+            method=method,
+            url=f"{INTERCOM_BASE_URL}{path}",
+            headers=_headers(),
+            params=params,
+            json=body,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+        if response.status_code == 429 and attempt == 0:
+            try:
+                retry_after = int(response.headers.get("Retry-After", "0"))
+            except ValueError:
+                retry_after = 0
+            if 0 < retry_after <= MAX_RETRY_AFTER_SECONDS:
+                time.sleep(retry_after)
+                continue
+        break
+
     try:
         response.raise_for_status()
     except requests.HTTPError as exc:
@@ -155,7 +178,7 @@ def intercom_get_contact(contact_id: str) -> str:
     Get an Intercom contact by id.
     """
     try:
-        contact = _request("GET", f"/contacts/{contact_id}")
+        contact = _request("GET", f"/contacts/{quote(contact_id, safe='')}")
         return _success(contact=contact)
     except Exception as e:
         logger.error(f"Error getting contact: {e}")
@@ -173,12 +196,25 @@ def intercom_list_conversations(state: str = "open", limit: int = 20) -> str:
         if state not in valid_states:
             raise ValueError(f"state must be one of {sorted(valid_states)}")
 
+        # `query` is a required field on /conversations/search (unlike
+        # GET /conversations, which has no filter and a different
+        # pagination/response shape) -- for "all" we still filter, on a
+        # predicate every real conversation satisfies, rather than switch
+        # endpoints just to express "no filter".
+        if state == "all":
+            query: dict[str, Any] = {
+                "field": "created_at",
+                "operator": ">",
+                "value": 0,
+            }
+        else:
+            query = {"field": "state", "operator": "=", "value": state}
+
         body: dict[str, Any] = {
+            "query": query,
             "pagination": {"per_page": max(1, min(limit, 100))},
             "sort": {"field": "updated_at", "order": "descending"},
         }
-        if state != "all":
-            body["query"] = {"field": "state", "operator": "=", "value": state}
 
         result = _request("POST", "/conversations/search", body=body)
         conversations = [
@@ -197,7 +233,9 @@ def intercom_get_conversation(conversation_id: str) -> str:
     (conversation_parts).
     """
     try:
-        conversation = _request("GET", f"/conversations/{conversation_id}")
+        conversation = _request(
+            "GET", f"/conversations/{quote(conversation_id, safe='')}"
+        )
         parts = (conversation.get("conversation_parts") or {}).get(
             "conversation_parts", []
         )
@@ -226,7 +264,7 @@ def intercom_reply_to_conversation(conversation_id: str, body: str) -> str:
     try:
         reply = _request(
             "POST",
-            f"/conversations/{conversation_id}/reply",
+            f"/conversations/{quote(conversation_id, safe='')}/reply",
             body={
                 "message_type": "comment",
                 "type": "admin",
@@ -249,7 +287,7 @@ def intercom_add_internal_note(conversation_id: str, body: str) -> str:
     try:
         reply = _request(
             "POST",
-            f"/conversations/{conversation_id}/reply",
+            f"/conversations/{quote(conversation_id, safe='')}/reply",
             body={
                 "message_type": "note",
                 "type": "admin",
@@ -271,7 +309,7 @@ def intercom_close_conversation(conversation_id: str) -> str:
     try:
         conversation = _request(
             "POST",
-            f"/conversations/{conversation_id}/parts",
+            f"/conversations/{quote(conversation_id, safe='')}/parts",
             body={
                 "message_type": "close",
                 "type": "admin",

--- a/src/xagent/web/tools/mcp/intercom.py
+++ b/src/xagent/web/tools/mcp/intercom.py
@@ -173,7 +173,8 @@ def intercom_search_contacts(query: str, limit: int = 10) -> str:
         result = _request("POST", "/contacts/search", body=body)
         contacts = [_contact_summary(c) for c in result.get("data", [])]
         return _success(
-            contacts=contacts, total=result.get("total_count", len(contacts))
+            contacts=contacts,
+            total_count=result.get("total_count", len(contacts)),
         )
     except Exception as e:
         logger.error(f"Error searching contacts: {e}")
@@ -194,12 +195,15 @@ def intercom_get_contact(contact_id: str) -> str:
 
 
 @mcp.tool()
-def intercom_list_conversations(state: str = "open", limit: int = 20) -> str:
+def intercom_list_conversations(
+    state: str = "open", limit: int = 20, starting_after: str | None = None
+) -> str:
     """
     List Intercom conversations. `state` is one of "open", "closed", "snoozed",
     or "all". Returns at most `limit` conversations (max 100), most recently
     updated first. `has_more` is true when the search matched more
-    conversations than were returned.
+    conversations than were returned; pass the returned `next_cursor` back in
+    as `starting_after` to fetch the following page.
     """
     try:
         valid_states = {"open", "closed", "snoozed", "all"}
@@ -221,9 +225,12 @@ def intercom_list_conversations(state: str = "open", limit: int = 20) -> str:
             query = {"field": "state", "operator": "=", "value": state}
 
         per_page = max(1, min(limit, 100))
+        pagination: dict[str, Any] = {"per_page": per_page}
+        if starting_after:
+            pagination["starting_after"] = starting_after
         body: dict[str, Any] = {
             "query": query,
-            "pagination": {"per_page": per_page},
+            "pagination": pagination,
             # `sort` is a common structure documented for both
             # /contacts/search and /conversations/search (Intercom docs,
             # "Pagination & Sorting (Search)"), not contacts-only.
@@ -236,11 +243,12 @@ def intercom_list_conversations(state: str = "open", limit: int = 20) -> str:
         ]
         # Intercom's search pagination carries a "next" cursor object under
         # "pages" only when more results remain past this page.
-        has_more = bool((result.get("pages") or {}).get("next"))
+        next_page = (result.get("pages") or {}).get("next") or {}
         return _success(
             conversations=conversations,
             total_count=result.get("total_count", len(conversations)),
-            has_more=has_more,
+            has_more=bool(next_page),
+            next_cursor=next_page.get("starting_after"),
         )
     except Exception as e:
         logger.error(f"Error listing conversations: {e}")

--- a/tests/alembic/test_20260812_seed_intercom_mcp_app.py
+++ b/tests/alembic/test_20260812_seed_intercom_mcp_app.py
@@ -1,0 +1,213 @@
+"""Tests for the Intercom MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260812_seed_intercom_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_intercom_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_tables(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE oauth_providers (
+                id INTEGER PRIMARY KEY,
+                provider_name VARCHAR(50) NOT NULL UNIQUE,
+                name VARCHAR(100) NOT NULL,
+                client_id VARCHAR(500) NOT NULL,
+                client_secret VARCHAR(500) NOT NULL,
+                auth_url VARCHAR(500) NOT NULL,
+                token_url VARCHAR(500) NOT NULL,
+                redirect_uri VARCHAR(500),
+                userinfo_url VARCHAR(500),
+                user_id_path VARCHAR(100),
+                email_path VARCHAR(100),
+                default_scopes JSON
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def _provider_names(connection):
+    return set(
+        connection.execute(text("SELECT provider_name FROM oauth_providers")).scalars()
+    )
+
+
+def test_upgrade_inserts_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "intercom" in _provider_names(connection)
+        assert "intercom" in _app_ids(connection)
+
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, is_visible_in_connector,"
+                " launch_config FROM public_mcp_apps WHERE app_id='intercom'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "intercom"
+        # Ships hidden pending manual verification against a live workspace;
+        # see builtin_mcp_registry.py's intercom app row for the rationale.
+        assert row[2] == 0
+        assert "xagent.web.tools.mcp.intercom" in str(row[3])
+        assert "INTERCOM_ACCESS_TOKEN" in str(row[3])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        app_count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='intercom'")
+        ).scalar()
+        assert app_count == 1
+        provider_count = connection.execute(
+            text("SELECT COUNT(*) FROM oauth_providers WHERE provider_name='intercom'")
+        ).scalar()
+        assert provider_count == 1
+
+
+def test_seed_rows_match_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    intercom rows (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_oauth_provider_rows,
+        get_builtin_public_mcp_app_rows,
+    )
+
+    migration = _load_migration_module()
+
+    registry_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "intercom"
+    )
+    assert migration._intercom_app_row() == registry_app
+
+    registry_provider = next(
+        row
+        for row in get_builtin_oauth_provider_rows()
+        if row["provider_name"] == "intercom"
+    )
+    assert migration._intercom_provider_row() == registry_provider
+
+
+def test_downgrade_removes_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "intercom" not in _app_ids(connection)
+        assert "intercom" not in _provider_names(connection)
+
+
+def test_downgrade_keeps_provider_when_custom_intercom_app_exists(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "INSERT INTO public_mcp_apps (app_id, name, transport, provider_name)"
+                    " VALUES ('custom-intercom', 'Custom Intercom', 'oauth', 'intercom')"
+                )
+            )
+            migration.downgrade()
+        assert "intercom" in _provider_names(connection)
+
+
+def test_downgrade_preserves_admin_created_intercom_provider(tmp_path):
+    """A pre-existing admin-created "intercom" provider (different shape than
+    the seeded row) must survive downgrade even when no intercom apps remain."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO oauth_providers"
+                " (provider_name, name, client_id, client_secret, auth_url, token_url)"
+                " VALUES ('intercom', 'Custom Intercom', 'cid', 'secret',"
+                " 'https://custom.example.com/authorize',"
+                " 'https://custom.example.com/token')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "intercom" not in _app_ids(connection)
+        assert "intercom" in _provider_names(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_tables(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "oauth_providers" not in table_names
+        assert "public_mcp_apps" not in table_names

--- a/tests/alembic/test_20260812_seed_intercom_mcp_app.py
+++ b/tests/alembic/test_20260812_seed_intercom_mcp_app.py
@@ -122,6 +122,45 @@ def test_upgrade_is_idempotent(tmp_path):
         assert provider_count == 1
 
 
+def test_upgrade_force_hides_a_pre_existing_visible_intercom_row(tmp_path):
+    """A hand-created "intercom" row (e.g. an operator adding it via
+    POST /admin/mcp/apps before this migration deployed) defaults to
+    visible. The builtin registry overlays this migration's real
+    transport/launch_config onto ANY row sharing this app_id at read time,
+    while is_visible_in_connector comes straight from the DB row -- so a
+    visible collision row would become a working, one-click-connectable,
+    unverified write-capable connector, defeating the hidden-rollout gate
+    with no further action. Same collision guard, same reasoning, as the
+    chrome seed migration (#1143)."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps"
+                " (app_id, name, transport, is_visible_in_connector)"
+                " VALUES ('intercom', 'Operator Intercom', 'oauth', 1)"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        row = connection.execute(
+            text(
+                "SELECT name, is_visible_in_connector FROM public_mcp_apps"
+                " WHERE app_id='intercom'"
+            )
+        ).first()
+        # The collision branch only flips visibility -- it must not clobber
+        # the operator's own name/description/transport choices.
+        assert row[0] == "Operator Intercom"
+        assert row[1] == 0
+        app_count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='intercom'")
+        ).scalar()
+        assert app_count == 1
+
+
 def test_seed_rows_match_registry(tmp_path):
     """The migration snapshot and the runtime registry must define the same
     intercom rows (the migration is a frozen copy; this catches drift)."""

--- a/tests/web/test_intercom_oauth.py
+++ b/tests/web/test_intercom_oauth.py
@@ -28,6 +28,29 @@ class MockResponse:
         return self._json_data
 
 
+class NonJsonResponse(MockResponse):
+    def json(self):
+        raise ValueError("response body is not JSON")
+
+
+def _intercom_app(*, is_visible_in_connector: bool) -> PublicMCPApp:
+    return PublicMCPApp(
+        app_id="intercom",
+        name="Intercom",
+        description="Intercom connector",
+        transport="oauth",
+        provider_name="intercom",
+        category="Support",
+        oauth_scopes=[],
+        is_visible_in_connector=is_visible_in_connector,
+        launch_config={
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.intercom"],
+            "env_mapping": {"INTERCOM_ACCESS_TOKEN": "access_token"},
+        },
+    )
+
+
 @pytest.fixture()
 def db_session(tmp_path):
     db_path = tmp_path / "test.db"
@@ -40,23 +63,32 @@ def db_session(tmp_path):
 
     user = User(username="alice", password_hash="x", is_admin=False)
     db.add(user)
-    db.add(
-        PublicMCPApp(
-            app_id="intercom",
-            name="Intercom",
-            description="Intercom connector",
-            transport="oauth",
-            provider_name="intercom",
-            category="Support",
-            oauth_scopes=[],
-            is_visible_in_connector=False,
-            launch_config={
-                "command": "python",
-                "args": ["-m", "xagent.web.tools.mcp.intercom"],
-                "env_mapping": {"INTERCOM_ACCESS_TOKEN": "access_token"},
-            },
-        )
+    # Visible here: these tests exercise token normalization/persistence, a
+    # concern orthogonal to the release-visibility gate. The gate itself
+    # (production ships this app with is_visible_in_connector=False) is
+    # covered separately below, against its own fixture.
+    db.add(_intercom_app(is_visible_in_connector=True))
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+@pytest.fixture()
+def hidden_db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
     )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(_intercom_app(is_visible_in_connector=False))
     db.commit()
     db.refresh(user)
 
@@ -211,3 +243,221 @@ def test_intercom_callback_fails_cleanly_when_token_exchange_yields_no_token(
         .count()
         == 0
     )
+
+
+def test_hidden_intercom_app_rejects_single_app_oauth_connect(
+    hidden_db_session, monkeypatch
+):
+    """Production ships Intercom with is_visible_in_connector=False pending
+    live-workspace verification. generic_oauth_callback's builtin_oauth path
+    used to be the one connect path _reject_hidden_catalog_app's docstring
+    flagged as NOT enforcing that gate (#1203) -- an authenticated user who
+    simply knew (or guessed) the app_id could still connect a hidden,
+    unverified, customer-facing write connector. This asserts the gate now
+    actually blocks it, symmetric with the existing mcp_oauth-path coverage
+    in test_mcp_oauth_flow.py::test_connect_app_rejects_hidden_mcp_oauth_app.
+    """
+    db, user = hidden_db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "intercom",
+            "app_id": "intercom",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "intercom-code", "state": state})
+    post_mock = Mock()
+    get_mock = Mock()
+    monkeypatch.setattr(auth_api.requests, "post", post_mock)
+    monkeypatch.setattr(auth_api.requests, "get", get_mock)
+
+    response = generic_oauth_callback("intercom", request, db, _intercom_provider())
+
+    assert response.status_code == 404
+    # The gate fires before any token exchange is attempted, not just before
+    # persistence -- a hidden app should not even reach the provider.
+    post_mock.assert_not_called()
+    get_mock.assert_not_called()
+    assert (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "intercom")
+        .count()
+        == 0
+    )
+    assert db.query(MCPServer).filter(MCPServer.name == "Intercom").count() == 0
+
+
+def test_hidden_intercom_app_is_skipped_during_bare_provider_oauth_connect(
+    hidden_db_session, monkeypatch
+):
+    """Mirror of the single-app case above, for the app_id-less ("bare
+    provider") batch connect branch: a hidden app must be skipped like a
+    mis-tagged non-oauth app, not abort the whole batch and not silently
+    create its MCPServer association."""
+    db, user = hidden_db_session
+    state = create_access_token(
+        data={"type": "oauth_state", "user_id": user.id, "provider": "intercom"},
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "intercom-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(return_value=MockResponse({"token": "raw-intercom-token"})),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"type": "admin", "id": "admin-1", "email": "alice@example.com"}
+            )
+        ),
+    )
+
+    response = generic_oauth_callback("intercom", request, db, _intercom_provider())
+
+    assert response.status_code == 200
+    # The bare provider-level grant is still created (same as the
+    # AppNotOAuthError skip case) -- only the app-specific MCPServer
+    # association for the hidden app is withheld.
+    assert (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "intercom")
+        .count()
+        == 1
+    )
+    assert db.query(MCPServer).filter(MCPServer.name == "Intercom").count() == 0
+
+
+def test_access_token_guard_applies_to_a_non_intercom_provider_too(monkeypatch):
+    """The access_token guard added alongside the intercom fix (auth.py) is
+    shared, provider-agnostic code -- it must not only be exercised through
+    provider="intercom". Zoom stands in for "some other provider" here."""
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+    user = User(username="bob", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        PublicMCPApp(
+            app_id="zoom",
+            name="Zoom",
+            transport="oauth",
+            provider_name="zoom",
+            is_visible_in_connector=True,
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    zoom_provider = SimpleNamespace(
+        provider_name="zoom",
+        client_id=encrypt_value("zoom-client-id"),
+        client_secret=encrypt_value("zoom-client-secret"),
+        token_url="https://zoom.us/oauth/token",
+        redirect_uri="https://app.example.com/api/auth/zoom/callback",
+        userinfo_url="https://api.zoom.us/v2/users/me",
+        user_id_path="id",
+        email_path="email",
+        default_scopes=[],
+    )
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "zoom",
+            "app_id": "zoom",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "zoom-code", "state": state})
+    # No "error" key (would hit the earlier guard) and no access_token: an
+    # atypical but real-world shape for a misbehaving/proxied token endpoint.
+    monkeypatch.setattr(
+        auth_api.requests, "post", Mock(return_value=MockResponse({"foo": "bar"}))
+    )
+    get_mock = Mock()
+    monkeypatch.setattr(auth_api.requests, "get", get_mock)
+
+    response = generic_oauth_callback("zoom", request, db, zoom_provider)
+
+    assert response.status_code == 400
+    assert "did not return an access token" in response.body.decode()
+    get_mock.assert_not_called()
+    assert db.query(UserOAuth).filter(UserOAuth.provider == "zoom").count() == 0
+    db.close()
+    engine.dispose()
+
+
+def test_intercom_callback_surfaces_500_for_non_json_token_response(
+    db_session, monkeypatch
+):
+    """Pre-existing behavior, not a new fix: a non-JSON token response has no
+    status check ahead of token_response.json(), so it falls through to the
+    generic exception handler as a 500 rather than the clean 400 guard."""
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "intercom",
+            "app_id": "intercom",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "bad-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(return_value=NonJsonResponse(status_code=502, text="<html>bad gateway")),
+    )
+
+    response = generic_oauth_callback("intercom", request, db, _intercom_provider())
+
+    assert response.status_code == 500
+    assert (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "intercom")
+        .count()
+        == 0
+    )
+
+
+def test_intercom_callback_hits_access_token_guard_on_non_200_json_response(
+    db_session, monkeypatch
+):
+    """A non-200 status with a JSON body carrying neither "error" nor a
+    token is untested territory: there is no explicit status check ahead of
+    the "error" in token_data guard, so this must still resolve cleanly via
+    the access_token guard rather than silently proceeding as if it were a
+    success."""
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "intercom",
+            "app_id": "intercom",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "bad-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(return_value=MockResponse({"foo": "bar"}, status_code=503)),
+    )
+    get_mock = Mock()
+    monkeypatch.setattr(auth_api.requests, "get", get_mock)
+
+    response = generic_oauth_callback("intercom", request, db, _intercom_provider())
+
+    assert response.status_code == 400
+    assert "did not return an access token" in response.body.decode()
+    get_mock.assert_not_called()

--- a/tests/web/test_intercom_oauth.py
+++ b/tests/web/test_intercom_oauth.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api import auth as auth_api
+from xagent.web.api.auth import create_access_token, generic_oauth_callback
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        PublicMCPApp(
+            app_id="intercom",
+            name="Intercom",
+            description="Intercom connector",
+            transport="oauth",
+            provider_name="intercom",
+            category="Support",
+            oauth_scopes=[],
+            is_visible_in_connector=False,
+            launch_config={
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.intercom"],
+                "env_mapping": {"INTERCOM_ACCESS_TOKEN": "access_token"},
+            },
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _intercom_provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider_name="intercom",
+        client_id=encrypt_value("intercom-client-id"),
+        client_secret=encrypt_value("intercom-client-secret"),
+        token_url="https://api.intercom.io/auth/eagle/token",
+        redirect_uri="https://app.example.com/api/auth/intercom/callback",
+        userinfo_url="https://api.intercom.io/me",
+        user_id_path="id",
+        email_path="email",
+        default_scopes=[],
+    )
+
+
+def test_normalize_intercom_token_response_maps_token_to_access_token():
+    result = auth_api._normalize_intercom_token_response(
+        "intercom", {"token": "raw-intercom-token"}
+    )
+    assert result == {
+        "token": "raw-intercom-token",
+        "access_token": "raw-intercom-token",
+    }
+
+
+def test_normalize_intercom_token_response_is_a_no_op_for_other_providers():
+    token_data = {"token": "not-an-access-token"}
+    result = auth_api._normalize_intercom_token_response("zoom", token_data)
+    assert result == token_data
+    assert "access_token" not in result
+
+
+def test_normalize_intercom_token_response_prefers_existing_access_token():
+    """If Intercom's response shape ever changes to include a real
+    access_token, do not clobber it with the (now-stale) `token` field."""
+    token_data = {"token": "legacy-token", "access_token": "real-access-token"}
+    result = auth_api._normalize_intercom_token_response("intercom", token_data)
+    assert result["access_token"] == "real-access-token"
+
+
+def test_normalize_intercom_token_response_leaves_tokenless_response_untouched():
+    token_data = {"type": "error.list", "errors": [{"message": "bad code"}]}
+    result = auth_api._normalize_intercom_token_response("intercom", token_data)
+    assert result == token_data
+
+
+def test_intercom_callback_persists_access_token_from_non_standard_response(
+    db_session, monkeypatch
+):
+    """Intercom's token endpoint returns {"token": ...}, not the standard
+    {"access_token": ...} -- end-to-end proof that generic_oauth_callback still
+    ends up persisting a usable access_token for it."""
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "intercom",
+            "app_id": "intercom",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "intercom-code", "state": state})
+
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(return_value=MockResponse({"token": "raw-intercom-token"})),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"type": "admin", "id": "admin-1", "email": "alice@example.com"}
+            )
+        ),
+    )
+
+    response = generic_oauth_callback("intercom", request, db, _intercom_provider())
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "intercom")
+        .one()
+    )
+    assert oauth_account.access_token == "raw-intercom-token"
+    assert oauth_account.provider_user_id == "admin-1"
+    assert oauth_account.email == "alice@example.com"
+
+    server = db.query(MCPServer).filter(MCPServer.name == "Intercom").one()
+    assert server.transport == "oauth"
+    user_mcp = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    assert user_mcp.is_active is True
+
+
+def test_intercom_callback_fails_cleanly_when_token_exchange_yields_no_token(
+    db_session, monkeypatch
+):
+    """Intercom's error envelope ({"type": "error.list", ...}) does not match
+    the `"error" in token_data` guard, so a failed exchange must still be
+    caught by the access_token guard rather than falling through to a raw
+    IntegrityError from UserOAuth.access_token's NOT NULL constraint."""
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "intercom",
+            "app_id": "intercom",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "bad-code", "state": state})
+
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {"type": "error.list", "errors": [{"message": "invalid code"}]}
+            )
+        ),
+    )
+    get_mock = Mock()
+    monkeypatch.setattr(auth_api.requests, "get", get_mock)
+
+    response = generic_oauth_callback("intercom", request, db, _intercom_provider())
+
+    assert response.status_code == 400
+    assert "did not return an access token" in response.body.decode()
+    assert "IntegrityError" not in response.body.decode()
+    get_mock.assert_not_called()
+    assert (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "intercom")
+        .count()
+        == 0
+    )

--- a/tests/web/test_intercom_oauth.py
+++ b/tests/web/test_intercom_oauth.py
@@ -10,7 +10,11 @@ from sqlalchemy.orm import sessionmaker
 
 from xagent.core.utils.encryption import encrypt_value
 from xagent.web.api import auth as auth_api
-from xagent.web.api.auth import create_access_token, generic_oauth_callback
+from xagent.web.api.auth import (
+    create_access_token,
+    generic_oauth_callback,
+    generic_oauth_login,
+)
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.public_mcp import PublicMCPApp
@@ -102,6 +106,7 @@ def _intercom_provider() -> SimpleNamespace:
         provider_name="intercom",
         client_id=encrypt_value("intercom-client-id"),
         client_secret=encrypt_value("intercom-client-secret"),
+        auth_url="https://app.intercom.com/oauth",
         token_url="https://api.intercom.io/auth/eagle/token",
         redirect_uri="https://app.example.com/api/auth/intercom/callback",
         userinfo_url="https://api.intercom.io/me",
@@ -234,8 +239,12 @@ def test_intercom_callback_fails_cleanly_when_token_exchange_yields_no_token(
     response = generic_oauth_callback("intercom", request, db, _intercom_provider())
 
     assert response.status_code == 400
-    assert "did not return an access token" in response.body.decode()
-    assert "IntegrityError" not in response.body.decode()
+    body = response.body.decode()
+    assert "did not return an access token" in body
+    # Pins _extract_provider_error_message: the error.list envelope's own
+    # detail must actually reach the response, not just a generic message.
+    assert "invalid code" in body
+    assert "IntegrityError" not in body
     get_mock.assert_not_called()
     assert (
         db.query(UserOAuth)
@@ -330,6 +339,30 @@ def test_hidden_intercom_app_is_skipped_during_bare_provider_oauth_connect(
         == 1
     )
     assert db.query(MCPServer).filter(MCPServer.name == "Intercom").count() == 0
+
+
+def test_hidden_intercom_app_rejects_oauth_login_redirect(hidden_db_session):
+    """The gate must also cover the login hop, not just the callback --
+    otherwise a hidden connector's real consent screen is still shown to the
+    user (no security bypass, since the callback still blocks the connect,
+    but confusing: the app doesn't feel hidden if you can watch it start
+    connecting at the provider)."""
+    db, user = hidden_db_session
+    token = create_access_token(
+        data={"sub": user.username, "type": "access"},
+        expires_delta=timedelta(minutes=5),
+    )
+
+    response = generic_oauth_login(
+        "intercom",
+        token=token,
+        app_id="intercom",
+        redirect=None,
+        db=db,
+        db_provider=_intercom_provider(),
+    )
+
+    assert response.status_code == 404
 
 
 def test_access_token_guard_applies_to_a_non_intercom_provider_too(monkeypatch):

--- a/tests/web/tools/test_intercom_mcp.py
+++ b/tests/web/tools/test_intercom_mcp.py
@@ -65,7 +65,9 @@ def test_get_contact_percent_encodes_id_with_query_injection(monkeypatch):
 
     called_url = mock_request.call_args.kwargs["url"]
     assert called_url == "https://api.intercom.io/contacts/123%3Fdisplay_as%3Dplaintext"
-    assert mock_request.call_args.kwargs["params"] is None
+    # _request has no params kwarg (dead code, removed) -- the encoded "?"
+    # must not somehow still end up attached as a query string.
+    assert "params" not in mock_request.call_args.kwargs
 
 
 def test_get_conversation_percent_encodes_id(monkeypatch):
@@ -76,6 +78,44 @@ def test_get_conversation_percent_encodes_id(monkeypatch):
 
     called_url = mock_request.call_args.kwargs["url"]
     assert called_url == "https://api.intercom.io/conversations/..%2Fadmins"
+
+
+def test_get_conversation_projects_populated_parts(monkeypatch):
+    """The only prior get_conversation test mocked an empty conversation, so
+    the conversation_parts projection never actually ran."""
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "id": "conv1",
+                    "conversation_parts": {
+                        "conversation_parts": [
+                            {
+                                "id": "part1",
+                                "author": {"name": "Alice"},
+                                "body": "<p>hi</p>",
+                                "created_at": 1700000000,
+                            }
+                        ]
+                    },
+                }
+            )
+        ),
+    )
+
+    result = json.loads(intercom.intercom_get_conversation("conv1"))
+
+    assert result["status"] == "success"
+    assert result["parts"] == [
+        {
+            "id": "part1",
+            "author": "Alice",
+            "body": "<p>hi</p>",
+            "created_at": 1700000000,
+        }
+    ]
 
 
 def test_reply_percent_encodes_conversation_id(monkeypatch):
@@ -94,6 +134,24 @@ def test_reply_percent_encodes_conversation_id(monkeypatch):
         reply_call.kwargs["url"]
         == "https://api.intercom.io/conversations/..%2Fadmins/reply"
     )
+    # Not just the URL -- swapping message_type comment<->note would change
+    # no URL, so the body must be asserted too.
+    assert reply_call.kwargs["json"] == {
+        "message_type": "comment",
+        "type": "admin",
+        "admin_id": "admin-1",
+        "body": "hello",
+    }
+
+
+def test_reply_rejects_blank_body(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    result = json.loads(intercom.intercom_reply_to_conversation("conv1", "   "))
+
+    assert result["status"] == "error"
+    mock_request.assert_not_called()
 
 
 def test_add_internal_note_percent_encodes_conversation_id(monkeypatch):
@@ -112,6 +170,22 @@ def test_add_internal_note_percent_encodes_conversation_id(monkeypatch):
         note_call.kwargs["url"]
         == "https://api.intercom.io/conversations/..%2Fadmins/reply"
     )
+    assert note_call.kwargs["json"] == {
+        "message_type": "note",
+        "type": "admin",
+        "admin_id": "admin-1",
+        "body": "internal note",
+    }
+
+
+def test_add_internal_note_rejects_blank_body(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    result = json.loads(intercom.intercom_add_internal_note("conv1", ""))
+
+    assert result["status"] == "error"
+    mock_request.assert_not_called()
 
 
 def test_close_conversation_percent_encodes_conversation_id(monkeypatch):
@@ -130,6 +204,11 @@ def test_close_conversation_percent_encodes_conversation_id(monkeypatch):
         close_call.kwargs["url"]
         == "https://api.intercom.io/conversations/..%2Fadmins/parts"
     )
+    assert close_call.kwargs["json"] == {
+        "message_type": "close",
+        "type": "admin",
+        "admin_id": "admin-1",
+    }
 
 
 def test_list_conversations_open_and_closed_filter_by_state(monkeypatch):
@@ -143,6 +222,60 @@ def test_list_conversations_open_and_closed_filter_by_state(monkeypatch):
     intercom.intercom_list_conversations(state="closed")
     body = mock_request.call_args.kwargs["json"]
     assert body["query"] == {"field": "state", "operator": "=", "value": "closed"}
+
+
+def test_list_conversations_snoozed_filters_by_state(monkeypatch):
+    """Intercom's conversation state enum is open/closed/snoozed; snoozed
+    must be a selectable state, not silently unreachable except via "all"."""
+    mock_request = Mock(return_value=MockResponse(json_data={"conversations": []}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_list_conversations(state="snoozed")
+
+    body = mock_request.call_args.kwargs["json"]
+    assert body["query"] == {"field": "state", "operator": "=", "value": "snoozed"}
+
+
+def test_list_conversations_returns_total_count_and_has_more(monkeypatch):
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "conversations": [{"id": "c1"}],
+                    "total_count": 5,
+                    "pages": {"next": {"starting_after": "cursor-2"}},
+                }
+            )
+        ),
+    )
+
+    result = json.loads(intercom.intercom_list_conversations())
+
+    assert result["status"] == "success"
+    assert result["total_count"] == 5
+    assert result["has_more"] is True
+
+
+def test_list_conversations_has_more_false_on_last_page(monkeypatch):
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "conversations": [{"id": "c1"}],
+                    "total_count": 1,
+                    "pages": {"next": None},
+                }
+            )
+        ),
+    )
+
+    result = json.loads(intercom.intercom_list_conversations())
+
+    assert result["has_more"] is False
 
 
 def test_list_conversations_all_state_still_sends_a_query(monkeypatch):
@@ -314,3 +447,99 @@ def test_search_contacts_returns_error_payload_on_failure(monkeypatch):
 
     assert result["status"] == "error"
     assert "bad token" in result["message"]
+
+
+def test_search_contacts_rejects_blank_query(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    result = json.loads(intercom.intercom_search_contacts("   "))
+
+    assert result["status"] == "error"
+    mock_request.assert_not_called()
+
+
+def test_get_contact_curates_the_response_like_search_does(monkeypatch):
+    """intercom_get_contact used to return the raw provider object while
+    search_contacts and get_conversation both curate via a summary helper --
+    internally inconsistent, and an unbounded passthrough of whatever fields
+    Intercom's API happens to include."""
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "id": "c1",
+                    "name": "Ada",
+                    "email": "ada@example.com",
+                    "phone": None,
+                    "role": "user",
+                    "last_seen_at": 1700000000,
+                    "custom_attributes": {"internal_notes": "sensitive stuff"},
+                }
+            )
+        ),
+    )
+
+    result = json.loads(intercom.intercom_get_contact("c1"))
+
+    assert result["contact"] == {
+        "id": "c1",
+        "name": "Ada",
+        "email": "ada@example.com",
+        "phone": None,
+        "role": "user",
+        "last_seen_at": 1700000000,
+    }
+    assert "custom_attributes" not in result["contact"]
+
+
+def test_request_truncates_long_unstructured_error_body(monkeypatch):
+    """An HTML gateway error page (or similar) landing in an unstructured
+    error body must not be forwarded to the LLM/logs verbatim and
+    unbounded, mirroring the Zoom sibling module."""
+    long_body = "x" * 5000
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text=long_body)),
+    )
+
+    result = json.loads(intercom.intercom_get_contact("c1"))
+
+    assert result["status"] == "error"
+    assert "[truncated]" in result["message"]
+    assert len(result["message"]) < len(long_body)
+
+
+def test_request_returns_empty_dict_on_204(monkeypatch):
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=204)),
+    )
+
+    assert intercom._request("POST", "/conversations/c1/parts") == {}
+
+
+def test_list_conversations_clamps_limit_to_the_documented_range(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"conversations": []}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_list_conversations(limit=500)
+    assert mock_request.call_args.kwargs["json"]["pagination"]["per_page"] == 100
+
+    intercom.intercom_list_conversations(limit=0)
+    assert mock_request.call_args.kwargs["json"]["pagination"]["per_page"] == 1
+
+
+def test_current_admin_id_raises_when_me_has_no_id(monkeypatch):
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"type": "admin"})),
+    )
+
+    with pytest.raises(RuntimeError, match="Could not resolve"):
+        intercom._current_admin_id()

--- a/tests/web/tools/test_intercom_mcp.py
+++ b/tests/web/tools/test_intercom_mcp.py
@@ -256,6 +256,29 @@ def test_list_conversations_returns_total_count_and_has_more(monkeypatch):
     assert result["status"] == "success"
     assert result["total_count"] == 5
     assert result["has_more"] is True
+    # has_more without an actionable cursor isn't useful -- the caller must
+    # get the cursor back to actually page through.
+    assert result["next_cursor"] == "cursor-2"
+
+
+def test_list_conversations_threads_starting_after_into_pagination(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"conversations": []}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_list_conversations(starting_after="cursor-2")
+
+    body = mock_request.call_args.kwargs["json"]
+    assert body["pagination"] == {"per_page": 20, "starting_after": "cursor-2"}
+
+
+def test_list_conversations_omits_starting_after_by_default(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"conversations": []}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_list_conversations()
+
+    body = mock_request.call_args.kwargs["json"]
+    assert "starting_after" not in body["pagination"]
 
 
 def test_list_conversations_has_more_false_on_last_page(monkeypatch):
@@ -276,6 +299,7 @@ def test_list_conversations_has_more_false_on_last_page(monkeypatch):
     result = json.loads(intercom.intercom_list_conversations())
 
     assert result["has_more"] is False
+    assert result["next_cursor"] is None
 
 
 def test_list_conversations_all_state_still_sends_a_query(monkeypatch):
@@ -431,7 +455,7 @@ def test_search_contacts_returns_success_payload(monkeypatch):
             "last_seen_at": None,
         }
     ]
-    assert result["total"] == 1
+    assert result["total_count"] == 1
 
 
 def test_search_contacts_returns_error_payload_on_failure(monkeypatch):

--- a/tests/web/tools/test_intercom_mcp.py
+++ b/tests/web/tools/test_intercom_mcp.py
@@ -1,0 +1,316 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.web.tools.mcp import intercom
+
+
+class MockResponse:
+    def __init__(self, json_data=None, text="", status_code=200, headers=None):
+        self._json_data = json_data if json_data is not None else {}
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.status_code = status_code
+        self.content = self.text.encode()
+        self.headers = headers or {}
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("INTERCOM_ACCESS_TOKEN", "access-token")
+    intercom._admin_id_cache.clear()
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("INTERCOM_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="INTERCOM_ACCESS_TOKEN"):
+        intercom._headers()
+
+
+def test_headers_include_bearer_token_and_api_version():
+    assert intercom._headers() == {
+        "Authorization": "Bearer access-token",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Intercom-Version": intercom.INTERCOM_API_VERSION,
+    }
+
+
+def test_get_contact_percent_encodes_id_with_path_separator(monkeypatch):
+    """A contact_id like "../admins" must not be able to redirect the request
+    to a different endpoint under the same bearer token (confused deputy)."""
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "c1"}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_get_contact("../admins")
+
+    called_url = mock_request.call_args.kwargs["url"]
+    assert called_url == "https://api.intercom.io/contacts/..%2Fadmins"
+
+
+def test_get_contact_percent_encodes_id_with_query_injection(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "c1"}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_get_contact("123?display_as=plaintext")
+
+    called_url = mock_request.call_args.kwargs["url"]
+    assert called_url == "https://api.intercom.io/contacts/123%3Fdisplay_as%3Dplaintext"
+    assert mock_request.call_args.kwargs["params"] is None
+
+
+def test_get_conversation_percent_encodes_id(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "conv1"}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_get_conversation("../admins")
+
+    called_url = mock_request.call_args.kwargs["url"]
+    assert called_url == "https://api.intercom.io/conversations/..%2Fadmins"
+
+
+def test_reply_percent_encodes_conversation_id(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "u1"}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+    # First call resolves the admin id via /me, second is the reply itself.
+    mock_request.side_effect = [
+        MockResponse(json_data={"id": "admin-1"}),
+        MockResponse(json_data={"id": "conv1"}),
+    ]
+
+    intercom.intercom_reply_to_conversation("../admins", "hello")
+
+    reply_call = mock_request.call_args_list[1]
+    assert (
+        reply_call.kwargs["url"]
+        == "https://api.intercom.io/conversations/..%2Fadmins/reply"
+    )
+
+
+def test_add_internal_note_percent_encodes_conversation_id(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data={"id": "admin-1"}),
+            MockResponse(json_data={"id": "conv1"}),
+        ]
+    )
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_add_internal_note("../admins", "internal note")
+
+    note_call = mock_request.call_args_list[1]
+    assert (
+        note_call.kwargs["url"]
+        == "https://api.intercom.io/conversations/..%2Fadmins/reply"
+    )
+
+
+def test_close_conversation_percent_encodes_conversation_id(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data={"id": "admin-1"}),
+            MockResponse(json_data={"id": "conv1"}),
+        ]
+    )
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_close_conversation("../admins")
+
+    close_call = mock_request.call_args_list[1]
+    assert (
+        close_call.kwargs["url"]
+        == "https://api.intercom.io/conversations/..%2Fadmins/parts"
+    )
+
+
+def test_list_conversations_open_and_closed_filter_by_state(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"conversations": []}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_list_conversations(state="open")
+    body = mock_request.call_args.kwargs["json"]
+    assert body["query"] == {"field": "state", "operator": "=", "value": "open"}
+
+    intercom.intercom_list_conversations(state="closed")
+    body = mock_request.call_args.kwargs["json"]
+    assert body["query"] == {"field": "state", "operator": "=", "value": "closed"}
+
+
+def test_list_conversations_all_state_still_sends_a_query(monkeypatch):
+    """Regression test: /conversations/search requires a `query` field on
+    every request, including "all" -- omitting it previously produced a
+    request Intercom would very likely reject with a 400."""
+    mock_request = Mock(return_value=MockResponse(json_data={"conversations": []}))
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    result = json.loads(intercom.intercom_list_conversations(state="all"))
+
+    assert result["status"] == "success"
+    body = mock_request.call_args.kwargs["json"]
+    assert "query" in body
+    assert body["query"]["field"] == "created_at"
+
+
+def test_list_conversations_rejects_unknown_state(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    result = json.loads(intercom.intercom_list_conversations(state="bogus"))
+
+    assert result["status"] == "error"
+    mock_request.assert_not_called()
+
+
+def test_request_does_not_retry_on_zero_retry_after(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(status_code=429, headers={"Retry-After": "0"}),
+            MockResponse(json_data={"id": "c1"}),
+        ]
+    )
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+    monkeypatch.setattr(intercom.time, "sleep", Mock())
+
+    # Retry-After of "0" does not satisfy `0 < retry_after`, so this call
+    # should NOT sleep/retry and must surface the 429 as an error instead.
+    result = json.loads(intercom.intercom_get_contact("c1"))
+    assert result["status"] == "error"
+    assert mock_request.call_count == 1
+
+
+def test_request_retries_once_on_429_with_positive_retry_after(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(status_code=429, headers={"Retry-After": "1"}),
+            MockResponse(json_data={"id": "c1"}),
+        ]
+    )
+    sleep_calls = []
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+    monkeypatch.setattr(intercom.time, "sleep", lambda s: sleep_calls.append(s))
+
+    result = json.loads(intercom.intercom_get_contact("c1"))
+
+    assert result["status"] == "success"
+    assert mock_request.call_count == 2
+    assert sleep_calls == [1]
+
+
+def test_request_does_not_retry_beyond_max_retry_after(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            status_code=429,
+            headers={"Retry-After": str(intercom.MAX_RETRY_AFTER_SECONDS + 1)},
+        )
+    )
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+    monkeypatch.setattr(intercom.time, "sleep", Mock())
+
+    result = json.loads(intercom.intercom_get_contact("c1"))
+
+    assert result["status"] == "error"
+    assert mock_request.call_count == 1
+
+
+def test_admin_id_is_cached_per_token(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data={"id": "admin-1"}),
+            MockResponse(json_data={"id": "conv1"}),
+            MockResponse(json_data={"id": "conv2"}),
+        ]
+    )
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+
+    intercom.intercom_reply_to_conversation("conv1", "hi")
+    intercom.intercom_reply_to_conversation("conv2", "hi again")
+
+    # /me is only called once across the two replies: the second reply hits
+    # the token-keyed cache instead of re-resolving the admin id.
+    me_calls = [
+        call
+        for call in mock_request.call_args_list
+        if call.kwargs["url"].endswith("/me")
+    ]
+    assert len(me_calls) == 1
+    assert mock_request.call_count == 3
+
+
+def test_admin_id_cache_does_not_leak_across_different_tokens(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data={"id": "admin-token-a"}),
+            MockResponse(json_data={"id": "conv1"}),
+        ]
+    )
+    monkeypatch.setattr(intercom.requests, "request", mock_request)
+    monkeypatch.setenv("INTERCOM_ACCESS_TOKEN", "token-a")
+    intercom.intercom_reply_to_conversation("conv1", "hi")
+    reply_body_a = mock_request.call_args.kwargs["json"]
+    assert reply_body_a["admin_id"] == "admin-token-a"
+
+    mock_request.side_effect = [
+        MockResponse(json_data={"id": "admin-token-b"}),
+        MockResponse(json_data={"id": "conv2"}),
+    ]
+    monkeypatch.setenv("INTERCOM_ACCESS_TOKEN", "token-b")
+    intercom.intercom_reply_to_conversation("conv2", "hi")
+    reply_body_b = mock_request.call_args.kwargs["json"]
+
+    # A different token must resolve (and use) its own admin id, not the
+    # first token's cached value.
+    assert reply_body_b["admin_id"] == "admin-token-b"
+
+
+def test_search_contacts_returns_success_payload(monkeypatch):
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "data": [{"id": "c1", "name": "Ada", "email": "ada@example.com"}],
+                    "total_count": 1,
+                }
+            )
+        ),
+    )
+
+    result = json.loads(intercom.intercom_search_contacts("ada"))
+
+    assert result["status"] == "success"
+    assert result["contacts"] == [
+        {
+            "id": "c1",
+            "name": "Ada",
+            "email": "ada@example.com",
+            "phone": None,
+            "role": None,
+            "last_seen_at": None,
+        }
+    ]
+    assert result["total"] == 1
+
+
+def test_search_contacts_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        intercom.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(status_code=401, text='{"message": "bad token"}')
+        ),
+    )
+
+    result = json.loads(intercom.intercom_search_contacts("ada"))
+
+    assert result["status"] == "error"
+    assert "bad token" in result["message"]


### PR DESCRIPTION
## Summary
- Adds Intercom as a built-in MCP connector (oauth_providers + public_mcp_apps catalog entry), following the existing HubSpot/Slack/Zoom pattern.
- New FastMCP tool module (`xagent.web.tools.mcp.intercom`) covering contact search/lookup, conversation listing/reading/replying, internal notes, and closing conversations, backed directly by Intercom's REST API.
- Normalizes Intercom's non-standard OAuth token response (`{"token": ...}` instead of `{"access_token": ...}`) in the generic OAuth callback.
- Uses the region-less `api.intercom.io` / `app.intercom.com` hosts, which auto-route per workspace — one connector config covers US/EU/AU-hosted workspaces, unlike Intercom's hosted MCP server (which has no AU support).
- Adds a seed migration for the new provider/app rows and documents the required `INTERCOM_CLIENT_ID`/`INTERCOM_CLIENT_SECRET`/`INTERCOM_REDIRECT_URI` env vars in `example.env`.

## Test plan
- [x] `ruff check` / `ruff format` / `mypy` pass on all changed files
- [x] `alembic upgrade head` / `downgrade -1` / `upgrade head` cycle verified against a local dev DB, seeding and cleanly removing both rows
- [x] `validate_builtin_public_mcp_apps` reports no drift after seeding
- [x] Verified end-to-end locally via ngrok: OAuth login/callback correctly resolves the Intercom provider and exchanges the token
- [ ] Manual verification of the individual Intercom MCP tools (search/reply/etc.) against a live workspace