### PR TITLE
feat(steps): surface planning phase from dag execution events

### DIFF
--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -39,6 +39,7 @@ Incremental projection:
     :class:`PublicStepProjector`, not in this function. The projector
     holds all the folding state a fold needs -- the pending
     (start-seen, end-not-yet-seen) table, the ``dag_plan_*`` replan
+    counter, and the independent ``dag_execution`` planning-phase
     counter -- so a caller can feed it one event at a time and read
     back the steps that changed. ``map_trace_events_to_public_steps``
     stays pure by constructing one fresh, throwaway projector per
@@ -58,6 +59,13 @@ Pairing rule:
       - ``dag_step_*`` events pair on ``step_id``.
       - ``dag_plan_*`` events pair on ``task_id`` (single planning
         phase per task; no per-plan identifier available).
+      - ``dag_execution`` events pair on ``data['phase']``: a
+        ``planning``/``replanning`` value opens a planning-phase
+        thinking step, an ``executing`` value closes the currently
+        open one. This is a second, independent source of the same
+        public phase as ``dag_plan_*`` above -- it keeps its own
+        counter and open key so the two families never collide, even
+        when both appear in the same event stream.
       - ``skill_select_*`` events pair on ``task_id`` (single skill
         selection phase per task).
 
@@ -158,6 +166,14 @@ class PublicStepProjector:
         # time); nesting would require a stack, which DAG doesn't emit.
         self._plan_counter = 0
         self._open_plan_key: Optional[str] = None
+        # ``dag_execution`` (phase planning/replanning/executing) is a
+        # second source of the same public planning phase, translated
+        # further down in ``feed``. It gets its own counter and open
+        # key so it never shares pairing state with ``dag_plan_*``
+        # above -- both families can appear in the same stream without
+        # cross-talk or id collisions.
+        self._dag_execution_counter = 0
+        self._open_dag_execution_key: Optional[str] = None
 
     @classmethod
     def from_history(cls, events: List[Any]) -> "PublicStepProjector":
@@ -272,8 +288,8 @@ class PublicStepProjector:
                     status="completed",
                 )
                 return [finalized] if finalized is not None else []
-            # other actions (e.g. dag_execution UPDATE) for these
-            # categories are not exposed.
+            # Events in these families that are neither a start nor an
+            # end carry no step transition.
             return []
 
         # ===== tool_call / agent_delegation: paired start/end + failure =====
@@ -381,6 +397,42 @@ class PublicStepProjector:
                 extra_data_fn=lambda ev: {"result": _data_get(ev, "result")},
             )
             return [finalized] if finalized is not None else []
+
+        # ===== dag_execution: translate an existing signal into the
+        # same public planning phase ``dag_plan_*`` produces =====
+        if event_type == "dag_execution":
+            phase = _data_get(event, "phase")
+            if not isinstance(phase, str):
+                # Missing/malformed phase: nothing to translate.
+                return []
+            if phase in ("planning", "replanning"):
+                self._dag_execution_counter += 1
+                task_ref = (
+                    _safe_get(event, "task_id")
+                    or _safe_get(event, "event_id")
+                    or "anon"
+                )
+                key = f"planning:{task_ref}:{self._dag_execution_counter}"
+                self._open_dag_execution_key = key
+                step = _build_thinking_start(event, phase="planning", key=key)
+                self._pending[("thinking", key)] = step
+                return [step]
+            if phase == "executing":
+                if self._open_dag_execution_key is None:
+                    # No open planning step to close: same policy as an
+                    # orphan end elsewhere in this module -- drop.
+                    return []
+                finalized = _finalize_pending(
+                    self._pending,
+                    self._finished,
+                    ("thinking", self._open_dag_execution_key),
+                    end_event=event,
+                    status="completed",
+                )
+                self._open_dag_execution_key = None
+                return [finalized] if finalized is not None else []
+            # Other phases (e.g. completion_assessment): not exposed.
+            return []
 
         # Everything else (llm_call_*, memory_*, dag_execute_*,
         # react_task_*, react_step_*, visualization_update,

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -84,9 +84,11 @@ Pairing rule:
     carry the same public step id (id and pairing key are derived from
     the same (type, key) pair), so a consumer folding ``feed`` results
     by id converges on the second step rather than being left with a
-    stranded ``running`` one. ``dag_plan_*`` is the one exception: it
-    has no natural key at all, so a counter gives every plan a
-    distinct one.
+    stranded ``running`` one. ``dag_plan_*`` and the planning-phase
+    steps ``dag_execution`` produces are the exception: neither has a
+    natural key at all, so each family keeps its own counter (and its
+    own ``plan:`` / ``planning:`` key prefix) to generate a distinct
+    one per occurrence.
 """
 
 from __future__ import annotations
@@ -245,6 +247,9 @@ class PublicStepProjector:
             # Special-cased because plan events have no per-plan id;
             # we generate one from a counter and remember the open
             # key so the next dag_plan_end pairs with the latest start.
+            # The dag_execution branch below keeps its own independent
+            # counter and "planning:" key prefix; keep pairing
+            # semantics changes in lockstep between the two branches.
             if event_type.endswith("_start"):
                 self._plan_counter += 1
                 task_ref = (

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1062,9 +1062,11 @@ async def get_chat_task_steps(
     The internal trace event taxonomy has ~32 ``event_type`` strings
     today; SDK callers see only the 4 types listed above. Internal
     events not on the public allow-list (LLM calls, memory ops,
-    visualization ticks, DAG bookkeeping) are silently dropped --
+    visualization ticks, most DAG bookkeeping) are silently dropped --
     intentionally, so internal trace evolution doesn't break the SDK
-    contract.
+    contract; the exception is dag_execution's planning/replanning/
+    executing phase transitions, which project onto a planning
+    thinking step.
 
     Args:
         task_id: Path parameter; the target task's primary key.

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -498,9 +498,10 @@ class TaskInfoResponse(BaseModel):
 # internal->public mapping table.
 PublicStepType = Literal["thinking", "tool_call", "agent_delegation", "message"]
 
-# ``running`` means a start event was seen with no matching end (the
-# task is still mid-step at the time of the GET). ``completed`` /
-# ``failed`` reflect the end event's success flag.
+# ``running`` means a start event was seen with no matching end; a
+# terminal task can still contain running steps (interrupted/cancelled
+# steps never get an end event). ``completed`` / ``failed`` reflect
+# the end event's success flag.
 PublicStepStatus = Literal["running", "completed", "failed"]
 
 
@@ -542,12 +543,12 @@ class PublicStep(BaseModel):
         ...,
         description=(
             "running while the corresponding end event has not yet "
-            "fired. A task in a terminal state can still contain "
-            "running steps: interrupted or cancelled steps never get "
-            "an end event, so terminal state is judged from the task's "
-            "own status, not from the absence of running steps. "
-            "completed on a normal end event, failed when the end "
-            "event carries success=false."
+            "fired, completed on a normal end event, failed when the "
+            "end event carries success=false. A task in a terminal "
+            "state can still contain running steps: interrupted or "
+            "cancelled steps never get an end event, so terminal "
+            "state is judged from the task's own status, not from "
+            "the absence of running steps."
         ),
     )
     started_at: datetime = Field(

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -542,9 +542,12 @@ class PublicStep(BaseModel):
         ...,
         description=(
             "running while the corresponding end event has not yet "
-            "fired (i.e. the SDK polled mid-step), completed on a "
-            "normal end event, failed when the end event carries "
-            "success=false."
+            "fired. A task in a terminal state can still contain "
+            "running steps: interrupted or cancelled steps never get "
+            "an end event, so terminal state is judged from the task's "
+            "own status, not from the absence of running steps. "
+            "completed on a normal end event, failed when the end "
+            "event carries success=false."
         ),
     )
     started_at: datetime = Field(

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -1192,6 +1192,29 @@ def test_dag_execution_planning_pair_becomes_thinking_planning():
     assert s["id"] == "thinking:planning:t1:1"
 
 
+def test_dag_execution_planning_pair_with_integer_task_id():
+    events = [
+        _dag_exec_ev(
+            "planning",
+            task_id=42,
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id=42,
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 1
+    s = steps[0]
+    # An int task_id must interpolate into the key the same way a str
+    # one does.
+    assert s["id"] == "thinking:planning:42:1"
+    assert s["status"] == "completed"
+    assert s["completed_at"] == events[1].timestamp
+
+
 def test_two_dag_execution_planning_entries_produce_two_separate_steps():
     """Each entry into planning -- not just replan -- produces its own
     step; a replanning entry reports the same public phase as a first

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -46,6 +46,25 @@ def _ev(
     )
 
 
+def _dag_exec_ev(
+    phase: str,
+    *,
+    task_id: Optional[str] = "t1",
+    timestamp: Optional[datetime] = None,
+    **extra_data: Any,
+) -> SimpleNamespace:
+    """Build a synthetic ``dag_execution`` event.
+
+    ``phase`` is the only field the projector reads out of ``data``;
+    ``extra_data`` lets callers attach the other fields a real
+    emission carries (``completed_step_count``, ``plan_step_count``,
+    ``steps``, ...) so a test can prove none of them leak into the
+    public step.
+    """
+    data: Dict[str, Any] = {"phase": phase, **extra_data}
+    return _ev("dag_execution", task_id=task_id, data=data, timestamp=timestamp)
+
+
 # ===== happy paths: each public type appears at least once =====
 
 
@@ -966,6 +985,62 @@ _PROJECTOR_EQUIVALENCE_CASES: Dict[str, List[SimpleNamespace]] = {
             timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
         ),
     ],
+    "dag_execution_planning_pair": [
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            completed_step_count=0,
+            previous_step_count=0,
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+            plan_step_count=2,
+            replan=False,
+            steps=[{"id": "s1"}, {"id": "s2"}],
+        ),
+    ],
+    "dag_execution_resume_sequence": [
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+    ],
+    "dag_plan_and_dag_execution_coexist": [
+        _ev(
+            "dag_plan_start",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "dag_plan_end",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+        ),
+    ],
     "unexposed_event_types_are_dropped": [
         _ev("llm_call_start", step_id="s1"),
         _ev("llm_call_end", step_id="s1"),
@@ -1083,3 +1158,254 @@ def test_feed_return_value_reflects_step_state_at_call_time():
 
     # Empty/falsy event_type: nothing identifiable to fold.
     assert PublicStepProjector().feed(_ev("", step_id="s1")) == []
+
+
+# ===== dag_execution: planning-phase visibility from an existing signal =====
+
+
+def test_dag_execution_planning_pair_becomes_thinking_planning():
+    events = [
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            completed_step_count=0,
+            previous_step_count=0,
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+            plan_step_count=2,
+            replan=False,
+            steps=[{"id": "s1"}, {"id": "s2"}],
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 1
+    s = steps[0]
+    assert s["type"] == "thinking"
+    assert s["data"]["phase"] == "planning"
+    assert s["status"] == "completed"
+    # id shape is pinned separately from the legacy dag_plan_* family
+    # so the two counters can never collide.
+    assert s["id"] == "thinking:planning:t1:1"
+
+
+def test_two_dag_execution_planning_entries_produce_two_separate_steps():
+    """Each entry into planning -- not just replan -- produces its own
+    step; a replanning entry reports the same public phase as a first
+    planning entry.
+    """
+    events = [
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "replanning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 2
+    assert all(s["data"]["phase"] == "planning" for s in steps)
+    assert all(s["status"] == "completed" for s in steps)
+    assert steps[0]["id"] == "thinking:planning:t1:1"
+    assert steps[1]["id"] == "thinking:planning:t1:2"
+
+
+def test_dag_execution_planning_without_executing_stays_running():
+    """No executing row (planning failed or task is still in flight):
+    the step stays running -- and the output is already non-empty with
+    the first step reporting phase=planning, i.e. visible without
+    waiting for the executing row.
+    """
+    events = [_dag_exec_ev("planning", task_id="t1")]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 1
+    assert steps[0]["type"] == "thinking"
+    assert steps[0]["data"]["phase"] == "planning"
+    assert steps[0]["status"] == "running"
+    assert steps[0]["completed_at"] is None
+
+
+def test_dag_execution_planning_failure_does_not_disturb_other_steps():
+    """A planning step left running does not block other, unrelated
+    steps in the same stream from folding normally."""
+    events = [
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "react_action_start",
+            step_id="s1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "react_action_end",
+            step_id="s1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 2
+    planning_step = next(s for s in steps if s["data"]["phase"] == "planning")
+    action_step = next(s for s in steps if s["data"]["phase"] == "action")
+    assert planning_step["status"] == "running"
+    assert action_step["status"] == "completed"
+
+
+def test_dag_execution_resume_sequence_first_running_second_completed():
+    """A resumed-after-interruption sequence (planning, planning,
+    executing -- no executing between the two plannings) leaves the
+    first step running and closes only the second."""
+    events = [
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 2
+    assert steps[0]["status"] == "running"
+    assert steps[0]["completed_at"] is None
+    assert steps[1]["status"] == "completed"
+    assert steps[1]["completed_at"] is not None
+    assert steps[0]["id"] != steps[1]["id"]
+
+
+def test_dag_execution_translated_step_data_is_phase_only():
+    """The translated step's ``data`` is exactly ``{"phase": ...}`` --
+    none of the source event's other fields (completed_step_count,
+    plan_step_count, replan, the full plan step list) leak through,
+    whether the step is still running or already completed.
+    """
+    running_only = map_trace_events_to_public_steps(
+        [
+            _dag_exec_ev(
+                "planning",
+                task_id="t1",
+                completed_step_count=1,
+                previous_step_count=2,
+            )
+        ]
+    )
+    assert set(running_only[0]["data"].keys()) == {"phase"}
+
+    events = [
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            completed_step_count=1,
+            previous_step_count=2,
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+            plan_step_count=3,
+            replan=True,
+            steps=[{"id": "s1", "task": "do x"}],
+        ),
+    ]
+    completed = map_trace_events_to_public_steps(events)
+    assert len(completed) == 1
+    assert set(completed[0]["data"].keys()) == {"phase"}
+    assert completed[0]["data"]["phase"] == "planning"
+
+
+@pytest.mark.parametrize("phase", ["completion_assessment", "some_future_phase"])
+def test_dag_execution_other_phases_are_dropped(phase):
+    """Phases outside {planning, replanning, executing} are not
+    translated -- current behavior for dag_execution is preserved."""
+    events = [_dag_exec_ev(phase, task_id="t1")]
+    assert map_trace_events_to_public_steps(events) == []
+
+
+def test_dag_execution_missing_or_malformed_phase_is_dropped():
+    """Fail-safe: a missing/non-string ``phase``, or a ``data``
+    payload that isn't even a dict, falls into the discard branch
+    instead of raising."""
+    no_phase = _dag_exec_ev("planning", task_id="t1")
+    no_phase.data = {}
+    non_str_phase = _dag_exec_ev("planning", task_id="t1")
+    non_str_phase.data = {"phase": 123}
+    none_phase = _dag_exec_ev("planning", task_id="t1")
+    none_phase.data = {"phase": None}
+    non_dict_data = _dag_exec_ev("planning", task_id="t1")
+    non_dict_data.data = None
+    for event in (no_phase, non_str_phase, none_phase, non_dict_data):
+        assert PublicStepProjector().feed(event) == []
+
+
+def test_dag_execution_executing_without_open_planning_is_noop():
+    """Orphan executing (no preceding planning start): drops silently,
+    same policy as an orphan end elsewhere in this module."""
+    events = [_dag_exec_ev("executing", task_id="t1", plan_step_count=1, steps=[])]
+    assert map_trace_events_to_public_steps(events) == []
+
+
+def test_dag_plan_and_dag_execution_coexist_without_id_collision():
+    """Legacy dag_plan_* and dag_execution-derived planning steps
+    interleaved in one stream fold independently: separate counters,
+    separate open keys, each end pairs with its own family's start,
+    and the resulting ids never collide.
+    """
+    events = [
+        _ev(
+            "dag_plan_start",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "dag_plan_end",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "executing",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 2
+    assert all(
+        s["type"] == "thinking" and s["data"] == {"phase": "planning"} for s in steps
+    )
+    assert all(s["status"] == "completed" for s in steps)
+    ids = {s["id"] for s in steps}
+    assert len(ids) == 2
+    assert ids == {"thinking:plan:t1:1", "thinking:planning:t1:1"}


### PR DESCRIPTION
## What

`/v1` steps (and the shared public step projection) now translate the existing `dag_execution` planning/replanning/executing phase transitions into a `planning` thinking step: pollers see "planning" within one event of plan generation starting, instead of an empty list for the whole planning window.

No new events and no new persistence — the translation reads rows the runtime already records. Each entry into planning (first plan or replan) yields its own step; a plan that never reaches the executing phase leaves its step `running`, matching how interrupted steps already behave. The step `status` OpenAPI description now states that terminal tasks may contain running steps and that terminal state is judged from the task's own status.

## Why

Task startup spends several seconds inside plan generation, during which the steps endpoint returned an empty list — pollers had no signal that the server was doing anything. The planning phase was already recorded in the trace stream; it was just never projected.

## Verification

- Pairing pins: planning/replanning opens a step, executing completes it, each planning entry yields an independent step; a failure sequence (no executing event) leaves the step running without disturbing other steps.
- Resume sequence (`planning, planning, executing`) pins first-running/second-completed.
- Data-shape pin: the translated step's `data` keys are exactly `{"phase"}`.
- Coexistence fixture: legacy `dag_plan_*` events and `dag_execution` translation fold independently with disjoint step ids.
- Full `tests/web/api/v1` suite green on top of the projector extraction.
