### PR TITLE
refactor(users): display email for account labels

### DIFF
--- a/frontend/src/app/settings/page.test.tsx
+++ b/frontend/src/app/settings/page.test.tsx
@@ -6,7 +6,7 @@ import SettingsPage from "./page"
 import { claimAuthLoginIntent, createAuthSession, inspectAuthSession, updateAuthSessionUser, type AuthSessionSnapshot, type AuthTokenPayload } from "@/lib/auth-cache"
 
 const authState = vi.hoisted(() => ({
-  user: { id: "1", username: "alice", email: "old@example.com" },
+  user: { id: "1", username: "alice", email: "old@example.com" as string | null },
   session: null as AuthSessionSnapshot | null,
 }))
 const apiRequest = vi.hoisted(() => vi.fn())
@@ -49,6 +49,7 @@ describe("SettingsPage auth profile synchronization", () => {
   beforeEach(async () => {
     localStorage.clear()
     apiRequest.mockReset()
+    authState.user = { id: "1", username: "alice", email: "old@example.com" }
     Object.defineProperty(navigator, "locks", {
       configurable: true,
       value: { request: vi.fn(async (_name: string, callback: () => Promise<unknown>) => callback()) },
@@ -60,6 +61,38 @@ describe("SettingsPage auth profile synchronization", () => {
     })
     if (created.status !== "created") throw new Error("expected session")
     authState.session = created.projection.snapshot
+  })
+
+  it("does not render the username when an email label is available", async () => {
+    apiRequest.mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      user: authState.user,
+    }), { headers: { "Content-Type": "application/json" } }))
+
+    render(<SettingsPage />)
+
+    await waitFor(() => expect(apiRequest).toHaveBeenCalledOnce())
+    expect(screen.queryByDisplayValue("alice")).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue("old@example.com")).toBeInTheDocument()
+  })
+
+  it("retains the username label for an email-less account", async () => {
+    authState.user = { id: "1", username: "legacy-admin", email: null }
+    const replacement = await createSession({
+      user: authState.user,
+      access_token: "legacy-access",
+      refresh_token: "legacy-refresh",
+    })
+    if (replacement.status !== "created") throw new Error("expected replacement")
+    authState.session = replacement.projection.snapshot
+    apiRequest.mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      user: authState.user,
+    }), { headers: { "Content-Type": "application/json" } }))
+
+    render(<SettingsPage />)
+
+    expect(screen.getByDisplayValue("legacy-admin")).toBeInTheDocument()
   })
 
   it("renders the distribution task runtime settings slot", async () => {

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -133,14 +133,12 @@ export default function SettingsPage() {
               </Alert>
             )}
 
-            <div className="space-y-2">
-              <Label htmlFor="account-username">{t("settings.email.username")}</Label>
-              <Input
-                id="account-username"
-                value={user?.username || ""}
-                disabled
-              />
-            </div>
+            {!user?.email?.trim() && user?.username?.trim() && (
+              <div className="space-y-2">
+                <Label htmlFor="account-username">{t("settings.email.username")}</Label>
+                <Input id="account-username" value={user.username} disabled />
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="account-email">{t("settings.email.current")}</Label>

--- a/frontend/src/components/example/api-example.test.tsx
+++ b/frontend/src/components/example/api-example.test.tsx
@@ -1,0 +1,49 @@
+import React from "react"
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ApiExample } from "./api-example"
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({
+    user: {
+      id: "1",
+      username: "acct_0123456789abcdef0123456789abcdef",
+      email: "current@example.com",
+    },
+    token: "access-token",
+    refreshToken: "refresh-token",
+  }),
+}))
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+vi.mock("@/hooks/use-api", () => ({
+  apiHooks: {
+    useGet: () => ({ data: [], loading: false, error: null, refetch: vi.fn() }),
+  },
+}))
+vi.mock("@/hooks/use-websocket", () => ({
+  useWebSocket: () => ({ isConnected: false, connectionError: null }),
+}))
+vi.mock("@/lib/api-wrapper", () => ({ apiRequest: vi.fn() }))
+vi.mock("@/lib/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/utils")>()),
+  getApiUrl: () => "http://api.test",
+}))
+
+describe("ApiExample current-user label", () => {
+  beforeEach(() => vi.stubGlobal("React", React))
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it("shows email without exposing the opaque username", () => {
+    render(<ApiExample />)
+
+    expect(screen.getByText(/current@example\.com/)).toBeInTheDocument()
+    expect(screen.queryByText(/acct_0123456789abcdef/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/example/api-example.test.tsx
+++ b/frontend/src/components/example/api-example.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ApiExample } from "./api-example"
 
+const translateMock = vi.hoisted(() => vi.fn((key: string) => key))
+
 vi.mock("@/contexts/auth-context", () => ({
   useAuth: () => ({
     user: {
@@ -16,7 +18,7 @@ vi.mock("@/contexts/auth-context", () => ({
   }),
 }))
 vi.mock("@/contexts/i18n-context", () => ({
-  useI18n: () => ({ t: (key: string) => key }),
+  useI18n: () => ({ t: translateMock }),
 }))
 vi.mock("@/hooks/use-api", () => ({
   apiHooks: {
@@ -33,7 +35,10 @@ vi.mock("@/lib/utils", async (importOriginal) => ({
 }))
 
 describe("ApiExample current-user label", () => {
-  beforeEach(() => vi.stubGlobal("React", React))
+  beforeEach(() => {
+    vi.stubGlobal("React", React)
+    translateMock.mockClear()
+  })
 
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -45,5 +50,14 @@ describe("ApiExample current-user label", () => {
 
     expect(screen.getByText(/current@example\.com/)).toBeInTheDocument()
     expect(screen.queryByText(/acct_0123456789abcdef/)).not.toBeInTheDocument()
+  })
+
+  it("uses an example-owned fallback label", () => {
+    render(<ApiExample />)
+
+    expect(translateMock).toHaveBeenCalledWith(
+      "agent.vibeMode.descriptions.think.examples.apiExample.labels.defaultUser",
+    )
+    expect(translateMock).not.toHaveBeenCalledWith("sidebar.user.defaultName")
   })
 })

--- a/frontend/src/components/example/api-example.tsx
+++ b/frontend/src/components/example/api-example.tsx
@@ -7,6 +7,7 @@ import { useWebSocket } from "@/hooks/use-websocket"
 import { getApiUrl } from "@/lib/utils"
 import { apiRequest } from "@/lib/api-wrapper"
 import { useI18n } from "@/contexts/i18n-context"
+import { userDisplayLabel } from "@/lib/user-display"
 
 export function ApiExample() {
   const { user, token, refreshToken } = useAuth()
@@ -57,6 +58,7 @@ export function ApiExample() {
   if (!user) {
     return <div>{t('agentStore.loginRequiredTitle')}</div>
   }
+  const userLabel = userDisplayLabel(user, t("sidebar.user.defaultName"))
 
   return (
     <div className="p-6 space-y-6">
@@ -65,7 +67,7 @@ export function ApiExample() {
 
         <div className="space-y-4">
           <div className="p-4 bg-gray-50 rounded">
-            <p><strong>{t('agent.vibeMode.descriptions.think.examples.apiExample.labels.currentUser')}</strong> {user.username}</p>
+            <p><strong>{t('agent.vibeMode.descriptions.think.examples.apiExample.labels.currentUser')}</strong> {userLabel}</p>
             <p><strong>{t('agent.vibeMode.descriptions.think.examples.apiExample.labels.accessTokenStatus')}</strong> {token ? t('agent.vibeMode.descriptions.think.examples.apiExample.status.obtained') : t('agent.vibeMode.descriptions.think.examples.apiExample.status.notObtained')}</p>
             <p><strong>{t('agent.vibeMode.descriptions.think.examples.apiExample.labels.refreshTokenStatus')}</strong> {refreshToken ? t('agent.vibeMode.descriptions.think.examples.apiExample.status.obtained') : t('agent.vibeMode.descriptions.think.examples.apiExample.status.notObtained')}</p>
             <p><strong>{t('agent.vibeMode.descriptions.think.examples.apiExample.labels.wsStatus')}</strong> {wsStatus}</p>

--- a/frontend/src/components/example/api-example.tsx
+++ b/frontend/src/components/example/api-example.tsx
@@ -58,7 +58,10 @@ export function ApiExample() {
   if (!user) {
     return <div>{t('agentStore.loginRequiredTitle')}</div>
   }
-  const userLabel = userDisplayLabel(user, t("sidebar.user.defaultName"))
+  const userLabel = userDisplayLabel(
+    user,
+    t("agent.vibeMode.descriptions.think.examples.apiExample.labels.defaultUser"),
+  )
 
   return (
     <div className="p-6 space-y-6">

--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -7,7 +7,14 @@ import type { NavigationGroup } from "@/lib/sidebar-navigation"
 
 import { Sidebar } from "./sidebar"
 
-const authState = vi.hoisted(() => ({ logout: vi.fn<() => Promise<boolean>>(), user: { id: "1", username: "alice" } }))
+const authState = vi.hoisted(() => ({
+  logout: vi.fn<() => Promise<boolean>>(),
+  user: {
+    id: "1",
+    username: "acct_0123456789abcdef0123456789abcdef",
+    email: "alice@example.com",
+  },
+}))
 const toast = vi.hoisted(() => ({ error: vi.fn() }))
 const routeState = vi.hoisted(() => ({ pathname: "/task" }))
 const navState = vi.hoisted(() => ({ groups: [] as unknown[] }))
@@ -41,7 +48,9 @@ describe("Sidebar logout", () => {
 
   it("keeps the menu open and reports a localized failure when logout cannot clear auth", async () => {
     render(<Sidebar />)
-    fireEvent.click(screen.getByRole("button", { name: /alice/i }))
+    const userMenu = screen.getByRole("button", { name: /alice@example\.com/i })
+    expect(screen.queryByText("acct_0123456789abcdef0123456789abcdef")).not.toBeInTheDocument()
+    fireEvent.click(userMenu)
     fireEvent.click(screen.getByRole("button", { name: "sidebar.user.logoutTitle" }))
     await waitFor(() => expect(authState.logout).toHaveBeenCalledOnce())
     expect(toast.error).toHaveBeenCalledWith("sidebar.user.logoutFailed")

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import { useApp } from "@/contexts/app-context-chat"
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { getChannelTooltip, getCompactChannelName } from "@/lib/channel-display"
+import { userDisplayLabel } from "@/lib/user-display"
 import { toast } from "@/components/ui/sonner"
 import extraNav from "@/lib/extra-nav"
 import {
@@ -139,6 +140,7 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
   const branding = getBrandingFromEnv()
   const { t } = useI18n()
   const { state } = useApp()
+  const userLabel = userDisplayLabel(user, t("sidebar.user.defaultName"))
   const githubUrl = process.env.NEXT_PUBLIC_GITHUB_URL || "https://github.com/xorbitsai/xagent"
   const normalizedGithubUrl = githubUrl.replace(/\.git$/, "").replace(/\/$/, "")
   const githubRepoDisplay = normalizedGithubUrl.replace(/^https?:\/\/github\.com\//i, "")
@@ -688,10 +690,10 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
           <button
             onClick={() => isAgentPage ? setIsExpanded(true) : setIsSidebarOpen(true)}
             className="flex items-center justify-center w-full p-2 hover:bg-accent rounded-[7px] transition-colors"
-            title={user?.username || t('sidebar.user.defaultName')}
+            title={userLabel}
           >
             <div className="h-7 w-7 rounded-full bg-primary flex items-center justify-center text-xs font-semibold text-white uppercase shrink-0">
-              {(user?.username || t('sidebar.user.defaultName')).charAt(0)}
+              {userLabel.charAt(0)}
             </div>
           </button>
         </div>
@@ -1085,10 +1087,10 @@ export function Sidebar({ className, allowCollapse = true }: SidebarProps) {
           className="flex w-full items-center gap-2.5 hover:bg-accent px-2 py-2 rounded-[7px] transition-colors text-left"
         >
           <div className="h-8 w-8 rounded-full bg-primary flex items-center justify-center text-xs font-semibold text-white uppercase shrink-0">
-            {(user?.username || t('sidebar.user.defaultName')).charAt(0)}
+            {userLabel.charAt(0)}
           </div>
           <div className="flex-1 min-w-0">
-            <p className="text-[13px] font-semibold text-foreground truncate">{user?.username || t('sidebar.user.defaultName')}</p>
+            <p className="text-[13px] font-semibold text-foreground truncate">{userLabel}</p>
           </div>
           <ChevronsUpDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         </button>

--- a/frontend/src/components/pages/knowledge-base.test.tsx
+++ b/frontend/src/components/pages/knowledge-base.test.tsx
@@ -6,6 +6,10 @@ const apiRequestMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
 const toastWarningMock = vi.hoisted(() => vi.fn())
 const toastSuccessMock = vi.hoisted(() => vi.fn())
+const authMock = vi.hoisted(() => ({
+  user: { id: 1, is_admin: false },
+  inTeam: true,
+}))
 
 vi.mock("@/lib/api-wrapper", () => ({
   apiRequest: apiRequestMock,
@@ -25,6 +29,9 @@ vi.mock("@/contexts/i18n-context", () => ({
       if (vars?.name) {
         return `${key}:${vars.name}`
       }
+      if (vars?.owners) {
+        return `${key}:${vars.owners}`
+      }
 
       return key
     },
@@ -32,10 +39,7 @@ vi.mock("@/contexts/i18n-context", () => ({
 }))
 
 vi.mock("@/contexts/auth-context", () => ({
-  useAuth: () => ({
-    user: { id: 1, is_admin: false },
-    inTeam: true,
-  }),
+  useAuth: () => authMock,
 }))
 
 vi.mock("sonner", () => ({
@@ -137,6 +141,7 @@ const ONE_COLLECTION = {
 
 describe("KnowledgeBasePage", () => {
   beforeEach(() => {
+    authMock.user.is_admin = false
     apiRequestMock.mockReset()
     toastErrorMock.mockReset()
     toastWarningMock.mockReset()
@@ -145,6 +150,36 @@ describe("KnowledgeBasePage", () => {
 
   afterEach(() => {
     cleanup()
+  })
+
+  it("shows owner email instead of an opaque username to administrators", async () => {
+    authMock.user.is_admin = true
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/kb/collections") {
+        return Promise.resolve(createJsonResponse({
+          collections: [{
+            ...ONE_COLLECTION.collections[0],
+            owners: [2],
+          }],
+        }))
+      }
+      if (url.startsWith("http://api.local/api/admin/users?")) {
+        return Promise.resolve(createJsonResponse({
+          users: [{
+            id: 2,
+            username: "acct_0123456789abcdef0123456789abcdef",
+            email: "owner@example.com",
+          }],
+          pages: 1,
+        }))
+      }
+      throw new Error(`Unhandled apiRequest: ${url}`)
+    })
+
+    render(<KnowledgeBasePage />)
+
+    expect(await screen.findByText("kb.card.ownerLabel:owner@example.com")).toBeInTheDocument()
+    expect(screen.queryByText(/acct_0123456789abcdef/)).not.toBeInTheDocument()
   })
 
   it("shows the collection delete action in the detail sheet flow", async () => {

--- a/frontend/src/components/pages/knowledge-base.test.tsx
+++ b/frontend/src/components/pages/knowledge-base.test.tsx
@@ -182,6 +182,31 @@ describe("KnowledgeBasePage", () => {
     expect(screen.queryByText(/acct_0123456789abcdef/)).not.toBeInTheDocument()
   })
 
+  it("formats an incomplete owner fallback with the account ID convention", async () => {
+    authMock.user.is_admin = true
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/kb/collections") {
+        return Promise.resolve(createJsonResponse({
+          collections: [{
+            ...ONE_COLLECTION.collections[0],
+            owners: [2],
+          }],
+        }))
+      }
+      if (url.startsWith("http://api.local/api/admin/users?")) {
+        return Promise.resolve(createJsonResponse({
+          users: [{ id: 2, username: "", email: null }],
+          pages: 1,
+        }))
+      }
+      return Promise.resolve(createStatusResponse(404, { detail: "not found" }))
+    })
+
+    render(<KnowledgeBasePage />)
+
+    expect(await screen.findByText("kb.card.ownerLabel:#2")).toBeInTheDocument()
+  })
+
   it("shows the collection delete action in the detail sheet flow", async () => {
     let collectionFetchCount = 0
 

--- a/frontend/src/components/pages/knowledge-base.tsx
+++ b/frontend/src/components/pages/knowledge-base.tsx
@@ -113,7 +113,7 @@ export function KnowledgeBasePage() {
           const data: AdminUserListResponse = await response.json()
           const users: AdminUser[] = data.users || []
           for (const u of users) {
-            map[u.id] = userDisplayLabel(u, String(u.id))
+            map[u.id] = userDisplayLabel(u, `#${u.id}`)
           }
 
           if (typeof data.pages === "number" && data.pages > 0) {

--- a/frontend/src/components/pages/knowledge-base.tsx
+++ b/frontend/src/components/pages/knowledge-base.tsx
@@ -36,6 +36,7 @@ import { KnowledgeBaseCreationDialog } from "@/components/kb/knowledge-base-crea
 import { FeatureEmptyState } from "@/components/ui/feature-empty-state"
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { toast } from "@/components/ui/sonner"
+import { userDisplayLabel } from "@/lib/user-display"
 
 interface Collection {
   name: string
@@ -53,6 +54,7 @@ interface Collection {
 interface AdminUser {
   id: number
   username: string
+  email: string | null
 }
 
 interface AdminUserListResponse {
@@ -111,7 +113,7 @@ export function KnowledgeBasePage() {
           const data: AdminUserListResponse = await response.json()
           const users: AdminUser[] = data.users || []
           for (const u of users) {
-            map[u.id] = u.username
+            map[u.id] = userDisplayLabel(u, String(u.id))
           }
 
           if (typeof data.pages === "number" && data.pages > 0) {

--- a/frontend/src/components/pages/personal-api-keys-panel.test.tsx
+++ b/frontend/src/components/pages/personal-api-keys-panel.test.tsx
@@ -94,7 +94,11 @@ function listResponse(canManageOthers: boolean): PersonalApiKeyListResponse {
       revoked_at: null as string | null,
       expires_at: null,
       created_at: "2026-07-22T00:00:00Z",
-      owner: { id: 1, username: "alice", email: "alice@example.com" },
+      owner: {
+        id: 1,
+        username: "acct_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        email: "alice@example.com",
+      },
     },
   ]
 
@@ -107,7 +111,11 @@ function listResponse(canManageOthers: boolean): PersonalApiKeyListResponse {
       revoked_at: null,
       expires_at: null,
       created_at: "2026-07-22T00:00:00Z",
-      owner: { id: 2, username: "bob", email: "bob@example.com" },
+      owner: {
+        id: 2,
+        username: "acct_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        email: "bob@example.com",
+      },
     })
   }
 
@@ -147,7 +155,7 @@ describe("PersonalApiKeysPanel", () => {
     render(<PersonalApiKeysPanel active />)
 
     expect(await screen.findByText("xag_personal_self123_••••••••")).toBeInTheDocument()
-    expect(screen.queryByText("bob")).not.toBeInTheDocument()
+    expect(screen.queryByText("bob@example.com")).not.toBeInTheDocument()
     expect(screen.queryByText("Owner")).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Create Personal Key" })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Create Personal Key for Me" })).not.toBeInTheDocument()
@@ -158,7 +166,8 @@ describe("PersonalApiKeysPanel", () => {
 
     render(<PersonalApiKeysPanel active />)
 
-    expect(await screen.findByText("bob")).toBeInTheDocument()
+    expect(await screen.findByText("bob@example.com")).toBeInTheDocument()
+    expect(screen.queryByText("acct_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")).not.toBeInTheDocument()
     expect(screen.getByText("Owner")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Create Personal Key for Me" })).toBeInTheDocument()
   })
@@ -191,10 +200,10 @@ describe("PersonalApiKeysPanel", () => {
 
     render(<PersonalApiKeysPanel active />)
 
-    await screen.findByText("bob")
+    await screen.findByText("bob@example.com")
     fireEvent.click(screen.getAllByRole("button", { name: "Revoke" })[1])
 
-    expect(screen.getByText("Revoke this personal key for bob?")).toBeInTheDocument()
+    expect(screen.getByText("Revoke this personal key for bob@example.com?")).toBeInTheDocument()
 
     fireEvent.click(screen.getAllByRole("button", { name: "Revoke" })[2])
     await waitFor(() => expect(revokePersonalApiKeyMock).toHaveBeenCalledWith(2))

--- a/frontend/src/components/pages/personal-api-keys-panel.tsx
+++ b/frontend/src/components/pages/personal-api-keys-panel.tsx
@@ -18,6 +18,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { toast } from "@/components/ui/sonner"
 import { useI18n } from "@/contexts/i18n-context"
 import { copyToClipboard } from "@/lib/clipboard"
+import { userDisplayLabel } from "@/lib/user-display"
 import {
   PersonalApiKeyCreated,
   PersonalApiKeyListItem,
@@ -137,10 +138,13 @@ export function PersonalApiKeysPanel({ active }: PersonalApiKeysPanelProps) {
   const activeCount = useMemo(() => keys.filter((k) => k.status === "active").length, [keys])
 
   const formatDate = (value: string) => new Date(value).toLocaleDateString()
+  const confirmOwner = confirmKey
+    ? userDisplayLabel(confirmKey.owner, `#${confirmKey.owner.id}`)
+    : ""
   const revokeDescription = confirmKey
     ? canManageOthers
-      ? t("personalApiKeys.confirm.revokeOtherDescription", { owner: confirmKey.owner.username }) ||
-        `Revoke this personal key for ${confirmKey.owner.username}?`
+      ? t("personalApiKeys.confirm.revokeOtherDescription", { owner: confirmOwner }) ||
+        `Revoke this personal key for ${confirmOwner}?`
       : t("personalApiKeys.confirm.revokeOwnDescription") || "Revoking immediately invalidates this key."
     : ""
 
@@ -230,7 +234,11 @@ export function PersonalApiKeysPanel({ active }: PersonalApiKeysPanelProps) {
                       {key.masked_key}
                     </span>
                   </TableCell>
-                  {canManageOthers && <TableCell className="text-sm">{key.owner.username}</TableCell>}
+                  {canManageOthers && (
+                    <TableCell className="text-sm">
+                      {userDisplayLabel(key.owner, `#${key.owner.id}`)}
+                    </TableCell>
+                  )}
                   <TableCell>
                     <span
                       className={`inline-flex text-[11px] px-2 py-0.5 rounded-full capitalize font-medium ${statusPillClass(key.status)}`}

--- a/frontend/src/components/pages/user-management.test.tsx
+++ b/frontend/src/components/pages/user-management.test.tsx
@@ -1,13 +1,15 @@
 import React from "react"
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import UserManagement from "./user-management"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const authMock = vi.hoisted(() => ({ user: { id: "1", is_admin: true } }))
+const toastMock = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }))
 
 vi.mock("@/lib/api-wrapper", () => ({ apiRequest: apiRequestMock }))
+vi.mock("@/components/ui/sonner", () => ({ toast: toastMock }))
 vi.mock("@/lib/utils", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/utils")>()),
   getApiUrl: () => "http://api.test",
@@ -28,25 +30,9 @@ describe("UserManagement account labels", () => {
   beforeEach(() => {
     vi.stubGlobal("React", React)
     apiRequestMock.mockReset()
-    apiRequestMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        users: [
-          {
-            id: 2,
-            username: "acct_0123456789abcdef0123456789abcdef",
-            email: "managed@example.com",
-            is_admin: false,
-            created_at: "2026-08-11T00:00:00Z",
-            updated_at: "2026-08-11T00:00:00Z",
-          },
-        ],
-        total: 1,
-        page: 1,
-        size: 20,
-        pages: 1,
-      }),
-    })
+    toastMock.success.mockReset()
+    toastMock.error.mockReset()
+    apiRequestMock.mockResolvedValue(userListResponse())
   })
 
   afterEach(() => {
@@ -72,4 +58,74 @@ describe("UserManagement account labels", () => {
       }),
     ).toBeInTheDocument()
   })
+
+  it("shows successful deletion feedback in a toast", async () => {
+    apiRequestMock.mockResolvedValueOnce(userListResponse())
+    apiRequestMock.mockResolvedValueOnce({ ok: true })
+    apiRequestMock.mockResolvedValueOnce(userListResponse())
+    render(<UserManagement />)
+
+    openDeleteConfirmation(await screen.findByText("managed@example.com"))
+    fireEvent.click(screen.getByRole("button", {
+      name: "userManagement.list.table.confirm_delete",
+    }))
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith(
+        "userManagement.list.alerts.delete_success_prefix" +
+        "managed@example.com" +
+        "userManagement.list.alerts.delete_success_suffix",
+      )
+    })
+  })
+
+  it("shows failed deletion feedback in a toast", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+    apiRequestMock.mockResolvedValueOnce(userListResponse())
+    apiRequestMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ detail: "cannot delete" }),
+    })
+    render(<UserManagement />)
+
+    openDeleteConfirmation(await screen.findByText("managed@example.com"))
+    fireEvent.click(screen.getByRole("button", {
+      name: "userManagement.list.table.confirm_delete",
+    }))
+
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledWith(
+        "userManagement.list.alerts.delete_failed_prefixcannot delete",
+      )
+    })
+  })
 })
+
+function userListResponse() {
+  return {
+    ok: true,
+    json: async () => ({
+      users: [
+        {
+          id: 2,
+          username: "acct_0123456789abcdef0123456789abcdef",
+          email: "managed@example.com",
+          is_admin: false,
+          created_at: "2026-08-11T00:00:00Z",
+          updated_at: "2026-08-11T00:00:00Z",
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 20,
+      pages: 1,
+    }),
+  }
+}
+
+function openDeleteConfirmation(accountLabel: HTMLElement) {
+  const row = accountLabel.closest("tr")
+  const button = row?.querySelector("button")
+  if (!button) throw new Error("expected account deletion button")
+  fireEvent.click(button)
+}

--- a/frontend/src/components/pages/user-management.test.tsx
+++ b/frontend/src/components/pages/user-management.test.tsx
@@ -62,4 +62,14 @@ describe("UserManagement account labels", () => {
       screen.queryByText("acct_0123456789abcdef0123456789abcdef"),
     ).not.toBeInTheDocument()
   })
+
+  it("labels the mixed-identity column as an account", async () => {
+    render(<UserManagement />)
+
+    expect(
+      await screen.findByRole("columnheader", {
+        name: "userManagement.list.table.account",
+      }),
+    ).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/pages/user-management.test.tsx
+++ b/frontend/src/components/pages/user-management.test.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import UserManagement from "./user-management"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const authMock = vi.hoisted(() => ({ user: { id: "1", is_admin: true } }))
+
+vi.mock("@/lib/api-wrapper", () => ({ apiRequest: apiRequestMock }))
+vi.mock("@/lib/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/utils")>()),
+  getApiUrl: () => "http://api.test",
+}))
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => authMock,
+}))
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({ locale: "en", t: (key: string) => key }),
+}))
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+
+describe("UserManagement account labels", () => {
+  beforeEach(() => {
+    vi.stubGlobal("React", React)
+    apiRequestMock.mockReset()
+    apiRequestMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        users: [
+          {
+            id: 2,
+            username: "acct_0123456789abcdef0123456789abcdef",
+            email: "managed@example.com",
+            is_admin: false,
+            created_at: "2026-08-11T00:00:00Z",
+            updated_at: "2026-08-11T00:00:00Z",
+          },
+        ],
+        total: 1,
+        page: 1,
+        size: 20,
+        pages: 1,
+      }),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it("shows email instead of an opaque username", async () => {
+    render(<UserManagement />)
+
+    expect(await screen.findByText("managed@example.com")).toBeInTheDocument()
+    expect(
+      screen.queryByText("acct_0123456789abcdef0123456789abcdef"),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/pages/user-management.tsx
+++ b/frontend/src/components/pages/user-management.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { toast } from "@/components/ui/sonner";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
 import { Trash2, Users, Search, ChevronLeft, ChevronRight, ArrowLeft } from "lucide-react";
@@ -88,13 +89,13 @@ export default function UserManagement() {
         throw new Error(errorData.detail || "Failed to delete user");
       }
 
-      alert(`${t('userManagement.list.alerts.delete_success_prefix')}${userLabel}${t('userManagement.list.alerts.delete_success_suffix')}`);
+      toast.success(`${t('userManagement.list.alerts.delete_success_prefix')}${userLabel}${t('userManagement.list.alerts.delete_success_suffix')}`);
 
       // Refresh users list
       fetchUsers();
     } catch (error: any) {
       console.error("Error deleting user:", error);
-      alert(`${t('userManagement.list.alerts.delete_failed_prefix')}${error.message || t('userManagement.list.alerts.delete_failed_suffix')}`);
+      toast.error(`${t('userManagement.list.alerts.delete_failed_prefix')}${error.message || t('userManagement.list.alerts.delete_failed_suffix')}`);
     }
   };
 

--- a/frontend/src/components/pages/user-management.tsx
+++ b/frontend/src/components/pages/user-management.tsx
@@ -14,10 +14,12 @@ import { apiRequest } from "@/lib/api-wrapper";
 import { getApiUrl } from "@/lib/utils";
 import Link from "next/link";
 import { useI18n } from "@/contexts/i18n-context";
+import { userDisplayLabel } from "@/lib/user-display";
 
 interface User {
   id: number;
   username: string;
+  email: string | null;
   is_admin: boolean;
   created_at: string;
   updated_at: string;
@@ -75,7 +77,7 @@ export default function UserManagement() {
     }
   };
 
-  const deleteUser = async (userId: number, username: string) => {
+  const deleteUser = async (userId: number, userLabel: string) => {
     try {
       const response = await apiRequest(`${getApiUrl()}/api/admin/users/${userId}`, {
         method: "DELETE",
@@ -86,7 +88,7 @@ export default function UserManagement() {
         throw new Error(errorData.detail || "Failed to delete user");
       }
 
-      alert(`${t('userManagement.list.alerts.delete_success_prefix')}${username}${t('userManagement.list.alerts.delete_success_suffix')}`);
+      alert(`${t('userManagement.list.alerts.delete_success_prefix')}${userLabel}${t('userManagement.list.alerts.delete_success_suffix')}`);
 
       // Refresh users list
       fetchUsers();
@@ -175,7 +177,7 @@ export default function UserManagement() {
                   <TableHeader>
                     <TableRow>
                       <TableHead>{t('userManagement.list.table.id')}</TableHead>
-                      <TableHead>{t('userManagement.list.table.username')}</TableHead>
+                      <TableHead>{t('userManagement.list.table.email')}</TableHead>
                       <TableHead>{t('userManagement.list.table.role')}</TableHead>
                       <TableHead>{t('userManagement.list.table.created_at')}</TableHead>
                       <TableHead>{t('userManagement.list.table.updated_at')}</TableHead>
@@ -188,7 +190,7 @@ export default function UserManagement() {
                         <TableCell className="font-medium">
                           {userItem.id}
                         </TableCell>
-                        <TableCell>{userItem.username}</TableCell>
+                        <TableCell>{userDisplayLabel(userItem, `#${userItem.id}`)}</TableCell>
                         <TableCell>
                           {userItem.is_admin ? (
                             <Badge variant="default">{t('userManagement.list.table.admin')}</Badge>
@@ -218,13 +220,13 @@ export default function UserManagement() {
                                 <AlertDialogHeader>
                                   <AlertDialogTitle>{t('userManagement.list.table.delete_confirm_title')}</AlertDialogTitle>
                                   <AlertDialogDescription>
-                                    {`${t('userManagement.list.table.delete_confirm_description_prefix')}${userItem.username}${t('userManagement.list.table.delete_confirm_description_suffix')}`}
+                                    {`${t('userManagement.list.table.delete_confirm_description_prefix')}${userDisplayLabel(userItem, `#${userItem.id}`)}${t('userManagement.list.table.delete_confirm_description_suffix')}`}
                                   </AlertDialogDescription>
                                 </AlertDialogHeader>
                                 <AlertDialogFooter>
                                   <AlertDialogCancel>{t('userManagement.list.table.cancel')}</AlertDialogCancel>
                                   <AlertDialogAction
-                                    onClick={() => deleteUser(userItem.id, userItem.username)}
+                                    onClick={() => deleteUser(userItem.id, userDisplayLabel(userItem, `#${userItem.id}`))}
                                     className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                                   >
                                     {t('userManagement.list.table.confirm_delete')}

--- a/frontend/src/components/pages/user-management.tsx
+++ b/frontend/src/components/pages/user-management.tsx
@@ -177,7 +177,7 @@ export default function UserManagement() {
                   <TableHeader>
                     <TableRow>
                       <TableHead>{t('userManagement.list.table.id')}</TableHead>
-                      <TableHead>{t('userManagement.list.table.email')}</TableHead>
+                      <TableHead>{t('userManagement.list.table.account')}</TableHead>
                       <TableHead>{t('userManagement.list.table.role')}</TableHead>
                       <TableHead>{t('userManagement.list.table.created_at')}</TableHead>
                       <TableHead>{t('userManagement.list.table.updated_at')}</TableHead>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -772,10 +772,10 @@ Build when you need.`,
     list: {
       title: "User List",
       description: "View and manage all users",
-      search_placeholder: "Search email...",
+      search_placeholder: "Search email or username...",
       table: {
         id: "ID",
-        email: "Email",
+        account: "Account",
         role: "Role",
         created_at: "Created At",
         updated_at: "Last Updated",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -772,10 +772,10 @@ Build when you need.`,
     list: {
       title: "User List",
       description: "View and manage all users",
-      search_placeholder: "Search username...",
+      search_placeholder: "Search email...",
       table: {
         id: "ID",
-        username: "Username",
+        email: "Email",
         role: "Role",
         created_at: "Created At",
         updated_at: "Last Updated",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2864,6 +2864,7 @@ Build when you need.`,
               title: "Token Refresh Demo",
               labels: {
                 currentUser: "Current user:",
+                defaultUser: "User",
                 accessTokenStatus: "Access Token status:",
                 refreshTokenStatus: "Refresh Token status:",
                 wsStatus: "WebSocket status:",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -772,10 +772,10 @@ const zh = {
     list: {
       title: "用户列表",
       description: "查看和管理系统中的所有用户",
-      search_placeholder: "搜索用户名...",
+      search_placeholder: "搜索邮箱...",
       table: {
         id: "ID",
-        username: "用户名",
+        email: "邮箱",
         role: "角色",
         created_at: "创建时间",
         updated_at: "最后更新",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -772,10 +772,10 @@ const zh = {
     list: {
       title: "用户列表",
       description: "查看和管理系统中的所有用户",
-      search_placeholder: "搜索邮箱...",
+      search_placeholder: "搜索邮箱或用户名...",
       table: {
         id: "ID",
-        email: "邮箱",
+        account: "账户",
         role: "角色",
         created_at: "创建时间",
         updated_at: "最后更新",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2864,6 +2864,7 @@ const zh = {
               title: "Token Refresh 演示",
               labels: {
                 currentUser: "当前用户:",
+                defaultUser: "用户",
                 accessTokenStatus: "Access Token状态:",
                 refreshTokenStatus: "Refresh Token状态:",
                 wsStatus: "WebSocket状态:",

--- a/frontend/src/i18n/translations.test.ts
+++ b/frontend/src/i18n/translations.test.ts
@@ -67,6 +67,21 @@ describe("translations", () => {
     assertTranslationTreeParity(translations.en, translations.zh)
   })
 
+  it("describes the admin account label and searchable identities", () => {
+    expect(translations.en.userManagement.list).toEqual(
+      expect.objectContaining({
+        search_placeholder: "Search email or username...",
+        table: expect.objectContaining({ account: "Account" }),
+      }),
+    )
+    expect(translations.zh.userManagement.list).toEqual(
+      expect.objectContaining({
+        search_placeholder: "搜索邮箱或用户名...",
+        table: expect.objectContaining({ account: "账户" }),
+      }),
+    )
+  })
+
   it("describes deployment configuration failure without a browser fallback", () => {
     expect(translations.zh.deployment_config.messages.load_failed).toBe(
       "部署配置加载失败。复制部署信息前请重试。",

--- a/frontend/src/lib/user-display.test.ts
+++ b/frontend/src/lib/user-display.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+
+import { userDisplayLabel } from "./user-display"
+
+describe("userDisplayLabel", () => {
+  it("prefers a normalized email over the internal username", () => {
+    expect(
+      userDisplayLabel(
+        { email: " account@example.com ", username: "acct_0123456789abcdef0123456789abcdef" },
+        "missing",
+      ),
+    ).toBe("account@example.com")
+  })
+
+  it("falls back through username to the caller label", () => {
+    expect(userDisplayLabel({ email: " ", username: " legacy-user " }, "missing")).toBe(
+      "legacy-user",
+    )
+    expect(userDisplayLabel({ email: null, username: null }, "missing")).toBe("missing")
+  })
+})

--- a/frontend/src/lib/user-display.ts
+++ b/frontend/src/lib/user-display.ts
@@ -1,0 +1,19 @@
+export interface UserDisplayIdentity {
+  email?: string | null
+  username?: string | null
+}
+
+/**
+ * Return the human-facing account label without changing account identity.
+ *
+ * Email is the product label because SaaS password registrations use opaque
+ * usernames. The username fallback keeps legacy email-less service accounts
+ * distinguishable while callers provide a final context-specific fallback for
+ * deleted or otherwise incomplete records.
+ */
+export function userDisplayLabel(
+  identity: UserDisplayIdentity | null | undefined,
+  fallback: string,
+): string {
+  return identity?.email?.trim() || identity?.username?.trim() || fallback
+}

--- a/src/xagent/web/api/admin_users.py
+++ b/src/xagent/web/api/admin_users.py
@@ -246,11 +246,11 @@ def _delete_user_rows_sync(*, user_id: int) -> bool:
 async def get_users(
     page: int = Query(1, ge=1, description="Page number"),
     size: int = Query(20, ge=1, le=100, description="Page size"),
-    search: str = Query("", description="Search username"),
+    search: str = Query("", description="Search username or email"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> UserListResponse:
-    """Get paginated list of users (admin only)"""
+    """Get an admin-only user list with email for human-facing labels."""
     if not current_user.is_admin:
         raise HTTPException(status_code=403, detail="Admin access required")
 
@@ -265,7 +265,7 @@ async def get_users(
 
     # Apply search filter
     if search:
-        query = query.filter(User.username.like(f"%{search}%"))
+        query = query.filter(User.username.like(f"%{search}%") | User.email.like(f"%{search}%"))
 
     # Get total count
     total = query.count()
@@ -371,7 +371,7 @@ async def delete_user(
             # no DB-visible marker, and a retry that re-dispatches them.
             settled: list[tuple[int, tuple[str, ...]]] = []
             cleanup_failures: list[tuple[int, BaseException]] = []
-            for (context, bindings), result in zip(
+            for (context, _bindings), result in zip(
                 bound_page, cleanup_results, strict=True
             ):
                 if isinstance(result, TaskRuntimeExtensionError):

--- a/src/xagent/web/api/admin_users.py
+++ b/src/xagent/web/api/admin_users.py
@@ -265,7 +265,9 @@ async def get_users(
 
     # Apply search filter
     if search:
-        query = query.filter(User.username.like(f"%{search}%") | User.email.like(f"%{search}%"))
+        query = query.filter(
+            User.username.like(f"%{search}%") | User.email.like(f"%{search}%")
+        )
 
     # Get total count
     total = query.count()

--- a/src/xagent/web/api/admin_users.py
+++ b/src/xagent/web/api/admin_users.py
@@ -263,10 +263,11 @@ async def get_users(
     if hidden:
         query = query.filter(User.id.notin_(hidden))
 
-    # Apply search filter
+    # Match account identifiers without exposing SQL LIKE wildcards from user input.
     if search:
         query = query.filter(
-            User.username.like(f"%{search}%") | User.email.like(f"%{search}%")
+            User.username.icontains(search, autoescape=True)
+            | User.email.icontains(search, autoescape=True)
         )
 
     # Get total count

--- a/src/xagent/web/schemas/user.py
+++ b/src/xagent/web/schemas/user.py
@@ -1,12 +1,15 @@
 from datetime import datetime
-from typing import Any, List
+from typing import Any
 
 from pydantic import BaseModel, field_validator
 
 
 class UserResponse(BaseModel):
+    """Administrative account data with separate identity and display fields."""
+
     id: int
     username: str
+    email: str | None = None
     is_admin: bool
     created_at: str
     updated_at: str
@@ -25,7 +28,7 @@ class UserResponse(BaseModel):
 
 
 class UserListResponse(BaseModel):
-    users: List[UserResponse]
+    users: list[UserResponse]
     total: int
     page: int
     size: int

--- a/tests/web/api/test_admin_users_hidden.py
+++ b/tests/web/api/test_admin_users_hidden.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import text
+
 from xagent.core.task_runtime import TaskRuntimeContribution
 from xagent.web.api.admin_users import delete_user, get_users
 from xagent.web.models.task import DAGExecution, DAGExecutionPhase, Task
@@ -140,9 +141,7 @@ async def test_admin_user_delete_runs_runtime_cleanup_before_task_delete():
         assert response == {"message": "User deleted successfully"}
         assert provider.task_existed_on_delete == [True]
         assert db.query(Task).filter(Task.id == task_id).count() == 0
-        assert (
-            db.query(DAGExecution).filter(DAGExecution.task_id == task_id).count() == 0
-        )
+        assert db.query(DAGExecution).filter(DAGExecution.task_id == task_id).count() == 0
         assert db.query(User).filter(User.id == target_id).count() == 0
     finally:
         unregister_task_extension("delete_observer")

--- a/tests/web/api/test_admin_users_hidden.py
+++ b/tests/web/api/test_admin_users_hidden.py
@@ -108,6 +108,42 @@ async def test_admin_users_include_email_and_support_email_search():
 
 
 @pytest.mark.asyncio
+async def test_admin_user_search_still_matches_username():
+    _admin_headers()
+    username = "searchable-user"
+    _register_second_user(username, "search-password")
+    db = _direct_db_session()
+    try:
+        admin = db.query(User).filter(User.username == "admin").one()
+
+        result = await get_users(1, 100, username, admin, db)
+
+        assert [user.username for user in result.users] == [username]
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_admin_user_list_serializes_null_email():
+    _admin_headers()
+    username = "email-less-user"
+    _register_second_user(username, "search-password")
+    db = _direct_db_session()
+    try:
+        admin = db.query(User).filter(User.username == "admin").one()
+        target = db.query(User).filter(User.username == username).one()
+        target.email = None
+        db.commit()
+
+        result = await get_users(1, 100, username, admin, db)
+
+        assert len(result.users) == 1
+        assert result.users[0].email is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
 async def test_admin_user_email_search_is_case_insensitive():
     _admin_headers()
     opaque_username = "acct_0123456789abcdef0123456789abcdef"

--- a/tests/web/api/test_admin_users_hidden.py
+++ b/tests/web/api/test_admin_users_hidden.py
@@ -141,7 +141,9 @@ async def test_admin_user_delete_runs_runtime_cleanup_before_task_delete():
         assert response == {"message": "User deleted successfully"}
         assert provider.task_existed_on_delete == [True]
         assert db.query(Task).filter(Task.id == task_id).count() == 0
-        assert db.query(DAGExecution).filter(DAGExecution.task_id == task_id).count() == 0
+        assert (
+            db.query(DAGExecution).filter(DAGExecution.task_id == task_id).count() == 0
+        )
         assert db.query(User).filter(User.id == target_id).count() == 0
     finally:
         unregister_task_extension("delete_observer")

--- a/tests/web/api/test_admin_users_hidden.py
+++ b/tests/web/api/test_admin_users_hidden.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import text
-
 from xagent.core.task_runtime import TaskRuntimeContribution
 from xagent.web.api.admin_users import delete_user, get_users
 from xagent.web.models.task import DAGExecution, DAGExecutionPhase, Task
@@ -82,6 +81,27 @@ async def test_hidden_users_excluded_from_admin_list_and_delete():
             await delete_user(ghost_id, admin, db)
         assert exc.value.status_code == 404
         assert db.query(User).filter(User.id == ghost_id).count() == 1
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_admin_users_include_email_and_support_email_search():
+    _admin_headers()
+    opaque_username = "acct_0123456789abcdef0123456789abcdef"
+    _register_second_user(opaque_username, "opaque-password")
+    db = _direct_db_session()
+    try:
+        admin = db.query(User).filter(User.username == "admin").one()
+        target = db.query(User).filter(User.username == opaque_username).one()
+        target.email = "display@example.com"
+        db.commit()
+
+        result = await get_users(1, 100, "display@example.com", admin, db)
+
+        assert len(result.users) == 1
+        assert result.users[0].username == opaque_username
+        assert result.users[0].email == "display@example.com"
     finally:
         db.close()
 

--- a/tests/web/api/test_admin_users_hidden.py
+++ b/tests/web/api/test_admin_users_hidden.py
@@ -108,6 +108,43 @@ async def test_admin_users_include_email_and_support_email_search():
 
 
 @pytest.mark.asyncio
+async def test_admin_user_email_search_is_case_insensitive():
+    _admin_headers()
+    opaque_username = "acct_0123456789abcdef0123456789abcdef"
+    _register_second_user(opaque_username, "opaque-password")
+    db = _direct_db_session()
+    try:
+        admin = db.query(User).filter(User.username == "admin").one()
+        target = db.query(User).filter(User.username == opaque_username).one()
+        target.email = "display@example.com"
+        db.commit()
+        db.execute(text("PRAGMA case_sensitive_like = ON"))
+
+        result = await get_users(1, 100, "DISPLAY@EXAMPLE.COM", admin, db)
+
+        assert [user.id for user in result.users] == [target.id]
+    finally:
+        db.execute(text("PRAGMA case_sensitive_like = OFF"))
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_admin_user_search_treats_wildcards_as_literal_text():
+    _admin_headers()
+    _register_second_user("search-user", "search-password")
+    db = _direct_db_session()
+    try:
+        admin = db.query(User).filter(User.username == "admin").one()
+
+        result = await get_users(1, 100, "%_", admin, db)
+
+        assert result.users == []
+        assert result.total == 0
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
 async def test_admin_user_delete_runs_runtime_cleanup_before_task_delete():
     _admin_headers()
     _register_second_user("runtime-user", "runtimepass1")


### PR DESCRIPTION
## Summary

- display user email addresses as the primary human-facing account label, with username and contextual fallbacks when email is unavailable
- expose email in the admin-user schema and allow administrators to search users by username or email
- clarify mixed email/username labels and update the affected English and Chinese translations
- add frontend and backend coverage for the display-label, fallback, search, and API-schema behavior

Internal usernames remain the stable account identity; this change only updates human-facing labels and admin search.

Accounts without an email continue to display their username because no better human-facing label exists; this includes legacy and API-provisioned accounts.

## Verification

- 35 focused frontend account-label tests passed
- 7 admin-user API tests passed
- TypeScript passed
- ESLint passed
- `git diff --check` passed for the complete rebased change range

## Follow-up

The dependent SaaS changes are in xorbitsai/xagent-saas#569, which updates SaaS-specific account labels and pins this revision.



