### PR TITLE
fix: point home get-started docs/guides links to help.xagent.co

### DIFF
--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -463,8 +463,8 @@ describe("Home", () => {
       render(<OldSurfaceHome />)
 
       expect(await screen.findByTestId("old-surface-extension")).toBeInTheDocument()
-      expectLinkedGetStartedCard("home.getStarted.docs.title", "https://docs.xagent.co/api-reference/introduction")
-      expectLinkedGetStartedCard("home.getStarted.guides.title", "https://docs.xagent.co/models/overview")
+      expectLinkedGetStartedCard("home.getStarted.docs.title", "https://help.xagent.co/overview.html")
+      expectLinkedGetStartedCard("home.getStarted.guides.title", "https://help.xagent.co/user-guide/overview.html")
       expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
     } finally {
       vi.doMock("@/lib/home-page-extension", createHomeExtensionMock)
@@ -483,8 +483,8 @@ describe("Home", () => {
   it("resolves canonical and distinct configured Get Started destinations per key", () => {
     render(<Home />)
 
-    expectLinkedGetStartedCard("home.getStarted.docs.title", "https://docs.xagent.co/api-reference/introduction")
-    expectLinkedGetStartedCard("home.getStarted.guides.title", "https://docs.xagent.co/models/overview")
+    expectLinkedGetStartedCard("home.getStarted.docs.title", "https://help.xagent.co/overview.html")
+    expectLinkedGetStartedCard("home.getStarted.guides.title", "https://help.xagent.co/user-guide/overview.html")
     expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
     expectInertGetStartedCard("home.getStarted.video.title")
 
@@ -628,7 +628,7 @@ describe("Home", () => {
           expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
         } else {
           expectLinkedGetStartedCard("home.getStarted.docs.title", "/valid-docs")
-          expectLinkedGetStartedCard("home.getStarted.guides.title", "https://docs.xagent.co/models/overview")
+          expectLinkedGetStartedCard("home.getStarted.guides.title", "https://help.xagent.co/user-guide/overview.html")
           expectInertGetStartedCard("home.getStarted.whatsNew.title")
         }
         expectInertGetStartedCard("home.getStarted.video.title")

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -115,6 +115,7 @@ vi.mock("@/components/welcome-modal", () => ({
 vi.mock("@/lib/home-page-extension", createHomeExtensionMock)
 
 import Home from "./page"
+import { defaultHomeGetStartedDestinations } from "@/lib/home-get-started-destinations"
 
 const successfulSelection = {
   kind: "success" as const,
@@ -463,9 +464,9 @@ describe("Home", () => {
       render(<OldSurfaceHome />)
 
       expect(await screen.findByTestId("old-surface-extension")).toBeInTheDocument()
-      expectLinkedGetStartedCard("home.getStarted.docs.title", "https://help.xagent.co/overview.html")
-      expectLinkedGetStartedCard("home.getStarted.guides.title", "https://help.xagent.co/user-guide/overview.html")
-      expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+      expectLinkedGetStartedCard("home.getStarted.docs.title", defaultHomeGetStartedDestinations.docs)
+      expectLinkedGetStartedCard("home.getStarted.guides.title", defaultHomeGetStartedDestinations.guides)
+      expectLinkedGetStartedCard("home.getStarted.whatsNew.title", defaultHomeGetStartedDestinations.whatsNew)
     } finally {
       vi.doMock("@/lib/home-page-extension", createHomeExtensionMock)
       vi.resetModules()
@@ -483,9 +484,9 @@ describe("Home", () => {
   it("resolves canonical and distinct configured Get Started destinations per key", () => {
     render(<Home />)
 
-    expectLinkedGetStartedCard("home.getStarted.docs.title", "https://help.xagent.co/overview.html")
-    expectLinkedGetStartedCard("home.getStarted.guides.title", "https://help.xagent.co/user-guide/overview.html")
-    expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+    expectLinkedGetStartedCard("home.getStarted.docs.title", defaultHomeGetStartedDestinations.docs)
+    expectLinkedGetStartedCard("home.getStarted.guides.title", defaultHomeGetStartedDestinations.guides)
+    expectLinkedGetStartedCard("home.getStarted.whatsNew.title", defaultHomeGetStartedDestinations.whatsNew)
     expectInertGetStartedCard("home.getStarted.video.title")
 
     cleanup()
@@ -621,14 +622,14 @@ describe("Home", () => {
         if (key === "docs") {
           expectInertGetStartedCard("home.getStarted.docs.title")
           expectLinkedGetStartedCard("home.getStarted.guides.title", "/valid-guides")
-          expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+          expectLinkedGetStartedCard("home.getStarted.whatsNew.title", defaultHomeGetStartedDestinations.whatsNew)
         } else if (key === "guides") {
           expectLinkedGetStartedCard("home.getStarted.docs.title", "/valid-docs")
           expectInertGetStartedCard("home.getStarted.guides.title")
-          expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+          expectLinkedGetStartedCard("home.getStarted.whatsNew.title", defaultHomeGetStartedDestinations.whatsNew)
         } else {
           expectLinkedGetStartedCard("home.getStarted.docs.title", "/valid-docs")
-          expectLinkedGetStartedCard("home.getStarted.guides.title", "https://help.xagent.co/user-guide/overview.html")
+          expectLinkedGetStartedCard("home.getStarted.guides.title", defaultHomeGetStartedDestinations.guides)
           expectInertGetStartedCard("home.getStarted.whatsNew.title")
         }
         expectInertGetStartedCard("home.getStarted.video.title")
@@ -645,7 +646,7 @@ describe("Home", () => {
 
     expectLinkedGetStartedCard("home.getStarted.docs.title", "custom:docs")
     expectInertGetStartedCard("home.getStarted.guides.title")
-    expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+    expectLinkedGetStartedCard("home.getStarted.whatsNew.title", defaultHomeGetStartedDestinations.whatsNew)
     expect([
       "home.getStarted.video.title",
       "home.getStarted.docs.title",
@@ -755,6 +756,7 @@ describe("Home", () => {
     const contractsSource = readFileSync("src/lib/page-extension-contracts.ts", "utf8")
     const extensionSource = readFileSync("src/lib/home-page-extension.tsx", "utf8")
     const pageSource = readFileSync("src/app/page.tsx", "utf8")
+    const destinationsSource = readFileSync("src/lib/home-get-started-destinations.ts", "utf8")
     const contractInterface = sourceSlice(
       contractsSource,
       "export interface HomeGetStartedDestinationOverrides",
@@ -774,7 +776,14 @@ describe("Home", () => {
     expect(pageSource).toMatch(
       /const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =\s*\(homePageExtensionModule as \{ homeGetStartedDestinationOverrides\?: HomeGetStartedDestinationOverrides \}\)\s*\.homeGetStartedDestinationOverrides \?\? \{\}/,
     )
-    expect(pageSource).toMatch(/const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = \{/)
+    expect(pageSource).toMatch(
+      /import \{ defaultHomeGetStartedDestinations \} from "@\/lib\/home-get-started-destinations";/,
+    )
+    expect(pageSource).not.toMatch(/const defaultHomeGetStartedDestinations/)
+    expect(destinationsSource).toMatch(/export const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = \{/)
+    expect(destinationsSource).toMatch(/docs: "https:\/\/help\.xagent\.co\/overview\.html"/)
+    expect(destinationsSource).toMatch(/guides: "https:\/\/help\.xagent\.co\/user-guide\/overview\.html"/)
+    expect(destinationsSource).toMatch(/whatsNew: "https:\/\/docs\.xagent\.co\/release-notes"/)
     expect(resolver).toContain("configured === undefined")
     expect(resolver).toContain("typeof configured !== \"string\"")
     expect(resolver).toContain("configured.trim().length === 0")

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -163,8 +163,8 @@ const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =
     .homeGetStartedDestinationOverrides ?? {}
 
 const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = {
-  docs: "https://docs.xagent.co/api-reference/introduction",
-  guides: "https://docs.xagent.co/models/overview",
+  docs: "https://help.xagent.co/overview.html",
+  guides: "https://help.xagent.co/user-guide/overview.html",
   whatsNew: "https://docs.xagent.co/release-notes",
 }
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -33,6 +33,7 @@ import { useVoiceInputControls } from "@/components/voice-input-controller";
 import * as homePageExtensionModule from "@/lib/home-page-extension";
 import { HomePageExtension } from "@/lib/home-page-extension";
 import type { HomeGetStartedDestinationOverrides } from "@/lib/page-extension-contracts";
+import { defaultHomeGetStartedDestinations } from "@/lib/home-get-started-destinations";
 import { toast } from "@/components/ui/sonner";
 
 interface HomeTemplateConnection {
@@ -161,12 +162,6 @@ function decodeRecentTasks(value: unknown): RecentTask[] | null {
 const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =
   (homePageExtensionModule as { homeGetStartedDestinationOverrides?: HomeGetStartedDestinationOverrides })
     .homeGetStartedDestinationOverrides ?? {}
-
-const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = {
-  docs: "https://help.xagent.co/overview.html",
-  guides: "https://help.xagent.co/user-guide/overview.html",
-  whatsNew: "https://docs.xagent.co/release-notes",
-}
 
 function resolveHomeGetStartedDestination(
   configured: unknown,

--- a/frontend/src/lib/home-get-started-destinations.ts
+++ b/frontend/src/lib/home-get-started-destinations.ts
@@ -1,0 +1,11 @@
+import type { HomeGetStartedDestinationOverrides } from "@/lib/page-extension-contracts"
+
+// Canonical OSS default destinations for the home page "Get started" cards.
+// Kept out of `page.tsx` (a Next.js App Router page file, which may only
+// export the reserved page members) so it can be imported by both the page
+// and its tests as a single source of truth.
+export const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = {
+  docs: "https://help.xagent.co/overview.html",
+  guides: "https://help.xagent.co/user-guide/overview.html",
+  whatsNew: "https://docs.xagent.co/release-notes",
+}


### PR DESCRIPTION
## Summary
- Point the Documentation card link from `docs.xagent.co/api-reference/introduction` to `https://help.xagent.co/overview.html`
- Point the How-to Guides card link from `docs.xagent.co/models/overview` to `https://help.xagent.co/user-guide/overview.html`
- Update the corresponding assertions in `page.test.tsx`

## Test plan
- [x] `npx vitest run src/app/page.test.tsx` (110 passed)
- [x] Manually verify both links on the home page navigate to the new help center pages