### PR TITLE
fix(tools): let media creator failures reach the factory handler

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/audio_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/audio_tool.py
@@ -251,14 +251,10 @@ async def create_audio_tools_from_config(config: "BaseToolConfig") -> List[Any]:
     if not workspace:
         return []
 
-    try:
-        return create_audio_tool(
-            asr_models=asr_models,
-            tts_models=tts_models,
-            workspace=workspace,
-            default_asr_model=config.get_asr_model(),
-            default_tts_model=config.get_tts_model(),
-        )
-    except Exception as e:
-        logger.warning(f"Failed to create audio tools: {e}")
-        return []
+    return create_audio_tool(
+        asr_models=asr_models,
+        tts_models=tts_models,
+        workspace=workspace,
+        default_asr_model=config.get_asr_model(),
+        default_tts_model=config.get_tts_model(),
+    )

--- a/src/xagent/core/tools/adapters/vibe/audio_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/audio_tool.py
@@ -8,7 +8,6 @@ This module provides audio processing capabilities including:
 Uses pre-configured ASR and TTS models passed from the web layer.
 """
 
-import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ....model.asr.base import BaseASR
@@ -17,8 +16,6 @@ from ....workspace import TaskWorkspace
 from ...core.audio_tool import AudioToolCore
 from .base import ToolCategory
 from .function import FunctionTool
-
-logger = logging.getLogger(__name__)
 
 
 class AudioFunctionTool(FunctionTool):

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -114,7 +114,9 @@ class ToolRegistry:
         Register a tool creator function.
 
         The creator function will be called during create_all_tools()
-        with the current config.
+        with the current config. Creators must not blanket-catch their own
+        failures: ``create_registered_tools`` is the single enforcement point
+        for the exception contract described in its docstring.
 
         Usage (bare decorator, no category metadata):
             @register_tool
@@ -218,6 +220,11 @@ class ToolRegistry:
         (dynamic ones: MCP / Custom API / Image / Audio) are always
         dispatched and are responsible for
         short-circuiting internally based on the spec.
+
+        Exception contract for creators: ``ConnectorRuntimeError`` and
+        ``RequiredMCPUnavailableError`` propagate to the caller; any other
+        exception is logged as a warning and that creator contributes no
+        tools. Creators rely on this and must not catch broadly themselves.
         """
         # Import tool modules on first call to trigger decorator registration
         cls._import_tool_modules()
@@ -242,7 +249,9 @@ class ToolRegistry:
             except RequiredMCPUnavailableError:
                 raise
             except Exception as e:
-                logger.warning(f"Tool creator {creator.__name__} failed: {e}")
+                logger.warning(
+                    f"Tool creator {creator.__name__} failed: {e}", exc_info=True
+                )
 
         # Sort tools by category priority
         tools = cls._sort_tools_by_category(tools)

--- a/src/xagent/core/tools/adapters/vibe/image_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/image_tool.py
@@ -5,7 +5,6 @@ This module provides image generation capabilities using pre-configured image mo
 passed from the web layer.
 """
 
-import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ....model.image.base import BaseImageModel
@@ -13,8 +12,6 @@ from ....workspace import TaskWorkspace
 from ...core.image_tool import ImageGenerationToolCore
 from .base import ToolCategory
 from .function import FunctionTool
-
-logger = logging.getLogger(__name__)
 
 
 class ImageGenerationFunctionTool(FunctionTool):
@@ -69,8 +66,10 @@ class ImageGenerationTool(ImageGenerationToolCore):
         """Get all tool instances."""
         # A note inside the description is not enough: models blind-retry a
         # registered-but-doomed tool, so an unusable one has to leave the schema.
-        # list_image_models stays either way — it is read-only, cannot fail, and
-        # is the only way to answer "why is there nothing here".
+        # list_image_models stays whenever the ability probes return — it is the
+        # only way to answer "why is there nothing here". A probe that *raises*
+        # takes the whole toolset with it, by design: that is a broken model
+        # class, not a deployment without image models.
         can_generate = self._get_model() is not None
         can_edit = self._get_edit_model() is not None
 

--- a/src/xagent/core/tools/adapters/vibe/image_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/image_tool.py
@@ -184,16 +184,12 @@ async def create_image_tools_from_config(config: "BaseToolConfig") -> List[Any]:
     if not workspace:
         return []
 
-    try:
-        default_generate_model = config.get_image_generate_model()
-        default_edit_model = config.get_image_edit_model()
+    default_generate_model = config.get_image_generate_model()
+    default_edit_model = config.get_image_edit_model()
 
-        return create_image_tool(
-            image_models,
-            workspace=workspace,
-            default_generate_model=default_generate_model,
-            default_edit_model=default_edit_model,
-        )
-    except Exception as e:
-        logger.warning(f"Failed to create image tools: {e}")
-        return []
+    return create_image_tool(
+        image_models,
+        workspace=workspace,
+        default_generate_model=default_generate_model,
+        default_edit_model=default_edit_model,
+    )

--- a/src/xagent/core/tools/adapters/vibe/music_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/music_tool.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Optional
 
 from ....model.music import BaseMusicModel
@@ -10,8 +9,6 @@ from ....workspace import TaskWorkspace
 from ...core.music_tool import MusicToolCore
 from .base import ToolCategory
 from .function import FunctionTool
-
-logger = logging.getLogger(__name__)
 
 
 class MusicFunctionTool(FunctionTool):

--- a/src/xagent/core/tools/adapters/vibe/music_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/music_tool.py
@@ -69,12 +69,8 @@ async def create_music_tools_from_config(
     workspace = ToolFactory.create_workspace(config.get_workspace_config())
     if workspace is None:
         return []
-    try:
-        return create_music_tools(
-            models=models,
-            workspace=workspace,
-            default_model=config.get_music_model(),
-        )
-    except Exception as exc:
-        logger.warning("Failed to create music tools: %s", exc)
-        return []
+    return create_music_tools(
+        models=models,
+        workspace=workspace,
+        default_model=config.get_music_model(),
+    )

--- a/src/xagent/core/tools/adapters/vibe/sound_effect_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/sound_effect_tool.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Optional
 
 from ....model.sound_effect import BaseSoundEffectModel
@@ -10,8 +9,6 @@ from ....workspace import TaskWorkspace
 from ...core.sound_effect_tool import SoundEffectToolCore
 from .base import ToolCategory
 from .function import FunctionTool
-
-logger = logging.getLogger(__name__)
 
 
 class SoundEffectFunctionTool(FunctionTool):

--- a/src/xagent/core/tools/adapters/vibe/sound_effect_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/sound_effect_tool.py
@@ -69,12 +69,8 @@ async def create_sound_effect_tools_from_config(
     workspace = ToolFactory.create_workspace(config.get_workspace_config())
     if workspace is None:
         return []
-    try:
-        return create_sound_effect_tools(
-            models=models,
-            workspace=workspace,
-            default_model=config.get_sound_effect_model(),
-        )
-    except Exception as exc:
-        logger.warning("Failed to create sound effect tools: %s", exc)
-        return []
+    return create_sound_effect_tools(
+        models=models,
+        workspace=workspace,
+        default_model=config.get_sound_effect_model(),
+    )

--- a/src/xagent/core/tools/adapters/vibe/video_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/video_tool.py
@@ -117,12 +117,8 @@ async def create_video_tools_from_config(config: "BaseToolConfig") -> List[Any]:
     if not workspace:
         return []
 
-    try:
-        return create_video_tool(
-            video_models,
-            workspace=workspace,
-            default_video_model=config.get_video_model(),
-        )
-    except Exception as e:
-        logger.warning("Failed to create video tools: %s", e)
-        return []
+    return create_video_tool(
+        video_models,
+        workspace=workspace,
+        default_video_model=config.get_video_model(),
+    )

--- a/src/xagent/core/tools/adapters/vibe/video_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/video_tool.py
@@ -5,7 +5,6 @@ This module provides video generation capabilities using pre-configured video
 models passed from the web layer.
 """
 
-import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -14,8 +13,6 @@ from ....workspace import TaskWorkspace
 from ...core.video_tool import VideoGenerationToolCore
 from .base import ToolCategory
 from .function import FunctionTool
-
-logger = logging.getLogger(__name__)
 
 
 class VideoGenerationFunctionTool(FunctionTool):

--- a/tests/core/tools/adapters/vibe/test_media_creator_contract.py
+++ b/tests/core/tools/adapters/vibe/test_media_creator_contract.py
@@ -1,0 +1,37 @@
+import pytest
+
+from xagent.core.tools.adapters.vibe.audio_tool import create_audio_tools_from_config
+from xagent.core.tools.adapters.vibe.config import ToolConfig
+from xagent.core.tools.adapters.vibe.image_tool import create_image_tools_from_config
+from xagent.core.tools.adapters.vibe.music_tool import create_music_tools_from_config
+from xagent.core.tools.adapters.vibe.sound_effect_tool import (
+    create_sound_effect_tools_from_config,
+)
+from xagent.core.tools.adapters.vibe.video_tool import create_video_tools_from_config
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "creator,getter",
+    [
+        (create_image_tools_from_config, "get_image_models"),
+        (create_video_tools_from_config, "get_video_models"),
+        (create_audio_tools_from_config, "get_asr_models"),
+        (create_music_tools_from_config, "get_music_models"),
+        (create_sound_effect_tools_from_config, "get_sound_effect_models"),
+    ],
+)
+async def test_media_creators_do_not_swallow_failures(
+    creator, getter, tmp_path
+) -> None:
+    # ToolFactory.create_registered_tools is the single enforcement point for the
+    # creator contract; a blanket handler in any creator hides the two exception
+    # types the factory promises to re-raise.
+    class _Config(ToolConfig):
+        def get_workspace_config(self):
+            return {"task_id": "creator-contract", "base_dir": str(tmp_path)}
+
+    setattr(_Config, getter, lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await creator(_Config({}))

--- a/tests/core/tools/test_image_tool.py
+++ b/tests/core/tools/test_image_tool.py
@@ -1000,3 +1000,26 @@ class TestImageToolCapabilityGating:
 
         assert result["success"] is False
         assert "model1 (abilities: edit)" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_creator_propagates_a_broken_model_instead_of_hiding_it(tmp_path) -> None:
+    # A blanket handler here would turn a broken model class into "this
+    # deployment has no image tools", indistinguishable from having none.
+    from xagent.core.tools.adapters.vibe.config import ToolConfig
+    from xagent.core.tools.adapters.vibe.image_tool import (
+        create_image_tools_from_config,
+    )
+
+    broken = Mock(spec=BaseImageModel)
+    broken.has_ability = Mock(side_effect=RuntimeError("ability probe exploded"))
+
+    class _Config(ToolConfig):
+        def get_image_models(self):
+            return {"broken": broken}
+
+        def get_workspace_config(self):
+            return {"task_id": "creator-propagation", "base_dir": str(tmp_path)}
+
+    with pytest.raises(RuntimeError, match="ability probe exploded"):
+        await create_image_tools_from_config(_Config({}))


### PR DESCRIPTION
Closes #1317. Raised in the #1294 review.

## Problem

Five media tool creators each wrap their construction in a bare
`except Exception` that duplicates the one `ToolFactory` already applies to every
creator — and partly defeats it.

`adapters/vibe/factory.py:237-245`:

```python
try:
    created_tools = await creator(config)
    tools.extend(created_tools)
except ConnectorRuntimeError:
    raise
except RequiredMCPUnavailableError:
    raise
except Exception as e:
    logger.warning(f"Tool creator {creator.__name__} failed: {e}")
```

The inner handlers (`image_tool.py`, `video_tool.py`, `audio_tool.py`,
`music_tool.py`, `sound_effect_tool.py`) catch `Exception` unconditionally and
return `[]`.

Three consequences:

1. **The factory's propagation contract is broken.** It names two exception types
   that must escape; the inner handler swallows them first. Not reachable today —
   the media config getters load from the database and never touch the connector
   runtime — but it is precisely the guard that would make a future
   connector-backed model lookup fail silently instead of surfacing its 503.
2. **Real defects hide behind a config-shaped message.** The `try` spans the whole
   construction, which for image tools now includes `get_tools()` and therefore
   every `model.has_ability(...)` call. A model class raising there takes down
   *all* image tools — including the read-only `list_image_models`, which exists
   to explain an empty toolset — leaving one `warning` that reads like
   misconfiguration.
3. **Same failure, two outcomes.** `create_image_tool()` is also called directly
   with no handler, so the identical bad model class either vanishes silently or
   raises loudly depending on the entry point.

## Change

Delete the five inner handlers. Net −20 lines of source.

The factory already logs, and its message names the creator (`Tool creator
create_image_tools_from_config failed: ...`) where the inner one did not. The
direct `create_image_tool()` path and the config-driven path now agree.

Behaviour for ordinary failures is unchanged: still a warning, still that
creator contributing nothing. What changes is that the two contract-critical
exception types now reach the caller, and that the log line identifies which
creator failed.

## Tests

One test asserting a model whose `has_ability` raises propagates out of
`create_image_tools_from_config` instead of being converted into an empty tool
list. Mutation-tested: reintroducing the inner handler turns it red — which is
the acceptance criterion in #1317.

`tests/core/tools` and `tests/web/tools` pass. (`test_aws_mcp.py` fails to
collect locally for a missing `boto3`, unrelated.)
