### PR TITLE
ref(steps): extract incremental public step projector

### DIFF
--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -33,6 +33,18 @@ Pure-function design:
     place SDK clients can observe a behavior change is through this
     one function's output -- which makes regressions easy to gate.
 
+Incremental projection:
+
+    The state machine that implements the pairing rules below lives in
+    :class:`PublicStepProjector`, not in this function. The projector
+    holds all the folding state a fold needs -- the pending
+    (start-seen, end-not-yet-seen) table, the ``dag_plan_*`` replan
+    counter -- so a caller can feed it one event at a time and read
+    back the steps that changed. ``map_trace_events_to_public_steps``
+    stays pure by constructing one fresh, throwaway projector per
+    call and reading back its materialized result; it keeps no
+    folding state of its own.
+
 Pairing rule:
 
     Start / end events are paired by a stable ``key``:
@@ -83,12 +95,14 @@ logger = logging.getLogger(__name__)
 class PublicStepProjector:
     """Incremental folding state machine: trace events -> public steps.
 
-    This holds exactly the folding state ``map_trace_events_to_public_steps``
-    used to keep as local variables -- the pending (start-seen,
-    end-not-yet-seen) pairing table and the ``dag_plan_*`` counter/open-key
-    used to disambiguate replan. Pulling it into an instance is what lets a
-    caller feed a live event stream one event at a time (see the module
-    docstring's pairing rules for what "pairing" means per event family).
+    Holds all the folding state a fold needs -- the pending
+    (start-seen, end-not-yet-seen) pairing table and the ``dag_plan_*``
+    counter/open-key used to disambiguate replan. The batch driver
+    (``map_trace_events_to_public_steps``) keeps none of its own: it
+    builds one instance and reads back the result. Holding this state
+    on an instance is what lets a caller feed a live event stream one
+    event at a time (see the module docstring's pairing rules for what
+    "pairing" means per event family).
 
     Two ways to build one:
 

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -433,8 +433,8 @@ def _thinking_pair_key(event: Any, phase: str) -> str:
 
     ``react_action_*`` and ``dag_step_*`` always carry a step_id
     which is the natural pairing key. Planning events are handled
-    inline in :func:`map_trace_events_to_public_steps` because they
-    lack a per-plan identifier and need a synthesized counter.
+    inline in :meth:`PublicStepProjector.feed` because they lack a
+    per-plan identifier and need a synthesized counter.
     """
     return str(_safe_get(event, "step_id") or _safe_get(event, "event_id") or "")
 

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -49,10 +49,11 @@ Pairing rule:
 
     Start / end events are paired by a stable ``key``:
 
-      - ``tool_execution_*`` events pair on ``data['tool_execution_id']``
-        when present, falling back to ``step_id``. The tool execution
-        id is generated per-invocation and is the only safe key when
-        the same tool is called twice in the same step.
+      - ``tool_execution_*`` events pair on ``data['tool_call_id']``
+        (the provider-assigned call id), falling back to ``step_id``.
+        ``tool_execution_id`` is accepted ahead of it for compatibility
+        but has no current producer. A per-invocation id is the only
+        safe key when the same tool is called twice in the same step.
       - ``react_action_*`` events pair on ``step_id``.
       - ``dag_step_*`` events pair on ``step_id``.
       - ``dag_plan_*`` events pair on ``task_id`` (single planning
@@ -285,10 +286,11 @@ class PublicStepProjector:
             is_delegation = is_agent_tool_name(tool_name)
             public_type = "agent_delegation" if is_delegation else "tool_call"
             # Pair on a per-invocation id (unique even when one step
-            # invokes the same tool twice). v1 emits
-            # ``tool_execution_id``; v2 emits ``tool_call_id``. Either
-            # is fine — the fallback chain accepts both. step_id alone
-            # is unsafe because one step may invoke multiple tools.
+            # invokes the same tool twice). The effective key today is
+            # ``tool_call_id``; ``tool_execution_id`` is accepted ahead
+            # of it for compatibility but has no current producer.
+            # step_id alone is unsafe because one step may invoke
+            # multiple tools.
             key = (
                 _data_get(event, "tool_execution_id")
                 or _data_get(event, "tool_call_id")

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -68,6 +68,16 @@ Pairing rule:
     Orphan starts (start with no matching end) are emitted with
     ``status='running'`` and ``completed_at=None``. This naturally
     handles the case where the SDK polls ``/steps`` mid-task.
+
+    Key collision -- two starts sharing one pairing key before either
+    ends -- is last-write-wins: the second start replaces the first
+    pending entry, so only the second reaches a terminal state. Both
+    carry the same public step id (id and pairing key are derived from
+    the same (type, key) pair), so a consumer folding ``feed`` results
+    by id converges on the second step rather than being left with a
+    stranded ``running`` one. ``dag_plan_*`` is the one exception: it
+    has no natural key at all, so a counter gives every plan a
+    distinct one.
 """
 
 from __future__ import annotations
@@ -119,6 +129,13 @@ class PublicStepProjector:
     resort is a batch-only concern (see ``map_trace_events_to_public_steps``):
     a live consumer wants steps in the order they actually resolved, not
     resorted on every event.
+
+    Preconditions for the incremental path: one instance per task, fed
+    in event order, from one thread/task at a time. ``feed`` mutates
+    the pairing tables without any locking, and the ``dag_plan_*`` open
+    key is a single slot, so two interleaved tasks would cross-pair.
+    The batch driver satisfies all three trivially -- it builds a fresh
+    throwaway instance per call.
     """
 
     def __init__(self) -> None:
@@ -164,6 +181,12 @@ class PublicStepProjector:
         Callers that need the public started_at-sorted order (currently
         only the ``map_trace_events_to_public_steps`` batch driver) sort
         this themselves.
+
+        The list itself is a fresh snapshot, but the step dicts inside
+        it are the projector's live objects: a still-``running`` step
+        is mutated in place when its end event arrives (see
+        :meth:`feed`). Treat them as read-only views -- a caller that
+        needs a stable picture must copy before storing.
         """
         steps = list(self._finished)
         steps.extend(self._pending.values())

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -80,6 +80,276 @@ logger = logging.getLogger(__name__)
 # timelines without pattern-matching tool names client-side.
 
 
+class PublicStepProjector:
+    """Incremental folding state machine: trace events -> public steps.
+
+    This holds exactly the folding state ``map_trace_events_to_public_steps``
+    used to keep as local variables -- the pending (start-seen,
+    end-not-yet-seen) pairing table and the ``dag_plan_*`` counter/open-key
+    used to disambiguate replan. Pulling it into an instance is what lets a
+    caller feed a live event stream one event at a time (see the module
+    docstring's pairing rules for what "pairing" means per event family).
+
+    Two ways to build one:
+
+      - ``PublicStepProjector()`` then repeated ``feed(event)`` calls, for
+        a live/incremental consumer.
+      - :meth:`from_history` to replay a full event list in one call and
+        get a projector whose state is exactly where it would be had it
+        been fed those events live -- this is what
+        ``map_trace_events_to_public_steps`` uses, and it's also how a
+        late-attaching consumer pre-warms pairing state instead of seeing
+        orphan ends for steps that started before it attached.
+
+    :meth:`materialized_steps` never sorts by ``started_at``. That global
+    resort is a batch-only concern (see ``map_trace_events_to_public_steps``):
+    a live consumer wants steps in the order they actually resolved, not
+    resorted on every event.
+    """
+
+    def __init__(self) -> None:
+        # In-progress (start seen, end not yet seen) steps keyed by
+        # (public_type, pairing_key). Order of insertion is preserved by
+        # Python 3.7+ dict semantics, which is what we use to emit final
+        # output in the order steps were started.
+        self._pending: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        # Completed-or-emitted-immediately steps. Filled in either by an
+        # end event matching a pending start, or by a one-shot event like
+        # ``user_message`` / ``ai_message`` which has no separate end.
+        self._finished: List[Dict[str, Any]] = []
+        # ``dag_plan_*`` has no per-plan identifier in the event data, so
+        # we synthesize one by counting starts and remembering the
+        # currently-open key. Replan in a single task (rare but legal)
+        # produces N >= 2 pairs; without this counter the second
+        # dag_plan_start would silently overwrite the first's pending
+        # entry. We assume plans don't nest (only one in flight at a
+        # time); nesting would require a stack, which DAG doesn't emit.
+        self._plan_counter = 0
+        self._open_plan_key: Optional[str] = None
+
+    @classmethod
+    def from_history(cls, events: List[Any]) -> "PublicStepProjector":
+        """Build a projector pre-warmed by replaying a full event history.
+
+        Feeds every event into a fresh instance, in order. The resulting
+        pairing state (open plan key/counter, any still-``pending``
+        starts) is identical to what a live consumer would have
+        accumulated by that point -- there is no separate "batch" code
+        path for the folding logic itself, only this replay.
+        """
+        projector = cls()
+        for event in events:
+            projector.feed(event)
+        return projector
+
+    def materialized_steps(self) -> List[Dict[str, Any]]:
+        """Return every step currently known, finished or still running.
+
+        Order: finished steps in the order they resolved, then any
+        still-``pending`` (``running``) steps in the order they started.
+        Callers that need the public started_at-sorted order (currently
+        only the ``map_trace_events_to_public_steps`` batch driver) sort
+        this themselves.
+        """
+        steps = list(self._finished)
+        steps.extend(self._pending.values())
+        return steps
+
+    def feed(self, event: Any) -> List[Dict[str, Any]]:
+        """Fold one trace event, returning the step(s) it changed.
+
+        A start event returns the new ``running`` step; an end event
+        (or failure event) returns the step now in its terminal state;
+        a one-shot event (``user_message`` / ``ai_message``) returns the
+        step it produces. Events that don't affect any public step --
+        unexposed types, orphan ends, non-terminal sub-events of an
+        exposed family -- return ``[]``.
+
+        The returned dict is the same object subsequently held in
+        :meth:`materialized_steps`'s backing storage (mutated in place
+        when a pending start is later finalized), so a caller folding
+        successive ``feed`` results by step id always ends up with the
+        current state of each step.
+        """
+        event_type = _safe_get(event, "event_type")
+        if not event_type:
+            return []
+
+        # ===== messages: one event per message, no pairing =====
+        if event_type == "user_message":
+            step = _build_message_step(event, role="user")
+            self._finished.append(step)
+            return [step]
+        if event_type == "ai_message":
+            step = _build_message_step(event, role="assistant")
+            self._finished.append(step)
+            return [step]
+
+        # ===== thinking: paired start/end =====
+        thinking_phase = _thinking_phase_for(event_type)
+        if thinking_phase == "planning":
+            # Special-cased because plan events have no per-plan id;
+            # we generate one from a counter and remember the open
+            # key so the next dag_plan_end pairs with the latest start.
+            if event_type.endswith("_start"):
+                self._plan_counter += 1
+                task_ref = (
+                    _safe_get(event, "task_id")
+                    or _safe_get(event, "event_id")
+                    or "anon"
+                )
+                self._open_plan_key = f"plan:{task_ref}:{self._plan_counter}"
+                step = _build_thinking_start(
+                    event, phase="planning", key=self._open_plan_key
+                )
+                self._pending[("thinking", self._open_plan_key)] = step
+                return [step]
+            if event_type.endswith("_end") and self._open_plan_key is not None:
+                finalized = _finalize_pending(
+                    self._pending,
+                    self._finished,
+                    ("thinking", self._open_plan_key),
+                    end_event=event,
+                    status="completed",
+                )
+                self._open_plan_key = None
+                return [finalized] if finalized is not None else []
+            # Orphan end with no open plan: drop silently (same policy
+            # as orphan tool_execution_end).
+            return []
+
+        if thinking_phase is not None:
+            # action / step branch -- step_id is the natural pair key.
+            key = _thinking_pair_key(event, thinking_phase)
+            if event_type.endswith("_start"):
+                step = _build_thinking_start(event, phase=thinking_phase, key=key)
+                self._pending[("thinking", key)] = step
+                return [step]
+            if event_type.endswith("_end"):
+                finalized = _finalize_pending(
+                    self._pending,
+                    self._finished,
+                    ("thinking", key),
+                    end_event=event,
+                    status="completed",
+                )
+                return [finalized] if finalized is not None else []
+            # other actions (e.g. dag_execution UPDATE) for these
+            # categories are not exposed.
+            return []
+
+        # ===== tool_call / agent_delegation: paired start/end + failure =====
+        if event_type in (
+            "tool_execution_start",
+            "tool_execution_end",
+            "tool_execution_failed",
+        ):
+            tool_name = _data_get(event, "tool_name")
+            is_delegation = is_agent_tool_name(tool_name)
+            public_type = "agent_delegation" if is_delegation else "tool_call"
+            # Pair on a per-invocation id (unique even when one step
+            # invokes the same tool twice). v1 emits
+            # ``tool_execution_id``; v2 emits ``tool_call_id``. Either
+            # is fine — the fallback chain accepts both. step_id alone
+            # is unsafe because one step may invoke multiple tools.
+            key = (
+                _data_get(event, "tool_execution_id")
+                or _data_get(event, "tool_call_id")
+                or _safe_get(event, "step_id")
+                or _safe_get(event, "event_id")
+            )
+            if not key:
+                return []
+
+            if event_type == "tool_execution_start":
+                step = _build_tool_start(
+                    event,
+                    public_type=public_type,
+                    tool_name=tool_name,
+                    key=str(key),
+                )
+                self._pending[(public_type, str(key))] = step
+                return [step]
+            if event_type == "tool_execution_end":
+                success = _data_get(event, "success", default=True)
+                status = "completed" if success else "failed"
+                # ``tool_call`` and ``agent_delegation`` use different keys
+                # on the public schema: tool_call exposes ``result``
+                # (generic tool return), agent_delegation exposes
+                # ``output`` (mirroring ``input`` on the start side). The
+                # underlying internal field is still ``data['result']`` --
+                # we only rename on the public surface. ``error`` is the
+                # same on both for failures.
+                success_key = (
+                    "output" if public_type == "agent_delegation" else "result"
+                )
+                finalized = _finalize_pending(
+                    self._pending,
+                    self._finished,
+                    (public_type, str(key)),
+                    end_event=event,
+                    status=status,
+                    extra_data_fn=lambda ev, succ=success, k=success_key: (
+                        {k: _data_get(ev, "result")}
+                        if succ
+                        else {
+                            "error": _data_get(ev, "error") or "Tool execution failed"
+                        }
+                    ),
+                )
+                return [finalized] if finalized is not None else []
+            # tool_execution_failed: v2 runtime emits a dedicated failure
+            # event (TraceCategory.TOOL + TraceAction.ERROR) instead of
+            # tool_execution_end with success=False. Without this branch
+            # the pending start was never finalized and the public step
+            # stayed at status='running' indefinitely.
+            finalized = _finalize_pending(
+                self._pending,
+                self._finished,
+                (public_type, str(key)),
+                end_event=event,
+                status="failed",
+                extra_data_fn=lambda ev: {
+                    "error": _data_get(ev, "error")
+                    or _data_get(ev, "error_message")
+                    or "Tool execution failed"
+                },
+            )
+            return [finalized] if finalized is not None else []
+
+        # ===== skill_select_*: surface as tool_call with skill name =====
+        if event_type in ("skill_select_start", "skill_select_end"):
+            key = (
+                _data_get(event, "skill_name")
+                or _safe_get(event, "step_id")
+                or str(_safe_get(event, "task_id") or "skill")
+            )
+            if event_type == "skill_select_start":
+                step = _build_tool_start(
+                    event,
+                    public_type="tool_call",
+                    tool_name=_data_get(event, "skill_name") or "skill_select",
+                    key=str(key),
+                )
+                self._pending[("tool_call", str(key))] = step
+                return [step]
+            finalized = _finalize_pending(
+                self._pending,
+                self._finished,
+                ("tool_call", str(key)),
+                end_event=event,
+                status="completed",
+                extra_data_fn=lambda ev: {"result": _data_get(ev, "result")},
+            )
+            return [finalized] if finalized is not None else []
+
+        # Everything else (llm_call_*, memory_*, dag_execute_*,
+        # react_task_*, react_step_*, visualization_update,
+        # task_completion, trace_error, action_*_compact) -- not
+        # exposed in the SDK contract. Silently drop.
+        return []
+
+
 def map_trace_events_to_public_steps(
     events: List[Any],
 ) -> List[Dict[str, Any]]:
@@ -123,201 +393,11 @@ def map_trace_events_to_public_steps(
           tables in this module) are silently dropped. Adding a new
           public type is a deliberate per-type opt-in.
     """
-    # In-progress (start seen, end not yet seen) steps keyed by
-    # (public_type, pairing_key). Order of insertion is preserved by
-    # Python 3.7+ dict semantics, which is what we use to emit final
-    # output in the order steps were started.
-    pending: Dict[Tuple[str, str], Dict[str, Any]] = {}
-    # Completed-or-emitted-immediately steps. Filled in either by an
-    # end event matching a pending start, or by a one-shot event like
-    # ``user_message`` / ``ai_message`` which has no separate end.
-    finished: List[Dict[str, Any]] = []
-    # ``dag_plan_*`` has no per-plan identifier in the event data, so
-    # we synthesize one by counting starts and remembering the
-    # currently-open key. Replan in a single task (rare but legal)
-    # produces N >= 2 pairs; without this counter the second
-    # dag_plan_start would silently overwrite the first's pending
-    # entry. We assume plans don't nest (only one in flight at a
-    # time); nesting would require a stack, which DAG doesn't emit.
-    plan_counter = 0
-    open_plan_key: Optional[str] = None
-
-    for event in events:
-        event_type = _safe_get(event, "event_type")
-        if not event_type:
-            continue
-
-        # ===== messages: one event per message, no pairing =====
-        if event_type == "user_message":
-            finished.append(_build_message_step(event, role="user"))
-            continue
-        if event_type == "ai_message":
-            finished.append(_build_message_step(event, role="assistant"))
-            continue
-
-        # ===== thinking: paired start/end =====
-        thinking_phase = _thinking_phase_for(event_type)
-        if thinking_phase == "planning":
-            # Special-cased because plan events have no per-plan id;
-            # we generate one from a counter and remember the open
-            # key so the next dag_plan_end pairs with the latest start.
-            if event_type.endswith("_start"):
-                plan_counter += 1
-                task_ref = (
-                    _safe_get(event, "task_id")
-                    or _safe_get(event, "event_id")
-                    or "anon"
-                )
-                open_plan_key = f"plan:{task_ref}:{plan_counter}"
-                pending[("thinking", open_plan_key)] = _build_thinking_start(
-                    event, phase="planning", key=open_plan_key
-                )
-            elif event_type.endswith("_end") and open_plan_key is not None:
-                _finalize_pending(
-                    pending,
-                    finished,
-                    ("thinking", open_plan_key),
-                    end_event=event,
-                    status="completed",
-                )
-                open_plan_key = None
-            # Orphan end with no open plan: drop silently (same policy
-            # as orphan tool_execution_end).
-            continue
-
-        if thinking_phase is not None:
-            # action / step branch -- step_id is the natural pair key.
-            key = _thinking_pair_key(event, thinking_phase)
-            if event_type.endswith("_start"):
-                pending[("thinking", key)] = _build_thinking_start(
-                    event, phase=thinking_phase, key=key
-                )
-            elif event_type.endswith("_end"):
-                _finalize_pending(
-                    pending,
-                    finished,
-                    ("thinking", key),
-                    end_event=event,
-                    status="completed",
-                )
-            # other actions (e.g. dag_execution UPDATE) for these
-            # categories are not exposed.
-            continue
-
-        # ===== tool_call / agent_delegation: paired start/end + failure =====
-        if event_type in (
-            "tool_execution_start",
-            "tool_execution_end",
-            "tool_execution_failed",
-        ):
-            tool_name = _data_get(event, "tool_name")
-            is_delegation = is_agent_tool_name(tool_name)
-            public_type = "agent_delegation" if is_delegation else "tool_call"
-            # Pair on a per-invocation id (unique even when one step
-            # invokes the same tool twice). v1 emits
-            # ``tool_execution_id``; v2 emits ``tool_call_id``. Either
-            # is fine — the fallback chain accepts both. step_id alone
-            # is unsafe because one step may invoke multiple tools.
-            key = (
-                _data_get(event, "tool_execution_id")
-                or _data_get(event, "tool_call_id")
-                or _safe_get(event, "step_id")
-                or _safe_get(event, "event_id")
-            )
-            if not key:
-                continue
-
-            if event_type == "tool_execution_start":
-                pending[(public_type, str(key))] = _build_tool_start(
-                    event,
-                    public_type=public_type,
-                    tool_name=tool_name,
-                    key=str(key),
-                )
-            elif event_type == "tool_execution_end":
-                success = _data_get(event, "success", default=True)
-                status = "completed" if success else "failed"
-                # ``tool_call`` and ``agent_delegation`` use different keys
-                # on the public schema: tool_call exposes ``result``
-                # (generic tool return), agent_delegation exposes
-                # ``output`` (mirroring ``input`` on the start side). The
-                # underlying internal field is still ``data['result']`` --
-                # we only rename on the public surface. ``error`` is the
-                # same on both for failures.
-                success_key = (
-                    "output" if public_type == "agent_delegation" else "result"
-                )
-                _finalize_pending(
-                    pending,
-                    finished,
-                    (public_type, str(key)),
-                    end_event=event,
-                    status=status,
-                    extra_data_fn=lambda ev, succ=success, k=success_key: (
-                        {k: _data_get(ev, "result")}
-                        if succ
-                        else {
-                            "error": _data_get(ev, "error") or "Tool execution failed"
-                        }
-                    ),
-                )
-            else:  # tool_execution_failed
-                # v2 runtime emits a dedicated failure event
-                # (TraceCategory.TOOL + TraceAction.ERROR) instead of
-                # tool_execution_end with success=False. Without this
-                # branch the pending start was never finalized and the
-                # public step stayed at status='running' indefinitely.
-                _finalize_pending(
-                    pending,
-                    finished,
-                    (public_type, str(key)),
-                    end_event=event,
-                    status="failed",
-                    extra_data_fn=lambda ev: {
-                        "error": _data_get(ev, "error")
-                        or _data_get(ev, "error_message")
-                        or "Tool execution failed"
-                    },
-                )
-            continue
-
-        # ===== skill_select_*: surface as tool_call with skill name =====
-        if event_type in ("skill_select_start", "skill_select_end"):
-            key = (
-                _data_get(event, "skill_name")
-                or _safe_get(event, "step_id")
-                or str(_safe_get(event, "task_id") or "skill")
-            )
-            if event_type == "skill_select_start":
-                pending[("tool_call", str(key))] = _build_tool_start(
-                    event,
-                    public_type="tool_call",
-                    tool_name=_data_get(event, "skill_name") or "skill_select",
-                    key=str(key),
-                )
-            else:
-                _finalize_pending(
-                    pending,
-                    finished,
-                    ("tool_call", str(key)),
-                    end_event=event,
-                    status="completed",
-                    extra_data_fn=lambda ev: {"result": _data_get(ev, "result")},
-                )
-            continue
-
-        # Everything else (llm_call_*, memory_*, dag_execute_*,
-        # react_task_*, react_step_*, visualization_update,
-        # task_completion, trace_error, action_*_compact) -- not
-        # exposed in the SDK contract. Silently drop.
-
-    # Emit pending starts as ``running`` steps. The insertion order in
-    # ``pending`` plus the iteration order of ``finished`` gives us a
-    # stable public ordering: ``finished`` are sorted by completion
-    # (which is the order they fired), and any still-running steps
-    # come after in started-at order.
-    output = list(finished)
-    output.extend(pending.values())
+    # The folding state machine itself lives in ``PublicStepProjector``;
+    # this is a thin batch driver that replays the full event list
+    # through a fresh instance and applies the one sort step that is a
+    # batch-only concern (see ``PublicStepProjector.materialized_steps``).
+    output = PublicStepProjector.from_history(events).materialized_steps()
     # Final sort by ``started_at`` so output is monotonic regardless of
     # whether a step finishes before the next one starts. Stable sort
     # preserves insertion order for ties.
@@ -476,16 +556,19 @@ def _finalize_pending(
     end_event: Any,
     status: str,
     extra_data_fn: Optional[Any] = None,
-) -> None:
+) -> Optional[Dict[str, Any]]:
     """Move ``pending[key]`` to ``finished`` and patch with end metadata.
 
     Orphan end (no matching start in ``pending``) is dropped on
-    purpose -- see module docstring.
+    purpose -- see module docstring. Returns the finalized step dict
+    (the same object moved into ``finished``), or ``None`` for a
+    dropped orphan end, so callers that need to report "what changed"
+    (:meth:`PublicStepProjector.feed`) don't have to re-derive it.
     """
     step = pending.pop(key, None)
     if step is None:
         # Orphan end event; skip.
-        return
+        return None
     step["status"] = status
     step["completed_at"] = _ts(end_event)
     if extra_data_fn is not None:
@@ -495,6 +578,7 @@ def _finalize_pending(
         except Exception as exc:  # defensive; data shape is external
             logger.debug("step extra_data_fn failed: %s", exc)
     finished.append(step)
+    return step
 
 
 # ===== attribute / data accessors =====

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -9,6 +9,7 @@ dict)`` works too -- but the attribute form is closer to production
 behavior.
 """
 
+import copy
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
@@ -678,16 +679,17 @@ def test_float_timestamp_is_coerced_to_datetime():
     assert steps[0]["completed_at"] - steps[0]["started_at"] == timedelta(seconds=1)
 
 
-# ===== PR-B0: PublicStepProjector <-> batch driver equivalence pin =====
+# ===== PublicStepProjector <-> batch driver equivalence pin =====
 #
-# ``map_trace_events_to_public_steps`` is being rewritten to be a thin
-# batch driver over ``PublicStepProjector`` (from_history + materialized
-# steps + the existing started_at sort). These cases cover every pairing
-# family the module docstring documents (thinking/planning incl. replan,
-# tool_call, agent_delegation, skill_select, message, orphan start/end,
-# unexposed-type filtering, out-of-order timestamps) so the equivalence
-# assertion below is a byte-for-byte pin on the refactor, not just a
-# smoke test.
+# ``map_trace_events_to_public_steps`` is a thin batch driver over
+# ``PublicStepProjector`` (from_history + materialized_steps + the
+# started_at sort): it holds no folding logic of its own. These cases
+# cover every pairing family the module docstring documents
+# (thinking/planning incl. replan, tool_call, agent_delegation,
+# skill_select, message, orphan start/end, unexposed-type filtering,
+# out-of-order timestamps) so the equivalence assertion below pins
+# that invariant -- the batch driver can never grow a second copy of
+# the folding logic without this test catching the divergence.
 
 _PROJECTOR_EQUIVALENCE_CASES: Dict[str, List[SimpleNamespace]] = {
     "react_action_pair": [
@@ -969,11 +971,11 @@ _PROJECTOR_EQUIVALENCE_CASES: Dict[str, List[SimpleNamespace]] = {
 )
 def test_projector_equivalent_to_batch(events):
     """``PublicStepProjector.from_history(events).materialized_steps()``,
-    sorted by the same ``started_at`` key the batch driver applies at
-    ``_step_mapping.py:324``, must equal ``map_trace_events_to_public_steps``
-    exactly. This is the byte-for-byte equivalence pin for the PR-B0
-    extraction: the batch function must remain a pure driver over the
-    projector, never a second copy of the folding logic.
+    sorted by the same ``started_at`` key the batch driver's trailing
+    sort applies, must equal ``map_trace_events_to_public_steps``
+    exactly. This is the byte-for-byte pin that the batch function
+    stays a pure driver over the projector, never a second copy of
+    the folding logic.
     """
     expected = map_trace_events_to_public_steps(events)
     projected = PublicStepProjector.from_history(events).materialized_steps()
@@ -1002,3 +1004,58 @@ def test_projector_incremental_feed_matches_materialized_steps(events):
     reconstructed = sorted(by_id.values(), key=lambda s: s["id"])
     materialized = sorted(projector.materialized_steps(), key=lambda s: s["id"])
     assert reconstructed == materialized
+
+
+def test_feed_return_value_reflects_step_state_at_call_time():
+    """``feed()``'s return is the same dict object later mutated in place
+    when the matching end event finalizes the step -- so a caller that
+    wants to know what a step looked like *at the moment of a given
+    feed() call* must deep-copy the return value immediately, which is
+    exactly what this test does. Without the ``copy.deepcopy`` calls
+    below, ``start_steps[0]`` would silently become the finalized
+    ``completed`` step by the time the last assertion runs, and this
+    test could only ever observe the terminal state.
+    """
+    projector = PublicStepProjector()
+
+    start_steps = copy.deepcopy(
+        projector.feed(
+            _ev(
+                "react_action_start",
+                step_id="s1",
+                timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            )
+        )
+    )
+    assert len(start_steps) == 1
+    assert start_steps[0]["status"] == "running"
+    assert start_steps[0]["completed_at"] is None
+
+    end_steps = copy.deepcopy(
+        projector.feed(
+            _ev(
+                "react_action_end",
+                step_id="s1",
+                timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+            )
+        )
+    )
+    assert len(end_steps) == 1
+    assert end_steps[0]["status"] == "completed"
+    assert end_steps[0]["completed_at"] is not None
+
+    # Proof the deep copy above actually decoupled the snapshot: the
+    # start-time copy must still read "running" now that the live
+    # object backing the un-copied return value has been mutated to
+    # "completed" by the end event.
+    assert start_steps[0]["status"] == "running"
+    assert start_steps[0]["completed_at"] is None
+
+    # Orphan end (no matching start): dropped silently, nothing to feed back.
+    assert PublicStepProjector().feed(_ev("react_action_end", step_id="orphan")) == []
+
+    # Unexposed event type: not part of the public step contract.
+    assert PublicStepProjector().feed(_ev("llm_call_start", step_id="s1")) == []
+
+    # Empty/falsy event_type: nothing identifiable to fold.
+    assert PublicStepProjector().feed(_ev("", step_id="s1")) == []

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -878,6 +878,25 @@ _PROJECTOR_EQUIVALENCE_CASES: Dict[str, List[SimpleNamespace]] = {
             timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
         ),
     ],
+    "tool_start_key_collision": [
+        _ev(
+            "tool_execution_start",
+            step_id="collide",
+            data={"tool_name": "tool_x", "tool_args": {"a": 1}},
+        ),
+        _ev(
+            "tool_execution_start",
+            step_id="collide",
+            data={"tool_name": "tool_y", "tool_args": {"b": 2}},
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "tool_execution_end",
+            step_id="collide",
+            data={"tool_name": "tool_y", "result": "result_y", "success": True},
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+    ],
     "skill_select_pair": [
         _ev(
             "skill_select_start",
@@ -976,6 +995,11 @@ def test_projector_equivalent_to_batch(events):
     exactly. This is the byte-for-byte pin that the batch function
     stays a pure driver over the projector, never a second copy of
     the folding logic.
+
+    Literal output shapes per event family are already pinned by this
+    file's 23 direct-call tests above, which now exercise the
+    projector itself. What this test guards instead is that the batch
+    driver never grows a second, independent folding implementation.
     """
     expected = map_trace_events_to_public_steps(events)
     projected = PublicStepProjector.from_history(events).materialized_steps()

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -13,7 +13,12 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
-from xagent.web.api.v1._step_mapping import map_trace_events_to_public_steps
+import pytest
+
+from xagent.web.api.v1._step_mapping import (
+    PublicStepProjector,
+    map_trace_events_to_public_steps,
+)
 
 
 def _ev(
@@ -671,3 +676,329 @@ def test_float_timestamp_is_coerced_to_datetime():
     assert isinstance(steps[0]["started_at"], datetime)
     assert isinstance(steps[0]["completed_at"], datetime)
     assert steps[0]["completed_at"] - steps[0]["started_at"] == timedelta(seconds=1)
+
+
+# ===== PR-B0: PublicStepProjector <-> batch driver equivalence pin =====
+#
+# ``map_trace_events_to_public_steps`` is being rewritten to be a thin
+# batch driver over ``PublicStepProjector`` (from_history + materialized
+# steps + the existing started_at sort). These cases cover every pairing
+# family the module docstring documents (thinking/planning incl. replan,
+# tool_call, agent_delegation, skill_select, message, orphan start/end,
+# unexposed-type filtering, out-of-order timestamps) so the equivalence
+# assertion below is a byte-for-byte pin on the refactor, not just a
+# smoke test.
+
+_PROJECTOR_EQUIVALENCE_CASES: Dict[str, List[SimpleNamespace]] = {
+    "react_action_pair": [
+        _ev("react_action_start", step_id="s1"),
+        _ev(
+            "react_action_end",
+            step_id="s1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ],
+    "dag_step_pair": [
+        _ev("dag_step_start", step_id="s2"),
+        _ev(
+            "dag_step_end",
+            step_id="s2",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ],
+    "dag_plan_pair": [
+        _ev("dag_plan_start", task_id="t1"),
+        _ev(
+            "dag_plan_end",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+    ],
+    "replan_two_plan_pairs": [
+        _ev(
+            "dag_plan_start",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "dag_plan_end",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "dag_plan_start",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "dag_plan_end",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+        ),
+    ],
+    "dag_plan_orphan_end_no_open_plan": [
+        _ev("dag_plan_end", task_id="t1"),
+    ],
+    "tool_call_success": [
+        _ev(
+            "tool_execution_start",
+            step_id="s3",
+            data={
+                "tool_name": "execute_python",
+                "tool_args": {"code": "print(1)"},
+                "tool_execution_id": "tx-1",
+            },
+        ),
+        _ev(
+            "tool_execution_end",
+            step_id="s3",
+            data={
+                "tool_name": "execute_python",
+                "tool_args": {"code": "print(1)"},
+                "tool_execution_id": "tx-1",
+                "result": {"output": "1\n"},
+                "success": True,
+            },
+            timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+        ),
+    ],
+    "tool_call_failure": [
+        _ev(
+            "tool_execution_start",
+            step_id="s5",
+            data={
+                "tool_name": "broken_tool",
+                "tool_args": {},
+                "tool_execution_id": "tx-3",
+            },
+        ),
+        _ev(
+            "tool_execution_end",
+            step_id="s5",
+            data={
+                "tool_name": "broken_tool",
+                "tool_args": {},
+                "tool_execution_id": "tx-3",
+                "success": False,
+                "error": "exploded",
+            },
+            timestamp=datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc),
+        ),
+    ],
+    "tool_execution_failed_event": [
+        _ev(
+            "tool_execution_start",
+            step_id="s_fail",
+            data={
+                "tool_name": "execute_python",
+                "tool_params": {"code": "1 / 0"},
+                "tool_call_id": "call-fail",
+            },
+        ),
+        _ev(
+            "tool_execution_failed",
+            step_id="s_fail",
+            data={
+                "tool_name": "execute_python",
+                "tool_call_id": "call-fail",
+                "error": "division by zero",
+            },
+            timestamp=datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc),
+        ),
+    ],
+    "agent_delegation": [
+        _ev(
+            "tool_execution_start",
+            step_id="s4",
+            data={
+                "tool_name": "agent_42",
+                "tool_args": {"text": "hello"},
+                "tool_execution_id": "tx-2",
+            },
+        ),
+        _ev(
+            "tool_execution_end",
+            step_id="s4",
+            data={
+                "tool_name": "agent_42",
+                "tool_args": {"text": "hello"},
+                "tool_execution_id": "tx-2",
+                "result": {"translated": "你好"},
+                "success": True,
+            },
+            timestamp=datetime(2026, 1, 1, 12, 0, 4, tzinfo=timezone.utc),
+        ),
+    ],
+    "two_tool_calls_same_step_id": [
+        _ev(
+            "tool_execution_start",
+            step_id="shared_step",
+            event_id="evt-1",
+            data={
+                "tool_name": "tool_a",
+                "tool_params": {"q": "a"},
+                "tool_call_id": "call-a",
+            },
+        ),
+        _ev(
+            "tool_execution_start",
+            step_id="shared_step",
+            event_id="evt-2",
+            data={
+                "tool_name": "tool_b",
+                "tool_params": {"q": "b"},
+                "tool_call_id": "call-b",
+            },
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "tool_execution_end",
+            step_id="shared_step",
+            event_id="evt-3",
+            data={
+                "tool_name": "tool_a",
+                "tool_call_id": "call-a",
+                "result": "result_a",
+                "success": True,
+            },
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "tool_execution_end",
+            step_id="shared_step",
+            event_id="evt-4",
+            data={
+                "tool_name": "tool_b",
+                "tool_call_id": "call-b",
+                "result": "result_b",
+                "success": True,
+            },
+            timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+        ),
+    ],
+    "skill_select_pair": [
+        _ev(
+            "skill_select_start",
+            data={"skill_name": "presentation"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "skill_select_end",
+            data={"skill_name": "presentation", "result": "ok"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ],
+    "user_and_ai_messages": [
+        _ev(
+            "user_message",
+            data={"message": "hello"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "ai_message",
+            data={"content": "hi back"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ],
+    "start_without_end_is_running": [
+        _ev("react_action_start", step_id="s1"),
+    ],
+    "orphan_end_is_dropped": [
+        _ev("react_action_end", step_id="s1"),
+    ],
+    "out_of_order_timestamps": [
+        _ev(
+            "react_action_start",
+            step_id="late",
+            timestamp=datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "react_action_end",
+            step_id="late",
+            timestamp=datetime(2026, 1, 1, 12, 0, 6, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "react_action_start",
+            step_id="early",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "react_action_end",
+            step_id="early",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+    ],
+    "pending_after_completed": [
+        _ev(
+            "react_action_start",
+            step_id="done",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "react_action_end",
+            step_id="done",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "react_action_start",
+            step_id="running",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+    ],
+    "unexposed_event_types_are_dropped": [
+        _ev("llm_call_start", step_id="s1"),
+        _ev("llm_call_end", step_id="s1"),
+        _ev("dag_execute_start"),
+        _ev("dag_execute_end"),
+        _ev("react_task_start"),
+        _ev("react_task_end"),
+        _ev("react_step_start", step_id="s1"),
+        _ev("react_step_end", step_id="s1"),
+        _ev("visualization_update"),
+        _ev("task_completion"),
+        _ev("trace_error"),
+    ],
+    "empty_event_list": [],
+}
+
+
+@pytest.mark.parametrize(
+    "events",
+    _PROJECTOR_EQUIVALENCE_CASES.values(),
+    ids=list(_PROJECTOR_EQUIVALENCE_CASES.keys()),
+)
+def test_projector_equivalent_to_batch(events):
+    """``PublicStepProjector.from_history(events).materialized_steps()``,
+    sorted by the same ``started_at`` key the batch driver applies at
+    ``_step_mapping.py:324``, must equal ``map_trace_events_to_public_steps``
+    exactly. This is the byte-for-byte equivalence pin for the PR-B0
+    extraction: the batch function must remain a pure driver over the
+    projector, never a second copy of the folding logic.
+    """
+    expected = map_trace_events_to_public_steps(events)
+    projected = PublicStepProjector.from_history(events).materialized_steps()
+    projected.sort(key=lambda s: s["started_at"])
+    assert projected == expected
+
+
+@pytest.mark.parametrize(
+    "events",
+    _PROJECTOR_EQUIVALENCE_CASES.values(),
+    ids=list(_PROJECTOR_EQUIVALENCE_CASES.keys()),
+)
+def test_projector_incremental_feed_matches_materialized_steps(events):
+    """Folding the per-event increments ``feed()`` returns (keyed by
+    step id, last write wins) must reconstruct exactly the same step
+    objects ``materialized_steps()`` holds afterwards -- pins that the
+    incremental ``feed()`` view and the projector's own materialized
+    state can never drift apart.
+    """
+    projector = PublicStepProjector()
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for event in events:
+        for step in projector.feed(event):
+            by_id[step["id"]] = step
+
+    reconstructed = sorted(by_id.values(), key=lambda s: s["id"])
+    materialized = sorted(projector.materialized_steps(), key=lambda s: s["id"])
+    assert reconstructed == materialized


### PR DESCRIPTION
## What

Extracts the trace-to-public-step folding logic out of `map_trace_events_to_public_steps` into an incremental `PublicStepProjector` (`feed` / `materialized_steps` / `from_history`). The batch function is now a thin driver: build one throwaway projector over the event history, read the materialized steps, and apply the final `started_at` ordering pass.

Behavior is byte-identical: every pre-existing test assertion passes unchanged.

## Why

The folding logic and the public step allow-list previously lived only inside the batch function, so nothing else could fold events one at a time without duplicating them. The projector is now the single owner of all folding state (pairing tables, plan counter); the batch endpoint keeps none.

## Verification

- All pre-existing assertions unchanged and green.
- Equivalence pins across 18 parameterized event sequences: batch output equals `from_history(...).materialized_steps()` plus the batch-only ordering pass; incremental `feed` results rebuild the same materialized state.
- `feed` return contract pinned with deep-copied snapshots: `running` at start-event time, `completed` (with `completed_at`) at end-event time; orphan ends, unlisted event types, and empty event types yield no steps.
