### PR TITLE
fix(image): gate image tools on the models' declared abilities

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/image_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/image_tool.py
@@ -69,10 +69,10 @@ class ImageGenerationTool(ImageGenerationToolCore):
         """Get all tool instances."""
         # A note inside the description is not enough: models blind-retry a
         # registered-but-doomed tool, so an unusable one has to leave the schema.
-        can_generate = self.has_generate_capable_model()
-        can_edit = self.has_edit_capable_model()
-        if not can_generate and not can_edit:
-            return []
+        # list_image_models stays either way — it is read-only, cannot fail, and
+        # is the only way to answer "why is there nothing here".
+        can_generate = self._get_model() is not None
+        can_edit = self._get_edit_model() is not None
 
         tools = []
 
@@ -110,7 +110,7 @@ class ImageGenerationTool(ImageGenerationToolCore):
             ImageGenerationFunctionTool(
                 self.list_available_models,
                 name="list_image_models",
-                description="List all available image generation models, including model ID, availability status, and detailed description information (Note: model information is already provided in the generate_image tool description)",
+                description="List all available image generation models, including model ID, availability status, and detailed description information",
             )
         )
 

--- a/src/xagent/core/tools/adapters/vibe/image_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/image_tool.py
@@ -67,31 +67,52 @@ class ImageGenerationTool(ImageGenerationToolCore):
 
     def get_tools(self) -> list:
         """Get all tool instances."""
-        # Format descriptions with model information
-        generate_description = self.GENERATE_IMAGE_DESCRIPTION.format(
-            self._model_info_text
-        )
-        edit_description = self.EDIT_IMAGE_DESCRIPTION.format(
-            self._edit_model_info_text
-        )
+        # A note inside the description is not enough: models blind-retry a
+        # registered-but-doomed tool, so an unusable one has to leave the schema.
+        can_generate = self.has_generate_capable_model()
+        can_edit = self.has_edit_capable_model()
+        if not can_generate and not can_edit:
+            return []
 
-        tools = [
-            ImageGenerationFunctionTool(
-                self.generate_image,
-                name="generate_image",
-                description=generate_description,
-            ),
-            ImageGenerationFunctionTool(
-                self.edit_image,
-                name="edit_image",
-                description=edit_description,
-            ),
+        tools = []
+
+        if can_generate:
+            generate_description = self.GENERATE_IMAGE_DESCRIPTION.format(
+                self._model_info_text
+            )
+            if not can_edit:
+                generate_description = (
+                    "IMAGE EDITING IS UNAVAILABLE here: no configured image model "
+                    "has the edit ability, so edit_image is not offered and passing "
+                    "images fails. Render each deliverable from a text prompt in "
+                    "one call.\n\n" + generate_description
+                )
+            tools.append(
+                ImageGenerationFunctionTool(
+                    self.generate_image,
+                    name="generate_image",
+                    description=generate_description,
+                )
+            )
+
+        if can_edit:
+            tools.append(
+                ImageGenerationFunctionTool(
+                    self.edit_image,
+                    name="edit_image",
+                    description=self.EDIT_IMAGE_DESCRIPTION.format(
+                        self._edit_model_info_text
+                    ),
+                )
+            )
+
+        tools.append(
             ImageGenerationFunctionTool(
                 self.list_available_models,
                 name="list_image_models",
                 description="List all available image generation models, including model ID, availability status, and detailed description information (Note: model information is already provided in the generate_image tool description)",
-            ),
-        ]
+            )
+        )
 
         return tools
 

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -324,7 +324,9 @@ Images are automatically saved to workspace.
                 return None
 
         # Use configured default generate model
-        if self._default_generate_model:
+        if self._default_generate_model and not self._denies_ability(
+            self._default_generate_model, "generate"
+        ):
             return self._default_generate_model
 
         # Fallback: return first available model with generate capability
@@ -346,8 +348,11 @@ Images are automatically saved to workspace.
                 logger.warning(f"Model {model_id} does not support editing")
                 return None
 
-        # Use configured default edit model
-        if self._default_edit_model:
+        # A default configured by hand is trusted unless the model itself denies
+        # the ability; otherwise it reaches the provider and raises there instead.
+        if self._default_edit_model and not self._denies_ability(
+            self._default_edit_model, "edit"
+        ):
             return self._default_edit_model
 
         # Fallback: return first available model with edit capability
@@ -356,6 +361,46 @@ Images are automatically saved to workspace.
                 return model
 
         return None
+
+    @staticmethod
+    def _denies_ability(model: Any, ability: str) -> bool:
+        """True only when the model explicitly reports it lacks ``ability``."""
+        has_ability = getattr(model, "has_ability", None)
+        return callable(has_ability) and not has_ability(ability)
+
+    def has_generate_capable_model(self) -> bool:
+        """Whether any configured model can generate. Gates generate_image."""
+        return self._get_model() is not None
+
+    def has_edit_capable_model(self) -> bool:
+        """Whether any configured model can edit. Gates edit_image registration."""
+        return self._get_edit_model() is not None
+
+    def _available_models_summary(self) -> str:
+        entries = []
+        for model_id, model in self._image_models.items():
+            abilities = getattr(model, "abilities", None)
+            if not isinstance(abilities, (list, tuple)):
+                abilities = []
+            joined = ", ".join(str(ability) for ability in abilities) or "unknown"
+            entries.append(f"{model_id} (abilities: {joined})")
+        return "; ".join(entries) or "none configured"
+
+    def _no_edit_model_error(self) -> str:
+        return (
+            "No available image models with edit capabilities. "
+            f"Configured image models: {self._available_models_summary()}. "
+            "Image editing is unavailable in this deployment: render what you need "
+            "from a text prompt with generate_image instead of retrying edit_image."
+        )
+
+    def _no_generate_model_error(self) -> str:
+        return (
+            "No available image models configured. "
+            f"Configured image models: {self._available_models_summary()}. "
+            "Retry without model_id to use the default, or pick a model listed above "
+            "that has the generate ability."
+        )
 
     def _resolve_image_path(self, image_input: str) -> str:
         """
@@ -570,7 +615,7 @@ Images are automatically saved to workspace.
             if not image_model:
                 return {
                     "success": False,
-                    "error": "No available image models configured",
+                    "error": self._no_generate_model_error(),
                     "image_path": None,
                 }
 
@@ -695,7 +740,7 @@ Images are automatically saved to workspace.
             if not image_model:
                 return {
                     "success": False,
-                    "error": "No available image models with edit capabilities",
+                    "error": self._no_edit_model_error(),
                     "image_path": None,
                 }
 

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -382,10 +382,17 @@ Images are automatically saved to workspace.
             entries.append(f"{model_id} (abilities: {joined})")
         return "; ".join(entries) or "none configured"
 
-    def _no_edit_model_error(self) -> str:
-        # The realistic trigger is generate_image(images=...) delegating here on a
-        # generate-only deployment, so never answer it with "use generate_image".
-        if self._get_model() is not None:
+    def _no_edit_model_error(self, model_id: Optional[str] = None) -> str:
+        # Each branch has to name a different way out, or the model retries the
+        # exact call it just made — the failure this whole error exists to stop.
+        if model_id and self._get_edit_model() is not None:
+            remedy = (
+                f"Model {model_id} cannot edit: retry edit_image without model_id, "
+                "or pick one listed above that has the edit ability."
+            )
+        elif self._get_model() is not None:
+            # generate_image(images=...) delegates here, so never answer that
+            # call with "use generate_image".
             remedy = (
                 "Image editing is unavailable in this deployment: retry "
                 "generate_image without images and describe the change in the "
@@ -401,12 +408,20 @@ Images are automatically saved to workspace.
             f"Configured image models: {self._available_models_summary()}. {remedy}"
         )
 
-    def _no_generate_model_error(self) -> str:
+    def _no_generate_model_error(self, model_id: Optional[str] = None) -> str:
+        if model_id and self._get_model() is not None:
+            remedy = (
+                f"Model {model_id} cannot generate: retry generate_image without "
+                "model_id, or pick one listed above that has the generate ability."
+            )
+        else:
+            remedy = (
+                "No configured model can generate images: stop retrying image "
+                "tools and report that to the user."
+            )
         return (
             "No available image models with generate capabilities. "
-            f"Configured image models: {self._available_models_summary()}. "
-            "Retry without model_id to use the default, or pick a model listed above "
-            "that has the generate ability."
+            f"Configured image models: {self._available_models_summary()}. {remedy}"
         )
 
     def _resolve_image_path(self, image_input: str) -> str:
@@ -622,7 +637,7 @@ Images are automatically saved to workspace.
             if not image_model:
                 return {
                     "success": False,
-                    "error": self._no_generate_model_error(),
+                    "error": self._no_generate_model_error(model_id),
                     "image_path": None,
                 }
 
@@ -747,7 +762,7 @@ Images are automatically saved to workspace.
             if not image_model:
                 return {
                     "success": False,
-                    "error": self._no_edit_model_error(),
+                    "error": self._no_edit_model_error(model_id),
                     "image_path": None,
                 }
 

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -317,21 +317,19 @@ Images are automatically saved to workspace.
         """Get image model with generate capability by ID or default model."""
         if model_id and model_id in self._image_models:
             model = self._image_models[model_id]
-            if hasattr(model, "has_ability") and model.has_ability("generate"):
+            if self._has_ability(model, "generate"):
                 return model
             else:
                 logger.warning(f"Model {model_id} does not support generation")
                 return None
 
         # Use configured default generate model
-        if self._default_generate_model and not self._denies_ability(
-            self._default_generate_model, "generate"
-        ):
+        if self._has_ability(self._default_generate_model, "generate"):
             return self._default_generate_model
 
         # Fallback: return first available model with generate capability
         for model in self._image_models.values():
-            if hasattr(model, "has_ability") and model.has_ability("generate"):
+            if self._has_ability(model, "generate"):
                 return model
 
         return None
@@ -342,61 +340,70 @@ Images are automatically saved to workspace.
         """Get image model with edit capability by ID or default edit model."""
         if model_id and model_id in self._image_models:
             model = self._image_models[model_id]
-            if hasattr(model, "has_ability") and model.has_ability("edit"):
+            if self._has_ability(model, "edit"):
                 return model
             else:
                 logger.warning(f"Model {model_id} does not support editing")
                 return None
 
-        # A default configured by hand is trusted unless the model itself denies
-        # the ability; otherwise it reaches the provider and raises there instead.
-        if self._default_edit_model and not self._denies_ability(
-            self._default_edit_model, "edit"
-        ):
+        # A hand-configured default still has to declare the ability, or it
+        # reaches the provider and raises there instead of returning our error.
+        if self._has_ability(self._default_edit_model, "edit"):
             return self._default_edit_model
 
         # Fallback: return first available model with edit capability
         for model in self._image_models.values():
-            if hasattr(model, "has_ability") and model.has_ability("edit"):
+            if self._has_ability(model, "edit"):
                 return model
 
         return None
 
     @staticmethod
-    def _denies_ability(model: Any, ability: str) -> bool:
-        """True only when the model explicitly reports it lacks ``ability``."""
+    def _has_ability(model: Any, ability: str) -> bool:
+        """Capable only when the model itself declares the ability."""
         has_ability = getattr(model, "has_ability", None)
-        return callable(has_ability) and not has_ability(ability)
-
-    def has_generate_capable_model(self) -> bool:
-        """Whether any configured model can generate. Gates generate_image."""
-        return self._get_model() is not None
-
-    def has_edit_capable_model(self) -> bool:
-        """Whether any configured model can edit. Gates edit_image registration."""
-        return self._get_edit_model() is not None
+        return callable(has_ability) and bool(has_ability(ability))
 
     def _available_models_summary(self) -> str:
         entries = []
         for model_id, model in self._image_models.items():
             abilities = getattr(model, "abilities", None)
-            if not isinstance(abilities, (list, tuple)):
-                abilities = []
-            joined = ", ".join(str(ability) for ability in abilities) or "unknown"
+            if abilities is None:
+                joined = "unknown"
+            elif not isinstance(abilities, (list, tuple)):
+                logger.warning(
+                    "Model %s reports a non-sequence abilities value of type %s",
+                    model_id,
+                    type(abilities).__name__,
+                )
+                joined = "unknown"
+            else:
+                joined = ", ".join(str(ability) for ability in abilities) or "none"
             entries.append(f"{model_id} (abilities: {joined})")
         return "; ".join(entries) or "none configured"
 
     def _no_edit_model_error(self) -> str:
+        # The realistic trigger is generate_image(images=...) delegating here on a
+        # generate-only deployment, so never answer it with "use generate_image".
+        if self._get_model() is not None:
+            remedy = (
+                "Image editing is unavailable in this deployment: retry "
+                "generate_image without images and describe the change in the "
+                "prompt instead."
+            )
+        else:
+            remedy = (
+                "No configured model can edit or generate images: stop retrying "
+                "image tools and report that to the user."
+            )
         return (
             "No available image models with edit capabilities. "
-            f"Configured image models: {self._available_models_summary()}. "
-            "Image editing is unavailable in this deployment: render what you need "
-            "from a text prompt with generate_image instead of retrying edit_image."
+            f"Configured image models: {self._available_models_summary()}. {remedy}"
         )
 
     def _no_generate_model_error(self) -> str:
         return (
-            "No available image models configured. "
+            "No available image models with generate capabilities. "
             f"Configured image models: {self._available_models_summary()}. "
             "Retry without model_id to use the default, or pick a model listed above "
             "that has the generate ability."

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -246,9 +246,9 @@ Images are automatically saved to workspace.
         default_model_lines = []
         other_model_lines = []
         for model_id, model in self._image_models.items():
-            if hasattr(model, "has_ability") and model.has_ability("generate"):
+            if self._has_ability(model, "generate"):
                 description = self._model_descriptions.get(model_id, "")
-                edit_marker = " ✎" if model.has_ability("edit") else ""
+                edit_marker = " ✎" if self._has_ability(model, "edit") else ""
                 is_default = model_id == default_generate_id
                 default_marker = " ⭐[DEFAULT]" if is_default else ""
 
@@ -275,7 +275,7 @@ Images are automatically saved to workspace.
         default_edit_lines = []
         other_edit_lines = []
         for model_id, model in self._image_models.items():
-            if hasattr(model, "has_ability") and model.has_ability("edit"):
+            if self._has_ability(model, "edit"):
                 description = self._model_descriptions.get(model_id, "")
                 is_default = model_id == default_edit_id
                 default_marker = " ⭐[DEFAULT]" if is_default else ""
@@ -872,10 +872,19 @@ Images are automatically saved to workspace.
         """
         try:
             models_info = []
-            for model_id in self._image_models.keys():
+            for model_id, model in self._image_models.items():
+                # When capability gating withholds every image tool this listing
+                # is the only thing left to explain why, so it has to report what
+                # each model can actually serve rather than a flat "available".
+                abilities = [
+                    ability
+                    for ability in ("generate", "edit")
+                    if self._has_ability(model, ability)
+                ]
                 model_info = {
                     "model_id": model_id,
-                    "available": True,
+                    "available": bool(abilities),
+                    "abilities": abilities,
                     "description": self._model_descriptions.get(model_id, ""),
                 }
                 models_info.append(model_info)

--- a/src/xagent/web/api/tools.py
+++ b/src/xagent/web/api/tools.py
@@ -235,6 +235,11 @@ def _withheld_edit_image_row(
     Without it the admin listing just drops the tool, losing the only prompt to
     register an edit-capable model.
     """
+    # Not dead code despite the status check below also rejecting this case: with
+    # no image model there is nothing to explain, and the route asserts it does no
+    # extra work here.
+    if not image_models:
+        return None
     if any(item.get("name") == "edit_image" for item in tools):
         return None
     row = _create_tool_info(

--- a/src/xagent/web/api/tools.py
+++ b/src/xagent/web/api/tools.py
@@ -123,7 +123,8 @@ def _create_tool_info(
         elif tool_name == "edit_image":
             # Special check for image editing capability
             has_edit_capability = any(
-                "edit" in model.abilities for model in image_models.values()
+                "edit" in (getattr(model, "abilities", None) or ())
+                for model in image_models.values()
             )
             if not has_edit_capability:
                 status = "missing_capability"

--- a/src/xagent/web/api/tools.py
+++ b/src/xagent/web/api/tools.py
@@ -235,8 +235,6 @@ def _withheld_edit_image_row(
     Without it the admin listing just drops the tool, losing the only prompt to
     register an edit-capable model.
     """
-    if not image_models:
-        return None
     if any(item.get("name") == "edit_image" for item in tools):
         return None
     row = _create_tool_info(

--- a/src/xagent/web/api/tools.py
+++ b/src/xagent/web/api/tools.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from datetime import datetime
+from types import SimpleNamespace
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -226,6 +227,30 @@ def _create_tool_info(
     }
 
 
+def _withheld_edit_image_row(
+    tools: list[dict[str, Any]], image_models: Any
+) -> dict[str, Any] | None:
+    """Row explaining an edit_image that capability gating kept out of the toolset.
+
+    Without it the admin listing just drops the tool, losing the only prompt to
+    register an edit-capable model.
+    """
+    if not image_models:
+        return None
+    if any(item.get("name") == "edit_image" for item in tools):
+        return None
+    row = _create_tool_info(
+        SimpleNamespace(
+            name="edit_image",
+            description="Edit an existing image with a text prompt",
+        ),
+        "image",
+        image_models=image_models,
+    )
+    # Only ever surface the disabled explanation, never invent an available tool.
+    return row if row["status"] == "missing_capability" else None
+
+
 @tools_router.get("/available")
 async def get_available_tools(
     current_user: User = Depends(get_current_user),
@@ -356,6 +381,10 @@ async def get_available_tools(
                     music_models,
                 )
             )
+
+        withheld = _withheld_edit_image_row(tools, image_models)
+        if withheld is not None:
+            tools.append(withheld)
 
         from collections import defaultdict
 

--- a/tests/core/tools/core/test_image_tool_core.py
+++ b/tests/core/tools/core/test_image_tool_core.py
@@ -223,7 +223,7 @@ class TestImageGenerationToolCore:
         result = await tool.generate_image("A test prompt")
 
         assert result["success"] is False
-        assert result["error"] == "No available image models configured"
+        assert "No available image models configured" in result["error"]
         assert result["image_path"] is None
 
     @pytest.mark.asyncio

--- a/tests/core/tools/core/test_image_tool_core.py
+++ b/tests/core/tools/core/test_image_tool_core.py
@@ -223,7 +223,8 @@ class TestImageGenerationToolCore:
         result = await tool.generate_image("A test prompt")
 
         assert result["success"] is False
-        assert "No available image models configured" in result["error"]
+        assert "No available image models with generate capabilities" in result["error"]
+        assert "Configured image models:" in result["error"]
         assert result["image_path"] is None
 
     @pytest.mark.asyncio

--- a/tests/core/tools/test_image_tool.py
+++ b/tests/core/tools/test_image_tool.py
@@ -948,6 +948,33 @@ class TestImageToolCapabilityGating:
         assert "retry edit_image without model_id" in edit["error"]
         assert "editing is unavailable" not in edit["error"].lower()
 
+    def test_listing_reports_what_each_model_can_actually_serve(
+        self, mock_image_models, mock_workspace
+    ):
+        # list_image_models is the only tool left in this state, so it has to
+        # explain the absence rather than claim everything is available.
+        self._set_abilities(mock_image_models, [])
+        tool = ImageGenerationTool(mock_image_models, workspace=mock_workspace)
+
+        listed = tool.list_available_models()["models"]
+
+        assert [m["available"] for m in listed] == [False, False]
+        assert [m["abilities"] for m in listed] == [[], []]
+
+        mock_image_models["model1"].has_ability = Mock(
+            side_effect=lambda a: a == "edit"
+        )
+        edit_only = ImageGenerationTool(
+            mock_image_models, workspace=mock_workspace
+        ).list_available_models()["models"]
+
+        assert edit_only[0] == {
+            "model_id": "model1",
+            "available": True,
+            "abilities": ["edit"],
+            "description": "",
+        }
+
     def test_a_model_without_has_ability_is_not_trusted(self, mock_workspace):
         # fail closed: an object that never declares the ability cannot serve it,
         # whether it arrives as a default or from the configured mapping.

--- a/tests/core/tools/test_image_tool.py
+++ b/tests/core/tools/test_image_tool.py
@@ -238,7 +238,8 @@ class TestImageGenerationTool:
         result = await tool.generate_image("A test prompt")
 
         assert result["success"] is False
-        assert "No available image models configured" in result["error"]
+        assert "No available image models with generate capabilities" in result["error"]
+        assert "Configured image models:" in result["error"]
         assert result["image_path"] is None
 
     @pytest.mark.asyncio
@@ -467,8 +468,7 @@ class TestImageGenerationTool:
         """Test that no generate_image tool is offered when no model can generate"""
         image_tool = ImageGenerationTool({}, {}, workspace=mock_workspace)
 
-        assert image_tool.get_tools() == []
-        assert "No image models" in image_tool._model_info_text
+        assert "generate_image" not in {t.metadata.name for t in image_tool.get_tools()}
 
     def test_model_info_text_generation(self, mock_workspace):
         """Test that model info text is generated correctly"""
@@ -702,8 +702,8 @@ class TestCreateImageTool:
         """Test create_image_tool function with empty models"""
         tools = create_image_tool({}, workspace=mock_workspace)
 
-        # Nothing can generate or edit, so no image tool is offered at all.
-        assert tools == []
+        # Nothing can generate or edit, so only the read-only listing remains.
+        assert {t.metadata.name for t in tools} == {"list_image_models"}
 
     def test_create_image_tool_with_descriptions(
         self, mock_image_models, model_descriptions, mock_workspace
@@ -813,11 +813,11 @@ class TestImageToolCapabilityGating:
         tools = ImageGenerationTool(
             mock_image_models, workspace=mock_workspace
         ).get_tools()
-        names = {tool.name for tool in tools}
+        names = {tool.metadata.name for tool in tools}
 
         assert "edit_image" not in names
         assert "generate_image" in names
-        generate = next(tool for tool in tools if tool.name == "generate_image")
+        generate = next(t for t in tools if t.metadata.name == "generate_image")
         assert "IMAGE EDITING IS UNAVAILABLE" in generate.description
 
     def test_edit_image_offered_when_a_model_can_edit(
@@ -828,10 +828,10 @@ class TestImageToolCapabilityGating:
         tools = ImageGenerationTool(
             mock_image_models, workspace=mock_workspace
         ).get_tools()
-        names = {tool.name for tool in tools}
+        names = {tool.metadata.name for tool in tools}
 
         assert "edit_image" in names
-        generate = next(tool for tool in tools if tool.name == "generate_image")
+        generate = next(t for t in tools if t.metadata.name == "generate_image")
         assert "IMAGE EDITING IS UNAVAILABLE" not in generate.description
 
     @pytest.mark.asyncio
@@ -845,7 +845,7 @@ class TestImageToolCapabilityGating:
 
         assert result["success"] is False
         assert "model1 (abilities: generate)" in result["error"]
-        assert "generate_image" in result["error"]
+        assert "retry generate_image without images" in result["error"]
 
     def test_default_edit_model_that_denies_edit_is_not_trusted(
         self, mock_image_models, mock_workspace
@@ -857,8 +857,8 @@ class TestImageToolCapabilityGating:
             default_edit_model=mock_image_models["model1"],
         )
 
-        assert tool.has_edit_capable_model() is False
-        assert "edit_image" not in {t.name for t in tool.get_tools()}
+        assert tool._get_edit_model() is None
+        assert "edit_image" not in {t.metadata.name for t in tool.get_tools()}
 
     def test_generate_image_withheld_when_only_editing_is_available(
         self, mock_image_models, mock_workspace
@@ -868,7 +868,7 @@ class TestImageToolCapabilityGating:
         tools = ImageGenerationTool(
             mock_image_models, workspace=mock_workspace
         ).get_tools()
-        names = {tool.name for tool in tools}
+        names = {tool.metadata.name for tool in tools}
 
         assert "generate_image" not in names
         assert "edit_image" in names
@@ -882,7 +882,51 @@ class TestImageToolCapabilityGating:
             mock_image_models, workspace=mock_workspace
         ).get_tools()
 
-        assert tools == []
+        # list_image_models is read-only and cannot fail, so it stays as the
+        # only way to answer "why is there nothing here".
+        assert {t.metadata.name for t in tools} == {"list_image_models"}
+
+    def test_default_generate_model_that_denies_generate_is_not_trusted(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, ["edit"])
+        tool = ImageGenerationTool(
+            mock_image_models,
+            workspace=mock_workspace,
+            default_generate_model=mock_image_models["model1"],
+        )
+
+        assert tool._get_model() is None
+        assert "generate_image" not in {t.metadata.name for t in tool.get_tools()}
+
+    @pytest.mark.asyncio
+    async def test_delegated_edit_does_not_recommend_the_tool_that_was_called(
+        self, mock_image_models, mock_workspace
+    ):
+        # generate_image(images=...) delegates into the edit path, so answering it
+        # with "use generate_image" would send the model back where it started.
+        self._set_abilities(mock_image_models, ["generate"])
+        tool = ImageGenerationTool(mock_image_models, workspace=mock_workspace)
+
+        result = await tool.generate_image("add a headline", images="file:abc123")
+
+        assert result["success"] is False
+        assert "retry generate_image without images" in result["error"]
+        assert "instead of retrying edit_image" not in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_edit_error_stops_retrying_when_nothing_can_generate_either(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, [])
+        tool = ImageGenerationTool(mock_image_models, workspace=mock_workspace)
+
+        result = await tool.edit_image(prompt="add a headline", image_url="file:abc")
+
+        assert result["success"] is False
+        assert "stop retrying image tools" in result["error"]
+        assert "retry generate_image" not in result["error"]
+        assert "model1 (abilities: none)" in result["error"]
 
     @pytest.mark.asyncio
     async def test_generate_error_lists_abilities(

--- a/tests/core/tools/test_image_tool.py
+++ b/tests/core/tools/test_image_tool.py
@@ -238,7 +238,7 @@ class TestImageGenerationTool:
         result = await tool.generate_image("A test prompt")
 
         assert result["success"] is False
-        assert result["error"] == "No available image models configured"
+        assert "No available image models configured" in result["error"]
         assert result["image_path"] is None
 
     @pytest.mark.asyncio
@@ -463,25 +463,12 @@ class TestImageGenerationTool:
         assert "images" in schema["properties"]
         assert "images (optional): source/reference image" in generate_tool.description
 
-    def test_generate_image_tool_description_without_models(self, mock_workspace):
-        """Test that generate_image tool description handles no models gracefully"""
-        # Create tool with no models
+    def test_no_generate_tool_without_models(self, mock_workspace):
+        """Test that no generate_image tool is offered when no model can generate"""
         image_tool = ImageGenerationTool({}, {}, workspace=mock_workspace)
-        tools = image_tool.get_tools()
 
-        # Find the generate_image tool
-        generate_tool = None
-        for tool in tools:
-            if tool.metadata.name == "generate_image":
-                generate_tool = tool
-                break
-
-        assert generate_tool is not None
-
-        # Check that the description handles no models case
-        description = generate_tool.description
-        assert "Available models" in description
-        assert "No image models available" in description
+        assert image_tool.get_tools() == []
+        assert "No image models" in image_tool._model_info_text
 
     def test_model_info_text_generation(self, mock_workspace):
         """Test that model info text is generated correctly"""
@@ -715,13 +702,8 @@ class TestCreateImageTool:
         """Test create_image_tool function with empty models"""
         tools = create_image_tool({}, workspace=mock_workspace)
 
-        assert len(tools) == 3
-
-        # Should still create the tools even with no models
-        tool_names = [tool.metadata.name for tool in tools]
-        assert "generate_image" in tool_names
-        assert "edit_image" in tool_names
-        assert "list_image_models" in tool_names
+        # Nothing can generate or edit, so no image tool is offered at all.
+        assert tools == []
 
     def test_create_image_tool_with_descriptions(
         self, mock_image_models, model_descriptions, mock_workspace
@@ -812,3 +794,104 @@ class TestCreateImageTool:
 
         assert result["success"] is True
         assert result["count"] == 2
+
+
+class TestImageToolCapabilityGating:
+    """A tool no configured model can serve must leave the schema entirely."""
+
+    @staticmethod
+    def _set_abilities(models, abilities):
+        for model in models.values():
+            model.abilities = list(abilities)
+            model.has_ability = Mock(side_effect=lambda a: a in abilities)
+
+    def test_edit_image_withheld_when_no_model_can_edit(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, ["generate"])
+
+        tools = ImageGenerationTool(
+            mock_image_models, workspace=mock_workspace
+        ).get_tools()
+        names = {tool.name for tool in tools}
+
+        assert "edit_image" not in names
+        assert "generate_image" in names
+        generate = next(tool for tool in tools if tool.name == "generate_image")
+        assert "IMAGE EDITING IS UNAVAILABLE" in generate.description
+
+    def test_edit_image_offered_when_a_model_can_edit(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, ["generate", "edit"])
+
+        tools = ImageGenerationTool(
+            mock_image_models, workspace=mock_workspace
+        ).get_tools()
+        names = {tool.name for tool in tools}
+
+        assert "edit_image" in names
+        generate = next(tool for tool in tools if tool.name == "generate_image")
+        assert "IMAGE EDITING IS UNAVAILABLE" not in generate.description
+
+    @pytest.mark.asyncio
+    async def test_error_lists_abilities_and_points_at_generate_image(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, ["generate"])
+        tool = ImageGenerationTool(mock_image_models, workspace=mock_workspace)
+
+        result = await tool.edit_image(prompt="add a headline", image_url="file:abc123")
+
+        assert result["success"] is False
+        assert "model1 (abilities: generate)" in result["error"]
+        assert "generate_image" in result["error"]
+
+    def test_default_edit_model_that_denies_edit_is_not_trusted(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, ["generate"])
+        tool = ImageGenerationTool(
+            mock_image_models,
+            workspace=mock_workspace,
+            default_edit_model=mock_image_models["model1"],
+        )
+
+        assert tool.has_edit_capable_model() is False
+        assert "edit_image" not in {t.name for t in tool.get_tools()}
+
+    def test_generate_image_withheld_when_only_editing_is_available(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, ["edit"])
+
+        tools = ImageGenerationTool(
+            mock_image_models, workspace=mock_workspace
+        ).get_tools()
+        names = {tool.name for tool in tools}
+
+        assert "generate_image" not in names
+        assert "edit_image" in names
+
+    def test_no_tools_when_configured_models_can_do_neither(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, [])
+
+        tools = ImageGenerationTool(
+            mock_image_models, workspace=mock_workspace
+        ).get_tools()
+
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_generate_error_lists_abilities(
+        self, mock_image_models, mock_workspace
+    ):
+        self._set_abilities(mock_image_models, ["edit"])
+        tool = ImageGenerationTool(mock_image_models, workspace=mock_workspace)
+
+        result = await tool.generate_image("a poster", model_id="model1")
+
+        assert result["success"] is False
+        assert "model1 (abilities: edit)" in result["error"]

--- a/tests/core/tools/test_image_tool.py
+++ b/tests/core/tools/test_image_tool.py
@@ -2,6 +2,7 @@
 Tests for Image Generation tool
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -912,7 +913,6 @@ class TestImageToolCapabilityGating:
 
         assert result["success"] is False
         assert "retry generate_image without images" in result["error"]
-        assert "instead of retrying edit_image" not in result["error"]
 
     @pytest.mark.asyncio
     async def test_edit_error_stops_retrying_when_nothing_can_generate_either(
@@ -927,6 +927,40 @@ class TestImageToolCapabilityGating:
         assert "stop retrying image tools" in result["error"]
         assert "retry generate_image" not in result["error"]
         assert "model1 (abilities: none)" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_wrong_model_id_points_at_the_models_that_can_serve_it(
+        self, mock_image_models, mock_workspace
+    ):
+        # A model_id that cannot edit must not be reported as "editing is
+        # unavailable" while another configured model can edit.
+        mock_image_models["model1"].abilities = ["generate"]
+        mock_image_models["model1"].has_ability = Mock(
+            side_effect=lambda a: a == "generate"
+        )
+        mock_image_models["model2"].abilities = ["generate", "edit"]
+        mock_image_models["model2"].has_ability = Mock(side_effect=lambda a: True)
+        tool = ImageGenerationTool(mock_image_models, workspace=mock_workspace)
+
+        edit = await tool.edit_image(prompt="x", image_url="file:a", model_id="model1")
+
+        assert "Model model1 cannot edit" in edit["error"]
+        assert "retry edit_image without model_id" in edit["error"]
+        assert "editing is unavailable" not in edit["error"].lower()
+
+    def test_a_model_without_has_ability_is_not_trusted(self, mock_workspace):
+        # fail closed: an object that never declares the ability cannot serve it,
+        # whether it arrives as a default or from the configured mapping.
+        opaque = SimpleNamespace(abilities=["generate", "edit"])
+        tool = ImageGenerationTool(
+            {"opaque": opaque},
+            workspace=mock_workspace,
+            default_generate_model=opaque,
+            default_edit_model=opaque,
+        )
+
+        assert tool._get_model() is None
+        assert tool._get_edit_model() is None
 
     @pytest.mark.asyncio
     async def test_generate_error_lists_abilities(

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -102,6 +102,76 @@ def test_music_tool_requires_music_model() -> None:
     assert available["status"] == "available"
 
 
+@pytest.mark.asyncio
+async def test_available_tools_route_surfaces_the_withheld_edit_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The helper's unit test cannot catch the wiring being dropped, and every
+    # other route test configures zero image models, which short-circuits it.
+    from xagent.web.api.tools import get_available_tools
+
+    class Config:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def get_vision_model(self):
+            return None
+
+        def get_image_models(self):
+            return {"img": SimpleNamespace(abilities=["generate"])}
+
+        def get_video_models(self):
+            return {}
+
+        def get_asr_models(self):
+            return {}
+
+        def get_tts_models(self):
+            return {}
+
+        def get_sound_effect_models(self):
+            return {}
+
+        def get_music_models(self):
+            return {}
+
+        def get_user_tool_overrides(self):
+            return {}
+
+        def close(self) -> None:
+            return None
+
+    async def create_all_tools(_config, apply_user_override_filter: bool = True):
+        # Capability gating already withheld edit_image.
+        return []
+
+    class Query:
+        def all(self) -> list[object]:
+            return []
+
+    class Database:
+        def query(self, _model: object) -> Query:
+            return Query()
+
+    monkeypatch.setattr("xagent.web.api.tools.WebToolConfig", Config)
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        create_all_tools,
+    )
+    monkeypatch.setattr("xagent.web.sandbox_manager.get_sandbox_manager", lambda: None)
+    monkeypatch.setattr("xagent.web.api.tools.get_default_tool_configs", lambda: [])
+
+    response = await get_available_tools(
+        current_user=SimpleNamespace(id=7, is_admin=False),
+        db=Database(),
+    )
+
+    rows = {item["name"]: item for item in response["tools"]}
+    assert rows["edit_image"]["enabled"] is False
+    assert rows["edit_image"]["status"] == "missing_capability"
+    assert "editing support" in rows["edit_image"]["status_reason"]
+
+
 class _AvailableToolsRouteHarness:
     def __init__(
         self,

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -63,6 +63,27 @@ def test_sound_effect_tool_requires_sound_effect_model() -> None:
     assert available["status"] == "available"
 
 
+def test_withheld_edit_image_keeps_its_admin_row() -> None:
+    from xagent.web.api.tools import _withheld_edit_image_row
+
+    generate_only = {"img": SimpleNamespace(abilities=["generate"])}
+    edit_capable = {"img": SimpleNamespace(abilities=["generate", "edit"])}
+
+    row = _withheld_edit_image_row([], generate_only)
+
+    assert row is not None
+    assert row["name"] == "edit_image"
+    assert row["enabled"] is False
+    assert row["status"] == "missing_capability"
+    assert "editing support" in row["status_reason"]
+
+    # Nothing to explain when the tool is present, or when no model is configured.
+    assert _withheld_edit_image_row([{"name": "edit_image"}], generate_only) is None
+    assert _withheld_edit_image_row([], {}) is None
+    # An edit-capable deployment must never grow a synthetic row.
+    assert _withheld_edit_image_row([], edit_capable) is None
+
+
 def test_music_tool_requires_music_model() -> None:
     class Tool:
         name = "generate_music"


### PR DESCRIPTION
Closes #1295. Sub-issue of #1289.

## Background

A production ad-creative task called `edit_image` 8 times in a row, each failing
instantly with `No available image models with edit capabilities`, then worked
around it by editing images through `execute_python_code` 16 more times. That
deployment has a single image model configured with `abilities = ["generate"]`.

The framework problem is that `edit_image` is registered unconditionally, with no
regard for whether any configured model can serve it. Worth recording: the
description already said so — `_edit_model_info_text` falls back to the literal
string `No image models with edit capabilities available` and that text is
formatted into the tool description. Production shows the model ignored that
passive note and blind-retried anyway, so rewording is not a fix; the tool has to
leave the schema.

Those ~24 doomed and detour calls each cost a full LLM round trip (the whole
history plus the tool schemas re-sent), which is where the bulk of that task's
token spend and its 28-minute wall time came from.

## Changes

1. **Capability gating** (`vibe/image_tool.py` `get_tools`) — no model with
   `generate` means `generate_image` is not registered; no model with `edit`
   means `edit_image` is not registered; neither means an empty tool list. When
   editing is unavailable, `generate_image` gets a leading prohibition in its
   description, because `generate_image(images=...)` delegates to the edit path
   and is the side door into the same failure.
2. **Self-correctable errors** (`core/image_tool.py`) — both "no usable model"
   errors now enumerate the configured models with their abilities and state what
   to do next. The original wording is kept as the prefix so existing log
   searches still match.
3. **Ability check on the default-model branches** of `_get_model` and
   `_get_edit_model` — the explicit `model_id` branch verified `has_ability`, but
   the `_default_*_model` branch trusted its input unconditionally. A
   generate-only model configured as `default_edit_model` therefore bypassed the
   check, reached the provider, and raised `RuntimeError` there instead of
   returning the friendly error. The check is deliberately lenient: it rejects
   only a model that explicitly reports lacking the ability, and still trusts one
   without a `has_ability` method.

## Why the long description template is left alone

`GENERATE_IMAGE_DESCRIPTION` teaches the `images` parameter in three separate
places. Trimming each would mean adding placeholders to the template for a much
wider diff, and existing tests assert against the class constant directly.
Instead, editing-unavailable deployments get one leading prohibition, backed by
`edit_image` being absent from the schema and by the self-correctable error. When
editing is available the description is byte-identical to before.

## Out of scope

- **Deployment-side follow-up**: grant the image model the edit ability, or
  register an edit-capable model. This change only guarantees that a tool nothing
  can serve is no longer offered to the model.
- Other items from the parent issue (retry predicate never passed to
  `create_retry_wrapper`, redundant fields in the tool-result observation,
  serial media tool execution, planner missing the deliverable type) are not in
  this PR.

## Verification

- New `TestImageToolCapabilityGating` with 7 cases: `edit_image` absent and the
  prohibition present when nothing can edit; both tools present and the
  description unchanged when a model can edit; `generate_image` absent when only
  editing is available; empty list when neither is available; a
  `default_edit_model` that denies `edit` is not trusted; both error strings
  enumerate abilities.
- Updated 3 existing cases that asserted the old contract (tool count with empty
  models; two exact error-string comparisons relaxed to substring).
- `tests/core/tools/` passes (exit 0). `test_command_path_guard_bash.py` and
  `test_command_executor.py` have pre-existing failures, reproduced on
  `origin/main` with these changes stashed to confirm they are unrelated.
- `ruff check`, `ruff format`, `mypy`, and the full pre-commit hook set pass.
