### PR TITLE
feat(interactions): retire the active interaction row on legacy resume injection

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -341,6 +341,9 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/migrations/test_20260813_trace_json_columns_to_jsonb.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
       - name: Test legacy resume interaction close rowcount grid (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -35,6 +35,7 @@ on:
       - 'src/xagent/web/services/ops_signals.py'
       - 'src/xagent/core/tools/adapters/vibe/ask_user_tool.py'
       - 'src/xagent/web/models/database.py'
+      - 'src/xagent/web/services/task_interaction_close.py'
       - 'tests/web/services/test_supersede_savepoint_postgresql.py'
       - 'tests/web/services/test_task_interaction_close_postgresql.py'
   pull_request:
@@ -103,6 +104,7 @@ jobs:
             src/xagent/web/services/ops_signals.py
             src/xagent/core/tools/adapters/vibe/ask_user_tool.py
             src/xagent/web/models/database.py
+            src/xagent/web/services/task_interaction_close.py
             tests/web/services/test_supersede_savepoint_postgresql.py
             tests/web/services/test_task_interaction_close_postgresql.py
           )

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -36,6 +36,7 @@ on:
       - 'src/xagent/core/tools/adapters/vibe/ask_user_tool.py'
       - 'src/xagent/web/models/database.py'
       - 'tests/web/services/test_supersede_savepoint_postgresql.py'
+      - 'tests/web/services/test_task_interaction_close_postgresql.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -103,6 +104,7 @@ jobs:
             src/xagent/core/tools/adapters/vibe/ask_user_tool.py
             src/xagent/web/models/database.py
             tests/web/services/test_supersede_savepoint_postgresql.py
+            tests/web/services/test_task_interaction_close_postgresql.py
           )
 
           case "$EVENT_NAME" in
@@ -337,6 +339,10 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/migrations/test_20260813_trace_json_columns_to_jsonb.py -m postgresql -q
+      - name: Test legacy resume interaction close rowcount grid (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/services/test_task_interaction_close_postgresql.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -61,6 +61,8 @@ from ..services.task_execution_controller import (
     TaskControlState,
     task_execution_controller,
 )
+from ..services.task_interaction_close import close_legacy_resume_interaction
+from ..services.task_interaction_schema import interaction_requests_table_exists
 from ..services.task_lease_service import (
     TaskLease,
     TaskLeaseHeartbeatOutcome,
@@ -311,6 +313,30 @@ def _update_a2a_resume_input_sync(
         if updated != 1:
             db.rollback()
             return False
+        # This update() call is the fence above, not a new transaction: a
+        # rollback here would undo it together with the input write, which
+        # is the point -- ownership and the interaction close are one
+        # atomic fact. No run_db_io_cancellation_safe wrap: the caller
+        # already wraps this whole function in one. No lock read either --
+        # the fence UPDATE above writes only non-key columns (input,
+        # output, error_message) and is already the first statement this
+        # transaction directs at tasks or task_interaction_requests, so it
+        # satisfies the same ordering and strength obligation a dedicated
+        # lock read would. If a future change adds a key column (or any
+        # column covered by a unique index) to that UPDATE's values, this
+        # judgment call must be redone -- the lock strength that UPDATE
+        # takes would change.
+        #
+        # The table-presence gate sits here, immediately before the close
+        # call and after the fence UPDATE, not at the top of the function:
+        # the gate only inspects the catalog and takes no row lock, so it
+        # does not count as preceding the fence UPDATE in the sense the
+        # ordering obligation above means.
+        assert task_lease.run_id is not None
+        if interaction_requests_table_exists(db):
+            close_legacy_resume_interaction(
+                db, task_id=task_lease.task_id, run_id=task_lease.run_id
+            )
         db.commit()
         return True
 

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -308,6 +308,17 @@ async def _restore_a2a_resume_prelease_isolated(
     )
 
 
+# The exact non-key column set the resume-input fence UPDATE below writes.
+# Shared with test_interaction_close_lock_ordering.py's static guard, which
+# asserts the UPDATE's values keys equal this set exactly: the fence's
+# no-lock-read argument (see the inline comment inside
+# _update_a2a_resume_input_sync) depends on every one of these columns being
+# a non-key column, so a future change widening the UPDATE's values must
+# widen this constant too, deliberately, not just add a key to a dict
+# literal the guard never looks at again.
+RESUME_INPUT_FENCE_UPDATE_COLUMNS = frozenset({"input", "output", "error_message"})
+
+
 def _update_a2a_resume_input_sync(
     task_lease: TaskLease,
     text: str,

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -61,7 +61,10 @@ from ..services.task_execution_controller import (
     TaskControlState,
     task_execution_controller,
 )
-from ..services.task_interaction_close import close_legacy_resume_interaction
+from ..services.task_interaction_close import (
+    clear_interaction_marker_if_unpaired,
+    close_legacy_resume_interaction,
+)
 from ..services.task_interaction_schema import interaction_requests_table_exists
 from ..services.task_lease_service import (
     TaskLease,
@@ -256,6 +259,14 @@ def _restore_a2a_resume_prelease_sync(
     retry with the same A2A message id is idempotent at the runner boundary.
     If ownership changed, no row is mutated and the current owner remains the
     sole lifecycle authority.
+
+    Two callers reach this today: the isolated wrapper right below, used by
+    the no-checkpoint and checkpoint-read-error fallbacks; and the cancel
+    settlement callback ``acquire_task_lease_cancellation_safe`` passes to
+    ``_resume_input_required_a2a_task``'s lease acquisition, which fires on
+    a cancellation with no ``posted`` outcome to consult at all -- the
+    marker clear below has to hold on that path too, not only on the two
+    ``posted``-gated fallbacks.
     """
 
     SessionLocal = get_session_local()
@@ -266,6 +277,18 @@ def _restore_a2a_resume_prelease_sync(
             status=status,
         )
         if restored:
+            # Mirror of the WebSocket lease restore: this is an abandoned
+            # resume, not a completed one, so only the marker may need
+            # reconciling -- see clear_interaction_marker_if_unpaired's
+            # docstring for the NOT EXISTS semantics. No lock read precedes
+            # this statement; release_task_lease_no_commit's own tasks
+            # UPDATE writes only non-key columns and is already the first
+            # statement this transaction directs at tasks or
+            # task_interaction_requests.
+            assert task_lease.run_id is not None
+            clear_interaction_marker_if_unpaired(
+                db, task_id=task_lease.task_id, run_id=task_lease.run_id
+            )
             db.commit()
         else:
             db.rollback()

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -59,6 +59,11 @@ from ...services.db_runtime import (
     run_db_io_cancellation_safe,
 )
 from ...services.task_execution_controller import TaskControlState
+from ...services.task_interaction_close import (
+    clear_interaction_marker_if_unpaired,
+    close_legacy_resume_interaction,
+)
+from ...services.task_interaction_schema import interaction_requests_table_exists
 from ...services.task_lease_service import (
     TaskLease,
     TaskLeaseHeartbeatOutcome,
@@ -266,6 +271,15 @@ def _restore_reply_prelease_sync(task_lease: TaskLease) -> bool:
     a client retry after a lost response is idempotent at the runner
     boundary. If ownership changed, no row is mutated and the current
     owner remains the sole lifecycle authority.
+
+    Mirrors the A2A prelease restore (``a2a._restore_a2a_resume_prelease_sync``):
+    a successful restore is an abandoned resume, not a completed one, so it
+    also reconciles the interaction marker via
+    ``clear_interaction_marker_if_unpaired`` -- see that function's docstring
+    for the NOT EXISTS semantics. No lock read precedes this call:
+    ``release_task_lease_no_commit``'s own tasks UPDATE writes only
+    non-key columns and is already the first statement this transaction
+    directs at tasks or task_interaction_requests.
     """
     SessionLocal = get_session_local()
     with SessionLocal() as db:
@@ -275,6 +289,10 @@ def _restore_reply_prelease_sync(task_lease: TaskLease) -> bool:
             status=TaskStatus.WAITING_FOR_USER,
         )
         if restored:
+            assert task_lease.run_id is not None
+            clear_interaction_marker_if_unpaired(
+                db, task_id=task_lease.task_id, run_id=task_lease.run_id
+            )
             db.commit()
         else:
             db.rollback()
@@ -285,6 +303,14 @@ async def _restore_reply_prelease_isolated(task_lease: TaskLease) -> bool:
     return await run_db_io_cancellation_safe(
         lambda: _restore_reply_prelease_sync(task_lease)
     )
+
+
+# The exact non-key column set the resume-input fence UPDATE below writes.
+# Shared with test_interaction_close_lock_ordering.py's static guard, which
+# asserts the UPDATE's values keys equal this set exactly -- see
+# a2a.RESUME_INPUT_FENCE_UPDATE_COLUMNS for the fence's no-lock-read
+# argument this set backs.
+RESUME_INPUT_FENCE_UPDATE_COLUMNS = frozenset({"input", "output", "error_message"})
 
 
 def _update_reply_input_sync(task_lease: TaskLease, text: str) -> bool:
@@ -311,6 +337,25 @@ def _update_reply_input_sync(task_lease: TaskLease, text: str) -> bool:
         if updated != 1:
             db.rollback()
             return False
+        # Mirrors a2a._update_a2a_resume_input_sync's fence-ordering argument:
+        # this update() call is the fence, not a new transaction, so a
+        # rollback here would undo it together with the input write -- the
+        # point is that ownership and the interaction close are one atomic
+        # fact. No lock read either -- the fence UPDATE above writes only
+        # non-key columns (input, output, error_message) and is already the
+        # first statement this transaction directs at tasks or
+        # task_interaction_requests, so it satisfies the same ordering and
+        # strength obligation a dedicated lock read would. The table-presence
+        # gate sits here, immediately before the close call and after the
+        # fence UPDATE, for the same reason as the A2A site: the gate only
+        # inspects the catalog and takes no row lock, so it does not count
+        # as preceding the fence UPDATE in the sense the ordering obligation
+        # means.
+        assert task_lease.run_id is not None
+        if interaction_requests_table_exists(db):
+            close_legacy_resume_interaction(
+                db, task_id=task_lease.task_id, run_id=task_lease.run_id
+            )
         db.commit()
         return True
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -150,7 +150,10 @@ from ..services.task_execution_controller import (
     task_control_snapshot,
     task_execution_controller,
 )
-from ..services.task_interaction_close import close_legacy_resume_interaction_sync
+from ..services.task_interaction_close import (
+    clear_interaction_marker_if_unpaired,
+    close_legacy_resume_interaction_sync,
+)
 from ..services.task_lease_service import (
     TaskLease,
     TaskLeaseHeartbeatOutcome,
@@ -2830,11 +2833,29 @@ def _restore_resumed_task_lease_to_prior_status(
     affects zero rows instead of double-releasing. The commit below is
     unconditional, unlike the A2A prelease restore: when the fence excludes
     every row, the UPDATE affects zero rows and this commits that no-op
-    rather than rolling back.
+    rather than rolling back. That unconditional commit is unrelated to the
+    protocol-marker clear below, which is conditioned on ``restored``: a
+    fence miss means this call lost the race for the row and must not touch
+    a marker some other winner now owns.
     """
     SessionLocal = get_session_local()
     with SessionLocal() as db:
         restored = release_task_lease_no_commit(db, lease, status=status)
+        if restored:
+            # This is a resume abandonment, not a completion: no injection
+            # ran, so there is no interaction row to close here, only a
+            # marker to reconcile if it no longer names an active row. See
+            # clear_interaction_marker_if_unpaired's docstring for the
+            # NOT EXISTS semantics. No lock read precedes this statement --
+            # release_task_lease_no_commit's own tasks UPDATE writes only
+            # non-key columns and is already the first statement this
+            # transaction directs at tasks or task_interaction_requests, so
+            # it already satisfies the ordering and strength obligation a
+            # dedicated lock read would.
+            assert lease.run_id is not None
+            clear_interaction_marker_if_unpaired(
+                db, task_id=lease.task_id, run_id=lease.run_id
+            )
         db.commit()
         return restored
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -6054,11 +6054,16 @@ async def _handle_chat_message_unserialized(
                                 turn_id,
                                 exc_info=True,
                             )
-                        # This call posted the durable message directly into a
-                        # live checkpoint instead of going through the native
-                        # interaction protocol's answer path, so any question
-                        # this run had open under that protocol is answered by
-                        # other means now. Retire it and clear the task's
+                        # `posted` is true, meaning a message with this
+                        # turn id is in a live checkpoint -- written by this
+                        # call, or already present from an earlier attempt
+                        # with the same turn id, which short-circuits without
+                        # persisting anything new (see
+                        # AgentRunner.inject_user_message) -- instead of
+                        # going through the native interaction
+                        # protocol's answer path, so any question this run
+                        # had open under that protocol is answered by other
+                        # means now. Retire it and clear the task's
                         # marker in the same short transaction. The run fence
                         # is live_task_lease.run_id, not task_run_id: posted
                         # being true only happens by way of the

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -150,6 +150,7 @@ from ..services.task_execution_controller import (
     task_control_snapshot,
     task_execution_controller,
 )
+from ..services.task_interaction_close import close_legacy_resume_interaction_sync
 from ..services.task_lease_service import (
     TaskLease,
     TaskLeaseHeartbeatOutcome,
@@ -3248,6 +3249,44 @@ async def execute_resume_background(
                     "checkpoint became available."
                 )
             delivery_was_dispatched = True
+            # Unconditional and not nested inside the delivery_turn_id branch
+            # below: retiring this run's active interaction row and clearing
+            # the task's protocol marker has nothing to do with whether a
+            # delivery-ack turn id is present. Borrowing that condition would
+            # give the close a gate it has no reason to have. Bound to a
+            # plain local first, not read from lease inside the lambda below:
+            # a narrowing assert on an enclosing-scope variable does not
+            # apply inside a nested closure.
+            assert lease.run_id is not None
+            close_run_id = lease.run_id
+            try:
+                await run_db_io_cancellation_safe(
+                    lambda: close_legacy_resume_interaction_sync(
+                        task_id,
+                        close_run_id,
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "legacy resume interaction close failed after deferred "
+                    "message seal for task %s run %s",
+                    task_id,
+                    close_run_id,
+                    exc_info=True,
+                )
+            except asyncio.CancelledError:
+                # See run_db_io_cancellation_safe's docstring: it drains its
+                # worker to completion before propagating a cancellation
+                # raised while awaiting it, so the close-and-clear
+                # transaction has already committed or failed by the time
+                # this branch runs. Only the log statement was interrupted.
+                logger.warning(
+                    "legacy resume interaction close was cancelled after "
+                    "deferred message seal for task %s run %s; continuing "
+                    "resume",
+                    task_id,
+                    close_run_id,
+                )
             if delivery_turn_id is not None:
                 try:
                     await run_db_io_cancellation_safe(
@@ -5993,6 +6032,56 @@ async def _handle_chat_message_unserialized(
                                 task_id,
                                 turn_id,
                                 exc_info=True,
+                            )
+                        # This call posted the durable message directly into a
+                        # live checkpoint instead of going through the native
+                        # interaction protocol's answer path, so any question
+                        # this run had open under that protocol is answered by
+                        # other means now. Retire it and clear the task's
+                        # marker in the same short transaction. The run fence
+                        # is live_task_lease.run_id, not task_run_id: posted
+                        # being true only happens by way of the
+                        # live_task_lease is not None branch above, which is
+                        # what makes this attribute access safe. Bound to a
+                        # plain local first, not read from live_task_lease
+                        # inside the lambda below: a narrowing assert on an
+                        # enclosing-scope variable does not apply inside a
+                        # nested closure.
+                        assert live_task_lease is not None
+                        assert live_task_lease.run_id is not None
+                        close_run_id = live_task_lease.run_id
+                        try:
+                            await run_db_io_cancellation_safe(
+                                lambda: close_legacy_resume_interaction_sync(
+                                    task_id,
+                                    close_run_id,
+                                )
+                            )
+                        except Exception:
+                            logger.warning(
+                                "legacy resume interaction close failed after "
+                                "registered resume handoff for task %s run %s",
+                                task_id,
+                                close_run_id,
+                                exc_info=True,
+                            )
+                        except asyncio.CancelledError:
+                            # run_db_io_cancellation_safe drains its worker
+                            # thread to completion before propagating a
+                            # cancellation raised while awaiting it, so by the
+                            # time this branch runs the close-and-clear
+                            # transaction has already committed or failed on
+                            # its own; there is nothing left in flight to
+                            # protect. This only logs the interruption instead
+                            # of letting it escape as an unhandled
+                            # cancellation. Unlike the delivery marker above,
+                            # this branch is deliberate, not a gap to copy.
+                            logger.warning(
+                                "legacy resume interaction close was cancelled "
+                                "for task %s run %s; the resume proceeds "
+                                "unaffected",
+                                task_id,
+                                close_run_id,
                             )
                 except BaseException:
                     if bg_task is not None and not handoff_registered:

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -202,14 +202,21 @@ class Task(Base):  # type: ignore
     lease_attempt_id = Column(String(64), nullable=True)
 
     # Protocol version of the interaction row that will back this task's
-    # current wait. Each of its two writer groups is spoken for, and none of
-    # those writers exists yet: the three wait finalizers will write it (1
-    # when a row was staged, NULL when staging degraded), and the three
-    # legacy-resume injection sites will clear it. Readers will need to gate
-    # on status == WAITING_FOR_USER first: a task that left the waiting
-    # state by a path with no injection site (cancel, delete, failure, TTL
-    # reclaim, admin cleanup) will be able to carry a stale 1, and the next
-    # wait will overwrite it either way.
+    # current wait. Three writer groups are spoken for. The three wait
+    # finalizers will write it (1 when a row was staged, NULL when staging
+    # degraded) and have no writer yet. The three legacy-resume injection
+    # sites clear it back to NULL unconditionally, paired with retiring the
+    # row they answered; that writer already exists in
+    # task_interaction_close.py (close_legacy_resume_interaction). The two
+    # resume-abandonment paths clear it back to NULL only when it no longer
+    # names any active row; that writer also already exists in
+    # task_interaction_close.py (clear_interaction_marker_if_unpaired),
+    # called from the A2A prelease restore (a2a.py) and the WebSocket lease
+    # restore (websocket.py), both production-reachable. Readers will need
+    # to gate on status == WAITING_FOR_USER first: a task that left the
+    # waiting state by a path with no injection site (cancel, delete,
+    # failure, TTL reclaim, admin cleanup) will be able to carry a stale 1,
+    # and the next wait will overwrite it either way.
     #
     # Why a column on tasks rather than an EXISTS over
     # task_interaction_requests: the read surface's first check is
@@ -224,8 +231,7 @@ class Task(Base):  # type: ignore
     # read path. The marker only ever decides priority, never whether the
     # legacy fallback exists: readers fall back unconditionally when no
     # active row matches, so a stale marker degrades to the legacy question
-    # rather than corrupting anything. Re-examine the status coupling when
-    # the first writer lands.
+    # rather than corrupting anything.
     interaction_protocol_version = Column(Integer, nullable=True)
 
     # Model configuration

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -204,19 +204,22 @@ class Task(Base):  # type: ignore
     # Protocol version of the interaction row that will back this task's
     # current wait. Three writer groups are spoken for. The three wait
     # finalizers will write it (1 when a row was staged, NULL when staging
-    # degraded) and have no writer yet. The three legacy-resume injection
-    # sites clear it back to NULL unconditionally, paired with retiring the
-    # row they answered; that writer already exists in
-    # task_interaction_close.py (close_legacy_resume_interaction). The two
-    # resume-abandonment paths clear it back to NULL only when it no longer
-    # names any active row; that writer also already exists in
-    # task_interaction_close.py (clear_interaction_marker_if_unpaired),
-    # called from the A2A prelease restore (a2a.py) and the WebSocket lease
-    # restore (websocket.py), both production-reachable. Readers will need
-    # to gate on status == WAITING_FOR_USER first: a task that left the
-    # waiting state by a path with no injection site (cancel, delete,
-    # failure, TTL reclaim, admin cleanup) will be able to carry a stale 1,
-    # and the next wait will overwrite it either way.
+    # degraded) and have no writer yet. The four legacy-resume injection
+    # sites (the two WebSocket sites, the A2A resume-input path, and the
+    # v1 reply resume-input path) clear it back to NULL unconditionally,
+    # paired with retiring the row they answered; that writer already
+    # exists in task_interaction_close.py
+    # (close_legacy_resume_interaction). The three resume-abandonment
+    # paths clear it back to NULL only when it no longer names any active
+    # row; that writer also already exists in task_interaction_close.py
+    # (clear_interaction_marker_if_unpaired), called from the A2A prelease
+    # restore (a2a.py), the WebSocket lease restore (websocket.py), and
+    # the v1 reply prelease restore (task_reply.py), all
+    # production-reachable. Readers will need to gate on status ==
+    # WAITING_FOR_USER first: a task that left the waiting state by a path
+    # with no injection site (cancel, delete, failure, TTL reclaim, admin
+    # cleanup) will be able to carry a stale 1, and the next wait will
+    # overwrite it either way.
     #
     # Why a column on tasks rather than an EXISTS over
     # task_interaction_requests: the read surface's first check is

--- a/src/xagent/web/models/task_interaction.py
+++ b/src/xagent/web/models/task_interaction.py
@@ -165,12 +165,16 @@ class TaskInteractionRequest(Base):  # type: ignore
     reject.
 
     ``terminal_reason`` vocabulary: each of the three members is spoken for
-    by exactly one intended writer, and none of those writers exists yet.
-    ``deadline_elapsed`` and ``run_superseded`` are the two reclaim
-    branches, arriving with the staging primitive; ``answered_via_legacy_resume``
-    arrives with the transitional close on the legacy answer path. It is
-    not the same outcome as ``answered`` -- that path recovers a free-text
-    chat message, not a protocol v1 structured response, and synthesizing a
+    by exactly one intended writer. ``deadline_elapsed`` and
+    ``run_superseded`` are the two reclaim branches the staging primitive's
+    ``_reclaim_stale_slot_stmt`` already writes (``task_interaction_staging.py``)
+    -- that write statement exists, but the staging primitive it belongs to
+    has no production caller yet, so neither value is reachable outside
+    tests; ``answered_via_legacy_resume`` already has both its write
+    statement and a production caller, the transitional close in
+    ``task_interaction_close.py`` on the legacy answer path. It is not the
+    same outcome as ``answered`` -- that path recovers a free-text chat
+    message, not a protocol v1 structured response, and synthesizing a
     payload for it would fabricate a contract the client never produced.
     ``operator_cancelled`` and ``task_terminated`` have no writer yet and are
     intentionally not in the vocabulary; the old name

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -66,6 +66,17 @@ INTERACTION_ANCHOR_CORRUPT = "interaction_anchor_corrupt"
 # working, not whether a particular task has been repaired.
 CLARIFICATION_LEGACY_SUPERSEDE_FAILED = "clarification_legacy_supersede_failed"
 
+# Set when a legacy-resume interaction close (task_interaction_close.py)
+# matches more than one active row for a single task -- structurally
+# impossible under uq_task_interaction_active_slot unless that constraint
+# has already been violated. Not paired with a clear_degradation() call,
+# like INTERACTION_ROLLOUT_UNKNOWN_TASK_SOURCE above: it reports evidence
+# that a uniqueness constraint was already broken, a schema fact this
+# module has no way to observe being fixed.
+INTERACTION_LEGACY_RESUME_CLOSE_ROWCOUNT_ANOMALY = (
+    "interaction_legacy_resume_close_rowcount_anomaly"
+)
+
 # task_clarification_draft.py registers this when a waiting run's result
 # carries no clarification draft to publish, and clears it the next time a
 # draft is successfully resolved to a publishable payload.

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -1,0 +1,171 @@
+"""Retire a run's active interaction row when a legacy resume path answers it.
+
+Three production sites inject a WebSocket or A2A user message straight into
+a checkpoint instead of going through the native interaction protocol's
+answer path: the online WebSocket injection, the deferred WebSocket
+injection (``execute_resume_background``), and the A2A resume-input path.
+Each of those sites, once its own message write has succeeded, must retire
+the run's active ``task_interaction_requests`` row (if any) as
+``terminated`` / ``answered_via_legacy_resume`` and clear
+``tasks.interaction_protocol_version`` back to ``NULL`` in the same
+transaction as that retirement -- otherwise a stale marker would keep
+pointing a reader at a question the legacy path already answered by other
+means.
+
+Every rowcount the close statement below produces is classified the same
+way, at the one place the classification happens
+(``_classify_close_rowcount``): exactly one row closed is the expected
+case and logs at info; zero rows is the overwhelmingly common case today
+(no production writer has inserted into ``task_interaction_requests``
+yet) and logs at debug; more than one row is impossible under
+``uq_task_interaction_active_slot`` (it allows at most one row per task
+with a non-NULL ``active_slot``), but if that schema invariant were ever
+broken, this module logs at error and registers a degradation signal
+rather than raising -- a resume injection or an already-durable input
+write must not be turned into a failure by a check meant only to catch
+schema corruption after the fact.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from ..models.database import get_session_local
+from ..models.task import Task
+from ..models.task_interaction import TaskInteractionRequest
+from .ops_signals import (
+    INTERACTION_LEGACY_RESUME_CLOSE_ROWCOUNT_ANOMALY,
+    register_degradation,
+)
+from .task_interaction_schema import interaction_requests_table_exists
+from .task_lease_service import _rowcount
+
+logger = logging.getLogger(__name__)
+
+
+def _classify_close_rowcount(rowcount: int, *, task_id: int, run_id: str) -> None:
+    if rowcount == 1:
+        logger.info(
+            "legacy resume closed the active interaction row task_id=%s run_id=%s",
+            task_id,
+            run_id,
+        )
+    elif rowcount == 0:
+        logger.debug(
+            "legacy resume close matched no active interaction row "
+            "task_id=%s run_id=%s",
+            task_id,
+            run_id,
+        )
+    else:
+        logger.error(
+            "legacy resume close matched %s active interaction rows for one "
+            "task, expected at most one task_id=%s run_id=%s",
+            rowcount,
+            task_id,
+            run_id,
+        )
+        register_degradation(
+            INTERACTION_LEGACY_RESUME_CLOSE_ROWCOUNT_ANOMALY,
+            f"task_id={task_id} run_id={run_id} matched {rowcount} rows",
+        )
+
+
+def close_legacy_resume_interaction(
+    db: Session,
+    *,
+    task_id: int,
+    run_id: str,
+) -> int:
+    """Retire the run's active interaction row and clear the task's marker.
+
+    Caller obligations, because neither happens here: the caller has
+    already confirmed ``interaction_requests_table_exists(db)`` -- this
+    function issues no catalog check of its own and unconditionally
+    targets both tables -- and the caller owns the transaction; this
+    function never commits or rolls back.
+
+    Both statements always run, regardless of the close statement's
+    rowcount: the clear is not conditioned on having actually closed a
+    row, because a task's marker can legitimately need clearing even when
+    this run never staged an interaction row at all (today's 100% case,
+    since this table has no production writer yet).
+
+    Returns the close statement's rowcount, classified and logged by
+    ``_classify_close_rowcount`` -- see the module docstring for why a
+    rowcount greater than 1 is logged, not raised.
+    """
+    now = datetime.now(timezone.utc)
+    close_result = db.execute(
+        sa.update(TaskInteractionRequest)
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.run_id == run_id,
+            TaskInteractionRequest.status == "active",
+            TaskInteractionRequest.active_slot.isnot(None),
+        )
+        .values(
+            status="terminated",
+            active_slot=None,
+            terminal_reason="answered_via_legacy_resume",
+            terminated_at=now,
+            # updated_at has onupdate=func.now(); bind it explicitly to
+            # this same caller-clock value instead of letting the server
+            # clock fill it, matching interaction_handoff's explicit
+            # created_at binding (task_interaction_staging.py). Do not
+            # delete this as redundant -- removing it would let this row's
+            # timestamp source diverge from every other writer's.
+            updated_at=now,
+        )
+    )
+    rowcount = _rowcount(close_result)
+    _classify_close_rowcount(rowcount, task_id=task_id, run_id=run_id)
+    db.execute(
+        sa.update(Task)
+        .where(Task.id == task_id, Task.run_id == run_id)
+        .values(interaction_protocol_version=None)
+    )
+    return rowcount
+
+
+def close_legacy_resume_interaction_sync(task_id: int, run_id: str) -> int:
+    """Close + clear from a synchronous or ``asyncio.to_thread`` caller.
+
+    Shared by both WebSocket legacy-resume injection sites (the online
+    handler and the deferred ``execute_resume_background`` path): each
+    calls this via ``run_db_io_cancellation_safe`` with no transaction of
+    its own open first, and this function commits before returning.
+
+    Skips entirely, without opening the lock read below, when
+    ``task_interaction_requests`` does not exist on this deployment -- a
+    deployment not yet migrated to that table must not pay for, or fail
+    on, a lock read against a table it does not have.
+    """
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        if not interaction_requests_table_exists(db):
+            return 0
+        # First statement this transaction directs at tasks or
+        # task_interaction_requests. purge_task_rows NULLs this task's checkpoint
+        # pointer columns on tasks (task_deletion.py:45) before it deletes the
+        # task's interaction rows, so closing the interaction row first and
+        # clearing the marker second would close a lock cycle with it -- at every
+        # lock level purge itself could take, because the cycle is closed by that
+        # UPDATE, not by purge's own locking read. FOR NO KEY UPDATE, not
+        # FOR UPDATE: a concurrent stager's replacement INSERT needs KEY SHARE on
+        # this same parent row for its foreign key, and FOR UPDATE would block it,
+        # closing a second cycle. Both halves are required; see the caller
+        # obligation in task_interaction_staging.py's module docstring. The gate
+        # call above only inspects the catalog and takes no row lock, so it does
+        # not precede this in the sense the obligation means. On SQLite the clause
+        # is dropped and the single-writer lock serializes instead.
+        db.execute(
+            sa.select(Task.id).where(Task.id == task_id).with_for_update(key_share=True)
+        ).first()
+        rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id=run_id)
+        db.commit()
+        return rowcount

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -1,9 +1,10 @@
 """Retire a run's active interaction row when a legacy resume path answers it.
 
-Three production sites inject a WebSocket or A2A user message straight into
-a checkpoint instead of going through the native interaction protocol's
-answer path: the online WebSocket injection, the deferred WebSocket
-injection (``execute_resume_background``), and the A2A resume-input path.
+Four production sites inject a WebSocket, A2A, or v1 SDK user message
+straight into a checkpoint instead of going through the native interaction
+protocol's answer path: the online WebSocket injection, the deferred
+WebSocket injection (``execute_resume_background``), the A2A resume-input
+path, and the v1 ``POST .../reply`` resume-input path (``task_reply.py``).
 Each of those sites, once its own message write has succeeded, must retire
 the run's active ``task_interaction_requests`` row (if any) as
 ``terminated`` / ``answered_via_legacy_resume`` and clear
@@ -12,33 +13,35 @@ transaction as that retirement -- otherwise a stale marker would keep
 pointing a reader at a question the legacy path already answered by other
 means.
 
-Two resume-abandonment paths (the WebSocket lease restore and the A2A
-prelease restore) do the mirror-image cleanup when a resume is undone
-instead of completed: if the marker no longer corresponds to any active
-row, clear it. That clear is conditioned on ``NOT EXISTS`` rather than
-unconditional, because an abandonment can also race a resume that never
-even reached the injection call -- clearing unconditionally there would
-erase a marker that is still correct for a question that is still active.
+Three resume-abandonment paths (the WebSocket lease restore, the A2A
+prelease restore, and the v1 reply prelease restore) do the mirror-image
+cleanup when a resume is undone instead of completed: if the marker no
+longer corresponds to any active row, clear it. That clear is conditioned
+on ``NOT EXISTS`` rather than unconditional, because an abandonment can
+also race a resume that never even reached the injection call -- clearing
+unconditionally there would erase a marker that is still correct for a
+question that is still active.
 
-The two WebSocket sites and the one A2A site do not give this close the
-same atomicity guarantee. At both WebSocket sites (``websocket.py``),
-``close_legacy_resume_interaction_sync`` opens its own short transaction
-only after the message write has already committed -- the close is a
-best-effort step that follows the message write, not part of it. If that
-separate transaction fails, both call sites only log the failure; they do
-not retry, raise, or register a degradation signal. That is a deliberate
-choice, not a gap: a stale marker degrades to the legacy fallback question
-by design -- the same guarantee documented in the marker comment on
-``Task.interaction_protocol_version`` (``models/task.py``) -- so there is
-nothing left to protect by escalating. Both WebSocket call sites handle the
-failure of the delivery marker write immediately beside each close call
-(``mark_user_message_delivery_sync``) the identical log-only way, for the
-identical reason; see the inline comments beside each pair. The A2A site
-is different: its close call runs inside
-``_update_a2a_resume_input_sync``'s own transaction, committed together
-with the ownership fence UPDATE that precedes it, so that site's close is
-genuinely atomic with the write that answered the question -- not a
-best-effort follow-up.
+The two WebSocket sites and the A2A and v1 reply sites do not give this
+close the same atomicity guarantee. At both WebSocket sites
+(``websocket.py``), ``close_legacy_resume_interaction_sync`` opens its own
+short transaction only after the message write has already committed --
+the close is a best-effort step that follows the message write, not part
+of it. If that separate transaction fails, both call sites only log the
+failure; they do not retry, raise, or register a degradation signal. That
+is a deliberate choice, not a gap: a stale marker degrades to the legacy
+fallback question by design -- the same guarantee documented in the marker
+comment on ``Task.interaction_protocol_version`` (``models/task.py``) -- so
+there is nothing left to protect by escalating. Both WebSocket call sites
+handle the failure of the delivery marker write immediately beside each
+close call (``mark_user_message_delivery_sync``) the identical log-only
+way, for the identical reason; see the inline comments beside each pair.
+The A2A and v1 reply sites are different: each close call runs inside its
+own resume-input fence transaction (``_update_a2a_resume_input_sync`` in
+``a2a.py``, ``_update_reply_input_sync`` in ``task_reply.py``), committed
+together with the ownership fence UPDATE that precedes it, so those two
+sites' closes are genuinely atomic with the write that answered the
+question -- not a best-effort follow-up.
 
 Every rowcount the close statement below produces is classified the same
 way, at the one place the classification happens
@@ -220,11 +223,11 @@ def clear_interaction_marker_if_unpaired(
 ) -> None:
     """Zero the protocol marker if it no longer names any active row.
 
-    Used by the two resume-abandonment paths (the WebSocket lease restore
-    and the A2A prelease restore) instead of
-    ``close_legacy_resume_interaction``: an abandonment can happen before
-    the injection call ever ran, so there is no row to close here -- only
-    a marker to reconcile.
+    Used by the three resume-abandonment paths (the WebSocket lease
+    restore, the A2A prelease restore, and the v1 reply prelease restore)
+    instead of ``close_legacy_resume_interaction``: an abandonment can
+    happen before the injection call ever ran, so there is no row to close
+    here -- only a marker to reconcile.
 
     The semantics are not "clear the marker" but "if the marker no longer
     corresponds to any active row, zero it": the UPDATE below only matches

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -20,6 +20,26 @@ unconditional, because an abandonment can also race a resume that never
 even reached the injection call -- clearing unconditionally there would
 erase a marker that is still correct for a question that is still active.
 
+The two WebSocket sites and the one A2A site do not give this close the
+same atomicity guarantee. At both WebSocket sites (``websocket.py``),
+``close_legacy_resume_interaction_sync`` opens its own short transaction
+only after the message write has already committed -- the close is a
+best-effort step that follows the message write, not part of it. If that
+separate transaction fails, both call sites only log the failure; they do
+not retry, raise, or register a degradation signal. That is a deliberate
+choice, not a gap: a stale marker degrades to the legacy fallback question
+by design -- the same guarantee documented in the marker comment on
+``Task.interaction_protocol_version`` (``models/task.py``) -- so there is
+nothing left to protect by escalating. Both WebSocket call sites handle the
+failure of the delivery marker write immediately beside each close call
+(``mark_user_message_delivery_sync``) the identical log-only way, for the
+identical reason; see the inline comments beside each pair. The A2A site
+is different: its close call runs inside
+``_update_a2a_resume_input_sync``'s own transaction, committed together
+with the ownership fence UPDATE that precedes it, so that site's close is
+genuinely atomic with the write that answered the question -- not a
+best-effort follow-up.
+
 Every rowcount the close statement below produces is classified the same
 way, at the one place the classification happens
 (``_classify_close_rowcount``): exactly one row closed is the expected
@@ -106,6 +126,19 @@ def close_legacy_resume_interaction(
     Returns the close statement's rowcount, classified and logged by
     ``_classify_close_rowcount`` -- see the module docstring for why a
     rowcount greater than 1 is logged, not raised.
+
+    A constraint on the batch that adds a production writer for
+    ``task_interaction_requests``: the close statement matches on
+    ``(task_id, run_id, active)`` alone -- nothing binds it to the
+    specific question the injected user message answered. That is sound
+    only while this run cannot stage a new row between the message write
+    and this close. Injecting the message is exactly what resumes the
+    agent, so once a production writer exists, the resumed agent may
+    stage a fresh question in that window and this statement would
+    retire it as if it had been answered. The writer batch must either
+    key this close on the row observed before injection (read the
+    primary key first) or add a staleness fence; it must not ship the
+    statement as-is.
     """
     now = datetime.now(timezone.utc)
     close_result = db.execute(

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -12,6 +12,14 @@ transaction as that retirement -- otherwise a stale marker would keep
 pointing a reader at a question the legacy path already answered by other
 means.
 
+Two resume-abandonment paths (the WebSocket lease restore and the A2A
+prelease restore) do the mirror-image cleanup when a resume is undone
+instead of completed: if the marker no longer corresponds to any active
+row, clear it. That clear is conditioned on ``NOT EXISTS`` rather than
+unconditional, because an abandonment can also race a resume that never
+even reached the injection call -- clearing unconditionally there would
+erase a marker that is still correct for a question that is still active.
+
 Every rowcount the close statement below produces is classified the same
 way, at the one place the classification happens
 (``_classify_close_rowcount``): exactly one row closed is the expected
@@ -169,3 +177,57 @@ def close_legacy_resume_interaction_sync(task_id: int, run_id: str) -> int:
         rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id=run_id)
         db.commit()
         return rowcount
+
+
+def clear_interaction_marker_if_unpaired(
+    db: Session,
+    *,
+    task_id: int,
+    run_id: str,
+) -> None:
+    """Zero the protocol marker if it no longer names any active row.
+
+    Used by the two resume-abandonment paths (the WebSocket lease restore
+    and the A2A prelease restore) instead of
+    ``close_legacy_resume_interaction``: an abandonment can happen before
+    the injection call ever ran, so there is no row to close here -- only
+    a marker to reconcile.
+
+    The semantics are not "clear the marker" but "if the marker no longer
+    corresponds to any active row, zero it": the UPDATE below only matches
+    when NOT EXISTS an active row for this exact (task_id, run_id) pair,
+    so a marker that still names a live question survives untouched.
+
+    Caller obligations: the caller owns the transaction (this function
+    never commits or rolls back) and has already confirmed the resume is
+    actually being abandoned (e.g. the lease restore's own ``restored``
+    flag) before calling this. No lock read precedes this statement --
+    unlike the close path, the caller's own non-key-column ``tasks`` UPDATE
+    (``release_task_lease_no_commit``) already is the first statement this
+    transaction directs at ``tasks`` or ``task_interaction_requests``, and
+    it satisfies the same ordering and strength obligation a dedicated
+    lock read would.
+
+    Skipped entirely when ``task_interaction_requests`` does not exist.
+    """
+    if not interaction_requests_table_exists(db):
+        return
+    still_active = (
+        sa.select(sa.literal(1))
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.run_id == run_id,
+            TaskInteractionRequest.status == "active",
+            TaskInteractionRequest.active_slot.isnot(None),
+        )
+        .exists()
+    )
+    db.execute(
+        sa.update(Task)
+        .where(
+            Task.id == task_id,
+            Task.run_id == run_id,
+            ~still_active,
+        )
+        .values(interaction_protocol_version=None)
+    )

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -22,6 +22,17 @@ also race a resume that never even reached the injection call -- clearing
 unconditionally there would erase a marker that is still correct for a
 question that is still active.
 
+A fourth WebSocket exit path does not clear the marker at all:
+``_settle_resumed_task_lease`` (``websocket.py``) settles a cancelled or
+failed resume by way of ``settle_task_lease_isolated`` ->
+``fail_and_release_task_lease_no_commit``, neither of which touches
+``interaction_protocol_version`` or ``task_interaction_requests``. This is
+not an oversight to fix here -- it is the same lazy-clear posture the
+marker's ownership comment on ``Task.interaction_protocol_version``
+already documents: every exit path with no injection point to hang a
+close or a clear on is allowed to leave a stale marker behind, because
+readers filter on ``status`` before ever consulting it.
+
 The two WebSocket sites and the A2A and v1 reply sites do not give this
 close the same atomicity guarantee. At both WebSocket sites
 (``websocket.py``), ``close_legacy_resume_interaction_sync`` opens its own
@@ -39,9 +50,22 @@ way, for the identical reason; see the inline comments beside each pair.
 The A2A and v1 reply sites are different: each close call runs inside its
 own resume-input fence transaction (``_update_a2a_resume_input_sync`` in
 ``a2a.py``, ``_update_reply_input_sync`` in ``task_reply.py``), committed
-together with the ownership fence UPDATE that precedes it, so those two
-sites' closes are genuinely atomic with the write that answered the
-question -- not a best-effort follow-up.
+together with the ownership fence UPDATE that precedes it -- that is what
+makes those two sites stronger than the WebSocket sites, not a claim that
+the close is atomic with the message injection itself. The message
+injection (``post_user_message`` at ``a2a.py:464`` / ``task_reply.py:512``)
+commits on its own, earlier, in ``AgentRunner._persist_injected_context``;
+only after that commit has already landed does the caller open the fence
+transaction that writes the resumed input and closes the interaction row
+together. A crash between those two commits leaves the interaction row
+``active`` and the marker still set to ``1`` even though the injected
+message already answered the question. That window is benign for the same
+reason as the reader fallback documented above: a reader keys off
+``status`` first, so a stale active row here just makes it fall back to
+asking the legacy question again -- the same family of harmless window
+as the message-injection replay that
+``AgentRunner.inject_user_message`` short-circuits on a repeated turn
+id.
 
 Every rowcount the close statement below produces is classified the same
 way, at the one place the classification happens
@@ -81,7 +105,7 @@ logger = logging.getLogger(__name__)
 def _classify_close_rowcount(rowcount: int, *, task_id: int, run_id: str) -> None:
     if rowcount == 1:
         logger.info(
-            "legacy resume closed the active interaction row task_id=%s run_id=%s",
+            "legacy resume closing the active interaction row task_id=%s run_id=%s",
             task_id,
             run_id,
         )

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -232,7 +232,12 @@ def clear_interaction_marker_if_unpaired(
     The semantics are not "clear the marker" but "if the marker no longer
     corresponds to any active row, zero it": the UPDATE below only matches
     when NOT EXISTS an active row for this exact (task_id, run_id) pair,
-    so a marker that still names a live question survives untouched.
+    so a marker that still names a live question survives untouched. The
+    outer ``Task.run_id == run_id`` predicate is what keeps this scoped to
+    the run being abandoned -- if another run now owns the task (a new
+    turn already started), this UPDATE matches zero rows regardless of the
+    NOT EXISTS check, so an abandoned resume can never clear a marker that
+    belongs to a run other than its own.
 
     Caller obligations: the caller owns the transaction (this function
     never commits or rolls back) and has already confirmed the resume is

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -22,6 +22,7 @@ from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.task_command import TaskExecutionCommand
+from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services.a2a_protocol import (
     A2A_MAX_MESSAGE_TEXT_LENGTH,
     A2AApiError,
@@ -84,6 +85,47 @@ def _create_published_agent_with_key() -> tuple[int, str]:
     key_response = client.post(f"/api/agents/{agent_id}/api-key", headers=headers)
     assert key_response.status_code == 200, key_response.text
     return agent_id, key_response.json()["full_key"]
+
+
+def _seed_active_interaction_row(
+    db: Session, *, task_id: int, run_id: str, idempotency_key: str
+) -> int:
+    """One legal active TaskInteractionRequest row, for the legacy resume
+    close/compensation tests below. Not the interaction staging primitive's
+    fixture builder (tests/web/services/task_interaction_schema_shared.py)
+    -- this file has no other reason to depend on that directory, so this
+    stays a small, local, single-purpose row builder instead."""
+    anchor = TraceEvent(
+        task_id=task_id,
+        event_id=f"anchor-{idempotency_key}",
+        event_type="agent_execution_checkpoint",
+        timestamp=datetime.now(UTC),
+        data={},
+    )
+    db.add(anchor)
+    db.flush()
+    row = TaskInteractionRequest(
+        task_id=task_id,
+        run_id=run_id,
+        kind="clarification",
+        protocol_version=1,
+        status="active",
+        active_slot=1,
+        origin="a2a",
+        request_payload={"prompt": "example"},
+        request_idempotency_key=idempotency_key,
+        resume_trace_event_id=int(anchor.id),
+        resume_event_id="resume-event-1",
+        resume_execution_id="resume-execution-1",
+        resume_locator_format="trace_event_pk_v1",
+        resume_checkpoint_type="agent_execution_checkpoint",
+        resume_run_partition=run_id,
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return int(row.id)
 
 
 def test_agent_card_exposes_published_agent(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -748,6 +790,72 @@ def test_checkpoint_resume_schedule_failure_exactly_restores_waiting_task() -> N
         assert restored.run_id == "run-a"
         assert restored.runner_id is None
         assert restored.lease_expires_at is None
+    finally:
+        db.close()
+
+
+def test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence() -> (
+    None
+):
+    """The fence UPDATE and the legacy resume interaction close are one
+    atomic write: a fence miss (ownership changed under this lease) must
+    roll back both together, not close the row while rejecting the input.
+
+    What this actually pins is that the close must never commit
+    independently of the host transaction -- reordering the two statements
+    within that same transaction changes nothing observable, because a
+    rollback undoes every statement issued since the last commit regardless
+    of program order. Turning this red needs two changes at once: the close
+    must move ahead of the fence's early return (unreachable there today,
+    since a fence miss returns before the close ever runs) and it must
+    commit independently of this function's session -- either change alone
+    leaves this cell green, verified directly.
+    """
+    db = _direct_db_session()
+    try:
+        agent_id, _full_key = _create_published_agent_with_key()
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="atomicity",
+            status=TaskStatus.RUNNING,
+            runner_id="current-runner",
+            run_id="run-atomicity",
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            interaction_protocol_version=1,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+        row_id = _seed_active_interaction_row(
+            db, task_id=task_id, run_id="run-atomicity", idempotency_key="atomicity-q1"
+        )
+    finally:
+        db.close()
+
+    # A different runner_id than the row's current one: the fence's WHERE
+    # clause requires an exact match, so this lease has already lost the
+    # race by the time the write is attempted.
+    stale_lease = TaskLease(
+        task_id=task_id, runner_id="a-different-runner", run_id="run-atomicity"
+    )
+    updated = a2a_api._update_a2a_resume_input_sync(stale_lease, "attempted text")
+
+    assert updated is False
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == row_id)
+            .one()
+        )
+        assert row.status == "active"
+        refreshed = db.query(Task).filter(Task.id == task_id).one()
+        assert refreshed.interaction_protocol_version == 1
+        assert refreshed.input is None
     finally:
         db.close()
 

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -860,6 +860,90 @@ def test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence
         db.close()
 
 
+def test_message_send_closes_the_legacy_resume_interaction_row_on_successful_injection() -> (
+    None
+):
+    """The success path this whole change exists for, driven through the
+    real HTTP message:send call rather than the sync helper directly: once
+    the fence UPDATE lands, the run's active interaction row is retired
+    (``terminated`` / ``answered_via_legacy_resume``) and the task's
+    protocol marker is cleared back to NULL in the same commit."""
+    agent_id, full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="legacy resume close success",
+            status=TaskStatus.PAUSED,
+            control_state=TaskControlState.PAUSED.value,
+            run_id="run-close-success",
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-close-success"},
+            interaction_protocol_version=1,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+        row_id = _seed_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id="run-close-success",
+            idempotency_key="close-success-q1",
+        )
+    finally:
+        db.close()
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    begin_turn = AsyncMock()
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=agent_manager,
+        ),
+        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume"),
+        patch(
+            "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+            new=begin_turn,
+        ),
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-close-success",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "answered via legacy resume"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    agent_service.post_user_message.assert_awaited_once()
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == row_id)
+            .one()
+        )
+        assert row.status == "terminated"
+        assert row.terminal_reason == "answered_via_legacy_resume"
+        refreshed = db.query(Task).filter(Task.id == task_id).one()
+        assert refreshed.interaction_protocol_version is None
+    finally:
+        db.close()
+
+
 @pytest.mark.asyncio
 async def test_a2a_handover_restores_input_required_on_unreadable_checkpoint() -> None:
     """The A2A handover carries the pre-claim status into the resume.

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -1196,6 +1196,149 @@ def test_failed_follow_up_restores_input_required_status() -> None:
         db.close()
 
 
+def test_failed_follow_up_leaves_a_still_active_question_and_marker_untouched() -> None:
+    """Injection never happened here (post_user_message returned False), so
+    the prelease restore's marker-clear compensation must not fire: the
+    active interaction row and the protocol marker are both untouched.
+
+    Deleting the NOT EXISTS guard from clear_interaction_marker_if_unpaired
+    would turn this red -- the marker would be zeroed out from under a
+    question that is still active.
+    """
+    agent_id, full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="waiting with an open question",
+            status=TaskStatus.WAITING_FOR_USER,
+            run_id="run-not-posted",
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-not-posted"},
+            interaction_protocol_version=1,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+        row_id = _seed_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id="run-not-posted",
+            idempotency_key="not-posted-q1",
+        )
+    finally:
+        db.close()
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(return_value=False)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-not-posted",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "no checkpoint available"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 400, response.text
+    db = _direct_db_session()
+    try:
+        recovered = db.query(Task).filter(Task.id == task_id).one()
+        assert recovered.status == TaskStatus.WAITING_FOR_USER
+        assert recovered.interaction_protocol_version == 1
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == row_id)
+            .one()
+        )
+        assert row.status == "active"
+    finally:
+        db.close()
+
+
+def test_prelease_restore_from_a_cancelled_acquisition_leaves_marker_untouched() -> (
+    None
+):
+    """``_restore_a2a_resume_prelease_sync`` is also the cleanup callback
+    ``acquire_task_lease_cancellation_safe`` invokes directly when the
+    acquisition committed a prelease but the caller was then cancelled --
+    no ``post_user_message`` outcome participates in that path at all.
+    Called here exactly as that callback calls it: with a live active
+    interaction row still in place, the marker must survive.
+
+    Deleting the NOT EXISTS guard would turn this red the same way it does
+    for the ``if not posted`` path above -- both routes converge on the
+    same shared clear_interaction_marker_if_unpaired call.
+    """
+    agent_id, _full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="prelease acquired then cancelled",
+            status=TaskStatus.RUNNING,
+            runner_id="cancelled-acquire-runner",
+            run_id="run-cancelled-acquire",
+            lease_expires_at=datetime.now(UTC) + timedelta(minutes=1),
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            interaction_protocol_version=1,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+        row_id = _seed_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id="run-cancelled-acquire",
+            idempotency_key="cancelled-acquire-q1",
+        )
+    finally:
+        db.close()
+
+    acquired_lease = TaskLease(
+        task_id=task_id,
+        runner_id="cancelled-acquire-runner",
+        run_id="run-cancelled-acquire",
+    )
+    restored = a2a_api._restore_a2a_resume_prelease_sync(
+        acquired_lease, status=TaskStatus.WAITING_FOR_USER
+    )
+
+    assert restored is True
+    db = _direct_db_session()
+    try:
+        recovered = db.query(Task).filter(Task.id == task_id).one()
+        assert recovered.status == TaskStatus.WAITING_FOR_USER
+        assert recovered.interaction_protocol_version == 1
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == row_id)
+            .one()
+        )
+        assert row.status == "active"
+    finally:
+        db.close()
+
+
 def test_checkpoint_resume_exception_restores_input_required_status() -> None:
     agent_id, full_key = _create_published_agent_with_key()
     db = _direct_db_session()

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -1642,6 +1642,123 @@ async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
     assert len(accepted) == 1
 
 
+@pytest.mark.asyncio
+async def test_live_close_failure_after_registered_handoff_is_still_accepted(
+    db_session,
+) -> None:
+    """A legacy resume interaction close failure must not turn an already
+    registered, already accepted resume handoff into a rejected one."""
+    owner = _user(db_session, "close-failure-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    task.runner_id = "close-failure-runner"
+    task.run_id = "close-failure-run"
+    db_session.commit()
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(return_value=True)
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=MagicMock(get_agent_for_task=AsyncMock(return_value=agent)),
+        ),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch("xagent.web.api.websocket.execute_resume_background", AsyncMock()),
+        patch(
+            "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
+            side_effect=RuntimeError("interaction close unavailable"),
+        ) as close_mock,
+    ):
+        await _handle_chat_message_unserialized(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Apply this once",
+                "client_message_id": "close-failure-turn",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    bg_mgr.register_reserved_resume.assert_called_once()
+    close_mock.assert_called_once_with(int(task.id), "close-failure-run")
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
+
+
+@pytest.mark.asyncio
+async def test_live_close_cancellation_does_not_abort_registered_handoff(
+    db_session,
+) -> None:
+    """Same guarantee as the failure case above, for the CancelledError
+    branch specifically -- deleting that branch must turn this red."""
+    owner = _user(db_session, "close-cancel-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    task.runner_id = "close-cancel-runner"
+    task.run_id = "close-cancel-run"
+    db_session.commit()
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(return_value=True)
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+
+    def raise_cancelled(*_args: object, **_kwargs: object) -> int:
+        raise asyncio.CancelledError
+
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=MagicMock(get_agent_for_task=AsyncMock(return_value=agent)),
+        ),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch("xagent.web.api.websocket.execute_resume_background", AsyncMock()),
+        patch(
+            "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
+            side_effect=raise_cancelled,
+        ) as close_mock,
+    ):
+        await _handle_chat_message_unserialized(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Apply this once",
+                "client_message_id": "close-cancel-turn",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    bg_mgr.register_reserved_resume.assert_called_once()
+    close_mock.assert_called_once_with(int(task.id), "close-cancel-run")
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
+
+
 def test_live_claim_unique_loser_returns_the_committed_winner(
     db_session,
 ) -> None:
@@ -3190,6 +3307,202 @@ async def test_deferred_injection_marker_cancellation_does_not_abort_resume(
         )
 
     agent.resume_execution_by_id.assert_awaited_once_with(str(task.id))
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
+
+
+@pytest.mark.asyncio
+async def test_deferred_injection_close_failure_does_not_abort_resume(
+    db_session,
+) -> None:
+    """Same guarantee as the deferred delivery-marker failure case above,
+    for the legacy resume interaction close issued right before it."""
+    owner = _user(db_session, "deferred-close-failure-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Deferred guidance",
+            message_type="user_message",
+            turn_id="deferred-close-failure-turn",
+            delivery_status=DELIVERY_PENDING,
+        )
+    )
+    db_session.commit()
+    context = SimpleNamespace(
+        messages=[
+            SimpleNamespace(
+                role="user",
+                metadata={"turn_id": "deferred-close-failure-turn"},
+            )
+        ]
+    )
+    agent = MagicMock(
+        post_user_message=AsyncMock(return_value=True),
+        resume_execution_by_id=AsyncMock(
+            return_value={
+                "status": "completed",
+                "success": True,
+                "output": "Applied",
+                "agent_result": {"context": context},
+            }
+        ),
+    )
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    # Recorded, not asserted, inside the side_effect below: the production
+    # code that calls close_legacy_resume_interaction_sync wraps it in
+    # ``except Exception:``, which would silently swallow an AssertionError
+    # raised from inside this callback the same way it swallows the
+    # RuntimeError this test is otherwise driving. The real assertions run
+    # after the `with` block, outside that handler's reach.
+    observed_close_calls: list[tuple[int, str, str | None]] = []
+
+    def fail_close(task_id_arg: int, run_id_arg: str) -> int:
+        # A fresh session, not db_session: this runs inside the worker
+        # thread run_db_io_cancellation_safe schedules it on, while the
+        # test's own db_session sits unused on the main thread -- sharing
+        # one Session across that handoff is not a pattern this suite uses
+        # elsewhere.
+        probe = next(get_db())
+        try:
+            live_run_id = probe.query(Task).filter(Task.id == task_id_arg).one().run_id
+        finally:
+            probe.close()
+        observed_close_calls.append((task_id_arg, run_id_arg, live_run_id))
+        raise RuntimeError("interaction close unavailable")
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager.promote_resume_task"),
+        patch(
+            "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
+            side_effect=fail_close,
+        ),
+    ):
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+            pending_user_message={
+                "execution_message": "Deferred guidance",
+                "display_message": "Deferred guidance",
+                "files": [],
+                "turn_id": "deferred-close-failure-turn",
+            },
+            delivery_turn_id="deferred-close-failure-turn",
+            delivery_websocket=MagicMock(),
+            delivery_client_message_id="deferred-close-failure-turn",
+        )
+
+    agent.resume_execution_by_id.assert_awaited_once_with(str(task.id))
+    assert len(observed_close_calls) == 1
+    called_task_id, called_run_id, live_run_id = observed_close_calls[0]
+    assert called_task_id == int(task.id)
+    assert called_run_id
+    assert called_run_id == live_run_id
+    accepted = [
+        call.args[0]
+        for call in ws_manager.send_personal_message.call_args_list
+        if call.args[0].get("type") == "message_accepted"
+    ]
+    assert len(accepted) == 1
+
+
+@pytest.mark.asyncio
+async def test_deferred_injection_close_cancellation_does_not_abort_resume(
+    db_session,
+) -> None:
+    """CancelledError branch specifically -- deleting it must turn this red."""
+    owner = _user(db_session, "deferred-close-cancel-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Deferred guidance",
+            message_type="user_message",
+            turn_id="deferred-close-cancel-turn",
+            delivery_status=DELIVERY_PENDING,
+        )
+    )
+    db_session.commit()
+    context = SimpleNamespace(
+        messages=[
+            SimpleNamespace(
+                role="user",
+                metadata={"turn_id": "deferred-close-cancel-turn"},
+            )
+        ]
+    )
+    agent = MagicMock(
+        post_user_message=AsyncMock(return_value=True),
+        resume_execution_by_id=AsyncMock(
+            return_value={
+                "status": "completed",
+                "success": True,
+                "output": "Applied",
+                "agent_result": {"context": context},
+            }
+        ),
+    )
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    # Recorded, not asserted, inside the side_effect below -- see the sibling
+    # failure-case test's comment: an AssertionError raised from inside this
+    # callback would be swallowed by the production code's own
+    # ``except Exception:`` the same way it swallows an ordinary failure.
+    observed_close_calls: list[tuple[int, str, str | None]] = []
+
+    def raise_cancelled(task_id_arg: int, run_id_arg: str) -> int:
+        probe = next(get_db())
+        try:
+            live_run_id = probe.query(Task).filter(Task.id == task_id_arg).one().run_id
+        finally:
+            probe.close()
+        observed_close_calls.append((task_id_arg, run_id_arg, live_run_id))
+        raise asyncio.CancelledError
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager.promote_resume_task"),
+        patch(
+            "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
+            side_effect=raise_cancelled,
+        ),
+    ):
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+            pending_user_message={
+                "execution_message": "Deferred guidance",
+                "display_message": "Deferred guidance",
+                "files": [],
+                "turn_id": "deferred-close-cancel-turn",
+            },
+            delivery_turn_id="deferred-close-cancel-turn",
+            delivery_websocket=MagicMock(),
+            delivery_client_message_id="deferred-close-cancel-turn",
+        )
+
+    agent.resume_execution_by_id.assert_awaited_once_with(str(task.id))
+    assert len(observed_close_calls) == 1
+    called_task_id, called_run_id, live_run_id = observed_close_calls[0]
+    assert called_task_id == int(task.id)
+    assert called_run_id
+    assert called_run_id == live_run_id
     accepted = [
         call.args[0]
         for call in ws_manager.send_personal_message.call_args_list

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -39,6 +39,7 @@ from xagent.web.api.websocket import (
     _handle_chat_message_unserialized,
     _handle_pause_task_unserialized,
     _handle_resume_task_unserialized,
+    _restore_resumed_task_lease_to_prior_status,
     _waiting_or_paused_event_fields,
     background_task_manager,
     execute_resume_background,
@@ -1757,6 +1758,58 @@ async def test_live_close_cancellation_does_not_abort_registered_handoff(
         if call.args[0].get("type") == "message_accepted"
     ]
     assert len(accepted) == 1
+
+
+def test_lease_restore_fence_miss_leaves_the_marker_untouched(db_session) -> None:
+    """When the exact-lease fence excludes every row (this call lost the
+    race for the row), the marker clear must not run at all -- not even
+    the no-op form. Flipping the ``if restored:`` guard to unconditional
+    would clear a marker this call never had authority to touch.
+    """
+    owner = _user(db_session, "restore-fence-miss-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.WAITING_FOR_USER)
+    task.runner_id = "current-runner"
+    task.run_id = "run-fence-miss"
+    task.interaction_protocol_version = 1
+    db_session.commit()
+
+    stale_lease = TaskLease(
+        task_id=int(task.id), runner_id="a-different-runner", run_id="run-fence-miss"
+    )
+    restored = _restore_resumed_task_lease_to_prior_status(
+        stale_lease, status=TaskStatus.WAITING_FOR_USER
+    )
+
+    assert restored is False
+    db_session.expire_all()
+    refreshed = db_session.query(Task).filter(Task.id == task.id).one()
+    assert refreshed.interaction_protocol_version == 1
+
+
+def test_lease_restore_clears_the_marker_once_no_active_row_remains(
+    db_session,
+) -> None:
+    """The mirror case: the fence matches (this call owns the row) and no
+    active interaction row remains, so the marker is stale and gets
+    zeroed."""
+    owner = _user(db_session, "restore-clears-marker-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.WAITING_FOR_USER)
+    task.runner_id = "current-runner"
+    task.run_id = "run-clears-marker"
+    task.interaction_protocol_version = 1
+    db_session.commit()
+
+    lease = TaskLease(
+        task_id=int(task.id), runner_id="current-runner", run_id="run-clears-marker"
+    )
+    restored = _restore_resumed_task_lease_to_prior_status(
+        lease, status=TaskStatus.WAITING_FOR_USER
+    )
+
+    assert restored is True
+    db_session.expire_all()
+    refreshed = db_session.query(Task).filter(Task.id == task.id).one()
+    assert refreshed.interaction_protocol_version is None
 
 
 def test_live_claim_unique_loser_returns_the_committed_winner(

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -9,6 +9,7 @@ up a real background execution, these tests patch the analogous
 """
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,7 +23,8 @@ from xagent.core.agent.checkpoint import (
 from xagent.web.api.v1 import task_reply as task_reply_module
 from xagent.web.models.agent import Agent
 from xagent.web.models.chat_message import TaskChatMessage
-from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.schemas.v1 import ReplyRequest
 from xagent.web.services.task_execution_controller import TaskControlState
 from xagent.web.services.task_lease_service import TaskLease, current_task_lease
@@ -147,6 +149,50 @@ def _patch_agent_service(post_user_message: AsyncMock):
 
 def _reply_body(agent_id: int, content: str = "yes, continue") -> dict:
     return {"agent_id": agent_id, "message": {"role": "user", "content": content}}
+
+
+def _seed_active_interaction_row(
+    task_id: int, *, run_id: str, idempotency_key: str
+) -> int:
+    """One legal active TaskInteractionRequest row, for the legacy resume
+    close test below. Mirrors test_a2a_api.py's identically-purposed
+    helper, with origin="sdk" instead of "a2a" to match this endpoint's
+    Task.source == "sdk" scoping."""
+    db = _direct_db_session()
+    try:
+        anchor = TraceEvent(
+            task_id=task_id,
+            event_id=f"anchor-{idempotency_key}",
+            event_type="agent_execution_checkpoint",
+            timestamp=datetime.now(timezone.utc),
+            data={},
+        )
+        db.add(anchor)
+        db.flush()
+        row = TaskInteractionRequest(
+            task_id=task_id,
+            run_id=run_id,
+            kind="clarification",
+            protocol_version=1,
+            status="active",
+            active_slot=1,
+            origin="sdk",
+            request_payload={"prompt": "example"},
+            request_idempotency_key=idempotency_key,
+            resume_trace_event_id=int(anchor.id),
+            resume_event_id="resume-event-1",
+            resume_execution_id="resume-execution-1",
+            resume_locator_format="trace_event_pk_v1",
+            resume_checkpoint_type="agent_execution_checkpoint",
+            resume_run_partition=run_id,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=15),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return int(row.id)
+    finally:
+        db.close()
 
 
 # ===== happy path =====
@@ -428,6 +474,111 @@ def test_reply_checkpoint_missing_is_fail_closed(mock_start_task):
         assert task.lease_expires_at is None
         assert task.run_id == "run-legacy"
         assert task.error_message is None
+    finally:
+        db.close()
+
+
+# ===== legacy resume interaction close =====
+
+
+def test_reply_closes_the_legacy_resume_interaction_row_on_successful_injection(
+    mock_start_task,
+):
+    """The success path this wiring exists for: once the reply's fence
+    UPDATE lands (``_update_reply_input_sync``), the run's active
+    interaction row is retired (``terminated`` /
+    ``answered_via_legacy_resume``) and the task's protocol marker is
+    cleared back to NULL in the same commit -- mirrors
+    test_a2a_api.py's
+    test_message_send_closes_the_legacy_resume_interaction_row_on_successful_injection.
+
+    Reverting the close wiring in ``_update_reply_input_sync`` turns this
+    red: the row stays "active" and the marker stays 1.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id="run-close-success")
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        task.interaction_protocol_version = 1
+        db.commit()
+    finally:
+        db.close()
+    row_id = _seed_active_interaction_row(
+        task_id, run_id="run-close-success", idempotency_key="reply-close-success-q1"
+    )
+
+    post_user_message = AsyncMock(return_value=True)
+    agent_patch, agent_service = _patch_agent_service(post_user_message)
+    with (
+        agent_patch,
+        patch(
+            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            new=AsyncMock(),
+        ),
+    ):
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+
+    assert resp.status_code == 202, resp.text
+    agent_service.post_user_message.assert_awaited_once()
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == row_id)
+            .one()
+        )
+        assert row.status == "terminated"
+        assert row.terminal_reason == "answered_via_legacy_resume"
+        refreshed = db.query(Task).filter(Task.id == task_id).one()
+        assert refreshed.interaction_protocol_version is None
+    finally:
+        db.close()
+
+
+def test_reply_checkpoint_missing_restore_clears_an_unpaired_marker(mock_start_task):
+    """The restore (abandonment) branch's compensation cleanup: when
+    post_user_message returns False, the prelease is released back to
+    waiting_for_user via ``_restore_reply_prelease_sync``, which must also
+    reconcile a marker that no longer names any active row -- there is no
+    active interaction row staged for this run, so the NOT EXISTS guard in
+    ``clear_interaction_marker_if_unpaired`` matches and the marker clears.
+
+    Reverting the ``clear_interaction_marker_if_unpaired`` call in
+    ``_restore_reply_prelease_sync`` turns this red: the marker stays 1
+    even though the task is back in waiting_for_user with no active row.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id="run-unpaired-marker")
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        task.interaction_protocol_version = 1
+        db.commit()
+    finally:
+        db.close()
+
+    agent_patch, _ = _patch_agent_service(AsyncMock(return_value=False))
+    with agent_patch:
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["error"]["code"] == "interaction_not_resumable"
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status == TaskStatus.WAITING_FOR_USER
+        assert task.interaction_protocol_version is None
     finally:
         db.close()
 

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -541,6 +541,70 @@ def test_reply_closes_the_legacy_resume_interaction_row_on_successful_injection(
         db.close()
 
 
+def test_update_reply_input_rolls_back_the_interaction_close_with_the_fence() -> None:
+    """Mirrors test_a2a_api.py's
+    test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence
+    for the reply site's own fence-and-close pair: the fence UPDATE and the
+    legacy resume interaction close are one atomic write in
+    ``_update_reply_input_sync`` too. A fence miss (ownership changed under
+    this lease) must roll back both together, not close the row while
+    rejecting the input.
+
+    What this actually pins is that the close must never commit
+    independently of the host transaction -- reordering the two statements
+    within that same transaction changes nothing observable, because a
+    rollback undoes every statement issued since the last commit regardless
+    of program order. Turning this red needs two changes at once, the same
+    pair the a2a-side test calls out: the close must move ahead of the
+    fence's early return (unreachable there today, since a fence miss
+    returns before the close ever runs) and it must commit independently of
+    this function's session.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id="run-reply-atomicity")
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        # _create_waiting_task leaves the task in waiting_for_user with no
+        # lease held (mirrors a real ask_user_question turn). This test
+        # needs a live RUNNING lease for the fence UPDATE to have a chance
+        # of matching, under a runner_id the stale lease below deliberately
+        # does not share -- the fence's WHERE clause requires an exact
+        # match, so that lease has already lost the race by the time the
+        # write is attempted.
+        task.status = TaskStatus.RUNNING
+        task.runner_id = "current-runner"
+        task.interaction_protocol_version = 1
+        db.commit()
+    finally:
+        db.close()
+    row_id = _seed_active_interaction_row(
+        task_id, run_id="run-reply-atomicity", idempotency_key="reply-atomicity-q1"
+    )
+
+    stale_lease = TaskLease(
+        task_id=task_id, runner_id="a-different-runner", run_id="run-reply-atomicity"
+    )
+    updated = task_reply_module._update_reply_input_sync(stale_lease, "attempted text")
+
+    assert updated is False
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == row_id)
+            .one()
+        )
+        assert row.status == "active"
+        refreshed = db.query(Task).filter(Task.id == task_id).one()
+        assert refreshed.interaction_protocol_version == 1
+        # Unchanged from _create_task's original content, not overwritten
+        # with the rejected fence write's "attempted text".
+        assert refreshed.input == "hello"
+    finally:
+        db.close()
+
+
 def test_reply_checkpoint_missing_restore_clears_an_unpaired_marker(mock_start_task):
     """The restore (abandonment) branch's compensation cleanup: when
     post_user_message returns False, the prelease is released back to

--- a/tests/web/services/task_interaction_schema_shared.py
+++ b/tests/web/services/task_interaction_schema_shared.py
@@ -183,6 +183,63 @@ def make_row(
     return row
 
 
+def seed_task_with_run(db: Session, *, run_id: str, marker: int | None) -> int:
+    """Create a task pinned to ``run_id`` with the given protocol marker.
+
+    Shared by test_task_interaction_close.py (SQLite) and
+    test_task_interaction_close_postgresql.py (PostgreSQL) -- previously
+    defined identically, six lines apart, in both files.
+    """
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    db.query(Task).filter(Task.id == task_id).update(
+        {Task.run_id: run_id, Task.interaction_protocol_version: marker}
+    )
+    db.commit()
+    return task_id
+
+
+def seed_active_row(db: Session, *, task_id: int, run_id: str) -> int:
+    """Create one active TaskInteractionRequest row for ``(task_id, run_id)``.
+
+    Shared by test_task_interaction_close.py and
+    test_task_interaction_close_postgresql.py.
+    """
+    anchor_id = make_trace_event(db, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_row(task_id=task_id, resume_trace_event_id=anchor_id, run_id=run_id)
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return int(row.id)
+
+
+def row_state(db: Session, row_id: int) -> TaskInteractionRequest:
+    """Re-read one TaskInteractionRequest row past the session's identity cache.
+
+    Shared by test_task_interaction_close.py and
+    test_task_interaction_close_postgresql.py.
+    """
+    db.expire_all()
+    return (
+        db.query(TaskInteractionRequest)
+        .filter(TaskInteractionRequest.id == row_id)
+        .one()
+    )
+
+
+def task_marker(db: Session, task_id: int) -> int | None:
+    """Re-read a task's interaction_protocol_version past the session's
+    identity cache.
+
+    Shared by test_task_interaction_close.py and
+    test_task_interaction_close_postgresql.py.
+    """
+    db.expire_all()
+    return db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
+
+
 def assert_accepted(db: Session, row: dict[str, object]) -> TaskInteractionRequest:
     """Insert ``row``, commit, and confirm it reads back.
 

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -122,14 +122,36 @@ def _call_lines(tree: ast.AST, *, attr: str) -> list[int]:
 
 
 def _key_share_lock_read_lines(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``with_for_update(...)`` call that actually
+    takes the FOR NO KEY UPDATE lock the ordering obligation requires.
+
+    Verified against this repo's SQLAlchemy 2.0.47: ``key_share=True``
+    alone renders FOR NO KEY UPDATE, the strength this obligation needs.
+    ``key_share=False`` renders plain FOR UPDATE -- a stronger, deadlock-
+    prone lock the obligation's argument does not sanction -- so a literal
+    ``True`` is required, not just the keyword's presence. Adding
+    ``read=True`` alongside ``key_share=True`` renders FOR KEY SHARE
+    instead, a weaker lock that does not carry the ordering argument
+    either, so any call with a ``read`` keyword is excluded regardless of
+    its value.
+    """
     lines = []
     for node in ast.walk(tree):
-        if (
+        if not (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "with_for_update"
-            and any(kw.arg == "key_share" for kw in node.keywords)
         ):
+            continue
+        key_share_kw = next((kw for kw in node.keywords if kw.arg == "key_share"), None)
+        if key_share_kw is None:
+            continue
+        is_literal_true = (
+            isinstance(key_share_kw.value, ast.Constant)
+            and key_share_kw.value.value is True
+        )
+        has_read_kw = any(kw.arg == "read" for kw in node.keywords)
+        if is_literal_true and not has_read_kw:
             lines.append(node.lineno)
     return lines
 

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -159,9 +159,15 @@ def test_both_websocket_injection_sites_call_the_shared_close_helper() -> None:
 
 
 def test_a2a_resume_input_fence_precedes_the_close_call() -> None:
-    """The A2A resume-input fence UPDATE is the first statement this
-    transaction directs at tasks or task_interaction_requests -- it must
-    precede the close call it satisfies the lock obligation for.
+    """The A2A resume-input fence UPDATE must precede the close call it
+    satisfies the lock obligation for.
+
+    This only checks source order between the fence UPDATE and the close
+    call, not that the fence UPDATE is literally the first statement the
+    transaction issues against ``tasks`` or ``task_interaction_requests``
+    -- see the module docstring and ``_update_a2a_resume_input_sync``'s own
+    inline comment for that broader claim, which this assertion does not
+    prove.
 
     Moving the fence UPDATE after the close call turns this red.
     """
@@ -186,6 +192,34 @@ def test_a2a_resume_input_fence_precedes_the_close_call() -> None:
         "the resume-input fence UPDATE must precede the call into "
         "close_legacy_resume_interaction"
     )
+
+
+def _fence_update_value_columns(fn: ast.AST) -> set[str]:
+    """Attribute names (``Task.<name>``) used as keys in the resume-input
+    fence's ``.update({...})`` values dict."""
+    for node in ast.walk(fn):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "update"
+            and node.args
+            and isinstance(node.args[0], ast.Dict)
+        ):
+            continue
+        return {key.attr for key in node.args[0].keys if isinstance(key, ast.Attribute)}
+    raise AssertionError("no .update({...}) call found")
+
+
+def test_a2a_resume_input_fence_writes_exactly_the_approved_columns() -> None:
+    """The fence UPDATE's no-lock-read argument (see
+    _update_a2a_resume_input_sync's inline comment) holds only because every
+    column it writes is a non-key column. Adding a key column -- or any
+    column covered by a unique index -- to the UPDATE's values without
+    re-justifying that argument and widening
+    a2a.RESUME_INPUT_FENCE_UPDATE_COLUMNS to match must turn this red.
+    """
+    fn = _find_function(ast.parse(_source(a2a)), "_update_a2a_resume_input_sync")
+    assert _fence_update_value_columns(fn) == set(a2a.RESUME_INPUT_FENCE_UPDATE_COLUMNS)
 
 
 def _sa_update_targets(tree: ast.AST) -> list[str]:

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -4,24 +4,26 @@ the shape and reach of the statements and functions that carry it out.
 purge_task_rows closes an interaction row's task before deleting the row
 itself, an ordering fixed by task_deletion.py. The legacy resume close
 statements run in the opposite order (interaction row first, task marker
-second), so each of the three call sites needs a lock read on the task row,
+second), so each of the four call sites needs a lock read on the task row,
 taken before either statement, to keep that reversed order from closing a
 lock cycle with purge at any lock level purge itself might take.
 
-The obligation splits into two halves because the three call sites satisfy
-it two different ways (see task_interaction_close.py's module docstring
-and _update_a2a_resume_input_sync's inline comment):
+The obligation splits into two halves because the four call sites satisfy
+it two different ways (see task_interaction_close.py's module docstring,
+_update_a2a_resume_input_sync's inline comment, and
+_update_reply_input_sync's inline comment):
 
 * The two WebSocket injection sites (websocket.py) share one
   short-transaction helper, close_legacy_resume_interaction_sync, which
   takes one explicit FOR NO KEY UPDATE / key_share=True lock read before
   calling into the close-and-clear function -- one lock read, not two,
   because the obligation moved into the shared helper.
-* The A2A resume-input site (a2a.py) takes no lock read of its own: the
-  resume-input fence UPDATE it already issues, ahead of the close call, is
-  the first statement that transaction directs at tasks or
-  task_interaction_requests, and (being a non-key-column UPDATE) already
-  carries the ordering and strength this obligation asks for.
+* The A2A resume-input site (a2a.py) and the v1 reply resume-input site
+  (task_reply.py) each take no lock read of their own: the resume-input
+  fence UPDATE each already issues, ahead of its close call, is the first
+  statement that transaction directs at tasks or task_interaction_requests,
+  and (being a non-key-column UPDATE) already carries the ordering and
+  strength this obligation asks for.
 
 This is a static, AST-based check of source order, not a live-database
 lock test: it proves the statements appear in the required order in the
@@ -36,11 +38,20 @@ the module issues exactly the three UPDATE statements the design calls
 for, against exactly the tables named; and the unlocked
 close_legacy_resume_interaction (no lock read of its own -- it relies on
 its caller to have taken one, or to already hold an equivalent guarantee)
-is called from nowhere outside this module except the one site that has
-proven it satisfies that obligation another way. A new caller added
-without a lock read of its own, or without the A2A site's fence-ordering
-argument, would defeat the whole point of splitting the obligation into
-two halves above.
+is called from nowhere outside this module except the two sites that have
+proven they satisfy that obligation another way. A new caller added
+without a lock read of its own, or without the fence-ordering argument the
+A2A and v1 reply sites each carry, would defeat the whole point of
+splitting the obligation into two halves above.
+
+A third guard (below the two per-obligation halves) covers a different
+question entirely: every web/ module that injects a message via
+post_user_message, regardless of whether it satisfies the lock-ordering
+obligation through the shared WebSocket helper or the fence-ordering
+argument, must also wire in some close-family function -- otherwise a
+legacy resume answers a question without ever retiring the marker that
+names it. That guard is a static, module-level check, not a proof that
+the close call runs on every code path.
 """
 
 from __future__ import annotations
@@ -50,17 +61,34 @@ from pathlib import Path
 
 import xagent
 from xagent.web.api import a2a, websocket
+from xagent.web.api.v1 import task_reply
 from xagent.web.services import task_interaction_close
 
 CLOSE_MODULE_NAME = "task_interaction_close"
 UNLOCKED_CLOSE_FUNCTION = "close_legacy_resume_interaction"
-# The only caller allowed to reach the unlocked function directly, because
-# it has its own argument for why no lock read is needed (see
-# _update_a2a_resume_input_sync's inline comment): its ownership fence
-# UPDATE is already the first statement the transaction directs at tasks
-# or task_interaction_requests. Any other name added here must carry the
-# same kind of argument, not just a passing test.
-APPROVED_UNLOCKED_CALLERS = frozenset({"a2a"})
+# The only callers allowed to reach the unlocked function directly, because
+# each has its own argument for why no lock read is needed (see
+# _update_a2a_resume_input_sync's and _update_reply_input_sync's inline
+# comments): each site's ownership fence UPDATE is already the first
+# statement the transaction directs at tasks or task_interaction_requests.
+# Any other name added here must carry the same kind of argument, not just
+# a passing test.
+APPROVED_UNLOCKED_CALLERS = frozenset({"a2a", "task_reply"})
+
+POST_USER_MESSAGE_CALL_NAME = "post_user_message"
+CLOSE_FAMILY_CALL_NAMES = frozenset(
+    {
+        "close_legacy_resume_interaction",
+        "close_legacy_resume_interaction_sync",
+        "clear_interaction_marker_if_unpaired",
+    }
+)
+# web/ modules that call post_user_message but are exempt from the
+# close-family wiring obligation checked below. Empty by construction:
+# every known post_user_message call site today (a2a.py, websocket.py,
+# task_reply.py) wires in a close-family call. A new call site should wire
+# one in too, not be added here as an exception.
+APPROVED_UNWIRED_POST_USER_MESSAGE_CALLERS: frozenset[str] = frozenset()
 
 
 def _source(module) -> str:
@@ -222,6 +250,50 @@ def test_a2a_resume_input_fence_writes_exactly_the_approved_columns() -> None:
     assert _fence_update_value_columns(fn) == set(a2a.RESUME_INPUT_FENCE_UPDATE_COLUMNS)
 
 
+def test_reply_resume_input_fence_precedes_the_close_call() -> None:
+    """The v1 reply resume-input fence UPDATE must precede the close call it
+    satisfies the lock obligation for -- the same argument as the A2A site,
+    applied to task_reply.py's own fence-and-close pair.
+
+    Moving the fence UPDATE after the close call turns this red.
+    """
+    fn = _find_function(ast.parse(_source(task_reply)), "_update_reply_input_sync")
+    fence_update_lines = [
+        node.lineno
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "update"
+    ]
+    assert len(fence_update_lines) == 1, (
+        "expected exactly one .update(...) call in "
+        f"_update_reply_input_sync, found {len(fence_update_lines)}"
+    )
+    close_call_lines = _call_lines(fn, attr="close_legacy_resume_interaction")
+    assert len(close_call_lines) == 1, (
+        "expected exactly one call into close_legacy_resume_interaction from "
+        f"_update_reply_input_sync, found {len(close_call_lines)}"
+    )
+    assert fence_update_lines[0] < close_call_lines[0], (
+        "the resume-input fence UPDATE must precede the call into "
+        "close_legacy_resume_interaction"
+    )
+
+
+def test_reply_resume_input_fence_writes_exactly_the_approved_columns() -> None:
+    """The v1 reply fence UPDATE's no-lock-read argument (see
+    _update_reply_input_sync's inline comment) holds only because every
+    column it writes is a non-key column, the same argument the A2A site
+    makes. Adding a key column -- or any column covered by a unique index --
+    to the UPDATE's values without re-justifying that argument and widening
+    task_reply.RESUME_INPUT_FENCE_UPDATE_COLUMNS to match must turn this red.
+    """
+    fn = _find_function(ast.parse(_source(task_reply)), "_update_reply_input_sync")
+    assert _fence_update_value_columns(fn) == set(
+        task_reply.RESUME_INPUT_FENCE_UPDATE_COLUMNS
+    )
+
+
 def _sa_update_targets(tree: ast.AST) -> list[str]:
     """The target table name of every ``sa.update(<Table>)`` call, in
     source order. Matched on ``sa.update(...)`` specifically (the Core
@@ -258,13 +330,13 @@ def _calls_to(tree: ast.AST, *, name: str) -> bool:
     return bool(_call_lines(tree, attr=name))
 
 
-def test_unlocked_close_is_only_called_from_the_approved_a2a_site() -> None:
+def test_unlocked_close_is_only_called_from_the_approved_sites() -> None:
     """close_legacy_resume_interaction takes no lock read of its own -- it
     relies on its caller to already satisfy that obligation another way
     (see the module docstring above). Scans every source file under the
     installed xagent package, so a new caller added anywhere without
     updating APPROVED_UNLOCKED_CALLERS is caught regardless of which
-    package it lands in, not only websocket.py and a2a.py.
+    package it lands in, not only websocket.py, a2a.py, and task_reply.py.
 
     Known blind spot, not fixed here: this matches the call as written
     (``close_legacy_resume_interaction(...)`` or
@@ -287,4 +359,41 @@ def test_unlocked_close_is_only_called_from_the_approved_a2a_site() -> None:
     assert callers == APPROVED_UNLOCKED_CALLERS, (
         f"unlocked close_legacy_resume_interaction is called from {callers}, "
         f"expected exactly {set(APPROVED_UNLOCKED_CALLERS)}"
+    )
+
+
+def test_every_post_user_message_caller_wires_the_close_family() -> None:
+    """Every web/ module that injects a message via post_user_message must
+    also call one of the close-family functions somewhere in the same
+    module, or a legacy resume can answer a question through that module
+    without ever retiring the marker that names it.
+
+    This is a module-level check, not a call-site-level one: it proves a
+    close-family call exists somewhere in the module, not that it runs on
+    every code path that reaches post_user_message. Today's three call
+    sites (a2a.py, websocket.py x2, task_reply.py) each carry their own
+    per-site argument for why their wiring is complete; see the tests
+    above and task_interaction_close.py's module docstring.
+
+    Deleting a close-family call from a module that calls
+    post_user_message, without adding the module to
+    APPROVED_UNWIRED_POST_USER_MESSAGE_CALLERS, turns this red.
+    """
+    root = Path(next(iter(xagent.__path__))) / "web"
+    unwired: set[str] = set()
+    for path in root.rglob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        if not _calls_to(tree, name=POST_USER_MESSAGE_CALL_NAME):
+            continue
+        if path.stem in APPROVED_UNWIRED_POST_USER_MESSAGE_CALLERS:
+            continue
+        if not any(_calls_to(tree, name=n) for n in CLOSE_FAMILY_CALL_NAMES):
+            unwired.add(path.stem)
+    assert not unwired, (
+        f"modules {unwired} call post_user_message but wire in no "
+        "close-family function (close_legacy_resume_interaction[_sync] / "
+        "clear_interaction_marker_if_unpaired); either wire one in or add "
+        "the module to APPROVED_UNWIRED_POST_USER_MESSAGE_CALLERS with a "
+        "documented reason"
     )

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -394,8 +394,8 @@ def test_every_post_user_message_caller_wires_the_close_family() -> None:
     close-family call exists somewhere in the module, not that it runs on
     every code path that reaches post_user_message. Today's four call
     sites across three modules (a2a.py, websocket.py x2, task_reply.py)
-    each carry their own
-    per-site argument for why their wiring is complete; see the tests
+    each carry their own per-site argument for why their wiring is
+    complete; see the tests
     above and task_interaction_close.py's module docstring.
 
     Deleting a close-family call from a module that calls

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -244,6 +244,84 @@ def test_a2a_resume_input_fence_precedes_the_close_call() -> None:
     )
 
 
+TABLE_EXISTS_CHECK_NAME = "interaction_requests_table_exists"
+
+
+def _table_exists_guard_line_for_close_call(
+    fn: ast.AST, *, close_call_attr: str
+) -> int | None:
+    """Line number of an ``if interaction_requests_table_exists(...):``
+    guard whose body contains a call to ``close_call_attr``, or ``None`` if
+    no such guard wraps that call."""
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        test_name = None
+        if isinstance(test, ast.Call):
+            func = test.func
+            test_name = (
+                func.attr
+                if isinstance(func, ast.Attribute)
+                else getattr(func, "id", None)
+            )
+        if test_name != TABLE_EXISTS_CHECK_NAME:
+            continue
+        for inner in ast.walk(node):
+            if inner is node:
+                continue
+            if not isinstance(inner, ast.Call):
+                continue
+            inner_func = inner.func
+            inner_name = (
+                inner_func.attr
+                if isinstance(inner_func, ast.Attribute)
+                else getattr(inner_func, "id", None)
+            )
+            if inner_name == close_call_attr:
+                return node.lineno
+    return None
+
+
+def test_a2a_resume_input_close_is_gated_by_table_exists_check() -> None:
+    """The A2A fence-and-close site must confirm
+    task_interaction_requests exists before calling
+    close_legacy_resume_interaction. Nothing else in this repo pins that
+    gate down: every test database already has the table, so deleting the
+    gate leaves the rest of the suite green.
+
+    Deleting the ``if interaction_requests_table_exists(db):`` guard, or
+    moving the close call outside its body, turns this red.
+    """
+    fn = _find_function(ast.parse(_source(a2a)), "_update_a2a_resume_input_sync")
+    guard_line = _table_exists_guard_line_for_close_call(
+        fn, close_call_attr="close_legacy_resume_interaction"
+    )
+    assert guard_line is not None, (
+        "expected close_legacy_resume_interaction to be called inside an "
+        "`if interaction_requests_table_exists(db):` guard in "
+        "_update_a2a_resume_input_sync"
+    )
+
+
+def test_reply_resume_input_close_is_gated_by_table_exists_check() -> None:
+    """Same obligation as the A2A site, above, for task_reply.py's
+    fence-and-close pair.
+
+    Deleting the ``if interaction_requests_table_exists(db):`` guard, or
+    moving the close call outside its body, turns this red.
+    """
+    fn = _find_function(ast.parse(_source(task_reply)), "_update_reply_input_sync")
+    guard_line = _table_exists_guard_line_for_close_call(
+        fn, close_call_attr="close_legacy_resume_interaction"
+    )
+    assert guard_line is not None, (
+        "expected close_legacy_resume_interaction to be called inside an "
+        "`if interaction_requests_table_exists(db):` guard in "
+        "_update_reply_input_sync"
+    )
+
+
 def _fence_update_value_columns(fn: ast.AST) -> set[str]:
     """Attribute names (``Task.<name>``) used as keys in the resume-input
     fence's ``.update({...})`` values dict."""
@@ -397,6 +475,15 @@ def test_every_post_user_message_caller_wires_the_close_family() -> None:
     each carry their own per-site argument for why their wiring is
     complete; see the tests
     above and task_interaction_close.py's module docstring.
+
+    Scan root is xagent/web, not the whole installed xagent package: the
+    scan is looking for callers of post_user_message, but post_user_message
+    is itself *defined* under xagent/core/agent (service.py, runner.py,
+    registry.py, execution_adapter.py), where each layer's delegation to
+    the next also matches the same AST call-name check. Widening the root
+    to include core/ would catch those internal delegations as unwired
+    callers and turn this permanently red for a reason unrelated to the
+    wiring obligation being checked.
 
     Deleting a close-family call from a module that calls
     post_user_message, without adding the module to

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -392,8 +392,9 @@ def test_every_post_user_message_caller_wires_the_close_family() -> None:
 
     This is a module-level check, not a call-site-level one: it proves a
     close-family call exists somewhere in the module, not that it runs on
-    every code path that reaches post_user_message. Today's three call
-    sites (a2a.py, websocket.py x2, task_reply.py) each carry their own
+    every code path that reaches post_user_message. Today's four call
+    sites across three modules (a2a.py, websocket.py x2, task_reply.py)
+    each carry their own
     per-site argument for why their wiring is complete; see the tests
     above and task_interaction_close.py's module docstring.
 

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -1,0 +1,256 @@
+"""Static guard: the legacy resume close's lock ordering against purge, plus
+the shape and reach of the statements and functions that carry it out.
+
+purge_task_rows closes an interaction row's task before deleting the row
+itself, an ordering fixed by task_deletion.py. The legacy resume close
+statements run in the opposite order (interaction row first, task marker
+second), so each of the three call sites needs a lock read on the task row,
+taken before either statement, to keep that reversed order from closing a
+lock cycle with purge at any lock level purge itself might take.
+
+The obligation splits into two halves because the three call sites satisfy
+it two different ways (see task_interaction_close.py's module docstring
+and _update_a2a_resume_input_sync's inline comment):
+
+* The two WebSocket injection sites (websocket.py) share one
+  short-transaction helper, close_legacy_resume_interaction_sync, which
+  takes one explicit FOR NO KEY UPDATE / key_share=True lock read before
+  calling into the close-and-clear function -- one lock read, not two,
+  because the obligation moved into the shared helper.
+* The A2A resume-input site (a2a.py) takes no lock read of its own: the
+  resume-input fence UPDATE it already issues, ahead of the close call, is
+  the first statement that transaction directs at tasks or
+  task_interaction_requests, and (being a non-key-column UPDATE) already
+  carries the ordering and strength this obligation asks for.
+
+This is a static, AST-based check of source order, not a live-database
+lock test: it proves the statements appear in the required order in the
+code, not that they behave correctly under real concurrent access. The real
+concurrency case (purge racing a close, expected to deadlock without the
+lock read) is out of scope here -- it needs the retirement finalizers in
+place to be exercised meaningfully at all.
+
+Two further guards close out what "the statements only live in one place,
+and the unlocked function is only reachable through it" actually means:
+the module issues exactly the three UPDATE statements the design calls
+for, against exactly the tables named; and the unlocked
+close_legacy_resume_interaction (no lock read of its own -- it relies on
+its caller to have taken one, or to already hold an equivalent guarantee)
+is called from nowhere outside this module except the one site that has
+proven it satisfies that obligation another way. A new caller added
+without a lock read of its own, or without the A2A site's fence-ordering
+argument, would defeat the whole point of splitting the obligation into
+two halves above.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import xagent
+from xagent.web.api import a2a, websocket
+from xagent.web.services import task_interaction_close
+
+CLOSE_MODULE_NAME = "task_interaction_close"
+UNLOCKED_CLOSE_FUNCTION = "close_legacy_resume_interaction"
+# The only caller allowed to reach the unlocked function directly, because
+# it has its own argument for why no lock read is needed (see
+# _update_a2a_resume_input_sync's inline comment): its ownership fence
+# UPDATE is already the first statement the transaction directs at tasks
+# or task_interaction_requests. Any other name added here must carry the
+# same kind of argument, not just a passing test.
+APPROVED_UNLOCKED_CALLERS = frozenset({"a2a"})
+
+
+def _source(module) -> str:
+    return Path(module.__file__).read_text()
+
+
+def _find_function(tree: ast.AST, name: str):
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ):
+            return node
+    raise AssertionError(f"function {name!r} not found")
+
+
+def _call_lines(tree: ast.AST, *, attr: str) -> list[int]:
+    """Line numbers of every Call whose callee name (attribute or bare
+    name) matches ``attr``."""
+    lines = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else None
+        if name is None and isinstance(func, ast.Name):
+            name = func.id
+        if name == attr:
+            lines.append(node.lineno)
+    return lines
+
+
+def _key_share_lock_read_lines(tree: ast.AST) -> list[int]:
+    lines = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "with_for_update"
+            and any(kw.arg == "key_share" for kw in node.keywords)
+        ):
+            lines.append(node.lineno)
+    return lines
+
+
+def test_close_sync_takes_the_lock_read_before_the_close_call() -> None:
+    """The two WebSocket injection sites' shared helper: one
+    key_share=True lock read, ahead of the call into the close-and-clear
+    function.
+
+    Deleting the lock read turns this red.
+    """
+    fn = _find_function(
+        ast.parse(_source(task_interaction_close)),
+        "close_legacy_resume_interaction_sync",
+    )
+    lock_read_lines = _key_share_lock_read_lines(fn)
+    assert len(lock_read_lines) == 1, (
+        "expected exactly one key_share=True lock read in "
+        f"close_legacy_resume_interaction_sync, found {len(lock_read_lines)}"
+    )
+    close_call_lines = _call_lines(fn, attr="close_legacy_resume_interaction")
+    assert len(close_call_lines) == 1, (
+        "expected exactly one call into close_legacy_resume_interaction from "
+        f"close_legacy_resume_interaction_sync, found {len(close_call_lines)}"
+    )
+    assert lock_read_lines[0] < close_call_lines[0], (
+        "the key_share lock read must precede the call into "
+        "close_legacy_resume_interaction"
+    )
+
+
+def test_both_websocket_injection_sites_call_the_shared_close_helper() -> None:
+    """The online and deferred injection handlers each call the shared
+    helper exactly once, and it is called from nowhere else in the
+    module."""
+    tree = ast.parse(_source(websocket))
+    online = _find_function(tree, "_handle_chat_message_unserialized")
+    deferred = _find_function(tree, "execute_resume_background")
+    online_calls = _call_lines(online, attr="close_legacy_resume_interaction_sync")
+    deferred_calls = _call_lines(deferred, attr="close_legacy_resume_interaction_sync")
+    assert len(online_calls) == 1, (
+        "expected exactly one close_legacy_resume_interaction_sync call in "
+        f"the online injection handler, found {len(online_calls)}"
+    )
+    assert len(deferred_calls) == 1, (
+        "expected exactly one close_legacy_resume_interaction_sync call in "
+        f"the deferred injection handler, found {len(deferred_calls)}"
+    )
+    all_calls = _call_lines(tree, attr="close_legacy_resume_interaction_sync")
+    assert len(all_calls) == 2, (
+        "close_legacy_resume_interaction_sync must be called from exactly "
+        f"the two websocket injection sites, found {len(all_calls)} call(s) "
+        "across the module"
+    )
+
+
+def test_a2a_resume_input_fence_precedes_the_close_call() -> None:
+    """The A2A resume-input fence UPDATE is the first statement this
+    transaction directs at tasks or task_interaction_requests -- it must
+    precede the close call it satisfies the lock obligation for.
+
+    Moving the fence UPDATE after the close call turns this red.
+    """
+    fn = _find_function(ast.parse(_source(a2a)), "_update_a2a_resume_input_sync")
+    fence_update_lines = [
+        node.lineno
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "update"
+    ]
+    assert len(fence_update_lines) == 1, (
+        "expected exactly one .update(...) call in "
+        f"_update_a2a_resume_input_sync, found {len(fence_update_lines)}"
+    )
+    close_call_lines = _call_lines(fn, attr="close_legacy_resume_interaction")
+    assert len(close_call_lines) == 1, (
+        "expected exactly one call into close_legacy_resume_interaction from "
+        f"_update_a2a_resume_input_sync, found {len(close_call_lines)}"
+    )
+    assert fence_update_lines[0] < close_call_lines[0], (
+        "the resume-input fence UPDATE must precede the call into "
+        "close_legacy_resume_interaction"
+    )
+
+
+def _sa_update_targets(tree: ast.AST) -> list[str]:
+    """The target table name of every ``sa.update(<Table>)`` call, in
+    source order. Matched on ``sa.update(...)`` specifically (the Core
+    form this module uses throughout), not ORM-style ``.query().update()``
+    calls, which this module never issues."""
+    targets = []
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "update"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "sa"
+        ):
+            continue
+        if len(node.args) == 1 and isinstance(node.args[0], ast.Name):
+            targets.append(node.args[0].id)
+        else:
+            targets.append("<unrecognized target shape>")
+    return targets
+
+
+def test_close_module_issues_exactly_the_expected_update_statements() -> None:
+    """The whole module issues exactly three UPDATE statements: the close
+    (task_interaction_requests), its paired unconditional clear (tasks),
+    and the compensation paths' shared NOT-EXISTS-guarded clear (tasks).
+    A fourth statement, or one against an unexpected table, means either a
+    duplicated write path or a table this design never named."""
+    targets = _sa_update_targets(ast.parse(_source(task_interaction_close)))
+    assert targets == ["TaskInteractionRequest", "Task", "Task"], targets
+
+
+def _calls_to(tree: ast.AST, *, name: str) -> bool:
+    return bool(_call_lines(tree, attr=name))
+
+
+def test_unlocked_close_is_only_called_from_the_approved_a2a_site() -> None:
+    """close_legacy_resume_interaction takes no lock read of its own -- it
+    relies on its caller to already satisfy that obligation another way
+    (see the module docstring above). Scans every source file under the
+    installed xagent package, so a new caller added anywhere without
+    updating APPROVED_UNLOCKED_CALLERS is caught regardless of which
+    package it lands in, not only websocket.py and a2a.py.
+
+    Known blind spot, not fixed here: this matches the call as written
+    (``close_legacy_resume_interaction(...)`` or
+    ``some_module.close_legacy_resume_interaction(...)``), not a name
+    reached through a re-export or an alias assigned to another name --
+    the same limitation the interaction-staging production gate documents
+    for its own equivalent scan.
+    """
+    root = Path(next(iter(xagent.__path__)))
+    callers: set[str] = set()
+    for path in root.rglob("*.py"):
+        if path.stem == CLOSE_MODULE_NAME:
+            # This module's own close_legacy_resume_interaction_sync is the
+            # approved lock-reading wrapper; it is expected to call the
+            # unlocked function and is not an "other" caller.
+            continue
+        source = path.read_text(encoding="utf-8")
+        if _calls_to(ast.parse(source), name=UNLOCKED_CLOSE_FUNCTION):
+            callers.add(path.stem)
+    assert callers == APPROVED_UNLOCKED_CALLERS, (
+        f"unlocked close_legacy_resume_interaction is called from {callers}, "
+        f"expected exactly {set(APPROVED_UNLOCKED_CALLERS)}"
+    )

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -15,6 +15,7 @@ tests/web/api/test_a2a_api.py.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -26,10 +27,20 @@ from tests.web.services.task_interaction_schema_shared import (
     make_user,
     tables_excluding_interaction_requests,
 )
-from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models import database as database_module
+from xagent.web.models.database import (
+    Base,
+    configure_db,
+    get_db,
+    get_engine,
+    get_session_local,
+    init_db,
+)
 from xagent.web.models.task import Task
 from xagent.web.models.task_interaction import TaskInteractionRequest
+from xagent.web.services import ops_signals
 from xagent.web.services.task_interaction_close import (
+    _classify_close_rowcount,
     clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction,
     close_legacy_resume_interaction_sync,
@@ -39,6 +50,17 @@ from xagent.web.services.task_interaction_staging import (
     InteractionSlotTaken,
     stage_interaction_request,
 )
+
+_CLOSE_MODULE_NAME = "xagent.web.services.task_interaction_close"
+
+
+@pytest.fixture(autouse=True)
+def _reset_ops_signals():
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+    yield
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
 
 
 @pytest.fixture()
@@ -85,6 +107,49 @@ def _row_state(db, row_id: int) -> TaskInteractionRequest:
 def _task_marker(db, task_id: int) -> int | None:
     db.expire_all()
     return db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
+
+
+# --------------------------------------------------------------------------
+# _classify_close_rowcount -- the one place every rowcount the close
+# statement can produce gets classified, called directly, no database
+# involved.
+# --------------------------------------------------------------------------
+
+
+def test_classify_close_rowcount_logs_info_for_the_expected_single_row_case(
+    caplog,
+) -> None:
+    with caplog.at_level(logging.INFO, logger=_CLOSE_MODULE_NAME):
+        _classify_close_rowcount(1, task_id=1, run_id="run-a")
+
+    assert [record.levelno for record in caplog.records] == [logging.INFO]
+    assert ops_signals.active_degradations() == {}
+
+
+def test_classify_close_rowcount_logs_debug_for_the_common_no_op_case(
+    caplog,
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger=_CLOSE_MODULE_NAME):
+        _classify_close_rowcount(0, task_id=1, run_id="run-a")
+
+    assert [record.levelno for record in caplog.records] == [logging.DEBUG]
+    assert ops_signals.active_degradations() == {}
+
+
+def test_classify_close_rowcount_logs_error_and_registers_a_signal_for_an_impossible_rowcount(
+    caplog,
+) -> None:
+    """rowcount > 1 is impossible under uq_task_interaction_active_slot
+    unless that constraint has already been violated -- see this module's
+    docstring. Logged at error and surfaced on /health, not raised."""
+    with caplog.at_level(logging.ERROR, logger=_CLOSE_MODULE_NAME):
+        _classify_close_rowcount(2, task_id=7, run_id="run-b")
+
+    assert [record.levelno for record in caplog.records] == [logging.ERROR]
+    assert (
+        ops_signals.INTERACTION_LEGACY_RESUME_CLOSE_ROWCOUNT_ANOMALY
+        in ops_signals.active_degradations()
+    )
 
 
 # --------------------------------------------------------------------------
@@ -210,21 +275,36 @@ def test_close_sync_opens_its_own_transaction_and_commits(db) -> None:
 
 @pytest.fixture()
 def db_without_interaction_table(tmp_path):
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import sessionmaker
+    """A deployment shape missing task_interaction_requests -- bound as the
+    *global* engine/session factory, not a private one.
 
-    from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
-
-    engine = create_engine(f"sqlite:///{tmp_path / 'no_interaction_table.db'}")
-    apply_sqlite_concurrency_pragmas(engine)
+    close_legacy_resume_interaction_sync (unlike the other functions this
+    module tests) takes no db argument of its own: it opens its own session
+    through get_session_local(), which reads the process-global factory.
+    A fixture that built its own private engine here and handed back a
+    session from it would leave that global factory pointed wherever the
+    previous test left it, so close_legacy_resume_interaction_sync would run
+    against a different database than the one this fixture seeds and
+    asserts against -- the table-absence gate it is supposed to exercise
+    would never actually see this fixture's schema. configure_db() only
+    binds the engine and session factory; it does not create any tables
+    (unlike init_db()), so the subset schema below is still built by hand.
+    """
+    previous_engine = database_module._engine
+    previous_session_local = database_module._SessionLocal
+    configure_db(db_url=f"sqlite:///{tmp_path / 'no_interaction_table.db'}")
     Base.metadata.create_all(
-        bind=engine, tables=tables_excluding_interaction_requests()
+        bind=get_engine(), tables=tables_excluding_interaction_requests()
     )
-    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+    session = get_session_local()()
     try:
         yield session
     finally:
         session.close()
+        # Restore the prior global factory so this fixture's rebinding does
+        # not leak into whatever test runs next in this file (or module).
+        database_module._engine = previous_engine
+        database_module._SessionLocal = previous_session_local
 
 
 def test_close_no_ops_when_the_interaction_table_does_not_exist(

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -1,0 +1,334 @@
+"""Pin the retirement statements a legacy resume path issues on injection.
+
+``close_legacy_resume_interaction`` (and its short-transaction wrapper
+``close_legacy_resume_interaction_sync``) are exercised directly here at
+the database level: rowcount classification across every input shape the
+close statement can see, the no-op behavior on a deployment without the
+interaction table, and a staging-primitive interaction proving the close
+is a real behavior change, not a no-op. The two WebSocket injection sites
+that wire this into production are covered separately in
+tests/web/api/test_websocket_owner_actor.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.web.services.task_interaction_schema_shared import (
+    make_row,
+    make_task,
+    make_trace_event,
+    make_user,
+    tables_excluding_interaction_requests,
+)
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task
+from xagent.web.models.task_interaction import TaskInteractionRequest
+from xagent.web.services.task_interaction_close import (
+    close_legacy_resume_interaction,
+    close_legacy_resume_interaction_sync,
+)
+from xagent.web.services.task_interaction_staging import (
+    InteractionAnchor,
+    InteractionSlotTaken,
+    stage_interaction_request,
+)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'interaction_close.db'}")
+    session = next(get_db())
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+def _seed_task_with_run(db, *, run_id: str, marker: int | None) -> int:
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    db.query(Task).filter(Task.id == task_id).update(
+        {Task.run_id: run_id, Task.interaction_protocol_version: marker}
+    )
+    db.commit()
+    return task_id
+
+
+def _seed_active_row(db, *, task_id: int, run_id: str) -> int:
+    anchor_id = make_trace_event(db, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_row(task_id=task_id, resume_trace_event_id=anchor_id, run_id=run_id)
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return int(row.id)
+
+
+def _row_state(db, row_id: int) -> TaskInteractionRequest:
+    db.expire_all()
+    return (
+        db.query(TaskInteractionRequest)
+        .filter(TaskInteractionRequest.id == row_id)
+        .one()
+    )
+
+
+def _task_marker(db, task_id: int) -> int | None:
+    db.expire_all()
+    return db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
+
+
+# --------------------------------------------------------------------------
+# Rowcount grid -- every input shape the close statement's WHERE fence sees.
+# --------------------------------------------------------------------------
+
+
+def test_close_retires_the_active_row_for_its_own_run(db) -> None:
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = _seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 1
+    row = _row_state(db, row_id)
+    assert row.status == "terminated"
+    assert row.active_slot is None
+    assert row.terminal_reason == "answered_via_legacy_resume"
+    assert row.terminated_at is not None
+    assert _task_marker(db, task_id) is None
+
+
+def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    anchor_id = make_trace_event(db, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_row(
+            task_id=task_id,
+            resume_trace_event_id=anchor_id,
+            run_id="run-a",
+            status="terminated",
+        )
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    row_id = int(row.id)
+    original_terminal_reason = row.terminal_reason
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 0
+    row = _row_state(db, row_id)
+    assert row.status == "terminated"
+    assert row.terminal_reason == original_terminal_reason
+    # The clear runs unconditionally: a marker left dangling by an earlier,
+    # incomplete write still gets zeroed even though this close matched no
+    # row of its own.
+    assert _task_marker(db, task_id) is None
+
+
+def test_close_is_a_no_op_with_no_interaction_rows_at_all(db) -> None:
+    """Today's 100% case: the table has no production writer yet."""
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=None)
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 0
+    assert _task_marker(db, task_id) is None
+
+
+def test_close_does_not_touch_a_different_runs_active_row(db) -> None:
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    orphan_row_id = _seed_active_row(db, task_id=task_id, run_id="run-b")
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 0
+    orphan = _row_state(db, orphan_row_id)
+    assert orphan.status == "active"
+    # This call's own run still gets its marker cleared -- the orphan row
+    # belongs to a different run's marker, which this call never touches.
+    assert _task_marker(db, task_id) is None
+
+
+def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_reason(
+    db,
+) -> None:
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=None)
+    anchor_id = make_trace_event(db, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_row(
+            task_id=task_id,
+            resume_trace_event_id=anchor_id,
+            run_id="run-a",
+            status="terminated",
+            terminal_reason="run_superseded",
+        )
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    row_id = int(row.id)
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 0
+    assert _row_state(db, row_id).terminal_reason == "run_superseded"
+
+
+def test_close_sync_opens_its_own_transaction_and_commits(db) -> None:
+    """The short-transaction wrapper the two WebSocket injection sites
+    share: no caller-held session."""
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = _seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a")
+
+    assert rowcount == 1
+    assert _row_state(db, row_id).status == "terminated"
+    assert _task_marker(db, task_id) is None
+
+
+# --------------------------------------------------------------------------
+# Table absent -- a deployment not yet migrated to task_interaction_requests.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_without_interaction_table(tmp_path):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'no_interaction_table.db'}")
+    apply_sqlite_concurrency_pragmas(engine)
+    Base.metadata.create_all(
+        bind=engine, tables=tables_excluding_interaction_requests()
+    )
+    session = sessionmaker(autocommit=False, autoflush=False, bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_close_no_ops_when_the_interaction_table_does_not_exist(
+    db_without_interaction_table,
+) -> None:
+    db = db_without_interaction_table
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    db.query(Task).filter(Task.id == task_id).update(
+        {Task.run_id: "run-a", Task.interaction_protocol_version: 1}
+    )
+    db.commit()
+
+    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a")
+
+    assert rowcount == 0
+    # The gate is checked before the marker clear too: close_legacy_resume_
+    # interaction_sync returns before opening the lock read or the clear
+    # statement, so a deployment without the table pays for neither.
+    db.expire_all()
+    assert (
+        db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
+        == 1
+    )
+
+
+# --------------------------------------------------------------------------
+# The close statement is a real behavior change, not a no-op: staging a
+# second question on the same run behaves differently depending on whether
+# it ran.
+# --------------------------------------------------------------------------
+
+
+def _stage(db, *, task_id: int, run_id: str, anchor_id: int, key: str):
+    now = datetime.now(timezone.utc)
+    return stage_interaction_request(
+        db,
+        task_id=task_id,
+        run_id=run_id,
+        anchor=InteractionAnchor(
+            trace_event_id=anchor_id,
+            resume_event_id="resume-event-1",
+            resume_execution_id="resume-exec-1",
+            resume_run_partition=run_id,
+        ),
+        kind="clarification",
+        protocol_version=1,
+        origin="internal",
+        request_payload={"prompt": key},
+        request_idempotency_key=key,
+        expires_at=now + timedelta(minutes=15),
+        now=now,
+    )
+
+
+def test_close_lets_a_second_question_on_the_same_run_become_active(db) -> None:
+    """Deleting the close call must turn this red: without it, the second
+    stage attempt collides with the first question's still-active slot and
+    raises InteractionSlotTaken instead of ever becoming the active row."""
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    anchor_id = make_trace_event(db, task_id=task_id)
+
+    first = _stage(db, task_id=task_id, run_id="run-a", anchor_id=anchor_id, key="q1")
+    db.commit()
+    assert first.created is True
+
+    close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    second = _stage(db, task_id=task_id, run_id="run-a", anchor_id=anchor_id, key="q2")
+    db.commit()
+
+    assert second.created is True
+    active = (
+        db.query(TaskInteractionRequest)
+        .filter(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.status == "active",
+        )
+        .one()
+    )
+    assert active.id == second.staged_db_id
+    assert active.request_idempotency_key == "q2"
+
+
+def test_without_the_close_call_a_second_question_cannot_become_active(db) -> None:
+    """The 'delete the close call' mutation, run for real: with no close in
+    between, the first question's active row is still fresh (not expired,
+    same run), so the second stage attempt's INSERT collides with the
+    unique active-slot constraint and raises InteractionSlotTaken -- the
+    first question remains the only active row."""
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    anchor_id = make_trace_event(db, task_id=task_id)
+
+    first = _stage(db, task_id=task_id, run_id="run-a", anchor_id=anchor_id, key="q1")
+    db.commit()
+
+    with pytest.raises(InteractionSlotTaken):
+        _stage(db, task_id=task_id, run_id="run-a", anchor_id=anchor_id, key="q2")
+    db.rollback()
+
+    active = (
+        db.query(TaskInteractionRequest)
+        .filter(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.status == "active",
+        )
+        .one()
+    )
+    assert active.id == first.staged_db_id
+    assert active.request_idempotency_key == "q1"

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -1,13 +1,16 @@
-"""Pin the retirement statements a legacy resume path issues on injection.
+"""Pin the retirement and marker-clear statements a legacy resume path issues.
 
 ``close_legacy_resume_interaction`` (and its short-transaction wrapper
-``close_legacy_resume_interaction_sync``) are exercised directly here at
-the database level: rowcount classification across every input shape the
-close statement can see, the no-op behavior on a deployment without the
-interaction table, and a staging-primitive interaction proving the close
-is a real behavior change, not a no-op. The two WebSocket injection sites
-that wire this into production are covered separately in
-tests/web/api/test_websocket_owner_actor.py.
+``close_legacy_resume_interaction_sync``) and
+``clear_interaction_marker_if_unpaired`` are exercised directly here at the
+database level: rowcount classification across every input shape the close
+statement can see, the no-op behavior on a deployment without the
+interaction table, the ``NOT EXISTS`` guard the two marker-clear-only call
+sites depend on, and a staging-primitive interaction proving the close is a
+real behavior change, not a no-op. The production call sites that wire
+these functions into the WebSocket and A2A resume paths are covered
+separately in tests/web/api/test_websocket_owner_actor.py and
+tests/web/api/test_a2a_api.py.
 """
 
 from __future__ import annotations
@@ -27,6 +30,7 @@ from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services.task_interaction_close import (
+    clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction,
     close_legacy_resume_interaction_sync,
 )
@@ -245,6 +249,70 @@ def test_close_no_ops_when_the_interaction_table_does_not_exist(
         db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
         == 1
     )
+
+
+def test_clear_marker_if_unpaired_no_ops_when_the_interaction_table_does_not_exist(
+    db_without_interaction_table,
+) -> None:
+    db = db_without_interaction_table
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    db.query(Task).filter(Task.id == task_id).update(
+        {Task.run_id: "run-a", Task.interaction_protocol_version: 1}
+    )
+    db.commit()
+
+    clear_interaction_marker_if_unpaired(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    db.expire_all()
+    assert (
+        db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
+        == 1
+    )
+
+
+# --------------------------------------------------------------------------
+# Compensation clear -- the NOT EXISTS guard.
+# --------------------------------------------------------------------------
+
+
+def test_clear_marker_if_unpaired_zeroes_a_marker_with_no_active_row(db) -> None:
+    """Sequence 'close already committed, then a compensation path runs'.
+
+    The row is already terminated (the close already ran); a marker left
+    at 1 -- however that happened -- has nothing to protect and is zeroed.
+    """
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    anchor_id = make_trace_event(db, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_row(
+            task_id=task_id,
+            resume_trace_event_id=anchor_id,
+            run_id="run-a",
+            status="terminated",
+        )
+    )
+    db.add(row)
+    db.commit()
+
+    clear_interaction_marker_if_unpaired(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert _task_marker(db, task_id) is None
+
+
+def test_clear_marker_if_unpaired_leaves_a_still_active_row_untouched(db) -> None:
+    """This is the mutation-testable half: removing the NOT EXISTS guard
+    would zero a marker that still names a live question."""
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = _seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    clear_interaction_marker_if_unpaired(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert _task_marker(db, task_id) == 1
+    assert _row_state(db, row_id).status == "active"
 
 
 # --------------------------------------------------------------------------

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -25,7 +25,11 @@ from tests.web.services.task_interaction_schema_shared import (
     make_task,
     make_trace_event,
     make_user,
+    row_state,
+    seed_active_row,
+    seed_task_with_run,
     tables_excluding_interaction_requests,
+    task_marker,
 )
 from xagent.web.models import database as database_module
 from xagent.web.models.database import (
@@ -72,41 +76,6 @@ def db(tmp_path):
     finally:
         session.close()
         Base.metadata.drop_all(bind=get_engine())
-
-
-def _seed_task_with_run(db, *, run_id: str, marker: int | None) -> int:
-    user_id = make_user(db)
-    task_id = make_task(db, user_id=user_id)
-    db.query(Task).filter(Task.id == task_id).update(
-        {Task.run_id: run_id, Task.interaction_protocol_version: marker}
-    )
-    db.commit()
-    return task_id
-
-
-def _seed_active_row(db, *, task_id: int, run_id: str) -> int:
-    anchor_id = make_trace_event(db, task_id=task_id)
-    row = TaskInteractionRequest(
-        **make_row(task_id=task_id, resume_trace_event_id=anchor_id, run_id=run_id)
-    )
-    db.add(row)
-    db.commit()
-    db.refresh(row)
-    return int(row.id)
-
-
-def _row_state(db, row_id: int) -> TaskInteractionRequest:
-    db.expire_all()
-    return (
-        db.query(TaskInteractionRequest)
-        .filter(TaskInteractionRequest.id == row_id)
-        .one()
-    )
-
-
-def _task_marker(db, task_id: int) -> int | None:
-    db.expire_all()
-    return db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
 
 
 # --------------------------------------------------------------------------
@@ -158,23 +127,23 @@ def test_classify_close_rowcount_logs_error_and_registers_a_signal_for_an_imposs
 
 
 def test_close_retires_the_active_row_for_its_own_run(db) -> None:
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
-    row_id = _seed_active_row(db, task_id=task_id, run_id="run-a")
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
     rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
     db.commit()
 
     assert rowcount == 1
-    row = _row_state(db, row_id)
+    row = row_state(db, row_id)
     assert row.status == "terminated"
     assert row.active_slot is None
     assert row.terminal_reason == "answered_via_legacy_resume"
     assert row.terminated_at is not None
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     anchor_id = make_trace_event(db, task_id=task_id)
     row = TaskInteractionRequest(
         **make_row(
@@ -194,45 +163,45 @@ def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
     db.commit()
 
     assert rowcount == 0
-    row = _row_state(db, row_id)
+    row = row_state(db, row_id)
     assert row.status == "terminated"
     assert row.terminal_reason == original_terminal_reason
     # The clear runs unconditionally: a marker left dangling by an earlier,
     # incomplete write still gets zeroed even though this close matched no
     # row of its own.
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_close_is_a_no_op_with_no_interaction_rows_at_all(db) -> None:
     """Today's 100% case: the table has no production writer yet."""
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=None)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=None)
 
     rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
     db.commit()
 
     assert rowcount == 0
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_close_does_not_touch_a_different_runs_active_row(db) -> None:
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
-    orphan_row_id = _seed_active_row(db, task_id=task_id, run_id="run-b")
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    orphan_row_id = seed_active_row(db, task_id=task_id, run_id="run-b")
 
     rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
     db.commit()
 
     assert rowcount == 0
-    orphan = _row_state(db, orphan_row_id)
+    orphan = row_state(db, orphan_row_id)
     assert orphan.status == "active"
     # This call's own run still gets its marker cleared -- the orphan row
     # belongs to a different run's marker, which this call never touches.
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_reason(
     db,
 ) -> None:
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=None)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=None)
     anchor_id = make_trace_event(db, task_id=task_id)
     row = TaskInteractionRequest(
         **make_row(
@@ -252,20 +221,20 @@ def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_rea
     db.commit()
 
     assert rowcount == 0
-    assert _row_state(db, row_id).terminal_reason == "run_superseded"
+    assert row_state(db, row_id).terminal_reason == "run_superseded"
 
 
 def test_close_sync_opens_its_own_transaction_and_commits(db) -> None:
     """The short-transaction wrapper the two WebSocket injection sites
     share: no caller-held session."""
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
-    row_id = _seed_active_row(db, task_id=task_id, run_id="run-a")
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
     rowcount = close_legacy_resume_interaction_sync(task_id, "run-a")
 
     assert rowcount == 1
-    assert _row_state(db, row_id).status == "terminated"
-    assert _task_marker(db, task_id) is None
+    assert row_state(db, row_id).status == "terminated"
+    assert task_marker(db, task_id) is None
 
 
 # --------------------------------------------------------------------------
@@ -363,7 +332,7 @@ def test_clear_marker_if_unpaired_zeroes_a_marker_with_no_active_row(db) -> None
     The row is already terminated (the close already ran); a marker left
     at 1 -- however that happened -- has nothing to protect and is zeroed.
     """
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     anchor_id = make_trace_event(db, task_id=task_id)
     row = TaskInteractionRequest(
         **make_row(
@@ -379,20 +348,20 @@ def test_clear_marker_if_unpaired_zeroes_a_marker_with_no_active_row(db) -> None
     clear_interaction_marker_if_unpaired(db, task_id=task_id, run_id="run-a")
     db.commit()
 
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_clear_marker_if_unpaired_leaves_a_still_active_row_untouched(db) -> None:
     """This is the mutation-testable half: removing the NOT EXISTS guard
     would zero a marker that still names a live question."""
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
-    row_id = _seed_active_row(db, task_id=task_id, run_id="run-a")
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
     clear_interaction_marker_if_unpaired(db, task_id=task_id, run_id="run-a")
     db.commit()
 
-    assert _task_marker(db, task_id) == 1
-    assert _row_state(db, row_id).status == "active"
+    assert task_marker(db, task_id) == 1
+    assert row_state(db, row_id).status == "active"
 
 
 # --------------------------------------------------------------------------
@@ -428,7 +397,7 @@ def test_close_lets_a_second_question_on_the_same_run_become_active(db) -> None:
     """Deleting the close call must turn this red: without it, the second
     stage attempt collides with the first question's still-active slot and
     raises InteractionSlotTaken instead of ever becoming the active row."""
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     anchor_id = make_trace_event(db, task_id=task_id)
 
     first = _stage(db, task_id=task_id, run_id="run-a", anchor_id=anchor_id, key="q1")
@@ -460,7 +429,7 @@ def test_without_the_close_call_a_second_question_cannot_become_active(db) -> No
     same run), so the second stage attempt's INSERT collides with the
     unique active-slot constraint and raises InteractionSlotTaken -- the
     first question remains the only active row."""
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     anchor_id = make_trace_event(db, task_id=task_id)
 
     first = _stage(db, task_id=task_id, run_id="run-a", anchor_id=anchor_id, key="q1")

--- a/tests/web/services/test_task_interaction_close_postgresql.py
+++ b/tests/web/services/test_task_interaction_close_postgresql.py
@@ -1,0 +1,208 @@
+"""The legacy resume close's rowcount grid, re-run on PostgreSQL.
+
+Companion to test_task_interaction_close.py, which carries the full suite
+(rowcount grid, table-absent no-op, NOT EXISTS guard, and the staging
+interaction to prove the close is a real behavior change) against SQLite.
+Every CHECK and unique constraint the rowcount grid depends on is already
+pinned on both backends by test_task_interaction_schema.py /
+test_task_interaction_schema_postgresql.py, so this file re-runs only the
+rowcount grid itself -- the one group whose statement targets a real table
+shape worth confirming on the production backend. Everything else in
+test_task_interaction_close.py (table-absent no-op, the NOT EXISTS guard,
+statement sequencing) is dialect-independent control flow, already covered
+there.
+
+Fixture pattern: a disposable, uniquely-named schema inside whatever
+database XAGENT_TEST_POSTGRES_URL names (CREATE SCHEMA / DROP SCHEMA
+CASCADE), matching test_interaction_staging_postgresql.py's convention --
+see that file's docstring for why a schema instead of the whole database.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from itertools import count
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from tests.web.services.task_interaction_schema_shared import (
+    make_row,
+    make_task,
+    make_trace_event,
+    make_user,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task
+from xagent.web.models.task_interaction import TaskInteractionRequest
+from xagent.web.services.task_interaction_close import close_legacy_resume_interaction
+
+_key_counter = count()
+
+pytestmark = pytest.mark.postgresql
+
+
+@pytest.fixture()
+def engine():
+    url = os.getenv("XAGENT_TEST_POSTGRES_URL")
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    schema = "legacy_resume_interaction_close_" + uuid.uuid4().hex[:8]
+    admin_engine = sa.create_engine(url)
+    with admin_engine.begin() as conn:
+        conn.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+    admin_engine.dispose()
+
+    eng = sa.create_engine(url, connect_args={"options": f"-csearch_path={schema}"})
+    Base.metadata.create_all(bind=eng)
+    yield eng
+    eng.dispose()
+
+    admin_engine = sa.create_engine(url)
+    with admin_engine.begin() as conn:
+        conn.execute(sa.text(f'DROP SCHEMA "{schema}" CASCADE'))
+    admin_engine.dispose()
+
+
+@pytest.fixture()
+def session_factory(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db(session_factory):
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _seed_task_with_run(db, *, run_id: str, marker: int | None) -> int:
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    db.query(Task).filter(Task.id == task_id).update(
+        {Task.run_id: run_id, Task.interaction_protocol_version: marker}
+    )
+    db.commit()
+    return task_id
+
+
+def _seed_active_row(db, *, task_id: int, run_id: str) -> int:
+    anchor_id = make_trace_event(db, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_row(task_id=task_id, resume_trace_event_id=anchor_id, run_id=run_id)
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return int(row.id)
+
+
+def _row_state(db, row_id: int) -> TaskInteractionRequest:
+    db.expire_all()
+    return (
+        db.query(TaskInteractionRequest)
+        .filter(TaskInteractionRequest.id == row_id)
+        .one()
+    )
+
+
+def _task_marker(db, task_id: int) -> int | None:
+    db.expire_all()
+    return db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
+
+
+def test_close_retires_the_active_row_for_its_own_run(db) -> None:
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = _seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 1
+    row = _row_state(db, row_id)
+    assert row.status == "terminated"
+    assert row.active_slot is None
+    assert row.terminal_reason == "answered_via_legacy_resume"
+    assert row.terminated_at is not None
+    assert _task_marker(db, task_id) is None
+
+
+def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    anchor_id = make_trace_event(db, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_row(
+            task_id=task_id,
+            resume_trace_event_id=anchor_id,
+            run_id="run-a",
+            status="terminated",
+        )
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    row_id = int(row.id)
+    original_terminal_reason = row.terminal_reason
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 0
+    row = _row_state(db, row_id)
+    assert row.status == "terminated"
+    assert row.terminal_reason == original_terminal_reason
+    assert _task_marker(db, task_id) is None
+
+
+def test_close_is_a_no_op_with_no_interaction_rows_at_all(db) -> None:
+    """Today's 100% case: the table has no production writer yet."""
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=None)
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 0
+    assert _task_marker(db, task_id) is None
+
+
+def test_close_does_not_touch_a_different_runs_active_row(db) -> None:
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    orphan_row_id = _seed_active_row(db, task_id=task_id, run_id="run-b")
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 0
+    orphan = _row_state(db, orphan_row_id)
+    assert orphan.status == "active"
+    assert _task_marker(db, task_id) is None
+
+
+def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_reason(
+    db,
+) -> None:
+    task_id = _seed_task_with_run(db, run_id="run-a", marker=None)
+    anchor_id = make_trace_event(db, task_id=task_id)
+    row = TaskInteractionRequest(
+        **make_row(
+            task_id=task_id,
+            resume_trace_event_id=anchor_id,
+            run_id="run-a",
+            status="terminated",
+            terminal_reason="run_superseded",
+        )
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    row_id = int(row.id)
+
+    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    db.commit()
+
+    assert rowcount == 0
+    assert _row_state(db, row_id).terminal_reason == "run_superseded"

--- a/tests/web/services/test_task_interaction_close_postgresql.py
+++ b/tests/web/services/test_task_interaction_close_postgresql.py
@@ -16,13 +16,27 @@ Fixture pattern: a disposable, uniquely-named schema inside whatever
 database XAGENT_TEST_POSTGRES_URL names (CREATE SCHEMA / DROP SCHEMA
 CASCADE), matching test_interaction_staging_postgresql.py's convention --
 see that file's docstring for why a schema instead of the whole database.
+
+Known coverage gap, not closed here: neither this file nor
+test_task_interaction_close.py ever calls
+close_legacy_resume_interaction_sync -- the one function that issues the
+FOR NO KEY UPDATE / key_share=True lock read the ordering obligation in
+test_interaction_close_lock_ordering.py depends on -- against a real
+PostgreSQL connection. test_task_interaction_close.py calls it on SQLite,
+where with_for_update's clause is silently dropped and the single-writer
+lock serializes instead, so it never issues the real statement either. No
+test anywhere in this repo, on this database, opens two sessions and
+proves FOR NO KEY UPDATE actually holds the lock the ordering argument
+claims (blocking a concurrent purge, not blocking a concurrent KEY SHARE
+stager) -- every case here runs one session against one fixture at a
+time. The lock-ordering guard is therefore statement-order-in-source-code
+evidence only, not lock-behavior evidence.
 """
 
 from __future__ import annotations
 
 import os
 import uuid
-from itertools import count
 
 import pytest
 import sqlalchemy as sa
@@ -30,16 +44,15 @@ from sqlalchemy.orm import sessionmaker
 
 from tests.web.services.task_interaction_schema_shared import (
     make_row,
-    make_task,
     make_trace_event,
-    make_user,
+    row_state,
+    seed_active_row,
+    seed_task_with_run,
+    task_marker,
 )
 from xagent.web.models.database import Base
-from xagent.web.models.task import Task
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services.task_interaction_close import close_legacy_resume_interaction
-
-_key_counter = count()
 
 pytestmark = pytest.mark.postgresql
 
@@ -80,59 +93,24 @@ def db(session_factory):
         session.close()
 
 
-def _seed_task_with_run(db, *, run_id: str, marker: int | None) -> int:
-    user_id = make_user(db)
-    task_id = make_task(db, user_id=user_id)
-    db.query(Task).filter(Task.id == task_id).update(
-        {Task.run_id: run_id, Task.interaction_protocol_version: marker}
-    )
-    db.commit()
-    return task_id
-
-
-def _seed_active_row(db, *, task_id: int, run_id: str) -> int:
-    anchor_id = make_trace_event(db, task_id=task_id)
-    row = TaskInteractionRequest(
-        **make_row(task_id=task_id, resume_trace_event_id=anchor_id, run_id=run_id)
-    )
-    db.add(row)
-    db.commit()
-    db.refresh(row)
-    return int(row.id)
-
-
-def _row_state(db, row_id: int) -> TaskInteractionRequest:
-    db.expire_all()
-    return (
-        db.query(TaskInteractionRequest)
-        .filter(TaskInteractionRequest.id == row_id)
-        .one()
-    )
-
-
-def _task_marker(db, task_id: int) -> int | None:
-    db.expire_all()
-    return db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
-
-
 def test_close_retires_the_active_row_for_its_own_run(db) -> None:
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
-    row_id = _seed_active_row(db, task_id=task_id, run_id="run-a")
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
     rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
     db.commit()
 
     assert rowcount == 1
-    row = _row_state(db, row_id)
+    row = row_state(db, row_id)
     assert row.status == "terminated"
     assert row.active_slot is None
     assert row.terminal_reason == "answered_via_legacy_resume"
     assert row.terminated_at is not None
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     anchor_id = make_trace_event(db, task_id=task_id)
     row = TaskInteractionRequest(
         **make_row(
@@ -152,40 +130,40 @@ def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
     db.commit()
 
     assert rowcount == 0
-    row = _row_state(db, row_id)
+    row = row_state(db, row_id)
     assert row.status == "terminated"
     assert row.terminal_reason == original_terminal_reason
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_close_is_a_no_op_with_no_interaction_rows_at_all(db) -> None:
     """Today's 100% case: the table has no production writer yet."""
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=None)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=None)
 
     rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
     db.commit()
 
     assert rowcount == 0
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_close_does_not_touch_a_different_runs_active_row(db) -> None:
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=1)
-    orphan_row_id = _seed_active_row(db, task_id=task_id, run_id="run-b")
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    orphan_row_id = seed_active_row(db, task_id=task_id, run_id="run-b")
 
     rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
     db.commit()
 
     assert rowcount == 0
-    orphan = _row_state(db, orphan_row_id)
+    orphan = row_state(db, orphan_row_id)
     assert orphan.status == "active"
-    assert _task_marker(db, task_id) is None
+    assert task_marker(db, task_id) is None
 
 
 def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_reason(
     db,
 ) -> None:
-    task_id = _seed_task_with_run(db, run_id="run-a", marker=None)
+    task_id = seed_task_with_run(db, run_id="run-a", marker=None)
     anchor_id = make_trace_event(db, task_id=task_id)
     row = TaskInteractionRequest(
         **make_row(
@@ -205,4 +183,4 @@ def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_rea
     db.commit()
 
     assert rowcount == 0
-    assert _row_state(db, row_id).terminal_reason == "run_superseded"
+    assert row_state(db, row_id).terminal_reason == "run_superseded"


### PR DESCRIPTION
## Summary

Four production paths can post a user message straight into a live or resumed checkpoint instead of going through the native interaction protocol's answer path: the two WebSocket injection paths, the A2A resume path, and the v1 `POST /chat/tasks/{id}/reply` path. Once that write succeeds, any question the run had open under the protocol has been answered by other means and must be retired: mark the run's active `task_interaction_requests` row `terminated` with `terminal_reason = 'answered_via_legacy_resume'`, and clear `tasks.interaction_protocol_version` back to `NULL`, in the same transaction as that write. Three resume-abandonment paths (a WebSocket lease restore, an A2A prelease restore, and the reply endpoint's prelease restore) do the mirror-image cleanup when a resume is undone instead of completed: if the marker no longer names any active row, clear it.

Every rowcount the close statement produces is classified the same way: exactly one row closed logs at info; zero rows — today's only reachable case, since `task_interaction_requests` has no production writer yet — logs at debug; more than one row is only reachable if the table's own uniqueness constraint has already been violated, and is logged at error with a degradation signal registered rather than raised, so a resume injection or an already-durable input write is never turned into a failure by a check meant only to catch schema corruption after the fact.

## Behavior today

- Only the close statements themselves (against `task_interaction_requests`, one per injection site) resolve to rowcount zero right now, because that table has no production writer. All seven marker-clear statements against `tasks` hit exactly one row every time they run, not zero: the four unconditional clears paired with each close call match on `task_id`/`run_id` alone, and the three `NOT EXISTS`-guarded compensation clears match too, because the guard is vacuously true (the interaction table is empty) and the abandonment paths they follow (`release_task_lease_no_commit`) never change `run_id`, so the clear's own `run_id` predicate still names the task's current row. Every one of those five UPDATEs rewrites `interaction_protocol_version` (`NULL -> NULL` today, since nothing sets it to `1` yet) and `updated_at` — `Task.updated_at` carries `onupdate=func.now()`, which SQLAlchemy appends automatically to any UPDATE that does not already set that column, so `updated_at` moves on every legacy-resume completion and every resume abandonment, even though the marker's own value does not change. (On the A2A and reply paths the preceding fence UPDATE in the same transaction has already advanced `updated_at` to the same transaction-start timestamp, so the clear adds no further observable movement there.) This change is therefore behavior-preserving on every currently reachable path in the sense that matters — no reader-visible outcome changes from the marker's value — but none of the marker-clear writes is a no-op today; only the close-table statements are.
- The two compensation clears are guarded by `NOT EXISTS`, not unconditional: the semantics are "if the marker no longer corresponds to any active row, zero it," not "always zero it." An abandonment can race a resume that never reached the injection call at all, and clearing unconditionally there would erase a marker that still names a live, unanswered question.
- The two WebSocket injection sites share one short-transaction helper. Before either the close or the clear, it takes a `FOR NO KEY UPDATE` / `key_share=True` lock read on the task row, ahead of a future deletion path's own locking read on that same row, to avoid a lock-ordering cycle between the two. The A2A resume-input site takes no lock read of its own: it already issues a fence UPDATE on non-key columns as the first statement in its transaction, ahead of the close call, which satisfies the same ordering and strength requirement a dedicated lock read would. Both halves are necessary and are pinned by a static, AST-based check of statement order.

## Known gaps, registered here

**A2A resume helper test coverage.** `_acquire_a2a_resume_prelease_sync`, `_update_a2a_resume_input_sync`, and `_restore_a2a_resume_prelease_sync` have no test coverage of their own before this change (confirmed: `grep -rn "_acquire_a2a_resume_prelease_sync\|_update_a2a_resume_input_sync\|_restore_a2a_resume_prelease" tests/` returns zero hits outside this change). Three obligations travel with the close statement folded into `_update_a2a_resume_input_sync`, restated here because the work to close this gap directly has not started: (1) the close must be atomic with that function's existing ownership fence — a fence miss rolls the close back with it; (2) the prelease acquire's failure path rolls back, unlike its WebSocket twin which commits, and no test pins that asymmetry; (3) the restore path's four call sites all pass an explicit status, so the signature default is load-bearing for nobody and must not be relied on.

**A replay window that predates this change.** `AgentRunner.inject_user_message` short-circuits when a user message with the same turn id is already present in the in-memory context, returning without persisting anything further. `post_user_message` is a plain alias for it, so a truthy result does not imply this turn crossed the durable-acceptance boundary the same function documents. Every close statement in this change fires whenever that result is truthy, so on the replay branch an interaction row can be marked `answered_via_legacy_resume` while the corresponding user message is not in any checkpoint. This is a pre-existing property of the injection path, not something this change introduces; it is registered here, not fixed.

**A batch-ordering constraint this change's behavior-preserving argument depends on.** Until the code that writes protocol-marker values of `1` and stages interaction rows exists, no production code other than the close statements in this change may insert or activate rows in `task_interaction_requests`. The "behavior-preserving today" argument above — zero rows, so every close resolves to rowcount zero — depends entirely on that constraint holding.

## Verification

- Every mandated behavior is pinned by a red/green pair: mutating the production code first reproduces a failing assertion, then reverting it restores a passing one.
- The close statement actually changes outcomes: deleting it turns a second question's staging attempt from succeeding into raising a slot-conflict error.
- The A2A fence and close commit as one unit, not just in one order: turning that assertion red needs two changes together, moving the close ahead of the fence's early return (otherwise unreachable on a fence miss) and letting it commit independently of the host session; either change alone leaves it green.
- The failure and cancellation branches around each WebSocket close call don't block an already-accepted injection, checked against the exact task and run each close call was passed, not only that it fired.
- Both compensation paths only clear the marker when the resume they guard was actually abandoned: a lease-restore fence miss (the restore never happened) must leave the marker untouched, and a successful restore with no active row remaining must clear it — pinned directly against the restore functions themselves, with both outcomes verified by mutation.
- Both compensation paths' `NOT EXISTS` guard holds a still-active question's marker in place: removing it turns the "injection never happened" and "lease acquisition was cancelled" assertions red simultaneously, since both routes share the same guarded statement.
- The close module issues exactly the UPDATE statements this design calls for, against exactly the tables named, and the unlocked close function is reachable from nowhere outside the module except the two approved fence-transaction sites (A2A and the v1 reply endpoint) that satisfy the same ordering obligation another way — both pinned by static, AST-based checks, alongside the lock-ordering assertions themselves. The fence UPDATE column sets at both fence-transaction sites are pinned the same way, against named constants shared between the production code and the guard.
- A module-level guard now pins the wiring obligation itself: every module under `web/` that calls `post_user_message` must also call one of the close-family functions, with an explicit (currently empty) exception list — so a future fifth injection site fails a test instead of relying on review to notice. The lock-read matcher was also tightened to accept only a literal `key_share=True` with no `read` keyword, after compiling all three keyword combinations against this repo's SQLAlchemy and finding two shapes (`key_share=False`, `read=True` with `key_share=True`) that produce different lock strengths yet previously passed the guard.

- The A2A success path is pinned end to end through the real `message:send` HTTP call, not just the sync helper directly: a successful injection retires the run's active interaction row and clears the task's marker in the same commit, verified by mutation against moving the close call after the commit, replacing it with a no-op, and passing it the wrong run id.
- `_classify_close_rowcount`'s three branches (one row, zero rows, more than one row) are pinned directly by unit tests against the log level each branch emits and, for the more-than-one-row branch, the degradation signal it registers.
- The full existing WebSocket and A2A test suites pass unmodified alongside the new coverage.
