### PR TITLE
fix(mcp): start the per-server OAuth flow for custom mcp_oauth connectors

### DIFF
--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -158,6 +158,9 @@ vi.mock("./official-mcp-settings-dialog", () => ({
       <button type="button" onClick={() => onConnectStart(mcpOauthApp())}>
         connect-granola
       </button>
+      <button type="button" onClick={() => onConnectStart(customMcpOauthApp())}>
+        connect-records
+      </button>
       <button type="button" onClick={() => onConnectStart(keylessApp())}>
         connect-chrome
       </button>
@@ -231,6 +234,25 @@ function mcpOauthApp() {
     description: "",
     icon: "",
     is_connected: false,
+    transport: "streamable_http",
+    auth_type: "mcp_oauth",
+  }
+}
+
+// A user-added mcp_oauth MCP server whose consent was never completed: it is
+// listed under location=local with a server_id, and authorizing it must go
+// through the per-server /api/mcp/{server_id}/oauth/connect — the catalog
+// route resolves app ids only and can never see it (#1313).
+function customMcpOauthApp() {
+  return {
+    id: "records",
+    name: "records",
+    description: "",
+    icon: "",
+    is_connected: false,
+    is_custom: true,
+    is_local: true,
+    server_id: 9,
     transport: "streamable_http",
     auth_type: "mcp_oauth",
   }
@@ -509,6 +531,102 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       expect(toastErrorMock).not.toHaveBeenCalled()
     } finally {
       openSpy.mockRestore()
+    }
+  })
+
+  it("connects a custom mcp_oauth server through the per-server oauth/connect endpoint", async () => {
+    // #1313: this Connect button used to be unreachable — local entries
+    // carried no auth_type, so the dispatch fell through to the
+    // mis-authored-entry toast. With the hint in place it must also avoid
+    // the catalog route: /api/mcp/apps/{id}/oauth/connect resolves catalog
+    // app ids only and would 404 on a user-added server.
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    try {
+      apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        if (url === "http://api.local/api/mcp/9/oauth/connect") {
+          expect(options?.method).toBe("POST")
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.example.com/authorize" }),
+          })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      renderDialog()
+      fireEvent.click(screen.getByRole("button", { name: "connect-records" }))
+
+      await waitFor(() => {
+        expect(popup.location.href).toBe("https://auth.example.com/authorize")
+      })
+      expect(popup.close).not.toHaveBeenCalled()
+      expect(toastErrorMock).not.toHaveBeenCalled()
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
+  it("rechecks a closed custom mcp_oauth popup against the local listing", async () => {
+    // The popup's opener link is severed, so a closed popup is ambiguous and
+    // the handler asks the backend what actually happened. A custom server
+    // only exists under location=local — querying the remote branch (as the
+    // catalog path does) would report every custom connect as a failure.
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    const onSuccess = vi.fn()
+    let localListCalls = 0
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === "http://api.local/api/mcp/9/oauth/connect") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.example.com/authorize" }),
+          })
+        }
+        if (url === "http://api.local/api/mcp/apps?location=local") {
+          localListCalls += 1
+          return Promise.resolve({
+            ok: true,
+            json: async () => [{ ...customMcpOauthApp(), is_connected: true }],
+          })
+        }
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+
+      // Fake timers only from here on: the poll's setInterval must be created
+      // under them to be advanceable, and @testing-library's async queries
+      // hang once they are active.
+      vi.useFakeTimers()
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "connect-records" }))
+      })
+
+      popup.closed = true
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500)
+      })
+
+      expect(localListCalls).toBe(1)
+      expect(onSuccess).toHaveBeenCalled()
+    } finally {
+      openSpy.mockRestore()
+      vi.useRealTimers()
     }
   })
 

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -630,6 +630,93 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     }
   })
 
+  // Pins the ordering the F5 fix depends on: a dialog close must beat a
+  // still-in-flight connect POST that resolves afterwards. isMountedRef
+  // alone cannot see this — it only flips false on unmount, and both real
+  // consumers of this dialog keep the component mounted across open/close
+  // (only the `open` prop toggles), so isMountedRef.current is still true
+  // here. Before the fix, that made the post-await guard pass regardless of
+  // the close, registering a poll after clearMcpOauthPollState() had already
+  // run — a poll nothing would ever clear, which would go on to recheck
+  // location=local and fire onSuccess against a dialog the user already
+  // closed.
+  it("skips registering a poll when the dialog closes before the connect POST resolves", async () => {
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    const onSuccess = vi.fn()
+    let localListCalls = 0
+    const connectResponse = deferred<{ ok: boolean; json: () => Promise<{ authorization_url: string }> }>()
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url === "http://api.local/api/mcp/9/oauth/connect") {
+          return connectResponse.promise
+        }
+        if (url === "http://api.local/api/mcp/apps?location=local") {
+          localListCalls += 1
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      const { rerender } = render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+
+      // Fake timers from here on, same as the recheck test above: the poll's
+      // setInterval (if one is wrongly registered) must be created under
+      // them to be advanceable, and this test issues no further async
+      // queries that would hang once they are active.
+      vi.useFakeTimers()
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "connect-records" }))
+      })
+
+      // Close the dialog while the connect POST above is still unresolved —
+      // only the `open` prop changes, so the component itself stays mounted
+      // and isMountedRef never flips. This is what runs
+      // clearMcpOauthPollState() and bumps the generation counter, ahead of
+      // the POST settling.
+      await act(async () => {
+        rerender(
+          <ConnectMcpDialog
+            open={false}
+            onOpenChange={vi.fn()}
+            selectedMcpServers={selectedMcpServers}
+            onSuccess={onSuccess}
+          />,
+        )
+      })
+
+      await act(async () => {
+        connectResponse.resolve({
+          ok: true,
+          json: async () => ({ authorization_url: "https://auth.example.com/authorize" }),
+        })
+        await connectResponse.promise
+      })
+
+      popup.closed = true
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500)
+      })
+
+      expect(localListCalls).toBe(0)
+      expect(onSuccess).not.toHaveBeenCalled()
+    } finally {
+      openSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("fires exactly one POST when a keyless connect is double-clicked in the same tick", async () => {
     // Round-9: keylessConnectsRef's guard had zero test coverage — removing
     // its .has()/.add() calls would leave every other test green. Without

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -710,12 +710,27 @@ export function ConnectMcpDialog({
     }
   }
 
-  // Remote-MCP OAuth catalog app (e.g. Granola): the backend ensures the
-  // shared server row + this user's association, runs Dynamic Client
-  // Registration when the provider has no static client, and returns the
-  // authorization URL. Mirrors custom-mcp-form's handleConnectMcpOAuth,
-  // but keyed by catalog app_id instead of a server id.
+  // A user-added (custom) MCP server is authorized per server row, not per
+  // catalog app id: /api/mcp/apps/{id}/oauth/connect resolves the catalog and
+  // nothing else, so custom servers must drive the per-server endpoint the
+  // custom MCP edit form already uses (#1313). Null for catalog apps.
+  const customMcpServerId = (app: AppIntegration): number | null =>
+    app.is_custom && Number.isInteger(app.server_id) ? (app.server_id as number) : null
+
+  // Remote-MCP OAuth app: the backend ensures the server row + this user's
+  // association, runs Dynamic Client Registration when the provider has no
+  // static client, and returns the authorization URL. Mirrors
+  // custom-mcp-form's handleConnectMcpOAuth. Serves both a catalog app
+  // (e.g. Granola), keyed by app_id, and a custom server, keyed by server id.
   const handleConnectMcpOAuthApp = async (app: AppIntegration, autoSelect: boolean) => {
+    const serverId = customMcpServerId(app)
+    const connectUrl = serverId === null
+      ? `${getApiUrl()}/api/mcp/apps/${app.id}/oauth/connect`
+      : `${getApiUrl()}/api/mcp/${serverId}/oauth/connect`
+    // The post-consent recheck below has to query the same listing branch the
+    // entry came from: a custom server only appears under location=local, so
+    // asking for remote would report every custom connect as a failure.
+    const refreshLocation = serverId === null ? "remote" : "local"
     markAppLoading(app.id)
     // Open the popup synchronously on the click, before any await — popup
     // blockers reject windows opened outside direct user-gesture handling.
@@ -737,7 +752,7 @@ export function ConnectMcpDialog({
     }
     popup.opener = null
     try {
-      const response = await apiRequest(`${getApiUrl()}/api/mcp/apps/${app.id}/oauth/connect`, {
+      const response = await apiRequest(connectUrl, {
         method: "POST",
         credentials: "include",
         headers: {
@@ -799,7 +814,7 @@ export function ConnectMcpDialog({
       void (async () => {
         let connected = false
         try {
-          const response = await apiRequest(`${getApiUrl()}/api/mcp/apps?location=remote`)
+          const response = await apiRequest(`${getApiUrl()}/api/mcp/apps?location=${refreshLocation}`)
           if (response.ok) {
             const data = sanitizeAppIntegrations(await response.json())
             connected = data.some(
@@ -826,8 +841,8 @@ export function ConnectMcpDialog({
   const handleConnectApp = (app: AppIntegration, autoSelect: boolean = false) => {
     if (app.auth_type !== "builtin_oauth") {
       // Key-based catalog app: collect the key; keyless app: connect directly;
-      // remote-MCP OAuth app: start the per-user OAuth (DCR) flow. Anything
-      // else is a mis-authored entry.
+      // remote-MCP OAuth app (catalog or user-added custom server): start the
+      // per-user OAuth (DCR) flow. Anything else is a mis-authored entry.
       if (app.auth_type === "api_key") {
         openKeyConnect(app);
       } else if (app.auth_type === "keyless") {

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -178,6 +178,18 @@ export function ConnectMcpDialog({
   // in-flight connect POST that resolves after the dialog (or the whole
   // component) is gone doesn't register a poll nothing will ever clear.
   const isMountedRef = React.useRef(true)
+  // F5 (close case): isMountedRef only flips on unmount, but both consumers
+  // of this dialog keep the component mounted across open/close — only the
+  // `open` prop changes. Checking `open` itself would be decorative here:
+  // it's a prop captured in handleConnectMcpOAuthApp's per-render closure,
+  // so by the time the async function resumes after the connect POST it's
+  // reading a stale value, same as the `|| !open` checks above. Instead this
+  // generation counter is bumped every time clearMcpOauthPollState() tears
+  // down poll state (dialog-close branch and unmount cleanup alike), so a
+  // connect POST that resolves after either teardown can tell its captured
+  // generation is stale and bail out before registering a poll nothing will
+  // ever clear.
+  const mcpOauthPollGenerationRef = React.useRef(0)
 
   // Custom MCP Server state
   const [isSavingCustom, setIsSavingCustom] = useState(false)
@@ -298,6 +310,10 @@ export function ConnectMcpDialog({
     // of which app(s) they belonged to, so it clears every in-flight app,
     // not just one.
     setLoadingApps(new Set())
+    // F5 (close case): bump so any handleConnectMcpOAuthApp call that
+    // captured the generation before this teardown ran can detect it's
+    // stale and skip registering a new poll.
+    mcpOauthPollGenerationRef.current += 1
   }
 
   useEffect(() => {
@@ -723,6 +739,10 @@ export function ConnectMcpDialog({
   // custom-mcp-form's handleConnectMcpOAuth. Serves both a catalog app
   // (e.g. Granola), keyed by app_id, and a custom server, keyed by server id.
   const handleConnectMcpOAuthApp = async (app: AppIntegration, autoSelect: boolean) => {
+    // F5 (close case): captured before the popup opens and before any await,
+    // so it reflects poll state as of this click — not a stale closure value
+    // read after the dialog has since closed and reopened.
+    const pollGeneration = mcpOauthPollGenerationRef.current
     const serverId = customMcpServerId(app)
     const connectUrl = serverId === null
       ? `${getApiUrl()}/api/mcp/apps/${app.id}/oauth/connect`
@@ -783,13 +803,18 @@ export function ConnectMcpDialog({
       clearAppLoading(app.id)
       return
     }
-    // F5: if the dialog closed (or this component unmounted) while the
-    // connect POST was in flight, don't register a poll after the cleanup
-    // effects have already run — it would never get cleared. The popup
-    // itself is left navigating to the authorization URL either way; the
-    // user can still complete auth in it, and the next apps refresh (e.g.
-    // reopening the dialog) will reflect it.
-    if (!isMountedRef.current) return
+    // F5: don't register a poll after the cleanup effects have already run
+    // — it would never get cleared. isMountedRef only covers the unmount
+    // case (the whole component gone); it stays true across an ordinary
+    // dialog close since both consumers keep this component mounted and
+    // only toggle the `open` prop. The close case — including a
+    // close-then-reopen while this POST was in flight — is instead covered
+    // by comparing the generation captured above against the counter, which
+    // clearMcpOauthPollState() bumps on every teardown (close branch and
+    // unmount alike). The popup itself is left navigating to the
+    // authorization URL either way; the user can still complete auth in it,
+    // and the next apps refresh (e.g. reopening the dialog) will reflect it.
+    if (!isMountedRef.current || pollGeneration !== mcpOauthPollGenerationRef.current) return
 
     // The popup's opener link is severed (popup.opener = null), so unlike the
     // builtin flow there is no postMessage channel — and a closed popup can

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1823,6 +1823,20 @@ def _connected_non_oauth_server_for_app(
     return cast(int, server.id)
 
 
+def _is_mcp_oauth_server(server: MCPServer) -> bool:
+    """Whether a stored server row is authorized through per-user MCP OAuth.
+
+    The shape check behind both the connection-state gate below and the
+    connector picker's `auth_type` hint, so the field that decides which
+    Connect flow the picker starts can't disagree with the field that decides
+    whether the server counts as connected."""
+    auth: dict[str, Any] = server.auth if isinstance(server.auth, dict) else {}
+    return (
+        str(server.transport or "").lower() in HTTP_MCP_TRANSPORTS
+        and auth.get("type") == "mcp_oauth"
+    )
+
+
 def _mcp_oauth_server_is_actually_connected(
     server: MCPServer, active_grant_server_ids: set[int]
 ) -> bool:
@@ -1833,11 +1847,7 @@ def _mcp_oauth_server_is_actually_connected(
     branch — shared so every code path that reports connection state for an
     mcp_oauth server (including the location=local/all branch, which used to
     bypass this check entirely) agrees (F1)."""
-    auth: dict[str, Any] = server.auth if isinstance(server.auth, dict) else {}
-    if (
-        str(server.transport or "").lower() not in HTTP_MCP_TRANSPORTS
-        or auth.get("type") != "mcp_oauth"
-    ):
+    if not _is_mcp_oauth_server(server):
         return True
     return cast(int, server.id) in active_grant_server_ids
 
@@ -2015,28 +2025,43 @@ def list_mcp_apps(
             if category and category != "All":
                 continue
 
-            results.append(
-                {
-                    "id": server.name,
-                    "name": server.name,
-                    "description": server.description or "Custom MCP Server",
-                    "icon": "",
-                    "users": "1",
-                    "transport": server.transport,
-                    # F1: this loop's own membership check above (name-based)
-                    # doesn't gate on a real grant, so a custom mcp_oauth
-                    # server the user abandoned mid-consent must not be
-                    # reported connected just because the row exists.
-                    "is_connected": _mcp_oauth_server_is_actually_connected(
-                        server, active_grant_server_ids
-                    ),
-                    "provider": "custom",
-                    "category": "Local",
-                    "is_local": True,
-                    "server_id": server.id,
-                    "is_custom": True,
-                }
-            )
+            entry = {
+                "id": server.name,
+                "name": server.name,
+                "description": server.description or "Custom MCP Server",
+                "icon": "",
+                "users": "1",
+                "transport": server.transport,
+                # F1: this loop's own membership check above (name-based)
+                # doesn't gate on a real grant, so a custom mcp_oauth
+                # server the user abandoned mid-consent must not be
+                # reported connected just because the row exists.
+                "is_connected": _mcp_oauth_server_is_actually_connected(
+                    server, active_grant_server_ids
+                ),
+                "provider": "custom",
+                "category": "Local",
+                "is_local": True,
+                "server_id": server.id,
+                "is_custom": True,
+            }
+            # The picker dispatches its Connect button on auth_type, and custom
+            # entries used to omit the field entirely — so an mcp_oauth server
+            # left unconnected by the check above had no way forward and hit
+            # the mis-authored-entry toast instead (#1313).
+            #
+            # Emitted only for the mcp_oauth shape, deliberately: every other
+            # custom shape is reported connected unconditionally (so its
+            # Connect button never renders), while tagging those rows with a
+            # catalog classification would repoint the settings dialog's
+            # Configure button away from the custom edit form. Inactive
+            # associations are excluded because the per-server OAuth endpoints
+            # require an active one — a deactivated server needs re-enabling,
+            # not re-authorization.
+            if user_mcp.is_active and _is_mcp_oauth_server(server):
+                entry["auth_type"] = "mcp_oauth"
+
+            results.append(entry)
 
         # Append Custom APIs
         user_custom_apis = (

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1842,6 +1842,85 @@ async def test_mcp_oauth_local_listing_also_requires_a_grant(db_session):
 
 
 @pytest.mark.asyncio
+async def test_local_mcp_oauth_listing_carries_the_auth_type_for_the_picker(
+    db_session,
+):
+    """#1313: the connector picker dispatches Connect on auth_type, which the
+    location=local branch never emitted — so a custom mcp_oauth server left
+    unconnected by the grant gate above had no branch to fall into and
+    dead-ended on the mis-authored-entry toast."""
+    db, user, _ = db_session
+    _add_mcp_oauth_server(db, user)
+
+    records = next(
+        a
+        for a in list_mcp_apps(location="local", current_user=user, db=db)
+        if a["id"] == "records"
+    )
+    assert records["is_connected"] is False
+    assert records["auth_type"] == "mcp_oauth"
+
+
+@pytest.mark.asyncio
+async def test_local_non_mcp_oauth_server_carries_no_auth_type(db_session):
+    """The hint is scoped to the mcp_oauth shape on purpose: a catalog
+    classification on any other custom server would repoint the settings
+    dialog's Configure button away from the custom edit form."""
+    db, user, _ = db_session
+    server = MCPServer.from_config(
+        {
+            "name": "local-notes",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "notes-mcp",
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id, mcpserver_id=server.id, is_owner=True, is_active=True
+        )
+    )
+    db.commit()
+
+    notes = next(
+        a
+        for a in list_mcp_apps(location="local", current_user=user, db=db)
+        if a["id"] == "local-notes"
+    )
+    assert notes["is_connected"] is True
+    assert "auth_type" not in notes
+
+
+@pytest.mark.asyncio
+async def test_local_mcp_oauth_listing_omits_auth_type_when_deactivated(db_session):
+    """The per-server OAuth endpoints require an active association, so
+    advertising the flow on a deactivated server would swap one dead end for
+    a 404 — such a server needs re-enabling, not re-authorization."""
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    assoc = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    assoc.is_active = False
+    db.commit()
+
+    records = next(
+        a
+        for a in list_mcp_apps(location="local", current_user=user, db=db)
+        if a["id"] == "records"
+    )
+    assert "auth_type" not in records
+
+
+@pytest.mark.asyncio
 async def test_delete_mcp_server_revokes_only_the_disconnecting_users_grant(
     db_session, monkeypatch
 ):


### PR DESCRIPTION
Fixes #1313

## Problem

A user-created MCP server with transport `streamable_http` and `auth: {"type": "mcp_oauth"}` could not be connected from the "+ Connector" picker. Its Connect button always failed with "This app is not configured for connection", and the dialog offered no way to start the authorization.

Two blockers stacked here:

1. The `location=local` branch of `GET /api/mcp/apps` built custom-server entries without an `auth_type` field, and `handleConnectApp` in the picker dispatches Connect on exactly that field — so the `mcp_oauth` branch was unreachable and every custom server fell through to the mis-authored-entry toast (`tools.mcp.alerts.notConfigured`).
2. Behind it, the picker's `mcp_oauth` handler posts to `/api/mcp/apps/{id}/oauth/connect`, which starts with `_ensure_catalog_mcp_oauth_server()` and so resolves catalog apps only — it can never see a user-added server.

The dead end became reachable after #1097 made `is_connected` for an mcp_oauth server require an active grant. Before that, local entries were reported connected unconditionally, so the Connect button never rendered.

## Changes

**Backend** (`src/xagent/web/api/mcp.py`)

- Extract `_is_mcp_oauth_server()` so the connection-state gate and the picker's new `auth_type` hint share one shape check and cannot drift.
- Emit `auth_type: "mcp_oauth"` on local entries for the mcp_oauth shape.

The hint is deliberately scoped to that shape. Every other custom shape is already reported connected unconditionally (so its Connect button never renders), and tagging those rows with a catalog classification would repoint the settings dialog's Configure button away from the custom edit form — to the key dialog for `api_key`, or removing it entirely for `keyless`.

**Frontend** (`frontend/src/components/mcp/connect-mcp-dialog.tsx`)

- Route the `mcp_oauth` connect to `/api/mcp/{server_id}/oauth/connect` for custom entries — the same per-server endpoint the custom MCP edit form already drives. Catalog apps keep using the catalog route.
- Recheck the connection against the listing branch the entry came from once the consent popup closes. A custom server only appears under `location=local`; querying the remote branch reported every custom connect as a failure.

No separate `discover` call is needed from the picker: `POST /{server_id}/oauth/connect` runs discovery internally. The edit form's Discover button only backfills form fields.

## Known limitations

- A deactivated association does not get `auth_type`. The per-server OAuth endpoints use `require_active=True`, so advertising the flow there would only swap the toast for a 404 — such a server needs re-enabling, not re-authorization. Documented inline.
- `_is_mcp_oauth_server` lowercases the transport while `_get_mcp_oauth_config` (mcp.py:597) matches exactly. A mixed-case transport is only storable via a direct API call or an admin PATCH (the form offers a fixed lowercase set), and the inconsistency predates this change, so it is left alone.

## Tests

Four regression tests, each verified to fail without the fix:

- `test_local_mcp_oauth_listing_carries_the_auth_type_for_the_picker`
- `test_local_non_mcp_oauth_server_carries_no_auth_type`
- `test_local_mcp_oauth_listing_omits_auth_type_when_deactivated`
- Frontend: per-server endpoint routing, and the `location=local` recheck after the popup closes

Verification: `tests/web/api/` 618 passed (3 skipped — no postgres URL set); `src/components/mcp` 61 passed; CI test manifest 76 passed; `npm run lint` and `npm run type-check` clean; `ruff check` and `ruff format --check` clean; mypy reports no errors in `mcp.py`.