### PR TITLE
enh(trace): store trace payloads as jsonb and sanitize them on write

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -328,6 +328,16 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      # The json -> jsonb conversion and its row cleanup only exist on
+      # PostgreSQL; the SQLite half of this file pins a no-op and runs in the
+      # ordinary suite.
+      - name: Test trace payload json to jsonb migration (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/migrations/test_20260813_trace_json_columns_to_jsonb.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
   migrations-summary:
     name: Migrations Summary
     runs-on: ubuntu-latest

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -159,7 +159,7 @@ corrupted and a retry succeeds, but roll the application out fully before
 migrating, or expect to run it more than once.
 
 Revision ID: 20260813_trace_json_columns_to_jsonb
-Revises: 20260810_add_hubspot_marketing_scopes
+Revises: 20260812_add_slack_history_reactions_files_scopes
 Create Date: 2026-08-13
 
 """
@@ -174,7 +174,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision: str = "20260813_trace_json_columns_to_jsonb"
-down_revision: Union[str, None] = "20260810_add_hubspot_marketing_scopes"
+down_revision: Union[str, None] = "20260812_add_slack_history_reactions_files_scopes"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -168,6 +168,19 @@ def _table_exists(name: str) -> bool:
 
 
 def _column_is_jsonb(table: str, column: str) -> bool:
+    """Whether the column is already jsonb. Callers must have established
+    that the table exists (both do, via _table_exists three lines up); a
+    missing one raises NoSuchTableError out of here rather than resolving
+    to a bool.
+
+    That is deliberate, not an oversight. This answer carries opposite
+    polarity in the two directions -- upgrade() reads False as "convert
+    this column", downgrade() reads False as "skip it" -- so there is no
+    default a missing table could safely collapse to. Swallowing it would
+    tell upgrade() to proceed against a table that is not there, and the
+    cleanup SELECT would raise the same failure one step later with a
+    worse message.
+    """
     for col in sa.inspect(op.get_bind()).get_columns(table):
         if col["name"] == column:
             return isinstance(col["type"], postgresql.JSONB)

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -133,13 +133,22 @@ _UNSTORABLE_CODE_POINTS = re.compile("[\x00\ud800-\udfff]")
 _REPLACEMENT_CHARACTER = "�"
 _EXPONENT_NOTATION_THRESHOLD = 1e16
 
-# Rows per cleanup batch. Small enough that one batch of checkpoint blobs
-# stays comfortably in memory, large enough that the scan is not dominated
-# by round trips on the usual case of nothing to fix.
-REWRITE_BATCH_SIZE = 100
+# Ids per cleanup batch. This bounds a list of integers, not payloads --
+# the rewrite loop reads one payload at a time (see
+# _rewrite_unconvertible_rows) -- so it can be generous without putting
+# blob rows in memory.
+REWRITE_BATCH_SIZE = 500
 
 
 def _sanitize(value: Any) -> Any:
+    """Rewrite one payload. Eager rather than copy-on-write, unlike the
+    app-side sanitizer this mirrors: every row that reaches here matched
+    the unconvertible-escape predicate, so the "clean payload, hand it back
+    untouched" fast path that motivates the copy-on-write version there
+    cannot fire here. ``re.sub`` already returns the original object when
+    nothing matches, so only the container spine is rebuilt, never the text
+    -- a few percent of the json.loads/json.dumps pair that brackets this
+    call, and far less than one payload."""
     if isinstance(value, str):
         return _UNSTORABLE_CODE_POINTS.sub(_REPLACEMENT_CHARACTER, value)
     # bool is an int subclass, and True/False are not numbers to normalize.
@@ -172,26 +181,33 @@ def _rewrite_unconvertible_rows(table: str, column: str) -> None:
     (younger) write-side sanitizer, so the scan usually matches nothing;
     the full-table regex pass runs once, here, not on any query path.
 
-    Matching rows are walked in id order, one bounded batch at a time,
-    rather than collected up front. These payloads are whole trace events
-    and checkpoint blobs -- the blob tables exist precisely because they
-    get large -- so a deployment that emitted bad output for a while could
-    otherwise materialize every poisoned payload in the migration process
-    at once. Keyset pagination, not OFFSET: the loop rewrites the rows it
-    just read, and an OFFSET walk would skip past rows as the result set
-    shifts under it.
+    The scan pages over matching *ids* and then reads one payload at a
+    time, so peak memory is one payload rather than a batch of them. That
+    split is the point: these values are whole trace events and checkpoint
+    blobs, and nothing caps their size -- the payload truncation in
+    ``core/agent/runtime.py`` applies to LLM-category events only, and
+    checkpoints are ``system_update_general``. Holding a batch of them, or
+    the whole matching set, would make the migration's memory a function of
+    how much bad output a deployment happened to emit.
+
+    Keyset pagination, not OFFSET: the loop rewrites the rows it just read,
+    so they drop out of the predicate, and an OFFSET walk would skip past
+    rows as the result set shifts under it.
     """
     bind = op.get_bind()
-    # noqa: S608 on both statements -- table/column come from
-    # TRACE_JSON_COLUMNS above, never from user input, and every payload
-    # pattern is bound as a parameter rather than interpolated.
-    select_batch = sa.text(
-        f"SELECT id, CAST({column} AS text) AS payload FROM {table} "  # noqa: S608
+    # noqa: S608 throughout -- table/column come from TRACE_JSON_COLUMNS
+    # above, never from user input, and every payload pattern is bound as a
+    # parameter rather than interpolated.
+    select_ids = sa.text(
+        f"SELECT id FROM {table} "  # noqa: S608
         f"WHERE id > :after "
         f"AND regexp_replace("
         f"replace(CAST({column} AS text), :bs, :standin), "
         f":pair, '', 'g') ~ :unsafe "
         f"ORDER BY id LIMIT :limit"
+    )
+    select_payload = sa.text(
+        f"SELECT CAST({column} AS text) FROM {table} WHERE id = :id"  # noqa: S608
     )
     # The column is still json at this point -- the ALTER runs after this
     # returns -- so the rewritten payload is cast back to json, not jsonb.
@@ -202,25 +218,35 @@ def _rewrite_unconvertible_rows(table: str, column: str) -> None:
 
     after = 0
     while True:
-        rows = bind.execute(
-            select_batch,
-            {
-                "after": after,
-                "bs": ESCAPED_BACKSLASH,
-                "standin": ESCAPED_BACKSLASH_STANDIN,
-                "pair": SURROGATE_PAIR_PATTERN,
-                "unsafe": UNSAFE_ESCAPE_PATTERN,
-                "limit": REWRITE_BATCH_SIZE,
-            },
-        ).fetchall()
-        if not rows:
+        row_ids = [
+            row[0]
+            for row in bind.execute(
+                select_ids,
+                {
+                    "after": after,
+                    "bs": ESCAPED_BACKSLASH,
+                    "standin": ESCAPED_BACKSLASH_STANDIN,
+                    "pair": SURROGATE_PAIR_PATTERN,
+                    "unsafe": UNSAFE_ESCAPE_PATTERN,
+                    "limit": REWRITE_BATCH_SIZE,
+                },
+            )
+        ]
+        if not row_ids:
             return
-        for row_id, payload_text in rows:
+        for row_id in row_ids:
+            payload_row = bind.execute(select_payload, {"id": row_id}).fetchone()
+            if payload_row is None:
+                # Deleted between the id scan and this read -- checkpoint
+                # pruning runs concurrently against these very tables, and
+                # a row that no longer exists needs no rewrite.
+                continue
+            payload_text = payload_row[0]
             cleaned = _sanitize(json.loads(payload_text))
             bind.execute(update, {"payload": json.dumps(cleaned), "id": row_id})
         # A rewritten row no longer matches the predicate, so the next
         # batch would find these again only by id -- advance past them.
-        after = rows[-1][0]
+        after = row_ids[-1]
 
 
 def upgrade() -> None:

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -46,17 +46,78 @@ duplicate keys cannot be produced by ``json.dumps`` from a dict in the
 first place -- the write path only ever serializes dicts.
 
 ``jsonb`` does, however, re-render numbers: a float stored as ``1e+16``
-reads back as the int ``10000000000000000``. The checkpoint blob path
-re-hashes payloads it reads and compares them against the write-time
-hash, so a *pre-existing* row carrying such a float becomes undecodable
+reads back as the int ``10000000000000000``, and ``-0.0`` as ``0.0``
+(``numeric`` has no signed zero). The checkpoint blob path re-hashes
+payloads it reads and compares them against the hash recorded at write
+time, so a *pre-existing* row carrying either shape becomes undecodable
 after this migration. New writes are covered -- the write-side sanitizer
-normalizes those floats before the hash is taken -- and rows this
-migration rewrites are normalized here too. Rows it does not touch are
-deliberately left alone: catching them would mean rewriting every row in
-the three tables to defend against a payload shape that requires a float
-above 2**53 in trace output, and the existing failure mode for an
-unreadable checkpoint row is already a logged skip that falls back to an
-older checkpoint (``web/api/trace_handlers.py``), not a lost task.
+normalizes both before the hash is taken -- and rows this migration
+rewrites get the same two normalizations applied here. Rows it does not
+touch are deliberately left alone: catching them would mean rewriting
+every row in all three tables to defend against shapes that need a float
+above 2**53, or a negative zero, in trace output.
+
+Rewriting a *blob* row has a cost the paragraph above does not cover, and
+it is the one thing to weigh before running this. Replacing NUL with
+U+FFFD changes the payload, so its canonical hash changes -- but the hash
+is also the blob's identity: ``trace_events.data`` references a blob by
+embedding the hash value itself, and strict restore re-hashes what it
+read and compares it against that reference
+(``_load_messages_by_refs`` / ``_load_checkpoint_blob_by_ref``,
+``web/services/trace_message_storage.py``). So a rewritten blob row still
+resolves but fails verification: ``CheckpointMessageDecodeError``, which
+``web/api/trace_handlers.py`` logs and treats as a skip, falling back to
+an older checkpoint row.
+
+Whether that fallback finds anything depends on which blob it was. Blob
+rows are deduplicated per task, and ``context.system_prompt`` and
+``context.metadata`` are typically byte-identical across every checkpoint
+of a task -- so for those, one poisoned row means *no* readable
+checkpoint at all, and the scan escalates to ``CheckpointCorruptError``:
+HTTP 400 from the a2a resume path and a non-recoverable verdict in lease
+recovery. For a mid-conversation message blob, checkpoints predating that
+message still decode, so the task loses progress rather than the task.
+
+The hash columns are therefore left verbatim on purpose, and the two
+alternatives were considered and rejected:
+
+* Recomputing ``message_hash``/``blob_hash`` from the rewritten payload
+  makes the row unreachable rather than unverifiable -- the references in
+  ``trace_events.data`` still name the old hash -- and it can abort the
+  migration outright: if the task re-checkpointed the same content after
+  the sanitizer landed, the new hash already exists and the UPDATE
+  violates ``uq_trace_message_blobs_task_hash``. Doing it properly would
+  mean remapping the hash inside every referring payload, including the
+  refs marker's own hash, which is the application's hashing contract
+  reimplemented in a migration.
+* Deleting the affected blob rows lands on the same
+  ``CheckpointMessageDecodeError`` for strict restore, so it buys nothing
+  there, and it costs the non-strict readers: every viewer path
+  (``api/conversation_logs.py``, ``api/workforces.py``,
+  ``services/task_setup_snapshot.py``) decodes with ``strict=False``,
+  which skips hash verification and renders the cleaned payload fine. A
+  deleted row breaks those too.
+
+Only NUL can reach a blob row this way. ``canonical_json_bytes`` uses
+``ensure_ascii=False``, so a payload carrying an unpaired surrogate
+raises ``UnicodeEncodeError`` before it can be hashed -- such a payload
+never became a blob row in the first place. It can sit in
+``trace_events.data``, which has no self-hash, and rewriting that column
+is harmless.
+
+Before running this on a deployment that predates the write-side
+sanitizer, count the blob rows that would be rewritten. Neither query
+writes anything:
+
+    SELECT count(*) FROM trace_message_blobs
+    WHERE CAST(message_data AS text) LIKE '%\\u0000%';
+
+    SELECT count(*) FROM trace_checkpoint_blobs
+    WHERE CAST(blob_data AS text) LIKE '%\\u0000%';
+
+A non-zero count means some tasks will lose strict checkpoint recovery.
+Pruning those tasks' checkpoint history first is the supported remedy and
+turns a surprise 400 into a deliberate one.
 
 The detection patterns assume a UTF8 server encoding, which is what the
 shipped compose file runs. On a server in another encoding the cast also
@@ -68,16 +129,34 @@ nothing is converted), but it needs the row cleaned by hand before the
 upgrade can proceed. The read guard in ``web/api/monitor.py`` documents
 the same limitation for the same patterns.
 
+Two further shapes are legal in ``json`` and rejected by ``jsonb``, and
+this cleanup handles neither: a number outside ``numeric``'s exponent
+range, and nesting past ``jsonb``'s depth limit. No application write path
+can produce either -- a Python float caps at ~1.8e308, ``json.dumps``
+recurses within the interpreter's own limit -- so only a manual or
+external writer could have planted one. Such a row fails the ALTER the
+same safe way as the encoding case above.
+
 Operationally this is the expensive kind of migration, and on a large
 deployment it should be scheduled rather than slipped into a routine
 restart. ``ALTER ... TYPE`` takes an ACCESS EXCLUSIVE lock and rewrites
 every row of the table -- there is no in-place path from ``json`` to
 ``jsonb``, because the on-disk representation genuinely differs -- and the
 cleanup scan that precedes it is an unindexed full-table regex pass over
-the same rows. Both run inside one transaction per table, so the lock is
-held for the whole of it, and ``trace_events`` is the table the monitoring
-dashboard already scans. Pruning checkpoint history first shortens both
-steps.
+the same rows. ``env.py`` sets ``transaction_per_migration=True`` on
+PostgreSQL, so all three tables' scans and ALTERs run in *one*
+transaction: the ``trace_events`` lock is taken first and held until the
+two blob tables have converted too. Budget the window for the whole
+migration, not per table, and note that ``trace_events`` is the table the
+monitoring dashboard already scans. Pruning checkpoint history first
+shortens every step.
+
+Deployment ordering matters for the same reason. An old instance still
+running without the write-side sanitizer can insert a fresh unconvertible
+row after the cleanup scan has passed it but before the ALTER takes its
+lock; the ALTER then fails and the whole migration rolls back. Nothing is
+corrupted and a retry succeeds, but roll the application out fully before
+migrating, or expect to run it more than once.
 
 Revision ID: 20260813_trace_json_columns_to_jsonb
 Revises: 20260810_add_hubspot_marketing_scopes
@@ -86,6 +165,7 @@ Create Date: 2026-08-13
 """
 
 import json
+import math
 import re
 from typing import Any, Sequence, Union
 
@@ -151,10 +231,14 @@ def _sanitize(value: Any) -> Any:
     call, and far less than one payload."""
     if isinstance(value, str):
         return _UNSTORABLE_CODE_POINTS.sub(_REPLACEMENT_CHARACTER, value)
-    # bool is an int subclass, and True/False are not numbers to normalize.
-    if isinstance(value, float) and not isinstance(value, bool):
+    # No bool guard needed: bool subclasses int, not float, so True/False
+    # never reach this branch.
+    if isinstance(value, float):
         if abs(value) >= _EXPONENT_NOTATION_THRESHOLD and value.is_integer():
             return int(value)
+        # numeric has no signed zero, so jsonb renders -0.0 as 0.0.
+        if value == 0.0 and math.copysign(1.0, value) < 0:
+            return 0.0
         return value
     if isinstance(value, dict):
         return {_sanitize(key): _sanitize(item) for key, item in value.items()}

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -58,6 +58,16 @@ above 2**53 in trace output, and the existing failure mode for an
 unreadable checkpoint row is already a logged skip that falls back to an
 older checkpoint (``web/api/trace_handlers.py``), not a lost task.
 
+The detection patterns assume a UTF8 server encoding, which is what the
+shipped compose file runs. On a server in another encoding the cast also
+rejects any escape naming a character outside that charset -- including a
+valid surrogate pair, which the pair-stripping step deliberately removes
+before matching -- so the cleanup would miss such a row and the ALTER
+would fail on it. That is a safe failure (the transaction rolls back and
+nothing is converted), but it needs the row cleaned by hand before the
+upgrade can proceed. The read guard in ``web/api/monitor.py`` documents
+the same limitation for the same patterns.
+
 Operationally this is the expensive kind of migration, and on a large
 deployment it should be scheduled rather than slipped into a routine
 restart. ``ALTER ... TYPE`` takes an ACCESS EXCLUSIVE lock and rewrites
@@ -123,6 +133,11 @@ _UNSTORABLE_CODE_POINTS = re.compile("[\x00\ud800-\udfff]")
 _REPLACEMENT_CHARACTER = "�"
 _EXPONENT_NOTATION_THRESHOLD = 1e16
 
+# Rows per cleanup batch. Small enough that one batch of checkpoint blobs
+# stays comfortably in memory, large enough that the scan is not dominated
+# by round trips on the usual case of nothing to fix.
+REWRITE_BATCH_SIZE = 100
+
 
 def _sanitize(value: Any) -> Any:
     if isinstance(value, str):
@@ -156,34 +171,56 @@ def _rewrite_unconvertible_rows(table: str, column: str) -> None:
     Rows carrying such payloads exist only where something slipped past the
     (younger) write-side sanitizer, so the scan usually matches nothing;
     the full-table regex pass runs once, here, not on any query path.
+
+    Matching rows are walked in id order, one bounded batch at a time,
+    rather than collected up front. These payloads are whole trace events
+    and checkpoint blobs -- the blob tables exist precisely because they
+    get large -- so a deployment that emitted bad output for a while could
+    otherwise materialize every poisoned payload in the migration process
+    at once. Keyset pagination, not OFFSET: the loop rewrites the rows it
+    just read, and an OFFSET walk would skip past rows as the result set
+    shifts under it.
     """
     bind = op.get_bind()
-    rows = bind.execute(
-        sa.text(
-            # noqa: S608 -- table/column come from TRACE_JSON_COLUMNS above,
-            # never from user input; the payload patterns are bound below.
-            f"SELECT id, CAST({column} AS text) AS payload FROM {table} "  # noqa: S608
-            f"WHERE regexp_replace("
-            f"replace(CAST({column} AS text), :bs, :standin), "
-            f":pair, '', 'g') ~ :unsafe"
-        ),
-        {
-            "bs": ESCAPED_BACKSLASH,
-            "standin": ESCAPED_BACKSLASH_STANDIN,
-            "pair": SURROGATE_PAIR_PATTERN,
-            "unsafe": UNSAFE_ESCAPE_PATTERN,
-        },
-    ).fetchall()
-
+    # noqa: S608 on both statements -- table/column come from
+    # TRACE_JSON_COLUMNS above, never from user input, and every payload
+    # pattern is bound as a parameter rather than interpolated.
+    select_batch = sa.text(
+        f"SELECT id, CAST({column} AS text) AS payload FROM {table} "  # noqa: S608
+        f"WHERE id > :after "
+        f"AND regexp_replace("
+        f"replace(CAST({column} AS text), :bs, :standin), "
+        f":pair, '', 'g') ~ :unsafe "
+        f"ORDER BY id LIMIT :limit"
+    )
     # The column is still json at this point -- the ALTER runs after this
     # returns -- so the rewritten payload is cast back to json, not jsonb.
     update = sa.text(
         f"UPDATE {table} SET {column} = CAST(:payload AS json) "  # noqa: S608
         f"WHERE id = :id"
     )
-    for row_id, payload_text in rows:
-        cleaned = _sanitize(json.loads(payload_text))
-        bind.execute(update, {"payload": json.dumps(cleaned), "id": row_id})
+
+    after = 0
+    while True:
+        rows = bind.execute(
+            select_batch,
+            {
+                "after": after,
+                "bs": ESCAPED_BACKSLASH,
+                "standin": ESCAPED_BACKSLASH_STANDIN,
+                "pair": SURROGATE_PAIR_PATTERN,
+                "unsafe": UNSAFE_ESCAPE_PATTERN,
+                "limit": REWRITE_BATCH_SIZE,
+            },
+        ).fetchall()
+        if not rows:
+            return
+        for row_id, payload_text in rows:
+            cleaned = _sanitize(json.loads(payload_text))
+            bind.execute(update, {"payload": json.dumps(cleaned), "id": row_id})
+        # A rewritten row no longer matches the predicate, so the next
+        # batch would find these again only by id -- advance past them.
+        after = rows[-1][0]
 
 
 def upgrade() -> None:

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -1,0 +1,257 @@
+"""convert trace payload columns from json to jsonb on PostgreSQL
+
+``trace_events.data`` was a ``json`` column, which validates syntax at
+write time and nothing else: it happily stores the NUL escape and either
+half of an unpaired UTF-16 surrogate, both of which ``->>`` then refuses
+to convert back to text -- one such row failed three monitoring endpoints
+whole-query (#1149). ``jsonb`` decodes escapes to native text at INSERT,
+so it rejects those payloads at the source (#1248). The two checkpoint
+blob tables carry the same payloads (their rows are hashed slices of the
+same trace data), so all three columns convert together:
+
+- ``trace_events.data``
+- ``trace_message_blobs.message_data``
+- ``trace_checkpoint_blobs.blob_data``
+
+``ALTER ... TYPE jsonb USING <col>::jsonb`` fails on any stored row that
+carries one of those escapes, so the online upgrade first rewrites such
+rows with the offending code points replaced by U+FFFD -- the same
+substitution the write-side sanitizer
+(``web/utils/json_payload_sanitizer.py``) applies to new payloads. Rows
+are found with the same normalize-then-match steps as the read guard in
+``web/api/monitor.py`` (``PG_ESCAPED_BACKSLASH`` and friends -- that file
+is the patterns' source of truth and documents why each step is
+load-bearing); the actual rewrite happens in Python, where escape
+semantics are exact, not with SQL regex surgery on the JSON text.
+
+This migration is PostgreSQL-only. SQLite stores JSON as TEXT and has no
+jsonb; both branches are no-ops there. On PostgreSQL the online branch
+guards on the table existing (a bare database has none of the three until
+``create_all`` runs) and on the column not already being jsonb (a
+create_all-first startup builds jsonb directly from the model, and this
+keeps the upgrade idempotent on rerun).
+
+The offline (--sql) branch emits only the three ALTERs: the cleanup step
+must read rows, which a MockConnection cannot. An offline script applied
+to a database still holding an unconvertible row fails on that ALTER --
+PostgreSQL offline scripts run inside the BEGIN/COMMIT wrapper Alembic
+emits, so the failure aborts the whole script and converts nothing.
+Clean such rows first (or run the migration online, which does it for
+you).
+
+``jsonb`` does not preserve key order or duplicate keys. Consumers of
+these columns deserialize into Python dicts (checkpoint restore, the
+monitoring endpoints), where key order already carries no meaning, and
+duplicate keys cannot be produced by ``json.dumps`` from a dict in the
+first place -- the write path only ever serializes dicts.
+
+``jsonb`` does, however, re-render numbers: a float stored as ``1e+16``
+reads back as the int ``10000000000000000``. The checkpoint blob path
+re-hashes payloads it reads and compares them against the write-time
+hash, so a *pre-existing* row carrying such a float becomes undecodable
+after this migration. New writes are covered -- the write-side sanitizer
+normalizes those floats before the hash is taken -- and rows this
+migration rewrites are normalized here too. Rows it does not touch are
+deliberately left alone: catching them would mean rewriting every row in
+the three tables to defend against a payload shape that requires a float
+above 2**53 in trace output, and the existing failure mode for an
+unreadable checkpoint row is already a logged skip that falls back to an
+older checkpoint (``web/api/trace_handlers.py``), not a lost task.
+
+Operationally this is the expensive kind of migration, and on a large
+deployment it should be scheduled rather than slipped into a routine
+restart. ``ALTER ... TYPE`` takes an ACCESS EXCLUSIVE lock and rewrites
+every row of the table -- there is no in-place path from ``json`` to
+``jsonb``, because the on-disk representation genuinely differs -- and the
+cleanup scan that precedes it is an unindexed full-table regex pass over
+the same rows. Both run inside one transaction per table, so the lock is
+held for the whole of it, and ``trace_events`` is the table the monitoring
+dashboard already scans. Pruning checkpoint history first shortens both
+steps.
+
+Revision ID: 20260813_trace_json_columns_to_jsonb
+Revises: 20260809_add_task_interaction_requests
+Create Date: 2026-08-13
+
+"""
+
+import json
+import re
+from typing import Any, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260813_trace_json_columns_to_jsonb"
+down_revision: Union[str, None] = "20260809_add_task_interaction_requests"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (table, column) pairs that hold trace payloads. All three receive slices
+# of the same event data, so a payload rejected by one would be rejected by
+# any -- they must convert together or the write path splits behaviour.
+TRACE_JSON_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("trace_events", "data"),
+    ("trace_message_blobs", "message_data"),
+    ("trace_checkpoint_blobs", "blob_data"),
+)
+
+# Detection patterns, copied verbatim from web/api/monitor.py
+# (PG_ESCAPED_BACKSLASH / PG_SURROGATE_PAIR_PATTERN /
+# PG_UNSAFE_ESCAPE_PATTERN) -- that file is the source of truth and
+# documents why each normalization step is load-bearing. Bound as
+# parameters, never interpolated, so SQL literal escaping cannot distort
+# them. The migration inlines the values instead of importing them: a
+# migration must stay runnable after the application module moves or
+# changes.
+ESCAPED_BACKSLASH = "\\\\"
+ESCAPED_BACKSLASH_STANDIN = "__"
+SURROGATE_PAIR_PATTERN = (
+    "\\\\u[dD][89abAB][0-9a-fA-F]{2}\\\\u[dD][c-fC-F][0-9a-fA-F]{2}"
+)
+UNSAFE_ESCAPE_PATTERN = (
+    "\\\\u0000|\\\\u[dD][89abAB][0-9a-fA-F]{2}|\\\\u[dD][c-fC-F][0-9a-fA-F]{2}"
+)
+
+# The Python-side rewrite: NUL and every surrogate code point become
+# U+FFFD, and floats jsonb would hand back as ints are converted up front.
+# Mirrors web/utils/json_payload_sanitizer.py, which documents both rules;
+# duplicated here because a migration must not import application code that
+# can drift.
+_UNSTORABLE_CODE_POINTS = re.compile("[\x00\ud800-\udfff]")
+_REPLACEMENT_CHARACTER = "�"
+_EXPONENT_NOTATION_THRESHOLD = 1e16
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, str):
+        return _UNSTORABLE_CODE_POINTS.sub(_REPLACEMENT_CHARACTER, value)
+    # bool is an int subclass, and True/False are not numbers to normalize.
+    if isinstance(value, float) and not isinstance(value, bool):
+        if abs(value) >= _EXPONENT_NOTATION_THRESHOLD and value.is_integer():
+            return int(value)
+        return value
+    if isinstance(value, dict):
+        return {_sanitize(key): _sanitize(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_sanitize(item) for item in value]
+    return value
+
+
+def _table_exists(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _column_is_jsonb(table: str, column: str) -> bool:
+    for col in sa.inspect(op.get_bind()).get_columns(table):
+        if col["name"] == column:
+            return isinstance(col["type"], postgresql.JSONB)
+    return False
+
+
+def _rewrite_unconvertible_rows(table: str, column: str) -> None:
+    """Replace unstorable escapes in rows the jsonb cast would reject.
+
+    Rows carrying such payloads exist only where something slipped past the
+    (younger) write-side sanitizer, so the scan usually matches nothing;
+    the full-table regex pass runs once, here, not on any query path.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            # noqa: S608 -- table/column come from TRACE_JSON_COLUMNS above,
+            # never from user input; the payload patterns are bound below.
+            f"SELECT id, CAST({column} AS text) AS payload FROM {table} "  # noqa: S608
+            f"WHERE regexp_replace("
+            f"replace(CAST({column} AS text), :bs, :standin), "
+            f":pair, '', 'g') ~ :unsafe"
+        ),
+        {
+            "bs": ESCAPED_BACKSLASH,
+            "standin": ESCAPED_BACKSLASH_STANDIN,
+            "pair": SURROGATE_PAIR_PATTERN,
+            "unsafe": UNSAFE_ESCAPE_PATTERN,
+        },
+    ).fetchall()
+
+    # The column is still json at this point -- the ALTER runs after this
+    # returns -- so the rewritten payload is cast back to json, not jsonb.
+    update = sa.text(
+        f"UPDATE {table} SET {column} = CAST(:payload AS json) "  # noqa: S608
+        f"WHERE id = :id"
+    )
+    for row_id, payload_text in rows:
+        cleaned = _sanitize(json.loads(payload_text))
+        bind.execute(update, {"payload": json.dumps(cleaned), "id": row_id})
+
+
+def upgrade() -> None:
+    context = op.get_context()
+    if context.dialect.name != "postgresql":
+        return
+
+    # Offline (--sql) generation runs against a MockConnection: reflection
+    # and the row-cleanup SELECT are both impossible, so emit the plain
+    # ALTERs a migration-built database needs (see the module docstring for
+    # what happens if unconvertible rows are still present).
+    if context.as_sql:
+        for table, column in TRACE_JSON_COLUMNS:
+            op.alter_column(
+                table,
+                column,
+                type_=postgresql.JSONB(),
+                existing_nullable=False,
+                postgresql_using=f"{column}::jsonb",
+            )
+        return
+
+    for table, column in TRACE_JSON_COLUMNS:
+        # trace_events is created by Base.metadata.create_all(), not by a
+        # migration; on a bare database none of the three tables exist yet.
+        if not _table_exists(table):
+            continue
+        # A create_all-first startup already built the column as jsonb from
+        # the model; converting again is a rerun no-op.
+        if _column_is_jsonb(table, column):
+            continue
+        _rewrite_unconvertible_rows(table, column)
+        op.alter_column(
+            table,
+            column,
+            type_=postgresql.JSONB(),
+            existing_nullable=False,
+            postgresql_using=f"{column}::jsonb",
+        )
+
+
+def downgrade() -> None:
+    context = op.get_context()
+    if context.dialect.name != "postgresql":
+        return
+
+    if context.as_sql:
+        for table, column in TRACE_JSON_COLUMNS:
+            op.alter_column(
+                table,
+                column,
+                type_=sa.JSON(),
+                existing_nullable=False,
+                postgresql_using=f"{column}::json",
+            )
+        return
+
+    # jsonb -> json always casts cleanly; the U+FFFD rewrites are not (and
+    # cannot be) undone.
+    for table, column in TRACE_JSON_COLUMNS:
+        if not _table_exists(table):
+            continue
+        if not _column_is_jsonb(table, column):
+            continue
+        op.alter_column(
+            table,
+            column,
+            type_=sa.JSON(),
+            existing_nullable=False,
+            postgresql_using=f"{column}::json",
+        )

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -80,7 +80,7 @@ dashboard already scans. Pruning checkpoint history first shortens both
 steps.
 
 Revision ID: 20260813_trace_json_columns_to_jsonb
-Revises: 20260809_add_task_interaction_requests
+Revises: 20260810_add_hubspot_marketing_scopes
 Create Date: 2026-08-13
 
 """
@@ -94,7 +94,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision: str = "20260813_trace_json_columns_to_jsonb"
-down_revision: Union[str, None] = "20260809_add_task_interaction_requests"
+down_revision: Union[str, None] = "20260810_add_hubspot_marketing_scopes"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -45,17 +45,38 @@ monitoring endpoints), where key order already carries no meaning, and
 duplicate keys cannot be produced by ``json.dumps`` from a dict in the
 first place -- the write path only ever serializes dicts.
 
-``jsonb`` does, however, re-render numbers: a float stored as ``1e+16``
-reads back as the int ``10000000000000000``, and ``-0.0`` as ``0.0``
-(``numeric`` has no signed zero). The checkpoint blob path re-hashes
-payloads it reads and compares them against the hash recorded at write
-time, so a *pre-existing* row carrying either shape becomes undecodable
-after this migration. New writes are covered -- the write-side sanitizer
-normalizes both before the hash is taken -- and rows this migration
-rewrites get the same two normalizations applied here. Rows it does not
-touch are deliberately left alone: catching them would mean rewriting
-every row in all three tables to defend against shapes that need a float
-above 2**53, or a negative zero, in trace output.
+``jsonb`` does, however, re-render numbers. Its numbers are ``numeric``,
+so it keeps the literal's exact value and prints it in plain notation:
+``1e+16`` reads back as the int ``10000000000000000``, ``1e25`` as 10^25,
+and ``-0.0`` as ``0.0`` (``numeric`` has no signed zero). A long decimal
+is preserved in full -- the retype is about *notation and Python type*,
+not precision.
+
+The checkpoint blob path re-hashes payloads it reads and compares them
+against the hash recorded at write time, so a *pre-existing* row carrying
+a shape whose Python type changes becomes undecodable after this
+migration. New writes are covered: the write-side sanitizer normalizes
+both shapes before the hash is taken. Rows this migration does not touch
+are deliberately left alone -- catching them would mean rewriting every
+row in all three tables to defend against shapes that need a float above
+2**53, or a negative zero, in trace output. That leaves such rows with a
+disclosed failure and no remedy of their own; the pre-flight below counts
+only the NUL rows this migration actually rewrites, and a float-shaped
+row hits the same escalation with no count query to warn about it. The
+supported remedy is the same one: prune the affected task's checkpoint
+history.
+
+The rows this migration *does* rewrite keep their numbers verbatim rather
+than being normalized here, so ``jsonb`` applies its own conversion on
+ingest identically for rewritten and untouched rows. Normalizing in the
+migration would make the two diverge, because reaching the number at all
+means parsing it, and a float64 round-trip is lossy where ``numeric`` is
+not: it renders ``1e25`` as 10000000000000000905969664 rather than 10^25,
+truncates a literal carrying more precision than a double holds, and
+turns ``1e1000`` into ``inf`` -- which ``json.dumps`` writes as
+``Infinity``, not JSON, failing the rewrite's own cast. Parsing to
+``Decimal`` and emitting each number as its own literal avoids all three;
+see ``_loads_preserving_numbers`` and ``_dumps_preserving_numbers``.
 
 Rewriting a *blob* row has a cost the paragraph above does not cover, and
 it is the one thing to weigh before running this. Replacing NUL with
@@ -165,8 +186,8 @@ Create Date: 2026-08-13
 """
 
 import json
-import math
 import re
+from decimal import Decimal
 from typing import Any, Sequence, Union
 
 import sqlalchemy as sa
@@ -205,13 +226,18 @@ UNSAFE_ESCAPE_PATTERN = (
 )
 
 # The Python-side rewrite: NUL and every surrogate code point become
-# U+FFFD, and floats jsonb would hand back as ints are converted up front.
-# Mirrors web/utils/json_payload_sanitizer.py, which documents both rules;
-# duplicated here because a migration must not import application code that
-# can drift.
+# U+FFFD. Mirrors the code-point half of
+# web/utils/json_payload_sanitizer.py, which documents the rule; duplicated
+# here because a migration must not import application code that can drift.
+# The sanitizer's number normalization has deliberately no counterpart here
+# -- see _sanitize.
 _UNSTORABLE_CODE_POINTS = re.compile("[\x00\ud800-\udfff]")
 _REPLACEMENT_CHARACTER = "�"
-_EXPONENT_NOTATION_THRESHOLD = 1e16
+
+# Placeholder marker for a number held out of json.dumps. Long and
+# namespaced so a collision with real payload text is implausible; checked
+# for anyway before any substitution runs.
+_NUMBER_TOKEN_PREFIX = "__xagent_jsonb_migration_number_"
 
 # Ids per cleanup batch. This bounds a list of integers, not payloads --
 # the rewrite loop reads one payload at a time (see
@@ -228,23 +254,72 @@ def _sanitize(value: Any) -> Any:
     cannot fire here. ``re.sub`` already returns the original object when
     nothing matches, so only the container spine is rebuilt, never the text
     -- a few percent of the json.loads/json.dumps pair that brackets this
-    call, and far less than one payload."""
+    call, and far less than one payload.
+
+    Numbers are deliberately not touched. They arrive as ``Decimal`` (see
+    ``_loads_preserving_numbers``) and leave verbatim, so ``jsonb`` applies
+    its own normalization on ingest -- identically for a row this rewrites
+    and a row it never looks at. Normalizing here instead would make the
+    two diverge: a float64 round-trip renders ``1e25`` as
+    10000000000000000905969664, where the cast produces 10^25.
+    """
     if isinstance(value, str):
         return _UNSTORABLE_CODE_POINTS.sub(_REPLACEMENT_CHARACTER, value)
-    # No bool guard needed: bool subclasses int, not float, so True/False
-    # never reach this branch.
-    if isinstance(value, float):
-        if abs(value) >= _EXPONENT_NOTATION_THRESHOLD and value.is_integer():
-            return int(value)
-        # numeric has no signed zero, so jsonb renders -0.0 as 0.0.
-        if value == 0.0 and math.copysign(1.0, value) < 0:
-            return 0.0
-        return value
     if isinstance(value, dict):
         return {_sanitize(key): _sanitize(item) for key, item in value.items()}
     if isinstance(value, list):
         return [_sanitize(item) for item in value]
     return value
+
+
+def _loads_preserving_numbers(payload_text: str) -> Any:
+    """Parse without letting a number through float64.
+
+    ``json.loads`` maps every JSON float onto a Python float, which silently
+    truncates a literal carrying more precision than a double holds and
+    turns ``1e1000`` into ``inf`` -- and ``json.dumps`` then writes
+    ``Infinity``, which is not JSON and fails the UPDATE's cast. ``jsonb``
+    itself does neither: its numbers are ``numeric``, so it keeps the exact
+    literal. Parsing to ``Decimal`` matches that, and integers are already
+    arbitrary precision.
+    """
+    return json.loads(payload_text, parse_float=Decimal)
+
+
+def _dumps_preserving_numbers(value: Any, *, payload_text: str) -> str:
+    """Serialize with every ``Decimal`` written as its own literal.
+
+    ``json.dumps`` cannot emit a ``Decimal`` (and ``default=`` would quote
+    it into a string), so each one is swapped for a placeholder string and
+    the placeholder's *quoted* form is substituted back afterwards. The
+    prefix is checked against the original payload first: a collision would
+    otherwise let payload text be replaced by a number.
+    """
+    if _NUMBER_TOKEN_PREFIX in payload_text:
+        raise RuntimeError(
+            f"payload already contains {_NUMBER_TOKEN_PREFIX!r}; refusing to "
+            "rewrite it rather than risk substituting into payload text"
+        )
+
+    literals: list[str] = []
+
+    def tokenize(item: Any) -> Any:
+        if isinstance(item, Decimal):
+            literals.append(str(item))
+            return f"{_NUMBER_TOKEN_PREFIX}{len(literals) - 1}__"
+        if isinstance(item, dict):
+            return {key: tokenize(sub) for key, sub in item.items()}
+        if isinstance(item, list):
+            return [tokenize(sub) for sub in item]
+        return item
+
+    text = json.dumps(tokenize(value))
+    for index, literal in enumerate(literals):
+        quoted = json.dumps(f"{_NUMBER_TOKEN_PREFIX}{index}__")
+        if quoted not in text:
+            raise RuntimeError(f"number placeholder {quoted} vanished during encode")
+        text = text.replace(quoted, literal, 1)
+    return text
 
 
 def _table_exists(name: str) -> bool:
@@ -339,8 +414,16 @@ def _rewrite_unconvertible_rows(table: str, column: str) -> None:
                 # a row that no longer exists needs no rewrite.
                 continue
             payload_text = payload_row[0]
-            cleaned = _sanitize(json.loads(payload_text))
-            bind.execute(update, {"payload": json.dumps(cleaned), "id": row_id})
+            cleaned = _sanitize(_loads_preserving_numbers(payload_text))
+            bind.execute(
+                update,
+                {
+                    "payload": _dumps_preserving_numbers(
+                        cleaned, payload_text=payload_text
+                    ),
+                    "id": row_id,
+                },
+            )
         # A rewritten row no longer matches the predicate, so the next
         # batch would find these again only by id -- advance past them.
         after = row_ids[-1]

--- a/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
+++ b/src/xagent/migrations/versions/20260813_trace_json_columns_to_jsonb.py
@@ -180,7 +180,7 @@ corrupted and a retry succeeds, but roll the application out fully before
 migrating, or expect to run it more than once.
 
 Revision ID: 20260813_trace_json_columns_to_jsonb
-Revises: 20260812_add_slack_history_reactions_files_scopes
+Revises: 20260812_seed_intercom_mcp_app
 Create Date: 2026-08-13
 
 """
@@ -195,7 +195,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision: str = "20260813_trace_json_columns_to_jsonb"
-down_revision: Union[str, None] = "20260812_add_slack_history_reactions_files_scopes"
+down_revision: Union[str, None] = "20260812_seed_intercom_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/web/api/monitor.py
+++ b/src/xagent/web/api/monitor.py
@@ -107,8 +107,21 @@ def get_json_field_expression(column: Any, field_path: str, db_session: Session)
         # stays because it is not this module's business to assume the
         # migration has run: a database still on the json type -- one upgraded
         # by hand, or mid-rollout -- carries exactly the rows it defends
-        # against. Per that issue, do not remove it while any deployment can
-        # still hold such a payload.
+        # against.
+        #
+        # Retirement condition, so this does not linger on an unmeasurable
+        # "while any deployment might still hold one": it can go once no
+        # supported upgrade path reaches this code with a json column -- that
+        # is, once skipping the 20260813 migration is no longer supported.
+        # What to check on a given database before removing it:
+        #
+        #     SELECT data_type FROM information_schema.columns
+        #     WHERE table_name = 'trace_events' AND column_name = 'data';
+        #
+        # Because jsonb makes this branch unreachable over the model's own
+        # table, its drop path is exercised against a throwaway native-json
+        # table by tests/web/api/test_monitor_postgresql.py's
+        # TestReadGuardAgainstNativeJson -- delete that alongside this.
         #
         # Matching runs on the column's text form because valid JSON never
         # holds a raw control character or a bare surrogate (RFC 8259 requires

--- a/src/xagent/web/api/monitor.py
+++ b/src/xagent/web/api/monitor.py
@@ -100,8 +100,15 @@ def get_json_field_expression(column: Any, field_path: str, db_session: Session)
         # NUL raises "unsupported Unicode escape sequence", an unpaired UTF-16
         # surrogate raises "invalid input syntax for type json" -- and one such
         # row fails the entire query. Null those payloads out before extracting
-        # so the row drops instead. jsonb would reject them at write time, but
-        # this column is json, which stores them happily.
+        # so the row drops instead.
+        #
+        # These columns are jsonb since #1248, and jsonb rejects such payloads
+        # at INSERT, so on a migrated database this guard can never match. It
+        # stays because it is not this module's business to assume the
+        # migration has run: a database still on the json type -- one upgraded
+        # by hand, or mid-rollout -- carries exactly the rows it defends
+        # against. Per that issue, do not remove it while any deployment can
+        # still hold such a payload.
         #
         # Matching runs on the column's text form because valid JSON never
         # holds a raw control character or a bare surrogate (RFC 8259 requires

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -183,6 +183,7 @@ from ..services.workforce_runtime import (
 from ..tracing import create_ephemeral_tracer
 from ..user_isolated_memory import UserContext
 from ..utils.db_timezone import safe_timestamp_to_unix
+from ..utils.json_payload_sanitizer import sanitize_json_payload
 from .public_trace_events import (
     is_audit_only_trace_data,
     normalize_public_trace_event,
@@ -769,6 +770,11 @@ def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
         data: Dict[str, Any] = cast(
             Dict[str, Any], event_data if isinstance(event_data, dict) else {}
         )
+        # This function builds its own TraceEvent row instead of going
+        # through stage_trace_event_row (see that module's "known bypass"
+        # note), so it must sanitize for itself: PostgreSQL's jsonb rejects
+        # NUL and unpaired-surrogate code points at INSERT (#1248).
+        data = sanitize_json_payload(data)
         timestamp = event.get("timestamp")
         if isinstance(timestamp, (int, float)):
             event_time = datetime.fromtimestamp(float(timestamp), timezone.utc)

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -16,10 +16,23 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from .database import Base
+
+# Trace payload columns are jsonb on PostgreSQL (#1248): jsonb decodes JSON
+# escapes to native text at write time, so it rejects at INSERT the two
+# shapes a plain json column stored happily and then failed to read back
+# through ->> (#1149) -- the NUL escape and either half of an unpaired
+# UTF-16 surrogate. Producers sanitize those code points away before the
+# write (web/utils/json_payload_sanitizer.py); this type is the backstop
+# that keeps any unsanitized path from planting a payload the database
+# cannot read. Existing json columns are converted by the
+# 20260813_trace_json_columns_to_jsonb migration. Other dialects keep the
+# generic JSON type.
+TRACE_PAYLOAD_JSON = JSON().with_variant(JSONB(), "postgresql")
 
 
 class TaskStatus(enum.Enum):
@@ -550,7 +563,7 @@ class TraceEvent(Base):  # type: ignore
     parent_event_id = Column(
         String(255), nullable=True
     )  # Parent event ID for hierarchy
-    data = Column(JSON, nullable=False)  # Event data payload
+    data = Column(TRACE_PAYLOAD_JSON, nullable=False)  # Event data payload
 
     # Relationships. foreign_keys is explicit because tasks and trace_events
     # now have two FK paths between them (this task_id, and
@@ -578,7 +591,7 @@ class TraceMessageBlob(Base):  # type: ignore
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False, index=True)
     execution_id = Column(String(255), nullable=False, index=True)
     message_hash = Column(String(80), nullable=False)
-    message_data = Column(JSON, nullable=False)
+    message_data = Column(TRACE_PAYLOAD_JSON, nullable=False)
     message_bytes = Column(Integer, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
@@ -610,7 +623,7 @@ class TraceCheckpointBlob(Base):  # type: ignore
     execution_id = Column(String(255), nullable=False, index=True)
     blob_kind = Column(String(255), nullable=False, index=True)
     blob_hash = Column(String(80), nullable=False)
-    blob_data = Column(JSON, nullable=False)
+    blob_data = Column(TRACE_PAYLOAD_JSON, nullable=False)
     blob_bytes = Column(Integer, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/src/xagent/web/services/trace_event_staging.py
+++ b/src/xagent/web/services/trace_event_staging.py
@@ -32,6 +32,16 @@ constructs its own ``TraceEvent`` row and adds it to the session directly,
 without going through ``_save_trace_event`` or this function. This function
 is the sole construction point on the ``_save_trace_event`` path, not the
 only place a trace row is ever built in the codebase.
+
+A third writer would have to sanitize for itself too (#1248): every payload
+reaching these columns must pass ``sanitize_json_payload`` first, and that
+is a convention here rather than something the type system enforces. It is
+not enforced structurally because the ordering is load-bearing -- the
+sanitize has to happen before ``encode_checkpoint_data_for_storage`` hashes
+the payload, which a column-level ``TypeDecorator`` (running at bind time,
+long after the hash) could not guarantee. On PostgreSQL a missed sanitize
+fails loudly at INSERT, since the columns are ``jsonb``; on SQLite it would
+store silently, so a new writer is worth checking by hand.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/trace_event_staging.py
+++ b/src/xagent/web/services/trace_event_staging.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm import Session
 
 from ...core.agent.checkpoint import CHECKPOINT_TYPE
 from ..models.task import TraceEvent as DatabaseTraceEvent
+from ..utils.json_payload_sanitizer import sanitize_json_payload
 from .task_lease_service import TASK_RUN_ID_TRACE_FIELD, TaskLease
 from .trace_message_storage import encode_checkpoint_data_for_storage
 
@@ -105,6 +106,14 @@ def stage_trace_event_row(
     a sub-agent checkpoint (``build_id`` set) must be passed
     ``checkpoint_lease=None`` regardless of whether a lease is live.
     """
+    # Sanitize before anything derives from the payload: the checkpoint
+    # branches below hash and deduplicate blob rows out of ``data``, and the
+    # stored hash must be computed over what actually lands in the column.
+    # PostgreSQL's jsonb rejects NUL and unpaired-surrogate code points at
+    # INSERT (#1248); on other dialects the same cleaning keeps stored
+    # payloads identical across backends.
+    data = sanitize_json_payload(data)
+
     is_checkpoint = (
         event_type == "system_update_general"
         and isinstance(data, dict)

--- a/src/xagent/web/utils/json_payload_sanitizer.py
+++ b/src/xagent/web/utils/json_payload_sanitizer.py
@@ -94,11 +94,17 @@ def sanitize_json_payload(value: Any) -> Any:
     ``"a\\ud800"`` both become ``"a\\ufffd"``); the later key wins, matching
     ``json.loads`` duplicate-key behaviour.
 
-    Recursion is unbounded on purpose. A cap would have to leave whatever
-    sits below it unsanitized, which is the payload shape this function
-    exists to keep out of the column -- so a structure deep enough to
-    exhaust the stack fails its write loudly instead of storing something
-    the database cannot read back.
+    Recursion is unbounded on purpose: a depth cap would have to leave
+    whatever sits below it unsanitized, which is the payload shape this
+    function exists to keep out of the column. A structure deep enough to
+    exhaust the stack therefore raises ``RecursionError`` rather than
+    storing something the database cannot read back -- but note that both
+    callers treat a raising trace write as best-effort (``websocket.py``
+    rolls back and logs; ``trace_handlers.py`` logs and continues), so the
+    row is dropped with a log line, not surfaced to the caller. Payloads
+    that deep are not a shape the write paths produce -- the staging path's
+    own ``serialize_value`` recursion would hit the limit first -- so this
+    is a stated boundary, not a guard anything relies on.
     """
     cleaned = _sanitize(value)
     return value if cleaned is _UNCHANGED else cleaned
@@ -107,9 +113,11 @@ def sanitize_json_payload(value: Any) -> Any:
 def _sanitize(value: Any) -> Any:
     """Return the sanitized form of ``value``, or ``_UNCHANGED``."""
     if isinstance(value, str):
-        if _UNSTORABLE_CODE_POINTS.search(value):
-            return _UNSTORABLE_CODE_POINTS.sub(REPLACEMENT_CHARACTER, value)
-        return _UNCHANGED
+        # One pass, not a search followed by a sub: re.sub hands back the
+        # original object when nothing matched, so identity answers the
+        # "did anything change" question for free.
+        cleaned = _UNSTORABLE_CODE_POINTS.sub(REPLACEMENT_CHARACTER, value)
+        return _UNCHANGED if cleaned is value else cleaned
     # No bool guard needed: bool subclasses int, not float, so True/False
     # never reach this branch.
     if isinstance(value, float):

--- a/src/xagent/web/utils/json_payload_sanitizer.py
+++ b/src/xagent/web/utils/json_payload_sanitizer.py
@@ -54,6 +54,7 @@ not rewritten wholesale.
 
 from __future__ import annotations
 
+import math
 import re
 from itertools import islice
 from typing import Any
@@ -109,10 +110,17 @@ def _sanitize(value: Any) -> Any:
         if _UNSTORABLE_CODE_POINTS.search(value):
             return _UNSTORABLE_CODE_POINTS.sub(REPLACEMENT_CHARACTER, value)
         return _UNCHANGED
-    # bool is an int subclass, and True/False are not numbers to normalize.
-    if isinstance(value, float) and not isinstance(value, bool):
+    # No bool guard needed: bool subclasses int, not float, so True/False
+    # never reach this branch.
+    if isinstance(value, float):
         if abs(value) >= _EXPONENT_NOTATION_THRESHOLD and value.is_integer():
             return int(value)
+        # PostgreSQL numeric has no signed zero, so jsonb renders -0.0 as
+        # 0.0 while json.dumps writes "-0.0". Same class of retype as the
+        # exponent case above, at the opposite end of the range. copysign,
+        # because -0.0 == 0.0 is True and cannot distinguish them.
+        if value == 0.0 and math.copysign(1.0, value) < 0:
+            return 0.0
         return _UNCHANGED
     if isinstance(value, dict):
         cleaned_dict: dict[Any, Any] | None = None

--- a/src/xagent/web/utils/json_payload_sanitizer.py
+++ b/src/xagent/web/utils/json_payload_sanitizer.py
@@ -1,0 +1,112 @@
+"""Make a payload survive a PostgreSQL ``jsonb`` column unchanged.
+
+Two separate hazards, both introduced by the column type itself.
+
+**Code points jsonb refuses to store.**
+
+The trace payload columns are ``jsonb`` on PostgreSQL (#1248). ``jsonb``
+decodes JSON escapes to native text on the way in, so it rejects two shapes
+the previous ``json`` columns stored happily and then failed to read back
+(#1149):
+
+- the NUL escape ``\\u0000`` -- PostgreSQL text cannot carry NUL; and
+- either half of an unpaired UTF-16 surrogate, which is not a Unicode
+  scalar value and has no UTF-8 form.
+
+Both reach this process through ordinary LLM or tool output: ``json.loads``
+accepts the escapes without complaint and hands back Python strings carrying
+the raw code points, and ``json.dumps`` re-emits them. Sanitizing at the
+write boundary keeps the rule in one place instead of at every producer.
+
+Offending code points become U+FFFD (REPLACEMENT CHARACTER), the designated
+marker for undecodable input -- replacement rather than deletion, so the
+mangling stays visible and adjacent text is not silently joined.
+
+A surrogate code point in a Python ``str`` is always garbage here: a *valid*
+pair never survives ``json.loads`` (it is combined into one astral
+character), and even a high+low adjacency built by hand cannot be encoded
+as UTF-8. So every surrogate is replaced, without pair-matching -- unlike
+the read-side guard in ``web/api/monitor.py``, which inspects the *text*
+form of stored JSON and must strip valid pairs before matching.
+
+**Numbers jsonb stores but hands back as a different type.**
+
+``jsonb`` parses numbers into ``numeric`` and re-renders them in plain
+notation, while ``json`` keeps the literal text. A float that ``repr``
+writes with an exponent -- ``1e+16`` -- therefore comes back from the
+database as the *int* ``10000000000000000``. Value-wise that is the same
+number, but it is not the same JSON, and the checkpoint blob path
+(``web/services/trace_message_storage.py``) re-hashes payloads it reads
+back and compares them against the hash stored at write time: a payload
+carrying such a float would be rejected as corrupt on restore, costing
+the task its checkpoint.
+
+Normalizing here, at the same boundary and before the hash is computed,
+makes the stored form and the read-back form identical. Every float at or
+above 1e16 is integral (the mantissa runs out of fractional bits above
+2**53), so the conversion loses nothing that ``jsonb`` would not have
+taken anyway.
+
+Rows written *before* the jsonb migration are not covered by this and may
+still carry such a float; see that migration's docstring for why they are
+not rewritten wholesale.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+REPLACEMENT_CHARACTER = "�"
+
+# NUL plus the whole surrogate range. Raw ranges are safe in a character
+# class; the pattern never leaves this module in source-escape form.
+_UNSTORABLE_CODE_POINTS = re.compile("[\x00\ud800-\udfff]")
+
+# Where repr switches a float to exponent notation. Below it, json and
+# jsonb agree on the text; at or above it, jsonb re-renders in plain
+# notation and json.loads reads an int back.
+_EXPONENT_NOTATION_THRESHOLD = 1e16
+
+
+def sanitize_json_payload(value: Any) -> Any:
+    """Return ``value`` in the form the jsonb column will hand back.
+
+    Unstorable code points become U+FFFD, and floats jsonb would return as
+    ints are converted up front. Walks strings, dicts (keys included),
+    lists, and tuples; every other type passes through untouched. A payload
+    that needs no change is returned as the *same object* -- this runs on
+    every trace write and almost every payload is clean, so the clean path
+    must not copy.
+
+    Two distinct dict keys can collide after replacement (``"a\\x00"`` and
+    ``"a\\ud800"`` both become ``"a\\ufffd"``); the later key wins, matching
+    ``json.loads`` duplicate-key behaviour.
+    """
+    if isinstance(value, str):
+        if _UNSTORABLE_CODE_POINTS.search(value):
+            return _UNSTORABLE_CODE_POINTS.sub(REPLACEMENT_CHARACTER, value)
+        return value
+    # bool is an int subclass, and True/False are not numbers to normalize.
+    if isinstance(value, float) and not isinstance(value, bool):
+        if abs(value) >= _EXPONENT_NOTATION_THRESHOLD and value.is_integer():
+            return int(value)
+        return value
+    if isinstance(value, dict):
+        changed = False
+        cleaned_dict: dict[Any, Any] = {}
+        for key, item in value.items():
+            cleaned_key = sanitize_json_payload(key)
+            cleaned_item = sanitize_json_payload(item)
+            if cleaned_key is not key or cleaned_item is not item:
+                changed = True
+            cleaned_dict[cleaned_key] = cleaned_item
+        return cleaned_dict if changed else value
+    if isinstance(value, (list, tuple)):
+        cleaned_items = [sanitize_json_payload(item) for item in value]
+        if all(new is old for new, old in zip(cleaned_items, value)):
+            return value
+        if isinstance(value, tuple):
+            return tuple(cleaned_items)
+        return cleaned_items
+    return value

--- a/src/xagent/web/utils/json_payload_sanitizer.py
+++ b/src/xagent/web/utils/json_payload_sanitizer.py
@@ -55,6 +55,7 @@ not rewritten wholesale.
 from __future__ import annotations
 
 import re
+from itertools import islice
 from typing import Any
 
 REPLACEMENT_CHARACTER = "�"
@@ -69,44 +70,79 @@ _UNSTORABLE_CODE_POINTS = re.compile("[\x00\ud800-\udfff]")
 _EXPONENT_NOTATION_THRESHOLD = 1e16
 
 
+# Returned by _sanitize for a value that needs no edit, so a container can
+# tell "nothing changed here" from "changed to something falsy" and skip
+# copying itself. A module-private sentinel, never part of a payload.
+_UNCHANGED = object()
+
+
 def sanitize_json_payload(value: Any) -> Any:
     """Return ``value`` in the form the jsonb column will hand back.
 
     Unstorable code points become U+FFFD, and floats jsonb would return as
     ints are converted up front. Walks strings, dicts (keys included),
-    lists, and tuples; every other type passes through untouched. A payload
-    that needs no change is returned as the *same object* -- this runs on
-    every trace write and almost every payload is clean, so the clean path
-    must not copy.
+    lists, and tuples; every other type passes through untouched.
+
+    A payload that needs no change is returned as the *same object*, and no
+    copy of it is built along the way: this runs on every trace write and
+    almost every payload is clean, so the clean path allocates nothing.
+    Containers copy on first change only, backfilling the prefix they had
+    already walked.
 
     Two distinct dict keys can collide after replacement (``"a\\x00"`` and
     ``"a\\ud800"`` both become ``"a\\ufffd"``); the later key wins, matching
     ``json.loads`` duplicate-key behaviour.
+
+    Recursion is unbounded on purpose. A cap would have to leave whatever
+    sits below it unsanitized, which is the payload shape this function
+    exists to keep out of the column -- so a structure deep enough to
+    exhaust the stack fails its write loudly instead of storing something
+    the database cannot read back.
     """
+    cleaned = _sanitize(value)
+    return value if cleaned is _UNCHANGED else cleaned
+
+
+def _sanitize(value: Any) -> Any:
+    """Return the sanitized form of ``value``, or ``_UNCHANGED``."""
     if isinstance(value, str):
         if _UNSTORABLE_CODE_POINTS.search(value):
             return _UNSTORABLE_CODE_POINTS.sub(REPLACEMENT_CHARACTER, value)
-        return value
+        return _UNCHANGED
     # bool is an int subclass, and True/False are not numbers to normalize.
     if isinstance(value, float) and not isinstance(value, bool):
         if abs(value) >= _EXPONENT_NOTATION_THRESHOLD and value.is_integer():
             return int(value)
-        return value
+        return _UNCHANGED
     if isinstance(value, dict):
-        changed = False
-        cleaned_dict: dict[Any, Any] = {}
-        for key, item in value.items():
-            cleaned_key = sanitize_json_payload(key)
-            cleaned_item = sanitize_json_payload(item)
-            if cleaned_key is not key or cleaned_item is not item:
-                changed = True
-            cleaned_dict[cleaned_key] = cleaned_item
-        return cleaned_dict if changed else value
+        cleaned_dict: dict[Any, Any] | None = None
+        for index, (key, item) in enumerate(value.items()):
+            new_key = _sanitize(key)
+            new_item = _sanitize(item)
+            if new_key is _UNCHANGED and new_item is _UNCHANGED:
+                if cleaned_dict is not None:
+                    cleaned_dict[key] = item
+                continue
+            if cleaned_dict is None:
+                # First change: take the prefix already walked, which by
+                # construction needed no edit, and copy from here on.
+                cleaned_dict = dict(islice(value.items(), index))
+            cleaned_dict[key if new_key is _UNCHANGED else new_key] = (
+                item if new_item is _UNCHANGED else new_item
+            )
+        return _UNCHANGED if cleaned_dict is None else cleaned_dict
     if isinstance(value, (list, tuple)):
-        cleaned_items = [sanitize_json_payload(item) for item in value]
-        if all(new is old for new, old in zip(cleaned_items, value)):
-            return value
-        if isinstance(value, tuple):
-            return tuple(cleaned_items)
-        return cleaned_items
-    return value
+        cleaned_items: list[Any] | None = None
+        for index, item in enumerate(value):
+            new_item = _sanitize(item)
+            if new_item is _UNCHANGED:
+                if cleaned_items is not None:
+                    cleaned_items.append(item)
+                continue
+            if cleaned_items is None:
+                cleaned_items = list(value[:index])
+            cleaned_items.append(new_item)
+        if cleaned_items is None:
+            return _UNCHANGED
+        return tuple(cleaned_items) if isinstance(value, tuple) else cleaned_items
+    return _UNCHANGED

--- a/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
+++ b/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
@@ -32,7 +32,7 @@ from sqlalchemy import create_engine, text
 
 from xagent.db.config import create_alembic_config
 
-PARENT_REVISION = "20260809_add_task_interaction_requests"
+PARENT_REVISION = "20260810_add_hubspot_marketing_scopes"
 TARGET_REVISION = "20260813_trace_json_columns_to_jsonb"
 
 TRACE_JSON_COLUMNS = (

--- a/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
+++ b/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
@@ -412,6 +412,68 @@ class TestUpgradePostgres:
         assert payload["cost"] == 10000000000000000
         assert isinstance(payload["cost"], int)
 
+    def test_rewrite_preserves_numbers_a_float_round_trip_would_damage(
+        self, postgres_engine
+    ) -> None:
+        """The rewrite must not launder numbers through float64. jsonb's
+        numbers are numeric, so it keeps the literal exactly; parsing to
+        float would truncate the long decimal, turn 1e1000 into inf (which
+        json.dumps writes as ``Infinity``, failing the rewrite's own cast),
+        and render 1e25 as 10000000000000000905969664 rather than 10^25.
+        """
+        with postgres_engine.begin() as conn:
+            _insert_trace_event(
+                conn,
+                row_id=1,
+                payload_json_text=(
+                    '{"v": "n' + NUL_ESCAPE + '", '
+                    '"precise": 0.123456789012345678901, '
+                    '"huge": 1e1000, "exp": 1e25}'
+                ),
+            )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT data->>'v', data->>'precise', data->>'huge', "
+                    "data->>'exp' FROM trace_events WHERE id = 1"
+                )
+            ).one()
+        assert row[0] == f"n{REPLACEMENT}"
+        # Exactly what a plain CAST would have produced for these numbers.
+        assert row[1] == "0.123456789012345678901"
+        assert row[2] == "1" + "0" * 1000
+        assert row[3] == "1" + "0" * 25
+
+    def test_untouched_row_and_rewritten_row_agree_on_numbers(
+        self, postgres_engine
+    ) -> None:
+        """The property that makes the choice defensible: whether or not a
+        row is rewritten must not change how its numbers land."""
+        numbers = '"precise": 0.123456789012345678901, "exp": 1e25'
+        with postgres_engine.begin() as conn:
+            _insert_trace_event(
+                conn,
+                row_id=1,
+                payload_json_text='{"v": "n' + NUL_ESCAPE + '", ' + numbers + "}",
+            )
+            _insert_trace_event(
+                conn, row_id=2, payload_json_text='{"v": "clean", ' + numbers + "}"
+            )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT data->>'precise', data->>'exp' FROM trace_events "
+                    "ORDER BY id"
+                )
+            ).fetchall()
+        assert rows[0] == rows[1]
+
     def test_benign_payloads_convert_unrewritten(self, postgres_engine) -> None:
         with postgres_engine.begin() as conn:
             _insert_trace_event(

--- a/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
+++ b/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
@@ -32,7 +32,7 @@ from sqlalchemy import create_engine, text
 
 from xagent.db.config import create_alembic_config
 
-PARENT_REVISION = "20260812_add_slack_history_reactions_files_scopes"
+PARENT_REVISION = "20260812_seed_intercom_mcp_app"
 TARGET_REVISION = "20260813_trace_json_columns_to_jsonb"
 
 TRACE_JSON_COLUMNS = (

--- a/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
+++ b/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
@@ -427,3 +427,67 @@ class TestOfflineSql:
         assert "%(" not in sql
         assert ":param" not in sql
         assert "?" not in sql
+
+
+@pytest.mark.postgresql
+class TestBatchedCleanup:
+    """The cleanup walks matching rows in bounded batches so the migration
+    never materializes every poisoned payload at once. A single batch is
+    exercised by the tests above; this class forces the loop to run more
+    than once, which is the only way the keyset advance is covered.
+    """
+
+    def test_rewrites_more_rows_than_one_batch(self, postgres_engine) -> None:
+        migration = _migration_module()
+        row_count = migration.REWRITE_BATCH_SIZE * 2 + 3
+        with postgres_engine.begin() as conn:
+            for row_id in range(1, row_count + 1):
+                _insert_trace_event(
+                    conn,
+                    row_id=row_id,
+                    payload_json_text='{"v": "n' + NUL_ESCAPE + '"}',
+                )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            distinct = conn.execute(
+                text("SELECT DISTINCT data->>'v' FROM trace_events")
+            ).fetchall()
+            total = conn.execute(text("SELECT count(*) FROM trace_events")).scalar_one()
+        # Every row rewritten, none skipped by the keyset advance and none
+        # left behind for the cast to choke on.
+        assert total == row_count
+        assert distinct == [(f"n{REPLACEMENT}",)]
+
+    def test_clean_rows_between_poisoned_ones_are_untouched(
+        self, postgres_engine
+    ) -> None:
+        """The batch predicate matches only poisoned rows, so the keyset
+        advance steps over clean rows rather than rewriting them."""
+        with postgres_engine.begin() as conn:
+            for row_id in range(1, migration_batch_span() + 1):
+                if row_id % 2:
+                    payload = '{"v": "bad' + NUL_ESCAPE + '"}'
+                else:
+                    payload = '{"v": "' + PAIR_ESCAPE + '"}'
+                _insert_trace_event(conn, row_id=row_id, payload_json_text=payload)
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            good = conn.execute(
+                text("SELECT count(*) FROM trace_events WHERE data->>'v' = :v"),
+                {"v": chr(0x1F600)},
+            ).scalar_one()
+            bad = conn.execute(
+                text("SELECT count(*) FROM trace_events WHERE data->>'v' = :v"),
+                {"v": f"bad{REPLACEMENT}"},
+            ).scalar_one()
+        assert good == migration_batch_span() // 2
+        assert bad == migration_batch_span() - migration_batch_span() // 2
+
+
+def migration_batch_span() -> int:
+    """One batch plus a remainder, so the loop runs twice."""
+    return _migration_module().REWRITE_BATCH_SIZE + 5

--- a/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
+++ b/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
@@ -429,24 +429,52 @@ class TestOfflineSql:
         assert "?" not in sql
 
 
+def _batch_span() -> int:
+    """One full id batch plus a remainder, so the cleanup loop runs twice.
+
+    Derived from the migration's own constant rather than hardcoded: the
+    point of these tests is that the loop iterates, which stops being true
+    if someone raises REWRITE_BATCH_SIZE past a fixed row count here.
+    """
+    return _migration_module().REWRITE_BATCH_SIZE + 3
+
+
+def _insert_many(conn: sa.engine.Connection, payloads: dict[int, str]) -> None:
+    """Seed rows in one round trip -- a batch-span worth of single INSERTs
+    dominates these tests' runtime otherwise."""
+    conn.execute(
+        text(
+            "INSERT INTO trace_events "
+            "(id, task_id, event_id, event_type, timestamp, data) "
+            "VALUES (:id, 1, :event_id, 'llm_call_start', "
+            "'2026-08-13 00:00:00', CAST(:payload AS json))"
+        ),
+        [
+            {"id": row_id, "event_id": f"evt-{row_id}", "payload": payload}
+            for row_id, payload in payloads.items()
+        ],
+    )
+
+
 @pytest.mark.postgresql
 class TestBatchedCleanup:
-    """The cleanup walks matching rows in bounded batches so the migration
-    never materializes every poisoned payload at once. A single batch is
-    exercised by the tests above; this class forces the loop to run more
-    than once, which is the only way the keyset advance is covered.
+    """The cleanup pages over matching ids and reads one payload at a time,
+    so neither the whole matching set nor a batch of payloads is ever
+    resident. The tests above stay inside a single batch; this class forces
+    the loop to iterate, which is the only way the keyset advance is
+    covered.
     """
 
     def test_rewrites_more_rows_than_one_batch(self, postgres_engine) -> None:
-        migration = _migration_module()
-        row_count = migration.REWRITE_BATCH_SIZE * 2 + 3
+        row_count = _batch_span()
         with postgres_engine.begin() as conn:
-            for row_id in range(1, row_count + 1):
-                _insert_trace_event(
-                    conn,
-                    row_id=row_id,
-                    payload_json_text='{"v": "n' + NUL_ESCAPE + '"}',
-                )
+            _insert_many(
+                conn,
+                {
+                    row_id: '{"v": "n' + NUL_ESCAPE + '"}'
+                    for row_id in range(1, row_count + 1)
+                },
+            )
 
         _upgrade(postgres_engine)
 
@@ -463,15 +491,21 @@ class TestBatchedCleanup:
     def test_clean_rows_between_poisoned_ones_are_untouched(
         self, postgres_engine
     ) -> None:
-        """The batch predicate matches only poisoned rows, so the keyset
-        advance steps over clean rows rather than rewriting them."""
+        """The id scan matches only poisoned rows, so the keyset advance
+        steps over clean rows rather than rewriting them."""
+        span = _batch_span()
         with postgres_engine.begin() as conn:
-            for row_id in range(1, migration_batch_span() + 1):
-                if row_id % 2:
-                    payload = '{"v": "bad' + NUL_ESCAPE + '"}'
-                else:
-                    payload = '{"v": "' + PAIR_ESCAPE + '"}'
-                _insert_trace_event(conn, row_id=row_id, payload_json_text=payload)
+            _insert_many(
+                conn,
+                {
+                    row_id: (
+                        '{"v": "bad' + NUL_ESCAPE + '"}'
+                        if row_id % 2
+                        else '{"v": "' + PAIR_ESCAPE + '"}'
+                    )
+                    for row_id in range(1, span + 1)
+                },
+            )
 
         _upgrade(postgres_engine)
 
@@ -484,10 +518,5 @@ class TestBatchedCleanup:
                 text("SELECT count(*) FROM trace_events WHERE data->>'v' = :v"),
                 {"v": f"bad{REPLACEMENT}"},
             ).scalar_one()
-        assert good == migration_batch_span() // 2
-        assert bad == migration_batch_span() - migration_batch_span() // 2
-
-
-def migration_batch_span() -> int:
-    """One batch plus a remainder, so the loop runs twice."""
-    return _migration_module().REWRITE_BATCH_SIZE + 5
+        assert good == span // 2
+        assert bad == span - span // 2

--- a/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
+++ b/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
@@ -1,0 +1,429 @@
+"""Tests for migration 20260813_trace_json_columns_to_jsonb (#1248).
+
+Following this repo's migration-test convention (see
+tests/migrations/test_20260804_add_task_checkpoint_trace_event_anchor.py):
+the trace tables' pre-migration shape is built directly with SQLAlchemy
+Core table objects, stamped to the parent revision, and only the migration
+under test is run against it.
+
+The migration is PostgreSQL-only, so the SQLite tests pin the no-op (both
+directions leave schema and rows untouched) and everything substantive --
+the row cleanup, the type change, idempotence, and the downgrade -- runs
+under ``@pytest.mark.postgresql`` against a real server, where ``json``
+vs ``jsonb`` semantics exist. The payload shapes mirror the seed data of
+``tests/web/api/test_monitor_postgresql.py``, the read-side test that
+documents why these exact escapes are hazardous.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from io import StringIO
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+from xagent.db.config import create_alembic_config
+
+PARENT_REVISION = "20260809_add_task_interaction_requests"
+TARGET_REVISION = "20260813_trace_json_columns_to_jsonb"
+
+TRACE_JSON_COLUMNS = (
+    ("trace_events", "data"),
+    ("trace_message_blobs", "message_data"),
+    ("trace_checkpoint_blobs", "blob_data"),
+)
+ALL_TABLES = ("alembic_version",) + tuple(t for t, _ in TRACE_JSON_COLUMNS)
+
+# Escape sequences as they sit in the stored JSON *text*: six literal
+# characters each, written with an escaped backslash so no editor or JSON
+# layer decodes them prematurely.
+BS = chr(92)
+NUL_ESCAPE = BS + "u0000"
+LONE_HIGH_ESCAPE = BS + "ud800"
+LONE_LOW_ESCAPE = BS + "udc00"
+# A valid pair (U+1F600) that must survive conversion as a real character.
+PAIR_ESCAPE = BS + "ud83d" + BS + "ude00"
+# Literal text that merely looks like an escape: the JSON carries a doubled
+# backslash, so the value is the six characters backslash-u0000.
+LITERAL_ESCAPE_TEXT = BS + BS + "u0000"
+REPLACEMENT = chr(0xFFFD)
+
+
+def _migration_module() -> ModuleType:
+    import xagent.migrations as migrations_pkg
+
+    migrations_dir = Path(next(iter(migrations_pkg.__path__)))
+    path = migrations_dir / "versions" / f"{TARGET_REVISION}.py"
+    spec = importlib.util.spec_from_file_location(TARGET_REVISION, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _pre_migration_metadata() -> sa.MetaData:
+    """The three trace tables, reduced to the columns the migration touches
+    plus their primary keys -- not the full production schema."""
+    metadata = sa.MetaData()
+    sa.Table(
+        "trace_events",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("task_id", sa.Integer, nullable=False),
+        sa.Column("event_id", sa.String(255), nullable=False),
+        sa.Column("event_type", sa.String(100), nullable=False),
+        sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("data", sa.JSON, nullable=False),
+    )
+    sa.Table(
+        "trace_message_blobs",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("message_data", sa.JSON, nullable=False),
+    )
+    sa.Table(
+        "trace_checkpoint_blobs",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("blob_data", sa.JSON, nullable=False),
+    )
+    return metadata
+
+
+def _stamp_parent_revision(engine: sa.engine.Engine) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(
+            text(
+                "INSERT INTO alembic_version (version_num) VALUES "
+                f"('{PARENT_REVISION}')"
+            )
+        )
+
+
+def _insert_trace_event(
+    conn: sa.engine.Connection, *, row_id: int, payload_json_text: str
+) -> None:
+    """Insert with the payload cast from raw JSON text, so escape sequences
+    reach the column exactly as written -- the json type accepts them, which
+    is the bug this migration removes."""
+    conn.execute(
+        text(
+            "INSERT INTO trace_events "
+            "(id, task_id, event_id, event_type, timestamp, data) "
+            "VALUES (:id, 1, :event_id, 'llm_call_start', "
+            "'2026-08-13 00:00:00', CAST(:payload AS json))"
+        ),
+        {"id": row_id, "event_id": f"evt-{row_id}", "payload": payload_json_text},
+    )
+
+
+def _alembic_config(engine: sa.engine.Engine):
+    config = create_alembic_config(engine)
+    config.set_main_option(
+        "sqlalchemy.url", engine.url.render_as_string(hide_password=False)
+    )
+    return config
+
+
+def _upgrade(engine: sa.engine.Engine, revision: str = TARGET_REVISION) -> None:
+    command.upgrade(_alembic_config(engine), revision)
+
+
+def _downgrade(engine: sa.engine.Engine, revision: str = PARENT_REVISION) -> None:
+    command.downgrade(_alembic_config(engine), revision)
+
+
+@pytest.fixture
+def sqlite_engine(tmp_path: Path) -> sa.engine.Engine:
+    engine = create_engine(f"sqlite:///{tmp_path / 'jsonb.db'}")
+    _pre_migration_metadata().create_all(bind=engine)
+    _stamp_parent_revision(engine)
+    return engine
+
+
+class TestSqliteNoOp:
+    def test_upgrade_leaves_schema_and_rows_untouched(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        payload = '{"model_name": "gpt-4o"}'
+        with sqlite_engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO trace_events "
+                    "(id, task_id, event_id, event_type, timestamp, data) "
+                    "VALUES (1, 1, 'evt-1', 'llm_call_start', "
+                    "'2026-08-13 00:00:00', :payload)"
+                ),
+                {"payload": payload},
+            )
+        before = {
+            c["name"]: str(c["type"])
+            for c in sa.inspect(sqlite_engine).get_columns("trace_events")
+        }
+
+        _upgrade(sqlite_engine)
+
+        after = {
+            c["name"]: str(c["type"])
+            for c in sa.inspect(sqlite_engine).get_columns("trace_events")
+        }
+        assert after == before
+        with sqlite_engine.begin() as conn:
+            stored = conn.execute(
+                text("SELECT data FROM trace_events WHERE id = 1")
+            ).scalar_one()
+        assert stored == payload
+
+    def test_downgrade_is_a_no_op(self, sqlite_engine: sa.engine.Engine) -> None:
+        _upgrade(sqlite_engine)
+        _downgrade(sqlite_engine)
+
+
+def _postgres_url() -> str | None:
+    return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
+        "POSTGRES_TEST_DATABASE_URL"
+    )
+
+
+@pytest.fixture
+def postgres_engine():
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        for table in ALL_TABLES:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+    _pre_migration_metadata().create_all(bind=engine)
+    _stamp_parent_revision(engine)
+    yield engine
+    with engine.begin() as conn:
+        for table in ALL_TABLES:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+    engine.dispose()
+
+
+def _column_type(engine, table: str, column: str) -> str:
+    with engine.begin() as conn:
+        return conn.execute(
+            text(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_name = :t AND column_name = :c"
+            ),
+            {"t": table, "c": column},
+        ).scalar_one()
+
+
+@pytest.mark.postgresql
+class TestUpgradePostgres:
+    def test_converts_all_three_columns_to_jsonb(self, postgres_engine) -> None:
+        _upgrade(postgres_engine)
+
+        for table, column in TRACE_JSON_COLUMNS:
+            assert _column_type(postgres_engine, table, column) == "jsonb"
+
+    def test_rewrites_rows_the_cast_would_reject(self, postgres_engine) -> None:
+        with postgres_engine.begin() as conn:
+            _insert_trace_event(
+                conn, row_id=1, payload_json_text='{"v": "a' + NUL_ESCAPE + 'b"}'
+            )
+            _insert_trace_event(
+                conn, row_id=2, payload_json_text='{"v": "x' + LONE_HIGH_ESCAPE + '"}'
+            )
+            _insert_trace_event(
+                conn, row_id=3, payload_json_text='{"v": "y' + LONE_LOW_ESCAPE + '"}'
+            )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            values = dict(
+                conn.execute(
+                    text("SELECT id, data->>'v' FROM trace_events ORDER BY id")
+                ).fetchall()
+            )
+        assert values == {
+            1: f"a{REPLACEMENT}b",
+            2: f"x{REPLACEMENT}",
+            3: f"y{REPLACEMENT}",
+        }
+
+    def test_benign_payloads_convert_unrewritten(self, postgres_engine) -> None:
+        with postgres_engine.begin() as conn:
+            _insert_trace_event(
+                conn, row_id=1, payload_json_text='{"v": "' + PAIR_ESCAPE + '"}'
+            )
+            _insert_trace_event(
+                conn,
+                row_id=2,
+                payload_json_text='{"v": "' + LITERAL_ESCAPE_TEXT + '"}',
+            )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            values = dict(
+                conn.execute(
+                    text("SELECT id, data->>'v' FROM trace_events ORDER BY id")
+                ).fetchall()
+            )
+        # The valid pair decodes to the astral character; the literal text
+        # keeps its backslash. Neither gains a replacement character.
+        assert values == {1: chr(0x1F600), 2: BS + "u0000"}
+
+    def test_cleans_the_blob_tables_too(self, postgres_engine) -> None:
+        with postgres_engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO trace_message_blobs (id, message_data) "
+                    "VALUES (1, CAST(:payload AS json))"
+                ),
+                {"payload": '{"m": "' + LONE_HIGH_ESCAPE + '"}'},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO trace_checkpoint_blobs (id, blob_data) "
+                    "VALUES (1, CAST(:payload AS json))"
+                ),
+                {"payload": '{"b": "' + NUL_ESCAPE + '"}'},
+            )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            message = conn.execute(
+                text("SELECT message_data->>'m' FROM trace_message_blobs")
+            ).scalar_one()
+            blob = conn.execute(
+                text("SELECT blob_data->>'b' FROM trace_checkpoint_blobs")
+            ).scalar_one()
+        assert message == REPLACEMENT
+        assert blob == REPLACEMENT
+
+    def test_jsonb_rejects_the_hazard_after_upgrade(self, postgres_engine) -> None:
+        """The invariant the whole migration exists to establish: after it,
+        the column can no longer hold a payload ``->>`` cannot read."""
+        _upgrade(postgres_engine)
+
+        with pytest.raises(sa.exc.DBAPIError):
+            with postgres_engine.begin() as conn:
+                _insert_trace_event(
+                    conn,
+                    row_id=99,
+                    payload_json_text='{"v": "' + LONE_HIGH_ESCAPE + '"}',
+                )
+
+    def test_upgrade_is_idempotent_when_rerun(self, postgres_engine) -> None:
+        migration = _migration_module()
+        _upgrade(postgres_engine)
+
+        # command.upgrade() short-circuits once stamped, so run the
+        # migration body itself a second time over the live connection.
+        with postgres_engine.begin() as conn:
+            context = MigrationContext.configure(conn)
+            with Operations.context(context):
+                migration.upgrade()
+
+        for table, column in TRACE_JSON_COLUMNS:
+            assert _column_type(postgres_engine, table, column) == "jsonb"
+
+    def test_missing_tables_are_skipped(self, postgres_engine) -> None:
+        """A bare database has none of the three tables when migrations run
+        (they are create_all-owned); each must be skipped independently."""
+        with postgres_engine.begin() as conn:
+            conn.execute(text("DROP TABLE trace_checkpoint_blobs"))
+
+        _upgrade(postgres_engine)
+
+        assert _column_type(postgres_engine, "trace_events", "data") == "jsonb"
+
+
+@pytest.mark.postgresql
+class TestDowngradePostgres:
+    def test_downgrade_restores_json(self, postgres_engine) -> None:
+        _upgrade(postgres_engine)
+        _downgrade(postgres_engine)
+
+        for table, column in TRACE_JSON_COLUMNS:
+            assert _column_type(postgres_engine, table, column) == "json"
+
+    def test_downgrade_preserves_rows(self, postgres_engine) -> None:
+        with postgres_engine.begin() as conn:
+            _insert_trace_event(
+                conn, row_id=1, payload_json_text='{"model_name": "gpt-4o"}'
+            )
+
+        _upgrade(postgres_engine)
+        _downgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            value = conn.execute(
+                text("SELECT data->>'model_name' FROM trace_events WHERE id = 1")
+            ).scalar_one()
+        assert value == "gpt-4o"
+
+
+def _offline_sql(dialect_name: str, operation: str) -> str:
+    migration = _migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name=dialect_name,
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        getattr(migration, operation)()
+
+    return output.getvalue()
+
+
+class TestOfflineSql:
+    def test_postgresql_upgrade_emits_the_three_alters(self) -> None:
+        sql = _offline_sql("postgresql", "upgrade")
+
+        for table, column in TRACE_JSON_COLUMNS:
+            assert (
+                f"ALTER TABLE {table} ALTER COLUMN {column} TYPE JSONB "
+                f"USING {column}::jsonb" in sql
+            )
+        # No row cleanup offline: a MockConnection cannot read rows. The
+        # module docstring documents the operator-facing consequence.
+        assert "UPDATE" not in sql
+        assert "SELECT" not in sql
+
+    def test_postgresql_downgrade_restores_json(self) -> None:
+        sql = _offline_sql("postgresql", "downgrade")
+
+        for table, column in TRACE_JSON_COLUMNS:
+            assert (
+                f"ALTER TABLE {table} ALTER COLUMN {column} TYPE JSON "
+                f"USING {column}::json" in sql
+            )
+
+    @pytest.mark.parametrize("operation", ["upgrade", "downgrade"])
+    def test_sqlite_emits_nothing(self, operation: str) -> None:
+        sql = _offline_sql("sqlite", operation)
+
+        assert "ALTER TABLE" not in sql
+
+    @pytest.mark.parametrize("dialect", ["sqlite", "postgresql"])
+    @pytest.mark.parametrize("operation", ["upgrade", "downgrade"])
+    def test_offline_sql_carries_no_bind_parameters(
+        self, dialect: str, operation: str
+    ) -> None:
+        sql = _offline_sql(dialect, operation)
+
+        assert "%(" not in sql
+        assert ":param" not in sql
+        assert "?" not in sql

--- a/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
+++ b/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
@@ -83,17 +83,30 @@ def _pre_migration_metadata() -> sa.MetaData:
         sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
         sa.Column("data", sa.JSON, nullable=False),
     )
+    # The hash and bytes columns are carried here even though the migration
+    # never writes them: that it leaves them verbatim is a contract (the
+    # hash is the blob's identity, referenced from trace_events.data), and
+    # a fixture without them cannot pin it.
     sa.Table(
         "trace_message_blobs",
         metadata,
         sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("task_id", sa.Integer, nullable=False),
+        sa.Column("execution_id", sa.String(255), nullable=False),
+        sa.Column("message_hash", sa.String(80), nullable=False),
         sa.Column("message_data", sa.JSON, nullable=False),
+        sa.Column("message_bytes", sa.Integer, nullable=False),
     )
     sa.Table(
         "trace_checkpoint_blobs",
         metadata,
         sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("task_id", sa.Integer, nullable=False),
+        sa.Column("execution_id", sa.String(255), nullable=False),
+        sa.Column("blob_kind", sa.String(255), nullable=False),
+        sa.Column("blob_hash", sa.String(80), nullable=False),
         sa.Column("blob_data", sa.JSON, nullable=False),
+        sa.Column("blob_bytes", sa.Integer, nullable=False),
     )
     return metadata
 
@@ -125,6 +138,54 @@ def _insert_trace_event(
             "'2026-08-13 00:00:00', CAST(:payload AS json))"
         ),
         {"id": row_id, "event_id": f"evt-{row_id}", "payload": payload_json_text},
+    )
+
+
+def _insert_message_blob(
+    conn: sa.engine.Connection,
+    *,
+    row_id: int,
+    payload_json_text: str,
+    message_hash: str | None = None,
+    message_bytes: int = 0,
+) -> None:
+    conn.execute(
+        text(
+            "INSERT INTO trace_message_blobs "
+            "(id, task_id, execution_id, message_hash, message_data, "
+            "message_bytes) VALUES (:id, 1, 'exec-1', :hash, "
+            "CAST(:payload AS json), :bytes)"
+        ),
+        {
+            "id": row_id,
+            "hash": message_hash or f"sha256:msg-{row_id}",
+            "payload": payload_json_text,
+            "bytes": message_bytes,
+        },
+    )
+
+
+def _insert_checkpoint_blob(
+    conn: sa.engine.Connection,
+    *,
+    row_id: int,
+    payload_json_text: str,
+    blob_hash: str | None = None,
+    blob_bytes: int = 0,
+) -> None:
+    conn.execute(
+        text(
+            "INSERT INTO trace_checkpoint_blobs "
+            "(id, task_id, execution_id, blob_kind, blob_hash, blob_data, "
+            "blob_bytes) VALUES (:id, 1, 'exec-1', 'context.metadata', "
+            ":hash, CAST(:payload AS json), :bytes)"
+        ),
+        {
+            "id": row_id,
+            "hash": blob_hash or f"sha256:blob-{row_id}",
+            "payload": payload_json_text,
+            "bytes": blob_bytes,
+        },
     )
 
 
@@ -185,9 +246,40 @@ class TestSqliteNoOp:
             ).scalar_one()
         assert stored == payload
 
-    def test_downgrade_is_a_no_op(self, sqlite_engine: sa.engine.Engine) -> None:
+    def test_downgrade_leaves_schema_and_rows_untouched(
+        self, sqlite_engine: sa.engine.Engine
+    ) -> None:
+        """Symmetric with the upgrade test above: the downgrade must also
+        assert, not merely run without raising."""
+        payload = '{"model_name": "gpt-4o"}'
+        with sqlite_engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO trace_events "
+                    "(id, task_id, event_id, event_type, timestamp, data) "
+                    "VALUES (1, 1, 'evt-1', 'llm_call_start', "
+                    "'2026-08-13 00:00:00', :payload)"
+                ),
+                {"payload": payload},
+            )
+        before = {
+            c["name"]: str(c["type"])
+            for c in sa.inspect(sqlite_engine).get_columns("trace_events")
+        }
+
         _upgrade(sqlite_engine)
         _downgrade(sqlite_engine)
+
+        after = {
+            c["name"]: str(c["type"])
+            for c in sa.inspect(sqlite_engine).get_columns("trace_events")
+        }
+        assert after == before
+        with sqlite_engine.begin() as conn:
+            stored = conn.execute(
+                text("SELECT data FROM trace_events WHERE id = 1")
+            ).scalar_one()
+        assert stored == payload
 
 
 def _postgres_url() -> str | None:
@@ -259,6 +351,67 @@ class TestUpgradePostgres:
             3: f"y{REPLACEMENT}",
         }
 
+    def test_rewrites_a_payload_mixing_valid_pairs_with_orphans(
+        self, postgres_engine
+    ) -> None:
+        """The shape the pair-strip and the unsafe predicate only interact
+        on: a valid surrogate pair sitting next to an orphan. The pair must
+        be stripped before matching, or the orphan behind it is missed and
+        the ALTER fails on the row."""
+        with postgres_engine.begin() as conn:
+            _insert_trace_event(
+                conn,
+                row_id=1,
+                payload_json_text=(
+                    '{"v": "' + PAIR_ESCAPE + LONE_LOW_ESCAPE + PAIR_ESCAPE + '"}'
+                ),
+            )
+            _insert_trace_event(
+                conn,
+                row_id=2,
+                payload_json_text=(
+                    '{"v": "' + LITERAL_ESCAPE_TEXT + LONE_HIGH_ESCAPE + '"}'
+                ),
+            )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            values = dict(
+                conn.execute(
+                    text("SELECT id, data->>'v' FROM trace_events ORDER BY id")
+                ).fetchall()
+            )
+        emoji = chr(0x1F600)
+        # Row 1: both valid pairs survive as real characters, the orphan
+        # between them is replaced. Row 2: text that only looks like an
+        # escape is preserved, the orphan after it is still caught.
+        assert values == {
+            1: f"{emoji}{REPLACEMENT}{emoji}",
+            2: BS + "u0000" + REPLACEMENT,
+        }
+
+    def test_rewrites_a_large_float_alongside_the_escape(self, postgres_engine) -> None:
+        """The migration's own float normalization: a row selected for its
+        escape also gets its exponent-notation floats converted, so the
+        rewritten payload matches what jsonb would hand back."""
+        with postgres_engine.begin() as conn:
+            _insert_trace_event(
+                conn,
+                row_id=1,
+                payload_json_text='{"v": "n' + NUL_ESCAPE + '", "cost": 1e16}',
+            )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            payload = conn.execute(
+                text("SELECT data FROM trace_events WHERE id = 1")
+            ).scalar_one()
+        assert payload["v"] == f"n{REPLACEMENT}"
+        assert payload["cost"] == 10000000000000000
+        assert isinstance(payload["cost"], int)
+
     def test_benign_payloads_convert_unrewritten(self, postgres_engine) -> None:
         with postgres_engine.begin() as conn:
             _insert_trace_event(
@@ -284,19 +437,11 @@ class TestUpgradePostgres:
 
     def test_cleans_the_blob_tables_too(self, postgres_engine) -> None:
         with postgres_engine.begin() as conn:
-            conn.execute(
-                text(
-                    "INSERT INTO trace_message_blobs (id, message_data) "
-                    "VALUES (1, CAST(:payload AS json))"
-                ),
-                {"payload": '{"m": "' + LONE_HIGH_ESCAPE + '"}'},
+            _insert_message_blob(
+                conn, row_id=1, payload_json_text='{"m": "' + LONE_HIGH_ESCAPE + '"}'
             )
-            conn.execute(
-                text(
-                    "INSERT INTO trace_checkpoint_blobs (id, blob_data) "
-                    "VALUES (1, CAST(:payload AS json))"
-                ),
-                {"payload": '{"b": "' + NUL_ESCAPE + '"}'},
+            _insert_checkpoint_blob(
+                conn, row_id=1, payload_json_text='{"b": "' + NUL_ESCAPE + '"}'
             )
 
         _upgrade(postgres_engine)
@@ -310,6 +455,38 @@ class TestUpgradePostgres:
             ).scalar_one()
         assert message == REPLACEMENT
         assert blob == REPLACEMENT
+
+    def test_blob_hash_columns_are_left_verbatim(self, postgres_engine) -> None:
+        """The hash is the blob's identity, not a checksum of the column:
+        ``trace_events.data`` references a blob by embedding the hash value,
+        so rewriting it would make the row unreachable instead of merely
+        unverifiable, and could collide with a post-sanitizer row under
+        uq_trace_message_blobs_task_hash. The migration therefore rewrites
+        the payload and leaves the hash alone -- a deliberate choice with a
+        documented cost (see the module docstring), which this pins so it
+        cannot be changed silently.
+        """
+        with postgres_engine.begin() as conn:
+            _insert_message_blob(
+                conn,
+                row_id=1,
+                payload_json_text='{"m": "n' + NUL_ESCAPE + '"}',
+                message_hash="sha256:deadbeef",
+                message_bytes=999,
+            )
+
+        _upgrade(postgres_engine)
+
+        with postgres_engine.begin() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT message_hash, message_bytes, message_data->>'m' "
+                    "FROM trace_message_blobs WHERE id = 1"
+                )
+            ).one()
+        assert row[0] == "sha256:deadbeef"
+        assert row[1] == 999
+        assert row[2] == f"n{REPLACEMENT}"
 
     def test_jsonb_rejects_the_hazard_after_upgrade(self, postgres_engine) -> None:
         """The invariant the whole migration exists to establish: after it,

--- a/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
+++ b/tests/migrations/test_20260813_trace_json_columns_to_jsonb.py
@@ -32,7 +32,7 @@ from sqlalchemy import create_engine, text
 
 from xagent.db.config import create_alembic_config
 
-PARENT_REVISION = "20260810_add_hubspot_marketing_scopes"
+PARENT_REVISION = "20260812_add_slack_history_reactions_files_scopes"
 TARGET_REVISION = "20260813_trace_json_columns_to_jsonb"
 
 TRACE_JSON_COLUMNS = (

--- a/tests/web/api/test_monitor_postgresql.py
+++ b/tests/web/api/test_monitor_postgresql.py
@@ -381,6 +381,47 @@ class TestJsonbRoundTripFidelity:
         ).one()
         assert isinstance(row.data["cost"], int)
 
+    def test_negative_zero_survives_as_the_same_json(self, pg_session: Session) -> None:
+        """The other end of the numeric range: PostgreSQL numeric has no
+        signed zero, so an unsanitized -0.0 comes back as 0.0 and breaks
+        the hash the same way a large float does."""
+        task = self._task(pg_session, "roundtrip-negzero")
+        payload = {"delta": -0.0, "ratio": 0.5}
+
+        stored = self._round_trip(pg_session, task, payload)
+
+        expected = sanitize_json_payload(payload)
+        assert json.dumps(stored, sort_keys=True) == json.dumps(
+            expected, sort_keys=True
+        )
+
+    def test_unsanitized_negative_zero_would_lose_its_sign(
+        self, pg_session: Session
+    ) -> None:
+        """Control for the test above: the sign really is dropped by the
+        column, so the normalization is load-bearing."""
+        task = self._task(pg_session, "roundtrip-negzero-control")
+        pg_session.add(
+            TraceEvent(
+                task_id=task.id,
+                event_id="roundtrip-negzero-control",
+                event_type="llm_call_start",
+                timestamp=datetime.now(),
+                data={"delta": -0.0},
+            )
+        )
+        pg_session.commit()
+        pg_session.expunge_all()
+
+        row = pg_session.execute(
+            TraceEvent.__table__.select().where(
+                TraceEvent.event_id == "roundtrip-negzero-control"
+            )
+        ).one()
+        # json.dumps of the *unsanitized* payload writes "-0.0"; what the
+        # column hands back no longer does.
+        assert json.dumps(row.data["delta"]) == "0.0"
+
     def test_ordinary_payload_survives_unchanged(self, pg_session: Session) -> None:
         task = self._task(pg_session, "roundtrip-plain")
         payload = {

--- a/tests/web/api/test_monitor_postgresql.py
+++ b/tests/web/api/test_monitor_postgresql.py
@@ -34,9 +34,12 @@ what this file can and must pin:
   seeded alongside text that merely looks like an escape.
 
 The read guard in ``get_json_field_expression`` still exists for databases
-whose migration has not run; with ``jsonb`` it can never match, so its
-matching behaviour stays pinned by the dialect-independent unit tests in
-``tests/web/test_monitor_api.py``, not here.
+whose migration has not run. With ``jsonb`` it can never match, so no test
+over the model's own table can reach its drop path any more --
+``TestReadGuardAgainstNativeJson`` therefore builds a throwaway table with
+a native ``json`` column and runs the guard against that, which keeps the
+branch's normalize-then-match SQL executing on real PostgreSQL rather than
+only in the dialect-independent mirrors in ``tests/web/test_monitor_api.py``.
 
 Fixture pattern copied from
 ``tests/web/services/test_task_status_storage_postgresql.py`` (skip-if-unset
@@ -51,10 +54,13 @@ from datetime import datetime
 from typing import Any, Iterator
 
 import pytest
+from sqlalchemy import JSON, Column, Integer, MetaData, Table, select
+from sqlalchemy import text as sa_text
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 
 from xagent.web.api.monitor import (
+    get_json_field_expression,
     get_model_stats,
     get_monitoring_stats,
     get_popular_tools,
@@ -433,3 +439,114 @@ class TestJsonbRoundTripFidelity:
         stored = self._round_trip(pg_session, task, payload)
 
         assert json.dumps(stored, sort_keys=True) == json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.postgresql
+class TestReadGuardAgainstNativeJson:
+    """The guard's drop path, executed against a real ``json`` column.
+
+    ``get_json_field_expression``'s PostgreSQL branch exists for databases
+    whose migration has not run yet. Since #1248 the model's own column is
+    ``jsonb``, so no test above can plant a payload the guard has to drop --
+    which left the branch's normalize-then-match SQL (the escaped-backslash
+    stand-in, the pair strip, the alternation) with no real-PostgreSQL
+    execution at all, only Python mirrors of its semantics.
+
+    This class restores that coverage by building a throwaway table whose
+    payload column is native ``json``, so the hazardous rows are storable
+    again, and running the guard expression against it. It is deliberately
+    not the model's table: the point is to exercise the branch on the shape
+    it was written for, and the model must stay ``jsonb``.
+    """
+
+    TABLE = "monitor_guard_native_json"
+
+    @pytest.fixture()
+    def native_json_table(self, pg_session: Session) -> Iterator[Any]:
+        pg_session.execute(
+            sa_text(
+                f"CREATE TABLE {self.TABLE} "
+                "(id integer PRIMARY KEY, data json NOT NULL)"
+            )
+        )
+        pg_session.commit()
+        table = Table(
+            self.TABLE,
+            MetaData(),
+            Column("id", Integer, primary_key=True),
+            Column("data", JSON, nullable=False),
+        )
+        try:
+            yield table
+        finally:
+            pg_session.rollback()
+            pg_session.execute(sa_text(f"DROP TABLE IF EXISTS {self.TABLE}"))
+            pg_session.commit()
+
+    def _seed(self, db: Session, rows: list[tuple[int, str]]) -> None:
+        for row_id, payload_json_text in rows:
+            db.execute(
+                sa_text(
+                    f"INSERT INTO {self.TABLE} (id, data) "
+                    "VALUES (:id, CAST(:payload AS json))"
+                ),
+                {"id": row_id, "payload": payload_json_text},
+            )
+        db.commit()
+
+    def test_hazardous_rows_are_dropped_and_benign_rows_survive(
+        self, pg_session: Session, native_json_table: Any
+    ) -> None:
+        """One query over a mix: without the guard this raises and takes
+        every row with it, which is exactly #1149."""
+        backslash = chr(92)
+        self._seed(
+            pg_session,
+            [
+                (1, '{"model_name": "plain"}'),
+                # Hazards the guard must null out.
+                (2, '{"model_name": "nul' + backslash + 'u0000"}'),
+                (3, '{"model_name": "high' + backslash + 'ud800"}'),
+                (4, '{"model_name": "low' + backslash + 'udc00"}'),
+                # An orphan hiding behind text shaped like the other half of
+                # a pair -- the case the escaped-backslash stand-in exists
+                # for. Read naively the two look like a valid pair.
+                (
+                    5,
+                    '{"model_name": "hidden'
+                    + backslash
+                    + backslash
+                    + "ud83d"
+                    + backslash
+                    + 'udc00"}',
+                ),
+                # Benign and must survive: a valid pair, and text that only
+                # looks like an escape.
+                (
+                    6,
+                    '{"model_name": "emoji'
+                    + backslash
+                    + "ud83d"
+                    + backslash
+                    + 'ude00"}',
+                ),
+                (7, '{"model_name": "literal' + backslash + backslash + 'u0000"}'),
+            ],
+        )
+
+        expression = get_json_field_expression(
+            native_json_table.c.data, "model_name", pg_session
+        )
+        rows = pg_session.execute(
+            select(native_json_table.c.id, expression).order_by(native_json_table.c.id)
+        ).fetchall()
+
+        assert dict(rows) == {
+            1: "plain",
+            2: None,
+            3: None,
+            4: None,
+            5: None,
+            6: f"emoji{NON_BMP_CHAR}",
+            7: "literal" + backslash + "u0000",
+        }

--- a/tests/web/api/test_monitor_postgresql.py
+++ b/tests/web/api/test_monitor_postgresql.py
@@ -18,11 +18,25 @@ The two symptoms differ by endpoint, which is why all three are covered here:
   query after their handler, so they returned HTTP 200 with an empty list --
   a dashboard of zeros with nothing but a log line to show for it.
 
-The seed data also pins which payloads the dialect guard drops. PostgreSQL
-accepts several escape sequences into a ``json`` column that ``->>`` then
-refuses to convert -- the NUL escape and either half of an unpaired UTF-16
-surrogate -- and one such row fails the whole query. A *valid* surrogate pair
-is not a hazard and must survive, so a non-BMP payload is seeded alongside.
+Since #1248 the column is ``jsonb``, which decodes escapes to native text at
+INSERT and therefore rejects the payload shapes that used to poison reads --
+the NUL escape and either half of an unpaired UTF-16 surrogate. That moves
+what this file can and must pin:
+
+- the hazardous shapes can no longer be seeded at all; a class of tests here
+  asserts the INSERT itself fails, which is the invariant the migration
+  exists to establish;
+- the write-side sanitizer (``web/utils/json_payload_sanitizer.py``) must
+  turn each of those shapes into something the column accepts and ``->>``
+  reads back;
+- the endpoints are exercised over storable payloads only. A *valid*
+  surrogate pair is not a hazard and must survive, so a non-BMP payload is
+  seeded alongside text that merely looks like an escape.
+
+The read guard in ``get_json_field_expression`` still exists for databases
+whose migration has not run; with ``jsonb`` it can never match, so its
+matching behaviour stays pinned by the dialect-independent unit tests in
+``tests/web/test_monitor_api.py``, not here.
 
 Fixture pattern copied from
 ``tests/web/services/test_task_status_storage_postgresql.py`` (skip-if-unset
@@ -31,11 +45,13 @@ via ``XAGENT_TEST_POSTGRES_URL``; CI provides it in the PostgreSQL job).
 
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime
 from typing import Any, Iterator
 
 import pytest
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 
 from xagent.web.api.monitor import (
@@ -46,13 +62,17 @@ from xagent.web.api.monitor import (
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TraceEvent
 from xagent.web.models.user import User
+from xagent.web.utils.json_payload_sanitizer import (
+    REPLACEMENT_CHARACTER,
+    sanitize_json_payload,
+)
 
-# String values PostgreSQL accepts into a ``json`` column but then refuses to
-# convert to text, so ``json ->> key`` raises on them and takes the whole query
-# down with it. These are the payload shapes the dialect branch's guard exists
-# to keep away from ``->>``. Built with ``chr`` because an editor will happily
-# turn an escape sequence into the character it names, and a lone surrogate
-# character is not encodable as UTF-8.
+# String values a ``json`` column accepted but ``->>`` then refused to convert
+# to text, taking the whole query down with it (#1149). ``jsonb`` refuses them
+# at INSERT instead (#1248), which is what the rejection tests below pin.
+# Built with ``chr`` because an editor will happily turn an escape sequence
+# into the character it names, and a lone surrogate character is not encodable
+# as UTF-8.
 NUL_PAYLOAD = chr(0x0000)  # -> ``unsupported Unicode escape sequence``
 LONE_HIGH_SURROGATE = chr(0xD800)  # -> ``invalid input syntax for type json``
 LONE_LOW_SURROGATE = chr(0xDC00)  # same, from the other side of the pair
@@ -98,9 +118,10 @@ def pg_session() -> Iterator[Session]:
 def _seed_admin_with_trace_events(db: Session) -> User:
     """One admin, one task, and the trace events the three endpoints count.
 
-    Every payload carrying an unconvertible escape is one the guard must drop
-    without failing the surrounding query; the paired-surrogate payload is one
-    it must leave alone.
+    Every payload here is one ``jsonb`` stores: the hazardous shapes are
+    unstorable since #1248 and are covered by ``TestJsonbRejectsHazards``
+    instead. The paired-surrogate and literal-escape payloads are the ones
+    nothing may drop.
     """
     admin = User(username="monitor-pg-admin", password_hash="hash", is_admin=True)
     db.add(admin)
@@ -118,23 +139,10 @@ def _seed_admin_with_trace_events(db: Session) -> User:
         ("llm_call_start", {"model_name": "gpt-4o", "step_id": "s1", "attempt": 1}),
         ("llm_call_start", {"model_name": "gpt-4o", "step_id": "s2", "attempt": 1}),
         ("llm_call_start", {"model_name": "claude-opus", "step_id": "s3"}),
-        # Kept: a valid surrogate pair is not a hazard and must still count.
+        # A valid surrogate pair is not a hazard and must still count.
         ("llm_call_start", {"model_name": emoji_model, "step_id": "s4"}),
-        # Dropped: one row per unconvertible escape class.
-        ("llm_call_start", {"model_name": "nul-model", "note": NUL_PAYLOAD}),
-        ("llm_call_start", {"model_name": "high-model", "note": LONE_HIGH_SURROGATE}),
-        ("llm_call_start", {"model_name": "low-model", "note": LONE_LOW_SURROGATE}),
-        # Dropped, with the escape in the extracted field rather than beside
-        # it: the guard reads the whole payload, so position must not matter.
-        ("llm_call_start", {"model_name": f"tainted-{NUL_PAYLOAD}"}),
-        # Dropped: a real unpaired surrogate hiding behind text that imitates
-        # the other half of a pair.
-        (
-            "llm_call_start",
-            {"model_name": "hidden-model", "note": SURROGATE_BEHIND_LITERAL},
-        ),
-        # Kept: text that only looks like an escape extracts fine, so the
-        # guard must not treat it as a hazard.
+        # Text that only looks like an escape extracts fine, so nothing may
+        # treat it as a hazard.
         (
             "llm_call_start",
             {"model_name": "literal-escape-model", "note": LITERAL_ESCAPE_TEXT},
@@ -142,11 +150,6 @@ def _seed_admin_with_trace_events(db: Session) -> User:
         ("tool_execution_start", {"tool_name": "calculator"}),
         ("tool_execution_start", {"tool_name": "calculator"}),
         ("tool_execution_start", {"tool_name": "web_search"}),
-        ("tool_execution_start", {"tool_name": "nul-tool", "note": NUL_PAYLOAD}),
-        (
-            "tool_execution_start",
-            {"tool_name": "surrogate-tool", "note": LONE_HIGH_SURROGATE},
-        ),
     ]
     for index, (event_type, data) in enumerate(payloads):
         db.add(
@@ -175,9 +178,9 @@ async def test_monitoring_stats_counts_active_models_on_postgresql(
 
     stats = await get_monitoring_stats(db=pg_session, current_user=admin)
 
-    # gpt-4o, claude-opus, the emoji model and the literal-escape model. The
-    # five payloads carrying an escape PostgreSQL cannot convert are dropped;
-    # a valid surrogate pair and text that merely looks like an escape are not.
+    # gpt-4o, claude-opus, the emoji model and the literal-escape model: a
+    # valid surrogate pair and text that merely looks like an escape both
+    # count as ordinary models.
     assert stats["activeModels"] == 4
 
 
@@ -211,3 +214,181 @@ async def test_model_stats_returns_per_model_calls_on_postgresql(
         f"emoji-model {NON_BMP_CHAR}": 1,
         "literal-escape-model": 1,
     }
+
+
+@pytest.mark.postgresql
+class TestJsonbRejectsHazards:
+    """The invariant #1248 establishes: the column can no longer hold a
+    payload ``->>`` cannot read back. Each shape that used to fail a whole
+    monitoring query now fails its own INSERT instead, which is a local,
+    attributable error rather than a silent dashboard of zeros.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "payload"),
+        [
+            ("nul", {"model_name": "nul-model", "note": NUL_PAYLOAD}),
+            ("high", {"model_name": "high-model", "note": LONE_HIGH_SURROGATE}),
+            ("low", {"model_name": "low-model", "note": LONE_LOW_SURROGATE}),
+            # The escape in the extracted field rather than beside it:
+            # position must not matter.
+            ("in-field", {"model_name": f"tainted-{NUL_PAYLOAD}"}),
+            # A real unpaired surrogate hiding behind text that imitates the
+            # other half of a pair.
+            (
+                "hidden",
+                {"model_name": "hidden-model", "note": SURROGATE_BEHIND_LITERAL},
+            ),
+        ],
+    )
+    def test_unstorable_payload_is_rejected_at_insert(
+        self, pg_session: Session, label: str, payload: dict[str, Any]
+    ) -> None:
+        admin = User(
+            username=f"reject-{label}-admin", password_hash="hash", is_admin=True
+        )
+        pg_session.add(admin)
+        pg_session.commit()
+        task = Task(user_id=admin.id, title=f"reject-{label}")
+        pg_session.add(task)
+        pg_session.commit()
+
+        pg_session.add(
+            TraceEvent(
+                task_id=task.id,
+                event_id=f"reject-{label}",
+                event_type="llm_call_start",
+                timestamp=datetime.now(),
+                data=payload,
+            )
+        )
+        with pytest.raises(DBAPIError):
+            pg_session.commit()
+        pg_session.rollback()
+
+    def test_sanitized_payload_is_storable_and_readable(
+        self, pg_session: Session
+    ) -> None:
+        """The other half of the contract: what the write-side sanitizer
+        produces from a hazardous payload must both store and read back --
+        otherwise the sanitizer would only be trading one failure for
+        another.
+        """
+        admin = User(username="sanitized-admin", password_hash="hash", is_admin=True)
+        pg_session.add(admin)
+        pg_session.commit()
+        task = Task(user_id=admin.id, title="sanitized")
+        pg_session.add(task)
+        pg_session.commit()
+
+        hazardous = {
+            "model_name": f"m{NUL_PAYLOAD}{LONE_HIGH_SURROGATE}",
+            "note": LONE_LOW_SURROGATE,
+        }
+        pg_session.add(
+            TraceEvent(
+                task_id=task.id,
+                event_id="sanitized-1",
+                event_type="llm_call_start",
+                timestamp=datetime.now(),
+                data=sanitize_json_payload(hazardous),
+            )
+        )
+        pg_session.commit()
+
+        stats = pg_session.execute(
+            TraceEvent.__table__.select().where(TraceEvent.event_id == "sanitized-1")
+        ).one()
+        assert stats.data["model_name"] == f"m{REPLACEMENT_CHARACTER * 2}"
+
+
+@pytest.mark.postgresql
+class TestJsonbRoundTripFidelity:
+    """What the checkpoint blob path depends on: a payload written through
+    the sanitizer must come back from ``jsonb`` as the *same JSON*, not
+    merely the same numbers. ``trace_message_storage`` re-hashes what it
+    reads and rejects a mismatch as corruption, so an int/float retype on
+    the way through the column would cost a task its checkpoint.
+    """
+
+    def _task(self, db: Session, label: str) -> Task:
+        admin = User(username=f"{label}-admin", password_hash="hash", is_admin=True)
+        db.add(admin)
+        db.commit()
+        task = Task(user_id=admin.id, title=label)
+        db.add(task)
+        db.commit()
+        return task
+
+    def _round_trip(self, db: Session, task: Task, payload: dict[str, Any]) -> Any:
+        task_id = int(task.id)
+        db.add(
+            TraceEvent(
+                task_id=task_id,
+                event_id=f"roundtrip-{task_id}",
+                event_type="llm_call_start",
+                timestamp=datetime.now(),
+                data=sanitize_json_payload(payload),
+            )
+        )
+        db.commit()
+        # Read through a Core select on a fresh transaction, so what comes
+        # back is what the column returned and not the dict still held in
+        # the session's identity map.
+        db.expunge_all()
+        row = db.execute(
+            TraceEvent.__table__.select().where(
+                TraceEvent.__table__.c.task_id == task_id
+            )
+        ).one()
+        return row.data
+
+    def test_large_float_survives_as_the_same_json(self, pg_session: Session) -> None:
+        task = self._task(pg_session, "roundtrip-float")
+        payload = {"cost": 1e16, "ratio": 0.1, "count": 3}
+
+        stored = self._round_trip(pg_session, task, payload)
+
+        # The sanitizer converted 1e16 up front, so what comes back matches
+        # byte for byte under the canonical form the blob hash uses.
+        expected = sanitize_json_payload(payload)
+        assert json.dumps(stored, sort_keys=True) == json.dumps(
+            expected, sort_keys=True
+        )
+
+    def test_unsanitized_large_float_would_change_type(
+        self, pg_session: Session
+    ) -> None:
+        """The control: without the sanitizer's normalization the retype is
+        real, so the test above is pinning behaviour and not a tautology."""
+        task = self._task(pg_session, "roundtrip-control")
+        pg_session.add(
+            TraceEvent(
+                task_id=task.id,
+                event_id="roundtrip-control",
+                event_type="llm_call_start",
+                timestamp=datetime.now(),
+                data={"cost": 1e16},
+            )
+        )
+        pg_session.commit()
+        pg_session.expunge_all()
+
+        row = pg_session.execute(
+            TraceEvent.__table__.select().where(
+                TraceEvent.event_id == "roundtrip-control"
+            )
+        ).one()
+        assert isinstance(row.data["cost"], int)
+
+    def test_ordinary_payload_survives_unchanged(self, pg_session: Session) -> None:
+        task = self._task(pg_session, "roundtrip-plain")
+        payload = {
+            "model_name": f"emoji {NON_BMP_CHAR}",
+            "nested": {"items": ["a", "b"], "ok": True, "score": 1.5},
+            "none": None,
+        }
+
+        stored = self._round_trip(pg_session, task, payload)
+
+        assert json.dumps(stored, sort_keys=True) == json.dumps(payload, sort_keys=True)

--- a/tests/web/services/test_trace_event_staging.py
+++ b/tests/web/services/test_trace_event_staging.py
@@ -638,3 +638,100 @@ def test_positive_control_both_run_partition_predicates_compile_identical_sql() 
             )
         )
         assert old == new
+
+
+# --------------------------------------------------------------------------
+# Write-side payload sanitation (#1248): code points PostgreSQL's jsonb
+# rejects at INSERT must never reach the row, on any path
+# --------------------------------------------------------------------------
+
+# chr, not source escapes: an editor will happily turn an escape into the
+# character it names, and a lone surrogate is not encodable as UTF-8.
+_NUL = chr(0x0000)
+_LONE_HIGH_SURROGATE = chr(0xD800)
+_REPLACEMENT = chr(0xFFFD)
+
+
+def test_stage_trace_event_row_sanitizes_unstorable_code_points(
+    tmp_path: Path,
+) -> None:
+    """A non-checkpoint payload carrying NUL or a lone surrogate is stored
+    with those code points replaced, and ``stored_data`` reports what was
+    actually written."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s8-sanitize")
+
+    staged = stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id=None,
+        event_id="evt-s8",
+        event_type="tool_execution_end",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data={
+            "tool_name": "noop",
+            "output": f"head{_NUL}tail",
+            "nested": [f"lone{_LONE_HIGH_SURROGATE}"],
+        },
+        checkpoint_lease=None,
+    )
+    db.commit()
+
+    expected = {
+        "tool_name": "noop",
+        "output": f"head{_REPLACEMENT}tail",
+        "nested": [f"lone{_REPLACEMENT}"],
+    }
+    assert staged.stored_data == expected
+
+    other = session_factory()
+    try:
+        row = other.query(DatabaseTraceEvent).filter_by(event_id="evt-s8").one()
+        assert row.data == expected
+    finally:
+        other.close()
+    db.close()
+
+
+def test_stage_trace_event_row_sanitizes_before_checkpoint_encoding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The checkpoint branch hashes blob rows out of the payload, so the
+    encoder must already see the sanitized form -- otherwise the stored
+    hash would be computed over content that never lands in the column."""
+    engine = _engine(tmp_path)
+    session_factory = _session_factory(engine)
+    db, task_id = _create_task(session_factory, username="s9-sanitize")
+
+    seen: list[Any] = []
+    original_encode = trace_event_staging.encode_checkpoint_data_for_storage
+
+    def capturing_encode(db, *, task_id, data, use_v2=None):  # noqa: ANN001
+        seen.append(data)
+        return original_encode(db, task_id=task_id, data=data, use_v2=use_v2)
+
+    monkeypatch.setattr(
+        trace_event_staging, "encode_checkpoint_data_for_storage", capturing_encode
+    )
+
+    dirty = _checkpoint_data("exec-s9", f"label{_NUL}")
+    stage_trace_event_row(
+        db,
+        task_id=task_id,
+        build_id="build-s9",
+        event_id="evt-s9",
+        event_type="system_update_general",
+        timestamp=datetime.now(timezone.utc),
+        step_id=None,
+        parent_event_id=None,
+        data=dirty,
+        checkpoint_lease=None,
+    )
+
+    assert len(seen) == 1
+    assert seen[0]["snapshot"] == {"label": f"label{_REPLACEMENT}"}
+    db.rollback()
+    db.close()

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -374,6 +374,67 @@ def test_persist_agent_outbound_event_uses_payload_ids(monkeypatch) -> None:
         db.close()
 
 
+def test_persist_agent_outbound_event_sanitizes_payload(monkeypatch) -> None:
+    """This function builds its own TraceEvent row without going through
+    stage_trace_event_row (the staging module's "known bypass"), so it must
+    sanitize for itself: PostgreSQL's jsonb rejects NUL and lone-surrogate
+    code points at INSERT (#1248)."""
+    engine = _shared_memory_sqlite_engine()
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        user = User(
+            username="sanitizer", password_hash="hashed_password", is_admin=False
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        task = Task(
+            user_id=int(user.id),
+            title="Chat task",
+            description="Task chat",
+            status=TaskStatus.PENDING,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    monkeypatch.setattr("xagent.web.api.websocket.get_db", get_test_db)
+
+    # chr, not source escapes: a lone surrogate is not encodable as UTF-8.
+    nul, lone_high, replacement = chr(0x0000), chr(0xD800), chr(0xFFFD)
+    event = create_stream_event(
+        "agent_progress",
+        int(task.id),
+        {
+            "event_id": "agent-event-dirty",
+            "message": f"head{nul}mid{lone_high}tail",
+            "expect_response": False,
+        },
+    )
+
+    _persist_agent_outbound_event(int(task.id), event)
+
+    db = SessionLocal()
+    try:
+        trace_event = (
+            db.query(DatabaseTraceEvent).filter_by(event_id="agent-event-dirty").one()
+        )
+        assert trace_event.data["message"] == f"head{replacement}mid{replacement}tail"
+    finally:
+        db.close()
+
+
 def _create_trace_handler_test_task(
     username: str,
     *,

--- a/tests/web/utils/test_json_payload_sanitizer.py
+++ b/tests/web/utils/test_json_payload_sanitizer.py
@@ -166,3 +166,51 @@ class TestFloatsJsonbWouldRetype:
         # json.loads models what psycopg2 does with the jsonb column's
         # plain-notation output.
         assert json.dumps(json.loads(stored), sort_keys=True) == stored
+
+
+class TestCleanPathAllocatesNothing:
+    """The hot-path contract the docstring states: a clean payload is not
+    merely returned unchanged, it is never copied on the way. Pinned because
+    the obvious implementation (build a copy, then decide whether to return
+    it) satisfies every other test in this file while doing the work anyway.
+    """
+
+    def test_clean_nested_payload_keeps_every_container_identity(self) -> None:
+        inner_list = ["a", "b"]
+        inner_dict = {"items": inner_list, "score": 1.5}
+        payload = {"model_name": "gpt-4o", "nested": inner_dict}
+
+        cleaned = sanitize_json_payload(payload)
+
+        assert cleaned is payload
+        assert cleaned["nested"] is inner_dict
+        assert cleaned["nested"]["items"] is inner_list
+
+    def test_unchanged_siblings_are_reused_not_rebuilt(self) -> None:
+        """Even when a copy is unavoidable, the branches that needed no edit
+        are carried over by reference rather than rebuilt."""
+        before = {"deep": ["untouched"]}
+        after = {"also": "clean"}
+        payload = {"before": before, "dirty": f"x{NUL}", "after": after}
+
+        cleaned = sanitize_json_payload(payload)
+
+        assert cleaned is not payload
+        # The prefix backfilled at the first change and the suffix walked
+        # afterwards must both be the original objects.
+        assert cleaned["before"] is before
+        assert cleaned["after"] is after
+
+    def test_dict_key_order_is_preserved_across_a_copy(self) -> None:
+        payload = {"first": 1, "dirty": f"x{NUL}", "last": 3}
+
+        cleaned = sanitize_json_payload(payload)
+
+        assert list(cleaned) == ["first", "dirty", "last"]
+
+    def test_list_order_is_preserved_across_a_copy(self) -> None:
+        payload = ["head", f"mid{NUL}", "tail"]
+
+        cleaned = sanitize_json_payload(payload)
+
+        assert cleaned == ["head", f"mid{REPLACEMENT_CHARACTER}", "tail"]

--- a/tests/web/utils/test_json_payload_sanitizer.py
+++ b/tests/web/utils/test_json_payload_sanitizer.py
@@ -1,0 +1,168 @@
+"""Contract tests for ``sanitize_json_payload`` (#1248).
+
+The sanitizer is the write-side half of the ``jsonb`` migration: PostgreSQL's
+``jsonb`` rejects the NUL escape and unpaired UTF-16 surrogates at INSERT
+time, so every payload headed for a trace table has to shed those code
+points first. The payload shapes pinned here mirror the seed data of
+``tests/web/api/test_monitor_postgresql.py`` -- the read-side test that
+documents why these exact code points are hazardous.
+
+Two properties matter beyond simple replacement:
+
+- a *valid* non-BMP character (an emoji in LLM output) must survive
+  untouched -- dropping it would corrupt ordinary payloads; and
+- an unchanged payload must come back as the *same object*, because the
+  sanitizer runs on every trace write and almost every payload is clean --
+  copying each one would be pure overhead on the hot path.
+"""
+
+from __future__ import annotations
+
+import json
+
+from xagent.web.utils.json_payload_sanitizer import (
+    REPLACEMENT_CHARACTER,
+    sanitize_json_payload,
+)
+
+# Built with ``chr`` because an editor will happily turn an escape sequence
+# into the character it names, and a lone surrogate is not encodable as
+# UTF-8 (same convention as tests/web/api/test_monitor_postgresql.py).
+NUL = chr(0x0000)
+LONE_HIGH_SURROGATE = chr(0xD800)
+LONE_LOW_SURROGATE = chr(0xDC00)
+NON_BMP_CHAR = chr(0x1F600)
+BACKSLASH = chr(92)
+LITERAL_ESCAPE_TEXT = BACKSLASH + "u0000"
+
+
+class TestOffendingCodePoints:
+    def test_nul_is_replaced(self) -> None:
+        assert sanitize_json_payload(f"a{NUL}b") == f"a{REPLACEMENT_CHARACTER}b"
+
+    def test_lone_high_surrogate_is_replaced(self) -> None:
+        result = sanitize_json_payload(f"x{LONE_HIGH_SURROGATE}y")
+        assert result == f"x{REPLACEMENT_CHARACTER}y"
+
+    def test_lone_low_surrogate_is_replaced(self) -> None:
+        result = sanitize_json_payload(f"x{LONE_LOW_SURROGATE}y")
+        assert result == f"x{REPLACEMENT_CHARACTER}y"
+
+    def test_adjacent_surrogates_are_both_replaced(self) -> None:
+        # A high+low pair of raw code points in a Python str is not an
+        # astral character -- it cannot be encoded as UTF-8 -- so it is
+        # replaced wholesale rather than treated as a valid pair.
+        result = sanitize_json_payload(LONE_HIGH_SURROGATE + LONE_LOW_SURROGATE)
+        assert result == REPLACEMENT_CHARACTER * 2
+
+    def test_sanitized_output_is_utf8_encodable(self) -> None:
+        payload = {
+            "message": f"{NUL}{LONE_HIGH_SURROGATE}{LONE_LOW_SURROGATE}",
+            "nested": [f"tail{LONE_LOW_SURROGATE}"],
+        }
+        cleaned = sanitize_json_payload(payload)
+        # The exact property jsonb requires: the payload decodes to native
+        # text. This raises UnicodeEncodeError on any surviving surrogate.
+        json.dumps(cleaned, ensure_ascii=False).encode("utf-8")
+
+
+class TestBenignPayloadsSurvive:
+    def test_non_bmp_character_is_preserved(self) -> None:
+        payload = f"emoji {NON_BMP_CHAR} stays"
+        assert sanitize_json_payload(payload) is payload
+
+    def test_literal_escape_text_is_preserved(self) -> None:
+        # Text that merely *looks* like an escape: a backslash followed by
+        # "u0000" is six ordinary characters, not a NUL.
+        assert sanitize_json_payload(LITERAL_ESCAPE_TEXT) is LITERAL_ESCAPE_TEXT
+
+    def test_clean_payload_returns_the_same_object(self) -> None:
+        payload = {
+            "model_name": "gpt-4o",
+            "attempt": 1,
+            "nested": {"items": ["a", "b"], "ok": True, "score": 1.5},
+            "none": None,
+        }
+        assert sanitize_json_payload(payload) is payload
+
+    def test_non_string_scalars_pass_through(self) -> None:
+        for scalar in (1, 1.5, True, None):
+            assert sanitize_json_payload(scalar) is scalar
+
+
+class TestStructureTraversal:
+    def test_nested_containers_are_sanitized(self) -> None:
+        payload = {
+            "outer": [{"inner": f"bad{NUL}"}, "clean"],
+            "clean": "ok",
+        }
+        cleaned = sanitize_json_payload(payload)
+        assert cleaned == {
+            "outer": [{"inner": f"bad{REPLACEMENT_CHARACTER}"}, "clean"],
+            "clean": "ok",
+        }
+
+    def test_dict_keys_are_sanitized(self) -> None:
+        payload = {f"key{LONE_HIGH_SURROGATE}": "value"}
+        cleaned = sanitize_json_payload(payload)
+        assert cleaned == {f"key{REPLACEMENT_CHARACTER}": "value"}
+
+    def test_tuple_stays_a_tuple(self) -> None:
+        cleaned = sanitize_json_payload((f"a{NUL}", "b"))
+        assert cleaned == (f"a{REPLACEMENT_CHARACTER}", "b")
+        assert isinstance(cleaned, tuple)
+
+    def test_clean_siblings_keep_identity_inside_changed_container(self) -> None:
+        clean_branch = {"deep": ["untouched"]}
+        payload = {"clean": clean_branch, "dirty": f"x{NUL}"}
+        cleaned = sanitize_json_payload(payload)
+        assert cleaned is not payload
+        assert cleaned["clean"] is clean_branch
+
+
+class TestFloatsJsonbWouldRetype:
+    """jsonb re-renders numbers in plain notation, so a float written as
+    ``1e+16`` reads back as an int. The checkpoint blob path re-hashes what
+    it reads and compares against the write-time hash, so the two forms have
+    to be reconciled before the hash is taken -- see the module docstring.
+    """
+
+    def test_float_at_the_threshold_becomes_an_int(self) -> None:
+        cleaned = sanitize_json_payload(1e16)
+        assert cleaned == 10000000000000000
+        assert isinstance(cleaned, int)
+
+    def test_large_float_becomes_an_int(self) -> None:
+        assert sanitize_json_payload(1.5e20) == 150000000000000000000
+        assert isinstance(sanitize_json_payload(1.5e20), int)
+
+    def test_negative_large_float_becomes_an_int(self) -> None:
+        assert sanitize_json_payload(-1e18) == -1000000000000000000
+        assert isinstance(sanitize_json_payload(-1e18), int)
+
+    def test_float_below_the_threshold_is_untouched(self) -> None:
+        # repr writes this one in plain notation, so json and jsonb agree.
+        value = 1e15
+        assert sanitize_json_payload(value) is value
+
+    def test_ordinary_floats_are_untouched(self) -> None:
+        for value in (0.1, 3.14, 2.0, 1e-10, 0.0):
+            assert sanitize_json_payload(value) is value
+
+    def test_bools_are_not_treated_as_numbers(self) -> None:
+        for value in (True, False):
+            assert sanitize_json_payload(value) is value
+
+    def test_normalization_reaches_nested_values(self) -> None:
+        cleaned = sanitize_json_payload({"outer": [{"n": 1e16}]})
+        assert cleaned == {"outer": [{"n": 10000000000000000}]}
+        assert isinstance(cleaned["outer"][0]["n"], int)
+
+    def test_canonical_form_is_stable_under_a_json_round_trip(self) -> None:
+        """The property the blob hash depends on: re-serializing what the
+        database returns must reproduce the text that was stored."""
+        cleaned = sanitize_json_payload({"n": 1e16})
+        stored = json.dumps(cleaned, sort_keys=True)
+        # json.loads models what psycopg2 does with the jsonb column's
+        # plain-notation output.
+        assert json.dumps(json.loads(stored), sort_keys=True) == stored

--- a/tests/web/utils/test_json_payload_sanitizer.py
+++ b/tests/web/utils/test_json_payload_sanitizer.py
@@ -19,6 +19,7 @@ Two properties matter beyond simple replacement:
 from __future__ import annotations
 
 import json
+import math
 
 from xagent.web.utils.json_payload_sanitizer import (
     REPLACEMENT_CHARACTER,
@@ -149,7 +150,27 @@ class TestFloatsJsonbWouldRetype:
         for value in (0.1, 3.14, 2.0, 1e-10, 0.0):
             assert sanitize_json_payload(value) is value
 
+    def test_negative_zero_is_normalized_to_positive_zero(self) -> None:
+        """PostgreSQL numeric has no signed zero, so jsonb renders -0.0 as
+        0.0 while json.dumps writes "-0.0". Without this the write-time
+        hash of a payload carrying -0.0 would not match what comes back."""
+        cleaned = sanitize_json_payload(-0.0)
+        assert json.dumps(cleaned) == "0.0"
+        assert math.copysign(1.0, cleaned) > 0
+
+    def test_negative_zero_is_normalized_when_nested(self) -> None:
+        cleaned = sanitize_json_payload({"outer": [{"n": -0.0}]})
+        assert json.dumps(cleaned, sort_keys=True) == '{"outer": [{"n": 0.0}]}'
+
+    def test_positive_zero_keeps_its_identity(self) -> None:
+        """The negative-zero branch must not turn every zero into a copy --
+        +0.0 already matches what jsonb hands back."""
+        value = 0.0
+        assert sanitize_json_payload(value) is value
+
     def test_bools_are_not_treated_as_numbers(self) -> None:
+        # bool subclasses int, not float, so the float branch never sees
+        # one; this pins the outcome rather than the mechanism.
         for value in (True, False):
             assert sanitize_json_payload(value) is value
 


### PR DESCRIPTION
Closes #1248.

## Background

`TraceEvent.data` was `Column(JSON)`, which on PostgreSQL is the `json` type: it validates syntax at write time and nothing else. It accepts the NUL escape and either half of an unpaired UTF-16 surrogate, both of which `->>` then refuses to convert back to text — and a single stored row of that shape failed three monitoring endpoints whole-query (#1149). #1222 guarded at read time; #1248 filed the design note that the guard is a workaround for an unvalidated write path.

`jsonb` decodes escapes to native text at INSERT, so it rejects those payloads at the source. That is option 1 in the issue, and the only option that removes the class.

## What this does

**Converts three columns, not one.** The checkpoint blob tables hold hashed slices of the same trace payloads, so they carry the same hazard and convert together:

- `trace_events.data`
- `trace_message_blobs.message_data`
- `trace_checkpoint_blobs.blob_data`

**Sanitizes on write.** `jsonb` alone would turn the problem from a failed read into a failed *write* — an ordinary LLM payload carrying one of these code points would stop being storable. A new sanitizer (`web/utils/json_payload_sanitizer.py`) replaces them with U+FFFD before the row is built, so the type change rejects nothing a producer legitimately emits. It runs at both `TraceEvent` construction sites — `stage_trace_event_row` and the `_persist_agent_outbound_event` path that bypasses it — and in staging it runs *before* checkpoint encoding, so blob hashes are computed over what actually lands in the column. The blob rows and the `ON CONFLICT` insert path both derive from that already-sanitized payload; `encode_checkpoint_data_for_storage` has exactly one caller.

**Migrates existing rows.** `ALTER ... TYPE jsonb` fails on any stored row carrying such an escape, so the upgrade first rewrites those rows, using the same detection steps as the read guard and doing the actual rewrite in Python where escape semantics are exact. Matching rows are walked in bounded keyset batches rather than collected up front — these payloads are whole checkpoint snapshots, and a deployment that emitted bad output for a while should not materialize all of them in the migration process at once. PostgreSQL-only; both branches are no-ops on SQLite.

**Keeps the read guard.** On a migrated database it can never match, but `monitor.py` cannot assume the migration has run — a database still on the `json` type carries exactly the rows it defends against. Per the issue, it stays until no deployment can hold such a payload.

## One regression this change would otherwise have introduced

`jsonb` re-renders numbers in plain notation, so a float written as `1e+16` reads back as the int `10000000000000000`. The checkpoint blob path re-hashes payloads it reads and compares them against the write-time hash (`strict=True` on restore), so such a payload would be rejected as corrupt and the task would silently lose its checkpoint.

The boundary is exact: only `|x| >= 1e16` is affected, because every float that large is integral (the mantissa runs out of fractional bits above 2**53). The sanitizer normalizes those floats at the same boundary, before the hash is taken, so the stored form and the read-back form are identical. A round-trip test pins this, with a control case that skips the sanitizer to prove the retype is real and the test is not a tautology.

Pre-existing rows carrying such a float are deliberately not rewritten; the migration docstring explains why, and the existing failure mode for an unreadable checkpoint row is already a logged skip that falls back to an older checkpoint.

## Testing

- 25 sanitizer unit tests, including identity assertions that pin the no-copy contract on clean payloads.
- 21 migration tests: conversion, row cleanup, benign payloads surviving, blob tables, idempotence, missing tables, downgrade, offline `--sql` rendering, and multi-batch cleanup covering the keyset advance.
- The PostgreSQL monitor tests are reworked: the hazardous shapes can no longer be seeded at all, so a new class asserts the INSERT itself fails — the invariant the migration exists to establish — alongside the sanitizer round-trip.
- 150 tests across the affected suites pass against a real PostgreSQL 16.
- Also verified by hand that the JSON path queries checkpoint restore depends on (`trace_handlers.py`) still work against a `jsonb` column; that path had no PostgreSQL coverage.

CI gets a step for the new migration's PostgreSQL tests.

## Deployment note

This is the expensive kind of migration. `ALTER ... TYPE` takes an ACCESS EXCLUSIVE lock and rewrites every row — there is no in-place path from `json` to `jsonb` — and the cleanup scan before it is an unindexed full-table pass. On a large deployment it should be scheduled rather than slipped into a routine restart; pruning checkpoint history first shortens both steps. The migration docstring carries this, along with the UTF8 server-encoding assumption the detection patterns inherit from the read guard.
