### PR TITLE
feat(interactions): resolve whether a clarification draft is publishable

### DIFF
--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -155,17 +155,19 @@ class ClarificationDraft:
 def _marker_clean(value: str) -> str:
     """Filter ``value`` to the character domain a marker may contain.
 
-    Four independent copies of this control-character filter exist in the
-    codebase, and all four must stay in the same domain: this function,
-    plus three web-layer closures that the core layer cannot import and so
+    Five independent copies of this control-character filter exist in the
+    codebase, and all five must stay in the same domain: this function,
+    three web-layer closures that the core layer cannot import and so
     cannot share code with -- ``src/xagent/web/api/trace_handlers.py``'s
     ``DatabaseTraceHandler._serialize_data_for_json`` (``clean_string``),
     ``src/xagent/web/api/ws_trace_handlers.py``'s
     ``WebSocketTraceHandler._serialize_data`` (``clean_string``), and
     ``src/xagent/web/api/websocket.py``'s
-    ``SharedWebSocketTracer._serialize_data`` (``clean_string``). If
-    someone changes the domain of any one of the four, the other three must
-    change with it. The test that watches for drift between this copy and
+    ``SharedWebSocketTracer._serialize_data`` (``clean_string``) -- and
+    ``src/xagent/web/services/task_clarification_draft.py``'s
+    ``_strip_control_characters``, for the same reason. If someone changes
+    the domain of any one of the five, the other four must change with it.
+    The test that watches for drift between this copy and
     the database-handler copy is
     ``test_marker_survives_trace_serialization_of_a_dirty_interaction_id`` in
     ``tests/core/agent/test_react_clarification_draft.py``, which calls the

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -56,6 +56,18 @@ INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED = (
 # would assert "the data got fixed" without evidence for it.
 INTERACTION_ANCHOR_CORRUPT = "interaction_anchor_corrupt"
 
+# task_clarification_draft.py registers this when a waiting run's result
+# carries no clarification draft to publish, and clears it the next time a
+# draft is successfully resolved to a publishable payload.
+CLARIFICATION_DRAFT_MISSING = "clarification_draft_missing"
+# task_clarification_draft.py registers this when the same batch produced
+# more than one waiting step and a losing step's draft was discarded.
+# Deliberately not cleared by the very publish that reports it -- a
+# successful publish this round does not undo the fact that a sibling's
+# question was dropped this round, so this stays visible until a later,
+# conflict-free resolution clears it.
+CLARIFICATION_MULTIPLE_DRAFTS = "clarification_multiple_drafts"
+
 _signals: dict[str, str] = {}
 _lock = threading.Lock()
 

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -301,9 +301,9 @@ def build_clarification_payload(draft: ClarificationDraft) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "question": question,
         "interactions": interactions_payload,
-        "message_type": draft.message_type,
+        "message_type": _strip_control_characters(draft.message_type),
         "source": draft.source,
-        "requests": [item.to_dict() for item in draft.requests],
+        "requests": [_clean_leaves(item.to_dict()) for item in draft.requests],
     }
     if question_truncated:
         payload["question_truncated"] = True
@@ -407,9 +407,10 @@ def resolve_publishable_clarification(
        against; this degrades, it does not fail the round.
     5b. The payload built from the draft fits the character domain and size
         limits in :func:`build_clarification_payload`; if it does not
-        (empty after filtering, or still oversized after truncation), that
-        also degrades rather than fails. This check runs last because it is
-        the only one that requires building the payload first.
+        (empty after filtering, or reduced to only whitespace, or still
+        oversized after truncation), that also degrades rather than fails.
+        This check runs last because it is the only one that requires
+        building the payload first.
 
     A cross-run anchor mismatch is deliberately absent from this sequence:
     that check belongs to ``interaction_handoff`` (it already raises a
@@ -418,12 +419,30 @@ def resolve_publishable_clarification(
 
     On success, this function clears ``CLARIFICATION_DRAFT_MISSING`` --
     reaching ``Publishable`` is itself the evidence that the draft pipeline
-    worked this time. ``CLARIFICATION_MULTIPLE_DRAFTS`` is different: it
-    reports that a concurrent-waiting-step conflict happened *this round*,
-    which a successful publish does not undo, so it is registered (not
-    cleared) whenever ``result["clarification_superseded_step_ids"]`` is
-    non-empty, and left alone otherwise.
+    worked this time.
+
+    ``CLARIFICATION_MULTIPLE_DRAFTS`` is registered before any guard below
+    gets a chance to return, not only on the ``Publishable`` path: whether
+    ``result["clarification_superseded_step_ids"]`` is non-empty is a fact
+    about this round's ``result`` that holds regardless of which guard
+    ultimately classifies it -- a losing waiting step can be superseded by
+    an interrupt that wins the same round, so ``NotApplicable(None)`` and
+    every other non-``Publishable`` outcome must still be able to report
+    the conflict. Clearing it is the opposite: confined to the
+    ``Publishable`` path only, alongside ``CLARIFICATION_DRAFT_MISSING`` --
+    a successful publish clears the signal only when nothing was
+    superseded *this same round* either, since publishing this round's
+    draft does not retroactively undo a sibling step's draft having been
+    discarded.
     """
+
+    superseded_step_ids = result.get("clarification_superseded_step_ids") or []
+    if superseded_step_ids:
+        register_degradation(
+            CLARIFICATION_MULTIPLE_DRAFTS,
+            f"task {task.id}: run {lease.run_id}: superseded step ids "
+            f"{list(superseded_step_ids)}",
+        )
 
     status = result.get("status")
     draft = result.get("clarification_draft")
@@ -466,21 +485,14 @@ def resolve_publishable_clarification(
 
     payload = build_clarification_payload(draft)
 
-    if not payload["question"]:
+    if not payload["question"].strip():
         return NotApplicable("empty_question")
 
     if _serialized_byte_length(payload) > _TOTAL_PAYLOAD_MAX_BYTES:
         return NotApplicable("payload_too_large")
 
     clear_degradation(CLARIFICATION_DRAFT_MISSING)
-    superseded_step_ids = result.get("clarification_superseded_step_ids") or []
-    if superseded_step_ids:
-        register_degradation(
-            CLARIFICATION_MULTIPLE_DRAFTS,
-            f"task {task.id}: run {lease.run_id}: superseded step ids "
-            f"{list(superseded_step_ids)}",
-        )
-    else:
+    if not superseded_step_ids:
         clear_degradation(CLARIFICATION_MULTIPLE_DRAFTS)
 
     return Publishable(

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -327,11 +327,27 @@ def parse_clarification_payload(
     interactions)`` shape ``get_latest_waiting_question``
     (``chat_history_service.py``) already returns for the legacy transcript
     path -- a cross-module contract with no shared base class to enforce it,
-    pinned by ``test_payload_round_trip_matches_the_legacy_reader_shape`` in
-    ``tests/web/services/test_task_clarification_draft.py``, which calls
+    pinned by ``test_payload_round_trip_matches_the_legacy_reader_shape*``
+    in ``tests/web/services/test_task_clarification_draft.py``, which calls
     the real ``get_latest_waiting_question`` and compares its return shape
     against this function's, rather than re-deriving the expectation from
     this function's own return type.
+
+    ``interactions`` comes back ``None``, not ``[]``, whenever the payload
+    carries no interaction items. ``get_latest_waiting_question`` itself is
+    not this consistent: it returns ``None`` for a persisted row whose
+    ``interactions`` column is ``NULL`` (the shape a ``send_message``-
+    sourced draft always produces, since that source's payload never has
+    any interactions to carry), but it returns ``[]`` for a row whose
+    column holds an actual empty list -- the shape an empty-form
+    ``ask_user_question`` call produces (a legal call: ``ask_user_question``
+    is classified by whether its request carries an ``interactions`` key at
+    all, not by whether that key's value is non-empty; see
+    ``draft_from_waiting_request``). That ``NULL``-vs-``[]`` split on the
+    legacy side is a known, un-reconciled divergence, not something this
+    function reproduces: every empty case collapses to ``None`` here,
+    deliberately, so a caller checking "did this turn have interactions"
+    never has to handle two different falsy shapes.
 
     This is the one place allowed to know what a payload's version implies:
     a reader elsewhere in the codebase must call this function rather than
@@ -344,7 +360,7 @@ def parse_clarification_payload(
     interactions = payload.get("interactions")
     return (
         question if isinstance(question, str) else None,
-        interactions if isinstance(interactions, list) else None,
+        interactions if isinstance(interactions, list) and interactions else None,
     )
 
 

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -1,0 +1,438 @@
+"""Decide whether a clarification draft attached to a finalizing run can be
+published as a structured interaction request, and build/parse the JSON
+payload a published row carries.
+
+This module answers one question: given the result dict a pattern run just
+produced, the task row and lease the caller already holds, and the resume
+anchor the caller already resolved, does the clarification draft attached to
+that result (if any) qualify to become a durable, structured interaction
+row? The answer is one of three outcomes, never folded into a boolean:
+
+* :class:`Publishable` -- the draft passed every precondition and is shaped
+  into the three keyword arguments ``interaction_handoff.stage()`` expects
+  (``request_payload``, ``request_idempotency_key``, ``expires_at``).
+* :class:`NotApplicable` -- nothing durable should be written this round,
+  but nothing failed either: either this run never produced a clarification
+  in the first place, or a waiting run's draft could not be turned into a
+  publishable payload (no resume anchor, or the payload could not be shaped
+  within the size and character limits below). The caller's own settlement
+  proceeds exactly as it would have before this module existed.
+* :class:`FailClosed` -- the caller must discard this round's settlement
+  wholesale, the same way it already discards a late, no-longer-owned
+  result. This happens only when the lease that produced the result can no
+  longer be trusted to speak for the task row.
+
+Guard order is a contract: the checks inside :func:`resolve_publishable_clarification`
+run in a fixed sequence, most specific and least data-exposing failure
+first, so that the classification a caller observes always names the first
+thing that actually went wrong -- never a later, coincidentally-true guard
+that happens to fail on the same input for an unrelated reason.
+
+Callers. This function's caller set is exactly the finalizers that settle a
+task run against its lease and load the task row under a lock: nothing else
+holds the combination of task, lease and anchor this function's guards
+depend on. A caller reached from anywhere else -- a builder chat session, a
+nested sub-agent's own turn -- was never going to be a caller in the first
+place, and this module makes no claim about what happens there. Extending
+the caller set to a fourth site is a reason to come back and re-read this
+module, not to assume its guards still describe the new caller's situation.
+
+This module is also the only place allowed to construct or parse the JSON
+shape a published row's ``request_payload`` carries -- see
+:func:`build_clarification_payload` and :func:`parse_clarification_payload`
+for the pairing rule and the version-evolution promise that comes with it.
+
+An application-layer invariant worth stating plainly: a task can have at
+most one *active* interaction row at a time (the database enforces this
+with a unique constraint on the active slot). Nothing in this module
+inserts a row -- that is the caller's job, via ``stage()`` -- but every
+guard below exists to make sure that when the caller does insert one, it is
+the single row this run is entitled to produce.
+
+One more precondition lives outside this module entirely and cannot be
+checked at run time: whichever deployment decides to start publishing
+structured rows for a given ``Task.source`` value needs that value to
+already appear in the model's ``INTERACTION_ORIGIN_VOCABULARY`` (see
+``xagent.web.models.task_interaction``). A source value outside that
+vocabulary is not rejected here -- it degrades one layer down, inside
+``interaction_handoff``, as an unrecognized origin swallowed into a generic
+degradation signal. Confirming vocabulary coverage against a live
+deployment's actual ``tasks.source`` values before turning publication on
+is the caller's obligation, not this module's.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Mapping
+
+from ...core.agent.clarification import ClarificationDraft
+from ..models.task import Task
+from .ops_signals import (
+    CLARIFICATION_DRAFT_MISSING,
+    CLARIFICATION_MULTIPLE_DRAFTS,
+    clear_degradation,
+    register_degradation,
+)
+from .task_interaction_staging import InteractionAnchor
+from .task_lease_service import TaskLease
+
+logger = logging.getLogger(__name__)
+
+# Deployment policy, not an invariant: this only bounds how long an
+# unanswered row sits before a reclaim job retires it. The read surface
+# does not consult ``expires_at`` at all, so a longer-lived row is still
+# shown to whoever is waiting on it; widen or narrow this once real
+# publication volume gives a basis for the number, not before.
+CLARIFICATION_REQUEST_TTL = timedelta(hours=24)
+
+# The character domain a payload's free-text leaves may contain, kept
+# byte-for-byte identical to ``xagent.core.agent.clarification``'s
+# ``_marker_clean`` whitelist. That module cannot import this one (core
+# layer never imports web layer), so the two copies cannot share code --
+# only this comment, on both sides, keeps them from drifting apart. If one
+# domain ever changes, change the other in the same commit.
+_CONTROL_CHAR_KEEP = "\n\r\t"
+
+# Three independent size ceilings, checked in this order because each one
+# can only be evaluated once the field(s) before it are already final.
+_QUESTION_MAX_BYTES = 16 * 1024
+_INTERACTIONS_MAX_BYTES = 64 * 1024
+_TOTAL_PAYLOAD_MAX_BYTES = 128 * 1024
+
+_QUESTION_TRUNCATION_SUFFIX = "\n\n[question truncated]"
+
+
+def _strip_control_characters(value: str) -> str:
+    """Remove NUL and C0 control characters, keeping the same three
+    whitespace exceptions ``_marker_clean`` keeps. See the module-level
+    comment above for the cross-layer contract this filter must not drift
+    from."""
+
+    cleaned = value.replace("\x00", "").replace("\u0000", "")
+    return "".join(ch for ch in cleaned if ord(ch) >= 32 or ch in _CONTROL_CHAR_KEEP)
+
+
+def _clean_leaves(value: Any) -> Any:
+    """Recursively apply :func:`_strip_control_characters` to every string
+    leaf inside a JSON-like structure, leaving every other value untouched."""
+
+    if isinstance(value, str):
+        return _strip_control_characters(value)
+    if isinstance(value, dict):
+        return {key: _clean_leaves(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_clean_leaves(item) for item in value]
+    return value
+
+
+def _serialized_byte_length(value: Any) -> int:
+    return len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
+
+
+def _truncate_to_byte_limit(text: str, max_bytes: int) -> str:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    # Decoding a byte-sliced UTF-8 string can land mid-character; dropping
+    # whatever partial tail remains is preferable to raising here, since
+    # this path must never fail the round it is degrading.
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+@dataclass(frozen=True)
+class Publishable:
+    """The draft passed every precondition; these three values are exactly
+    the keyword arguments ``interaction_handoff.stage()`` expects beyond
+    ``kind`` and ``protocol_version``, which the caller supplies directly."""
+
+    request_payload: dict[str, Any]
+    request_idempotency_key: str
+    expires_at: datetime
+    fail_closed_reason: None = field(default=None, init=False, repr=False)
+
+
+@dataclass(frozen=True)
+class NotApplicable:
+    """No durable row should be written this round, and nothing failed.
+
+    ``reason`` is ``None`` for the ordinary case -- this finalization was
+    never a waiting-for-user turn with a draft attached, so publication
+    simply does not apply, and the caller's settlement proceeds exactly as
+    it would without this module. ``reason`` is one of ``"no_anchor"``,
+    ``"payload_too_large"``, or ``"empty_question"`` when a waiting turn's
+    draft existed but could not be shaped into a publishable payload; each
+    of those is a degrade, not a failure -- the run is not discarded.
+    """
+
+    reason: str | None
+    fail_closed_reason: None = field(default=None, init=False, repr=False)
+
+
+@dataclass(frozen=True)
+class FailClosed:
+    """This round's settlement must be discarded wholesale: whatever the
+    caller already does for a late, no-longer-owned result is what must
+    happen here too, via that caller's own existing exit -- this module
+    adds no new one."""
+
+    reason: str
+
+    @property
+    def fail_closed_reason(self) -> str:
+        return self.reason
+
+
+ClarificationResolution = Publishable | NotApplicable | FailClosed
+
+
+def clarification_idempotency_key(draft: ClarificationDraft) -> str:
+    """Derive a ``stage()`` idempotency key from the draft's content.
+
+    Reads only ``turn_marker`` -- never ``message`` or ``interactions`` --
+    so that truncating or otherwise reshaping the payload in
+    :func:`build_clarification_payload` can never change the key a re-entrant
+    resume of the same turn produces. A key that moved with the payload
+    would turn a replay that should cost nothing (the active row already
+    matches) into a fresh request every time the payload's shape changed.
+    """
+
+    digest = hashlib.sha256(draft.turn_marker.encode("utf-8")).hexdigest()[:32]
+    return f"clarification.{digest}"
+
+
+def build_clarification_payload(draft: ClarificationDraft) -> dict[str, Any]:
+    """Build the v1 ``request_payload`` shape for a clarification draft.
+
+    Processing order is fixed: character-domain filtering happens first,
+    length truncation second. Reversing the order would make the same input
+    produce a different truncated length depending on how many control
+    characters a truncated tail happened to contain -- the same input must
+    always truncate to the same length.
+
+    Every step here degrades rather than raises: a control character is
+    dropped silently (it was never visible to begin with), an over-length
+    ``question`` is cut with a fixed suffix and flagged, and an over-length
+    ``interactions`` list is dropped to an empty list and flagged --
+    truncating half of a multi-field form is worse than presenting none of
+    it. The one condition worth a log line is a ``question`` that comes out
+    empty after filtering: that is not a truncation, it means the visible
+    question is gone.
+
+    ``protocol_version`` is not a key in this dict on purpose -- the caller
+    passes it to ``stage()`` directly, matching that primitive's own
+    signature. This payload's own version-evolution promise, independent of
+    that column, is: as long as this shape stays v1, only optional fields
+    may be added here. Renaming a key, changing a key's type, removing a
+    key, or changing what an existing key means requires bumping the
+    protocol version and giving :func:`parse_clarification_payload` an
+    explicit branch for the old shape -- never a silent redefinition of what
+    v1 means.
+    """
+
+    original_question = draft.message
+    cleaned_question = _strip_control_characters(original_question)
+    stripped_characters = len(original_question) - len(cleaned_question)
+
+    if not cleaned_question:
+        logger.error(
+            "clarification question was empty after removing control characters",
+            extra={
+                "original_length": len(original_question),
+                "stripped_characters": stripped_characters,
+            },
+        )
+
+    question_truncated = False
+    question = cleaned_question
+    if len(cleaned_question.encode("utf-8")) > _QUESTION_MAX_BYTES:
+        suffix_bytes = len(_QUESTION_TRUNCATION_SUFFIX.encode("utf-8"))
+        question = (
+            _truncate_to_byte_limit(
+                cleaned_question, _QUESTION_MAX_BYTES - suffix_bytes
+            )
+            + _QUESTION_TRUNCATION_SUFFIX
+        )
+        question_truncated = True
+
+    interactions_cleaned = [_clean_leaves(dict(item)) for item in draft.interactions]
+    interactions_dropped = False
+    interactions_payload: list[Any] = interactions_cleaned
+    if _serialized_byte_length(interactions_cleaned) > _INTERACTIONS_MAX_BYTES:
+        interactions_payload = []
+        interactions_dropped = True
+
+    payload: dict[str, Any] = {
+        "question": question,
+        "interactions": interactions_payload,
+        "message_type": draft.message_type,
+        "source": draft.source,
+        "requests": [item.to_dict() for item in draft.requests],
+    }
+    if question_truncated:
+        payload["question_truncated"] = True
+    if interactions_dropped:
+        payload["interactions_dropped"] = True
+
+    total_bytes = _serialized_byte_length(payload)
+    if total_bytes > _TOTAL_PAYLOAD_MAX_BYTES:
+        logger.error(
+            "clarification payload exceeded the maximum size even after truncation",
+            extra={"serialized_length": total_bytes},
+        )
+
+    return payload
+
+
+def parse_clarification_payload(
+    payload: Mapping[str, Any],
+) -> tuple[str | None, list[dict[str, Any]] | None]:
+    """Read a v1 clarification payload back into the ``(question,
+    interactions)`` shape ``get_latest_waiting_question``
+    (``chat_history_service.py``) already returns for the legacy transcript
+    path -- a cross-module contract with no shared base class to enforce it,
+    pinned only by the test that compares the two shapes directly.
+
+    This is the one place allowed to know what a payload's version implies:
+    a reader elsewhere in the codebase must call this function rather than
+    reach into ``payload["question"]`` itself, so that a future protocol
+    version bump only needs a new branch here, not a new branch at every
+    call site.
+    """
+
+    question = payload.get("question")
+    interactions = payload.get("interactions")
+    return (
+        question if isinstance(question, str) else None,
+        interactions if isinstance(interactions, list) else None,
+    )
+
+
+def resolve_publishable_clarification(
+    result: Mapping[str, Any],
+    *,
+    task: Task,
+    lease: TaskLease,
+    anchor: InteractionAnchor | None,
+    now: datetime,
+) -> ClarificationResolution:
+    """Classify one finalizing run's clarification draft.
+
+    Guard order is the contract (most specific, least data-exposing failure
+    first):
+
+    1. ``result["status"] == "waiting_for_user"`` paired against draft
+       presence. A waiting result with no draft is a fail-closed
+       ``"missing_draft"``: nothing about this run says a question should
+       have existed, but the pattern says the user should be asked one, and
+       there is nothing to ask. A non-waiting result carrying a draft
+       (never expected from the core pattern layer, only reachable if a
+       caller mixes up two results) is fail-closed ``"draft_status_mismatch"``,
+       and the stray draft is discarded rather than acted on. Either of the
+       two matched pairs -- waiting-with-draft, or non-waiting-with-nothing
+       -- is not a failure: the first continues to the remaining guards, the
+       second is simply not applicable, and the caller's own non-waiting
+       settlement proceeds untouched.
+    2. ``lease.run_id is not None`` -- an unfenced lease cannot prove which
+       run produced this result.
+    3. ``task.runner_id == lease.runner_id and task.run_id == lease.run_id``
+       -- the task row must still be owned by the lease that produced the
+       result.
+    4. ``lease.attempt_id is None or task.lease_attempt_id == lease.attempt_id``
+       -- ``None`` means the lease cannot prove attempt identity at all and
+       must be treated as "skip this check", never as "matches" (the same
+       reading ``interaction_handoff`` itself uses for the identical
+       sentinel). A concrete mismatch means a later attempt has already
+       claimed the row, and this settlement must be discarded wholesale
+       rather than degrade -- an attempt that is no longer current has no
+       business writing anything at all.
+    5. ``anchor is not None`` -- no resume anchor means this run's most
+       recent checkpoint was never one a structured interaction can resume
+       against; this degrades, it does not fail the round.
+    5b. The payload built from the draft fits the character domain and size
+        limits in :func:`build_clarification_payload`; if it does not
+        (empty after filtering, or still oversized after truncation), that
+        also degrades rather than fails. This check runs last because it is
+        the only one that requires building the payload first.
+
+    A cross-run anchor mismatch is deliberately absent from this sequence:
+    that check belongs to ``interaction_handoff`` (it already raises a
+    dedicated exception for exactly this case, reported under its own
+    degradation signal), not to this resolver.
+
+    On success, this function clears ``CLARIFICATION_DRAFT_MISSING`` --
+    reaching ``Publishable`` is itself the evidence that the draft pipeline
+    worked this time. ``CLARIFICATION_MULTIPLE_DRAFTS`` is different: it
+    reports that a concurrent-waiting-step conflict happened *this round*,
+    which a successful publish does not undo, so it is registered (not
+    cleared) whenever ``result["clarification_superseded_step_ids"]`` is
+    non-empty, and left alone otherwise.
+    """
+
+    status = result.get("status")
+    draft = result.get("clarification_draft")
+    is_waiting = status == "waiting_for_user"
+
+    if is_waiting and draft is None:
+        logger.error(
+            "a waiting run produced no clarification draft to publish",
+            extra={"task_id": task.id, "run_id": lease.run_id},
+        )
+        register_degradation(
+            CLARIFICATION_DRAFT_MISSING,
+            f"task {task.id}: waiting run produced no clarification draft",
+        )
+        return FailClosed("missing_draft")
+
+    if not is_waiting and draft is not None:
+        logger.error(
+            "a non-waiting run carried a clarification draft; discarding it",
+            extra={"task_id": task.id, "run_id": lease.run_id, "status": status},
+        )
+        return FailClosed("draft_status_mismatch")
+
+    if not is_waiting:
+        return NotApplicable(None)
+
+    assert draft is not None  # narrowed by the two branches above
+
+    if lease.run_id is None:
+        return FailClosed("unfenced_lease")
+
+    if task.runner_id != lease.runner_id or task.run_id != lease.run_id:
+        return FailClosed("ownership_changed")
+
+    if lease.attempt_id is not None and task.lease_attempt_id != lease.attempt_id:
+        return FailClosed("attempt_mismatch")
+
+    if anchor is None:
+        return NotApplicable("no_anchor")
+
+    payload = build_clarification_payload(draft)
+
+    if not payload["question"]:
+        return NotApplicable("empty_question")
+
+    if _serialized_byte_length(payload) > _TOTAL_PAYLOAD_MAX_BYTES:
+        return NotApplicable("payload_too_large")
+
+    clear_degradation(CLARIFICATION_DRAFT_MISSING)
+    superseded_step_ids = result.get("clarification_superseded_step_ids") or []
+    if superseded_step_ids:
+        register_degradation(
+            CLARIFICATION_MULTIPLE_DRAFTS,
+            f"task {task.id}: run {lease.run_id}: superseded step ids "
+            f"{list(superseded_step_ids)}",
+        )
+    else:
+        clear_degradation(CLARIFICATION_MULTIPLE_DRAFTS)
+
+    return Publishable(
+        request_payload=payload,
+        request_idempotency_key=clarification_idempotency_key(draft),
+        expires_at=now + CLARIFICATION_REQUEST_TTL,
+    )

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -43,6 +43,12 @@ place, and this module makes no claim about what happens there. Extending
 the caller set to a fourth site is a reason to come back and re-read this
 module, not to assume its guards still describe the new caller's situation.
 
+Timing is as strict as the caller set: the finalizer must call this
+function before it releases the lease, against the same task row it
+already holds locked under ``SELECT ... FOR UPDATE`` -- never a row
+re-read afterward, which could already reflect a different attempt's
+ownership by the time this function's ownership and attempt guards run.
+
 This module is also the only place allowed to construct or parse the JSON
 shape a published row's ``request_payload`` carries -- see
 :func:`build_clarification_payload` and :func:`parse_clarification_payload`
@@ -133,6 +139,14 @@ def _strip_control_characters(value: str) -> str:
     comment above for the cross-layer contract this filter must not drift
     from."""
 
+    # Both replaces below target the same code point, NUL (U+0000); the
+    # second is a no-op after the first. It is kept so this filter's
+    # character-handling semantics match clarification.py's
+    # ``_marker_clean`` exactly, for the five-copy comparison the
+    # cross-layer contract in the comment above ``_CONTROL_CHAR_KEEP``
+    # depends on -- not because the two copies are written alike
+    # line-for-line: that one uses two separate statements, this one
+    # chains both replaces into a single line.
     cleaned = value.replace("\x00", "").replace("\u0000", "")
     return "".join(ch for ch in cleaned if ord(ch) >= 32 or ch in _CONTROL_CHAR_KEEP)
 
@@ -432,23 +446,29 @@ def resolve_publishable_clarification(
     dedicated exception for exactly this case, reported under its own
     degradation signal), not to this resolver.
 
-    On success, this function clears ``CLARIFICATION_DRAFT_MISSING`` --
-    reaching ``Publishable`` is itself the evidence that the draft pipeline
-    worked this time.
+    ``now`` must be an aware UTC datetime -- the same obligation
+    ``stage_interaction_request`` documents for its own ``now`` parameter
+    (``task_interaction_staging.py``). It is folded into ``expires_at``
+    (``now + CLARIFICATION_REQUEST_TTL``) on the ``Publishable`` path, and a
+    naive or non-UTC value would corrupt that column the same way an
+    unvalidated ``expires_at`` would. This function does not itself
+    validate ``now``: ``stage_interaction_request``'s own validation of the
+    ``expires_at`` this function hands it already enforces the obligation
+    downstream, so a second check here would only duplicate that guard.
 
     ``CLARIFICATION_MULTIPLE_DRAFTS`` is registered before any guard below
     gets a chance to return, not only on the ``Publishable`` path: whether
     ``result["clarification_superseded_step_ids"]`` is non-empty is a fact
     about this round's ``result`` that holds regardless of which guard
     ultimately classifies it -- a losing waiting step can be superseded by
-    an interrupt that wins the same round, so ``NotApplicable(None)`` and
-    every other non-``Publishable`` outcome must still be able to report
-    the conflict. Clearing it is the opposite: confined to the
-    ``Publishable`` path only, alongside ``CLARIFICATION_DRAFT_MISSING`` --
-    a successful publish clears the signal only when nothing was
-    superseded *this same round* either, since publishing this round's
-    draft does not retroactively undo a sibling step's draft having been
-    discarded.
+    an interrupt that wins the same round (see ``AgentExecutionAdapter``'s
+    ``"interrupted"`` branch), so ``NotApplicable(None)`` and every other
+    non-``Publishable`` outcome must still be able to report the conflict.
+    Clearing it is the opposite: confined to the ``Publishable`` path only,
+    alongside ``CLARIFICATION_DRAFT_MISSING`` -- a successful publish
+    clears the signal only when nothing was superseded *this same round*
+    either, since publishing this round's draft does not retroactively
+    undo a sibling step's draft having been discarded.
     """
 
     superseded_step_ids = result.get("clarification_superseded_step_ids") or []

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -84,7 +84,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 
 from ...core.agent.clarification import ClarificationDraft
 from ..models.task import Task
@@ -164,6 +164,21 @@ def _truncate_to_byte_limit(text: str, max_bytes: int) -> str:
     return encoded[:max_bytes].decode("utf-8", errors="ignore")
 
 
+# The full value sets below, enumerated from every construction site in
+# :func:`resolve_publishable_clarification` and from :class:`NotApplicable`
+# and :class:`FailClosed`'s own docstrings. Both are ``str`` at runtime --
+# ``Literal`` only narrows what a type checker accepts, so a caller reading
+# ``resolution.fail_closed_reason == "attempt_mismatch"`` needs no change.
+NotApplicableReason = Literal["no_anchor", "payload_too_large", "empty_question"]
+FailClosedReason = Literal[
+    "missing_draft",
+    "draft_status_mismatch",
+    "unfenced_lease",
+    "ownership_changed",
+    "attempt_mismatch",
+]
+
+
 @dataclass(frozen=True)
 class Publishable:
     """The draft passed every precondition; these three values are exactly
@@ -189,7 +204,7 @@ class NotApplicable:
     of those is a degrade, not a failure -- the run is not discarded.
     """
 
-    reason: str | None
+    reason: NotApplicableReason | None
     fail_closed_reason: None = field(default=None, init=False, repr=False)
 
 
@@ -212,10 +227,10 @@ class FailClosed:
     late-result exit -- this module adds no new one.
     """
 
-    reason: str
+    reason: FailClosedReason
 
     @property
-    def fail_closed_reason(self) -> str:
+    def fail_closed_reason(self) -> FailClosedReason:
         return self.reason
 
 

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -17,10 +17,16 @@ row? The answer is one of three outcomes, never folded into a boolean:
   publishable payload (no resume anchor, or the payload could not be shaped
   within the size and character limits below). The caller's own settlement
   proceeds exactly as it would have before this module existed.
-* :class:`FailClosed` -- the caller must discard this round's settlement
-  wholesale, the same way it already discards a late, no-longer-owned
-  result. This happens only when the lease that produced the result can no
-  longer be trusted to speak for the task row.
+* :class:`FailClosed` -- carries one of five reason strings that split into
+  two different consequences, not one. Two of them (from the guard that
+  pairs waiting status against draft presence) do not discard the round at
+  all: no structured row is written, but the finalizer's existing path for
+  that status proceeds unchanged. The other three (an unfenced lease, a
+  task row no longer owned by the lease that produced this result, or an
+  attempt that is no longer current) do mean the caller must discard this
+  round's settlement wholesale, the same way it already discards a late,
+  no-longer-owned result. See :class:`FailClosed` itself for which reason
+  is which.
 
 Guard order is a contract: the checks inside :func:`resolve_publishable_clarification`
 run in a fixed sequence, most specific and least data-exposing failure
@@ -41,6 +47,16 @@ This module is also the only place allowed to construct or parse the JSON
 shape a published row's ``request_payload`` carries -- see
 :func:`build_clarification_payload` and :func:`parse_clarification_payload`
 for the pairing rule and the version-evolution promise that comes with it.
+
+Two of that payload's fields, ``source`` and ``requests``, have no reader
+anywhere in this delivery. They are there for whichever change adds the
+response-routing path that answers a multi-tool waiting turn: that reader
+needs to know which source produced the draft and which pending tool call
+each answer belongs to, and once this payload is published, it is the only
+place that information still lives. Do not remove either field for being
+unread today -- removing them now would trade the free "add an optional
+field" path above for a version bump later, to add back exactly what was
+just deleted.
 
 An application-layer invariant worth stating plainly: a task can have at
 most one *active* interaction row at a time (the database enforces this
@@ -94,8 +110,12 @@ CLARIFICATION_REQUEST_TTL = timedelta(hours=24)
 # byte-for-byte identical to ``xagent.core.agent.clarification``'s
 # ``_marker_clean`` whitelist. That module cannot import this one (core
 # layer never imports web layer), so the two copies cannot share code --
-# only this comment, on both sides, keeps them from drifting apart. If one
-# domain ever changes, change the other in the same commit.
+# ``_marker_clean``'s own docstring enumerates this copy among its five.
+# What actually pins the two domains against drifting apart is
+# ``test_character_domain_matches_the_marker_cleaning_domain`` in
+# ``tests/web/services/test_task_clarification_draft.py``, which calls the
+# real ``_marker_clean`` and compares it against this filter directly. If
+# one domain ever changes, that test is what will turn red.
 _CONTROL_CHAR_KEEP = "\n\r\t"
 
 # Three independent size ceilings, checked in this order because each one
@@ -175,10 +195,22 @@ class NotApplicable:
 
 @dataclass(frozen=True)
 class FailClosed:
-    """This round's settlement must be discarded wholesale: whatever the
-    caller already does for a late, no-longer-owned result is what must
-    happen here too, via that caller's own existing exit -- this module
-    adds no new one."""
+    """No structured row is published this round. What the caller must do
+    about the *round itself* depends on which guard produced ``reason`` --
+    the five values split into two different consequences, not one.
+
+    ``"missing_draft"`` and ``"draft_status_mismatch"`` come from guard 1
+    (the waiting-status/draft-presence pairing) and do not discard the
+    round: no structured row is written and a stray draft is dropped, but
+    the finalizer's existing path for that status proceeds exactly as it
+    already does today.
+
+    ``"unfenced_lease"``, ``"ownership_changed"``, and ``"attempt_mismatch"``
+    come from guards 2 through 4 and mean the opposite: this round's
+    settlement must be discarded wholesale, the same way the caller already
+    discards a late, no-longer-owned result, via that caller's own existing
+    late-result exit -- this module adds no new one.
+    """
 
     reason: str
 
@@ -295,7 +327,11 @@ def parse_clarification_payload(
     interactions)`` shape ``get_latest_waiting_question``
     (``chat_history_service.py``) already returns for the legacy transcript
     path -- a cross-module contract with no shared base class to enforce it,
-    pinned only by the test that compares the two shapes directly.
+    pinned by ``test_payload_round_trip_matches_the_legacy_reader_shape`` in
+    ``tests/web/services/test_task_clarification_draft.py``, which calls
+    the real ``get_latest_waiting_question`` and compares its return shape
+    against this function's, rather than re-deriving the expectation from
+    this function's own return type.
 
     This is the one place allowed to know what a payload's version implies:
     a reader elsewhere in the codebase must call this function rather than

--- a/tests/web/services/test_clarification_publication_gate.py
+++ b/tests/web/services/test_clarification_publication_gate.py
@@ -1,0 +1,163 @@
+"""Zero-production-caller gate for ``resolve_publishable_clarification``.
+
+This resolver ships with no production writer: nothing in the finalize
+paths that settle a task run against its lease calls it yet. A static test
+asserts exactly that -- no production code path calls it -- so the module
+cannot end up half-wired, called from one finalizer but not the other two.
+
+The gate's expected call count today is zero. It becomes exactly three
+(one call in each of the two finalizers that settle a running task, one in
+the finalizer that settles a resumed one) only once all three of those
+finalizers call it, the task-side protocol marker exists, and the read
+surface that consumes a published row is switched on together -- not one
+finalizer at a time. This mirrors the existing zero-to-nonzero gate this
+suite already carries for the interaction-staging primitive; see
+``test_interaction_staging_production_gate.py`` for the precedent.
+
+AST, not substring grep: a source-text scan would also match this test
+file's own docstrings and this module's own definition of the gated name,
+forcing every future mention of ``resolve_publishable_clarification`` in
+prose to dodge the scanner.
+
+Known blind spots, not fixed here because closing them is out of scope for
+a static AST scan of one package tree:
+
+(a) Dynamic access: ``importlib.import_module(...)`` plus ``getattr(...)``
+    matches none of the node shapes below.
+(b) A gated name reached through an alias chain the AST walk does not
+    resolve -- re-exporting it under a different name from a third module
+    and importing *that* name elsewhere.
+(c) The primitive-module exclusion is stem-keyed, not path-keyed: any
+    other file anywhere under this package that happened to also be named
+    ``task_clarification_draft.py`` would be excluded from the scan right
+    alongside the real one, on filename alone.
+(d) The scan root is ``xagent.__path__`` (``src/xagent``), not the
+    repository root -- a caller under the top-level ``scripts/`` directory
+    is invisible to this gate entirely.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import xagent
+from xagent.web.services import (  # noqa: F401 -- negative control import
+    task_clarification_draft as resolver_module,
+)
+
+GATED_NAMES = frozenset({"resolve_publishable_clarification"})
+PRIMITIVE_MODULE = "task_clarification_draft"
+
+
+def _production_uses(source: str) -> set[str]:
+    """Gated names this module imports or calls."""
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.ImportFrom):
+            if (node.module or "").split(".")[-1] == PRIMITIVE_MODULE:
+                found.update(a.name for a in node.names if a.name in GATED_NAMES)
+                if any(a.name == "*" for a in node.names):
+                    found.update(GATED_NAMES)
+            found.update(a.name for a in node.names if a.name == PRIMITIVE_MODULE)
+        elif isinstance(node, ast.Import):
+            found.update(
+                a.name.split(".")[-1]
+                for a in node.names
+                if a.name.split(".")[-1] == PRIMITIVE_MODULE
+            )
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in GATED_NAMES:
+                found.add(func.id)
+            elif isinstance(func, ast.Attribute) and func.attr in GATED_NAMES:
+                found.add(func.attr)
+    return found
+
+
+def _production_modules() -> list[Path]:
+    root = Path(next(iter(xagent.__path__)))
+    modules = [path for path in root.rglob("*.py") if path.stem != PRIMITIVE_MODULE]
+    assert modules, "production scan set is empty"
+    return modules
+
+
+# --------------------------------------------------------------------------
+# The gate itself
+# --------------------------------------------------------------------------
+
+
+def test_no_production_module_calls_the_resolver() -> None:
+    offenders: dict[str, set[str]] = {}
+    for path in _production_modules():
+        try:
+            source = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise RuntimeError(
+                f"{path}: not valid UTF-8, cannot be AST-scanned by this gate"
+            ) from exc
+        uses = _production_uses(source)
+        if uses:
+            offenders[str(path)] = uses
+    assert offenders == {}, offenders
+
+
+# --------------------------------------------------------------------------
+# Positive controls -- three import/call shapes, each individually detected
+# --------------------------------------------------------------------------
+
+
+def test_detects_from_import_and_direct_call() -> None:
+    source = textwrap.dedent(
+        """
+        from xagent.web.services.task_clarification_draft import resolve_publishable_clarification
+
+        def finalize(result, task, lease, anchor, now):
+            return resolve_publishable_clarification(
+                result, task=task, lease=lease, anchor=anchor, now=now
+            )
+        """
+    )
+    assert _production_uses(source) == {"resolve_publishable_clarification"}
+
+
+def test_detects_module_import_and_attribute_call() -> None:
+    source = textwrap.dedent(
+        """
+        from xagent.web.services import task_clarification_draft
+
+        def finalize(**kwargs):
+            return task_clarification_draft.resolve_publishable_clarification(**kwargs)
+        """
+    )
+    uses = _production_uses(source)
+    assert "task_clarification_draft" in uses
+    assert "resolve_publishable_clarification" in uses
+
+
+def test_detects_bare_module_import() -> None:
+    source = "import xagent.web.services.task_clarification_draft\n"
+    assert _production_uses(source) == {"task_clarification_draft"}
+
+
+def test_detects_star_import() -> None:
+    source = "from xagent.web.services.task_clarification_draft import *\n"
+    assert _production_uses(source) == GATED_NAMES
+
+
+# --------------------------------------------------------------------------
+# Negative controls -- test consumers and the module's own definition
+# --------------------------------------------------------------------------
+
+
+def test_test_module_consumers_are_not_flagged() -> None:
+    scanned = {str(path) for path in _production_modules()}
+    this_file = str(Path(__file__).resolve())
+    assert this_file not in scanned
+    assert all("/tests/" not in path for path in scanned)
+
+
+def test_resolver_module_itself_is_not_flagged() -> None:
+    modules = _production_modules()
+    assert all(path.stem != PRIMITIVE_MODULE for path in modules)

--- a/tests/web/services/test_clarification_publication_gate.py
+++ b/tests/web/services/test_clarification_publication_gate.py
@@ -5,9 +5,13 @@ paths that settle a task run against its lease calls it yet. A static test
 asserts exactly that -- no production code path calls it -- so the module
 cannot end up half-wired, called from one finalizer but not the other two.
 
-The gate's expected call count today is zero. It becomes exactly three
-(one call in each of the two finalizers that settle a running task, one in
-the finalizer that settles a resumed one) only once all three of those
+None of today's three finalizers has a pipeline that hands it both the
+pattern's result dict and the resume anchor this resolver needs --
+``finalize_managed_task_lease_result``'s current signature
+(``managed_task_lease.py``), for instance, takes neither. The gate's
+expected call count today is zero. It becomes exactly three (one call in
+each of the two finalizers that settle a running task, one in the
+finalizer that settles a resumed one) only once all three of those
 finalizers call it, the task-side protocol marker exists, and the read
 surface that consumes a published row is switched on together -- not one
 finalizer at a time. This mirrors the existing zero-to-nonzero gate this

--- a/tests/web/services/test_clarification_publication_gate.py
+++ b/tests/web/services/test_clarification_publication_gate.py
@@ -47,7 +47,13 @@ from xagent.web.services import (  # noqa: F401 -- negative control import
     task_clarification_draft as resolver_module,
 )
 
-GATED_NAMES = frozenset({"resolve_publishable_clarification"})
+GATED_NAMES = frozenset(
+    {
+        "resolve_publishable_clarification",
+        "parse_clarification_payload",
+        "build_clarification_payload",
+    }
+)
 PRIMITIVE_MODULE = "task_clarification_draft"
 
 

--- a/tests/web/services/test_clarification_resolver_capability_boundaries.py
+++ b/tests/web/services/test_clarification_resolver_capability_boundaries.py
@@ -1,0 +1,264 @@
+"""Static guards for two boundaries the clarification resolver leans on
+without re-checking them itself.
+
+First: a resume anchor's mere existence is trusted by
+``resolve_publishable_clarification`` to already mean "the task row was
+``RUNNING``, owned by the runner and run that wrote this checkpoint, and not
+scoped to a child build" -- the resolver never re-queries the task row for
+any of that. That trust is only sound as long as the one place an anchor's
+backing pointer gets written (``trace_handlers.py``'s checkpoint pointer
+UPDATE) keeps exactly those conditions in its own ``where`` clause and
+keeps computing the lease it updates against under the same
+``build_id is None`` gate. If a future change loosens that UPDATE's
+guard, the resolver would silently inherit the loosened guarantee with no
+test anywhere pointing at the connection -- these two tests are that
+pointer.
+
+Second: the resolver and the ops-signal registry it uses are both web-layer
+modules; nothing in the core agent/pattern layer is allowed to import the
+registry directly, since a degradation signal is meaningful only once a
+web-layer caller has resolved a Task row's ownership -- the pattern layer
+never holds that context.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import xagent.web.api.trace_handlers as trace_handlers_module
+
+TRACE_HANDLERS_PATH = Path(trace_handlers_module.__file__)
+
+
+def _function_named(tree: ast.Module, name: str) -> ast.AST:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ):
+            return node
+    raise AssertionError(f"no function named {name!r} found")
+
+
+def _pointer_update_where_calls(func_node: ast.AST) -> list[ast.Call]:
+    """``.where(...)`` calls chained directly onto ``update(Task)``."""
+
+    calls = []
+    for node in ast.walk(func_node):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "where"
+            and isinstance(node.func.value, ast.Call)
+            and isinstance(node.func.value.func, ast.Name)
+            and node.func.value.func.id == "update"
+            and node.func.value.args
+            and isinstance(node.func.value.args[0], ast.Name)
+            and node.func.value.args[0].id == "Task"
+        ):
+            calls.append(node)
+    return calls
+
+
+def _task_equality_targets(where_call: ast.Call) -> set[str]:
+    """``Task.<attr>`` names compared with ``==`` among this call's args."""
+
+    targets: set[str] = set()
+    for arg in where_call.args:
+        if (
+            isinstance(arg, ast.Compare)
+            and len(arg.ops) == 1
+            and isinstance(arg.ops[0], ast.Eq)
+            and isinstance(arg.left, ast.Attribute)
+            and isinstance(arg.left.value, ast.Name)
+            and arg.left.value.id == "Task"
+        ):
+            targets.add(arg.left.attr)
+    return targets
+
+
+def _status_compares_to_running(where_call: ast.Call) -> bool:
+    for arg in where_call.args:
+        if not (
+            isinstance(arg, ast.Compare)
+            and len(arg.ops) == 1
+            and isinstance(arg.ops[0], ast.Eq)
+            and isinstance(arg.left, ast.Attribute)
+            and arg.left.attr == "status"
+            and len(arg.comparators) == 1
+        ):
+            continue
+        comparator = arg.comparators[0]
+        if (
+            isinstance(comparator, ast.Attribute)
+            and isinstance(comparator.value, ast.Name)
+            and comparator.value.id == "TaskStatus"
+            and comparator.attr == "RUNNING"
+        ):
+            return True
+    return False
+
+
+def _checkpoint_lease_gated_by_build_id_is_none(func_node: ast.AST) -> bool:
+    """Whether some ``checkpoint_lease = ...`` assignment in ``func_node``
+    is a ternary whose test is exactly ``self.build_id is None``."""
+
+    for node in ast.walk(func_node):
+        if not (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "checkpoint_lease"
+                for target in node.targets
+            )
+            and isinstance(node.value, ast.IfExp)
+        ):
+            continue
+        test = node.value.test
+        if (
+            isinstance(test, ast.Compare)
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], ast.Is)
+            and isinstance(test.left, ast.Attribute)
+            and isinstance(test.left.value, ast.Name)
+            and test.left.value.id == "self"
+            and test.left.attr == "build_id"
+            and len(test.comparators) == 1
+            and isinstance(test.comparators[0], ast.Constant)
+            and test.comparators[0].value is None
+        ):
+            return True
+    return False
+
+
+def checkpoint_pointer_guard_findings(source: str) -> dict[str, object]:
+    """Everything the real assertion below needs, factored out so the
+    mutation tests can exercise it against synthetic fixtures too."""
+
+    tree = ast.parse(source)
+    func_node = _function_named(tree, "_save_trace_event")
+    where_calls = _pointer_update_where_calls(func_node)
+    targets: set[str] = set()
+    status_ok = False
+    for call in where_calls:
+        targets |= _task_equality_targets(call)
+        status_ok = status_ok or _status_compares_to_running(call)
+    return {
+        "where_call_count": len(where_calls),
+        "equality_targets": targets,
+        "status_compares_to_running": status_ok,
+        "checkpoint_lease_gated": _checkpoint_lease_gated_by_build_id_is_none(
+            func_node
+        ),
+    }
+
+
+REQUIRED_EQUALITY_TARGETS = {"runner_id", "run_id"}
+
+
+def test_checkpoint_pointer_update_carries_its_representation_guards() -> None:
+    source = TRACE_HANDLERS_PATH.read_text(encoding="utf-8")
+    findings = checkpoint_pointer_guard_findings(source)
+    assert findings["where_call_count"] >= 1
+    assert REQUIRED_EQUALITY_TARGETS <= findings["equality_targets"]
+    assert findings["status_compares_to_running"] is True
+    assert findings["checkpoint_lease_gated"] is True
+
+
+def test_dropping_the_build_id_gate_is_caught_by_the_guard() -> None:
+    """Mutation control: a version of the function that always resolves a
+    lease, dropping the ``self.build_id is None`` ternary, must be flagged
+    -- this is the regression the guard above exists to catch."""
+
+    mutated = """
+def _save_trace_event(self, db, event):
+    checkpoint_lease = current_task_lease()
+    db.execute(
+        update(Task)
+        .where(
+            Task.id == self.task_id,
+            Task.status == TaskStatus.RUNNING,
+            Task.runner_id == checkpoint_lease.runner_id,
+            Task.run_id == checkpoint_lease.run_id,
+        )
+        .values(last_checkpoint_event_id=str(event.id))
+    )
+"""
+    findings = checkpoint_pointer_guard_findings(mutated)
+    assert findings["checkpoint_lease_gated"] is False
+
+
+def test_dropping_a_where_condition_is_caught_by_the_guard() -> None:
+    """Mutation control: dropping the ``run_id`` fence from the ``where``
+    clause must be flagged."""
+
+    mutated = """
+def _save_trace_event(self, db, event):
+    checkpoint_lease = current_task_lease() if self.build_id is None else None
+    db.execute(
+        update(Task)
+        .where(
+            Task.id == self.task_id,
+            Task.status == TaskStatus.RUNNING,
+            Task.runner_id == checkpoint_lease.runner_id,
+        )
+        .values(last_checkpoint_event_id=str(event.id))
+    )
+"""
+    findings = checkpoint_pointer_guard_findings(mutated)
+    assert not (REQUIRED_EQUALITY_TARGETS <= findings["equality_targets"])
+
+
+def test_a_function_with_no_pointer_update_reports_zero_where_calls() -> None:
+    """Negative control: a function that never touches the pointer at all
+    must not be mistaken for one that carries the guard."""
+
+    source = """
+def _save_trace_event(self, db, event):
+    pass
+"""
+    findings = checkpoint_pointer_guard_findings(source)
+    assert findings["where_call_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Core layer must not import the web-layer degradation registry
+# ---------------------------------------------------------------------------
+
+
+def _imports_ops_signals(source: str) -> bool:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").split(".")[-1] == (
+            "ops_signals"
+        ):
+            return True
+        if isinstance(node, ast.Import) and any(
+            alias.name.split(".")[-1] == "ops_signals" for alias in node.names
+        ):
+            return True
+    return False
+
+
+def test_core_agent_layer_never_imports_the_degradation_registry() -> None:
+    import xagent.core as core_package
+
+    root = Path(next(iter(core_package.__path__)))
+    offenders = []
+    for path in root.rglob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        if _imports_ops_signals(source):
+            offenders.append(str(path))
+    assert offenders == [], offenders
+
+
+def test_import_detector_catches_a_synthetic_offender() -> None:
+    """Positive control for the detector itself."""
+
+    source = "from xagent.web.services.ops_signals import register_degradation\n"
+    assert _imports_ops_signals(source) is True
+
+
+def test_import_detector_ignores_unrelated_imports() -> None:
+    source = "from xagent.web.services import task_lease_service\n"
+    assert _imports_ops_signals(source) is False

--- a/tests/web/services/test_clarification_resolver_capability_boundaries.py
+++ b/tests/web/services/test_clarification_resolver_capability_boundaries.py
@@ -229,10 +229,21 @@ def _save_trace_event(self, db, event):
 def _imports_ops_signals(source: str) -> bool:
     tree = ast.parse(source)
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and (node.module or "").split(".")[-1] == (
-            "ops_signals"
-        ):
-            return True
+        if isinstance(node, ast.ImportFrom):
+            # Two independent forms, neither implying the other:
+            # ``from ...services.ops_signals import X`` (the module path
+            # itself ends with "ops_signals") versus
+            # ``from ...services import ops_signals`` (the module name is
+            # imported as a name, from its *parent* package -- checking
+            # only ``node.module`` would never catch this shape, since the
+            # parent package's own path does not end with "ops_signals").
+            # Three real occurrences of this second form exist in the
+            # repo today, and a detector that only checks ``node.module``
+            # misses every one of them.
+            if (node.module or "").split(".")[-1] == "ops_signals":
+                return True
+            if any(alias.name == "ops_signals" for alias in node.names):
+                return True
         if isinstance(node, ast.Import) and any(
             alias.name.split(".")[-1] == "ops_signals" for alias in node.names
         ):
@@ -256,6 +267,17 @@ def test_import_detector_catches_a_synthetic_offender() -> None:
     """Positive control for the detector itself."""
 
     source = "from xagent.web.services.ops_signals import register_degradation\n"
+    assert _imports_ops_signals(source) is True
+
+
+def test_import_detector_catches_the_parent_package_import_form() -> None:
+    """The other import shape the detector must catch: the module name
+    imported from its parent package rather than named directly in the
+    module path. Three real call sites in this repo use this form today
+    (all in test modules), and a detector that only checks the module
+    path misses every one of them."""
+
+    source = "from xagent.web.services import ops_signals\n"
     assert _imports_ops_signals(source) is True
 
 

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -538,6 +538,56 @@ def test_oversized_interactions_are_dropped_entirely() -> None:
     assert payload["question"] == draft.message
 
 
+def test_request_leaf_control_characters_are_stripped_from_the_payload() -> None:
+    """``requests`` is built from ``ClarificationRequestItem.to_dict()``,
+    whose string fields (``tool_name``, ``tool_call_id``,
+    ``interaction_id``) come from the same untrusted tool-call surface as
+    ``interactions``' free-text leaves and must go through the same
+    ``_clean_leaves`` filter, not straight into the payload."""
+
+    dirty_requests = (
+        ClarificationRequestItem("tool\x07one", "call\x00-1", "call\x00-1"),
+    )
+    draft = _draft(requests=dirty_requests)
+    payload = build_clarification_payload(draft)
+    assert payload["requests"] == [
+        {
+            "tool_name": "toolone",
+            "tool_call_id": "call-1",
+            "interaction_id": "call-1",
+        }
+    ]
+
+    # The idempotency key is derived only from turn_marker (computed from
+    # the *raw*, unfiltered requests), so filtering the payload's requests
+    # leaves must not move it.
+    key_before = clarification_idempotency_key(draft)
+    build_clarification_payload(draft)
+    assert clarification_idempotency_key(draft) == key_before
+
+
+def test_message_type_control_characters_are_stripped_from_the_payload() -> None:
+    """``message_type`` reaches ``ClarificationDraft`` by way of
+    ``react.py``'s ``send_message`` handler --
+    ``str(args.get("message_type", "info"))``, a raw LLM tool-call
+    argument with no runtime validation against the tool schema's declared
+    ``enum``. A JSON-schema ``enum`` is a hint the model is told to follow,
+    not a constraint this code enforces, so ``message_type`` needs the
+    same control-character filtering ``question`` already gets, not a
+    straight pass-through."""
+
+    draft = _draft(message_type="info\x07\x00BEL-AND-NUL")
+    payload = build_clarification_payload(draft)
+    assert payload["message_type"] == "infoBEL-AND-NUL"
+
+    # Same independence check as the requests-leaf test above: filtering
+    # message_type must not move the idempotency key, since that key is
+    # derived only from turn_marker.
+    key_before = clarification_idempotency_key(draft)
+    build_clarification_payload(draft)
+    assert clarification_idempotency_key(draft) == key_before
+
+
 def test_payload_still_too_large_after_truncation_is_not_applicable() -> None:
     """Only ``tool_waiting`` -- the multi-tool waiting point -- can
     realistically produce thousands of ``requests`` entries;
@@ -561,6 +611,22 @@ def test_payload_still_too_large_after_truncation_is_not_applicable() -> None:
 
 def test_question_emptied_by_character_filtering_is_not_applicable() -> None:
     draft = _draft(message="\x00\x01\x02\x1f")
+    result = {"status": "waiting_for_user", "clarification_draft": draft}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, NotApplicable)
+    assert resolution.reason == "empty_question"
+
+
+def test_whitespace_only_question_is_not_applicable() -> None:
+    """A question made only of whitespace -- including a tab -- survives
+    ``_strip_control_characters`` unchanged, since ``\\n``, ``\\r``, and
+    ``\\t`` are the three exceptions that filter keeps. The guard must
+    still treat it as empty rather than let a blank question through as
+    ``Publishable``."""
+
+    draft = _draft(message="   \t  \n  ")
     result = {"status": "waiting_for_user", "clarification_draft": draft}
     resolution = resolve_publishable_clarification(
         result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
@@ -642,6 +708,57 @@ def test_superseded_steps_register_the_multiple_drafts_signal_and_it_stays_up() 
         result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
     )
     assert isinstance(resolution, Publishable)
+    assert (
+        ops_signals.CLARIFICATION_MULTIPLE_DRAFTS in ops_signals.active_degradations()
+    )
+
+
+def test_interrupted_winner_with_superseded_steps_registers_the_multiple_drafts_signal() -> (
+    None
+):
+    """When an interrupt wins a wakeup that also superseded a losing
+    waiting step, ``AgentExecutionAdapter`` puts
+    ``clarification_superseded_step_ids`` on the *interrupted* result, not
+    a waiting one (see the ``"interrupted"`` branch of
+    ``AgentExecutionAdapter._normalize_result`` in ``execution_adapter.py``).
+    The signal has to register here even though the guard sequence
+    classifies this round ``NotApplicable(None)`` well before it would
+    otherwise touch ``clarification_superseded_step_ids`` -- registering
+    must not be gated behind reaching the ``Publishable`` path."""
+
+    result = {
+        "status": "interrupted",
+        "clarification_superseded_step_ids": ["step-2"],
+    }
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, NotApplicable)
+    assert resolution.reason is None
+    assert (
+        ops_signals.CLARIFICATION_MULTIPLE_DRAFTS in ops_signals.active_degradations()
+    )
+
+
+def test_waiting_with_superseded_steps_and_no_anchor_registers_the_multiple_drafts_signal() -> (
+    None
+):
+    """Same point as the interrupted-winner case above, for the other
+    degrade-not-fail exit: a waiting round with no resume anchor still
+    reports a sibling step having been superseded, even though it never
+    reaches the ``Publishable`` branch that used to be the only place this
+    registered."""
+
+    result = {
+        "status": "waiting_for_user",
+        "clarification_draft": _draft(),
+        "clarification_superseded_step_ids": ["step-2"],
+    }
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=None, now=_now()
+    )
+    assert isinstance(resolution, NotApplicable)
+    assert resolution.reason == "no_anchor"
     assert (
         ops_signals.CLARIFICATION_MULTIPLE_DRAFTS in ops_signals.active_degradations()
     )

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -261,6 +261,23 @@ def test_none_attempt_id_skips_the_attempt_guard() -> None:
     assert isinstance(resolution, Publishable)
 
 
+def test_missing_draft_guard_wins_over_unfenced_lease_guard() -> None:
+    """Guard 1 (waiting-status vs. draft-presence pairing) must run before
+    guard 2 (lease fencing). A waiting run with neither a draft nor a
+    fenced lease has to classify as ``missing_draft`` -- whose caller
+    contract is "don't discard the round" -- not ``unfenced_lease``, whose
+    contract is "discard the round wholesale". Swapping the two guards'
+    order would still return a ``FailClosed`` here, but with the wrong
+    reason and therefore the wrong consequence for the caller."""
+
+    result = {"status": "waiting_for_user"}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(run_id=None), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "missing_draft"
+
+
 def test_missing_anchor_is_not_applicable_not_fail_closed() -> None:
     result = {"status": "waiting_for_user", "clarification_draft": _draft()}
     resolution = resolve_publishable_clarification(
@@ -529,6 +546,26 @@ def test_oversized_question_is_truncated_and_the_idempotency_key_is_unaffected()
     assert key_before == key_after
 
 
+def test_oversized_multi_byte_question_truncates_on_a_character_boundary() -> None:
+    """Every character here encodes to 3 UTF-8 bytes, so a byte-slice that
+    ignores character boundaries would land mid-character. ``errors="ignore"``
+    in ``_truncate_to_byte_limit`` drops a partial trailing character rather
+    than raising, but nothing pinned that the result stays valid UTF-8 with
+    no stray replacement character -- this test is that pin."""
+
+    long_question = "你" * (10 * 1024)  # ~30 KiB, over the 16 KiB limit
+    draft = _draft(message=long_question)
+    payload = build_clarification_payload(draft)
+
+    assert payload["question_truncated"] is True
+    encoded = payload["question"].encode("utf-8")
+    assert len(encoded) <= 16 * 1024
+    # Round-trips cleanly and introduces no U+FFFD replacement character --
+    # a mid-character byte slice would either raise here or leave one.
+    assert encoded.decode("utf-8") == payload["question"]
+    assert "�" not in payload["question"]
+
+
 def test_oversized_interactions_are_dropped_entirely() -> None:
     huge_interactions = tuple({"field": "x" * 2000, "index": i} for i in range(64))
     draft = _draft(interactions=huge_interactions)
@@ -586,6 +623,20 @@ def test_message_type_control_characters_are_stripped_from_the_payload() -> None
     key_before = clarification_idempotency_key(draft)
     build_clarification_payload(draft)
     assert clarification_idempotency_key(draft) == key_before
+
+
+def test_interaction_leaf_control_characters_are_stripped_through_full_payload_assembly() -> (
+    None
+):
+    """``test_character_domain_matches_the_marker_cleaning_domain`` pins
+    ``_strip_control_characters`` in isolation; this pins the same
+    filtering as it actually runs inside ``build_clarification_payload``
+    for a form's ``interactions`` leaves."""
+
+    dirty_interactions = ({"prompt": "pick\x07one", "id": "opt\x00-1"},)
+    draft = _draft(interactions=dirty_interactions)
+    payload = build_clarification_payload(draft)
+    assert payload["interactions"] == [{"prompt": "pickone", "id": "opt-1"}]
 
 
 def test_payload_still_too_large_after_truncation_is_not_applicable() -> None:

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -3,13 +3,16 @@
 Pure-function coverage (guard order, payload construction, idempotency key
 derivation) needs no database at all: every argument
 ``resolve_publishable_clarification`` takes is an in-memory value the
-caller already holds. Two tests are the exceptions, each opening a private
-SQLite database the same way the interaction-staging suite does: the
-cross-run anchor scenario, which stages a real interaction row through
+caller already holds. Four tests are the exceptions, each opening a
+private SQLite database the same way the interaction-staging suite does:
+the cross-run anchor scenario, which stages a real interaction row through
 ``interaction_handoff`` to confirm the downstream primitive -- not this
-module -- is what degrades a cross-run mismatch; and the payload/legacy-
-reader shape comparison, which calls the real
-``get_latest_waiting_question`` against a persisted chat message rather
+module -- is what degrades a cross-run mismatch; and three payload/legacy-
+reader shape comparisons (a ``send_message`` draft, a draft with
+interactions, and an empty-form ``ask_user_question`` draft where the two
+readers are known to still disagree), which build their drafts through
+the real ``draft_from_waiting_request`` and call the real
+``get_latest_waiting_question`` against a persisted chat message, rather
 than checking this module's own output against itself.
 """
 
@@ -29,13 +32,19 @@ from tests.web.services.task_interaction_schema_shared import (
     make_user,
 )
 from xagent.core.agent import clarification as clarification_module
-from xagent.core.agent.clarification import ClarificationDraft, ClarificationRequestItem
+from xagent.core.agent.clarification import (
+    ClarificationDraft,
+    ClarificationRequestItem,
+    draft_from_waiting_request,
+)
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
-from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task
 from xagent.web.services import ops_signals
-from xagent.web.services.chat_history_service import get_latest_waiting_question
+from xagent.web.services.chat_history_service import (
+    get_latest_waiting_question,
+    persist_assistant_message,
+)
 from xagent.web.services.task_clarification_draft import (
     CLARIFICATION_REQUEST_TTL,
     FailClosed,
@@ -61,6 +70,18 @@ def _now() -> datetime:
 def _draft(
     *, message: str = "what is your favorite color?", **overrides: Any
 ) -> ClarificationDraft:
+    """Build a :class:`ClarificationDraft` for guard/payload tests that do
+    not care where a draft came from.
+
+    ``turn_marker`` is computed with the real ``_compose_turn_marker`` from
+    whatever ``turn_message_count`` / ``origin_step_id`` / ``requests``
+    this call ends up with (defaults or overrides), rather than pinned to a
+    literal string: a hand-written marker can drift from what
+    ``_compose_turn_marker``'s length-prefixed encoding actually produces
+    (component lengths are on the *filtered* value, not letter-counted by
+    eye) without any test here noticing.
+    """
+
     values: dict[str, Any] = {
         "source": "send_message",
         "message": message,
@@ -70,9 +91,14 @@ def _draft(
         "origin_step_id": "step-1",
         "origin_execution_id": "exec-1",
         "turn_message_count": 3,
-        "turn_marker": "3:3|6:step-1|1:1|6:call-1|6:call-1",
     }
     values.update(overrides)
+    if "turn_marker" not in values:
+        values["turn_marker"] = clarification_module._compose_turn_marker(
+            turn_message_count=values["turn_message_count"],
+            origin_step_id=values["origin_step_id"],
+            requests=values["requests"],
+        )
     return ClarificationDraft(**values)
 
 
@@ -265,15 +291,26 @@ def test_cross_run_anchor_mismatch_still_resolves_as_publishable() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_payload_round_trip_matches_the_legacy_reader_shape(tmp_path: Path) -> None:
+def test_payload_round_trip_matches_the_legacy_reader_shape_for_a_send_message_draft(
+    tmp_path: Path,
+) -> None:
     """``parse_clarification_payload`` must return the exact shape the real
     ``get_latest_waiting_question`` (``chat_history_service.py``) returns
     for the legacy transcript path -- checked against that real function,
-    not against this module's own return-type promise. A version of the
-    legacy reader that returned, say, a dict instead of a list for
-    interactions would be caught here because both readers' actual return
-    values are compared to each other, not merely each checked in
-    isolation against a type it is guaranteed to satisfy by construction."""
+    not against this module's own return-type promise.
+
+    ``send_message`` is the source that actually reaches this comparison
+    with no interactions: its waiting request never carries an
+    ``"interactions"`` key at all (see the ``send_message`` branch of
+    ``ReActPattern._handle_control_tool`` in ``react.py``), so
+    ``draft_from_waiting_request`` always builds it with an empty
+    ``interactions`` tuple, and the websocket outbound-message path that
+    persists the matching chat row (``websocket.py``, the
+    ``expect_response`` branch) never passes an ``interactions`` keyword
+    either, leaving the column ``NULL``. Both readers must call that "no
+    interactions", i.e. ``None`` -- never ``[]``, which would claim a form
+    existed when none did.
+    """
 
     engine = _engine(tmp_path)
     session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -289,24 +326,89 @@ def test_payload_round_trip_matches_the_legacy_reader_shape(tmp_path: Path) -> N
         empty_payload_result = parse_clarification_payload({})
         assert no_question == (None, None)
         assert empty_payload_result == (None, None)
-        assert type(no_question[0]) is type(empty_payload_result[0])
-        assert type(no_question[1]) is type(empty_payload_result[1])
 
-        db.add(
-            TaskChatMessage(
-                task_id=task_id,
-                user_id=user_id,
-                role="assistant",
-                content="pick one",
-                message_type="question",
-                interactions=[{"prompt": "pick one"}],
-            )
+        waiting_request = {
+            "tool_call_id": "call-1",
+            "tool_name": "send_message",
+            "message": "what is your favorite color?",
+            "message_type": "info",
+            "task_text": "pick a color",
+            "message_count": 3,
+        }
+        draft = draft_from_waiting_request(
+            waiting_request, execution_id="exec-1", step_id="step-1"
         )
-        db.commit()
+        assert draft is not None
+        assert draft.source == "send_message"
+        assert draft.interactions == ()
+
+        persist_assistant_message(
+            db,
+            task_id=task_id,
+            user_id=user_id,
+            content=draft.message,
+            message_type="question",
+        )
 
         real_question, real_interactions = get_latest_waiting_question(db, task_id)
+        payload = build_clarification_payload(draft)
+        parsed_question, parsed_interactions = parse_clarification_payload(payload)
 
-        draft = _draft(message="pick one", interactions=({"prompt": "pick one"},))
+        assert type(real_question) is type(parsed_question)
+        assert isinstance(real_question, str) and isinstance(parsed_question, str)
+        assert real_interactions is None
+        assert parsed_interactions is None
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def test_payload_round_trip_matches_the_legacy_reader_shape_for_a_draft_with_interactions(
+    tmp_path: Path,
+) -> None:
+    """The ``ask_user_question`` source is the one whose waiting request
+    always carries a populated ``"interactions"`` key (see the
+    ``ask_user_question`` branch of ``ReActPattern._handle_control_tool``
+    in ``react.py``), and the websocket outbound-message path persists
+    that same list into the chat row's ``interactions`` column. Both
+    readers must return that list back as a list of dicts, not merely
+    each checked in isolation against a type it is guaranteed to satisfy
+    by construction."""
+
+    engine = _engine(tmp_path)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = session_factory()
+    try:
+        user_id = make_user(db)
+        task_id = make_task(db, user_id=user_id)
+
+        interactions = [{"prompt": "pick one"}]
+        waiting_request = {
+            "tool_call_id": "call-1",
+            "tool_name": "ask_user_question",
+            "message": "pick one",
+            "message_type": "question",
+            "interactions": interactions,
+            "task_text": "pick one",
+            "message_count": 5,
+        }
+        draft = draft_from_waiting_request(
+            waiting_request, execution_id="exec-1", step_id="step-1"
+        )
+        assert draft is not None
+        assert draft.source == "ask_user_question"
+        assert draft.interactions == ({"prompt": "pick one"},)
+
+        persist_assistant_message(
+            db,
+            task_id=task_id,
+            user_id=user_id,
+            content=draft.message,
+            message_type="question",
+            interactions=interactions,
+        )
+
+        real_question, real_interactions = get_latest_waiting_question(db, task_id)
         payload = build_clarification_payload(draft)
         parsed_question, parsed_interactions = parse_clarification_payload(payload)
 
@@ -318,6 +420,77 @@ def test_payload_round_trip_matches_the_legacy_reader_shape(tmp_path: Path) -> N
         )
         assert all(isinstance(item, dict) for item in real_interactions)
         assert all(isinstance(item, dict) for item in parsed_interactions)
+        assert real_interactions == parsed_interactions == [{"prompt": "pick one"}]
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def test_payload_round_trip_diverges_from_the_legacy_reader_for_an_empty_form_ask_user_question(
+    tmp_path: Path,
+) -> None:
+    """This pins a known, un-reconciled gap between the two readers, not an
+    ideal contract they are supposed to share.
+
+    An empty-form ``ask_user_question`` call is legal: the source is
+    classified by whether its waiting request carries an ``"interactions"``
+    key at all, not by whether that key's value is non-empty (see
+    ``draft_from_waiting_request``). Carried through the real path --
+    ``_normalize_ask_user_interactions`` in ``react.py`` turns a missing or
+    empty ``interactions`` argument into ``[]``, and ``websocket.py``'s
+    outbound-message handler passes that ``[]`` straight through to
+    ``persist_assistant_message`` because it is a list, not ``None`` -- the
+    persisted row's ``interactions`` column ends up holding an actual empty
+    list, not ``NULL``. ``get_latest_waiting_question`` therefore returns
+    ``[]`` for this row. ``parse_clarification_payload`` still normalizes
+    every empty case to ``None``, so the two readers disagree here: ``[]``
+    on the legacy side, ``None`` on this module's side. That is today's
+    actual behavior, asserted as such -- not a bug this test is waiting to
+    catch.
+    """
+
+    engine = _engine(tmp_path)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = session_factory()
+    try:
+        user_id = make_user(db)
+        task_id = make_task(db, user_id=user_id)
+
+        waiting_request = {
+            "tool_call_id": "call-1",
+            "tool_name": "ask_user_question",
+            "message": "anything else?",
+            "message_type": "question",
+            "interactions": [],
+            "task_text": "anything else?",
+            "message_count": 5,
+        }
+        draft = draft_from_waiting_request(
+            waiting_request, execution_id="exec-1", step_id="step-1"
+        )
+        assert draft is not None
+        assert draft.source == "ask_user_question"
+        assert draft.interactions == ()
+
+        # Mirrors the real websocket outbound-message path: metadata's
+        # "interactions" is a list ([]), so it is passed through as [],
+        # not None -- the persisted column ends up [], not NULL.
+        persist_assistant_message(
+            db,
+            task_id=task_id,
+            user_id=user_id,
+            content=draft.message,
+            message_type="question",
+            interactions=[],
+        )
+
+        real_question, real_interactions = get_latest_waiting_question(db, task_id)
+        payload = build_clarification_payload(draft)
+        parsed_question, parsed_interactions = parse_clarification_payload(payload)
+
+        assert isinstance(real_question, str) and isinstance(parsed_question, str)
+        assert real_interactions == []
+        assert parsed_interactions is None
     finally:
         db.close()
         engine.dispose()
@@ -366,11 +539,18 @@ def test_oversized_interactions_are_dropped_entirely() -> None:
 
 
 def test_payload_still_too_large_after_truncation_is_not_applicable() -> None:
+    """Only ``tool_waiting`` -- the multi-tool waiting point -- can
+    realistically produce thousands of ``requests`` entries;
+    ``send_message`` and ``ask_user_question`` always contribute exactly
+    one (see ``ClarificationDraft.requests``'s docstring), so a
+    ``send_message`` draft with 6000 requests is not a shape production
+    can ever hand this function."""
+
     many_requests = tuple(
         ClarificationRequestItem(f"tool-{i}", f"call-{i}", f"call-{i}")
         for i in range(6000)
     )
-    draft = _draft(requests=many_requests)
+    draft = _draft(source="tool_waiting", requests=many_requests)
     result = {"status": "waiting_for_user", "clarification_draft": draft}
     resolution = resolve_publishable_clarification(
         result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -3,11 +3,14 @@
 Pure-function coverage (guard order, payload construction, idempotency key
 derivation) needs no database at all: every argument
 ``resolve_publishable_clarification`` takes is an in-memory value the
-caller already holds. The one exception is the cross-run anchor scenario,
-which stages a real interaction row through ``interaction_handoff`` to
-confirm the downstream primitive -- not this module -- is what degrades a
-cross-run mismatch; that one test opens a private SQLite database the same
-way the interaction-staging suite does.
+caller already holds. Two tests are the exceptions, each opening a private
+SQLite database the same way the interaction-staging suite does: the
+cross-run anchor scenario, which stages a real interaction row through
+``interaction_handoff`` to confirm the downstream primitive -- not this
+module -- is what degrades a cross-run mismatch; and the payload/legacy-
+reader shape comparison, which calls the real
+``get_latest_waiting_question`` against a persisted chat message rather
+than checking this module's own output against itself.
 """
 
 from __future__ import annotations
@@ -28,9 +31,11 @@ from tests.web.services.task_interaction_schema_shared import (
 from xagent.core.agent import clarification as clarification_module
 from xagent.core.agent.clarification import ClarificationDraft, ClarificationRequestItem
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task
 from xagent.web.services import ops_signals
+from xagent.web.services.chat_history_service import get_latest_waiting_question
 from xagent.web.services.task_clarification_draft import (
     CLARIFICATION_REQUEST_TTL,
     FailClosed,
@@ -260,20 +265,62 @@ def test_cross_run_anchor_mismatch_still_resolves_as_publishable() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_payload_round_trip_matches_the_legacy_reader_shape() -> None:
-    """``parse_clarification_payload`` must return the exact
-    ``(str | None, list[dict] | None)`` shape
-    ``get_latest_waiting_question`` (``chat_history_service.py``) already
-    returns for the legacy transcript path -- the two readers must be
-    interchangeable from a caller's point of view."""
+def test_payload_round_trip_matches_the_legacy_reader_shape(tmp_path: Path) -> None:
+    """``parse_clarification_payload`` must return the exact shape the real
+    ``get_latest_waiting_question`` (``chat_history_service.py``) returns
+    for the legacy transcript path -- checked against that real function,
+    not against this module's own return-type promise. A version of the
+    legacy reader that returned, say, a dict instead of a list for
+    interactions would be caught here because both readers' actual return
+    values are compared to each other, not merely each checked in
+    isolation against a type it is guaranteed to satisfy by construction."""
 
-    draft = _draft(interactions=({"prompt": "pick one"},))
-    payload = build_clarification_payload(draft)
-    question, interactions = parse_clarification_payload(payload)
-    assert question == draft.message
-    assert interactions == [{"prompt": "pick one"}]
-    assert isinstance(question, (str, type(None)))
-    assert isinstance(interactions, (list, type(None)))
+    engine = _engine(tmp_path)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = session_factory()
+    try:
+        user_id = make_user(db)
+        task_id = make_task(db, user_id=user_id)
+
+        # No question persisted yet: the legacy reader's "nothing found"
+        # branch must agree in shape with the parser's "empty payload"
+        # branch.
+        no_question = get_latest_waiting_question(db, task_id)
+        empty_payload_result = parse_clarification_payload({})
+        assert no_question == (None, None)
+        assert empty_payload_result == (None, None)
+        assert type(no_question[0]) is type(empty_payload_result[0])
+        assert type(no_question[1]) is type(empty_payload_result[1])
+
+        db.add(
+            TaskChatMessage(
+                task_id=task_id,
+                user_id=user_id,
+                role="assistant",
+                content="pick one",
+                message_type="question",
+                interactions=[{"prompt": "pick one"}],
+            )
+        )
+        db.commit()
+
+        real_question, real_interactions = get_latest_waiting_question(db, task_id)
+
+        draft = _draft(message="pick one", interactions=({"prompt": "pick one"},))
+        payload = build_clarification_payload(draft)
+        parsed_question, parsed_interactions = parse_clarification_payload(payload)
+
+        assert type(real_question) is type(parsed_question)
+        assert type(real_interactions) is type(parsed_interactions)
+        assert isinstance(real_question, str) and isinstance(parsed_question, str)
+        assert isinstance(real_interactions, list) and isinstance(
+            parsed_interactions, list
+        )
+        assert all(isinstance(item, dict) for item in real_interactions)
+        assert all(isinstance(item, dict) for item in parsed_interactions)
+    finally:
+        db.close()
+        engine.dispose()
 
 
 def test_idempotency_key_matches_the_command_id_pattern() -> None:

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -1,0 +1,506 @@
+"""Behavior tests for ``task_clarification_draft.py``.
+
+Pure-function coverage (guard order, payload construction, idempotency key
+derivation) needs no database at all: every argument
+``resolve_publishable_clarification`` takes is an in-memory value the
+caller already holds. The one exception is the cross-run anchor scenario,
+which stages a real interaction row through ``interaction_handoff`` to
+confirm the downstream primitive -- not this module -- is what degrades a
+cross-run mismatch; that one test opens a private SQLite database the same
+way the interaction-staging suite does.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from tests.web.services.task_interaction_schema_shared import (
+    make_task,
+    make_trace_event,
+    make_user,
+)
+from xagent.core.agent import clarification as clarification_module
+from xagent.core.agent.clarification import ClarificationDraft, ClarificationRequestItem
+from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task
+from xagent.web.services import ops_signals
+from xagent.web.services.task_clarification_draft import (
+    CLARIFICATION_REQUEST_TTL,
+    FailClosed,
+    NotApplicable,
+    Publishable,
+    build_clarification_payload,
+    clarification_idempotency_key,
+    parse_clarification_payload,
+    resolve_publishable_clarification,
+)
+from xagent.web.services.task_command_transport import COMMAND_ID_PATTERN
+from xagent.web.services.task_interaction_staging import (
+    InteractionAnchor,
+    interaction_handoff,
+)
+from xagent.web.services.task_lease_service import TaskLease
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _draft(
+    *, message: str = "what is your favorite color?", **overrides: Any
+) -> ClarificationDraft:
+    values: dict[str, Any] = {
+        "source": "send_message",
+        "message": message,
+        "message_type": "info",
+        "interactions": (),
+        "requests": (ClarificationRequestItem("respond", "call-1", "call-1"),),
+        "origin_step_id": "step-1",
+        "origin_execution_id": "exec-1",
+        "turn_message_count": 3,
+        "turn_marker": "3:3|6:step-1|1:1|6:call-1|6:call-1",
+    }
+    values.update(overrides)
+    return ClarificationDraft(**values)
+
+
+def _task(**overrides: Any) -> Task:
+    values: dict[str, Any] = {
+        "id": 1,
+        "runner_id": "runner-a",
+        "run_id": "run-a",
+        "lease_attempt_id": "attempt-a",
+    }
+    values.update(overrides)
+    return Task(**values)
+
+
+def _lease(**overrides: Any) -> TaskLease:
+    values: dict[str, Any] = {
+        "task_id": 1,
+        "runner_id": "runner-a",
+        "run_id": "run-a",
+        "attempt_id": "attempt-a",
+    }
+    values.update(overrides)
+    return TaskLease(**values)
+
+
+def _anchor(**overrides: Any) -> InteractionAnchor:
+    values: dict[str, Any] = {
+        "trace_event_id": 42,
+        "resume_event_id": "resume-event-1",
+        "resume_execution_id": "resume-exec-1",
+        "resume_run_partition": "run-a",
+    }
+    values.update(overrides)
+    return InteractionAnchor(**values)
+
+
+@pytest.fixture(autouse=True)
+def _reset_ops_signals():
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+    yield
+    for name in list(ops_signals.active_degradations()):
+        ops_signals.clear_degradation(name)
+
+
+# ---------------------------------------------------------------------------
+# The four-way pairing between run status and draft presence
+# ---------------------------------------------------------------------------
+
+
+def test_waiting_with_draft_is_publishable() -> None:
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, Publishable)
+    assert resolution.fail_closed_reason is None
+
+
+def test_waiting_without_draft_fails_closed_as_missing_draft() -> None:
+    result = {"status": "waiting_for_user"}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "missing_draft"
+
+
+def test_non_waiting_with_draft_fails_closed_as_draft_status_mismatch() -> None:
+    result = {"status": "completed", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "draft_status_mismatch"
+
+
+def test_non_waiting_without_draft_is_not_applicable() -> None:
+    result = {"status": "completed"}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, NotApplicable)
+    assert resolution.reason is None
+    assert resolution.fail_closed_reason is None
+
+
+# ---------------------------------------------------------------------------
+# The remaining guards, each in isolation
+# ---------------------------------------------------------------------------
+
+
+def test_unfenced_lease_fails_closed() -> None:
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(run_id=None), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "unfenced_lease"
+
+
+def test_ownership_changed_fails_closed() -> None:
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result,
+        task=_task(runner_id="someone-else"),
+        lease=_lease(),
+        anchor=_anchor(),
+        now=_now(),
+    )
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "ownership_changed"
+
+
+def test_attempt_mismatch_fails_closed() -> None:
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result,
+        task=_task(lease_attempt_id="a-later-attempt"),
+        lease=_lease(),
+        anchor=_anchor(),
+        now=_now(),
+    )
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "attempt_mismatch"
+
+
+def test_guards_run_most_specific_failure_first() -> None:
+    """When ownership *and* attempt identity are both wrong on the same
+    input, the ownership check must win -- it comes first in the guard
+    sequence because it is the more specific, less data-exposing failure.
+    A resolver that checked attempt identity before ownership would report
+    the wrong classification here even though both are genuinely wrong."""
+
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result,
+        task=_task(runner_id="someone-else", lease_attempt_id="a-later-attempt"),
+        lease=_lease(),
+        anchor=_anchor(),
+        now=_now(),
+    )
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "ownership_changed"
+
+
+def test_none_attempt_id_skips_the_attempt_guard() -> None:
+    """``lease.attempt_id is None`` cannot prove attempt identity at all and
+    must be treated as "skip this check", never as "matches" -- the same
+    reading ``interaction_handoff`` uses for the identical sentinel."""
+
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result,
+        task=_task(lease_attempt_id="whatever-is-on-the-row"),
+        lease=_lease(attempt_id=None),
+        anchor=_anchor(),
+        now=_now(),
+    )
+    assert isinstance(resolution, Publishable)
+
+
+def test_missing_anchor_is_not_applicable_not_fail_closed() -> None:
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=None, now=_now()
+    )
+    assert isinstance(resolution, NotApplicable)
+    assert resolution.reason == "no_anchor"
+
+
+def test_cross_run_anchor_mismatch_still_resolves_as_publishable() -> None:
+    """A cross-run anchor is not rejected by this module -- that check was
+    deliberately moved to ``interaction_handoff``, which owns a dedicated
+    exception and degradation signal for exactly this mismatch."""
+
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        result,
+        task=_task(),
+        lease=_lease(),
+        anchor=_anchor(resume_run_partition="a-different-run"),
+        now=_now(),
+    )
+    assert isinstance(resolution, Publishable)
+
+
+# ---------------------------------------------------------------------------
+# Payload construction and parsing
+# ---------------------------------------------------------------------------
+
+
+def test_payload_round_trip_matches_the_legacy_reader_shape() -> None:
+    """``parse_clarification_payload`` must return the exact
+    ``(str | None, list[dict] | None)`` shape
+    ``get_latest_waiting_question`` (``chat_history_service.py``) already
+    returns for the legacy transcript path -- the two readers must be
+    interchangeable from a caller's point of view."""
+
+    draft = _draft(interactions=({"prompt": "pick one"},))
+    payload = build_clarification_payload(draft)
+    question, interactions = parse_clarification_payload(payload)
+    assert question == draft.message
+    assert interactions == [{"prompt": "pick one"}]
+    assert isinstance(question, (str, type(None)))
+    assert isinstance(interactions, (list, type(None)))
+
+
+def test_idempotency_key_matches_the_command_id_pattern() -> None:
+    draft = _draft()
+    key = clarification_idempotency_key(draft)
+    assert COMMAND_ID_PATTERN.fullmatch(key) is not None
+    assert key.startswith("clarification.")
+    assert len(key) == 46
+
+
+def test_idempotency_key_ignores_message_content() -> None:
+    """The key is derived only from ``turn_marker``; changing ``message``
+    (including via truncation) must never change it."""
+
+    base = _draft(message="short")
+    changed = _draft(message="a completely different, much longer question")
+    assert clarification_idempotency_key(base) == clarification_idempotency_key(changed)
+
+
+def test_oversized_question_is_truncated_and_the_idempotency_key_is_unaffected() -> (
+    None
+):
+    long_question = "q" * (32 * 1024)
+    draft = _draft(message=long_question)
+    payload = build_clarification_payload(draft)
+    assert payload["question_truncated"] is True
+    assert len(payload["question"].encode("utf-8")) <= 16 * 1024
+    assert payload["question"] != long_question
+
+    key_before = clarification_idempotency_key(draft)
+    truncated_variant = _draft(message=long_question[: len(long_question) // 2])
+    key_after = clarification_idempotency_key(truncated_variant)
+    assert key_before == key_after
+
+
+def test_oversized_interactions_are_dropped_entirely() -> None:
+    huge_interactions = tuple({"field": "x" * 2000, "index": i} for i in range(64))
+    draft = _draft(interactions=huge_interactions)
+    payload = build_clarification_payload(draft)
+    assert payload["interactions_dropped"] is True
+    assert payload["interactions"] == []
+    assert payload["question"] == draft.message
+
+
+def test_payload_still_too_large_after_truncation_is_not_applicable() -> None:
+    many_requests = tuple(
+        ClarificationRequestItem(f"tool-{i}", f"call-{i}", f"call-{i}")
+        for i in range(6000)
+    )
+    draft = _draft(requests=many_requests)
+    result = {"status": "waiting_for_user", "clarification_draft": draft}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, NotApplicable)
+    assert resolution.reason == "payload_too_large"
+
+
+def test_question_emptied_by_character_filtering_is_not_applicable() -> None:
+    draft = _draft(message="\x00\x01\x02\x1f")
+    result = {"status": "waiting_for_user", "clarification_draft": draft}
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, NotApplicable)
+    assert resolution.reason == "empty_question"
+
+
+def test_character_domain_matches_the_marker_cleaning_domain() -> None:
+    """This module's own character filter and
+    ``clarification.py``'s marker-cleaning filter cannot share code (the
+    core layer never imports the web layer), so both copies must agree on
+    every probe string here or the two have silently drifted apart."""
+
+    from xagent.web.services.task_clarification_draft import (
+        _strip_control_characters,
+    )
+
+    probes = [
+        "plain text",
+        "line one\nline two",
+        "tab\tseparated",
+        "carriage\rreturn",
+        "null\x00byte",
+        "unit separator\x1f",
+        "bell\x07character",
+        "",
+    ]
+    for probe in probes:
+        assert _strip_control_characters(probe) == clarification_module._marker_clean(
+            probe
+        ), probe
+
+
+def test_expires_at_is_now_plus_the_ttl_constant() -> None:
+    result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    now = _now()
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=now
+    )
+    assert isinstance(resolution, Publishable)
+    assert resolution.expires_at == now + CLARIFICATION_REQUEST_TTL
+
+
+# ---------------------------------------------------------------------------
+# The multiple-drafts degradation signal
+# ---------------------------------------------------------------------------
+
+
+def test_single_waiting_step_does_not_register_the_multiple_drafts_signal() -> None:
+    result = {
+        "status": "waiting_for_user",
+        "clarification_draft": _draft(),
+        "clarification_superseded_step_ids": [],
+    }
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, Publishable)
+    assert (
+        ops_signals.CLARIFICATION_MULTIPLE_DRAFTS
+        not in ops_signals.active_degradations()
+    )
+
+
+def test_superseded_steps_register_the_multiple_drafts_signal_and_it_stays_up() -> None:
+    """Registering the signal is not undone by the very publish that
+    reports it: a successful publish this round does not erase the fact
+    that a sibling step's draft was discarded this round, so the signal
+    must still be registered once ``resolve_publishable_clarification``
+    returns."""
+
+    result = {
+        "status": "waiting_for_user",
+        "clarification_draft": _draft(),
+        "clarification_superseded_step_ids": ["step-2"],
+    }
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, Publishable)
+    assert (
+        ops_signals.CLARIFICATION_MULTIPLE_DRAFTS in ops_signals.active_degradations()
+    )
+
+
+def test_missing_draft_registers_and_a_later_publish_clears_it() -> None:
+    missing_result = {"status": "waiting_for_user"}
+    resolve_publishable_clarification(
+        missing_result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert ops_signals.CLARIFICATION_DRAFT_MISSING in ops_signals.active_degradations()
+
+    clean_result = {"status": "waiting_for_user", "clarification_draft": _draft()}
+    resolution = resolve_publishable_clarification(
+        clean_result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, Publishable)
+    assert (
+        ops_signals.CLARIFICATION_DRAFT_MISSING not in ops_signals.active_degradations()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-run anchor: this module lets it through; the staging primitive
+# downstream is what actually degrades it.
+# ---------------------------------------------------------------------------
+
+
+def _engine(tmp_path: Path):
+    db_path = tmp_path / "clarification_draft.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    apply_sqlite_concurrency_pragmas(engine)
+    Base.metadata.create_all(bind=engine)
+    return engine
+
+
+def test_cross_run_anchor_mismatch_degrades_downstream_in_the_staging_primitive(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path)
+    session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = session_factory()
+    try:
+        user_id = make_user(db)
+        task_id = make_task(db, user_id=user_id)
+        anchor_trace_event_id = make_trace_event(db, task_id=task_id)
+
+        task = db.get(Task, task_id)
+        task.runner_id = "runner-a"
+        task.run_id = "run-a"
+        db.flush([task])
+
+        lease = TaskLease(
+            task_id=task_id, runner_id="runner-a", run_id="run-a", attempt_id=None
+        )
+        draft = _draft()
+        result = {"status": "waiting_for_user", "clarification_draft": draft}
+        mismatched_anchor = _anchor(
+            trace_event_id=anchor_trace_event_id, resume_run_partition="a-different-run"
+        )
+
+        resolution = resolve_publishable_clarification(
+            result, task=task, lease=lease, anchor=mismatched_anchor, now=_now()
+        )
+        assert isinstance(resolution, Publishable)
+
+        with interaction_handoff(
+            db, lease, task=task, anchor=mismatched_anchor, now=_now()
+        ) as handoff:
+            handoff.stage(
+                kind="clarification",
+                protocol_version=1,
+                request_payload=resolution.request_payload,
+                request_idempotency_key=resolution.request_idempotency_key,
+                expires_at=resolution.expires_at,
+            )
+        db.rollback()
+
+        assert (
+            ops_signals.INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED
+            in ops_signals.active_degradations()
+        )
+        assert (
+            ops_signals.INTERACTION_HANDOFF_DEGRADED
+            not in ops_signals.active_degradations()
+        )
+    finally:
+        db.close()
+        engine.dispose()


### PR DESCRIPTION
Resolves the publication question for a clarification draft attached to a finalizing run: given the task row, lease, and resume anchor a caller already holds, can this run's draft become a structured, durable interaction request?

The answer is one of three outcomes. It can be published, in which case the resolver hands back the exact arguments the interaction-staging primitive's `stage()` call needs. It can be not applicable for this round -- either because the run was never a waiting-for-user turn with a draft attached, or because a waiting draft exists but could not be safely turned into a payload (no resume anchor, or the payload could not fit the character and size limits). Or it can be fail-closed, which covers two situations with two different consequences for the round itself (see below): a draft turned up on a run that was not waiting, or the lease that produced this result can no longer speak for the task row -- unfenced, no longer the row's owner, or superseded by a later attempt.

Guard order is the contract. Checks run in a fixed sequence, from most specific to least: does the run's status agree with whether a draft is attached; is the lease fenced to a real run; does the task row still belong to that lease's runner and run; does the lease's attempt still match the task's current attempt; does a resume anchor exist; does the constructed payload fit the character domain and size limits. The size and character checks run last because they are the only ones that need the payload built first.

Three of the guards discard a run's settlement wholesale when they fail: an unfenced lease, a task row no longer owned by the lease that produced this result, and an attempt that is no longer current. Every other unsatisfied guard -- including a waiting run with no draft to publish, or a non-waiting run that stray-carries one -- means no structured row gets written this round, but the round itself is not discarded: whatever a finalizer already does for that situation keeps working exactly as it does today.

The payload's construction and parsing live together in one module, and reading it back always goes through the parser here rather than through ad hoc key access, so a future protocol version only needs one new branch. As long as the payload stays version 1, only optional fields may be added to it; renaming, retyping, or removing a field requires bumping the version and giving the parser an explicit branch for the old shape.

The idempotency key is derived from the draft's own content -- specifically the same turn marker the core draft type already produces -- rather than from the resume anchor. A resume anchor changes on every re-entrant checkpoint of the same turn, which would turn a replay that should cost nothing into a brand-new request each time. Deriving the key from content instead means the same question, asked again during the same turn, keeps requesting under the same key.

This change has no production caller. A static test enforces that directly, matching the equivalent gate already in place for the interaction-staging primitive it builds on. The module exists so that whichever change wires up the finalizers has a resolver to call; nothing in this change makes that call itself.
