### PR TITLE
fix(react): reject final_answer that carries an empty answer

### DIFF
--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -366,6 +366,20 @@ class AgentExecutionAdapter:
                 # ``agent_result`` specifically so a backfilled preamble
                 # cannot be mistaken for a real final answer.
                 output = self._latest_assistant_message(result.get("context"))
+        if not output:
+            # A run that reports success with nothing to show is a bug in the
+            # pattern that produced it, and the placeholder erases the evidence.
+            # Log before substituting so there is something to debug from.
+            logger.warning(
+                "Agent %r produced no output; substituting the placeholder. "
+                "execution_type=%s pattern=%s status=%s success=%s task_id=%s",
+                self.config.name,
+                execution_type,
+                self.config.pattern,
+                status,
+                result.get("success"),
+                execution_id,
+            )
         normalized = {
             "status": status,
             "output": output or NO_OUTPUT_PLACEHOLDER,

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -366,10 +366,15 @@ class AgentExecutionAdapter:
                 # ``agent_result`` specifically so a backfilled preamble
                 # cannot be mistaken for a real final answer.
                 output = self._latest_assistant_message(result.get("context"))
-        if not output:
+        if not output and result.get("success"):
             # A run that reports success with nothing to show is a bug in the
             # pattern that produced it, and the placeholder erases the evidence.
             # Log before substituting so there is something to debug from.
+            #
+            # Gated on ``success`` because an empty output is legitimate on every
+            # non-success path: a ``waiting_for_user`` pause carries only its
+            # message, so warning on emptiness alone would fire on the ordinary
+            # first-turn clarification and drown the real signal.
             logger.warning(
                 "Agent %r produced no output; substituting the placeholder. "
                 "execution_type=%s pattern=%s status=%s success=%s task_id=%s",

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -36,6 +36,7 @@ import copy
 import hashlib
 import inspect
 import json
+import logging
 from dataclasses import dataclass, replace
 from datetime import timezone
 from enum import Enum
@@ -71,6 +72,8 @@ from ...runtime import (
 )
 from ..base import AgentPattern, PatternResult, truncate_prompt_preview
 from ..final_answer_stream import ReActFinalAnswerStreamer
+
+logger = logging.getLogger(__name__)
 
 
 class ReActReasoningMode(str, Enum):
@@ -590,6 +593,20 @@ class ReActPattern(AgentPattern):
                     normalized,
                     force_final_answer=force_final_answer_now,
                 )
+                empty_final_answer = self._empty_final_answer_call(normalized)
+                if empty_final_answer is not None:
+                    logger.warning(
+                        "ReAct final_answer carried no answer text; discarding the "
+                        "response and retrying. iteration=%s arg_keys=%s",
+                        iteration,
+                        sorted(self._tool_call_args_dict(empty_final_answer)),
+                    )
+                if recover_full_tool_set:
+                    recovery_reason: str | None = "unavailable_tool_call"
+                elif empty_final_answer is not None:
+                    recovery_reason = "empty_final_answer"
+                else:
+                    recovery_reason = None
                 try:
                     (
                         response,
@@ -603,9 +620,7 @@ class ReActPattern(AgentPattern):
                         force_final_answer=(
                             force_final_answer_now and not recover_full_tool_set
                         ),
-                        recovery_reason=(
-                            "unavailable_tool_call" if recover_full_tool_set else None
-                        ),
+                        recovery_reason=recovery_reason,
                     )
                 except LLMCallInterrupted:
                     interrupted = await self._interrupt_if_requested(
@@ -699,6 +714,11 @@ class ReActPattern(AgentPattern):
         answer_streamer: ReActFinalAnswerStreamer | None,
         stream_failure_message: str,
     ) -> dict[str, Any]:
+        logger.warning(
+            "ReAct failing the run after an invalid tool protocol: %s (iteration=%s)",
+            stream_failure_message,
+            iteration,
+        )
         if answer_streamer is not None:
             await answer_streamer.fail(stream_failure_message)
         await runtime.checkpoint(
@@ -864,6 +884,16 @@ class ReActPattern(AgentPattern):
                 "complete user-facing response in its answer field."
             )
             retry_phase = "malformed_tool_arguments_recovery"
+        elif recovery_reason == "empty_final_answer":
+            retry_instruction = (
+                "The previous response called final_answer with an empty answer "
+                "field, so the user received no reply at all. Retry this turn: if "
+                "the task is complete, call final_answer again with the complete "
+                "user-facing response in its answer field; if work remains, call "
+                "the appropriate available work tool instead. Never call "
+                "final_answer with an omitted, empty, or whitespace-only answer."
+            )
+            retry_phase = "empty_final_answer_recovery"
         else:
             retry_instruction = (
                 "The previous response used an invalid tool protocol. Retry the same "
@@ -960,7 +990,32 @@ class ReActPattern(AgentPattern):
                 continue
             if force_final_answer and tool_call.get("name") != "final_answer":
                 return True
-        return False
+        return self._empty_final_answer_call(normalized) is not None
+
+    def _empty_final_answer_call(
+        self, normalized: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Return the first ``final_answer`` call that carries no answer text.
+
+        Under ``tool_choice="required"`` ``final_answer`` is the only way ReAct
+        can reply, so an empty ``answer`` produces a run that completes with
+        nothing streamed and nothing persisted. Treating it as a tool-protocol
+        violation routes it into the pattern's existing single repair retry
+        instead of finalizing silently.
+        """
+
+        for tool_call in normalized.get("tool_calls") or []:
+            if not isinstance(tool_call, dict):
+                continue
+            if tool_call.get("name") != "final_answer":
+                continue
+            args = tool_call.get("args")
+            answer = args.get("answer") if isinstance(args, dict) else None
+            # Coerce exactly as ``_handle_control_tool`` does, so this check and
+            # the finalization it guards agree on what counts as an answer.
+            if answer is None or not str(answer).strip():
+                return tool_call
+        return None
 
     def _requires_full_tool_set_recovery(
         self,
@@ -1390,21 +1445,24 @@ class ReActPattern(AgentPattern):
                 function_payload = tool_call.get("function")
                 if isinstance(function_payload, dict):
                     arguments = function_payload.get("arguments", {})
+                    name = function_payload.get("name")
                     normalized.append(
                         {
                             "id": tool_call.get("id") or f"tool_call_{index}",
-                            "name": function_payload.get("name"),
-                            "args": self._coerce_arguments(arguments),
+                            "name": name,
+                            "args": self._coerce_arguments(arguments, tool_name=name),
                         }
                     )
                     continue
 
+                name = tool_call.get("name")
                 normalized.append(
                     {
                         "id": tool_call.get("id") or f"tool_call_{index}",
-                        "name": tool_call.get("name"),
+                        "name": name,
                         "args": self._coerce_arguments(
-                            tool_call.get("args", tool_call.get("arguments", {}))
+                            tool_call.get("args", tool_call.get("arguments", {})),
+                            tool_name=name,
                         ),
                     }
                 )
@@ -1412,12 +1470,14 @@ class ReActPattern(AgentPattern):
 
             function_payload = getattr(tool_call, "function", None)
             if function_payload is not None:
+                name = getattr(function_payload, "name", None)
                 normalized.append(
                     {
                         "id": getattr(tool_call, "id", None) or f"tool_call_{index}",
-                        "name": getattr(function_payload, "name", None),
+                        "name": name,
                         "args": self._coerce_arguments(
-                            getattr(function_payload, "arguments", {})
+                            getattr(function_payload, "arguments", {}),
+                            tool_name=name,
                         ),
                     }
                 )
@@ -1442,16 +1502,48 @@ class ReActPattern(AgentPattern):
                 self.pending_tool_call_content[tool_call_id] = content
             return
 
-    def _coerce_arguments(self, arguments: Any) -> dict[str, Any]:
+    def _coerce_arguments(
+        self, arguments: Any, *, tool_name: str | None = None
+    ) -> dict[str, Any]:
         if isinstance(arguments, dict):
             return arguments
         if isinstance(arguments, str):
             try:
                 parsed = json.loads(arguments)
             except json.JSONDecodeError:
-                return {"input": arguments}
-            return parsed if isinstance(parsed, dict) else {"input": parsed}
+                logger.warning(
+                    "ReAct tool call %s returned malformed JSON arguments "
+                    "(%d chars); treating them as absent.",
+                    tool_name or "<unknown>",
+                    len(arguments),
+                )
+                return self._fallback_arguments(tool_name, arguments)
+            if isinstance(parsed, dict):
+                return parsed
+            logger.warning(
+                "ReAct tool call %s returned non-object JSON arguments (%s).",
+                tool_name or "<unknown>",
+                type(parsed).__name__,
+            )
+            return self._fallback_arguments(tool_name, parsed)
         return {}
+
+    def _fallback_arguments(
+        self, tool_name: str | None, payload: Any
+    ) -> dict[str, Any]:
+        """Wrap unusable tool arguments, or drop them for control tools.
+
+        Work tools tolerate an opaque ``input`` passthrough. Control tools do
+        not: ``final_answer`` owns the run's only user-visible exit, so smuggling
+        a malformed payload through as ``input`` would silently strip ``answer``
+        and finalize the run with nothing to show. Returning empty args instead
+        lets ``_response_requires_tool_protocol_retry`` reject the call and spend
+        the pattern's one repair retry on it.
+        """
+
+        if tool_name in self._control_tool_names():
+            return {}
+        return {"input": payload}
 
     def _build_tool_schema(self, tool: Any) -> dict[str, Any]:
         name = self._tool_name(tool)
@@ -1684,6 +1776,9 @@ class ReActPattern(AgentPattern):
 
         if name == "final_answer":
             answer = str(args.get("answer", ""))
+            if not answer.strip():
+                self._reject_empty_final_answer(tool_call, context)
+                return None
             outcome = self._final_answer_outcome(args.get("outcome"))
             self._record_tool_call(
                 tool_call,
@@ -1825,6 +1920,41 @@ class ReActPattern(AgentPattern):
             }
 
         return None
+
+    def _reject_empty_final_answer(
+        self, tool_call: dict[str, Any], context: Any
+    ) -> None:
+        """Refuse to finalize on an empty ``final_answer`` and re-request one.
+
+        ``_response_requires_tool_protocol_retry`` catches this on the turn the
+        model produces it, so this guard covers the paths that reach the handler
+        without passing through response normalization — most importantly a
+        checkpoint resume that restores ``pending_tool_calls`` verbatim.
+
+        Returning ``None`` keeps the run in the loop; ``force_final_answer_next``
+        makes the next turn re-request ``final_answer``, and if that turn is empty
+        too the normalization guard fails the run instead of looping.
+        """
+
+        logger.warning(
+            "ReAct refusing to finalize on final_answer with no answer text; "
+            "re-requesting a final answer. tool_call_id=%s arg_keys=%s",
+            tool_call.get("id"),
+            sorted(self._tool_call_args_dict(tool_call)),
+        )
+        error = (
+            "final_answer was called with an empty answer, so the user received "
+            "nothing. Call final_answer again with the complete user-facing "
+            "response in its answer field."
+        )
+        self._record_tool_call(tool_call, status="failed", error=error)
+        context.add_tool_result(
+            tool_name="final_answer",
+            result={"error": error},
+            tool_call_id=tool_call.get("id"),
+        )
+        self.status = "thinking"
+        self.force_final_answer_next = True
 
     def _tool_is_concurrency_safe(self, name: str, tools: list[Any]) -> bool:
         """Whether ``name`` may run concurrently with other safe tools.

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -586,6 +586,9 @@ class ReActPattern(AgentPattern):
                         iteration=iteration,
                         answer_streamer=answer_streamer,
                         stream_failure_message=("invalid tool protocol after recovery"),
+                        empty_final_answer=(
+                            self._empty_final_answer_call(normalized) is not None
+                        ),
                     )
                 if answer_streamer is not None:
                     await answer_streamer.fail("invalid tool protocol, retrying")
@@ -599,7 +602,7 @@ class ReActPattern(AgentPattern):
                         "ReAct final_answer carried no answer text; discarding the "
                         "response and retrying. iteration=%s arg_keys=%s",
                         iteration,
-                        sorted(self._tool_call_args_dict(empty_final_answer)),
+                        sorted(self._tool_call_args_dict(empty_final_answer), key=str),
                     )
                 if recover_full_tool_set:
                     recovery_reason: str | None = "unavailable_tool_call"
@@ -648,6 +651,9 @@ class ReActPattern(AgentPattern):
                         iteration=iteration,
                         answer_streamer=answer_streamer,
                         stream_failure_message="invalid tool protocol after retry",
+                        empty_final_answer=(
+                            self._empty_final_answer_call(normalized) is not None
+                        ),
                     )
             if force_final_answer_now and not normalized.get("tool_calls"):
                 normalized["done"] = True
@@ -714,11 +720,24 @@ class ReActPattern(AgentPattern):
         iteration: int,
         answer_streamer: ReActFinalAnswerStreamer | None,
         stream_failure_message: str,
+        empty_final_answer: bool = False,
     ) -> dict[str, Any]:
+        """Abandon the run after the one repair attempt failed.
+
+        ``empty_final_answer`` distinguishes "the model never produced an answer"
+        from the status's other producers (provider protocol errors, mixed
+        control calls, a non-``final_answer`` tool on a forced turn), whose
+        ``error`` text is the only signal a caller has. Delegated-child
+        classification reads it to avoid collapsing all four into "never
+        produced an answer" - see ``agent_tool._classify_delegated_failure``.
+        """
+
         logger.warning(
-            "ReAct failing the run after an invalid tool protocol: %s (iteration=%s)",
+            "ReAct failing the run after an invalid tool protocol: %s "
+            "(iteration=%s empty_final_answer=%s)",
             stream_failure_message,
             iteration,
+            empty_final_answer,
         )
         if answer_streamer is not None:
             await answer_streamer.fail(stream_failure_message)
@@ -728,15 +747,20 @@ class ReActPattern(AgentPattern):
             pattern=self,
             metadata={"iteration": iteration},
         )
+        error = (
+            "The model called final_answer without an answer twice, so the run "
+            "produced no response."
+            if empty_final_answer
+            else "The model returned an invalid tool protocol response "
+            "after one repair attempt."
+        )
         return PatternResult(
             success=False,
-            error=(
-                "The model returned an invalid tool protocol response "
-                "after one repair attempt."
-            ),
+            error=error,
             metadata={
                 "iterations": iteration + 1,
                 "status": "invalid_tool_protocol",
+                "empty_final_answer": empty_final_answer,
             },
         ).to_dict()
 
@@ -1657,8 +1681,8 @@ class ReActPattern(AgentPattern):
                             "answer": {
                                 "type": "string",
                                 "description": (
-                                    "Complete user-facing answer. It must match "
-                                    "response_language. "
+                                    "Complete user-facing answer. It must be "
+                                    "non-empty and must match response_language. "
                                     f"{final_answer_language_rule()}"
                                 ),
                             },
@@ -1967,37 +1991,54 @@ class ReActPattern(AgentPattern):
         makes the next turn re-request ``final_answer``, and if that turn is empty
         too the normalization guard fails the run instead of looping.
 
-        Two deliberate differences from the fresh-turn path. The rest of the
-        batch is discarded, matching the fresh path's whole-response rejection:
-        otherwise a resumed ``[final_answer(""), work_tool]`` batch would execute
-        a side-effecting tool that the fresh path never runs. And the next turn is
-        forced to ``final_answer`` alone, where the fresh path restores the full
-        tool set - forcing guarantees termination and no tool re-execution after a
-        resume, at the cost that a resumed run with genuinely incomplete work must
-        answer or fail rather than continue that work.
+        Two deliberate differences from the fresh-turn path.
+
+        Sibling calls still pending are discarded, matching the fresh path's
+        whole-response rejection for the order that matters: a resumed
+        ``[final_answer(""), work_tool]`` batch would otherwise execute a
+        side-effecting tool that the fresh path never runs. The match is not
+        exact in the reverse order - in ``[work_tool, final_answer("")]`` the
+        work tool has already executed by the time this runs, and nothing here
+        undoes it.
+
+        And the next turn is forced to ``final_answer`` alone, where the fresh
+        path restores the full tool set. That bounds the run: a second empty
+        answer ends it as ``invalid_tool_protocol`` rather than looping. It does
+        not prevent tool re-execution outright - if the forced turn calls a
+        non-``final_answer`` tool, ``_requires_full_tool_set_recovery`` restores
+        the full set and clears the flag, so a discarded work tool can be
+        re-invoked on that turn.
         """
 
         logger.warning(
             "ReAct refusing to finalize on final_answer with no answer text; "
             "re-requesting a final answer. tool_call_id=%s arg_keys=%s",
             tool_call.get("id"),
-            sorted(self._tool_call_args_dict(tool_call)),
+            sorted(self._tool_call_args_dict(tool_call), key=str),
         )
         error = (
             "final_answer was called with an empty answer, so the user received "
             "nothing. Call final_answer again with the complete user-facing "
             "response in its answer field."
         )
-        self._record_tool_call(tool_call, status="failed", error=error)
+        # Carry the classification keys ``tool_result_succeeded`` reads, so this
+        # failure is not read back as a success, and record the same shape in the
+        # ledger as the cancelled siblings below.
+        failure = {"success": False, "status": "error", "error": error}
+        self._record_tool_call(tool_call, status="failed", result=failure, error=error)
         context.add_tool_result(
             tool_name="final_answer",
-            result={"error": error},
+            result=failure,
             tool_call_id=tool_call.get("id"),
         )
         # Leave only the rejected call for the caller to pop, and close out the
         # rest of the batch so no unexecuted call is left without a result.
-        remaining = self.pending_tool_calls[1:]
-        self.pending_tool_calls = self.pending_tool_calls[:1]
+        # Selected by identity rather than position: the caller happens to pass
+        # the head of the queue today, but nothing here depends on that.
+        remaining = [
+            pending for pending in self.pending_tool_calls if pending is not tool_call
+        ]
+        self.pending_tool_calls = [tool_call]
         self._cancel_tool_calls(
             remaining,
             context,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -621,6 +621,7 @@ class ReActPattern(AgentPattern):
                             force_final_answer_now and not recover_full_tool_set
                         ),
                         recovery_reason=recovery_reason,
+                        empty_final_answer=empty_final_answer is not None,
                     )
                 except LLMCallInterrupted:
                     interrupted = await self._interrupt_if_requested(
@@ -764,7 +765,7 @@ class ReActPattern(AgentPattern):
                 continue
             args = tool_call.get("args")
             if isinstance(args, dict):
-                return str(args.get("answer", ""))
+                return self._final_answer_text(args)
         return None
 
     def _messages_for_llm(
@@ -854,6 +855,7 @@ class ReActPattern(AgentPattern):
         tool_schemas: list[dict[str, Any]],
         force_final_answer: bool,
         recovery_reason: str | None = None,
+        empty_final_answer: bool = False,
     ) -> tuple[Any, ReActFinalAnswerStreamer]:
         tools = (
             [self._final_answer_tool_schema()] if force_final_answer else tool_schemas
@@ -885,13 +887,24 @@ class ReActPattern(AgentPattern):
             )
             retry_phase = "malformed_tool_arguments_recovery"
         elif recovery_reason == "empty_final_answer":
+            # On a forced turn ``tools`` above is final_answer alone, so offering
+            # a work tool would instruct the model to do something the schema
+            # forbids and waste the one repair attempt.
             retry_instruction = (
                 "The previous response called final_answer with an empty answer "
-                "field, so the user received no reply at all. Retry this turn: if "
-                "the task is complete, call final_answer again with the complete "
-                "user-facing response in its answer field; if work remains, call "
-                "the appropriate available work tool instead. Never call "
-                "final_answer with an omitted, empty, or whitespace-only answer."
+                "field, so the user received no reply at all. "
+                + (
+                    "final_answer is the only tool available on this turn: call it "
+                    "again with the complete user-facing response in its answer "
+                    "field."
+                    if force_final_answer
+                    else "Retry this turn: if the task is complete, call "
+                    "final_answer again with the complete user-facing response in "
+                    "its answer field; if work remains, call the appropriate "
+                    "available work tool instead."
+                )
+                + " Never call final_answer with an omitted, empty, or "
+                "whitespace-only answer."
             )
             retry_phase = "empty_final_answer_recovery"
         else:
@@ -903,6 +916,15 @@ class ReActPattern(AgentPattern):
                 "call final_answer only when the task is actually complete."
             )
             retry_phase = "tool_protocol_retry"
+        if empty_final_answer and recovery_reason != "empty_final_answer":
+            # A more fundamental repair owns the instruction, but the empty answer
+            # was still detected on this response and would otherwise go
+            # unmentioned.
+            retry_instruction = (
+                f"{retry_instruction} The previous response also called "
+                "final_answer with an empty answer field; never call final_answer "
+                "with an omitted, empty, or whitespace-only answer."
+            )
         messages[0] = {
             **messages[0],
             "content": f"{messages[0].get('content', '')}\n\n{retry_instruction}",
@@ -1016,10 +1038,12 @@ class ReActPattern(AgentPattern):
     def _final_answer_text(self, args: Any) -> str:
         """Coerce a ``final_answer`` argument payload into its answer text.
 
-        The single coercion for both this check and the finalization it guards,
-        so the two cannot disagree on what counts as an answer. ``None`` must
-        become the empty string rather than ``str(None)``, which would yield the
-        literal ``"None"`` and be sent to the user as the answer.
+        The single coercion for every site that reads an answer out of
+        ``final_answer`` args - this check, the finalization it guards, and the
+        streamer's candidate lookup - so they cannot disagree on what counts as
+        an answer. ``None`` must become the empty string rather than
+        ``str(None)``, which would yield the literal ``"None"`` and be sent to
+        the user as the answer.
         """
 
         if not isinstance(args, dict):
@@ -1453,46 +1477,33 @@ class ReActPattern(AgentPattern):
     def _normalize_tool_calls(self, tool_calls: list[Any]) -> list[dict[str, Any]]:
         normalized: list[dict[str, Any]] = []
         for index, tool_call in enumerate(tool_calls):
+            # Three provider shapes: a dict with a nested ``function`` payload, a
+            # flat dict, and an object with a ``function`` attribute. Each yields
+            # the same (id, name, arguments) triple.
             if isinstance(tool_call, dict):
+                call_id = tool_call.get("id")
                 function_payload = tool_call.get("function")
                 if isinstance(function_payload, dict):
-                    arguments = function_payload.get("arguments", {})
                     name = function_payload.get("name")
-                    normalized.append(
-                        {
-                            "id": tool_call.get("id") or f"tool_call_{index}",
-                            "name": name,
-                            "args": self._coerce_arguments(arguments, tool_name=name),
-                        }
-                    )
+                    arguments = function_payload.get("arguments", {})
+                else:
+                    name = tool_call.get("name")
+                    arguments = tool_call.get("args", tool_call.get("arguments", {}))
+            else:
+                function_payload = getattr(tool_call, "function", None)
+                if function_payload is None:
                     continue
-
-                name = tool_call.get("name")
-                normalized.append(
-                    {
-                        "id": tool_call.get("id") or f"tool_call_{index}",
-                        "name": name,
-                        "args": self._coerce_arguments(
-                            tool_call.get("args", tool_call.get("arguments", {})),
-                            tool_name=name,
-                        ),
-                    }
-                )
-                continue
-
-            function_payload = getattr(tool_call, "function", None)
-            if function_payload is not None:
+                call_id = getattr(tool_call, "id", None)
                 name = getattr(function_payload, "name", None)
-                normalized.append(
-                    {
-                        "id": getattr(tool_call, "id", None) or f"tool_call_{index}",
-                        "name": name,
-                        "args": self._coerce_arguments(
-                            getattr(function_payload, "arguments", {}),
-                            tool_name=name,
-                        ),
-                    }
-                )
+                arguments = getattr(function_payload, "arguments", {})
+
+            normalized.append(
+                {
+                    "id": call_id or f"tool_call_{index}",
+                    "name": name,
+                    "args": self._coerce_arguments(arguments, tool_name=name),
+                }
+            )
 
         return [call for call in normalized if call.get("name")]
 
@@ -1525,7 +1536,8 @@ class ReActPattern(AgentPattern):
             except json.JSONDecodeError:
                 logger.warning(
                     "ReAct tool call %s returned malformed JSON arguments "
-                    "(%d chars); treating them as absent.",
+                    "(%d chars); dropping them for control tools and passing "
+                    "them through as `input` otherwise.",
                     tool_name or "<unknown>",
                     len(arguments),
                 )
@@ -1545,12 +1557,19 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any]:
         """Wrap unusable tool arguments, or drop them for control tools.
 
-        Work tools tolerate an opaque ``input`` passthrough. Control tools do
-        not: ``final_answer`` owns the run's only user-visible exit, so smuggling
-        a malformed payload through as ``input`` would silently strip ``answer``
-        and finalize the run with nothing to show. Returning empty args instead
-        lets ``_response_requires_tool_protocol_retry`` reject the call and spend
-        the pattern's one repair retry on it.
+        Work tools tolerate an opaque ``input`` passthrough, so they keep the
+        payload. Control tools drop it, because ``input`` is never a field any of
+        them declares: carrying it forward only disguises the loss as a populated
+        arguments object.
+
+        For ``final_answer`` dropping it is also load-bearing. That tool owns the
+        run's only user-visible exit, so a payload smuggled through as ``input``
+        would silently strip ``answer`` and finalize the run with nothing to
+        show; empty args instead let
+        ``_response_requires_tool_protocol_retry`` reject the call and spend the
+        pattern's one repair retry on it. ``send_message`` and
+        ``ask_user_question`` have no such guard - they degrade to an empty
+        message either way, exactly as they did before this branch existed.
         """
 
         if tool_name in self._control_tool_names():
@@ -1803,8 +1822,9 @@ class ReActPattern(AgentPattern):
                 result={"answer": answer, "outcome": outcome},
                 tool_call_id=tool_call.get("id"),
             )
-            if answer:
-                context.add_assistant_message(answer)
+            # Unconditional: the empty-answer rejection above is the only way
+            # into finalization, so an answer here always has text.
+            context.add_assistant_message(answer)
             return await self._finalize_outcome(
                 context=context,
                 runtime=runtime,
@@ -1946,6 +1966,15 @@ class ReActPattern(AgentPattern):
         Returning ``None`` keeps the run in the loop; ``force_final_answer_next``
         makes the next turn re-request ``final_answer``, and if that turn is empty
         too the normalization guard fails the run instead of looping.
+
+        Two deliberate differences from the fresh-turn path. The rest of the
+        batch is discarded, matching the fresh path's whole-response rejection:
+        otherwise a resumed ``[final_answer(""), work_tool]`` batch would execute
+        a side-effecting tool that the fresh path never runs. And the next turn is
+        forced to ``final_answer`` alone, where the fresh path restores the full
+        tool set - forcing guarantees termination and no tool re-execution after a
+        resume, at the cost that a resumed run with genuinely incomplete work must
+        answer or fail rather than continue that work.
         """
 
         logger.warning(
@@ -1964,6 +1993,18 @@ class ReActPattern(AgentPattern):
             tool_name="final_answer",
             result={"error": error},
             tool_call_id=tool_call.get("id"),
+        )
+        # Leave only the rejected call for the caller to pop, and close out the
+        # rest of the batch so no unexecuted call is left without a result.
+        remaining = self.pending_tool_calls[1:]
+        self.pending_tool_calls = self.pending_tool_calls[:1]
+        self._cancel_tool_calls(
+            remaining,
+            context,
+            reason=(
+                "Discarded because final_answer was called with an empty answer; "
+                "the agent will produce a final answer instead."
+            ),
         )
         self.status = "thinking"
         self.force_final_answer_next = True
@@ -2050,15 +2091,26 @@ class ReActPattern(AgentPattern):
         self.pending_tool_calls = []
         self.repeated_tool_decision = None
         self.force_final_answer_next = False
-        for tool_call in discarded_calls:
-            result = {
-                "success": False,
-                "status": "cancelled",
-                "error": (
-                    "Discarded because an earlier tool requires user input; "
-                    "the agent will replan after the user responds."
-                ),
-            }
+        self._cancel_tool_calls(
+            discarded_calls,
+            context,
+            reason=(
+                "Discarded because an earlier tool requires user input; "
+                "the agent will replan after the user responds."
+            ),
+        )
+
+    def _cancel_tool_calls(
+        self, tool_calls: list[dict[str, Any]], context: Any, *, reason: str
+    ) -> None:
+        """Close calls that will never run, one result each.
+
+        Preserves I2 (one result per ``tool_call_id``) for abandoned calls, so a
+        discarded batch cannot leave a tool call dangling without a result.
+        """
+
+        for tool_call in tool_calls:
+            result = {"success": False, "status": "cancelled", "error": reason}
             self._backfill_result(tool_call, result, context)
             self._record_tool_call(
                 tool_call,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -592,6 +592,14 @@ class ReActPattern(AgentPattern):
                     )
                 if answer_streamer is not None:
                     await answer_streamer.fail("invalid tool protocol, retrying")
+                # Rejecting the whole response drops any assistant preamble it
+                # carried: the response is discarded before ``add_assistant_message``,
+                # so the retry rebuilds from context without it. Deliberate - the
+                # preamble arrived attached to a protocol violation, so it is not a
+                # vetted user-facing answer, and replaying the model's own discarded
+                # prose invites it to treat that text as already committed. The cost
+                # is that a model which keeps emitting "preamble + empty answer"
+                # fails the run without the user seeing the preamble.
                 recover_full_tool_set = self._requires_full_tool_set_recovery(
                     normalized,
                     force_final_answer=force_final_answer_now,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1009,13 +1009,25 @@ class ReActPattern(AgentPattern):
                 continue
             if tool_call.get("name") != "final_answer":
                 continue
-            args = tool_call.get("args")
-            answer = args.get("answer") if isinstance(args, dict) else None
-            # Coerce exactly as ``_handle_control_tool`` does, so this check and
-            # the finalization it guards agree on what counts as an answer.
-            if answer is None or not str(answer).strip():
+            if not self._final_answer_text(tool_call.get("args")).strip():
                 return tool_call
         return None
+
+    def _final_answer_text(self, args: Any) -> str:
+        """Coerce a ``final_answer`` argument payload into its answer text.
+
+        The single coercion for both this check and the finalization it guards,
+        so the two cannot disagree on what counts as an answer. ``None`` must
+        become the empty string rather than ``str(None)``, which would yield the
+        literal ``"None"`` and be sent to the user as the answer.
+        """
+
+        if not isinstance(args, dict):
+            return ""
+        answer = args.get("answer")
+        if answer is None:
+            return ""
+        return str(answer)
 
     def _requires_full_tool_set_recovery(
         self,
@@ -1775,7 +1787,7 @@ class ReActPattern(AgentPattern):
         args = tool_call.get("args", {})
 
         if name == "final_answer":
-            answer = str(args.get("answer", ""))
+            answer = self._final_answer_text(args)
             if not answer.strip():
                 self._reject_empty_final_answer(tool_call, context)
                 return None

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1523,6 +1523,17 @@ _MISSING_CHILD_OUTPUT_MESSAGE = (
     "output, so there is no answer from it to use."
 )
 
+_CHILD_NO_ANSWER_MESSAGE = (
+    "The delegated agent never produced an answer, so there is no result from "
+    "it to use."
+)
+
+# Child statuses that mean "the pattern ended without ever producing an answer".
+# Their own ``error`` text names runtime internals, which the parent model
+# cannot act on, so they get the message above and the allowlisted
+# ``missing_delegated_output`` code instead of the raw diagnostic.
+_CHILD_NO_ANSWER_STATUSES = frozenset({"invalid_tool_protocol"})
+
 # Recognized, not produced, here: ``AgentExecutionAdapter._normalize_result``
 # and this module's own post-run default substitute these when a run left no
 # text of its own behind on the normalized fallback surface. A completed
@@ -1646,6 +1657,11 @@ def _classify_delegated_child_failure(
 
     status_is_incomplete = isinstance(status, str) and status.lower() != "completed"
     if result.get("success") is False or status_is_incomplete:
+        if isinstance(status, str) and status.lower() in _CHILD_NO_ANSWER_STATUSES:
+            return _classified_failure(
+                _CHILD_NO_ANSWER_MESSAGE,
+                failure_code="missing_delegated_output",
+            )
         error_text = result.get("error")
         output_text = result.get("output")
         if isinstance(error_text, str) and error_text:

--- a/src/xagent/core/tools/adapters/vibe/agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool.py
@@ -1528,11 +1528,28 @@ _CHILD_NO_ANSWER_MESSAGE = (
     "it to use."
 )
 
-# Child statuses that mean "the pattern ended without ever producing an answer".
-# Their own ``error`` text names runtime internals, which the parent model
-# cannot act on, so they get the message above and the allowlisted
-# ``missing_delegated_output`` code instead of the raw diagnostic.
-_CHILD_NO_ANSWER_STATUSES = frozenset({"invalid_tool_protocol"})
+
+def _child_never_answered(result: dict[str, Any]) -> bool:
+    """Whether the child's pattern ended without ever producing an answer.
+
+    ``invalid_tool_protocol`` alone is not enough: it also covers provider
+    protocol errors, mixed control calls, and a non-``final_answer`` tool on a
+    forced turn, all of which predate the empty-answer guard and may follow a
+    child that did produce text. For those the child's own ``error`` is the
+    parent's only signal, so it must survive rather than being replaced by
+    "never produced an answer". ReAct marks the empty-answer case explicitly
+    (``ReActPattern._invalid_tool_protocol_result``); only that maps here.
+    """
+
+    if result.get("empty_final_answer") is True:
+        return True
+    # ``AgentExecutionAdapter._normalize_result`` keeps the pattern's own result
+    # under ``agent_result``; the marker only survives there once normalized.
+    agent_result = result.get("agent_result")
+    return isinstance(agent_result, dict) and (
+        agent_result.get("empty_final_answer") is True
+    )
+
 
 # Recognized, not produced, here: ``AgentExecutionAdapter._normalize_result``
 # and this module's own post-run default substitute these when a run left no
@@ -1657,7 +1674,7 @@ def _classify_delegated_child_failure(
 
     status_is_incomplete = isinstance(status, str) and status.lower() != "completed"
     if result.get("success") is False or status_is_incomplete:
-        if isinstance(status, str) and status.lower() in _CHILD_NO_ANSWER_STATUSES:
+        if _child_never_answered(result):
             return _classified_failure(
                 _CHILD_NO_ANSWER_MESSAGE,
                 failure_code="missing_delegated_output",

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -9,6 +9,7 @@ import pytest
 
 from xagent.core.agent import AgentExecutionAdapter, AgentExecutionConfig
 from xagent.core.agent.execution_adapter import INTERRUPTED_USER_MESSAGE
+from xagent.core.agent.result import NO_OUTPUT_PLACEHOLDER
 from xagent.core.agent.service import AgentService
 from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
 
@@ -1326,3 +1327,87 @@ async def test_set_interrupt_checker_propagates_to_prebuilt_adapter() -> None:
     assert service._execution_adapter.config.interrupt_checker is checker
     service.set_interrupt_checker(None)
     assert service._execution_adapter.config.interrupt_checker is None
+
+
+def _placeholder_warning_records(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if "produced no output" in record.getMessage()
+    ]
+
+
+def test_execution_adapter_warns_when_a_successful_run_produced_no_output(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The placeholder erases the evidence, so the substitution must be logged."""
+
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="silent",
+            pattern="react",
+            llm=FakeLLM([]),
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    with caplog.at_level("WARNING", logger="xagent.core.agent.execution_adapter"):
+        result = adapter._normalize_result(
+            result={"success": True, "status": "completed"},
+            execution_type="agent_react",
+            execution_id="silent-exec",
+        )
+
+    assert result["output"] == NO_OUTPUT_PLACEHOLDER
+    assert len(_placeholder_warning_records(caplog)) == 1
+
+
+@pytest.mark.parametrize(
+    "paused",
+    [
+        pytest.param(
+            {
+                "success": False,
+                "status": "waiting_for_user",
+                "message": "Which region did you mean?",
+                "message_type": "question",
+            },
+            id="send-message",
+        ),
+        pytest.param(
+            {
+                "success": False,
+                "status": "waiting_for_user",
+                "message": "Pick one",
+                "interactions": [{"type": "select", "field": "x", "label": "X"}],
+            },
+            id="ask-user-question",
+        ),
+    ],
+)
+def test_execution_adapter_stays_silent_when_a_paused_run_has_no_output(
+    paused: dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    """A pause carries only its message, so emptiness there is not a defect.
+
+    Warning on emptiness alone would fire on the ordinary first-turn
+    clarification and drown the diagnostic it exists to provide.
+    """
+
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="paused",
+            pattern="react",
+            llm=FakeLLM([]),
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    with caplog.at_level("WARNING", logger="xagent.core.agent.execution_adapter"):
+        adapter._normalize_result(
+            result=paused,
+            execution_type="agent_react",
+            execution_id="paused-exec",
+        )
+
+    assert _placeholder_warning_records(caplog) == []

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5410,3 +5410,69 @@ def test_empty_final_answer_call_detects_blank_answers() -> None:
         )
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_react_discards_rest_of_resumed_batch_after_empty_final_answer() -> None:
+    """A rejected resume batch must not run work the fresh path would discard.
+
+    The fresh-turn path throws away the whole offending response, so a
+    ``[final_answer(""), work_tool]`` batch never executes the work tool. A
+    resumed batch has to match, or a pre-fix checkpoint replays a side effect
+    that the same model output would never have produced on a live turn.
+    """
+
+    llm = StreamingEmptyFinalAnswerLLM()
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+    tool = FakeTool()
+    pattern.status = "acting"
+    pattern.pending_tool_calls = [
+        {
+            "id": "call_resumed",
+            "name": "final_answer",
+            "args": {"response_language": "English", "outcome": "completed"},
+        },
+        {"id": "call_work", "name": "calculator", "args": {"expression": "2+2"}},
+    ]
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    # The side-effecting tool never ran.
+    assert tool.calls == []
+    # I2: the abandoned call still got exactly one result.
+    assert pattern.tool_ledger["call_work"].status == "cancelled"
+    assert pattern.tool_ledger["call_resumed"].status == "failed"
+    assert pattern.pending_tool_calls == []
+
+
+@pytest.mark.asyncio
+async def test_react_finalizes_a_scalar_zero_answer() -> None:
+    """``answer=0`` is an answer, not an absent one.
+
+    The empty check coerces before testing, so a falsy scalar must survive the
+    guard and reach the user rather than being rejected as blank.
+    """
+
+    llm = StreamingEmptyFinalAnswerLLM(
+        broken_arguments='{"response_language":"English","answer":0,"outcome":"completed"}',
+    )
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "0"
+    # Accepted on the first turn: no repair retry was spent.
+    assert len(llm.stream_calls) == 1

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -19,6 +19,7 @@ from xagent.core.agent import (
     ToolCallInterrupted,
     ToolCallRecord,
 )
+from xagent.core.agent.result import tool_result_succeeded
 from xagent.core.model.chat.basic.router import RouterLLM
 from xagent.core.model.chat.exceptions import LLMToolProtocolError
 from xagent.core.model.chat.tool_protocol import (
@@ -5476,3 +5477,209 @@ async def test_react_finalizes_a_scalar_zero_answer() -> None:
     assert result["response"] == "0"
     # Accepted on the first turn: no repair retry was spent.
     assert len(llm.stream_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_react_marks_the_abandoned_run_when_the_answer_stayed_empty() -> None:
+    """The abandoned result distinguishes "never answered" from other violations.
+
+    ``invalid_tool_protocol`` also covers provider protocol errors, mixed control
+    calls, and a non-``final_answer`` tool on a forced turn. Delegated-child
+    classification reads this marker so it does not collapse all of them into
+    "never produced an answer" and discard the child's own diagnostic.
+    """
+
+    llm = StreamingEmptyFinalAnswerLLM(recover=False)
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "invalid_tool_protocol"
+    assert result["empty_final_answer"] is True
+    assert "final_answer without an answer" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_react_does_not_mark_other_tool_protocol_violations() -> None:
+    """A non-empty-answer violation keeps the generic error and no marker."""
+
+    llm = StreamingInvalidToolProtocolFinalAnswerLLM(
+        structured_work_tool=True,
+        invalid_retry=True,
+    )
+    pattern = ReActPattern(max_iterations=3, finalize_after_tool_result=True)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Find an audio clip")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "invalid_tool_protocol"
+    assert result["empty_final_answer"] is False
+    assert "invalid tool protocol response" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_react_resumed_empty_final_answer_survives_a_state_roundtrip() -> None:
+    """The post-rejection state is recoverable through the real mechanism.
+
+    The guard exists for checkpoint resumes, so the rejection it performs has to
+    survive ``get_state``/``load_state`` rather than only an in-process mutation.
+    """
+
+    pattern = ReActPattern(max_iterations=3)
+    pattern.status = "acting"
+    pattern.pending_tool_calls = [
+        {
+            "id": "call_resumed",
+            "name": "final_answer",
+            "args": {"response_language": "English", "outcome": "completed"},
+        }
+    ]
+
+    resumed = ReActPattern(max_iterations=3)
+    resumed.load_state(pattern.get_state())
+    assert resumed.pending_tool_calls == pattern.pending_tool_calls
+
+    llm = StreamingEmptyFinalAnswerLLM()
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("What is 2+2?")
+    result = await resumed.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=PatternRuntime(execution_id="task-1"),
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+
+    # The forcing the rejection installed is itself serializable, which is what a
+    # crash between the rejection and the next turn would depend on.
+    carried = ReActPattern()
+    carried.load_state(resumed.get_state())
+    assert carried.force_final_answer_next is False  # cleared once answered
+    assert carried.tool_ledger["call_resumed"].status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_react_resumed_empty_final_answer_abandons_after_forced_retry() -> None:
+    """resume -> reject -> forced turn -> empty -> in-turn retry -> abandon."""
+
+    llm = StreamingEmptyFinalAnswerLLM(recover=False)
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+    pattern.status = "acting"
+    pattern.pending_tool_calls = [
+        {
+            "id": "call_resumed",
+            "name": "final_answer",
+            "args": {"response_language": "English", "outcome": "completed"},
+        }
+    ]
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "invalid_tool_protocol"
+    assert result["empty_final_answer"] is True
+    assert pattern.pending_tool_calls == []
+    # The forced turn plus its one in-turn repair attempt, and no more.
+    assert len(llm.stream_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_react_resumed_reverse_batch_order_cannot_undo_an_executed_tool() -> None:
+    """Pins the documented limit of the resume guard's batch discard.
+
+    In ``[work_tool, final_answer("")]`` the work tool has already executed by
+    the time the rejection runs, so the match with the fresh path's
+    whole-response rejection is exact only when the empty answer comes first.
+    """
+
+    llm = StreamingEmptyFinalAnswerLLM()
+    tool = FakeTool()
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+    pattern.status = "acting"
+    pattern.pending_tool_calls = [
+        {"id": "call_work", "name": "calculator", "args": {"expression": "2+2"}},
+        {
+            "id": "call_resumed",
+            "name": "final_answer",
+            "args": {"response_language": "English", "outcome": "completed"},
+        },
+    ]
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    # The work tool ran: the rejection cannot reach back past it.
+    assert tool.calls == [{"expression": "2+2"}]
+    assert pattern.tool_ledger["call_work"].status == "completed"
+    assert pattern.tool_ledger["call_resumed"].status == "failed"
+
+
+def test_rejected_empty_final_answer_is_recorded_as_a_failure() -> None:
+    """The rejection must not read back as a successful tool result."""
+
+    pattern = ReActPattern()
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("What is 2+2?")
+    tool_call = {"id": "call_1", "name": "final_answer", "args": {"answer": ""}}
+    pattern.pending_tool_calls = [tool_call]
+
+    pattern._reject_empty_final_answer(tool_call, context)
+
+    recorded = pattern.tool_ledger["call_1"]
+    assert recorded.status == "failed"
+    # The recorded result carries the keys ``tool_result_succeeded`` reads, so a
+    # consumer cannot read this failure back as a success.
+    assert tool_result_succeeded(recorded.result) is False
+    # Same shape as the cancelled siblings, so the ledger is uniform.
+    assert recorded.result["status"] == "error"
+    tool_messages = [m for m in context.messages if getattr(m, "role", None) == "tool"]
+    assert "empty answer" in tool_messages[-1].content
+
+
+def test_reject_empty_final_answer_tolerates_non_string_arg_keys() -> None:
+    """Log formatting must not abort the run it is diagnosing.
+
+    ``sorted`` over mixed-type keys raises ``TypeError``, and ``run()`` re-raises
+    from its ``except``, so an unsortable payload would fail the run at exactly
+    the point this guard exists to recover from.
+    """
+
+    pattern = ReActPattern()
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("What is 2+2?")
+    tool_call = {
+        "id": "call_1",
+        "name": "final_answer",
+        "args": {"answer": "", 1: "numeric", None: "null"},
+    }
+    pattern.pending_tool_calls = [tool_call]
+
+    pattern._reject_empty_final_answer(tool_call, context)
+
+    assert pattern.force_final_answer_next is True

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 from types import SimpleNamespace
 from typing import Any
@@ -5115,3 +5116,262 @@ async def test_final_answer_preserves_semantic_completion_outcome() -> None:
     assert result["success"] is True
     assert result["status"] == "completed"
     assert result["completion_outcome"] == "partial"
+
+
+class StreamingEmptyFinalAnswerLLM:
+    """Calls ``final_answer`` with an unusable answer, then optionally recovers.
+
+    Models the two observed shapes of xorbitsai/xagent#1312: an arguments object
+    that omits ``answer`` entirely (truncated output), and an arguments payload
+    that fails JSON parsing.
+    """
+
+    RECOVERED_ARGUMENTS = (
+        '{"response_language":"English","answer":"The result is 4.",'
+        '"outcome":"completed"}'
+    )
+
+    def __init__(
+        self,
+        *,
+        recover: bool = True,
+        broken_arguments: str = '{"response_language":"English","outcome":"completed"}',
+    ) -> None:
+        self.recover = recover
+        self.broken_arguments = broken_arguments
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        raise AssertionError("empty final answer path should stay streaming")
+
+    async def stream_chat(
+        self, messages: list[dict[str, Any]] | None = None, **kwargs: Any
+    ) -> Any:
+        if messages is not None:
+            kwargs["messages"] = messages
+        self.stream_calls.append(kwargs)
+        call_index = len(self.stream_calls) - 1
+        arguments = (
+            self.RECOVERED_ARGUMENTS
+            if call_index > 0 and self.recover
+            else self.broken_arguments
+        )
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "id": f"call_final_{call_index}",
+                    "function": {"name": "final_answer", "arguments": arguments},
+                }
+            ],
+        )
+        yield StreamChunk(type=ChunkType.END)
+
+
+def _react_empty_final_answer_fixture() -> tuple[
+    ReActPattern,
+    ExecutionContext,
+    PatternRuntime,
+    OutboundCollector,
+    TraceEventRecorder,
+]:
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("What is 2+2?")
+    outbound = OutboundCollector()
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(
+        execution_id="task-1",
+        tracer=tracer,
+        outbound_message_handler=outbound,
+    )
+    return pattern, context, runtime, outbound, tracer
+
+
+@pytest.mark.asyncio
+async def test_react_retries_final_answer_that_omits_the_answer_field() -> None:
+    llm = StreamingEmptyFinalAnswerLLM()
+    pattern, context, runtime, outbound, tracer = _react_empty_final_answer_fixture()
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert len(llm.stream_calls) == 2
+
+    retry_starts = [
+        event
+        for event in tracer.events
+        if event["event_type"] == "action_start_llm"
+        and event["data"].get("phase") == "empty_final_answer_recovery"
+    ]
+    assert len(retry_starts) == 1
+    assert retry_starts[0]["data"]["recovery_reason"] == "empty_final_answer"
+
+    # The discarded turn must not leak a partial stream to the user.
+    assert [event["type"] for event in outbound.events] == [
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_end",
+    ]
+    assert outbound.events[-1]["content"] == "The result is 4."
+
+
+@pytest.mark.asyncio
+async def test_react_fails_when_final_answer_stays_empty_after_retry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    llm = StreamingEmptyFinalAnswerLLM(recover=False)
+    pattern, context, runtime, outbound, tracer = _react_empty_final_answer_fixture()
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        result = await pattern.run(
+            context=context,
+            tools=[FakeTool()],
+            llm=llm,
+            runtime=runtime,
+        )
+
+    # The core regression: an empty answer must never finalize as success with
+    # the "No output provided" placeholder.
+    assert result["success"] is False
+    assert result["status"] == "invalid_tool_protocol"
+    assert "output" not in result
+    assert len(llm.stream_calls) == 2
+    assert outbound.events == []
+
+    discarded = [
+        event["data"]["phase"]
+        for event in tracer.events
+        if event["event_type"] == "action_end_llm"
+        and event["data"].get("success") is False
+    ]
+    assert discarded == [
+        "discarded_invalid_tool_protocol",
+        "discarded_invalid_tool_protocol_retry",
+    ]
+
+    # Neither condition was logged before this fix, leaving nothing to debug from.
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("final_answer carried no answer text" in m for m in messages)
+    assert any(
+        "invalid tool protocol after retry" in m and "failing the run" in m
+        for m in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_react_retries_final_answer_with_malformed_arguments() -> None:
+    llm = StreamingEmptyFinalAnswerLLM(
+        broken_arguments='{"response_language":"English","answer":"The res',
+    )
+    pattern, context, runtime, outbound, _tracer = _react_empty_final_answer_fixture()
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert len(llm.stream_calls) == 2
+    # Truncated arguments can stream a partial answer before the call is
+    # rejected. That partial is closed with an error and superseded by a fresh
+    # stream, matching how the pattern already handles a protocol retry - the
+    # point is that the run ends with a real answer instead of nothing.
+    assert [event["type"] for event in outbound.events] == [
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_error",
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_end",
+    ]
+    assert outbound.events[-1]["content"] == "The result is 4."
+
+
+@pytest.mark.asyncio
+async def test_react_re_requests_final_answer_for_resumed_empty_pending_call() -> None:
+    """A pending call restored from a checkpoint bypasses response normalization."""
+
+    llm = StreamingEmptyFinalAnswerLLM()
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+    pattern.status = "acting"
+    pattern.pending_tool_calls = [
+        {
+            "id": "call_resumed",
+            "name": "final_answer",
+            "args": {"response_language": "English", "outcome": "completed"},
+        }
+    ]
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert pattern.tool_ledger["call_resumed"].status == "failed"
+    assert pattern.pending_tool_calls == []
+    # The next turn is forced back to final_answer only.
+    assert [
+        tool["function"]["name"] for tool in llm.stream_calls[0].get("tools") or []
+    ] == ["final_answer"]
+
+
+def test_coerce_arguments_drops_unusable_control_tool_payloads() -> None:
+    pattern = ReActPattern()
+
+    # Work tools keep the opaque passthrough so existing behavior is unchanged.
+    assert pattern._coerce_arguments("not json", tool_name="calculator") == {
+        "input": "not json"
+    }
+    assert pattern._coerce_arguments("[1, 2]", tool_name="calculator") == {
+        "input": [1, 2]
+    }
+
+    # Control tools must not smuggle a malformed payload through as ``input``,
+    # which would silently strip ``answer`` and finalize with nothing to show.
+    assert pattern._coerce_arguments("not json", tool_name="final_answer") == {}
+    assert pattern._coerce_arguments('"just a string"', tool_name="final_answer") == {}
+    assert pattern._coerce_arguments("not json", tool_name="send_message") == {}
+
+    # Well-formed payloads are untouched.
+    assert pattern._coerce_arguments('{"answer":"hi"}', tool_name="final_answer") == {
+        "answer": "hi"
+    }
+
+
+def test_empty_final_answer_call_detects_blank_answers() -> None:
+    pattern = ReActPattern()
+
+    def normalized(args: Any) -> dict[str, Any]:
+        return {"tool_calls": [{"id": "c1", "name": "final_answer", "args": args}]}
+
+    assert pattern._empty_final_answer_call(normalized({})) is not None
+    assert pattern._empty_final_answer_call(normalized({"answer": ""})) is not None
+    assert pattern._empty_final_answer_call(normalized({"answer": "  \n"})) is not None
+    assert pattern._empty_final_answer_call(normalized({"answer": None})) is not None
+    assert pattern._empty_final_answer_call(normalized({"answer": "done"})) is None
+    # Coercion must match ``_handle_control_tool``, which stringifies the value,
+    # so a scalar answer is not mistaken for a missing one.
+    assert pattern._empty_final_answer_call(normalized({"answer": 0})) is None
+    assert pattern._empty_final_answer_call({"tool_calls": []}) is None
+    assert (
+        pattern._empty_final_answer_call(
+            {"tool_calls": [{"id": "c1", "name": "calculator", "args": {}}]}
+        )
+        is None
+    )

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5300,7 +5300,21 @@ async def test_react_retries_final_answer_with_malformed_arguments() -> None:
 
 
 @pytest.mark.asyncio
-async def test_react_re_requests_final_answer_for_resumed_empty_pending_call() -> None:
+@pytest.mark.parametrize(
+    "blank_answer",
+    [
+        pytest.param({}, id="missing"),
+        pytest.param({"answer": ""}, id="empty-string"),
+        pytest.param({"answer": "   \n"}, id="whitespace"),
+        # ``str(None)`` is the literal "None", which would sail past a naive
+        # ``str(args.get("answer", "")).strip()`` check and be finalized as the
+        # user-facing answer.
+        pytest.param({"answer": None}, id="none"),
+    ],
+)
+async def test_react_re_requests_final_answer_for_resumed_empty_pending_call(
+    blank_answer: dict[str, Any],
+) -> None:
     """A pending call restored from a checkpoint bypasses response normalization."""
 
     llm = StreamingEmptyFinalAnswerLLM()
@@ -5310,7 +5324,11 @@ async def test_react_re_requests_final_answer_for_resumed_empty_pending_call() -
         {
             "id": "call_resumed",
             "name": "final_answer",
-            "args": {"response_language": "English", "outcome": "completed"},
+            "args": {
+                "response_language": "English",
+                "outcome": "completed",
+                **blank_answer,
+            },
         }
     ]
 
@@ -5329,6 +5347,23 @@ async def test_react_re_requests_final_answer_for_resumed_empty_pending_call() -
     assert [
         tool["function"]["name"] for tool in llm.stream_calls[0].get("tools") or []
     ] == ["final_answer"]
+
+
+def test_final_answer_text_treats_none_as_absent() -> None:
+    """One coercion for both the protocol check and finalization.
+
+    ``str(None)`` is the literal "None"; if the two sites coerce independently
+    they drift, and a null answer gets finalized as the string "None".
+    """
+
+    pattern = ReActPattern()
+
+    assert pattern._final_answer_text({"answer": None}) == ""
+    assert pattern._final_answer_text({}) == ""
+    assert pattern._final_answer_text(None) == ""
+    assert pattern._final_answer_text({"answer": ""}) == ""
+    assert pattern._final_answer_text({"answer": "  hi  "}) == "  hi  "
+    assert pattern._final_answer_text({"answer": 0}) == "0"
 
 
 def test_coerce_arguments_drops_unusable_control_tool_payloads() -> None:

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5137,9 +5137,11 @@ class StreamingEmptyFinalAnswerLLM:
         *,
         recover: bool = True,
         broken_arguments: str = '{"response_language":"English","outcome":"completed"}',
+        preamble: str = "",
     ) -> None:
         self.recover = recover
         self.broken_arguments = broken_arguments
+        self.preamble = preamble
         self.stream_calls: list[dict[str, Any]] = []
 
     async def chat(self, **kwargs: Any) -> Any:
@@ -5157,6 +5159,8 @@ class StreamingEmptyFinalAnswerLLM:
             if call_index > 0 and self.recover
             else self.broken_arguments
         )
+        if self.preamble:
+            yield StreamChunk(type=ChunkType.TOKEN, delta=self.preamble)
         yield StreamChunk(
             type=ChunkType.TOOL_CALL,
             tool_calls=[
@@ -5683,3 +5687,32 @@ def test_reject_empty_final_answer_tolerates_non_string_arg_keys() -> None:
     pattern._reject_empty_final_answer(tool_call, context)
 
     assert pattern.force_final_answer_next is True
+
+
+@pytest.mark.asyncio
+async def test_react_discards_the_preamble_with_the_rejected_response() -> None:
+    """Pins the documented cost of whole-response rejection.
+
+    The preamble arrived attached to a protocol violation, so it is not a vetted
+    answer and is dropped with the response rather than replayed into the retry.
+    A model that recovers supersedes it; one that repeats the pattern fails the
+    run and the preamble is never shown.
+    """
+
+    llm = StreamingEmptyFinalAnswerLLM(preamble="Let me look into that.")
+    pattern, context, runtime, outbound, _tracer = _react_empty_final_answer_fixture()
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert "Let me look into that." not in str(result["response"])
+    assert all(
+        "Let me look into that." not in str(event.get("content") or event.get("delta"))
+        for event in outbound.events
+    )

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -1072,6 +1072,54 @@ async def test_agent_tool_real_child_with_stale_assistant_preamble_fails_closed(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("marker", "expects_no_answer_classification"),
+    [
+        pytest.param(True, True, id="empty-answer"),
+        pytest.param(False, False, id="other-protocol-violation"),
+    ],
+)
+async def test_agent_tool_child_protocol_failure_keeps_its_diagnostic(
+    monkeypatch, marker, expects_no_answer_classification
+):
+    """Only a genuinely unanswered child is classified as missing output.
+
+    ``invalid_tool_protocol`` also covers provider protocol errors, mixed
+    control calls, and a non-``final_answer`` tool on a forced turn, which can
+    follow a child that did produce text. For those the child's own error is the
+    parent's only way to tell "the child model misbehaved" from "the child had
+    nothing to say", so it must survive classification.
+    """
+
+    child_error = "The model returned an invalid tool protocol response."
+
+    async def execute_task():
+        return {
+            "status": "invalid_tool_protocol",
+            "success": False,
+            "error": child_error,
+            "empty_final_answer": marker,
+        }
+
+    _patch_delegated_runtime(
+        monkeypatch, execute_task, close_config=_SucceedingCloseConfig
+    )
+    tool = _delegated_agent_tool()
+    monkeypatch.setattr(tool, "_create_child_execution_tracer", lambda **_kwargs: None)
+
+    result = await tool.run_json_async({"task": "run"})
+
+    assert result["status"] == "error"
+    assert result["success"] is False
+    if expects_no_answer_classification:
+        assert result["failure_code"] == "missing_delegated_output"
+        assert child_error not in result["output"]
+    else:
+        assert "failure_code" not in result
+        assert result["output"] == child_error
+
+
+@pytest.mark.asyncio
 async def test_agent_tool_real_child_answering_with_placeholder_text_succeeds(
     monkeypatch, tmp_path
 ):

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -856,10 +856,10 @@ async def test_agent_tool_without_resolved_model_fails_closed(monkeypatch):
 class _StubSingleCallLLM:
     """Minimal LLM stub returning one fixed tool call from ``chat()``.
 
-    Each scenario below only needs a single LLM turn: both the
-    ``ask_user_question`` and the empty ``final_answer`` control tools end
-    the ReAct loop immediately once handled, so no follow-up response is
-    ever requested.
+    ``ask_user_question`` ends the ReAct loop immediately once handled, so
+    those scenarios only need a single turn. An empty ``final_answer`` is
+    rejected as a tool-protocol violation and re-requested once, so those
+    scenarios take two turns and get this same fixed response both times.
     """
 
     model_name = "stub-model"
@@ -977,12 +977,15 @@ async def test_agent_tool_real_child_with_empty_final_answer_fails_closed(
 ):
     """A real ReAct child that answers with an empty ``final_answer`` fails closed.
 
-    The classifier reads the child's raw ``""`` final answer directly, so
-    this scenario never touches the placeholder constants at all; it is
-    ``test_agent_tool_completed_child_without_usable_output_fails_closed``'s
-    parametrized rows (which do exercise the literal placeholder strings)
-    that serve as the drift detector for ``NO_OUTPUT_PLACEHOLDER`` /
-    ``NO_RESPONSE_PLACEHOLDER``.
+    ReAct now rejects an empty ``final_answer`` as a tool-protocol violation and
+    spends its one repair retry on it, so this scenario fails inside the child's
+    own run rather than reaching the parent as a ``completed`` result for the
+    classifier to reject. The fail-closed property is what matters here; the
+    classifier's ``missing_delegated_output`` branch is still reached by
+    completed-but-empty children and stays covered by
+    ``test_agent_tool_completed_child_without_usable_output_fails_closed``,
+    whose parametrized rows also serve as the drift detector for
+    ``NO_OUTPUT_PLACEHOLDER`` / ``NO_RESPONSE_PLACEHOLDER``.
     """
 
     llm = _StubSingleCallLLM(
@@ -1004,25 +1007,27 @@ async def test_agent_tool_real_child_with_empty_final_answer_fails_closed(
 
     result = await tool.run_json_async({"task": "run"})
 
-    assert result["failure_code"] == "missing_delegated_output"
     assert result["status"] == "error"
     assert result["success"] is False
+    assert tool_result_succeeded(result) is False
+    # The child re-requested an answer once before giving up, instead of
+    # finalizing the empty one.
+    assert llm.calls == 2
 
 
 @pytest.mark.asyncio
 async def test_agent_tool_real_child_with_stale_assistant_preamble_fails_closed(
     monkeypatch, tmp_path
 ):
-    """A completed child with an empty final answer fails closed even when
-    the adapter backfilled a non-empty earlier assistant message as output.
+    """A child with an empty final answer never surfaces a stale preamble.
 
     The single LLM turn carries both a reasoning preamble (assistant
-    ``content``) and an empty ``final_answer``. ``AgentExecutionAdapter``
-    backfills the normalized ``output`` from that preamble via
-    ``_latest_assistant_message`` because the pattern's own answer is falsy
-    (execution_adapter.py:362-363, 399-409) — without reading the raw
-    ``agent_result`` envelope, the classifier would see a non-empty
-    ``output`` and let this reach the parent as a completed response.
+    ``content``) and an empty ``final_answer``. The preamble is exactly what
+    ``AgentExecutionAdapter`` would backfill as ``output`` via
+    ``_latest_assistant_message`` when the pattern's own answer is falsy, so
+    the invariant under test is that it must never reach the parent as the
+    child's answer. ReAct now rejects the empty ``final_answer`` before the run
+    can complete, so the failure is reported instead of the preamble.
     """
 
     llm = _StubSingleCallLLM(
@@ -1044,9 +1049,14 @@ async def test_agent_tool_real_child_with_stale_assistant_preamble_fails_closed(
 
     result = await tool.run_json_async({"task": "run"})
 
-    assert result["failure_code"] == "missing_delegated_output"
     assert result["status"] == "error"
     assert result["success"] is False
+    assert tool_result_succeeded(result) is False
+    # The invariant: the preamble must not be laundered into the child's answer.
+    assert "Let me look into that for you." not in json.dumps(
+        {key: value for key, value in result.items() if key != "agent_result"},
+        default=str,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/test_agent_tool_session_isolation.py
+++ b/tests/core/tools/test_agent_tool_session_isolation.py
@@ -12,7 +12,10 @@ from sqlalchemy.orm import sessionmaker
 import xagent.core.tools.adapters.vibe.agent_tool as mod
 import xagent.core.tools.adapters.vibe.db_session as db_session_module
 from xagent.core.agent.result import tool_result_succeeded
-from xagent.core.tools.adapters.vibe.agent_tool import AgentTool
+from xagent.core.tools.adapters.vibe.agent_tool import (
+    _CHILD_NO_ANSWER_MESSAGE,
+    AgentTool,
+)
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.database import Base
 from xagent.web.models.model import Model
@@ -978,14 +981,17 @@ async def test_agent_tool_real_child_with_empty_final_answer_fails_closed(
     """A real ReAct child that answers with an empty ``final_answer`` fails closed.
 
     ReAct now rejects an empty ``final_answer`` as a tool-protocol violation and
-    spends its one repair retry on it, so this scenario fails inside the child's
-    own run rather than reaching the parent as a ``completed`` result for the
-    classifier to reject. The fail-closed property is what matters here; the
-    classifier's ``missing_delegated_output`` branch is still reached by
-    completed-but-empty children and stays covered by
-    ``test_agent_tool_completed_child_without_usable_output_fails_closed``,
-    whose parametrized rows also serve as the drift detector for
-    ``NO_OUTPUT_PLACEHOLDER`` / ``NO_RESPONSE_PLACEHOLDER``.
+    spends its one repair retry on it, so the child fails inside its own run
+    instead of reaching the parent as a ``completed`` result. It still classifies
+    as ``missing_delegated_output`` — the child never produced an answer either
+    way — but via the no-answer-status branch rather than the completed-but-empty
+    one, and the parent sees an actionable message instead of the runtime's
+    "invalid tool protocol" diagnostic.
+
+    ``test_agent_tool_completed_child_without_usable_output_fails_closed``
+    covers the completed-but-empty branch, and its parametrized rows serve as
+    the drift detector for ``NO_OUTPUT_PLACEHOLDER`` /
+    ``NO_RESPONSE_PLACEHOLDER``.
     """
 
     llm = _StubSingleCallLLM(
@@ -1007,12 +1013,17 @@ async def test_agent_tool_real_child_with_empty_final_answer_fails_closed(
 
     result = await tool.run_json_async({"task": "run"})
 
+    assert result["failure_code"] == "missing_delegated_output"
     assert result["status"] == "error"
     assert result["success"] is False
     assert tool_result_succeeded(result) is False
     # The child re-requested an answer once before giving up, instead of
     # finalizing the empty one.
     assert llm.calls == 2
+    # The parent gets an actionable message, not the child's internal
+    # "invalid tool protocol" diagnostic.
+    assert "tool protocol" not in result["output"]
+    assert result["output"] == _CHILD_NO_ANSWER_MESSAGE
 
 
 @pytest.mark.asyncio
@@ -1049,6 +1060,7 @@ async def test_agent_tool_real_child_with_stale_assistant_preamble_fails_closed(
 
     result = await tool.run_json_async({"task": "run"})
 
+    assert result["failure_code"] == "missing_delegated_output"
     assert result["status"] == "error"
     assert result["success"] is False
     assert tool_result_succeeded(result) is False


### PR DESCRIPTION
Fixes #1312.

## Problem

Under `tool_choice="required"`, `final_answer` is the only way ReAct can reply to the user. When the model called it with a missing, blank, or malformed `answer`, the run still finalized as `success=True` / `status="completed"`: nothing was streamed to the UI, the persisted assistant message fell back to the `"No output provided"` placeholder, and neither condition was logged — so the failure left no trace to debug from.

`AutoPattern` already rejected an empty final answer and fell back to a full reasoning pass. ReAct had no equivalent guard, even though it is the pattern where `final_answer` is the only exit.

## Fix

Treat an empty answer as a tool-protocol violation, so it flows into the pattern's **existing** single repair retry rather than needing new control flow — and fail the run explicitly when the retry is empty too.

- **`_response_requires_tool_protocol_retry`** rejects a `final_answer` whose `answer` is missing or blank. It previously checked the forced-final-answer turn by tool *name* only and never inspected the arguments. A new `empty_final_answer` recovery reason carries a tailored retry instruction — worded differently on a forced turn, where `final_answer` is the only available tool — and its own trace phase (`empty_final_answer_recovery`).
- **`_coerce_arguments`** no longer coerces malformed JSON into `{"input": ...}` for control tools. That path silently stripped `answer` and let the run finalize with nothing to show; it now logs and drops the payload so the check above rejects the call. Work tools keep the opaque passthrough unchanged.
- **`_handle_control_tool`** refuses to finalize on an empty answer and re-requests one. This covers the paths that reach the handler without passing through response normalization — most importantly a checkpoint resume, which restores `pending_tool_calls` verbatim. It returns control to the loop with `force_final_answer_next` set, so the normalization guard bounds the retry instead of letting it spin.
- **Logging** at both conditions and at the give-up path, plus a warning in `AgentExecutionAdapter._normalize_result` before it substitutes `NO_OUTPUT_PLACEHOLDER`.

### Bounding

The retry is bounded by the mechanism it reuses: one repair attempt, then `_invalid_tool_protocol_result` returns `success=False` with `status="invalid_tool_protocol"`. The handler-level guard is bounded by the normalization guard on the following turn. An unbounded "force another reasoning turn" would have spun, because on the forced branch the tool set is reduced to `final_answer` alone.

## Two suggestions from the issue deliberately not applied

**Reordering the schema so `answer` comes first.** `response_language` is sequenced first so the model commits to an output language before writing prose, and `AutoDecision.to_payload` orders the two fields the same way. `answer` is already in `required` with `additionalProperties: False`, so the trigger was never a permissive schema — it was providers that do not enforce strict schemas, `max_tokens` truncation, and the swallowed parse error. Reordering would invert deliberate sequencing to mitigate only the truncation case, which the guard now catches anyway.

**Making the adapter report `success=False` on empty output.** The comment at `execution_adapter.py:363-367` documents that the delegated-child classifier in `agent_tool.py` reads the pre-backfill answer from `agent_result` specifically so a backfilled preamble cannot be mistaken for a real final answer. Changing the success semantics there risks that contract; the root cause is in ReAct. Logging is safe, so that is all this PR does at that layer — gated on `success`, since an empty output is legitimate on every non-success path.

## Tests

Six regression tests in `tests/core/agent/test_react.py`, each verified to fail without the fix:

| Test | Pre-fix failure |
|---|---|
| `test_react_retries_final_answer_that_omits_the_answer_field` | `assert '' == 'The result is 4.'` |
| `test_react_fails_when_final_answer_stays_empty_after_retry` | `assert True is False` on `success` — the exact reported symptom |
| `test_react_retries_final_answer_with_malformed_arguments` | same empty finalization via the JSON path |
| `test_react_re_requests_final_answer_for_resumed_empty_pending_call` | resume path bypasses normalization |
| `test_coerce_arguments_drops_unusable_control_tool_payloads` | `tool_name` kwarg did not exist |
| `test_empty_final_answer_call_detects_blank_answers` | helper did not exist |

The failure test also asserts the warning lines are emitted, since "no trace to debug from" was half the report.

One behavior worth flagging, asserted rather than left implicit: truncated arguments can stream a partial answer before the call is rejected. That partial is closed with `final_answer_error` and superseded by a fresh stream — the same shape the pattern already uses for a protocol retry. The point is that the run now ends with a real answer instead of nothing.

## Verification

- `tests/core/agent` (289 tests) and `tests/core/model` pass.
- ruff 0.12.3, mypy 1.19.0, and all pre-commit hooks pass.

My local environment is not provisioned for the whole suite — on an **unmodified** tree it already has 164 failures across ~40 files, from missing optional dependencies (pptxgenjs/Node, SVG rasterization, sandbox/Docker, OAuth, deepdoc) plus a set of ordering-dependent `caplog` tests. I captured that baseline by reverting this diff and re-running the identical command, so the pre-existing set is known rather than assumed; in particular every failure in `test_web_tool_config_session_factory.py` and `test_task_tracker.py` is present with this change reverted. CI is the authority on suite health here.
