### PR TITLE
fix(mcp): stop gating connector attach on the editor's own OAuth grant (#1332)

### DIFF
--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -1683,8 +1683,20 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     )
     await screen.findByText("Chrome")
 
+    // The card must render selected from the id-only seed before the click —
+    // isSelected matches by id OR name, not just name.
+    expect(screen.getByTestId("connector-card-chrome-devtools")).toHaveAttribute(
+      "data-selected",
+      "true",
+    )
+
     // One click on the visually-selected card must deselect it outright.
     fireEvent.click(screen.getByText("Chrome"))
+
+    expect(screen.getByTestId("connector-card-chrome-devtools")).toHaveAttribute(
+      "data-selected",
+      "false",
+    )
 
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenCalledWith([])
@@ -1699,13 +1711,19 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
   // grant (#1332).
   const unauthorizedCustomMcp = () => ({ ...customMcpOauthApp(), name: "Records MCP" })
 
-  function renderSelectModeWith(apps: object[], onConnectSelected: () => void) {
+  // Shared by renderSelectModeWith below and the non-select-mode card-click
+  // test, which otherwise duplicated this exact mockImplementation block.
+  function mockAppsList(apps: object[]) {
     apiRequestMock.mockImplementation((url: string) => {
       if (url.includes("/api/mcp/apps?")) {
         return Promise.resolve({ ok: true, json: async () => apps })
       }
       throw new Error(`Unexpected request: ${url}`)
     })
+  }
+
+  function renderSelectModeWith(apps: object[], onConnectSelected: () => void) {
+    mockAppsList(apps)
     return render(
       <ConnectMcpDialog
         open
@@ -1726,8 +1744,12 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(screen.getByTestId("settings-open-app").textContent).toBe("")
     // Becoming attachable must not change connected-state display: this
     // connector is still unconnected (is_connected: false), so it must stay
-    // unchecked.
-    expect(screen.queryByTestId("connected-check")).toBeNull()
+    // unchecked. Scoped through the card: connected-check is non-unique
+    // across the grid by construction, so an ungrounded query would throw as
+    // soon as a second connected app rendered.
+    expect(
+      within(screen.getByTestId("connector-card-records")).queryByTestId("connected-check"),
+    ).toBeNull()
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith(["Records MCP"])
 
@@ -1747,7 +1769,12 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
     expect(screen.getByRole("button", { name: "tools.mcp.dialog.configure" })).not.toBeNull()
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
-    expect(screen.getByTestId("connected-check")).not.toBeNull()
+    // Scoped through the card: connected-check is non-unique across the grid
+    // by construction, so an ungrounded query would throw as soon as a
+    // second connected app rendered.
+    expect(
+      within(screen.getByTestId("connector-card-records")).getByTestId("connected-check"),
+    ).not.toBeNull()
   })
 
   it("keeps the per-server OAuth flow reachable from the card in select mode (#1323)", async () => {
@@ -1795,13 +1822,19 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })
 
-  it("still gates selection on a custom mcp_oauth entry whose association is deactivated", async () => {
+  it("still gates selection on a custom mcp_oauth entry whose association was deactivated before consent completed", async () => {
     // list_mcp_apps' local loop does not filter is_active, and emits auth_type
     // only while the association *is* active — so a deactivated mcp_oauth
-    // server is listed as is_connected: false with no auth_type. The runtime's
-    // server query drops inactive associations outright, so attaching one would
-    // silently load zero tools; it needs re-enabling, not re-authorization, and
-    // must keep its card-click route to the detail modal.
+    // server with no completed grant is listed as is_connected: false with no
+    // auth_type. (toggle_mcp_server never revokes a completed grant, so this
+    // only holds pre-consent: deactivating *after* consent instead lists
+    // is_connected: true and is attachable through the first disjunct, with
+    // the checkmark and Configure — that population is exercised elsewhere.)
+    // The runtime's server query drops inactive associations outright, so
+    // attaching this one would silently load zero tools — hence it must keep
+    // its card-click route to the detail modal rather than becoming
+    // selectable. That route offers no recovery today either; see the
+    // isAttachable comment.
     const onConnectSelected = vi.fn()
     const dormant: Record<string, unknown> = { ...unauthorizedCustomMcp() }
     delete dormant.auth_type
@@ -1819,12 +1852,7 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
   it("opens the detail modal on card click outside select mode", async () => {
     // The Tools page has no selection to toggle, so the card click keeps its
     // original destination for connected and unconnected entries alike.
-    apiRequestMock.mockImplementation((url: string) => {
-      if (url.includes("/api/mcp/apps?")) {
-        return Promise.resolve({ ok: true, json: async () => [unauthorizedCustomMcp()] })
-      }
-      throw new Error(`Unexpected request: ${url}`)
-    })
+    mockAppsList([unauthorizedCustomMcp()])
     render(<ConnectMcpDialog open onOpenChange={vi.fn()} selectedMcpServers={selectedMcpServers} />)
     await screen.findByText("Records MCP")
 

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -123,11 +123,15 @@ vi.mock("./custom-mcp-form", () => ({
 
 vi.mock("./official-mcp-settings-dialog", () => ({
   OfficialMcpSettingsDialog: ({
+    app,
+    open,
     isConnecting,
     onConfigure,
     onOpenChange,
     onConnectStart,
   }: {
+    app?: { name?: string } | null
+    open?: boolean
     isConnecting?: boolean
     onConfigure: (app: object) => void
     onOpenChange: (open: boolean) => void
@@ -140,6 +144,10 @@ vi.mock("./official-mcp-settings-dialog", () => ({
       <div data-testid="settings-is-connecting">
         {isConnecting ? "connecting" : "idle"}
       </div>
+      {/* Which app the detail modal is open for (empty when closed). The mock
+          renders unconditionally, so `open` is the only way a test can tell
+          whether a card click routed to the modal or toggled the selection. */}
+      <div data-testid="settings-open-app">{open ? app?.name ?? "" : ""}</div>
       <button
         type="button"
         onClick={() => onConfigure(customApiApp(1, "aggregated-a"))}
@@ -1665,5 +1673,122 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenCalledWith([])
+  })
+
+  // A custom mcp_oauth connector whose access tokens are supplied out of band
+  // through set_oauth_token_resolver_hook: is_connected stays false forever
+  // because no MCPOAuthGrant is ever written for the editor, so gating the
+  // select-mode toggle on it made the connector permanently unattachable —
+  // even though the agent endpoints accept its selector with no
+  // connected-state check and the runtime resolves credentials without a
+  // grant (#1332).
+  const unauthorizedCustomMcp = () => ({ ...customMcpOauthApp(), name: "Records MCP" })
+
+  function renderSelectModeWith(apps: object[], onConnectSelected: () => void) {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => apps })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    return render(
+      <ConnectMcpDialog
+        open
+        onOpenChange={vi.fn()}
+        selectedMcpServers={selectedMcpServers}
+        onConnectSelected={onConnectSelected}
+      />,
+    )
+  }
+
+  it("selects and deselects a custom mcp_oauth connector the editor holds no grant for (#1332)", async () => {
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([unauthorizedCustomMcp()], onConnectSelected)
+    await screen.findByText("Records MCP")
+
+    fireEvent.click(screen.getByText("Records MCP"))
+    // The click must toggle the selection, not divert to the detail modal.
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith(["Records MCP"])
+
+    // Removal has to work too, or an accidental attach would be unrevertable.
+    fireEvent.click(screen.getByText("Records MCP"))
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("keeps the per-server OAuth flow reachable from the card in select mode (#1323)", async () => {
+    // The card click no longer opens the detail modal for these entries, so
+    // the Connect button repaired in #1323 needs its own trigger — otherwise
+    // relaxing the gate would strip the interactive flow from editors who do
+    // authorize personally.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([unauthorizedCustomMcp()], onConnectSelected)
+    await screen.findByText("Records MCP")
+
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.authorize" }))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
+
+    // Opening the modal must not have counted as a selection toggle.
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("still gates selection on connected state for an unconnected catalog app", async () => {
+    // Only local/custom entries are relaxed. A catalog app reporting
+    // is_connected: false has no association row for this user at all, so
+    // connecting is a genuine prerequisite and the card must keep routing to
+    // the detail modal instead of attaching a connector that does not exist
+    // for them.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([keylessApp()], onConnectSelected)
+    await screen.findByText("Chrome")
+
+    fireEvent.click(screen.getByText("Chrome"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Chrome")
+    // No card-level Authorize trigger either: that is the mcp_oauth shape only.
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("still gates selection on a custom mcp_oauth entry whose association is deactivated", async () => {
+    // list_mcp_apps' local loop does not filter is_active, and emits auth_type
+    // only while the association *is* active — so a deactivated mcp_oauth
+    // server is listed as is_connected: false with no auth_type. The runtime's
+    // server query drops inactive associations outright, so attaching one would
+    // silently load zero tools; it needs re-enabling, not re-authorization, and
+    // must keep its card-click route to the detail modal.
+    const onConnectSelected = vi.fn()
+    const dormant: Record<string, unknown> = { ...unauthorizedCustomMcp() }
+    delete dormant.auth_type
+    renderSelectModeWith([dormant], onConnectSelected)
+    await screen.findByText("Records MCP")
+
+    fireEvent.click(screen.getByText("Records MCP"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("opens the detail modal on card click outside select mode", async () => {
+    // The Tools page has no selection to toggle, so the card click keeps its
+    // original destination for connected and unconnected entries alike.
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => [unauthorizedCustomMcp()] })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    render(<ConnectMcpDialog open onOpenChange={vi.fn()} selectedMcpServers={selectedMcpServers} />)
+    await screen.findByText("Records MCP")
+
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
+    fireEvent.click(screen.getByText("Records MCP"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
   })
 })

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -1342,6 +1342,18 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       })
 
       expect(onSuccess).toHaveBeenCalled()
+
+      // Commit the selection to observe the auto-select this test is named
+      // for: the append is local state, so onConnectSelected only sees it
+      // through the footer. Granola is the fixture that makes the assertion
+      // discriminating — its id ("granola") and display name ("Granola")
+      // differ, so this fails if the append ever switches to app.id, whereas
+      // the custom-server equivalent below cannot tell the two apart (its id
+      // and name are both "records").
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+      })
+      expect(onConnectSelected).toHaveBeenCalledWith(["Granola"])
     } finally {
       openSpy.mockRestore()
       vi.useRealTimers()
@@ -1767,14 +1779,13 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     renderSelectModeWith([{ ...unauthorizedCustomMcp(), is_connected: true }], onConnectSelected)
     await screen.findByText("Records MCP")
 
-    expect(screen.getByRole("button", { name: "tools.mcp.dialog.configure" })).not.toBeNull()
+    // getBy* throws when absent, so the bare calls are the assertions.
+    screen.getByRole("button", { name: "tools.mcp.dialog.configure" })
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
     // Scoped through the card: connected-check is non-unique across the grid
     // by construction, so an ungrounded query would throw as soon as a
     // second connected app rendered.
-    expect(
-      within(screen.getByTestId("connector-card-records")).getByTestId("connected-check"),
-    ).not.toBeNull()
+    within(screen.getByTestId("connector-card-records")).getByTestId("connected-check")
   })
 
   it("keeps the per-server OAuth flow reachable from the card in select mode (#1323)", async () => {
@@ -1829,7 +1840,11 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     // auth_type. (toggle_mcp_server never revokes a completed grant, so this
     // only holds pre-consent: deactivating *after* consent instead lists
     // is_connected: true and is attachable through the first disjunct, with
-    // the checkmark and Configure — that population is exercised elsewhere.)
+    // the checkmark and Configure. No test renders that exact shape — it is
+    // indistinguishable here from an ordinary connected entry, and the
+    // regression it would guard against, replacing the first disjunct with
+    // one that also demands auth_type, already fails the seeded keyless
+    // test below.)
     // The runtime's server query drops inactive associations outright, so
     // attaching this one would silently load zero tools — hence it must keep
     // its card-click route to the detail modal rather than becoming

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -578,14 +578,20 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     }
   })
 
-  it("rechecks a closed custom mcp_oauth popup against the local listing", async () => {
+  it("rechecks a closed custom mcp_oauth popup against the local listing and auto-selects it", async () => {
     // The popup's opener link is severed, so a closed popup is ambiguous and
     // the handler asks the backend what actually happened. A custom server
     // only exists under location=local — querying the remote branch (as the
     // catalog path does) would report every custom connect as a failure.
+    //
+    // Passing onConnectSelected also puts the dialog in select mode, which is
+    // what makes the connect-records trigger's autoSelect true — so a
+    // recheck that confirms the connection must also land "records" in the
+    // committed selection (#1332).
     const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
     const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
     const onSuccess = vi.fn()
+    const onConnectSelected = vi.fn()
     let localListCalls = 0
     try {
       apiRequestMock.mockImplementation((url: string) => {
@@ -614,6 +620,7 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
           onOpenChange={vi.fn()}
           selectedMcpServers={selectedMcpServers}
           onSuccess={onSuccess}
+          onConnectSelected={onConnectSelected}
         />,
       )
 
@@ -632,6 +639,14 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
       expect(localListCalls).toBe(1)
       expect(onSuccess).toHaveBeenCalled()
+
+      // Commit the selection to observe it. Fake timers are still active, so
+      // this must stay on synchronous queries (getByRole) — findBy*/waitFor
+      // would hang.
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+      })
+      expect(onConnectSelected).toHaveBeenCalledWith(["records"])
     } finally {
       openSpy.mockRestore()
       vi.useRealTimers()
@@ -1709,6 +1724,10 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     fireEvent.click(screen.getByText("Records MCP"))
     // The click must toggle the selection, not divert to the detail modal.
     expect(screen.getByTestId("settings-open-app").textContent).toBe("")
+    // Becoming attachable must not change connected-state display: this
+    // connector is still unconnected (is_connected: false), so it must stay
+    // unchecked.
+    expect(screen.queryByTestId("connected-check")).toBeNull()
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith(["Records MCP"])
 
@@ -1716,6 +1735,19 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     fireEvent.click(screen.getByText("Records MCP"))
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("shows Configure and the connected checkmark, not Authorize, for a connected custom mcp_oauth entry (#1332)", async () => {
+    // isAttachable widening the select-mode gate must not disturb the
+    // isGloballyConnected branch of the footer ternary: a connected entry
+    // has to keep showing Configure plus the checkmark, never Authorize.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([{ ...unauthorizedCustomMcp(), is_connected: true }], onConnectSelected)
+    await screen.findByText("Records MCP")
+
+    expect(screen.getByRole("button", { name: "tools.mcp.dialog.configure" })).not.toBeNull()
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
+    expect(screen.getByTestId("connected-check")).not.toBeNull()
   })
 
   it("keeps the per-server OAuth flow reachable from the card in select mode (#1323)", async () => {
@@ -1735,19 +1767,28 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })
 
-  it("still gates selection on connected state for an unconnected catalog app", async () => {
-    // Only local/custom entries are relaxed. A catalog app reporting
-    // is_connected: false has no association row for this user at all, so
-    // connecting is a genuine prerequisite and the card must keep routing to
-    // the detail modal instead of attaching a connector that does not exist
-    // for them.
+  it("still gates selection on connected state for unconnected catalog apps", async () => {
+    // Only local/custom entries are relaxed. mcpOauthApp() (Granola) is the
+    // load-bearing fixture here: it carries the exact same auth_type as the
+    // custom mcp_oauth population this predicate widens, but it is a
+    // *catalog* entry, so its is_connected: false means the user has no
+    // association row for it at all — connecting really is a prerequisite,
+    // and dropping the is_custom conjunct would wrongly attach it. keylessApp
+    // (Chrome) is included alongside it as a non-mcp_oauth catalog control.
+    // Both must keep routing the card click to the detail modal instead of
+    // attaching a connector that does not exist for them.
     const onConnectSelected = vi.fn()
-    renderSelectModeWith([keylessApp()], onConnectSelected)
+    renderSelectModeWith([mcpOauthApp(), keylessApp()], onConnectSelected)
     await screen.findByText("Chrome")
+
+    fireEvent.click(screen.getByText("Granola"))
+    // Assert right after each click: a later click would overwrite this.
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Granola")
 
     fireEvent.click(screen.getByText("Chrome"))
     expect(screen.getByTestId("settings-open-app").textContent).toBe("Chrome")
-    // No card-level Authorize trigger either: that is the mcp_oauth shape only.
+
+    // No card-level Authorize trigger for either: is_custom is required too.
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
 
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -216,6 +216,14 @@ export function ConnectMcpDialog({
   // agent create/update endpoints accept its `mcp:<name>` selector with no
   // connected-state check and the runtime resolves credentials without a grant.
   //
+  // A custom mcp_oauth server whose consent was simply never started, or was
+  // abandoned partway, is indistinguishable in this listing from a
+  // hook-resolved one — create_mcp_server writes the association row at
+  // creation time, long before any consent, so is_connected is false either
+  // way. This predicate makes that server attachable too: the card shows no
+  // checkmark and offers Authorize as a one-click recovery, and the agent
+  // create/update endpoints never validated connected state to begin with.
+  //
   // Both conjuncts are load-bearing, and neither can be widened:
   //
   // - is_custom, because a *catalog* mcp_oauth app (e.g. Granola) carries the
@@ -224,11 +232,20 @@ export function ConnectMcpDialog({
   //   attaching it would select a connector that does not exist for them.
   // - auth_type, because the backend emits it on a local entry only for the
   //   mcp_oauth shape *and only while the association is active* (see
-  //   list_mcp_apps). A deactivated association is still listed with
-  //   is_connected: false, and the runtime's server query drops inactive
-  //   associations outright — attaching one would silently load zero tools.
-  //   That entry keeps its existing card-click route to the detail modal, where
-  //   it needs re-enabling rather than re-authorization.
+  //   list_mcp_apps). An association deactivated before any grant completed is
+  //   listed with is_connected: false and no auth_type, so it keeps its
+  //   existing card-click route to the detail modal, where it needs
+  //   re-enabling rather than re-authorization. That matters because the
+  //   runtime's server query drops inactive associations outright, so
+  //   attaching one would have loaded zero tools.
+  //
+  //   Deactivation *after* consent is a different, pre-existing story:
+  //   toggle_mcp_server only flips is_active and never revokes the grant, so
+  //   such an entry lists as is_connected: true and is attachable through the
+  //   first conjunct regardless of this one — showing the checkmark plus
+  //   Configure, never Authorize. The runtime still drops it, but the old gate
+  //   was is_connected alone, so that card behaves here exactly as it did
+  //   before this predicate existed.
   const isAttachable = (app: AppIntegration) =>
     isAppConnected(app) || (Boolean(app.is_custom) && app.auth_type === "mcp_oauth")
 
@@ -1301,7 +1318,7 @@ export function ConnectMcpDialog({
                       return (
                         <Card key={app.id} className={`p-[0] cursor-pointer transition-colors shadow-sm relative ${isSelectMode && isSelected ? 'border-blue-500 bg-blue-50/30 ring-1 ring-blue-500' : 'hover:border-slate-300 border-slate-200'}`} onClick={() => handleCardClick(app)}>
                           {isGloballyConnected && (
-                            <div className="absolute top-4 right-4 text-green-500">
+                            <div data-testid="connected-check" className="absolute top-4 right-4 text-green-500">
                               <CheckCircle2 className="h-5 w-5 fill-green-100" />
                             </div>
                           )}

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -232,10 +232,14 @@ export function ConnectMcpDialog({
   //   attaching it would select a connector that does not exist for them.
   // - auth_type, because the backend emits it on a local entry only when a
   //   personal association exists, is active, and the server is the
-  //   mcp_oauth shape (see list_mcp_apps). One consequence: a team-owned
-  //   connector surfaced by #1338's visibility overlay has no personal
-  //   association, so it gets no auth_type either, and this predicate routes
-  //   it to the detail modal instead of making it attachable.
+  //   mcp_oauth shape (see list_mcp_apps). One consequence, once #1338's team
+  //   visibility overlay is in the tree (it is on main, but landed after this
+  //   branch was cut, so the population is not reproducible from this
+  //   branch's own backend): a team-owned connector the overlay surfaces has
+  //   no personal association, so it gets no auth_type either, and this
+  //   predicate routes it to the detail modal instead of making it
+  //   attachable. #1347 tracks expressing that case as attachable-but-not-
+  //   authorizable rather than deciding it by an absent hint.
   //
   //   An association deactivated before any grant completed is likewise
   //   listed with is_connected: false and no auth_type, so it keeps its

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -204,6 +204,34 @@ export function ConnectMcpDialog({
 
   const isAppConnected = (app: AppIntegration) => Boolean(app.is_connected)
 
+  // Whether select mode may toggle this entry into the agent's selection.
+  //
+  // #1332: is_connected must not gate this for a custom mcp_oauth connector.
+  // is_connected is false for one there precisely when *this editor* holds no
+  // completed MCPOAuthGrant — but an embedding application can supply those
+  // access tokens out of band via set_oauth_token_resolver_hook (per end user,
+  // provisioned server-to-server), and then there is no interactive consent, no
+  // identity the editor could sign in as, and therefore never a grant row. The
+  // connector was permanently unattachable from the picker even though the
+  // agent create/update endpoints accept its `mcp:<name>` selector with no
+  // connected-state check and the runtime resolves credentials without a grant.
+  //
+  // Both conjuncts are load-bearing, and neither can be widened:
+  //
+  // - is_custom, because a *catalog* mcp_oauth app (e.g. Granola) carries the
+  //   same auth_type while is_connected: false there means the user has no
+  //   association row for it at all. Connecting really is a prerequisite, so
+  //   attaching it would select a connector that does not exist for them.
+  // - auth_type, because the backend emits it on a local entry only for the
+  //   mcp_oauth shape *and only while the association is active* (see
+  //   list_mcp_apps). A deactivated association is still listed with
+  //   is_connected: false, and the runtime's server query drops inactive
+  //   associations outright — attaching one would silently load zero tools.
+  //   That entry keeps its existing card-click route to the detail modal, where
+  //   it needs re-enabling rather than re-authorization.
+  const isAttachable = (app: AppIntegration) =>
+    isAppConnected(app) || (Boolean(app.is_custom) && app.auth_type === "mcp_oauth")
+
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300)
     return () => clearTimeout(timer)
@@ -952,8 +980,8 @@ export function ConnectMcpDialog({
     mcpOauthPollTimersRef.current.add(checkPopup)
   }
 
-  const handleCardClick = (app: AppIntegration, isGloballyConnected: boolean) => {
-    if (isSelectMode && isGloballyConnected) {
+  const handleCardClick = (app: AppIntegration) => {
+    if (isSelectMode && isAttachable(app)) {
       // Match isSelected's own check (id OR name) below, not just name: a
       // consumer (e.g. agent-builder.tsx re-seeding after save) can store
       // this connector's id instead of its display name once resolved to
@@ -1271,7 +1299,7 @@ export function ConnectMcpDialog({
                       const isSelected = localSelectedServers.includes(app.id) || localSelectedServers.includes(app.name)
                       const isLoading = loadingApps.has(app.id)
                       return (
-                        <Card key={app.id} className={`p-[0] cursor-pointer transition-colors shadow-sm relative ${isSelectMode && isSelected ? 'border-blue-500 bg-blue-50/30 ring-1 ring-blue-500' : 'hover:border-slate-300 border-slate-200'}`} onClick={() => handleCardClick(app, isGloballyConnected)}>
+                        <Card key={app.id} className={`p-[0] cursor-pointer transition-colors shadow-sm relative ${isSelectMode && isSelected ? 'border-blue-500 bg-blue-50/30 ring-1 ring-blue-500' : 'hover:border-slate-300 border-slate-200'}`} onClick={() => handleCardClick(app)}>
                           {isGloballyConnected && (
                             <div className="absolute top-4 right-4 text-green-500">
                               <CheckCircle2 className="h-5 w-5 fill-green-100" />
@@ -1325,7 +1353,7 @@ export function ConnectMcpDialog({
                               <div className="flex items-center gap-2">
                                 {isLoading ? (
                                   <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
-                                ) : isGloballyConnected && (
+                                ) : isGloballyConnected ? (
                                   <Button
                                     variant="ghost"
                                     size="sm"
@@ -1337,7 +1365,34 @@ export function ConnectMcpDialog({
                                   >
                                     <Settings className="h-3 w-3 mr-1" /> {t('tools.mcp.dialog.configure')}
                                   </Button>
-                                )}
+                                ) : isSelectMode && isAttachable(app) ? (
+                                  // #1332: in select mode the card click now
+                                  // toggles selection for these entries, so it
+                                  // no longer opens the detail modal — which is
+                                  // where the per-server OAuth flow repaired in
+                                  // #1323 is started from. Keep that route
+                                  // reachable with its own trigger instead of
+                                  // dropping it, for editors who do authorize
+                                  // personally.
+                                  //
+                                  // Keyed on isAttachable, not its own
+                                  // predicate, so this stays exactly the set of
+                                  // cards whose click was diverted to selection:
+                                  // every entry that loses the modal route gets
+                                  // this trigger, and no entry that kept the
+                                  // route gets a redundant second one.
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 text-xs text-blue-600 hover:text-blue-700 px-2 bg-blue-50 hover:bg-blue-100"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setSelectedApp(app);
+                                    }}
+                                  >
+                                    <Plug className="h-3 w-3 mr-1" /> {t('tools.mcp.dialog.authorize')}
+                                  </Button>
+                                ) : null}
                               </div>
                             </div>
                           </CardContent>

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -230,12 +230,23 @@ export function ConnectMcpDialog({
   //   same auth_type while is_connected: false there means the user has no
   //   association row for it at all. Connecting really is a prerequisite, so
   //   attaching it would select a connector that does not exist for them.
-  // - auth_type, because the backend emits it on a local entry only for the
-  //   mcp_oauth shape *and only while the association is active* (see
-  //   list_mcp_apps). An association deactivated before any grant completed is
+  // - auth_type, because the backend emits it on a local entry only when a
+  //   personal association exists, is active, and the server is the
+  //   mcp_oauth shape (see list_mcp_apps). One consequence: a team-owned
+  //   connector surfaced by #1338's visibility overlay has no personal
+  //   association, so it gets no auth_type either, and this predicate routes
+  //   it to the detail modal instead of making it attachable.
+  //
+  //   An association deactivated before any grant completed is likewise
   //   listed with is_connected: false and no auth_type, so it keeps its
-  //   existing card-click route to the detail modal, where it needs
-  //   re-enabling rather than re-authorization. That matters because the
+  //   existing card-click route to the detail modal — and that route offers
+  //   no recovery today: the modal's Connect button has no auth_type to
+  //   dispatch on, so it falls through to the mis-authored-entry toast, and
+  //   nothing in the frontend calls the toggle endpoint that would
+  //   reactivate the association. (list_mcp_apps withholds auth_type here
+  //   because, in its own words, "a deactivated server needs re-enabling,
+  //   not re-authorization" — that is the backend's rationale for omitting
+  //   the field, not a recovery this modal actually offers.) Regardless, the
   //   runtime's server query drops inactive associations outright, so
   //   attaching one would have loaded zero tools.
   //
@@ -1316,7 +1327,13 @@ export function ConnectMcpDialog({
                       const isSelected = localSelectedServers.includes(app.id) || localSelectedServers.includes(app.name)
                       const isLoading = loadingApps.has(app.id)
                       return (
-                        <Card key={app.id} className={`p-[0] cursor-pointer transition-colors shadow-sm relative ${isSelectMode && isSelected ? 'border-blue-500 bg-blue-50/30 ring-1 ring-blue-500' : 'hover:border-slate-300 border-slate-200'}`} onClick={() => handleCardClick(app)}>
+                        <Card
+                          key={app.id}
+                          data-testid={`connector-card-${app.id}`}
+                          data-selected={isSelectMode && isSelected}
+                          className={`p-[0] cursor-pointer transition-colors shadow-sm relative ${isSelectMode && isSelected ? 'border-blue-500 bg-blue-50/30 ring-1 ring-blue-500' : 'hover:border-slate-300 border-slate-200'}`}
+                          onClick={() => handleCardClick(app)}
+                        >
                           {isGloballyConnected && (
                             <div data-testid="connected-check" className="absolute top-4 right-4 text-green-500">
                               <CheckCircle2 className="h-5 w-5 fill-green-100" />

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1130,6 +1130,10 @@ Build when you need.`,
         selected: "{count} selected",
         connect: "Connect",
         connecting: "Connecting...",
+        // Card-level trigger for the per-server OAuth flow of an unauthorized
+        // custom mcp_oauth connector. Deliberately not "Connect": the select
+        // mode footer already uses that label to commit the selection.
+        authorize: "Authorize",
         apiKeyOptionalHint: "Enter your API key to connect.",
         apiKeyOverrideHint: "Or enter your own key to override the shared one.",
         sharedKeyConfigured: "A shared key is already configured — you can connect with it directly.",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1130,6 +1130,10 @@ const zh = {
         selected: "已选 {count} 个",
         connect: "连接",
         connecting: "连接中...",
+        // Card-level trigger for the per-server OAuth flow of an unauthorized
+        // custom mcp_oauth connector. Deliberately not "Connect": the select
+        // mode footer already uses that label to commit the selection.
+        authorize: "授权",
         apiKeyOptionalHint: "输入你的 API key 以连接。",
         apiKeyOverrideHint: "或填写你自己的 key 覆盖共享密钥。",
         sharedKeyConfigured: "已配置共享 key,可直接使用连接。",


### PR DESCRIPTION
Closes #1332.

## Problem

In the "+ Connector" picker's select mode, a card could only be toggled into the agent's selection when its entry reported `is_connected`. For a custom `mcp_oauth` connector that flag is false precisely when **this editor** holds no completed `MCPOAuthGrant` — and an embedding application can supply those access tokens out of band through `set_oauth_token_resolver_hook`, per end user and provisioned server-to-server. In that model there is no interactive consent, no identity the editor could sign in as, and therefore never a grant row for them, so the connector was permanently unattachable from the picker.

The gate was UI-only: the agent create/update endpoints accept the connector's `mcp:<name>` selector with no connected-state validation, and the runtime resolves credentials through the hook regardless of grants (`_resolve_oauth_token_from_hook`, `src/xagent/web/tools/config.py`). #1323 fixed the Connect button's dead end behind this gate; the gate itself remained.

## Change

`handleCardClick` now consults a new `isAttachable` predicate instead of `is_connected` directly:

```ts
isAppConnected(app) || (Boolean(app.is_custom) && app.auth_type === "mcp_oauth")
```

Both conjuncts are load-bearing, and neither can be widened:

- **`is_custom`** — a *catalog* `mcp_oauth` app (e.g. Granola) carries the same `auth_type`, but there `is_connected: false` means the user has no association row for it at all. Connecting really is a prerequisite, so attaching it would select a connector that does not exist for them. Catalog entries stay gated.
- **`auth_type`** — `list_mcp_apps` emits it on a local entry only for the `mcp_oauth` shape *and only while the association is active* (`src/xagent/web/api/mcp.py`). A deactivated association is still listed with `is_connected: false`, and the runtime's server query filters on `UserMCPServer.is_active` (`src/xagent/core/tools/adapters/vibe/factory.py`) — so attaching one would silently load zero tools. That entry needs re-enabling rather than re-authorization, and keeps its existing card-click route to the detail modal.

Because the card click now toggles selection for the relaxed entries instead of opening the detail modal, the card gets its own trigger for that modal (`tools.mcp.dialog.authorize`), so the per-server OAuth flow repaired in #1323 stays reachable for editors who do authorize personally. It is keyed on the same `isAttachable` predicate, so every card that loses the click route gains the trigger and no card that kept the route gets a redundant second one. The label is deliberately not "Connect" — the select-mode footer already uses that label to commit the selection.

Connected-state display is untouched: the checkmark, the sharing badges and the settings dialog all keep reading `is_connected` exactly as before.

## Acceptance criteria

- [x] In select mode, a custom `mcp_oauth` server with no active grant for the editor can be added to (and removed from) the agent's selection from the picker.
- [x] The Connect action remains available for editors who use the interactive flow (#1323 behavior unchanged).
- [x] Connected-state display is unchanged; only the selection gating is relaxed.

## Tests

Six tests in `frontend/src/components/mcp/connect-mcp-dialog.test.tsx`. Two go red against the pre-change component:

- selects **and deselects** a custom `mcp_oauth` connector the editor holds no grant for;
- the card's Authorize trigger opens the detail modal without counting as a selection toggle.

The rest are regression guards that pass on the old behavior by construction, but each kills a distinct mutation of the new code:

| Guard | Mutation it kills |
| --- | --- |
| unconnected **catalog** apps stay gated (Granola + a keyless control) | dropping `isAttachable`'s `is_custom` conjunct |
| a **deactivated** custom `mcp_oauth` entry stays gated (no `auth_type`) | dropping the `auth_type` conjunct |
| a **connected** custom `mcp_oauth` entry shows Configure + checkmark, never Authorize | swapping the two card-footer branches |
| a confirmed consent **auto-selects** the connector (extends the existing popup-recheck test) | deleting the auto-select append in `handleConnectMcpOAuthApp` |
| outside select mode the card click keeps its original destination | dropping the `isSelectMode` guard |

The shared settings-dialog mock now surfaces its `open`/`app` props so a test can tell a modal route from a selection toggle, and the checkmark wrapper gained a `data-testid` so the display assertions name it instead of matching on layout classes.

Verified: `src/components/mcp` 69 tests pass, `tsc --noEmit` clean, `eslint` introduces no new problems on the changed files, plus `test:ci-manifest`, `test:home-build-contracts`, `src/i18n` (locale-tree parity) and `src/components/build` green. Every mutation in the table above was applied, run, and reverted.

## Scope

Frontend only — `src/xagent/web/api/mcp.py` is untouched.

An earlier version of this section claimed the change would make team-owned `mcp_oauth` connectors selectable once #1321 landed. #1321 has since landed as #1338, and on current main that claim is false, so it is withdrawn:

- A team-owned MCP row has no personal association, so `list_mcp_apps` withholds `auth_type` from it deliberately — `/{server_id}/oauth/connect` requires an active personal association and would 404. With `auth_type` absent, `isAttachable` gates the row, exactly as the old `is_connected` gate did. This PR does not change that, and it is not a regression: before #1338 the row was not listed at all.
- Team-owned **non**-`mcp_oauth` MCP servers and Custom APIs report `is_connected: true`, so #1338 alone made those attachable. This PR is not what makes them selectable either.

Expressing that population properly needs attachability and authorizability to be separate fields rather than inferred from the presence of `auth_type`; that is #1347, which tracks it as acceptance criterion 3.
