### PR TITLE
fix(skill): contradict skill guidance that assumes edit_image is registered

### DIFF
--- a/src/xagent/core/agent/context/enrichment.py
+++ b/src/xagent/core/agent/context/enrichment.py
@@ -16,6 +16,9 @@ MEMORY_CONTEXT_METADATA_KEY = "retrieved_memory_context"
 RETRIEVED_MEMORIES_METADATA_KEY = "retrieved_memories"
 SELECTED_SKILL_METADATA_KEY = "selected_skill"
 SKILL_CONTEXT_METADATA_KEY = "selected_skill_context"
+# True only when generate_image is registered and edit_image is not; a deployment
+# with no image tools at all leaves it False.
+IMAGE_EDIT_UNAVAILABLE_METADATA_KEY = "image_edit_unavailable"
 
 
 async def enrich_context_with_memory(

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -56,6 +56,7 @@ COMPACT_DROPPED_TOOL_NAME_MAX_CHARS = 64
 # nothing a dropped observation held.
 NON_EVIDENCE_TOOL_NAMES = CONTROL_TOOL_NAMES | {LOAD_SKILL_TOOL_NAME}
 COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES = 20
+IMAGE_EDIT_UNAVAILABLE_METADATA_KEY = "image_edit_unavailable"
 
 
 def _utcnow() -> datetime:
@@ -606,6 +607,19 @@ class ExecutionContext:
                 "Selected skill guidance. Use it when relevant to the current task:\n"
                 f"{str(skill_context).strip()}"
             )
+            # Skill text is injected verbatim and cannot know which tools were
+            # registered, so the correction has to come after it.
+            if self.metadata.get(IMAGE_EDIT_UNAVAILABLE_METADATA_KEY):
+                parts.append(
+                    "Correction to the skill guidance above: image editing is "
+                    "unavailable here. No configured image model has the edit "
+                    "ability, so edit_image is not in your tools and passing "
+                    "images to generate_image fails. Ignore any instruction to "
+                    "edit an existing image or to attach a reference through "
+                    "images; render each deliverable from a text prompt in one "
+                    "call, and describe in the prompt what a reference would "
+                    "have contributed."
+                )
         return "\n\n".join(part for part in parts if part.strip())
 
     def get_recent_messages(self, n: int = 10) -> list[Message]:

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -35,7 +35,11 @@ from .components import (
     WorkspaceComponent,
     clone_component,
 )
-from .enrichment import MEMORY_CONTEXT_METADATA_KEY, SKILL_CONTEXT_METADATA_KEY
+from .enrichment import (
+    IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
+    MEMORY_CONTEXT_METADATA_KEY,
+    SKILL_CONTEXT_METADATA_KEY,
+)
 from .memory_tool import MEMORY_TOOLS_METADATA_KEY
 from .message import LLMCallRecord, Message
 from .skill_tool import (
@@ -56,10 +60,6 @@ COMPACT_DROPPED_TOOL_NAME_MAX_CHARS = 64
 # nothing a dropped observation held.
 NON_EVIDENCE_TOOL_NAMES = CONTROL_TOOL_NAMES | {LOAD_SKILL_TOOL_NAME}
 COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES = 20
-# True only when generate_image is registered and edit_image is not; a deployment
-# with no image tools at all leaves it False. Lives here, not in enrichment.py
-# with the other metadata keys, because react.py already imports from this module.
-IMAGE_EDIT_UNAVAILABLE_METADATA_KEY = "image_edit_unavailable"
 
 
 def _utcnow() -> datetime:
@@ -612,9 +612,12 @@ class ExecutionContext:
             )
             # Skill text is injected verbatim and cannot know which tools were
             # registered, so the correction has to come after it.
-            if self.metadata.get(
-                IMAGE_EDIT_UNAVAILABLE_METADATA_KEY
-            ) and "edit_image" in str(skill_context):
+            if (
+                self.metadata.get(IMAGE_EDIT_UNAVAILABLE_METADATA_KEY)
+                and "edit_image" in str(skill_context).lower()
+            ):
+                # Last sentence pair mirrors the capability prefix in
+                # tools/adapters/vibe/image_tool.py; edit both together.
                 parts.append(
                     "Correction to the skill guidance above: image editing is "
                     "unavailable here. edit_image is not in your tools, and "

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -56,6 +56,9 @@ COMPACT_DROPPED_TOOL_NAME_MAX_CHARS = 64
 # nothing a dropped observation held.
 NON_EVIDENCE_TOOL_NAMES = CONTROL_TOOL_NAMES | {LOAD_SKILL_TOOL_NAME}
 COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES = 20
+# True only when generate_image is registered and edit_image is not; a deployment
+# with no image tools at all leaves it False. Lives here, not in enrichment.py
+# with the other metadata keys, because react.py already imports from this module.
 IMAGE_EDIT_UNAVAILABLE_METADATA_KEY = "image_edit_unavailable"
 
 
@@ -609,16 +612,18 @@ class ExecutionContext:
             )
             # Skill text is injected verbatim and cannot know which tools were
             # registered, so the correction has to come after it.
-            if self.metadata.get(IMAGE_EDIT_UNAVAILABLE_METADATA_KEY):
+            if self.metadata.get(
+                IMAGE_EDIT_UNAVAILABLE_METADATA_KEY
+            ) and "edit_image" in str(skill_context):
                 parts.append(
                     "Correction to the skill guidance above: image editing is "
-                    "unavailable here. No configured image model has the edit "
-                    "ability, so edit_image is not in your tools and passing "
-                    "images to generate_image fails. Ignore any instruction to "
-                    "edit an existing image or to attach a reference through "
-                    "images; render each deliverable from a text prompt in one "
-                    "call, and describe in the prompt what a reference would "
-                    "have contributed."
+                    "unavailable here. edit_image is not in your tools, and "
+                    "passing images to generate_image routes into the same "
+                    "absent edit path. Ignore any instruction to edit an "
+                    "existing image or to attach a reference through images; "
+                    "render each deliverable from a text prompt in one call, "
+                    "and describe in the prompt what a reference would have "
+                    "contributed."
                 )
         return "\n\n".join(part for part in parts if part.strip())
 

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -10,6 +10,7 @@ from json_repair import loads as repair_json_loads
 
 from ....model.chat.exceptions import LLMToolProtocolError
 from ...context.enrichment import (
+    IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     MEMORY_CONTEXT_METADATA_KEY,
     RETRIEVED_MEMORIES_METADATA_KEY,
     SELECTED_SKILL_METADATA_KEY,
@@ -17,7 +18,6 @@ from ...context.enrichment import (
     enrich_context_with_memory,
     latest_user_text,
 )
-from ...context.execution import IMAGE_EDIT_UNAVAILABLE_METADATA_KEY
 from ...context.skill_tool import (
     LOAD_SKILL_TOOL_NAME,
     LOADED_SKILLS_METADATA_KEY,

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -17,6 +17,7 @@ from ...context.enrichment import (
     enrich_context_with_memory,
     latest_user_text,
 )
+from ...context.execution import IMAGE_EDIT_UNAVAILABLE_METADATA_KEY
 from ...context.skill_tool import (
     LOAD_SKILL_TOOL_NAME,
     LOADED_SKILLS_METADATA_KEY,
@@ -1803,6 +1804,7 @@ class AutoPattern(AgentPattern):
             SKILL_CONTEXT_METADATA_KEY,
             SKILL_INDEX_METADATA_KEY,
             LOADED_SKILLS_METADATA_KEY,
+            IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
         ):
             metadata.pop(key, None)
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -390,7 +390,12 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any]:
         self.status = "thinking"
         self._tool_decision_groups_by_name = self._tool_decision_groups_for_tools(tools)
-        self._record_image_edit_availability(context)
+        # Skill text names edit_image unconditionally; get_system_context needs
+        # this to contradict it.
+        context.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = (
+            "generate_image" in self._tool_decision_groups_by_name
+            and "edit_image" not in self._tool_decision_groups_by_name
+        )
         base_tool_schemas = (
             []
             if self.tool_choice == "none"
@@ -1120,20 +1125,6 @@ class ReActPattern(AgentPattern):
             if isinstance(function, dict) and function.get("name"):
                 names.append(str(function["name"]))
         return names
-
-    def _record_image_edit_availability(self, context: Any) -> None:
-        """Flag a deployment that can generate images but not edit them.
-
-        Injected skill text names edit_image unconditionally; the system context
-        needs this to contradict it.
-        """
-        metadata = getattr(context, "metadata", None)
-        if metadata is None:
-            return
-        names = self._tool_decision_groups_by_name
-        metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = (
-            "generate_image" in names and "edit_image" not in names
-        )
 
     def _tool_decision_groups_for_tools(self, tools: list[Any]) -> dict[str, str]:
         groups: dict[str, str] = {}

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -50,10 +50,10 @@ from ....tools.user_interaction import (
 )
 from ...clarification import draft_from_waiting_request
 from ...context.enrichment import (
+    IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     enrich_context_with_memory,
     latest_user_text,
 )
-from ...context.execution import IMAGE_EDIT_UNAVAILABLE_METADATA_KEY
 from ...context.memory_tool import build_memory_tools
 from ...context.skill_tool import build_load_skill_tool
 from ...grounding import grounding_rule
@@ -390,8 +390,7 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any]:
         self.status = "thinking"
         self._tool_decision_groups_by_name = self._tool_decision_groups_for_tools(tools)
-        # Skill text names edit_image unconditionally; get_system_context needs
-        # this to contradict it.
+        # Read by get_system_context to contradict skill text naming edit_image.
         context.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = (
             "generate_image" in self._tool_decision_groups_by_name
             and "edit_image" not in self._tool_decision_groups_by_name

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -53,6 +53,7 @@ from ...context.enrichment import (
     enrich_context_with_memory,
     latest_user_text,
 )
+from ...context.execution import IMAGE_EDIT_UNAVAILABLE_METADATA_KEY
 from ...context.memory_tool import build_memory_tools
 from ...context.skill_tool import build_load_skill_tool
 from ...grounding import grounding_rule
@@ -389,6 +390,7 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any]:
         self.status = "thinking"
         self._tool_decision_groups_by_name = self._tool_decision_groups_for_tools(tools)
+        self._record_image_edit_availability(context)
         base_tool_schemas = (
             []
             if self.tool_choice == "none"
@@ -1118,6 +1120,20 @@ class ReActPattern(AgentPattern):
             if isinstance(function, dict) and function.get("name"):
                 names.append(str(function["name"]))
         return names
+
+    def _record_image_edit_availability(self, context: Any) -> None:
+        """Flag a deployment that can generate images but not edit them.
+
+        Injected skill text names edit_image unconditionally; the system context
+        needs this to contradict it.
+        """
+        metadata = getattr(context, "metadata", None)
+        if metadata is None:
+            return
+        names = self._tool_decision_groups_by_name
+        metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = (
+            "generate_image" in names and "edit_image" not in names
+        )
 
     def _tool_decision_groups_for_tools(self, tools: list[Any]) -> dict[str, str]:
         groups: dict[str, str] = {}

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -2269,9 +2269,7 @@ async def test_auto_decision_prompt_includes_memory_rule_only_with_store() -> No
 
 
 def test_clearing_request_scoped_enrichment_drops_the_image_edit_flag() -> None:
-    # The flag survives to_dict/from_dict and child-context copies, so a stale
-    # True would reach a routing prompt rendered before the loop recomputes it.
-    from xagent.core.agent.context.execution import (
+    from xagent.core.agent.context.enrichment import (
         IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     )
 

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -2266,3 +2266,18 @@ async def test_auto_decision_prompt_includes_memory_rule_only_with_store() -> No
 
     assert "memory tools can persist" in with_memory
     assert "memory tools can persist" not in without_memory
+
+
+def test_clearing_request_scoped_enrichment_drops_the_image_edit_flag() -> None:
+    # The flag survives to_dict/from_dict and child-context copies, so a stale
+    # True would reach a routing prompt rendered before the loop recomputes it.
+    from xagent.core.agent.context.execution import (
+        IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
+    )
+
+    context = ExecutionContext(system_prompt="Base prompt.")
+    context.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = True
+
+    AutoPattern()._clear_request_scoped_enrichment(context)
+
+    assert IMAGE_EDIT_UNAVAILABLE_METADATA_KEY not in context.metadata

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -619,6 +619,48 @@ def test_get_messages_for_llm_coalesces_system_messages() -> None:
     assert result[2] == {"role": "user", "content": "hello"}
 
 
+def test_skill_guidance_is_corrected_when_image_editing_is_unavailable() -> None:
+    from xagent.core.agent.context.execution import (
+        IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
+    )
+
+    ctx = ExecutionContext(system_prompt="Base prompt.")
+    ctx.metadata[SKILL_CONTEXT_METADATA_KEY] = (
+        "## Available Skill: static-visual-design\n\nUse `edit_image` to refine."
+    )
+    ctx.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = True
+    ctx.add_user_message("make an ad")
+
+    system_content = ctx.get_messages_for_llm()[0]["content"]
+
+    assert "image editing is unavailable here" in system_content
+    # The correction is worthless unless it lands after the text it contradicts.
+    assert system_content.index("Selected skill guidance") < system_content.index(
+        "Correction to the skill guidance above"
+    )
+
+
+def test_no_correction_when_editing_works_or_no_skill_is_loaded() -> None:
+    from xagent.core.agent.context.execution import (
+        IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
+    )
+
+    with_edit = ExecutionContext(system_prompt="Base prompt.")
+    with_edit.metadata[SKILL_CONTEXT_METADATA_KEY] = "## Available Skill: design"
+    with_edit.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = False
+    with_edit.add_user_message("x")
+
+    no_skill = ExecutionContext(system_prompt="Base prompt.")
+    no_skill.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = True
+    no_skill.add_user_message("x")
+
+    for ctx in (with_edit, no_skill):
+        assert (
+            "Correction to the skill guidance"
+            not in (ctx.get_messages_for_llm()[0]["content"])
+        )
+
+
 def test_get_messages_for_llm_injects_memory_and_skill_context() -> None:
     ctx = ExecutionContext(system_prompt="Base prompt.")
     ctx.metadata[MEMORY_CONTEXT_METADATA_KEY] = (

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -620,7 +620,7 @@ def test_get_messages_for_llm_coalesces_system_messages() -> None:
 
 
 def test_skill_guidance_is_corrected_when_image_editing_is_unavailable() -> None:
-    from xagent.core.agent.context.execution import (
+    from xagent.core.agent.context.enrichment import (
         IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     )
 
@@ -635,15 +635,28 @@ def test_skill_guidance_is_corrected_when_image_editing_is_unavailable() -> None
 
     assert "image editing is unavailable here" in system_content
     # The correction is worthless unless it lands after the text it contradicts.
-    # Anchor on the guidance body, not its header, so splitting the skill block
-    # cannot silently make this pass for the wrong reason.
     assert system_content.index("Use `edit_image` to refine.") < system_content.index(
         "Correction to the skill guidance above"
     )
 
 
+def test_correction_matches_edit_image_case_insensitively() -> None:
+    from xagent.core.agent.context.enrichment import (
+        IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
+    )
+
+    ctx = ExecutionContext(system_prompt="Base prompt.")
+    ctx.metadata[SKILL_CONTEXT_METADATA_KEY] = "Call EDIT_IMAGE to refine."
+    ctx.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = True
+    ctx.add_user_message("x")
+
+    assert (
+        "image editing is unavailable here" in ctx.get_messages_for_llm()[0]["content"]
+    )
+
+
 def test_no_correction_when_editing_works_or_the_skill_never_named_it() -> None:
-    from xagent.core.agent.context.execution import (
+    from xagent.core.agent.context.enrichment import (
         IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     )
 
@@ -656,7 +669,6 @@ def test_no_correction_when_editing_works_or_the_skill_never_named_it() -> None:
     no_skill.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = True
     no_skill.add_user_message("x")
 
-    # 8 of the 9 builtin skills never mention edit_image; they get no correction.
     unrelated_skill = ExecutionContext(system_prompt="Base prompt.")
     unrelated_skill.metadata[SKILL_CONTEXT_METADATA_KEY] = "Write the report first."
     unrelated_skill.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = True

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -635,18 +635,20 @@ def test_skill_guidance_is_corrected_when_image_editing_is_unavailable() -> None
 
     assert "image editing is unavailable here" in system_content
     # The correction is worthless unless it lands after the text it contradicts.
-    assert system_content.index("Selected skill guidance") < system_content.index(
+    # Anchor on the guidance body, not its header, so splitting the skill block
+    # cannot silently make this pass for the wrong reason.
+    assert system_content.index("Use `edit_image` to refine.") < system_content.index(
         "Correction to the skill guidance above"
     )
 
 
-def test_no_correction_when_editing_works_or_no_skill_is_loaded() -> None:
+def test_no_correction_when_editing_works_or_the_skill_never_named_it() -> None:
     from xagent.core.agent.context.execution import (
         IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     )
 
     with_edit = ExecutionContext(system_prompt="Base prompt.")
-    with_edit.metadata[SKILL_CONTEXT_METADATA_KEY] = "## Available Skill: design"
+    with_edit.metadata[SKILL_CONTEXT_METADATA_KEY] = "Use `edit_image` to refine."
     with_edit.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = False
     with_edit.add_user_message("x")
 
@@ -654,7 +656,13 @@ def test_no_correction_when_editing_works_or_no_skill_is_loaded() -> None:
     no_skill.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = True
     no_skill.add_user_message("x")
 
-    for ctx in (with_edit, no_skill):
+    # 8 of the 9 builtin skills never mention edit_image; they get no correction.
+    unrelated_skill = ExecutionContext(system_prompt="Base prompt.")
+    unrelated_skill.metadata[SKILL_CONTEXT_METADATA_KEY] = "Write the report first."
+    unrelated_skill.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] = True
+    unrelated_skill.add_user_message("x")
+
+    for ctx in (with_edit, no_skill, unrelated_skill):
         assert (
             "Correction to the skill guidance"
             not in (ctx.get_messages_for_llm()[0]["content"])

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5716,3 +5716,52 @@ async def test_react_discards_the_preamble_with_the_rejected_response() -> None:
         "Let me look into that." not in str(event.get("content") or event.get("delta"))
         for event in outbound.events
     )
+
+
+@pytest.mark.asyncio
+async def test_run_flags_missing_image_editing_for_the_skill_correction() -> None:
+    # Covers the wiring: the helper's own test passes even if the call inside
+    # the tool-calling loop is deleted.
+    from xagent.core.agent.context.execution import (
+        IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
+    )
+
+    from .concurrency_harness import FakeTool as NamedFakeTool
+
+    llm = FakeLLM(responses=[{"content": "done", "done": True}])
+    pattern = ReActPattern(max_iterations=2)
+    context = ExecutionContext(system_prompt="You are helpful.")
+    context.add_user_message("make an ad")
+
+    await pattern.run(context=context, tools=[NamedFakeTool("generate_image")], llm=llm)
+
+    assert context.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] is True
+
+
+@pytest.mark.parametrize(
+    ("tool_names", "unavailable"),
+    [
+        (["generate_image", "list_image_models"], True),
+        (["generate_image", "edit_image"], False),
+        (["web_search"], False),
+    ],
+)
+def test_records_whether_image_editing_is_available(
+    tool_names: list[str], unavailable: bool
+) -> None:
+    from xagent.core.agent.context.execution import (
+        IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
+        ExecutionContext,
+    )
+
+    from .concurrency_harness import FakeTool, make_react
+
+    pattern = make_react()
+    pattern._tool_decision_groups_by_name = pattern._tool_decision_groups_for_tools(
+        [FakeTool(name) for name in tool_names]
+    )
+    context = ExecutionContext(system_prompt="Base prompt.")
+
+    pattern._record_image_edit_availability(context)
+
+    assert context.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] is unavailable

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5718,10 +5718,22 @@ async def test_react_discards_the_preamble_with_the_rejected_response() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("tool_names", "unavailable"),
+    [
+        # A generate-only deployment keeps list_image_models registered; this is
+        # the shape the generate_image precondition exists for.
+        (["generate_image", "list_image_models"], True),
+        (["generate_image", "edit_image"], False),
+        (["list_image_models"], False),
+        (["web_search"], False),
+    ],
+)
 @pytest.mark.asyncio
-async def test_run_flags_missing_image_editing_for_the_skill_correction() -> None:
-    # Covers the wiring: the helper's own test passes even if the call inside
-    # the tool-calling loop is deleted.
+async def test_run_flags_missing_image_editing_and_renders_the_correction(
+    tool_names: list[str], unavailable: bool
+) -> None:
+    from xagent.core.agent.context.enrichment import SKILL_CONTEXT_METADATA_KEY
     from xagent.core.agent.context.execution import (
         IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     )
@@ -5731,37 +5743,15 @@ async def test_run_flags_missing_image_editing_for_the_skill_correction() -> Non
     llm = FakeLLM(responses=[{"content": "done", "done": True}])
     pattern = ReActPattern(max_iterations=2)
     context = ExecutionContext(system_prompt="You are helpful.")
+    context.metadata[SKILL_CONTEXT_METADATA_KEY] = "Use `edit_image` to refine."
     context.add_user_message("make an ad")
 
-    await pattern.run(context=context, tools=[NamedFakeTool("generate_image")], llm=llm)
-
-    assert context.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] is True
-
-
-@pytest.mark.parametrize(
-    ("tool_names", "unavailable"),
-    [
-        (["generate_image", "list_image_models"], True),
-        (["generate_image", "edit_image"], False),
-        (["web_search"], False),
-    ],
-)
-def test_records_whether_image_editing_is_available(
-    tool_names: list[str], unavailable: bool
-) -> None:
-    from xagent.core.agent.context.execution import (
-        IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
-        ExecutionContext,
+    await pattern.run(
+        context=context,
+        tools=[NamedFakeTool(name) for name in tool_names],
+        llm=llm,
     )
-
-    from .concurrency_harness import FakeTool, make_react
-
-    pattern = make_react()
-    pattern._tool_decision_groups_by_name = pattern._tool_decision_groups_for_tools(
-        [FakeTool(name) for name in tool_names]
-    )
-    context = ExecutionContext(system_prompt="Base prompt.")
-
-    pattern._record_image_edit_availability(context)
 
     assert context.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] is unavailable
+    rendered = llm.calls[0]["messages"][0]["content"]
+    assert ("image editing is unavailable here" in rendered) is unavailable

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5721,8 +5721,6 @@ async def test_react_discards_the_preamble_with_the_rejected_response() -> None:
 @pytest.mark.parametrize(
     ("tool_names", "unavailable"),
     [
-        # A generate-only deployment keeps list_image_models registered; this is
-        # the shape the generate_image precondition exists for.
         (["generate_image", "list_image_models"], True),
         (["generate_image", "edit_image"], False),
         (["list_image_models"], False),
@@ -5733,9 +5731,9 @@ async def test_react_discards_the_preamble_with_the_rejected_response() -> None:
 async def test_run_flags_missing_image_editing_and_renders_the_correction(
     tool_names: list[str], unavailable: bool
 ) -> None:
-    from xagent.core.agent.context.enrichment import SKILL_CONTEXT_METADATA_KEY
-    from xagent.core.agent.context.execution import (
+    from xagent.core.agent.context.enrichment import (
         IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
+        SKILL_CONTEXT_METADATA_KEY,
     )
 
     from .concurrency_harness import FakeTool as NamedFakeTool
@@ -5755,3 +5753,4 @@ async def test_run_flags_missing_image_editing_and_renders_the_correction(
     assert context.metadata[IMAGE_EDIT_UNAVAILABLE_METADATA_KEY] is unavailable
     rendered = llm.calls[0]["messages"][0]["content"]
     assert ("image editing is unavailable here" in rendered) is unavailable
+    assert ("attach a reference through images" in rendered) is unavailable


### PR DESCRIPTION
Closes #1307.

## Problem

`static-visual-design` names `edit_image` and the `images` argument
unconditionally. Skill text is injected verbatim — `SkillParser` stores the whole
file as one blob (`src/xagent/skills/parser.py:80`) — and grepping the skills
package for `has_ability`, `abilities`, `registered_tools`, or `available_tools`
returns nothing. So on a generate-only deployment the agent is instructed to use
a tool that is not in its schema, by text that has no way of knowing that.

#1294 made this reachable: `edit_image` used to exist and fail, so the skill was
merely optimistic. Now it points at something absent.

## Approach

Of the three directions in #1307 this takes the runtime correction, emitted
**after** the skill guidance in the system context. The skill cannot know what
was registered, so the contradiction has to come from something that does — and
it has to come later to win.

Two pieces:

- **`ReActPattern` records the capability.** It reuses the
  `_tool_decision_groups_by_name` map it already builds each turn for the circuit
  breaker, so there is no extra pass over the tools. DAG steps and single_call
  both construct `ReActPattern`s and inherit it.
- **`ExecutionContext.get_system_context` emits the correction**, but only when
  skill guidance is actually present. Without that condition every image task
  carries the paragraph, and the no-skill case is already covered by the
  `IMAGE EDITING IS UNAVAILABLE` prefix #1294 puts on the `generate_image`
  description.

Three decisions worth flagging:

**The flag is `generate_image present && edit_image absent`**, not just
`edit_image absent`. A deployment with no image tools at all should not be told
that image editing is unavailable.

**The correction denies the argument, not only the tool.** `SKILL.md:192` teaches
`images`, and `images` remains a real parameter on `generate_image` that
delegates into the edit path. Denying `edit_image` alone leaves that route open.

**It offers a way forward** ("describe in the prompt what a reference would have
contributed") rather than only a prohibition, so the model has somewhere to go.

## Why not withhold the skill instead

The obvious alternative — do not load a skill whose guidance is partly
inapplicable — costs far more than it saves. The skill is 376 lines; exactly 3
name `edit_image` or `images`. The rest is design method: establishing the brief,
developing campaign directions before rendering, single-canvas structure,
per-candidate `understand_media` inspection, identity-asset handling, and the
completion gate. None of it depends on edit capability, and a creative-deliverable
task needs it — the zero-delivery run in #1289 is what its absence looks like.

Same shape as the `list_image_models` decision in #1294: the unit of
unavailability is one tool, not the whole box.

## Tests

Both directions plus ordering: the correction appears only when editing is
unavailable *and* a skill is loaded, and it lands after the guidance it
contradicts.

Mutation-tested — each of these turns the suite red:

| Mutation | Why it matters |
|---|---|
| Delete the call in the tool-calling loop | The helper's own test passes without it; this is wiring, not logic |
| Drop the `generate_image` precondition | Would add noise on deployments with no image tools |
| Disable the correction block | Base behaviour |
| Move the correction before the skill text | Ordering *is* the mechanism |

The first one is the reason there is an end-to-end test through `pattern.run()`
alongside the unit test — the unit test alone left the wiring unguarded.

Full `tests/core/agent` passes.

## Note on the acceptance criteria

#1307's first acceptance line originally required that nothing in the injected
skill context mention `edit_image` or `images`, which requires conditional
sections in the skill system. I relaxed it to an outcome-based criterion and
recorded the reasoning in the issue.
