### PR TITLE
perf(tools): drop redundant metadata from artifact observations

### DIFF
--- a/src/xagent/core/tools/artifacts.py
+++ b/src/xagent/core/tools/artifacts.py
@@ -49,6 +49,21 @@ LOCAL_PATH_KEYS = {
     "output_dir",
     "output_path",
 }
+# Dropped from the model-facing observation only, never from the tool result.
+# The artifact lines already carry file identity; the rest is telemetry, raw
+# provider payloads, or transient URLs the model must not reference.
+OBSERVATION_REDUNDANT_KEYS = {
+    "artifacts",
+    "generated_files",
+    "image_url",
+    "last_frame_url",
+    "raw_response",
+    "request_id",
+    "saved_to_workspace",
+    "task_metric",
+    "usage",
+    "video_url",
+}
 
 GeneratedArtifactSnapshot = dict[Path, tuple[int, int]]
 
@@ -125,8 +140,18 @@ def format_tool_result_for_observation(tool_name: str, result: Any) -> str:
         + "\nUse the Markdown/chat form in assistant messages. "
         + "When writing HTML for Xagent preview, reference the same file_id "
         + "through the file preview service instead of local filesystem paths. "
-        + f"Sanitized result metadata: {sanitized}"
+        + f"Sanitized result metadata: {_observation_metadata(sanitized)}"
     )
+
+
+def _observation_metadata(sanitized: Any) -> Any:
+    if not isinstance(sanitized, dict):
+        return sanitized
+    return {
+        key: value
+        for key, value in sanitized.items()
+        if key not in OBSERVATION_REDUNDANT_KEYS
+    }
 
 
 def _format_artifact_lines(artifacts: list[Any]) -> list[str]:

--- a/src/xagent/core/tools/artifacts.py
+++ b/src/xagent/core/tools/artifacts.py
@@ -41,13 +41,19 @@ SAFE_FILE_REF_KEYS = {
     "relative_path",
     "size",
 }
+# Every media tool returns its artifact as <kind>_path alongside file_id/file_ref.
+# Missing keys were redacted only by coincidence: file_ref.file_path registers the
+# same string, which stops holding when building the FileRef fails.
 LOCAL_PATH_KEYS = {
     "absolute_path",
+    "audio_path",
     "file_path",
     "image_path",
     "local_path",
     "output_dir",
     "output_path",
+    "transcription_path",
+    "video_path",
 }
 # Dropped from the model-facing observation only, never from the tool result, and
 # only at the top level. Keep out anything the model still acts on: last_frame_url

--- a/src/xagent/core/tools/artifacts.py
+++ b/src/xagent/core/tools/artifacts.py
@@ -49,14 +49,12 @@ LOCAL_PATH_KEYS = {
     "output_dir",
     "output_path",
 }
-# Dropped from the model-facing observation only, never from the tool result.
-# The artifact lines already carry file identity; the rest is telemetry, raw
-# provider payloads, or transient URLs the model must not reference.
+# Dropped from the model-facing observation only, never from the tool result, and
+# only at the top level. Keep out anything the model still acts on: last_frame_url
+# is an input to the next generate_video call and has no artifact of its own.
 OBSERVATION_REDUNDANT_KEYS = {
     "artifacts",
     "generated_files",
-    "image_url",
-    "last_frame_url",
     "raw_response",
     "request_id",
     "saved_to_workspace",
@@ -144,9 +142,7 @@ def format_tool_result_for_observation(tool_name: str, result: Any) -> str:
     )
 
 
-def _observation_metadata(sanitized: Any) -> Any:
-    if not isinstance(sanitized, dict):
-        return sanitized
+def _observation_metadata(sanitized: dict[str, Any]) -> dict[str, Any]:
     return {
         key: value
         for key, value in sanitized.items()

--- a/src/xagent/core/tools/artifacts.py
+++ b/src/xagent/core/tools/artifacts.py
@@ -52,7 +52,7 @@ LOCAL_PATH_KEYS = {
 # Dropped from the model-facing observation only, never from the tool result, and
 # only at the top level. Keep out anything the model still acts on: last_frame_url
 # is an input to the next generate_video call and has no artifact of its own.
-OBSERVATION_REDUNDANT_KEYS = {
+_OBSERVATION_EXCLUDED_KEYS = {
     "artifacts",
     "generated_files",
     "raw_response",
@@ -62,6 +62,9 @@ OBSERVATION_REDUNDANT_KEYS = {
     "usage",
     "video_url",
 }
+# Without artifact lines the URLs and filenames are the model's only handle on the
+# result, so the failure path only sheds the unbounded provider payload.
+_UNBOUNDED_PAYLOAD_KEYS = {"raw_response"}
 
 GeneratedArtifactSnapshot = dict[Path, tuple[int, int]]
 
@@ -122,32 +125,32 @@ def format_tool_result_for_observation(tool_name: str, result: Any) -> str:
     if not isinstance(result, dict):
         return str(result)
 
-    artifacts = result.get("artifacts")
-    if not isinstance(artifacts, list) or not artifacts:
-        return str(result)
-
     sanitized = sanitize_file_refs_for_observation(result)
 
-    artifact_lines = _format_artifact_lines(artifacts)
+    artifacts = result.get("artifacts")
+    artifact_lines = (
+        _format_artifact_lines(artifacts) if isinstance(artifacts, list) else []
+    )
     if not artifact_lines:
-        return str(sanitized)
+        # A failed download still reports through this path, so it has to be
+        # redacted too — it carries the same signed URLs and provider payloads.
+        return str(_observation_metadata(sanitized, _UNBOUNDED_PAYLOAD_KEYS))
 
+    metadata = _observation_metadata(sanitized, _OBSERVATION_EXCLUDED_KEYS)
     return (
         f"Tool '{tool_name}' produced displayable artifact(s):\n"
         + "\n".join(artifact_lines)
         + "\nUse the Markdown/chat form in assistant messages. "
         + "When writing HTML for Xagent preview, reference the same file_id "
-        + "through the file preview service instead of local filesystem paths. "
-        + f"Sanitized result metadata: {_observation_metadata(sanitized)}"
+        + "through the file preview service instead of local filesystem paths."
+        + (f" Sanitized result metadata: {metadata}" if metadata else "")
     )
 
 
-def _observation_metadata(sanitized: dict[str, Any]) -> dict[str, Any]:
-    return {
-        key: value
-        for key, value in sanitized.items()
-        if key not in OBSERVATION_REDUNDANT_KEYS
-    }
+def _observation_metadata(
+    sanitized: dict[str, Any], excluded: set[str]
+) -> dict[str, Any]:
+    return {key: value for key, value in sanitized.items() if key not in excluded}
 
 
 def _format_artifact_lines(artifacts: list[Any]) -> list[str]:

--- a/tests/core/tools/test_artifacts_observation.py
+++ b/tests/core/tools/test_artifacts_observation.py
@@ -180,6 +180,7 @@ def test_format_tool_result_for_observation_drops_redundant_image_metadata():
                 "filename": "creative.png",
                 "relative_path": "creative.png",
             },
+            "generated_files": ["creative.png"],
             "usage": {"prompt_tokens": 12, "total_tokens": 34},
             "task_metric": {"latency_ms": 8123},
             "request_id": "req-abc123",
@@ -191,9 +192,15 @@ def test_format_tool_result_for_observation_drops_redundant_image_metadata():
     assert "![creative.png](file:image-file-id)" in observation
     assert "gemini-2.5-flash-image" in observation
     assert "relative_path" in observation
-    for dropped in ("prompt_tokens", "latency_ms", "req-abc123", "saved_to_workspace"):
+    for dropped in (
+        "'artifacts'",
+        "generated_files",
+        "prompt_tokens",
+        "latency_ms",
+        "req-abc123",
+        "saved_to_workspace",
+    ):
         assert dropped not in observation
-    assert "inline" not in observation
 
 
 def test_format_tool_result_for_observation_drops_raw_video_provider_payload():
@@ -202,7 +209,7 @@ def test_format_tool_result_for_observation_drops_raw_video_provider_payload():
         {
             "success": True,
             "video_url": "https://provider.example/signed/clip.mp4?token=secret",
-            "last_frame_url": "https://provider.example/signed/frame.png?token=secret",
+            "last_frame_url": "https://frames.example/last-frame.png",
             "video_path": "/tmp/xagent/output/clip.mp4",
             "file_id": "video-file-id",
             "artifacts": [
@@ -224,6 +231,8 @@ def test_format_tool_result_for_observation_drops_raw_video_provider_payload():
     assert "1080p" in observation
     assert "xxxx" not in observation
     assert "provider.example" not in observation
+    # last_frame_url is an input to the next generate_video call, not telemetry.
+    assert "https://frames.example/last-frame.png" in observation
 
 
 def test_snapshot_generated_artifact_files_skips_files_deleted_before_stat(

--- a/tests/core/tools/test_artifacts_observation.py
+++ b/tests/core/tools/test_artifacts_observation.py
@@ -159,6 +159,73 @@ def test_format_tool_result_for_observation_normalizes_artifact_type_case():
     assert "Markdown/chat image" in observation
 
 
+def test_format_tool_result_for_observation_drops_redundant_image_metadata():
+    observation = format_tool_result_for_observation(
+        "generate_image",
+        {
+            "success": True,
+            "image_path": "/tmp/xagent/output/creative.png",
+            "file_id": "image-file-id",
+            "artifacts": [
+                {
+                    "type": "image",
+                    "file_id": "image-file-id",
+                    "filename": "creative.png",
+                    "mime_type": "image/png",
+                    "display": "inline",
+                }
+            ],
+            "file_ref": {
+                "file_id": "image-file-id",
+                "filename": "creative.png",
+                "relative_path": "creative.png",
+            },
+            "usage": {"prompt_tokens": 12, "total_tokens": 34},
+            "task_metric": {"latency_ms": 8123},
+            "request_id": "req-abc123",
+            "model_used": "gemini-2.5-flash-image",
+            "saved_to_workspace": True,
+        },
+    )
+
+    assert "![creative.png](file:image-file-id)" in observation
+    assert "gemini-2.5-flash-image" in observation
+    assert "relative_path" in observation
+    for dropped in ("prompt_tokens", "latency_ms", "req-abc123", "saved_to_workspace"):
+        assert dropped not in observation
+    assert "inline" not in observation
+
+
+def test_format_tool_result_for_observation_drops_raw_video_provider_payload():
+    observation = format_tool_result_for_observation(
+        "generate_video",
+        {
+            "success": True,
+            "video_url": "https://provider.example/signed/clip.mp4?token=secret",
+            "last_frame_url": "https://provider.example/signed/frame.png?token=secret",
+            "video_path": "/tmp/xagent/output/clip.mp4",
+            "file_id": "video-file-id",
+            "artifacts": [
+                {
+                    "type": "video",
+                    "file_id": "video-file-id",
+                    "filename": "clip.mp4",
+                    "mime_type": "video/mp4",
+                    "display": "inline",
+                }
+            ],
+            "duration": 5,
+            "resolution": "1080p",
+            "raw_response": {"data": {"binary": "x" * 4096}},
+        },
+    )
+
+    assert "[clip.mp4](file:video-file-id)" in observation
+    assert "1080p" in observation
+    assert "xxxx" not in observation
+    assert "provider.example" not in observation
+
+
 def test_snapshot_generated_artifact_files_skips_files_deleted_before_stat(
     tmp_path, monkeypatch
 ):

--- a/tests/core/tools/test_artifacts_observation.py
+++ b/tests/core/tools/test_artifacts_observation.py
@@ -261,6 +261,28 @@ def test_format_tool_result_for_observation_redacts_the_download_failure_shape()
     assert "https://provider.example/signed/clip.mp4?token=secret" in observation
 
 
+def test_media_paths_are_redacted_without_a_file_ref_to_register_them():
+    # build_workspace_file_ref failing leaves file_ref None, so nothing else
+    # carries the path — the media *_path keys have to stand on their own.
+    for key, filename in (
+        ("video_path", "clip.mp4"),
+        ("audio_path", "voice.mp3"),
+        ("transcription_path", "transcript.json"),
+    ):
+        observation = format_tool_result_for_observation(
+            "media_tool",
+            {
+                "success": True,
+                key: f"/Users/someone/.xagent/workspaces/w1/output/{filename}",
+                "file_id": "media-file-id",
+                "file_ref": None,
+            },
+        )
+
+        assert "/Users/someone" not in observation, key
+        assert key not in observation, key
+
+
 def test_observation_metadata_drops_exactly_the_excluded_keys():
     from xagent.core.tools.artifacts import (
         _OBSERVATION_EXCLUDED_KEYS,

--- a/tests/core/tools/test_artifacts_observation.py
+++ b/tests/core/tools/test_artifacts_observation.py
@@ -235,6 +235,63 @@ def test_format_tool_result_for_observation_drops_raw_video_provider_payload():
     assert "https://frames.example/last-frame.png" in observation
 
 
+def test_format_tool_result_for_observation_redacts_the_download_failure_shape():
+    # A failed video download reports artifacts=[], which used to skip redaction
+    # entirely and leak the raw payload plus the signed URL verbatim.
+    observation = format_tool_result_for_observation(
+        "generate_video",
+        {
+            "success": True,
+            "video_url": "https://provider.example/signed/clip.mp4?token=secret",
+            "video_path": None,
+            "file_id": None,
+            "artifacts": [],
+            "file_ref": {
+                "file_id": "vid",
+                "filename": "clip.mp4",
+                "file_path": "/tmp/xagent/output/clip.mp4",
+            },
+            "raw_response": {"data": {"binary": "x" * 4096}},
+        },
+    )
+
+    assert "xxxx" not in observation
+    assert "/tmp/xagent/output/clip.mp4" not in observation
+    # Without artifact lines the URL is the model's only handle on the result.
+    assert "https://provider.example/signed/clip.mp4?token=secret" in observation
+
+
+def test_observation_metadata_drops_exactly_the_excluded_keys():
+    from xagent.core.tools.artifacts import (
+        _OBSERVATION_EXCLUDED_KEYS,
+        _UNBOUNDED_PAYLOAD_KEYS,
+        _observation_metadata,
+    )
+
+    payload = {
+        "success": True,
+        "model_used": "gemini",
+        "usage": {},
+        "task_metric": {},
+        "request_id": "r",
+        "saved_to_workspace": True,
+        "artifacts": [],
+        "generated_files": [],
+        "video_url": "u",
+        "raw_response": {},
+        "last_frame_url": "f",
+    }
+
+    assert set(_observation_metadata(payload, _OBSERVATION_EXCLUDED_KEYS)) == {
+        "success",
+        "model_used",
+        "last_frame_url",
+    }
+    assert set(_observation_metadata(payload, _UNBOUNDED_PAYLOAD_KEYS)) == set(
+        payload
+    ) - {"raw_response"}
+
+
 def test_snapshot_generated_artifact_files_skips_files_deleted_before_stat(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Sub-issue of #1289 (A4).

## Problem

`format_tool_result_for_observation` appends a `repr` of the entire sanitized
result dict after the human-readable artifact lines. Those lines already carry
every file's identity — filename, `file_id`, and the Markdown reference — so the
appended dict repeats all of it and adds fields the model cannot act on.

The waste compounds. An observation stays in the conversation history, so every
byte is re-sent on each subsequent LLM call. In the production ad-creative trace
behind #1289 (106 LLM calls, 6.5M input tokens, `cached_tokens: 0` on most
calls), each generated image carried roughly 200 tokens of duplicate metadata
that were then re-billed for the rest of the task.

The video tool is the worse case: its result includes `raw_response`, the
provider's full API payload, which lands in the observation verbatim.

## Change

`OBSERVATION_REDUNDANT_KEYS` drops these top-level keys from the model-facing
observation only:

| Key | Why |
|---|---|
| `artifacts`, `generated_files` | file identity is already in the artifact lines |
| `raw_response` | full provider payload, unbounded size |
| `video_url` | temporary provider URL; the downloaded file is the artifact |
| `usage`, `task_metric`, `request_id`, `saved_to_workspace` | telemetry the model cannot act on |

The tool result itself is untouched — this only narrows what the model sees.

## What is deliberately kept

- **`last_frame_url`** — not telemetry. It is an input to the next
  `generate_video` call (`last_frame_image_url`, `video_tool.py:688`), and the
  last frame is never downloaded, so it has no artifact of its own. Dropping it
  would silently break the opt-in `return_last_frame` continuation workflow.
- **`file_ref` / `file_refs`** — they carry `relative_path`, `download_url`, and
  `preview_url`, which the artifact lines do not.

Filtering is top-level only. No current tool nests these keys, and a full-tree
walk would risk stripping legitimate nested data.

## The failure path is redacted too

Correcting an earlier claim in this description: the no-artifact fallback used to
return `str(result)` — the *unsanitized* dict — so a failed video download leaked
the full `raw_response` and the signed `video_url` verbatim, which is exactly the
case this PR was written for. Both fallback returns now go through the same
sanitizer.

That path sheds only `raw_response`: without artifact lines, the URLs and
filenames are the model's only handle on the result, so `video_url` and
`saved_to_workspace` stay visible for diagnosis.

Path redaction is unaffected: `_collect_known_local_paths` runs over the complete
result before this filter, so removing keys can only shrink the exposed surface,
never remove a path from the replacement table.

`generated_files` is safe to drop — `javascript_executor` also appends the names
to `output`, and every entry has a matching artifact line built in the same loop
(`build_generated_file_metadata`).

## Tests

Two new cases in `tests/core/tools/test_artifacts_observation.py`: a full
`generate_image` result (kept: markdown ref, `model_used`, `relative_path`;
dropped: artifacts/generated files/usage/metric/request id/workspace flag) and a
`generate_video` result asserting the 4 KB `raw_response` and the temporary video
URL never reach the observation while `last_frame_url` still does.

A third case covers the `artifacts: []` download-failure shape, and a fourth
asserts on `_observation_metadata`'s returned keys directly rather than through
substring matching.

Mutation-tested: removing any one of the eight keys from the set turns the suite
red, and so does adding `last_frame_url` back to it, reverting the failure path
to `str(result)`, or swapping either call site's exclusion set for the other.

Full `tests/core/tools` passes. `test_command_path_guard_bash.py` and
`test_command_executor.py` fail on `origin/main` too — unrelated.
