### PR TITLE
feat(api): expose the pending interaction and add the task reply endpoint

### DIFF
--- a/src/xagent/web/api/v1/errors.py
+++ b/src/xagent/web/api/v1/errors.py
@@ -190,7 +190,7 @@ _DEFAULT_MESSAGES: dict[V1ErrorCode, str] = {
     V1ErrorCode.DELEGATED_AUTHORIZATION_FAILED: "Delegated authorization failed.",
     V1ErrorCode.INTERACTION_RESPONSE_REQUIRED: (
         "This task is waiting for an answer to a pending question; use "
-        "POST /v1/chat/tasks/{task_id}/reply instead."
+        "the task reply endpoint (POST .../reply) instead."
     ),
     V1ErrorCode.INTERACTION_NOT_RESUMABLE: (
         "This task's saved progress cannot be resumed; it remains in "

--- a/src/xagent/web/api/v1/errors.py
+++ b/src/xagent/web/api/v1/errors.py
@@ -122,6 +122,29 @@ class V1ErrorCode(str, Enum):
     MCP_OAUTH_AUTHORIZATION_FAILED = "mcp_oauth_authorization_failed"
     DELEGATED_AUTHORIZATION_FAILED = "delegated_authorization_failed"
 
+    # The task is waiting on an answer to a pending agent question and
+    # cannot accept a plain append. 409. Client should call
+    # ``POST /v1/chat/tasks/{id}/reply`` instead of retrying the append.
+    INTERACTION_RESPONSE_REQUIRED = "interaction_response_required"
+
+    # The task is waiting_for_user, but its saved execution progress
+    # cannot be resumed (no run-fenced checkpoint, or the checkpoint is
+    # unreadable/superseded). 409, not retryable -- the task stays in
+    # waiting_for_user and the caller must start a new task.
+    INTERACTION_NOT_RESUMABLE = "interaction_not_resumable"
+
+    # ``POST /v1/chat/tasks/{id}/reply`` was called on a task that is not
+    # currently waiting on a question (pending / paused / completed /
+    # failed). 409. Not retryable as-is; use ``append`` to start a new
+    # turn, or wait for the task to reach waiting_for_user.
+    NO_PENDING_INTERACTION = "no_pending_interaction"
+
+    # A reply's saved progress could not be read due to a transient
+    # infrastructure failure. 503, retryable -- distinct from
+    # ``interaction_not_resumable`` (which means resuming can never
+    # succeed) so clients know whether to retry or give up.
+    TEMPORARILY_UNAVAILABLE = "temporarily_unavailable"
+
 
 # Default human-readable text per code. Endpoints may override the
 # message when more specific context is available (e.g. surfacing
@@ -165,6 +188,20 @@ _DEFAULT_MESSAGES: dict[V1ErrorCode, str] = {
     V1ErrorCode.CONNECTOR_RUNTIME_UNAVAILABLE: "Connector runtime context is unavailable.",
     V1ErrorCode.MCP_OAUTH_AUTHORIZATION_FAILED: "MCP OAuth authorization is unavailable.",
     V1ErrorCode.DELEGATED_AUTHORIZATION_FAILED: "Delegated authorization failed.",
+    V1ErrorCode.INTERACTION_RESPONSE_REQUIRED: (
+        "This task is waiting for an answer to a pending question; use "
+        "POST /v1/chat/tasks/{task_id}/reply instead."
+    ),
+    V1ErrorCode.INTERACTION_NOT_RESUMABLE: (
+        "This task's saved progress cannot be resumed; it remains in "
+        "waiting_for_user. Start a new task instead of retrying."
+    ),
+    V1ErrorCode.NO_PENDING_INTERACTION: (
+        "This task has no pending question to answer."
+    ),
+    V1ErrorCode.TEMPORARILY_UNAVAILABLE: (
+        "The task's saved progress could not be read. Please retry."
+    ),
 }
 
 
@@ -214,6 +251,12 @@ _TURN_REJECTION_CODES: dict[str, tuple[V1ErrorCode, int]] = {
     # reaper) -- same "conversation no longer available" outcome as
     # workforce_run_not_found from the SDK's perspective.
     "workforce_run_not_active": (V1ErrorCode.TASK_NOT_FOUND, 404),
+    # The task is waiting on an answer to a pending question; append is
+    # not the right entrypoint for that -- POST .../reply is.
+    "interaction_response_required": (
+        V1ErrorCode.INTERACTION_RESPONSE_REQUIRED,
+        409,
+    ),
 }
 
 

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -1,0 +1,515 @@
+"""``POST /v1/chat/tasks/{task_id}/reply``: answer a waiting task's question.
+
+A task in ``waiting_for_user`` has a paused execution, not an idle one --
+its agent asked a question via ``ask_user_question`` / a ``send_message``
+call with ``expect_response=True`` and is suspended waiting for the
+answer. Answering it means resuming that exact paused run, not starting
+a new turn the way ``POST /v1/chat/tasks/{task_id}/messages`` does. This
+module implements that resume, mirroring the shape of the A2A
+``message:send`` input-required resume in ``web/api/a2a.py``
+(``_resume_input_required_a2a_task``) with four differences:
+
+  - Scoped to ``Task.source == "sdk"`` plus the v1 SDK ownership rules
+    (agent-bound or workforce-bound key) instead of A2A's
+    ``Task.source == "a2a"`` plus a bare ``agent_id`` match.
+  - Only ``WAITING_FOR_USER`` is accepted; ``PAUSED`` is left to the
+    existing append endpoint, which already handles it and already has
+    its own failure policy for that status.
+  - Errors are translated to the stable ``V1ApiError`` envelope instead
+    of A2A's own error shape.
+  - The synthetic ``turn_id`` is derived from a fresh UUID
+    (``v1:reply:{task_id}:{uuid4()}``) rather than an A2A message id,
+    because the v1 request body carries no client-supplied message
+    identity to derive one from. This endpoint intentionally does not
+    implement idempotency: a client-side retry after a timeout can post
+    the answer twice. Callers that want to avoid that should ``GET`` the
+    task and confirm it has left ``waiting_for_user`` before retrying.
+
+The rest of the resume mechanics -- the two-phase prelease (claim, then
+either commit past it or restore it exactly), the heartbeat guarding the
+injection, and the fail-closed handling of every checkpoint outcome --
+are intentionally duplicated from ``a2a.py`` rather than factored into a
+shared helper. The two call sites answer to different protocols with
+independently evolving error contracts; a shared helper would couple
+them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy import func
+
+from ....core.agent.checkpoint import (
+    CheckpointAccessRefusedError,
+    CheckpointCorruptError,
+    CheckpointReadError,
+)
+from ...models.database import get_session_local
+from ...models.task import Task, TaskStatus
+from ...schemas.v1 import ReplyRequest, ReplyResponse
+from ...services.db_runtime import (
+    cancel_and_drain_async_task,
+    drain_async_task_cancellation_safe,
+    run_db_io_cancellation_safe,
+)
+from ...services.task_execution_controller import TaskControlState
+from ...services.task_lease_service import (
+    TaskLease,
+    TaskLeaseHeartbeatOutcome,
+    TaskLeaseLostError,
+    acquire_task_lease_cancellation_safe,
+    acquire_task_lease_no_commit,
+    bind_task_lease_context,
+    release_task_lease_no_commit,
+    run_task_lease_heartbeat,
+    run_while_task_lease_owned,
+    stop_task_lease_heartbeat,
+)
+from .deps import ApiKeyPrincipal, record_key_usage
+from .errors import V1ApiError, V1ErrorCode
+from .tasks import _resolve_task_or_404, _validate_owner_scope
+
+logger = logging.getLogger(__name__)
+
+# Control states a waiting task may be claimed from. Mirrors the a2a
+# resume prelease's acceptance set for WAITING_FOR_USER: a task parked
+# there sits at either the plain WAITING_FOR_USER control state, or, on
+# a database left over from an interrupted prior resume attempt, IDLE.
+_RESUMABLE_CONTROL_STATES = frozenset(
+    {
+        TaskControlState.IDLE.value,
+        TaskControlState.WAITING_FOR_USER.value,
+    }
+)
+
+
+@dataclass(frozen=True)
+class _ReplyContext:
+    """Detached, already-authorized inputs the resume phase needs."""
+
+    task_id: int
+    agent_id: int
+    task_owner_user_id: int
+    run_id: str | None
+    text: str
+
+
+def _status_rejection(status: TaskStatus) -> V1ApiError:
+    """Map a non-waiting task status to its reply-rejection error.
+
+    RUNNING is the one truly transient case (a real turn is in flight;
+    retrying later can succeed), so it keeps the generic retryable
+    ``task_busy``. Every other non-waiting status means "there is
+    nothing to reply to right now" -- ``no_pending_interaction``, not
+    retryable as such. The caller's remedy differs by status: for
+    paused / completed / failed, ``append`` starts the next turn; for
+    pending, the task hasn't started executing yet -- it is not in
+    ``_APPENDABLE_STATUSES`` either, so there is no turn to append to
+    yet. The only remedy is to wait for it to leave pending.
+    """
+    if status == TaskStatus.RUNNING:
+        return V1ApiError(V1ErrorCode.TASK_BUSY, 409)
+    return V1ApiError(V1ErrorCode.NO_PENDING_INTERACTION, 409)
+
+
+def _prepare_reply_context_sync(
+    *,
+    task_id: int,
+    principal: ApiKeyPrincipal,
+    request: ReplyRequest,
+) -> _ReplyContext:
+    """Authorize the call and validate the body against the task's status.
+
+    A pure read -- no mutation happens here. The actual state transition
+    is the prelease claim in :func:`_acquire_reply_prelease_sync`, run
+    afterwards under ``acquire_task_lease_cancellation_safe``.
+    """
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = _resolve_task_or_404(task_id, principal, db)
+        _validate_owner_scope(
+            principal,
+            request_agent_id=request.agent_id,
+            request_workforce_id=request.workforce_id,
+        )
+        if request.message.files:
+            raise V1ApiError(
+                V1ErrorCode.INVALID_INPUT,
+                422,
+                message=(
+                    "files are not accepted on reply; attach files via a "
+                    "follow-up POST /v1/chat/tasks/{task_id}/messages call"
+                ),
+            )
+        if task.status != TaskStatus.WAITING_FOR_USER:
+            raise _status_rejection(task.status)
+        return _ReplyContext(
+            task_id=int(task.id),
+            agent_id=int(task.agent_id),
+            task_owner_user_id=int(task.user_id),
+            run_id=str(task.run_id) if task.run_id is not None else None,
+            text=request.message.content,
+        )
+
+
+def _acquire_reply_prelease_sync(
+    *,
+    task_id: int,
+    agent_id: int,
+    previous_run_id: str | None,
+    result_holder: dict[str, Any],
+) -> TaskLease | None:
+    """Claim and commit one exact reply-resume lease in a worker transaction.
+
+    ``agent_id`` re-checks the task row against the value
+    ``_resolve_task_or_404`` already authorized for this call -- ownership
+    itself (agent-bound vs workforce-bound key) was established there;
+    this claim only needs to confirm the row's identity hasn't moved
+    since, which a scalar ``agent_id`` match does without a join.
+
+    ``result_holder`` is filled in with the post-claim ``state_version``
+    / ``control_state`` before commit, so the caller can report the
+    response's real values without a second query racing the
+    background resume this claim is about to hand off to. It stays
+    empty when the claim fails.
+    """
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        claimed = (
+            db.query(Task)
+            .filter(
+                Task.id == task_id,
+                Task.agent_id == agent_id,
+                Task.source == "sdk",
+                Task.status == TaskStatus.WAITING_FOR_USER,
+                Task.control_state.in_(_RESUMABLE_CONTROL_STATES),
+            )
+            .update(
+                {
+                    Task.control_state: TaskControlState.RESUME_REQUESTED.value,
+                    Task.state_version: func.coalesce(Task.state_version, 0) + 1,
+                },
+                synchronize_session=False,
+            )
+        )
+        if claimed != 1:
+            db.rollback()
+            return None
+        task_lease = acquire_task_lease_no_commit(
+            db,
+            task_id,
+            expected_run_id=previous_run_id,
+        )
+        if task_lease is None or task_lease.run_id is None:
+            db.rollback()
+            return None
+        refreshed = (
+            db.query(Task.state_version, Task.control_state)
+            .filter(Task.id == task_id)
+            .one()
+        )
+        result_holder["state_version"] = int(refreshed.state_version or 0)
+        result_holder["control_state"] = str(refreshed.control_state or "idle")
+        db.commit()
+        return task_lease
+
+
+def _restore_reply_prelease_sync(task_lease: TaskLease) -> bool:
+    """Release one exact reply prelease in a worker-owned short Session.
+
+    A successful restore retains the run id and its tagged checkpoint, so
+    a client retry after a lost response is idempotent at the runner
+    boundary. If ownership changed, no row is mutated and the current
+    owner remains the sole lifecycle authority.
+    """
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        restored = release_task_lease_no_commit(
+            db,
+            task_lease,
+            status=TaskStatus.WAITING_FOR_USER,
+        )
+        if restored:
+            db.commit()
+        else:
+            db.rollback()
+        return restored
+
+
+async def _restore_reply_prelease_isolated(task_lease: TaskLease) -> bool:
+    return await run_db_io_cancellation_safe(
+        lambda: _restore_reply_prelease_sync(task_lease)
+    )
+
+
+def _update_reply_input_sync(task_lease: TaskLease, text: str) -> bool:
+    """Persist the reply's input only while the exact prelease remains current."""
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        updated = (
+            db.query(Task)
+            .filter(
+                Task.id == task_lease.task_id,
+                Task.status == TaskStatus.RUNNING,
+                Task.runner_id == task_lease.runner_id,
+                Task.run_id == task_lease.run_id,
+            )
+            .update(
+                {
+                    Task.input: text,
+                    Task.output: None,
+                    Task.error_message: None,
+                },
+                synchronize_session=False,
+            )
+        )
+        if updated != 1:
+            db.rollback()
+            return False
+        db.commit()
+        return True
+
+
+async def _schedule_waiting_reply_resume(
+    *,
+    task_id: int,
+    agent_service: Any,
+    task_owner_user_id: int,
+    task_lease: TaskLease,
+    heartbeat_stop: asyncio.Event,
+    heartbeat_task: "asyncio.Task[TaskLeaseHeartbeatOutcome]",
+) -> None:
+    from .. import websocket
+
+    if task_lease.task_id != task_id or task_lease.run_id is None:
+        raise ValueError("Reply resume scheduling requires an exact task lease")
+    if not websocket.background_task_manager.reserve_resume(task_id):
+        # A same-process resume is already registered for this task despite
+        # the exclusive DB claim above -- report it the same way a caller
+        # would read a lost race on the claim itself, rather than a bare
+        # 500: retrying (after the other resume settles) can succeed.
+        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409)
+    previous_task = websocket.background_task_manager.running_tasks.get(task_id)
+    bg_task: "asyncio.Task[None] | None" = None
+    try:
+        bg_task = asyncio.create_task(
+            websocket.execute_resume_background(
+                task_id=task_id,
+                agent_service=agent_service,
+                task_owner_user_id=task_owner_user_id,
+                expected_run_id=task_lease.run_id,
+                previous_task=previous_task,
+                preacquired_lease=task_lease,
+                preacquired_heartbeat_stop=heartbeat_stop,
+                preacquired_heartbeat_task=heartbeat_task,
+                # The prelease claimed this task out of waiting_for_user;
+                # hand that over so a checkpoint the resume cannot read
+                # restores it instead of failing it terminally.
+                preacquired_prior_status=TaskStatus.WAITING_FOR_USER,
+            )
+        )
+        websocket.background_task_manager.register_reserved_resume(task_id, bg_task)
+    except BaseException:
+        if bg_task is not None:
+            await cancel_and_drain_async_task(bg_task)
+        websocket.background_task_manager.release_resume_reservation(task_id)
+        raise
+
+
+async def reply_to_task(
+    *,
+    task_id: int,
+    request: ReplyRequest,
+    principal: ApiKeyPrincipal,
+) -> ReplyResponse:
+    """Resume a ``waiting_for_user`` task with the user's answer.
+
+    Args:
+        task_id: Path parameter; the target task's primary key.
+        request: Validated :class:`ReplyRequest`.
+        principal: Key-bound owner from the auth dependency.
+
+    Returns:
+        :class:`ReplyResponse` with ``status='running'`` and the same
+        ``run_id`` the task was waiting on.
+
+    Raises:
+        V1ApiError 401: missing / invalid / revoked key.
+        V1ApiError 404: task not found, not owned by the key, or
+            body.agent_id / body.workforce_id doesn't match the bound
+            owner.
+        V1ApiError 422: body.message.files is non-empty, or
+            body.agent_id is missing for an agent-bound key.
+        V1ApiError 409: ``task_busy`` (task is RUNNING, or the resume
+            lease was lost to a concurrent reply -- retryable);
+            ``no_pending_interaction`` (task is not currently waiting
+            on a question); ``interaction_not_resumable`` (the task's
+            saved progress cannot be resumed -- NOT retryable, the task
+            stays in waiting_for_user and the caller must start a new
+            task).
+        V1ApiError 503: ``temporarily_unavailable`` -- the saved
+            progress could not be read due to a transient failure;
+            retryable.
+        500: any other unexpected error (V1 envelope via the global
+            handler), including a lease lost mid-resume.
+    """
+    ctx = await run_db_io_cancellation_safe(
+        lambda: _prepare_reply_context_sync(
+            task_id=task_id,
+            principal=principal,
+            request=request,
+        )
+    )
+
+    prelease_info: dict[str, Any] = {}
+    task_lease = await acquire_task_lease_cancellation_safe(
+        lambda: _acquire_reply_prelease_sync(
+            task_id=ctx.task_id,
+            agent_id=ctx.agent_id,
+            previous_run_id=ctx.run_id,
+            result_holder=prelease_info,
+        ),
+        lambda acquired: _restore_reply_prelease_sync(acquired),
+    )
+    if task_lease is None or task_lease.run_id is None:
+        raise V1ApiError(V1ErrorCode.TASK_BUSY, 409)
+
+    heartbeat_stop = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        run_task_lease_heartbeat(task_lease, heartbeat_stop)
+    )
+    ownership_transferred = False
+    prelease_cleanup_done = False
+
+    async def stop_and_restore_prelease() -> bool:
+        nonlocal prelease_cleanup_done
+        if prelease_cleanup_done:
+            return False
+        prelease_cleanup_done = True
+        try:
+            outcome = await stop_task_lease_heartbeat(heartbeat_task, heartbeat_stop)
+        except BaseException:
+            logger.error(
+                "Reply prelease heartbeat failed before task %s could be "
+                "restored; retaining run %s for TTL recovery",
+                task_id,
+                task_lease.run_id,
+                exc_info=True,
+            )
+            return False
+        if outcome.requires_ttl_recovery:
+            logger.error(
+                "Reply prelease for task %s became unhealthy; retaining "
+                "run %s for TTL recovery (lost=%s, pool_timeout=%s)",
+                task_id,
+                task_lease.run_id,
+                outcome.lease_lost,
+                outcome.pool_timeout is not None,
+            )
+            return False
+        return await _restore_reply_prelease_isolated(task_lease)
+
+    try:
+
+        async def inject_user_message() -> tuple[Any, bool]:
+            from .. import chat
+
+            agent_service = await chat.get_agent_manager().get_agent_for_task(
+                task_id,
+                None,
+                task_owner_user_id=ctx.task_owner_user_id,
+            )
+            posted = await agent_service.post_user_message(
+                str(task_id),
+                execution_message=ctx.text,
+                display_message=ctx.text,
+                turn_id=f"v1:reply:{task_id}:{uuid4()}",
+                request_interrupt=False,
+                reason="V1 interaction response",
+            )
+            return agent_service, bool(posted)
+
+        with bind_task_lease_context(task_lease):
+            agent_service, posted = await run_while_task_lease_owned(
+                inject_user_message(),
+                heartbeat_task,
+            )
+
+        if not posted:
+            # No run-fenced checkpoint is available to resume onto. Never
+            # fabricate a run or fall back to a transcript replay: release
+            # the exact prelease back to waiting_for_user and fail closed
+            # so the caller must start a new task explicitly.
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            if not await drain_async_task_cancellation_safe(cleanup_task):
+                raise TaskLeaseLostError(
+                    f"Task {task_id} lease changed before reply fallback"
+                )
+            raise V1ApiError(V1ErrorCode.INTERACTION_NOT_RESUMABLE, 409)
+
+        updated = await run_db_io_cancellation_safe(
+            lambda: _update_reply_input_sync(task_lease, ctx.text)
+        )
+        if not updated:
+            raise TaskLeaseLostError(
+                f"Task {task_id} lease changed before reply resume scheduling"
+            )
+
+        await _schedule_waiting_reply_resume(
+            task_id=task_id,
+            agent_service=agent_service,
+            task_owner_user_id=ctx.task_owner_user_id,
+            task_lease=task_lease,
+            heartbeat_stop=heartbeat_stop,
+            heartbeat_task=heartbeat_task,
+        )
+        ownership_transferred = True
+    except CheckpointReadError as exc:
+        if not ownership_transferred and not prelease_cleanup_done:
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            if not await drain_async_task_cancellation_safe(cleanup_task):
+                raise TaskLeaseLostError(
+                    f"Task {task_id} lease changed before reply "
+                    "checkpoint-failure fallback"
+                ) from exc
+        if isinstance(exc, CheckpointCorruptError):
+            raise V1ApiError(V1ErrorCode.INTERACTION_NOT_RESUMABLE, 409) from exc
+        if isinstance(exc, CheckpointAccessRefusedError):
+            if exc.reason == "superseded_legacy":
+                raise V1ApiError(V1ErrorCode.INTERACTION_NOT_RESUMABLE, 409) from exc
+            raise V1ApiError(V1ErrorCode.TASK_BUSY, 409) from exc
+        # CheckpointUnavailableError, or any future CheckpointReadError
+        # subclass this dispatch does not yet know about: treat it
+        # conservatively as retryable rather than assuming a terminal
+        # failure, so an unrecognized failure mode never silently
+        # collapses into a data-losing branch.
+        raise V1ApiError(V1ErrorCode.TEMPORARILY_UNAVAILABLE, 503) from exc
+    except BaseException:
+        if not ownership_transferred and not prelease_cleanup_done:
+            cleanup_task = asyncio.create_task(stop_and_restore_prelease())
+            await drain_async_task_cancellation_safe(cleanup_task)
+        raise
+    finally:
+        if not ownership_transferred and not prelease_cleanup_done:
+            await stop_task_lease_heartbeat(heartbeat_task, heartbeat_stop)
+
+    await record_key_usage(str(principal.key.key_prefix))
+
+    return ReplyResponse(
+        task_id=ctx.task_id,
+        agent_id=ctx.agent_id,
+        workforce_id=(
+            int(principal.workforce.id) if principal.workforce is not None else None
+        ),
+        status=TaskStatus.RUNNING.value,
+        accepted_at=datetime.now(timezone.utc),
+        run_id=task_lease.run_id,
+        state_version=prelease_info["state_version"],
+        control_state=prelease_info["control_state"],
+    )

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -144,7 +144,8 @@ def _prepare_reply_context_sync(
                 422,
                 message=(
                     "files are not accepted on reply; attach files via a "
-                    "follow-up POST /v1/chat/tasks/{task_id}/messages call"
+                    "follow-up call to the task append endpoint "
+                    "(POST .../messages) instead"
                 ),
             )
         if task.status != TaskStatus.WAITING_FOR_USER:
@@ -158,6 +159,33 @@ def _prepare_reply_context_sync(
         )
 
 
+# Four different mechanisms keep this claim from racing every other writer
+# that can touch a WAITING_FOR_USER task, none of which overlap by accident:
+#
+# 1. Append (task_orchestrator._claim_turn_no_commit): its claim filters
+#    Task.status.in_(_APPENDABLE_STATUSES), and this PR removed
+#    WAITING_FOR_USER from that set. A row this claim can match (status ==
+#    WAITING_FOR_USER) is therefore structurally outside append's status
+#    filter -- the two claims can never both succeed on the same row, by
+#    construction of the two status sets being disjoint.
+# 2. A second reply on the same task: the claim below is a single
+#    conditional UPDATE (status == WAITING_FOR_USER AND control_state in
+#    _RESUMABLE_CONTROL_STATES); whichever request's UPDATE commits first
+#    flips control_state away from those values, so a concurrent request's
+#    UPDATE matches zero rows and returns None. Covered by
+#    test_concurrent_reply_race_exactly_one_winner.
+# 3. A2A's own resume (a2a._acquire_a2a_resume_prelease_sync): its claim
+#    filters Task.source == "a2a"; this claim filters Task.source == "sdk".
+#    A task row has exactly one source value, so the two filters can never
+#    both match the same row.
+# 4. The WebSocket live-control resume path: unlike the three cases above,
+#    it does NOT filter by Task.source at all, so it is not excluded from a
+#    "sdk" row by a source predicate. Its exclusivity instead comes from
+#    two other mechanisms: the in-process reservation in
+#    background_task_manager (reserve_resume / resume_tasks) that allows
+#    only one live resume coroutine per task_id, and the exact-run-fenced
+#    lease acquired below, which a second claimant with a stale or missing
+#    run_id cannot pass.
 def _acquire_reply_prelease_sync(
     *,
     task_id: int,
@@ -201,6 +229,17 @@ def _acquire_reply_prelease_sync(
         if claimed != 1:
             db.rollback()
             return None
+        # A legacy row with run_id already NULL passes previous_run_id=None
+        # here. acquire_task_lease_no_commit mints a fresh UUID for that
+        # case rather than reusing anything, and (since the row isn't a
+        # live RUNNING row with a run id) also clears both checkpoint
+        # pointer columns (last_checkpoint_event_id /
+        # last_checkpoint_trace_event_id) as part of the same UPDATE. If
+        # this reply later fails closed, releasing the lease back to
+        # waiting_for_user does not restore those two columns -- they stay
+        # cleared. This is not a behavior change worth guarding against:
+        # a row with no run_id never had a run-fenced checkpoint to
+        # recover in the first place, so nothing resumable is lost.
         task_lease = acquire_task_lease_no_commit(
             db,
             task_id,

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -867,6 +867,28 @@ def _load_task_steps_snapshot(
         )
 
 
+def _filter_interaction_descriptors(
+    interactions: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    """Drop non-mapping elements from a stored interactions list.
+
+    ``PendingInteraction.interactions`` is typed ``list[dict[str, Any]] |
+    None``. A row written by an older or buggy writer can carry a list
+    with non-dict elements (e.g. a bare string); passing that straight
+    into the schema fails Pydantic validation and 500s the GET
+    permanently, for as long as the dirty row exists. Filtering here --
+    not in ``get_latest_waiting_question`` or the schema type -- keeps
+    the fix scoped to this read path's output contract; the shared
+    reader and its other consumers (websocket.py, chat.py) are
+    untouched. Same semantics as react.py's
+    ``_normalize_ask_user_interactions``: a non-dict element is dropped,
+    not coerced or repaired.
+    """
+    if interactions is None:
+        return None
+    return [item for item in interactions if isinstance(item, dict)]
+
+
 def _get_chat_task_sync(
     task_id: int,
     principal: ApiKeyPrincipal,
@@ -888,7 +910,7 @@ def _get_chat_task_sync(
     pending_interaction = (
         PendingInteraction(
             question=task.pending_question,
-            interactions=task.pending_interactions,
+            interactions=_filter_interaction_descriptors(task.pending_interactions),
         )
         if task.pending_question is not None
         else None

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -958,12 +958,13 @@ async def append_message_to_task(
          provided with a workforce key, must match the bound workforce
          (404 ``workforce_not_found`` otherwise).
       3. Rejects the call with 409 ``task_busy`` if the task is
-         currently ``RUNNING`` -- the SDK client should poll
-         ``GET /v1/chat/tasks/{id}`` until status leaves RUNNING and
-         retry. Workforce turn rejections map to their own stable
-         codes (``workforce_archived`` / ``workforce_config_changed``,
-         409 -- NOT retryable) so clients aren't told to retry a
-         permanently-rejected conversation.
+         currently ``RUNNING``, or 409 ``interaction_response_required``
+         if it is ``WAITING_FOR_USER`` -- that status answers a pending
+         agent question and is handled by
+         ``POST /v1/chat/tasks/{id}/reply`` instead. Workforce turn
+         rejections map to their own stable codes (``workforce_archived``
+         / ``workforce_config_changed``, 409 -- NOT retryable) so clients
+         aren't told to retry a permanently-rejected conversation.
       4. Otherwise persists the new user message to
          ``task_chat_messages``, updates ``task.input`` to record
          this turn's input, and kicks off the next background turn
@@ -983,8 +984,9 @@ async def append_message_to_task(
         V1ApiError 404: task not found OR not owned by the key OR
             body.agent_id / body.workforce_id doesn't match the bound
             owner.
-        V1ApiError 409: ``task_busy`` (retryable) or a workforce
-            rejection code (not retryable).
+        V1ApiError 409: ``task_busy`` (retryable), a workforce rejection
+            code (not retryable), or ``interaction_response_required``
+            (use ``reply`` instead).
         500: any other unexpected error (V1 envelope via global handler).
     """
     actor_user_id = principal.owner_user_id

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -40,12 +40,14 @@ from ...schemas.v1 import (
     AppendMessageResponse,
     CreateTaskRequest,
     CreateTaskResponse,
+    PendingInteraction,
     PublicStep,
     StepsResponse,
     TaskInfoResponse,
     UploadedFileInfo,
     UploadFilesResponse,
 )
+from ...services.chat_history_service import get_latest_waiting_question
 from ...services.connector_runtime import (
     bind_create_connector_runtime_plan,
     persist_create_connector_runtime_context,
@@ -653,6 +655,8 @@ class _TaskInfoSnapshot:
     error: str | None
     created_at: datetime | None
     updated_at: datetime | None
+    pending_question: str | None
+    pending_interactions: list[dict[str, Any]] | None
 
 
 @dataclass(frozen=True)
@@ -751,6 +755,12 @@ def _load_task_info_snapshot(
     SessionLocal = get_session_local()
     with SessionLocal() as db:
         task = _resolve_task_or_404(task_id, principal, db)
+        pending_question: str | None = None
+        pending_interactions: list[dict[str, Any]] | None = None
+        if task.status == TaskStatus.WAITING_FOR_USER:
+            pending_question, pending_interactions = get_latest_waiting_question(
+                db, task_id
+            )
         return _TaskInfoSnapshot(
             task_id=int(task.id),
             agent_id=int(task.agent_id),
@@ -763,6 +773,8 @@ def _load_task_info_snapshot(
             error=cast(str | None, task.error_message),
             created_at=cast(datetime | None, task.created_at),
             updated_at=cast(datetime | None, task.updated_at),
+            pending_question=pending_question,
+            pending_interactions=pending_interactions,
         )
 
 
@@ -832,15 +844,34 @@ def _get_chat_task_sync(
     task_id: int,
     principal: ApiKeyPrincipal,
 ) -> TaskInfoResponse:
-    """Build one task response without retaining a Session during cache I/O."""
+    """Build one task response without retaining a Session during cache I/O.
+
+    ``pending_interaction`` is deliberately kept OUT of the cached
+    response body and stitched on after every cache read/write. The
+    cache entry's freshness token is ``tasks.updated_at`` (see
+    ``task_updated_at`` below), but the pending question lives in
+    ``task_chat_messages`` -- a write there does not touch
+    ``tasks.updated_at``, so a cached entry has no way to prove its
+    ``pending_interaction`` is still current. Caching it anyway would
+    let a stale question survive a cache hit indefinitely.
+    """
 
     task = _load_task_info_snapshot(task_id, principal)
     completed_at = task.updated_at if task.status in _TERMINAL_STATUSES else None
+    pending_interaction = (
+        PendingInteraction(
+            question=task.pending_question,
+            interactions=task.pending_interactions,
+        )
+        if task.pending_question is not None
+        else None
+    )
     cache_key = task_snapshot_key(task_id)
     task_updated_at = cache_version_token(task.updated_at)
     cached = cache_get(cache_key)
     if isinstance(cached, dict) and cached.get("updated_at") == task_updated_at:
-        return TaskInfoResponse.model_validate(cached["response"])
+        response = TaskInfoResponse.model_validate(cached["response"])
+        return response.model_copy(update={"pending_interaction": pending_interaction})
 
     response = TaskInfoResponse(
         task_id=task.task_id,
@@ -866,7 +897,7 @@ def _get_chat_task_sync(
         },
         ttl_seconds=task_cache_ttl_seconds(),
     )
-    return response
+    return response.model_copy(update={"pending_interaction": pending_interaction})
 
 
 def _get_chat_task_steps_sync(

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -42,6 +42,8 @@ from ...schemas.v1 import (
     CreateTaskResponse,
     PendingInteraction,
     PublicStep,
+    ReplyRequest,
+    ReplyResponse,
     StepsResponse,
     TaskInfoResponse,
     UploadedFileInfo,
@@ -423,6 +425,46 @@ def _prepare_created_task_isolated(
         _retire_turn_session_best_effort(db, task_id=owned_task_id)
 
 
+def _validate_owner_scope(
+    principal: ApiKeyPrincipal,
+    *,
+    request_agent_id: int | None,
+    request_workforce_id: int | None,
+) -> None:
+    """Validate a request body's owner-scoping fields against the key.
+
+    Shared by every ``/v1/chat/tasks/{task_id}/*`` write that reuses the
+    ``AppendMessageRequest``-shaped owner fields (append, reply): an
+    agent-bound key must pass a matching ``agent_id`` and no
+    ``workforce_id``; a workforce-bound key must not pass ``agent_id``
+    and, if it passes ``workforce_id``, it must match the bound
+    workforce. Task ownership itself must already be resolved (e.g. via
+    :func:`_resolve_task_or_404`) before calling this, so an unrelated
+    task stays an opaque ``task_not_found`` even when the body also
+    names the wrong owner.
+    """
+    if principal.agent is not None:
+        if request_agent_id is None:
+            raise V1ApiError(
+                V1ErrorCode.INVALID_INPUT,
+                422,
+                message="agent_id is required",
+            )
+        if request_agent_id != principal.agent.id:
+            raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404)
+        if request_workforce_id is not None:
+            raise V1ApiError(V1ErrorCode.WORKFORCE_NOT_FOUND, 404)
+    else:
+        assert principal.workforce is not None
+        if request_agent_id is not None:
+            raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404)
+        if (
+            request_workforce_id is not None
+            and request_workforce_id != principal.workforce.id
+        ):
+            raise V1ApiError(V1ErrorCode.WORKFORCE_NOT_FOUND, 404)
+
+
 def _prepare_append_turn_isolated(
     *,
     task_id: int,
@@ -444,26 +486,11 @@ def _prepare_append_turn_isolated(
 
         # Task ownership is resolved first so an unrelated task remains an
         # opaque task_not_found even when the body also names the wrong owner.
-        if principal.agent is not None:
-            if request_agent_id is None:
-                raise V1ApiError(
-                    V1ErrorCode.INVALID_INPUT,
-                    422,
-                    message="agent_id is required",
-                )
-            if request_agent_id != principal.agent.id:
-                raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404)
-            if request_workforce_id is not None:
-                raise V1ApiError(V1ErrorCode.WORKFORCE_NOT_FOUND, 404)
-        else:
-            assert principal.workforce is not None
-            if request_agent_id is not None:
-                raise V1ApiError(V1ErrorCode.AGENT_NOT_FOUND, 404)
-            if (
-                request_workforce_id is not None
-                and request_workforce_id != principal.workforce.id
-            ):
-                raise V1ApiError(V1ErrorCode.WORKFORCE_NOT_FOUND, 404)
+        _validate_owner_scope(
+            principal,
+            request_agent_id=request_agent_id,
+            request_workforce_id=request_workforce_id,
+        )
 
         runtime_agent = db.get(Agent, int(task.agent_id))
         if runtime_agent is None:
@@ -1048,6 +1075,36 @@ async def append_message_to_task(
         state_version=started.state_version,
         control_state=started.control_state,
     )
+
+
+@router.post(
+    "/chat/tasks/{task_id}/reply",
+    status_code=202,
+    response_model=ReplyResponse,
+)
+async def reply_to_waiting_task(
+    task_id: int,
+    request: ReplyRequest,
+    principal: ApiKeyPrincipal = Depends(get_principal_from_api_key),
+) -> ReplyResponse:
+    """Answer the agent's pending question on a ``waiting_for_user`` task.
+
+    Route declaration lives here alongside the other task endpoints;
+    the implementation is in ``task_reply.py`` because it resumes an
+    existing run rather than claiming a new turn -- a different
+    lifecycle from create/append that deserves its own module. See
+    :func:`xagent.web.api.v1.task_reply.reply_to_task` for the full
+    contract (accepted states, error codes, fail-closed checkpoint
+    handling).
+
+    Imported inside the handler (not at module level) because
+    ``task_reply`` imports ownership-resolution helpers back from this
+    module; deferring the import here breaks that cycle without
+    duplicating those helpers.
+    """
+    from .task_reply import reply_to_task
+
+    return await reply_to_task(task_id=task_id, request=request, principal=principal)
 
 
 @router.get("/chat/tasks/{task_id}", response_model=TaskInfoResponse)

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -368,6 +368,95 @@ class AppendMessageResponse(BaseModel):
     control_state: str = Field(..., description="Detailed task control state.")
 
 
+class ReplyRequest(BaseModel):
+    """Body for ``POST /v1/chat/tasks/{task_id}/reply``.
+
+    Answers the agent's pending question on a task whose
+    ``status == 'waiting_for_user'``, resuming the same run rather than
+    starting a new turn. Owner-scoping fields have the same shape and
+    semantics as :class:`AppendMessageRequest`: agent-bound keys pass
+    ``agent_id`` (required), workforce-bound keys optionally pass
+    ``workforce_id``.
+
+    Deliberately narrower than :class:`AppendMessageRequest`:
+
+    - No ``files``: the resume reattaches to the paused run, which has
+      no turn-file binding point (that only exists when a new turn is
+      claimed).
+    - No ``connector_runtime_context``: the resume reuses the connector
+      context already resolved for the run in progress.
+    - No ``metadata``: not passed through by this endpoint.
+    - No idempotency key: a retried reply can be posted twice; callers
+      that need to avoid a duplicate answer should ``GET`` the task and
+      confirm it has left ``waiting_for_user`` before retrying.
+    """
+
+    agent_id: Optional[int] = Field(
+        None,
+        description=(
+            "Target agent's primary key. Required for agent-bound keys; "
+            "must match the agent the key is bound to and the task's "
+            "agent_id. Omit for workforce-bound keys."
+        ),
+    )
+    workforce_id: Optional[int] = Field(
+        None,
+        description=(
+            "Target workforce's primary key. Optional for workforce-bound "
+            "keys; must match the workforce the key is bound to when "
+            "provided. Omit for agent-bound keys."
+        ),
+    )
+    message: MessageBody = Field(
+        ..., description="The user's answer to the agent's pending question."
+    )
+
+
+class ReplyResponse(BaseModel):
+    """``POST /v1/chat/tasks/{task_id}/reply`` -> 202 Accepted response.
+
+    Same fields and semantics as :class:`AppendMessageResponse`, except:
+    ``status`` is always ``'running'`` (a reply always resumes
+    execution), and ``run_id`` is the *same* run the task was waiting
+    on -- the reply resumes the paused execution rather than starting a
+    new one.
+    """
+
+    task_id: int = Field(..., description="Existing task primary key.")
+    agent_id: int = Field(
+        ...,
+        description=(
+            "Agent the task is bound to. For workforce runs this is the "
+            "workforce's manager agent."
+        ),
+    )
+    workforce_id: Optional[int] = Field(
+        None,
+        description=(
+            "Workforce the task belongs to when the key is workforce-bound; "
+            "null for agent-bound keys."
+        ),
+    )
+    status: str = Field(
+        ..., description="Always 'running': a reply always resumes execution."
+    )
+    accepted_at: datetime = Field(
+        ...,
+        description="UTC timestamp when the server accepted the reply.",
+    )
+    run_id: str = Field(
+        ...,
+        description=(
+            "Identity of the resumed execution run -- the same run_id the "
+            "task was waiting on before this reply."
+        ),
+    )
+    state_version: int = Field(
+        ..., description="Monotonic version of the task control state."
+    )
+    control_state: str = Field(..., description="Detailed task control state.")
+
+
 class CreateWorkforceRunRequest(BaseModel):
     """Body for ``POST /v1/workforces/{workforce_id}/runs``.
 

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -459,7 +459,10 @@ class TaskInfoResponse(BaseModel):
     )
     status: str = Field(
         ...,
-        description="One of: pending / running / paused / completed / failed.",
+        description=(
+            "One of: pending / running / paused / waiting_for_user / "
+            "completed / failed."
+        ),
     )
     run_id: Optional[str] = Field(None, description="Current execution run identity.")
     state_version: int = Field(

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -529,7 +529,7 @@ class CreateWorkforceRunResponse(BaseModel):
 
 
 class PendingInteraction(BaseModel):
-    """The agent's latest unanswered question on a waiting task.
+    """The agent's most recent question on a waiting task.
 
     ``interactions`` is an opaque list of structured-control descriptors
     (the agent tool's own JSON shape, e.g. ``{"type": "text_input",
@@ -609,14 +609,18 @@ class TaskInfoResponse(BaseModel):
     pending_interaction: Optional[PendingInteraction] = Field(
         None,
         description=(
-            "Convenience projection of the agent's most recent unanswered "
-            "question. Always present in the response body, but null "
-            "unless status='waiting_for_user' AND the task has at least "
-            "one persisted question message -- a task can reach "
-            "waiting_for_user with no question recorded (e.g. an empty "
-            "message body), and this field is null in that case too. "
-            "This is a convenience read, not the historical interaction "
-            "record; see #1079 for the full typed interaction surface."
+            "Convenience projection of the agent's most recent question. "
+            "Always present in the response body, but null unless "
+            "status='waiting_for_user' AND the task has at least one "
+            "persisted question message. A task can reach waiting_for_user "
+            "with no question ever recorded (e.g. an empty message body), "
+            "in which case this field is null too -- but if an earlier "
+            "turn already persisted a question, this field surfaces that "
+            "earlier question rather than null, since the read returns "
+            "the latest persisted question row regardless of which turn "
+            "wrote it. This is a convenience read, not the historical "
+            "interaction record; see #1079 for the full typed interaction "
+            "surface."
         ),
     )
 

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -439,6 +439,31 @@ class CreateWorkforceRunResponse(BaseModel):
     control_state: str = Field("idle", description="Detailed task control state.")
 
 
+class PendingInteraction(BaseModel):
+    """The agent's latest unanswered question on a waiting task.
+
+    ``interactions`` is an opaque list of structured-control descriptors
+    (the agent tool's own JSON shape, e.g. ``{"type": "text_input",
+    "field": ..., "label": ...}``) passed through as-is rather than typed
+    against a fixed schema, because the seven-value ``type`` enum lives
+    with the agent tool and duplicating it here would be a second source
+    of truth to keep in sync. ``[]`` and ``null`` both mean "no
+    structured control, answer with plain text" and are intentionally
+    not normalized to one value server-side -- callers should treat them
+    the same way.
+    """
+
+    question: str = Field(..., description="The agent's pending question text.")
+    interactions: Optional[List[Dict[str, Any]]] = Field(
+        None,
+        description=(
+            "Opaque structured-control descriptors for this question, or "
+            "null. May also be an empty list; treat [] and null the same "
+            "way (both mean plain-text answer)."
+        ),
+    )
+
+
 class TaskInfoResponse(BaseModel):
     """``GET /v1/chat/tasks/{task_id}`` response.
 
@@ -490,6 +515,19 @@ class TaskInfoResponse(BaseModel):
         description=(
             "UTC timestamp when the task reached a terminal state "
             "(completed or failed). Null while still running."
+        ),
+    )
+    pending_interaction: Optional[PendingInteraction] = Field(
+        None,
+        description=(
+            "Convenience projection of the agent's most recent unanswered "
+            "question. Always present in the response body, but null "
+            "unless status='waiting_for_user' AND the task has at least "
+            "one persisted question message -- a task can reach "
+            "waiting_for_user with no question recorded (e.g. an empty "
+            "message body), and this field is null in that case too. "
+            "This is a convenience read, not the historical interaction "
+            "record; see #1079 for the full typed interaction surface."
         ),
     )
 

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -102,7 +102,9 @@ logger = logging.getLogger(__name__)
 # Statuses for the "can a user message start the next turn?" check. A
 # task in any of these is eligible for ``TurnKind.APPEND``. PENDING is
 # claimed by ``CREATE``; RUNNING is still busy; WAITING_FOR_USER is an
-# answer to an explicit pending agent question and resumes that execution.
+# answer to a pending agent question and is handled by the dedicated
+# reply endpoint instead, which resumes the existing run rather than
+# claiming a new turn.
 _APPENDABLE_STATUSES = (
     TaskStatus.COMPLETED,
     TaskStatus.FAILED,

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -987,12 +987,14 @@ def _claim_turn_no_commit(
     )
     if claimed == 0:
         owned = (
-            db.query(Task.id)
+            db.query(Task.id, Task.status)
             .filter(Task.id == task_id, Task.user_id == task_owner_user_id)
             .first()
         )
         if owned is None:
             raise TaskTurnNotFoundError(task_id)
+        if owned.status == TaskStatus.WAITING_FOR_USER:
+            raise TaskTurnError("interaction_response_required")
         raise TaskTurnError("busy")
 
     task_lease = acquire_task_lease_no_commit(

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -445,6 +445,9 @@ class TaskTurnOrchestrator:
             TaskTurnError("bg_inflight"): a previous bg coroutine is running.
             TaskTurnError("busy"): the row exists and is owned but its status
                 did not match the claim filter.
+            TaskTurnError("interaction_response_required"): ``kind ==
+                APPEND`` and the row's status is ``WAITING_FOR_USER`` --
+                use the reply endpoint instead of append.
             TaskTurnNotFoundError: no row matched id + owner.
         """
         if kind == TurnKind.CREATE and force_fresh:
@@ -1082,7 +1085,10 @@ def _begin_turn_atomic_sync(
 
       - row missing / not owned by ``task_owner_user_id`` →
         :class:`TaskTurnNotFoundError`
-      - row exists + owned but wrong status → ``TaskTurnError("busy")``
+      - row exists + owned but wrong status → ``TaskTurnError("busy")``,
+        or ``TaskTurnError("interaction_response_required")`` when the
+        row's status is ``WAITING_FOR_USER`` (use the reply endpoint
+        instead of append)
 
     The committed-row snapshot is SELECTed pre-commit (read-your-writes within
     the transaction; a bulk ``.update(synchronize_session=False)`` leaves no

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -1,0 +1,664 @@
+"""Integration tests for ``POST /v1/chat/tasks/{task_id}/reply``.
+
+Mirrors the structure of ``tests/web/api/test_a2a_api.py``'s
+input-required resume tests, since ``task_reply.py`` copies that
+resume's mechanics. Where a2a's test patches
+``xagent.web.api.a2a._schedule_waiting_a2a_resume`` to avoid spinning
+up a real background execution, these tests patch the analogous
+``xagent.web.api.v1.task_reply._schedule_waiting_reply_resume``.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xagent.core.agent.checkpoint import (
+    CheckpointAccessRefusedError,
+    CheckpointCorruptError,
+    CheckpointReadError,
+    CheckpointUnavailableError,
+)
+from xagent.web.api.v1 import task_reply as task_reply_module
+from xagent.web.models.agent import Agent
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.schemas.v1 import ReplyRequest
+from xagent.web.services.task_execution_controller import TaskControlState
+from xagent.web.services.task_lease_service import TaskLease, current_task_lease
+
+from ..conftest import _admin_headers, _direct_db_session, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+# ===== helpers =====
+
+
+_agent_name_counter = 0
+
+
+def _create_agent_with_key() -> tuple[int, str]:
+    global _agent_name_counter
+    _agent_name_counter += 1
+    headers = _admin_headers()
+    agent_resp = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": f"v1 reply test agent {_agent_name_counter}",
+            "description": "test",
+            "instructions": "you are a test agent",
+            "execution_mode": "balanced",
+        },
+    )
+    assert agent_resp.status_code == 200, agent_resp.text
+    agent_id = agent_resp.json()["id"]
+    key_resp = client.post(f"/api/agents/{agent_id}/api-key", headers=headers)
+    assert key_resp.status_code == 200, key_resp.text
+    return agent_id, key_resp.json()["full_key"]
+
+
+def _bearer(full_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {full_key}"}
+
+
+@pytest.fixture(autouse=True)
+def mock_start_task():
+    """Stub the leaf that starts a real background turn for the seed POST.
+
+    Only the initial ``POST /v1/chat/tasks`` used to create fixtures goes
+    through this path; the reply endpoint itself never calls it.
+    """
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ) as mocked:
+        yield mocked
+
+
+def _create_task(full_key: str, agent_id: int, content: str = "hello") -> int:
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={"agent_id": agent_id, "message": {"role": "user", "content": content}},
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()["task_id"]
+
+
+def _create_waiting_task(
+    full_key: str,
+    agent_id: int,
+    *,
+    run_id: str | None = "run-original",
+    content: str = "hello",
+) -> int:
+    """Create a task and force it straight to waiting_for_user with a run_id.
+
+    Mirrors what a real ask_user_question turn leaves behind: RUNNING ->
+    WAITING_FOR_USER, lease released, run_id retained.
+    """
+    task_id = _create_task(full_key, agent_id, content=content)
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        task.status = TaskStatus.WAITING_FOR_USER
+        task.control_state = TaskControlState.WAITING_FOR_USER.value
+        task.run_id = run_id
+        task.runner_id = None
+        task.lease_expires_at = None
+        task.last_heartbeat_at = None
+        db.commit()
+    finally:
+        db.close()
+    return task_id
+
+
+def _insert_question_message(task_id: int, *, content: str = "Continue?") -> None:
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        db.add(
+            TaskChatMessage(
+                task_id=task_id,
+                user_id=int(task.user_id),
+                role="assistant",
+                content=content,
+                message_type="question",
+                turn_id=f"question-{task_id}",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _patch_agent_service(post_user_message: AsyncMock):
+    agent_service = MagicMock()
+    agent_service.post_user_message = post_user_message
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    return patch(
+        "xagent.web.api.chat.get_agent_manager",
+        return_value=agent_manager,
+    ), agent_service
+
+
+def _reply_body(agent_id: int, content: str = "yes, continue") -> dict:
+    return {"agent_id": agent_id, "message": {"role": "user", "content": content}}
+
+
+# ===== happy path =====
+
+
+def test_reply_happy_path_resumes_the_same_run(mock_start_task):
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id="run-original")
+    _insert_question_message(task_id)
+
+    post_user_message = AsyncMock(return_value=True)
+    agent_patch, agent_service = _patch_agent_service(post_user_message)
+    with (
+        agent_patch,
+        patch(
+            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            new=AsyncMock(),
+        ) as schedule_resume,
+    ):
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["task_id"] == task_id
+    assert body["agent_id"] == agent_id
+    assert body["status"] == "running"
+    assert body["run_id"] == "run-original"
+
+    agent_service.post_user_message.assert_awaited_once()
+    call_kwargs = agent_service.post_user_message.call_args.kwargs
+    assert call_kwargs["execution_message"] == "yes, continue"
+    assert call_kwargs["display_message"] == "yes, continue"
+    assert call_kwargs["request_interrupt"] is False
+    assert call_kwargs["turn_id"].startswith(f"v1:reply:{task_id}:")
+    schedule_resume.assert_called_once()
+    scheduled_lease = schedule_resume.call_args.kwargs["task_lease"]
+    assert scheduled_lease.run_id == "run-original"
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status == TaskStatus.RUNNING
+        assert task.run_id == "run-original"
+        assert task.input == "yes, continue"
+        assert task.output is None
+        assert task.error_message is None
+    finally:
+        db.close()
+
+
+# ===== status matrix =====
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [
+        (TaskStatus.PENDING, "no_pending_interaction"),
+        (TaskStatus.RUNNING, "task_busy"),
+        (TaskStatus.PAUSED, "no_pending_interaction"),
+        (TaskStatus.COMPLETED, "no_pending_interaction"),
+        (TaskStatus.FAILED, "no_pending_interaction"),
+    ],
+)
+def test_reply_status_matrix(mock_start_task, status: TaskStatus, expected_code: str):
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        task.status = status
+        db.commit()
+    finally:
+        db.close()
+
+    resp = client.post(
+        f"/v1/chat/tasks/{task_id}/reply",
+        headers=_bearer(full_key),
+        json=_reply_body(agent_id),
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["error"]["code"] == expected_code
+
+
+def test_reply_waiting_status_is_not_rejected_by_the_status_gate(mock_start_task):
+    """The waiting row of the status matrix: WAITING_FOR_USER must fall
+    through the status gate (not be rejected there) -- verified via the
+    lease-acquisition dimension being reached instead."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id)
+    _insert_question_message(task_id)
+
+    post_user_message = AsyncMock(return_value=True)
+    agent_patch, _ = _patch_agent_service(post_user_message)
+    with (
+        agent_patch,
+        patch(
+            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            new=AsyncMock(),
+        ),
+    ):
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+    assert resp.status_code == 202, resp.text
+
+
+# ===== ownership =====
+
+
+def test_reply_with_body_agent_id_mismatch_returns_404(mock_start_task):
+    """The request body's agent_id must match the key-bound agent; a
+    mismatch is 404 agent_not_found (not 403, so the existence of the
+    other agent isn't leaked). Same key throughout -- this exercises
+    body validation, not cross-key ownership (see the dedicated
+    cross-key test below for that)."""
+    agent_id, full_key = _create_agent_with_key()
+    other_agent_id, _other_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id)
+    _insert_question_message(task_id)
+
+    resp = client.post(
+        f"/v1/chat/tasks/{task_id}/reply",
+        headers=_bearer(full_key),
+        json=_reply_body(other_agent_id),
+    )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["error"]["code"] == "agent_not_found"
+
+
+def test_reply_with_a_different_agents_key_returns_404_task_not_found(
+    mock_start_task,
+):
+    """A key bound to a DIFFERENT agent than the task's owner must not
+    reach the task at all -- 404 task_not_found from
+    _resolve_task_or_404's ownership predicate, not the body-validation
+    404 the test above exercises. Body is self-consistent (the second
+    agent's own id) so only the ownership predicate can be at fault."""
+    agent_id, full_key = _create_agent_with_key()
+    other_agent_id, other_full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id)
+    _insert_question_message(task_id)
+
+    resp = client.post(
+        f"/v1/chat/tasks/{task_id}/reply",
+        headers=_bearer(other_full_key),
+        json=_reply_body(other_agent_id),
+    )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["error"]["code"] == "task_not_found"
+
+
+def test_reply_to_non_sdk_source_task_returns_404(mock_start_task):
+    agent_id, full_key = _create_agent_with_key()
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        task = Task(
+            user_id=int(agent.user_id),
+            title="web ui task",
+            status=TaskStatus.WAITING_FOR_USER,
+            control_state=TaskControlState.WAITING_FOR_USER.value,
+            run_id="run-web",
+            agent_id=agent_id,
+            source="web",
+            is_visible=True,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+    finally:
+        db.close()
+
+    resp = client.post(
+        f"/v1/chat/tasks/{task_id}/reply",
+        headers=_bearer(full_key),
+        json=_reply_body(agent_id),
+    )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["error"]["code"] == "task_not_found"
+
+
+def test_reply_to_unknown_task_returns_404(mock_start_task):
+    _agent_id, full_key = _create_agent_with_key()
+    resp = client.post(
+        "/v1/chat/tasks/999999999/reply",
+        headers=_bearer(full_key),
+        json=_reply_body(_agent_id),
+    )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["error"]["code"] == "task_not_found"
+
+
+# ===== files rejected =====
+
+
+def test_reply_with_files_returns_422(mock_start_task):
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id)
+    _insert_question_message(task_id)
+
+    resp = client.post(
+        f"/v1/chat/tasks/{task_id}/reply",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "here", "files": ["file-1"]},
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+def test_reply_missing_agent_id_returns_422(mock_start_task):
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id)
+    _insert_question_message(task_id)
+
+    resp = client.post(
+        f"/v1/chat/tasks/{task_id}/reply",
+        headers=_bearer(full_key),
+        json={"message": {"role": "user", "content": "here"}},
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+# ===== checkpoint missing (endpoint layer) =====
+
+
+def test_reply_checkpoint_missing_is_fail_closed(mock_start_task):
+    """post_user_message returns False (no checkpoint found) -> 409
+    interaction_not_resumable, task restored to waiting_for_user with
+    zero residue: no runner_id, no lease, run_id unchanged, no error."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id="run-legacy")
+    _insert_question_message(task_id)
+
+    observed_lease: dict[str, TaskLease] = {}
+
+    async def post_user_message(*_args, **_kwargs) -> bool:
+        lease = current_task_lease()
+        assert lease is not None
+        assert lease.run_id == "run-legacy"
+        observed_lease["lease"] = lease
+        verify_db = _direct_db_session()
+        try:
+            leased = verify_db.query(Task).filter(Task.id == task_id).one()
+            assert leased.status == TaskStatus.RUNNING
+            assert leased.run_id == lease.run_id
+        finally:
+            verify_db.close()
+        return False
+
+    agent_patch, _ = _patch_agent_service(AsyncMock(side_effect=post_user_message))
+    with agent_patch:
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["error"]["code"] == "interaction_not_resumable"
+    assert observed_lease, "post_user_message stub never ran"
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status == TaskStatus.WAITING_FOR_USER
+        assert task.control_state == TaskControlState.WAITING_FOR_USER.value
+        assert task.runner_id is None
+        assert task.lease_expires_at is None
+        assert task.run_id == "run-legacy"
+        assert task.error_message is None
+    finally:
+        db.close()
+
+
+# ===== checkpoint read errors =====
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_status", "expected_code"),
+    [
+        (
+            CheckpointCorruptError("all matching rows undecodable"),
+            409,
+            "interaction_not_resumable",
+        ),
+        (
+            CheckpointAccessRefusedError("refused", reason="superseded_legacy"),
+            409,
+            "interaction_not_resumable",
+        ),
+        (
+            CheckpointAccessRefusedError("refused", reason="lease_mismatch"),
+            409,
+            "task_busy",
+        ),
+        (
+            CheckpointAccessRefusedError("refused", reason="active_run"),
+            409,
+            "task_busy",
+        ),
+        (
+            CheckpointUnavailableError("checkpoint store unavailable"),
+            503,
+            "temporarily_unavailable",
+        ),
+    ],
+)
+def test_reply_checkpoint_read_error_maps_to_distinct_code(
+    mock_start_task,
+    error: Exception,
+    expected_status: int,
+    expected_code: str,
+):
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(
+        full_key, agent_id, run_id=f"run-{type(error).__name__}"
+    )
+    _insert_question_message(task_id)
+
+    agent_patch, _ = _patch_agent_service(AsyncMock(side_effect=error))
+    with agent_patch:
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+
+    assert resp.status_code == expected_status, resp.text
+    assert resp.json()["error"]["code"] == expected_code
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status == TaskStatus.WAITING_FOR_USER
+        assert task.control_state == TaskControlState.WAITING_FOR_USER.value
+        assert task.runner_id is None
+        assert task.lease_expires_at is None
+    finally:
+        db.close()
+
+
+def test_reply_unknown_checkpoint_read_error_subclass_is_treated_as_retryable(
+    mock_start_task,
+):
+    """A future CheckpointReadError subclass this dispatch does not
+    recognize must fall to the conservative 503 branch, not silently
+    collapse into the terminal interaction_not_resumable code."""
+
+    class _FutureCheckpointError(CheckpointReadError):
+        pass
+
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id)
+    _insert_question_message(task_id)
+
+    agent_patch, _ = _patch_agent_service(
+        AsyncMock(side_effect=_FutureCheckpointError("unknown failure mode"))
+    )
+    with agent_patch:
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+
+    assert resp.status_code == 503, resp.text
+    assert resp.json()["error"]["code"] == "temporarily_unavailable"
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status == TaskStatus.WAITING_FOR_USER
+        assert task.control_state == TaskControlState.WAITING_FOR_USER.value
+        assert task.runner_id is None
+        assert task.lease_expires_at is None
+    finally:
+        db.close()
+
+
+# ===== concurrent reply race =====
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reply_race_exactly_one_winner(mock_start_task):
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id="run-race")
+    _insert_question_message(task_id)
+
+    db = _direct_db_session()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).one()
+        owner_user_id = int(agent.user_id)
+    finally:
+        db.close()
+
+    post_user_message = AsyncMock(return_value=True)
+    agent_patch, _ = _patch_agent_service(post_user_message)
+
+    from xagent.web.api.v1.deps import (
+        AgentPrincipalSnapshot,
+        ApiKeyPrincipal,
+        RuntimeApiKeySnapshot,
+    )
+
+    principal = ApiKeyPrincipal(
+        key=RuntimeApiKeySnapshot(key_prefix="xag_test"),
+        agent=AgentPrincipalSnapshot(
+            id=agent_id,
+            user_id=owner_user_id,
+            execution_mode="balanced",
+            status="published",
+            origin="user_created",
+        ),
+    )
+
+    async def attempt(content: str) -> object:
+        try:
+            return await task_reply_module.reply_to_task(
+                task_id=task_id,
+                request=ReplyRequest(
+                    agent_id=agent_id,
+                    message={"role": "user", "content": content},
+                ),
+                principal=principal,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return exc
+
+    with (
+        agent_patch,
+        patch(
+            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            new=AsyncMock(),
+        ),
+    ):
+        result_a, result_b = await asyncio.gather(
+            attempt("answer A"), attempt("answer B")
+        )
+
+    from xagent.web.api.v1.errors import V1ApiError
+
+    results = [result_a, result_b]
+    successes = [r for r in results if not isinstance(r, Exception)]
+    failures = [r for r in results if isinstance(r, Exception)]
+    assert len(successes) == 1, (result_a, result_b)
+    assert len(failures) == 1, (result_a, result_b)
+    assert isinstance(failures[0], V1ApiError)
+    assert failures[0].code.value == "task_busy"
+
+    db = _direct_db_session()
+    try:
+        # post_user_message is mocked (no real transcript write here), but
+        # the winner must be exactly one: exactly one successful claim,
+        # exactly one input write.
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status == TaskStatus.RUNNING
+        assert task.input in ("answer A", "answer B")
+    finally:
+        db.close()
+    assert post_user_message.await_count == 1
+
+
+# ===== run_id NULL historical waiting row =====
+
+
+def test_reply_untagged_checkpoint_is_not_resumed_without_an_exact_run(mock_start_task):
+    """A legacy waiting task with no run_id: the prelease mints a new run
+    (no run fence to preserve), post_user_message finds no checkpoint
+    fenced to that fresh run, and the endpoint fails closed."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id=None)
+    _insert_question_message(task_id)
+
+    async def post_user_message(*_args, **_kwargs) -> bool:
+        lease = current_task_lease()
+        assert lease is not None
+        assert lease.run_id is not None
+        verify_db = _direct_db_session()
+        try:
+            leased = verify_db.query(Task).filter(Task.id == task_id).one()
+            assert leased.run_id == lease.run_id
+        finally:
+            verify_db.close()
+        return False
+
+    agent_patch, _ = _patch_agent_service(AsyncMock(side_effect=post_user_message))
+    with agent_patch:
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["error"]["code"] == "interaction_not_resumable"
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        assert task.status == TaskStatus.WAITING_FOR_USER
+        assert task.runner_id is None
+        assert task.lease_expires_at is None
+        assert task.run_id is not None
+    finally:
+        db.close()

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -2753,6 +2753,73 @@ def test_append_message_to_running_task_returns_409(mock_start_task):
     assert mock_start_task.call_count == 0
 
 
+def test_append_message_to_waiting_task_returns_interaction_response_required(
+    mock_start_task,
+):
+    """Appending to a waiting_for_user task is rejected with the
+    dedicated code (not task_busy), points at reply, and leaves the task
+    completely untouched -- no new transcript row, same status, same
+    run_id, no new background kickoff."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _force_task_status(task_id, TaskStatus.WAITING_FOR_USER)
+
+    db = _direct_db_session()
+    try:
+        before = db.query(Task).filter(Task.id == task_id).one()
+        run_id_before = before.run_id
+        from xagent.web.models.chat_message import TaskChatMessage
+
+        message_count_before = (
+            db.query(TaskChatMessage).filter(TaskChatMessage.task_id == task_id).count()
+        )
+    finally:
+        db.close()
+    mock_start_task.reset_mock()
+
+    resp = client.post(
+        f"/v1/chat/tasks/{task_id}/messages",
+        headers=_bearer(full_key),
+        json={"agent_id": agent_id, "message": {"role": "user", "content": "hello"}},
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["error"]["code"] == "interaction_response_required"
+    assert "reply" in resp.json()["error"]["message"]
+    assert mock_start_task.call_count == 0
+
+    db = _direct_db_session()
+    try:
+        after = db.query(Task).filter(Task.id == task_id).one()
+        assert after.status == TaskStatus.WAITING_FOR_USER
+        assert after.run_id == run_id_before
+        from xagent.web.models.chat_message import TaskChatMessage
+
+        message_count_after = (
+            db.query(TaskChatMessage).filter(TaskChatMessage.task_id == task_id).count()
+        )
+        assert message_count_after == message_count_before
+    finally:
+        db.close()
+
+
+def test_append_message_to_running_task_still_returns_task_busy(mock_start_task):
+    """The new waiting-specific code must not leak onto the
+    unrelated RUNNING rejection -- RUNNING keeps plain task_busy."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _force_task_status(task_id, TaskStatus.RUNNING)
+    mock_start_task.reset_mock()
+
+    resp = client.post(
+        f"/v1/chat/tasks/{task_id}/messages",
+        headers=_bearer(full_key),
+        json={"agent_id": agent_id, "message": {"role": "user", "content": "hello"}},
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["error"]["code"] == "task_busy"
+    assert mock_start_task.call_count == 0
+
+
 def test_append_message_claims_slot_atomically(mock_start_task):
     """Successful append flips task.status to RUNNING in the same
     transaction as the input write, so a concurrent POST can't pass

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -3129,6 +3129,180 @@ def test_get_task_cache_io_runs_after_database_session_closes(
         engine.dispose()
 
 
+# ===== GET pending_interaction projection =====
+
+
+def _insert_question_message(
+    task_id: int,
+    *,
+    content: str = "Where are you flying to?",
+    interactions: list[dict] | None = None,
+    turn_id: str | None = None,
+) -> None:
+    """Write one assistant question row directly, bypassing the WS writer.
+
+    Mirrors the shape ``_persist_agent_outbound_event`` in
+    ``api/websocket.py`` writes for ``expect_response`` outbound events:
+    ``role='assistant'``, ``message_type='question'``.
+    """
+    from xagent.web.models.chat_message import TaskChatMessage
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        assert task is not None
+        db.add(
+            TaskChatMessage(
+                task_id=task_id,
+                user_id=int(task.user_id),
+                role="assistant",
+                content=content,
+                message_type="question",
+                interactions=interactions,
+                turn_id=turn_id or f"question-{content[:8]}-{id(content)}",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_get_task_waiting_returns_pending_interaction_with_structured_controls(
+    mock_start_task,
+):
+    """Waiting task with a structured question returns question +
+    non-empty interactions."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _force_task_status(task_id, TaskStatus.WAITING_FOR_USER)
+    _insert_question_message(
+        task_id,
+        content="Where are you flying to?",
+        interactions=[
+            {"type": "text_input", "field": "destination", "label": "Destination"}
+        ],
+    )
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "waiting_for_user"
+    assert body["pending_interaction"] is not None
+    assert body["pending_interaction"]["question"] == "Where are you flying to?"
+    assert body["pending_interaction"]["interactions"] == [
+        {"type": "text_input", "field": "destination", "label": "Destination"}
+    ]
+
+
+def test_get_task_waiting_null_interactions_stays_null(mock_start_task):
+    """A plain-text question (interactions stored NULL) must come
+    back as null, not []."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _force_task_status(task_id, TaskStatus.WAITING_FOR_USER)
+    _insert_question_message(task_id, content="Should I continue?", interactions=None)
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()["pending_interaction"]
+    assert body["question"] == "Should I continue?"
+    assert body["interactions"] is None
+
+
+def test_get_task_waiting_empty_interactions_list_stays_empty_list(mock_start_task):
+    """An empty structured-controls list must come back as [], not
+    null -- the server does not normalize [] and null together."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _force_task_status(task_id, TaskStatus.WAITING_FOR_USER)
+    _insert_question_message(task_id, content="Should I continue?", interactions=[])
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()["pending_interaction"]
+    assert body["question"] == "Should I continue?"
+    assert body["interactions"] == []
+
+
+def test_get_task_waiting_with_no_question_row_returns_null(mock_start_task):
+    """A task can reach waiting_for_user with no question message
+    persisted (e.g. an empty outbound message string). pending_interaction
+    must be null, and the response must still be 200, not 500."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _force_task_status(task_id, TaskStatus.WAITING_FOR_USER)
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["pending_interaction"] is None
+
+
+def test_get_task_non_waiting_never_queries_for_a_question(
+    mock_start_task,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A non-waiting task's pending_interaction is null, and the
+    server must not even issue the question lookup query."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _force_task_status(task_id, TaskStatus.COMPLETED)
+
+    called = False
+
+    def spy_get_latest_waiting_question(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return None, None
+
+    monkeypatch.setattr(
+        v1_tasks, "get_latest_waiting_question", spy_get_latest_waiting_question
+    )
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["pending_interaction"] is None
+    assert called is False
+
+
+def test_get_task_pending_interaction_bypasses_stale_cache_entry(mock_start_task):
+    """Cache isolation. The task is already waiting_for_user (with
+    no question yet) when the first GET populates the snapshot cache. A
+    question row is then inserted directly into ``task_chat_messages`` --
+    which, unlike a ``Task`` column write, never touches ``tasks.updated_at``
+    -- so the cache's freshness token is still valid on the next GET. That
+    next GET must still surface the new question: the cache entry itself
+    must never carry ``pending_interaction``, or this second read would
+    serve the pre-question snapshot forever (until the cache TTL expires).
+
+    Needs a real cache backend (the default test backend is a no-op), or
+    this test would pass vacuously without ever exercising a cache hit.
+    """
+    set_cache_backend_for_testing(InMemoryTTLCache())
+    try:
+        agent_id, full_key = _create_agent_with_key()
+        task_id = _create_task(full_key, agent_id)
+        _force_task_status(task_id, TaskStatus.WAITING_FOR_USER)
+
+        first = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+        assert first.status_code == 200, first.text
+        assert first.json()["status"] == "waiting_for_user"
+        assert first.json()["pending_interaction"] is None
+
+        # This insert does not touch the tasks row at all, so
+        # tasks.updated_at -- the cache's only freshness token -- is
+        # unchanged. The next GET is a genuine cache hit on the base body.
+        _insert_question_message(task_id, content="Should I continue?")
+
+        second = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+        assert second.status_code == 200, second.text
+        body = second.json()
+        assert body["status"] == "waiting_for_user"
+        assert body["pending_interaction"] is not None
+        assert body["pending_interaction"]["question"] == "Should I continue?"
+    finally:
+        set_cache_backend_for_testing(None)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("read_surface", ["task", "steps"])
 async def test_task_read_pool_wait_does_not_block_event_loop(

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -3291,6 +3291,32 @@ def test_get_task_waiting_empty_interactions_list_stays_empty_list(mock_start_ta
     assert body["interactions"] == []
 
 
+def test_get_task_waiting_drops_non_mapping_interaction_elements(mock_start_task):
+    """A dirty row whose stored interactions list mixes dicts with a
+    non-dict element (e.g. a bare string a buggy writer once persisted)
+    must not 500 the GET forever -- the v1 read path filters non-mapping
+    elements out, keeping only the valid dict entries."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _force_task_status(task_id, TaskStatus.WAITING_FOR_USER)
+    _insert_question_message(
+        task_id,
+        content="Should I continue?",
+        interactions=[
+            {"type": "text_input", "field": "destination", "label": "Destination"},
+            "not a mapping",
+        ],
+    )
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}", headers=_bearer(full_key))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()["pending_interaction"]
+    assert body["question"] == "Should I continue?"
+    assert body["interactions"] == [
+        {"type": "text_input", "field": "destination", "label": "Destination"}
+    ]
+
+
 def test_get_task_waiting_with_no_question_row_returns_null(mock_start_task):
     """A task can reach waiting_for_user with no question message
     persisted (e.g. an empty outbound message string). pending_interaction


### PR DESCRIPTION
## Summary

`GET /v1/chat/tasks/{task_id}` could tell an SDK caller a task was
`waiting_for_user` but not what it was waiting for, and
`POST /v1/chat/tasks/{task_id}/messages` (append) silently accepted a
waiting task's status filter miss and fell into the generic `task_busy`
409 -- whose default message tells the client to retry, which is
misleading for a task that is not busy, just waiting on an answer.

This PR adds:

- `TaskInfoResponse.pending_interaction` (`PendingInteraction | None`):
  always present in the response body, null unless
  `status == 'waiting_for_user'` **and** the task has at least one
  persisted question message. Carries the question text and an opaque
  list of structured-control descriptors (or `null`) -- passed through
  as-is rather than typed against the agent tool's seven-value `type`
  enum, so this schema doesn't become a second source of truth for it.
  `[]` and `null` are intentionally not normalized together; both mean
  "no structured control, answer with plain text."
- `POST /v1/chat/tasks/{task_id}/reply`: the only way to answer a
  waiting task's question and resume the paused execution. Structurally
  mirrors the A2A input-required resume
  (`web/api/a2a.py::_resume_input_required_a2a_task`) -- same two-phase
  prelease (claim, then either commit past it or restore it exactly),
  same heartbeat guarding the injection, same fail-closed handling of
  every checkpoint outcome -- scoped instead to `Task.source == "sdk"`
  and the v1 SDK's agent/workforce ownership rules, accepting only
  `WAITING_FOR_USER` (not `PAUSED`, which append already handles).
- Four new stable error codes: `interaction_response_required` (409,
  what append now returns for a waiting task), `no_pending_interaction`
  (409, reply called on a non-waiting task), `interaction_not_resumable`
  (409, the task's saved progress can't be resumed -- not retryable),
  `temporarily_unavailable` (503, a transient read failure -- retryable).
- Corrected the `_APPENDABLE_STATUSES` comment (it described
  `WAITING_FOR_USER` as append-resumable, which the tuple never
  actually allowed) and the v1 `status` field description (it listed
  five statuses and silently dropped `waiting_for_user`).
- The v1 read path that builds `pending_interaction` now filters the
  stored `interactions` list down to dict elements before handing it
  to the schema. A row written by an older or buggy writer can carry
  a non-dict element in that list, which previously failed Pydantic
  validation and 500'd `GET` on that task permanently, until the row
  was fixed by hand. Scoped to this one read path's output --
  `get_latest_waiting_question` and the schema type are unchanged, so
  the shared reader's other consumers (`websocket.py`, `chat.py`)
  keep their existing behavior.

## Fail-closed checkpoint handling

When a reply's saved execution progress can't be resumed -- no
run-fenced checkpoint, a corrupt checkpoint, or a superseded legacy
partition -- the endpoint returns an error, releases the prelease back
to `waiting_for_user`, and leaves the task exactly where it was. For a
task that already has a `run_id`, the reply never fabricates a
different one or falls back to a transcript replay; the caller's only
path forward is to start a new task. (A legacy task whose `run_id` is
already `NULL` is a separate case, not covered by that guarantee: the
prelease claim mints a fresh run id for it, since there is no existing
run to preserve. That fresh run has no checkpoint fenced to it either,
so the same fail-closed error still applies once the checkpoint read
comes back empty -- the task lands back in `waiting_for_user` either
way, just by two different routes depending on whether a `run_id` was
already on record.) A transient infrastructure read failure gets the
distinct retryable `temporarily_unavailable` (503) instead of being
folded into the terminal `interaction_not_resumable` (409), so a
client can tell "give up" from "try again."

## Not idempotent

`reply()` carries no request-level idempotency key. The request body
has nothing to derive one from, and deriving one from server-side state
(e.g. `run_id` + question id) breaks the moment a caller legitimately
answers twice with different text -- a genuine correction would collide
on the same derived key as the first answer, and the runner's existing
`turn_id` reuse semantics turn a mismatched-content collision into a
`ValueError`. A client-side timeout on `reply()` does not tell the
caller whether the answer was delivered; callers that need to avoid a
duplicate should `GET` the task and confirm it has left
`waiting_for_user` before retrying.

## Compatibility

- `pending_interaction` is a pure field addition to
  `TaskInfoResponse`. An SDK that hasn't upgraded silently drops the
  unknown key (its `TypeAdapter` parse already discards unrecognized
  fields) -- this is not a breaking change for existing clients.
- The four new error codes are additive to the `V1ErrorCode` enum,
  which is documented as an allowed addition (see `errors.py`'s own
  docstring: "Adding new codes is allowed; renaming or removing
  existing ones is a breaking change"). An SDK built before this PR
  maps any code it doesn't recognize to a generic internal error, so
  an old SDK hitting the new `interaction_response_required` /
  `no_pending_interaction` / `interaction_not_resumable` /
  `temporarily_unavailable` codes degrades to that generic error
  rather than crashing or misparsing.
- `reply()` on the SDK side is a companion change tracked separately
  (see below); a client running against this server without the
  updated SDK simply has no way to call the new endpoint, which is a
  capability gap, not a compatibility break.

## Relationship to tracked issues

Part of xorbitsai/xagent#1079 (typed interaction endpoints, full
version) -- delivers its pending-interaction projection (verification
point 2) and the append error split (verification point 4). Not a
`Closes` reference: the rest of #1079 (interaction IDs, the
list/get/respond endpoint trio, an idempotency envelope) remains
tracked there and is deliberately out of scope here.

The companion SDK change (`reply()`, `pending_interaction` on
`TaskInfo`, the matching exception classes) is a separate PR against
xagent-sdk-python; this server change should land and deploy before
that SDK release is published.

## Test plan

- [x] `uv run pytest tests/web/api/v1/test_tasks.py
      tests/web/api/v1/test_task_reply.py tests/web/api/test_a2a_api.py
      tests/core/agent/test_runner.py
      tests/web/services/test_interaction_staging_production_gate.py`
      -- 225 passed.
- [x] Broader adjacent sweep (`tests/web/api/v1/`,
      `tests/web/api/test_a2a_api.py`, `tests/core/agent/test_runner.py`,
      the interaction-staging production gate,
      `tests/web/services/test_task_orchestrator.py`,
      `tests/web/test_chat_history_service.py`,
      `tests/web/test_task_lease_service.py`,
      `tests/web/services/test_acquire_task_lease_isolated.py`,
      `tests/web/services/test_managed_task_lease.py`) -- 510 passed.
- [x] New: a waiting task whose stored `interactions` list mixes dict
      and non-dict elements (e.g. a bare string) now returns 200 with
      the non-dict elements dropped from the projection, instead of
      500ing every `GET` on that task. Mutation-checked: removing the
      filter turns the ValidationError loose again and the test goes
      red.
- [x] `pre-commit run` over every changed/new file (ruff-check,
      ruff-format, mypy, isort, codespell, end-of-file,
      trailing-whitespace) -- clean.
- [x] Every new assertion was manually mutated once (field-drop,
      cache-boundary violation, status-guard widening, error-code
      fallback, checkpoint-branch collapse, prelease
      check-then-write race, legacy-run fail-closed bypass, ownership
      predicate bypass) and confirmed it goes red, then reverted and
      confirmed green. The concurrent-reply-race mutation (atomic
      UPDATE replaced with check-then-write) was additionally re-run 3
      times to rule out a timing-dependent false pass.
- [x] Re-verified the two WS cross-surface safety facts the reason
      change depends on against the current baseline: the
      `_TURN_REJECTION_MESSAGES` lookup on the WS layer is a
      default-valued `.get()` (no `KeyError` on an unrecognized
      reason), and WS never reaches `begin_turn` while a task is
      `WAITING_FOR_USER` (intercepted earlier by the live-control
      path per that code's own comment).
- [x] Ran the existing `test_interaction_staging_production_gate.py`
      unmodified -- still green, confirming this PR's new code never
      imports the still-unwired interaction-staging primitive.
- [x] The runner-layer authoritative semantics for "no checkpoint
      found" (an execution id with nothing recorded returns `None`
      rather than raising) is already covered by the existing
      `test_runner_treats_canonical_empty_checkpoint_as_authoritative`
      in `tests/core/agent/test_runner.py`; this PR's own tests cover
      the endpoint-layer translation of that `None` into
      `interaction_not_resumable` and don't duplicate the runner-level
      case.
