### PR TITLE
fix(mcp): apply the team visibility overlay to the connector picker

### DIFF
--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2009,8 +2009,37 @@ def list_mcp_apps(
             results.append(app_copy)
 
     if location in ["local", "all"]:
+        # Sharing a connector with a team writes a team link row and no
+        # per-member association, so the personal queries above resolve nothing
+        # for every member but the creator. Overlay the team-owned ids the way
+        # get_mcp_servers does, or the Tools page would list a connector the
+        # picker cannot offer (#1321). Scoped to this branch on purpose: the
+        # remote branch's lookups answer "is this catalog app connected *for
+        # me*", which only a personal association can establish. Standalone
+        # deployments install no hook, resolve empty, and take the same path
+        # they always did.
+        from ..services.connector_team_scope import visible_team_connector_ids
+
+        team_ids = visible_team_connector_ids(db, cast(int, current_user.id))
+
+        # (server, user_mcp) for a personal row; (server, None) for a
+        # team-owned connector the user holds no association for. Excluding the
+        # ids already covered personally is what keeps a member who holds both
+        # from seeing the connector twice.
+        local_mcps: list[tuple[MCPServer, UserMCPServer | None]] = list(user_mcps)
+        missing_mcp = [
+            sid for sid in team_ids["mcp"] if sid not in user_mcp_by_server_id
+        ]
+        if missing_mcp:
+            local_mcps.extend(
+                (server, None)
+                for server in db.query(MCPServer)
+                .filter(MCPServer.id.in_(missing_mcp))
+                .all()
+            )
+
         library_names = {app["name"].lower() for app in library_apps}
-        for server, user_mcp in user_mcps:
+        for server, user_mcp in local_mcps:
             if server.name.lower() in library_names:
                 continue
 
@@ -2057,8 +2086,15 @@ def list_mcp_apps(
             # Configure button away from the custom edit form. Inactive
             # associations are excluded because the per-server OAuth endpoints
             # require an active one — a deactivated server needs re-enabling,
-            # not re-authorization.
-            if user_mcp.is_active and _is_mcp_oauth_server(server):
+            # not re-authorization. A team-owned server (user_mcp is None) is
+            # excluded for the same reason, more strongly: the member holds no
+            # association at all, so /{server_id}/oauth/connect would 404 and
+            # the advertised flow would dead-end in a failed popup.
+            if (
+                user_mcp is not None
+                and user_mcp.is_active
+                and _is_mcp_oauth_server(server)
+            ):
                 entry["auth_type"] = "mcp_oauth"
 
             results.append(entry)
@@ -2071,7 +2107,20 @@ def list_mcp_apps(
             .all()
         )
 
-        for user_api, api in user_custom_apis:
+        # Same overlay as the MCP half above: a team-owned Custom API has no
+        # UserCustomApi row for the member. Nothing in the entry below reads
+        # the association, so team-owned APIs need no stand-in — only the id.
+        local_custom_apis: list[CustomApi] = [
+            api for _user_api, api in user_custom_apis
+        ]
+        own_api_ids = {cast(int, api.id) for api in local_custom_apis}
+        missing_api = [aid for aid in team_ids["custom_api"] if aid not in own_api_ids]
+        if missing_api:
+            local_custom_apis.extend(
+                db.query(CustomApi).filter(CustomApi.id.in_(missing_api)).all()
+            )
+
+        for api in local_custom_apis:
             if search:
                 search_lower = search.lower()
                 if search_lower not in api.name.lower() and (

--- a/tests/web/api/test_mcp_apps_team_visibility.py
+++ b/tests/web/api/test_mcp_apps_team_visibility.py
@@ -65,7 +65,9 @@ def _install_visibility(mapping: dict[int, dict[str, set[int]]]) -> None:
     connector_team_scope.set_connector_team_hooks(visibility=visibility)
 
 
-def _add_server(db, owner: User | None, name: str = "records") -> MCPServer:
+def _add_server(
+    db, owner: User, name: str = "records", *, is_active: bool = True
+) -> MCPServer:
     server = MCPServer.from_config(
         {
             "name": name,
@@ -78,20 +80,37 @@ def _add_server(db, owner: User | None, name: str = "records") -> MCPServer:
     db.add(server)
     db.commit()
     db.refresh(server)
-    if owner is not None:
-        db.add(
-            UserMCPServer(
-                user_id=owner.id,
-                mcpserver_id=server.id,
-                is_owner=True,
-                is_active=True,
-            )
+    db.add(
+        UserMCPServer(
+            user_id=owner.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=is_active,
         )
-        db.commit()
+    )
+    db.commit()
     return server
 
 
-def _add_oauth_server(db, owner: User | None, name: str = "notes") -> MCPServer:
+def _add_unowned_server(db, name: str) -> MCPServer:
+    """A server row with no personal association for anyone — reachable only
+    through the team overlay."""
+    server = MCPServer.from_config(
+        {
+            "name": name,
+            "description": f"{name} MCP server",
+            "managed": "external",
+            "transport": "stdio",
+            "command": f"{name}-mcp",
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    return server
+
+
+def _add_oauth_server(db, owner: User, name: str = "notes") -> MCPServer:
     server = MCPServer.from_config(
         {
             "name": name,
@@ -109,20 +128,19 @@ def _add_oauth_server(db, owner: User | None, name: str = "notes") -> MCPServer:
     db.add(server)
     db.commit()
     db.refresh(server)
-    if owner is not None:
-        db.add(
-            UserMCPServer(
-                user_id=owner.id,
-                mcpserver_id=server.id,
-                is_owner=True,
-                is_active=True,
-            )
+    db.add(
+        UserMCPServer(
+            user_id=owner.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
         )
-        db.commit()
+    )
+    db.commit()
     return server
 
 
-def _add_custom_api(db, owner: User | None, name: str = "billing") -> CustomApi:
+def _add_custom_api(db, owner: User, name: str = "billing") -> CustomApi:
     api = CustomApi(
         name=name,
         description=f"{name} API",
@@ -132,16 +150,15 @@ def _add_custom_api(db, owner: User | None, name: str = "billing") -> CustomApi:
     db.add(api)
     db.commit()
     db.refresh(api)
-    if owner is not None:
-        db.add(
-            UserCustomApi(
-                user_id=owner.id,
-                custom_api_id=api.id,
-                is_owner=True,
-                is_active=True,
-            )
+    db.add(
+        UserCustomApi(
+            user_id=owner.id,
+            custom_api_id=api.id,
+            is_owner=True,
+            is_active=True,
         )
-        db.commit()
+    )
+    db.commit()
     return api
 
 
@@ -222,19 +239,30 @@ def test_a_personal_row_plus_a_team_link_lists_the_connector_exactly_once(db_ses
 
 
 def test_a_connector_owned_by_another_team_is_never_listed(db_session):
-    """AC4: the overlay adds exactly what the hook reports for this user."""
-    db, creator, member = db_session
-    _add_server(db, creator)
-    _add_custom_api(db, creator)
-    # The hook answers empty for `member`: they belong to no team owning these.
-    _install_visibility({int(creator.id): {"mcp": set(), "custom_api": set()}})
+    """AC4: the overlay is keyed on the *requesting* user, so a connector a
+    live hook reports for someone else must not reach this user's picker.
 
+    `shared` has no personal association for anyone, so it is reachable only
+    through the overlay: the creator's assertion fails if the overlay is
+    deleted, and the member's fails if it ignores the requesting user. An
+    answer that was empty for everyone — or a connector the creator also owned
+    personally — would leave both assertions true either way."""
+    db, creator, member = db_session
+    shared = _add_unowned_server(db, "shared")
+    _install_visibility(
+        {int(creator.id): {"mcp": {int(shared.id)}, "custom_api": set()}}
+    )
+
+    assert _local_ids(db, creator) == ["shared"]
     assert _local_ids(db, member) == []
 
 
 def test_standalone_response_is_unchanged_with_no_hook_installed(db_session):
     """AC5: `visible_team_connector_ids` resolves empty without a hook, so a
-    standalone deployment sees byte-identical results."""
+    standalone deployment takes the pre-overlay path. Entry *fields* on that
+    path are pinned by the existing tests in test_mcp_oauth_flow.py; what this
+    pins is that the overlay adds and removes nothing when no hook is
+    installed."""
     db, creator, member = db_session
     _add_server(db, creator)
     _add_custom_api(db, creator)
@@ -294,9 +322,13 @@ def test_a_team_owned_mcp_oauth_server_carries_no_auth_type(db_session):
     assert "auth_type" not in entry
 
 
-def test_search_and_category_filters_apply_to_overlaid_connectors(db_session):
-    """The overlay feeds the same loops, so the existing filters must still
-    narrow the result rather than being bypassed for team-owned rows."""
+def test_the_search_filter_applies_to_overlaid_connectors(db_session):
+    """The overlay feeds the same loops, so the existing search filter must
+    still narrow the result rather than being bypassed for team-owned rows.
+
+    No category assertion here: the local branch discards *every* row for any
+    category other than "All", so a category assertion holds even with the
+    overlay deleted and would pin nothing."""
     db, creator, member = db_session
     records = _add_server(db, creator, name="records")
     shipping = _add_server(db, creator, name="shipping")
@@ -323,9 +355,64 @@ def test_search_and_category_filters_apply_to_overlaid_connectors(db_session):
         )
     ] == ["records"]
 
-    assert (
-        list_mcp_apps(
-            location="local", category="Productivity", current_user=member, db=db
-        )
-        == []
+
+@pytest.mark.parametrize("location", ["local", "all"])
+def test_the_overlay_applies_to_both_local_and_all(db_session, location):
+    """`location="all"` runs the same branch as "local". The frontend only
+    sends "local" today, so pin that the branch is entered for both rather
+    than leaving "all" to drift."""
+    db, creator, member = db_session
+    server = _add_server(db, creator)
+    api = _add_custom_api(db, creator)
+    _install_visibility(
+        {
+            int(member.id): {
+                "mcp": {int(server.id)},
+                "custom_api": {int(api.id)},
+            }
+        }
     )
+
+    ids = [
+        a["id"] for a in list_mcp_apps(location=location, current_user=member, db=db)
+    ]
+    assert ids == ["records", "billing"]
+
+
+def test_an_inactive_personal_row_plus_a_team_link_lists_one_entry(db_session):
+    """A member who deactivated their own association while the connector stays
+    team-owned must still see exactly one row, not one per source.
+
+    The dedup index is built from *all* personal associations regardless of
+    `is_active`, matching `get_mcp_servers`' `own_mcp_ids`; an index that
+    filtered on `is_active` would overlay a second copy of this server."""
+    db, creator, _member = db_session
+    server = _add_server(db, creator, is_active=False)
+    _install_visibility(
+        {int(creator.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    assert _local_ids(db, creator).count("records") == 1
+
+
+def test_a_hook_answering_string_ids_is_not_silently_resolved(db_session):
+    """Regression pin for a fail-open path: SQLite's numeric affinity makes
+    `id IN ('1')` match an INTEGER primary key, so a hook answering string ids
+    would list a connector the dedup index (int-keyed) considered missing.
+
+    Element types are the hook's contract (`dict[str, set[int]]`). This pins
+    today's behavior so a future validator in `connector_team_scope` — which
+    must check element types, not just the container shape — has a test that
+    changes when the behavior does."""
+    db, creator, member = db_session
+    server = _add_server(db, creator)
+    _install_visibility(
+        {int(member.id): {"mcp": {str(server.id)}, "custom_api": set()}}  # type: ignore[dict-item]
+    )
+
+    listed = _local_ids(db, member)
+    # Documents the current fail-open outcome rather than asserting it is
+    # correct: a string id resolves through the IN clause and reaches the
+    # picker. A validator rejecting non-int members would turn this into a
+    # raised error, and this assertion is where that change surfaces.
+    assert listed == ["records"]

--- a/tests/web/api/test_mcp_apps_team_visibility.py
+++ b/tests/web/api/test_mcp_apps_team_visibility.py
@@ -1,0 +1,331 @@
+"""`/api/mcp/apps?location=local` must resolve the same connector set as
+`/api/mcp/servers` (#1321).
+
+Sharing a connector with a team writes a team link row and no per-member
+association, so the picker's personal-association queries resolve nothing for
+every member but the creator. Both endpoints overlay the team-owned ids the
+`connector_team_scope` visibility hook reports; these tests pin that the
+picker's local branch does it too, and that the standalone (no hook) and
+remote responses are untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.web.api.mcp import list_mcp_apps
+from xagent.web.models.custom_api import CustomApi, UserCustomApi
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.services import connector_team_scope
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "mcp-apps-team.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    creator = User(username="alice", password_hash="x", is_admin=False)
+    member = User(username="bob", password_hash="x", is_admin=False)
+    db.add_all([creator, member])
+    db.commit()
+    db.refresh(creator)
+    db.refresh(member)
+
+    yield db, creator, member
+    db.close()
+    engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_connector_team_hooks():
+    """The hooks are process-global; never leak one into a sibling test."""
+    yield
+    connector_team_scope.set_connector_team_hooks()
+
+
+def _install_visibility(mapping: dict[int, dict[str, set[int]]]) -> None:
+    """Install a user-keyed visibility hook answering from ``mapping``."""
+
+    def visibility(_db, user_id: int) -> dict[str, set[int]]:
+        answer = mapping.get(int(user_id))
+        if answer is None:
+            return {"mcp": set(), "custom_api": set()}
+        return {"mcp": set(answer["mcp"]), "custom_api": set(answer["custom_api"])}
+
+    connector_team_scope.set_connector_team_hooks(visibility=visibility)
+
+
+def _add_server(db, owner: User | None, name: str = "records") -> MCPServer:
+    server = MCPServer.from_config(
+        {
+            "name": name,
+            "description": f"{name} MCP server",
+            "managed": "external",
+            "transport": "stdio",
+            "command": f"{name}-mcp",
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    if owner is not None:
+        db.add(
+            UserMCPServer(
+                user_id=owner.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+    return server
+
+
+def _add_oauth_server(db, owner: User | None, name: str = "notes") -> MCPServer:
+    server = MCPServer.from_config(
+        {
+            "name": name,
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://mcp.example.com/mcp",
+            "auth": {
+                "type": "mcp_oauth",
+                "resource": "https://mcp.example.com/mcp",
+                "issuer": "https://auth.example.com",
+                "scope": "notes.read",
+            },
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    if owner is not None:
+        db.add(
+            UserMCPServer(
+                user_id=owner.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+    return server
+
+
+def _add_custom_api(db, owner: User | None, name: str = "billing") -> CustomApi:
+    api = CustomApi(
+        name=name,
+        description=f"{name} API",
+        url="https://api.example.com/v1",
+        method="GET",
+    )
+    db.add(api)
+    db.commit()
+    db.refresh(api)
+    if owner is not None:
+        db.add(
+            UserCustomApi(
+                user_id=owner.id,
+                custom_api_id=api.id,
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+    return api
+
+
+def _add_catalog_app(
+    db, app_id: str = "granola", name: str = "Granola"
+) -> PublicMCPApp:
+    app = PublicMCPApp(
+        app_id=app_id,
+        name=name,
+        description="A catalog app",
+        icon="",
+        category="Productivity",
+        transport="streamable_http",
+        is_visible_in_connector=True,
+    )
+    db.add(app)
+    db.commit()
+    db.refresh(app)
+    return app
+
+
+def _local_ids(db, user: User) -> list[str]:
+    return [a["id"] for a in list_mcp_apps(location="local", current_user=user, db=db)]
+
+
+def test_local_branch_lists_a_team_owned_mcp_server_without_a_personal_row(db_session):
+    """AC1: the connector the Tools page already shows must reach the picker."""
+    db, creator, member = db_session
+    server = _add_server(db, creator)
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    entry = next(
+        a
+        for a in list_mcp_apps(location="local", current_user=member, db=db)
+        if a["id"] == "records"
+    )
+    assert entry["server_id"] == server.id
+    assert entry["is_custom"] is True
+    assert entry["is_connected"] is True
+
+
+def test_local_branch_lists_a_team_owned_custom_api_without_a_personal_row(db_session):
+    """AC2: the Custom API half of the branch has the same association-only
+    shape, so it drops team-owned APIs for the same reason."""
+    db, creator, member = db_session
+    api = _add_custom_api(db, creator)
+    _install_visibility({int(member.id): {"mcp": set(), "custom_api": {int(api.id)}}})
+
+    entry = next(
+        a
+        for a in list_mcp_apps(location="local", current_user=member, db=db)
+        if a["id"] == "billing"
+    )
+    assert entry["server_id"] == api.id
+    assert entry["transport"] == "custom_api"
+    assert entry["is_connected"] is True
+
+
+def test_a_personal_row_plus_a_team_link_lists_the_connector_exactly_once(db_session):
+    """AC3: the creator holds both; the overlay must not duplicate the entry."""
+    db, creator, _member = db_session
+    server = _add_server(db, creator)
+    api = _add_custom_api(db, creator)
+    _install_visibility(
+        {
+            int(creator.id): {
+                "mcp": {int(server.id)},
+                "custom_api": {int(api.id)},
+            }
+        }
+    )
+
+    ids = _local_ids(db, creator)
+    assert ids.count("records") == 1
+    assert ids.count("billing") == 1
+
+
+def test_a_connector_owned_by_another_team_is_never_listed(db_session):
+    """AC4: the overlay adds exactly what the hook reports for this user."""
+    db, creator, member = db_session
+    _add_server(db, creator)
+    _add_custom_api(db, creator)
+    # The hook answers empty for `member`: they belong to no team owning these.
+    _install_visibility({int(creator.id): {"mcp": set(), "custom_api": set()}})
+
+    assert _local_ids(db, member) == []
+
+
+def test_standalone_response_is_unchanged_with_no_hook_installed(db_session):
+    """AC5: `visible_team_connector_ids` resolves empty without a hook, so a
+    standalone deployment sees byte-identical results."""
+    db, creator, member = db_session
+    _add_server(db, creator)
+    _add_custom_api(db, creator)
+
+    assert _local_ids(db, creator) == ["records", "billing"]
+    assert _local_ids(db, member) == []
+
+
+def test_remote_results_are_unchanged_by_the_team_overlay(db_session):
+    """AC6: the overlay is scoped to the local branch. A team-owned server must
+    not leak into the remote branch's connection-state lookups, which answer
+    "is this catalog app connected *for me*" from personal associations only."""
+    db, creator, member = db_session
+    _add_catalog_app(db)
+    server = _add_server(db, creator, name="granola")
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    remote = list_mcp_apps(location="remote", current_user=member, db=db)
+    granola = next(a for a in remote if a["id"] == "granola")
+    assert granola["is_connected"] is False
+    assert "server_id" not in granola
+
+
+def test_a_team_owned_server_named_like_a_catalog_app_is_skipped(db_session):
+    """The local branch excludes servers backing a catalog app so they are not
+    listed twice; an overlaid server must obey the same rule."""
+    db, creator, member = db_session
+    _add_catalog_app(db)
+    server = _add_server(db, creator, name="Granola")
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    assert "Granola" not in _local_ids(db, member)
+
+
+def test_a_team_owned_mcp_oauth_server_carries_no_auth_type(db_session):
+    """`auth_type` tells the picker to POST `/{server_id}/oauth/connect`, which
+    requires an *active personal association* and 404s without one. A team
+    member holds no association at all, so advertising the flow would trade a
+    missing entry for a failed popup — the same reasoning that already excludes
+    deactivated associations."""
+    db, creator, member = db_session
+    server = _add_oauth_server(db, creator)
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    entry = next(
+        a
+        for a in list_mcp_apps(location="local", current_user=member, db=db)
+        if a["id"] == "notes"
+    )
+    assert entry["is_connected"] is False
+    assert "auth_type" not in entry
+
+
+def test_search_and_category_filters_apply_to_overlaid_connectors(db_session):
+    """The overlay feeds the same loops, so the existing filters must still
+    narrow the result rather than being bypassed for team-owned rows."""
+    db, creator, member = db_session
+    records = _add_server(db, creator, name="records")
+    shipping = _add_server(db, creator, name="shipping")
+    billing = _add_custom_api(db, creator, name="billing")
+    _install_visibility(
+        {
+            int(member.id): {
+                "mcp": {int(records.id), int(shipping.id)},
+                "custom_api": {int(billing.id)},
+            }
+        }
+    )
+
+    assert [
+        a["id"]
+        for a in list_mcp_apps(
+            location="local", search="bill", current_user=member, db=db
+        )
+    ] == ["billing"]
+    assert [
+        a["id"]
+        for a in list_mcp_apps(
+            location="local", search="record", current_user=member, db=db
+        )
+    ] == ["records"]
+
+    assert (
+        list_mcp_apps(
+            location="local", category="Productivity", current_user=member, db=db
+        )
+        == []
+    )


### PR DESCRIPTION
Closes #1321

## Problem

`GET /api/mcp/apps?location=local` backs the agent's "+ Connector" dialog, but resolved connectors from the requesting user's own association rows only:

```python
db.query(MCPServer, UserMCPServer)
  .join(UserMCPServer, UserMCPServer.mcpserver_id == MCPServer.id)
  .filter(UserMCPServer.user_id == current_user.id)
```

`GET /api/mcp/servers` (the Tools page) additionally overlays the team-owned ids reported by `visible_team_connector_ids`. Sharing a connector with a team writes a team link row and **no** per-member association, so for every member but the creator both of the picker's loops resolved nothing: the connector was listed on the Tools page yet absent from the picker and impossible to attach to an agent. The Custom API half of the branch has the identical shape and dropped team-owned APIs for the same reason.

## Fix

Overlay the same team-owned ids in the local branch, for MCP servers and Custom APIs alike, excluding the ids already covered by a personal row so a member holding both sees the connector exactly once. No new hook shape is required — `visible_team_connector_ids(db, user_id)` answers exactly the question the picker needs, and is the same user-keyed hook `get_mcp_servers` already calls.

Two deliberate scoping decisions:

- **Local branch only.** Team servers are not injected into `user_mcps`, because that list also feeds `_build_active_oauth_server_lookup` / `_build_active_non_oauth_server_lookup` in the remote branch, which answer "is this catalog app connected *for me*" — a question only a personal association can establish. `location=remote` results are unchanged.

- **Team-owned rows do not carry the `auth_type: "mcp_oauth"` picker hint.** That hint tells the frontend to `POST /{server_id}/oauth/connect`, which calls `_get_user_mcp_server_or_404(..., require_active=True)`. A team member holds no association at all, so it would 404 and dead-end in a failed popup. Suppressing the hint mirrors the existing exclusion of deactivated associations, and leaves team-owned `mcp_oauth` connectors listed-but-unconnectable — outside this issue's scope (see #1313).

  To be precise about what that looks like, since an earlier version of this description overstated the parity: the picker renders a Connect button for any unconnected entry (`official-mcp-settings-dialog.tsx:214-227`), and with no `auth_type` the click falls through to the mis-authored-entry toast (`connect-mcp-dialog.tsx:878`). The Tools page serializes the same rows through `_TeamOwnedUserMCP` as inert cards with no Connect button, so the two surfaces are **not** identical here. The alternative is strictly worse (emitting the hint yields a popup that 404s), and before this PR the connector was invisible in the picker entirely — but it is a dead button, not a no-op, and `test_a_team_owned_mcp_oauth_server_carries_no_auth_type` pins it deliberately.

- **Team rows carry no ownership marker in this endpoint's entry shape.** Overlaid rows are indistinguishable from personal ones in the `/api/mcp/apps` payload; the frontend recognizes team tools and hides edit controls via the separate `POST /api/connectors/status` overlay (`connect-mcp-dialog.tsx:243`, `tools/page.tsx:306`), which is an overlay-only route absent in standalone. Backend `PUT`/`DELETE` stay 403-guarded regardless, so a missing overlay degrades decoration only — noting the dependency explicitly since this PR relies on it.

Standalone xagent installs no visibility hook, resolves empty, and takes the path it always did.

## Acceptance criteria

- [x] `/api/mcp/apps?location=local` lists a team-owned MCP connector for a member holding no personal association row.
- [x] The same holds for a team-owned Custom API.
- [x] A member holding both a personal association and a team link sees the connector exactly once.
- [x] A connector owned by a team the user does not belong to is never listed.
- [x] With no team hook installed (standalone), the response is unchanged.
- [x] `location=remote` results are unchanged.

## Tests

New `tests/web/api/test_mcp_apps_team_visibility.py` — 13 tests, one per acceptance criterion plus the catalog-name skip, the `mcp_oauth` hint suppression, and search filtering over overlaid rows. Written test-first.

Tightened in d0ff87b after review, because several assertions held regardless of the overlay:

- **AC4** installed a hook answering empty for *every* user, so it passed with the overlay deleted. It now reports a connector with no personal association for anyone — reachable only through the overlay — so the creator's assertion fails if the overlay is removed and the member's fails if it stops keying on the requesting user.
- **The category assertion was vacuous** (the local branch discards every row for any category other than `"All"`, so it held for any implementation) and is removed.
- **The AC5 docstring** promised "byte-identical" while asserting only id lists; reworded to what it pins.
- **Added:** `location="all"` (same branch as `"local"`, previously untested); an inactive personal row plus a team link listing one entry (pinning that the dedup index spans all associations regardless of `is_active`); and a hook answering string ids.

That last one documents a real fail-**open** path: SQLite's numeric affinity makes `id IN ('1')` match an INTEGER primary key, so a string-id answer resolves and lists the connector. I had claimed the opposite in an earlier review reply and have [corrected it](https://github.com/xorbitsai/xagent/pull/1338#discussion_r3776871363). Note that exact-`set` shape validation would not catch `{"1"}` — any hardening PR on `connector_team_scope` must validate element types, not just the container.

Mutation-checked against main's `list_mcp_apps`: 8 of 13 tests now fail without the fix, up from 4. The 5 that still pass are the intentional invariance tests (dedup, standalone, remote, catalog-name skip, inactive row).

Also verified: `tests/web/api/`, `tests/web/tools/`, and `tests/web/test_team_sharing_hooks.py` all pass; `mypy src/xagent/web/api/mcp.py` and `ruff` are clean.
