### PR TITLE
feat(v1): stream task lifecycle events over SSE

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.svg,*.png,*.jpg,*.jpeg,*.gif,*.ico,*.webp,pyproject.toml,*node_modules*,uploads/,generated_db_for_test/,memory_store/,data/lancedb/,**/package-lock.json
-ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit
+ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -137,6 +137,13 @@ class V1EventStreamSink:
     ``_resolve_task_or_404``.
     """
 
+    # This sink only consumes the broadcast fan-out; it must never be
+    # picked as the target for a personal reply to a durable command (see
+    # ``websocket.py``'s ``_execute_durable_task_command``), since it only
+    # understands versioned task-status events and would silently drop
+    # anything else routed to it.
+    is_broadcast_only = True
+
     def __init__(
         self, *, task_id: int, principal_key_prefix: str, initial_status: str
     ) -> None:

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -83,6 +83,37 @@ _MIN_WAIT_BUDGET_SECONDS = 0.05
 
 _TERMINAL_STATUSES = (TaskStatus.COMPLETED, TaskStatus.FAILED)
 _TERMINAL_STATUS_VALUES = {status.value for status in _TERMINAL_STATUSES}
+# A task moving to ``waiting_for_user`` also warrants an early watchdog
+# wake, same as a terminal one -- both are broadcasts that make the
+# authoritative row read (by the watchdog, or the attach-time snapshot)
+# worth re-running sooner than the next scheduled cycle.
+_EARLY_WAKE_STATUS_VALUES = _TERMINAL_STATUS_VALUES | {
+    TaskStatus.WAITING_FOR_USER.value
+}
+
+
+def _stream_close_reason(status: TaskStatus, control_state: str | None) -> str | None:
+    """Shared close determination for a task's authoritative row state.
+
+    Both the watchdog (``watchdog_check_once``, polling) and the
+    attach-time fast path (``build_event_stream_response``, one-shot at
+    open) need to reach the same conclusion from the same two fields, so
+    they call this instead of duplicating the condition. Returns
+    ``"terminal"`` when the task is completed/failed, ``"input_required"``
+    when it's stuck waiting on user input (and not mid-resume), or
+    ``None`` when the stream should keep going. Each caller still builds
+    its own output from the category -- a close frame on the watchdog's
+    already-open stream, or a fast-path response before one ever opens.
+    """
+    if status in _TERMINAL_STATUSES:
+        return "terminal"
+    if (
+        status is TaskStatus.WAITING_FOR_USER
+        and control_state != TaskControlState.RESUME_REQUESTED.value
+    ):
+        return "input_required"
+    return None
+
 
 # A sync callable: (task_id, principal) -> ``_TaskInfoSnapshot``-shaped
 # object (duck-typed: ``.status`` / ``.control_state`` / ``.output`` /
@@ -250,8 +281,6 @@ class V1EventStreamSink:
             message = json.loads(text)
             if not isinstance(message, dict):
                 return
-            if not self._binding_matches(message):
-                return
             if message.get("type") == "task_completed":
                 # Acceleration signal only: the authoritative completion
                 # frame still comes from the watchdog reading the task
@@ -264,11 +293,18 @@ class V1EventStreamSink:
                 status = message.get("status")
                 if isinstance(status, str):
                     self.enqueue_status(status)
-                    if status in _TERMINAL_STATUS_VALUES:
+                    if status in _EARLY_WAKE_STATUS_VALUES:
                         # A failed task's broadcast (``task_error``) never
-                        # carries ``type == "task_completed"``, so it would
-                        # otherwise miss the acceleration signal above and
-                        # wait out the watchdog's normal cadence.
+                        # carries ``type == "task_completed"``, and a task
+                        # moving to ``waiting_for_user`` never does either,
+                        # so both would otherwise miss the acceleration
+                        # signal above and wait out the watchdog's normal
+                        # cadence. Safe to wake early on either: the
+                        # watchdog re-reads the authoritative row (via
+                        # ``_stream_close_reason``) before closing anything,
+                        # including the ``resume_requested`` carve-out, so
+                        # an early wake never closes a stream that a fresh
+                        # read wouldn't have closed anyway.
                         self.completion_hint.set()
         except Exception:
             self.dropped_frame_count += 1
@@ -276,7 +312,7 @@ class V1EventStreamSink:
                 "v1 SSE sink dropped a broadcast frame for task %s", self.task_id
             )
 
-    async def close(self, *args: Any, **kwargs: Any) -> None:
+    async def close(self) -> None:
         """No-op. Duck-types ``WebSocket.close`` -- task deletion
         (``chat.py``'s ``_cleanup_runtime_state``) calls ``close()`` on every
         connection still registered for the task, and a missing method here
@@ -285,23 +321,6 @@ class V1EventStreamSink:
         ``finally`` block is what actually tears the stream down.
         """
         return None
-
-    def _binding_matches(self, message: dict[str, Any]) -> bool:
-        """Drop frames whose task_id doesn't match this stream's binding
-        (defense in depth -- ``manager`` already scopes delivery to this
-        task's connections, so this only matters if a connection is ever
-        reassigned via ``move_connection``)."""
-        candidate = message.get("task_id")
-        if candidate is None and message.get("type") == "task_completed":
-            task_obj = message.get("task")
-            if isinstance(task_obj, dict):
-                candidate = task_obj.get("id")
-        if candidate is None:
-            return True
-        try:
-            return int(candidate) == self.task_id
-        except (TypeError, ValueError):
-            return False
 
 
 # -- Per-principal concurrency accounting --------------------------------
@@ -397,7 +416,8 @@ async def watchdog_check_once(
         raise
 
     status = snapshot.status
-    if status in _TERMINAL_STATUSES:
+    close_reason = _stream_close_reason(status, snapshot.control_state)
+    if close_reason == "terminal":
         return sink.enqueue_close(
             completed_frame(
                 status=status.value,
@@ -405,10 +425,7 @@ async def watchdog_check_once(
                 error=snapshot.error,
             )
         )
-    if (
-        status is TaskStatus.WAITING_FOR_USER
-        and snapshot.control_state != TaskControlState.RESUME_REQUESTED.value
-    ):
+    if close_reason == "input_required":
         return sink.enqueue_close(input_required_frame(task_id))
     if status is TaskStatus.PAUSED:
         # SDK wait() semantics: PAUSED keeps waiting, doesn't close.
@@ -435,8 +452,8 @@ async def _watchdog_loop(
     interval_seconds: float,
 ) -> None:
     """Runs every ``interval_seconds`` and also wakes early on a
-    completion hint from a terminal (completed or failed) broadcast:
-    same check, just run sooner.
+    completion hint from a terminal (completed or failed) or
+    waiting-for-user broadcast: same check, just run sooner.
 
     A single failed check (e.g. a transient DB error) must not end
     watchdog coverage for the rest of the stream's lifetime -- that
@@ -469,6 +486,15 @@ async def _watchdog_loop(
 
 
 # -- Response assembly ----------------------------------------------------
+
+# nginx buffers proxied responses by default; X-Accel-Buffering is the
+# per-response override that keeps SSE frames flowing immediately instead
+# of waiting for the proxy buffer to fill.
+_SSE_HEADERS = {"X-Accel-Buffering": "no", "Cache-Control": "no-cache"}
+
+
+def _sse_response(body: AsyncIterator[str]) -> StreamingResponse:
+    return StreamingResponse(body, media_type="text/event-stream", headers=_SSE_HEADERS)
 
 
 async def _terminal_snapshot_stream(
@@ -658,20 +684,14 @@ async def build_event_stream_response(
     per-principal reservation) ever exists, so a rejected attach never
     touches ``manager`` or the per-principal counter.
     """
-    if initial_snapshot.status in _TERMINAL_STATUSES:
-        return StreamingResponse(
-            _terminal_snapshot_stream(initial_snapshot),
-            media_type="text/event-stream",
-        )
+    close_reason = _stream_close_reason(
+        initial_snapshot.status, initial_snapshot.control_state
+    )
+    if close_reason == "terminal":
+        return _sse_response(_terminal_snapshot_stream(initial_snapshot))
 
-    if (
-        initial_snapshot.status is TaskStatus.WAITING_FOR_USER
-        and initial_snapshot.control_state != TaskControlState.RESUME_REQUESTED.value
-    ):
-        return StreamingResponse(
-            _input_required_snapshot_stream(initial_snapshot),
-            media_type="text/event-stream",
-        )
+    if close_reason == "input_required":
+        return _sse_response(_input_required_snapshot_stream(initial_snapshot))
 
     if count_task_sinks(task_id) >= PER_TASK_STREAM_CAP:
         raise V1ApiError(V1ErrorCode.RATE_LIMITED, 429)
@@ -680,7 +700,7 @@ async def build_event_stream_response(
     if not principal_slot_available(key_prefix):
         raise V1ApiError(V1ErrorCode.RATE_LIMITED, 429)
 
-    return StreamingResponse(
+    return _sse_response(
         _generate(
             task_id,
             principal,
@@ -690,6 +710,5 @@ async def build_event_stream_response(
             watchdog_interval_seconds=watchdog_interval_seconds,
             stream_max_duration_seconds=stream_max_duration_seconds,
             heartbeat_interval_seconds=heartbeat_interval_seconds,
-        ),
-        media_type="text/event-stream",
+        )
     )

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -47,6 +47,7 @@ from ...models.agent_api_key import AgentApiKey
 from ...models.database import get_session_local
 from ...models.task import TaskStatus
 from ...services.db_runtime import run_db_io_cancellation_safe
+from ...services.task_execution_controller import TaskControlState
 from ..websocket import _is_versioned_task_event, manager
 from .deps import ApiKeyPrincipal, active_runtime_key_filters
 from .errors import V1ApiError, V1ErrorCode
@@ -75,8 +76,13 @@ STREAM_MAX_DURATION_SECONDS = 60.0 * 60.0
 OUTBOUND_QUEUE_MAX_SIZE = 256
 PER_TASK_STREAM_CAP = 2
 PER_PRINCIPAL_STREAM_CAP = 32
+# Floor for the final wait when the 1-hour deadline is close: keeps the
+# queue wait from being called with a near-zero timeout, which would spin
+# the loop instead of actually waiting.
+_MIN_WAIT_BUDGET_SECONDS = 0.05
 
 _TERMINAL_STATUSES = (TaskStatus.COMPLETED, TaskStatus.FAILED)
+_TERMINAL_STATUS_VALUES = {status.value for status in _TERMINAL_STATUSES}
 
 # A sync callable: (task_id, principal) -> ``_TaskInfoSnapshot``-shaped
 # object (duck-typed: ``.status`` / ``.control_state`` / ``.output`` /
@@ -256,11 +262,27 @@ class V1EventStreamSink:
                 status = message.get("status")
                 if isinstance(status, str):
                     self.enqueue_status(status)
+                    if status in _TERMINAL_STATUS_VALUES:
+                        # A failed task's broadcast (``task_error``) never
+                        # carries ``type == "task_completed"``, so it would
+                        # otherwise miss the acceleration signal above and
+                        # wait out the watchdog's normal cadence.
+                        self.completion_hint.set()
         except Exception:
             self.dropped_frame_count += 1
             logger.exception(
                 "v1 SSE sink dropped a broadcast frame for task %s", self.task_id
             )
+
+    async def close(self, *args: Any, **kwargs: Any) -> None:
+        """No-op. Duck-types ``WebSocket.close`` -- task deletion
+        (``chat.py``'s ``_cleanup_runtime_state``) calls ``close()`` on every
+        connection still registered for the task, and a missing method here
+        would log a misleading "failed to close" warning for a sink that was
+        never a real socket in the first place. This generator's own
+        ``finally`` block is what actually tears the stream down.
+        """
+        return None
 
     def _binding_matches(self, message: dict[str, Any]) -> bool:
         """Drop frames whose task_id doesn't match this stream's binding
@@ -383,7 +405,7 @@ async def watchdog_check_once(
         )
     if (
         status is TaskStatus.WAITING_FOR_USER
-        and snapshot.control_state != "resume_requested"
+        and snapshot.control_state != TaskControlState.RESUME_REQUESTED.value
     ):
         return sink.enqueue_close(input_required_frame(task_id))
     if status is TaskStatus.PAUSED:
@@ -456,6 +478,18 @@ async def _terminal_snapshot_stream(
     yield completed_frame(
         status=snapshot.status.value, output=snapshot.output, error=snapshot.error
     )
+
+
+async def _input_required_snapshot_stream(
+    snapshot: "_TaskInfoSnapshot",
+) -> AsyncIterator[str]:
+    """Attach-time fast path for a task already waiting on user input (and
+    not mid-resume): emit ``task.status`` + ``task.input_required`` and
+    end. Same rationale as ``_terminal_snapshot_stream`` -- without this,
+    the same conclusion is only reached via the watchdog's first cycle,
+    up to ``watchdog_interval_seconds`` (30s in production) after attach."""
+    yield status_frame(snapshot.status.value)
+    yield input_required_frame(snapshot.task_id)
 
 
 async def _generate(
@@ -539,7 +573,19 @@ async def _generate(
                 # First-to-close-wins: a no-op if the watchdog already
                 # closed the stream first in the same tick.
                 sink.enqueue_close(error_frame("stream_expired"))
-            wait_budget = heartbeat_interval_seconds if remaining > 0 else 1.0
+            # Capped at the heartbeat interval so the deadline check above
+            # re-runs often enough, but never let it run past the deadline
+            # itself -- otherwise an idle stream whose last ping landed just
+            # before the deadline could sleep a full heartbeat interval past
+            # ``stream_max_duration_seconds`` before ``stream_expired`` is
+            # even enqueued.
+            wait_budget = (
+                min(
+                    heartbeat_interval_seconds, max(remaining, _MIN_WAIT_BUDGET_SECONDS)
+                )
+                if remaining > 0
+                else 1.0
+            )
             try:
                 frame_text, is_close = await asyncio.wait_for(
                     sink.queue.get(), timeout=wait_budget
@@ -609,6 +655,15 @@ async def build_event_stream_response(
     if initial_snapshot.status in _TERMINAL_STATUSES:
         return StreamingResponse(
             _terminal_snapshot_stream(initial_snapshot),
+            media_type="text/event-stream",
+        )
+
+    if (
+        initial_snapshot.status is TaskStatus.WAITING_FOR_USER
+        and initial_snapshot.control_state != TaskControlState.RESUME_REQUESTED.value
+    ):
+        return StreamingResponse(
+            _input_required_snapshot_stream(initial_snapshot),
             media_type="text/event-stream",
         )
 

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -150,7 +150,7 @@ _ERROR_MESSAGES = {
     "resync_required": (
         "The output queue overflowed; call steps() to resync, then re-attach."
     ),
-    "unauthorized": "The API key used to open this stream is no longer valid.",
+    "unauthorized": "The API key used to open this stream has been revoked or paused.",
     "task_deleted": "The task no longer exists.",
     "stream_expired": "This stream reached its maximum allowed duration.",
 }
@@ -263,12 +263,12 @@ class V1EventStreamSink:
     async def send_text(self, text: str) -> None:
         """Receive one broadcast frame. Duck-types ``WebSocket.send_text``.
 
-        Must never raise. ``broadcast_to_task`` (``websocket.py:4504-4532``)
+        Must never raise. ``ConnectionManager.broadcast_to_task``
         catches network errors from a connection's ``send_text`` and drops
-        the connection, but re-raises anything else (``:4525-4532``) --
-        that re-raise happens on the *task's own* outbound event path, so
-        an uncaught exception here would abort the broadcast for every
-        other listener on the task, not just this stream. This is the
+        the connection, but re-raises anything else -- that re-raise
+        happens on the *task's own* outbound event path, so an uncaught
+        exception here would abort the broadcast for every other
+        listener on the task, not just this stream. This is the
         one deliberate blanket ``except Exception`` in this module; every
         drop is logged via ``logger.exception`` below, and also counted
         on ``dropped_frame_count`` for tests to assert against (no

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -238,8 +238,10 @@ class V1EventStreamSink:
         that re-raise happens on the *task's own* outbound event path, so
         an uncaught exception here would abort the broadcast for every
         other listener on the task, not just this stream. This is the
-        one deliberate blanket ``except Exception`` in this module;
-        dropped frames are counted, not silent.
+        one deliberate blanket ``except Exception`` in this module; every
+        drop is logged via ``logger.exception`` below, and also counted
+        on ``dropped_frame_count`` for tests to assert against (no
+        production code reads that counter today).
         """
         try:
             self._assert_owner_loop()
@@ -433,7 +435,8 @@ async def _watchdog_loop(
     interval_seconds: float,
 ) -> None:
     """Runs every ``interval_seconds`` and also wakes early on a
-    ``task_completed`` broadcast hint: same check, just run sooner.
+    completion hint from a terminal (completed or failed) broadcast:
+    same check, just run sooner.
 
     A single failed check (e.g. a transient DB error) must not end
     watchdog coverage for the rest of the stream's lifetime -- that
@@ -538,13 +541,16 @@ async def _generate(
         # concurrent burst of attaches for the same principal all pass the
         # earlier read-only check and then land here before any of them
         # releases a slot, `try_reserve_principal_slot` returns False for
-        # the late arrivals: the count is briefly over `PER_PRINCIPAL_STREAM_CAP`,
-        # it's logged, and the stream is served anyway. The sentinel
-        # (`principal_slot_reserved`) stays False for these streams, so the
-        # `finally` below correctly skips `release_principal_slot` for them
-        # -- nothing was reserved, so nothing is released. The count
-        # self-heals as soon as any concurrently-open stream for this
-        # principal finishes and releases its own slot.
+        # the late arrivals: the number of open streams for this principal
+        # can briefly exceed `PER_PRINCIPAL_STREAM_CAP` -- the counter
+        # itself never does, since `try_reserve_principal_slot` checks
+        # before it increments -- it's logged, and the stream is served
+        # anyway. The sentinel (`principal_slot_reserved`) stays False for
+        # these streams, so the `finally` below correctly skips
+        # `release_principal_slot` for them -- nothing was reserved, so
+        # nothing is released. The open-stream count self-heals as soon as
+        # any concurrently-open stream for this principal finishes and
+        # releases its own slot.
         principal_slot_reserved = try_reserve_principal_slot(key_prefix)
         if not principal_slot_reserved:
             logger.warning(

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -489,7 +489,29 @@ async def _generate(
     principal_slot_reserved = False
     watchdog_task: "asyncio.Task[None] | None" = None
     try:
+        # Soft cap: `principal_slot_available` in `build_event_stream_response`
+        # already did the *check* before this generator started, and that
+        # check is what carries the normal 429 -- an attach that loses the
+        # race here has already been told "yes, come in", so this
+        # reservation only accounts for capacity, it never rejects. If a
+        # concurrent burst of attaches for the same principal all pass the
+        # earlier read-only check and then land here before any of them
+        # releases a slot, `try_reserve_principal_slot` returns False for
+        # the late arrivals: the count is briefly over `PER_PRINCIPAL_STREAM_CAP`,
+        # it's logged, and the stream is served anyway. The sentinel
+        # (`principal_slot_reserved`) stays False for these streams, so the
+        # `finally` below correctly skips `release_principal_slot` for them
+        # -- nothing was reserved, so nothing is released. The count
+        # self-heals as soon as any concurrently-open stream for this
+        # principal finishes and releases its own slot.
         principal_slot_reserved = try_reserve_principal_slot(key_prefix)
+        if not principal_slot_reserved:
+            logger.warning(
+                "v1 SSE per-principal cap best-effort exceeded for "
+                "key_prefix=%s under concurrent attach burst; serving the "
+                "stream anyway (soft cap, no reservation held)",
+                key_prefix,
+            )
         manager.register_connection(cast(WebSocket, sink), task_id)
         watchdog_task = asyncio.create_task(
             _watchdog_loop(
@@ -527,26 +549,35 @@ async def _generate(
             if is_close:
                 return
     finally:
-        if watchdog_task is not None:
-            watchdog_task.cancel()
-            # Narrowed to ``CancelledError`` only (not a blanket
-            # ``BaseException``): the watchdog loop itself now catches
-            # and logs every per-cycle ``Exception`` internally (see
-            # ``_watchdog_loop``) and retries rather than dying, so the
-            # only exception this teardown should ever observe here is
-            # the cancellation just requested above. If the watchdog
-            # task raises anything else, that's a real bug and must
-            # propagate instead of being silently swallowed.
-            with contextlib.suppress(asyncio.CancelledError):
-                await watchdog_task
-        # ``manager`` is typed against a real ``WebSocket``; this sink only
-        # duck-types its ``send_text`` contract (module docstring) -- the
-        # cast documents that intentional narrowing instead of suppressing
-        # the type error blanket-wide. A safe no-op if registration above
-        # never ran or never completed.
-        manager.disconnect(cast(WebSocket, sink))
-        if principal_slot_reserved:
-            release_principal_slot(key_prefix)
+        # The watchdog wait-and-cancel is wrapped in its own try/finally so
+        # that `manager.disconnect` and `release_principal_slot` below --
+        # the two calls that actually undo what this generator reserved --
+        # still run even if awaiting the cancelled watchdog task raises
+        # something unexpected. Without this inner `finally`, a raise here
+        # would skip straight past both cleanup calls, leaking the sink
+        # registration and (if held) the per-principal slot.
+        try:
+            if watchdog_task is not None:
+                watchdog_task.cancel()
+                # Narrowed to ``CancelledError`` only (not a blanket
+                # ``BaseException``): the watchdog loop itself now catches
+                # and logs every per-cycle ``Exception`` internally (see
+                # ``_watchdog_loop``) and retries rather than dying, so the
+                # only exception this teardown should ever observe here is
+                # the cancellation just requested above. If the watchdog
+                # task raises anything else, that's a real bug and must
+                # propagate instead of being silently swallowed.
+                with contextlib.suppress(asyncio.CancelledError):
+                    await watchdog_task
+        finally:
+            # ``manager`` is typed against a real ``WebSocket``; this sink only
+            # duck-types its ``send_text`` contract (module docstring) -- the
+            # cast documents that intentional narrowing instead of suppressing
+            # the type error blanket-wide. A safe no-op if registration above
+            # never ran or never completed.
+            manager.disconnect(cast(WebSocket, sink))
+            if principal_slot_reserved:
+                release_principal_slot(key_prefix)
 
 
 async def build_event_stream_response(

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -10,14 +10,22 @@ and nothing else.
 
 Explicitly out of scope here:
   - Projecting ``step.*`` / ``message.*`` content from trace events.
-  - Buffering live frames during attach warm-up. Without that buffer,
-    a live status update emitted between sink registration and the
-    first ``task.status`` frame can arrive out of order or duplicate
-    the first frame; this is accepted. Worst case the client sees one
-    extra, stale ``task.status``. That's harmless because the
-    authoritative terminal/close determination always comes from the
-    watchdog reading the task row (or the attach-time snapshot read),
-    never from frame ordering.
+  - Buffering live frames during attach warm-up, or reconciling frame
+    order at all. No ``task.status`` frame is ever guaranteed to be
+    fresh or in order: ``ConnectionManager.broadcast_to_task`` stamps
+    each event with whatever ``run_id`` / ``state_version`` tuple its
+    producer captured, falling back to a fresh read of the task row
+    (status included) when the producer didn't capture one, and this
+    sink never compares that stamp against anything -- it just forwards
+    each status string it sees, deduped only against the last one it
+    sent. A stale or out-of-order
+    ``task.status`` frame can therefore reach the client at any point
+    during the stream's life, not only right after attach. This is
+    accepted: the only frames this module treats as authoritative are
+    the three close frames -- ``task.completed``, ``task.input_required``,
+    and ``stream.error`` -- and all three are produced by the watchdog
+    (or the attach-time snapshot read) reading the task row directly,
+    never inferred from frame ordering.
   - Populating ``task.input_required``'s ``prompt`` field from the
     agent's question text. Only the watchdog closes the stream on a
     task stuck waiting for user input (within one watchdog cycle), and

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1,0 +1,526 @@
+"""SSE transport layer for ``GET /v1/chat/tasks/{task_id}/events``.
+
+This module owns everything about *moving bytes to the client and
+deciding when to stop* -- registration into the shared connection
+``manager``, the outbound frame queue, the 30-second watchdog, the
+1-hour absolute duration cap, and per-task / per-principal concurrency
+limits. It emits three lifecycle events -- ``task.status``,
+``task.completed``, and ``stream.error`` -- and nothing else.
+
+Explicitly out of scope here:
+  - Projecting ``step.*`` / ``message.*`` content from trace events.
+  - Buffering live frames during attach warm-up. Without that buffer,
+    a live status update emitted between sink registration and the
+    first ``task.status`` frame can arrive out of order or duplicate
+    the first frame; this is accepted. Worst case the client sees one
+    extra, stale ``task.status``. That's harmless because the
+    authoritative terminal/close determination always comes from the
+    watchdog reading the task row (or the attach-time snapshot read),
+    never from frame ordering.
+  - Populating ``task.input_required``'s ``prompt`` field from the
+    agent's question text. Only the watchdog closes the stream on a
+    task stuck waiting for user input (within one watchdog cycle), and
+    it always sends ``prompt: null`` -- question-text sniffing from
+    live frames belongs to the content-projection layer, not this
+    transport layer.
+
+Sink instances duck-type the ``websocket.ConnectionManager`` connection
+contract (an object with an async ``send_text(str)`` method) so they
+register into the *same* shared ``manager`` real WebSocket connections
+use, and ride the same ``broadcast_to_task`` fan-out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from time import monotonic
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, cast
+
+from fastapi import WebSocket
+from fastapi.responses import StreamingResponse
+
+from ...models.agent_api_key import AgentApiKey
+from ...models.database import get_session_local
+from ...models.task import TaskStatus
+from ...services.db_runtime import run_db_io_cancellation_safe
+from ..websocket import _is_versioned_task_event, manager
+from .deps import ApiKeyPrincipal, active_runtime_key_filters
+from .errors import V1ApiError, V1ErrorCode
+
+if TYPE_CHECKING:
+    # Only for the type checker -- importing ``tasks`` at module scope
+    # would cycle back here (``tasks.py`` imports this module to wire the
+    # endpoint). Callers pass a snapshot-reading callable at call time
+    # instead (see ``TaskSnapshotReader`` below).
+    from .tasks import _TaskInfoSnapshot
+
+logger = logging.getLogger(__name__)
+
+# -- Tunables (all injectable per-call for tests; production always uses
+# the defaults below via ``tasks.py``). ---------------------------------
+
+HEARTBEAT_INTERVAL_SECONDS = 15.0
+WATCHDOG_INTERVAL_SECONDS = 30.0
+# Same shape/value as A2A's cap (``web/api/a2a.py:105``); a separate v1
+# constant because the two streams' generators are structurally different
+# (A2A polls every <=0.5s and re-checks the deadline for free; v1 is
+# queue-consumption-based, so each wait on the outbound queue must be
+# capped at the heartbeat interval so the deadline gets re-checked often
+# enough).
+STREAM_MAX_DURATION_SECONDS = 60.0 * 60.0
+OUTBOUND_QUEUE_MAX_SIZE = 256
+PER_TASK_STREAM_CAP = 2
+PER_PRINCIPAL_STREAM_CAP = 32
+
+_TERMINAL_STATUSES = (TaskStatus.COMPLETED, TaskStatus.FAILED)
+
+# A sync callable: (task_id, principal) -> ``_TaskInfoSnapshot``-shaped
+# object (duck-typed: ``.status`` / ``.control_state`` / ``.output`` /
+# ``.error``), raising ``V1ApiError(TASK_NOT_FOUND, 404)`` when the task
+# is missing or not owned. Always run through ``run_db_io_cancellation_safe``
+# by this module -- never called directly.
+TaskSnapshotReader = Callable[[int, "ApiKeyPrincipal"], Any]
+
+
+# -- Wire format --------------------------------------------------------
+
+
+def _sse_frame(event: str, data: dict[str, Any]) -> str:
+    return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
+
+
+def status_frame(status: str) -> str:
+    return _sse_frame("task.status", {"status": status})
+
+
+def completed_frame(*, status: str, output: str | None, error: str | None) -> str:
+    return _sse_frame(
+        "task.completed", {"status": status, "output": output, "error": error}
+    )
+
+
+def input_required_frame(task_id: int) -> str:
+    # ``prompt`` is always null: populating it from the agent's question
+    # text is the content-projection layer's job, not this transport.
+    return _sse_frame("task.input_required", {"task_id": task_id, "prompt": None})
+
+
+_ERROR_MESSAGES = {
+    "resync_required": (
+        "The output queue overflowed; call steps() to resync, then re-attach."
+    ),
+    "unauthorized": "The API key used to open this stream is no longer valid.",
+    "task_deleted": "The task no longer exists.",
+    "stream_expired": "This stream reached its maximum allowed duration.",
+}
+
+
+def error_frame(code: str) -> str:
+    return _sse_frame("stream.error", {"code": code, "message": _ERROR_MESSAGES[code]})
+
+
+# -- Sink -----------------------------------------------------------------
+
+
+class V1EventStreamSink:
+    """One SSE consumer's broadcast-frame filter and outbound queue.
+
+    Bound to exactly one ``task_id`` and one ``principal`` for the life
+    of the connection. The principal is used only for quota accounting
+    and the watchdog's key-validity check -- it is **not** an
+    authorization gate for who may act on the task; that check already
+    happened once, at attach time, via ``get_principal_from_api_key`` +
+    ``_resolve_task_or_404``.
+    """
+
+    def __init__(
+        self, *, task_id: int, principal_key_prefix: str, initial_status: str
+    ) -> None:
+        self.task_id = task_id
+        self.principal_key_prefix = principal_key_prefix
+        self.dropped_frame_count = 0
+        self.completion_hint = asyncio.Event()
+        self._queue: "asyncio.Queue[str]" = asyncio.Queue(
+            maxsize=OUTBOUND_QUEUE_MAX_SIZE
+        )
+        self._closing = False
+        self._last_status = initial_status
+        # Recorded at construction time (always inside the endpoint's own
+        # request coroutine) so later state-mutating calls -- however they
+        # got here -- can be asserted to run on the same loop.
+        self._owner_loop = asyncio.get_running_loop()
+
+    @property
+    def closing(self) -> bool:
+        return self._closing
+
+    @property
+    def queue(self) -> "asyncio.Queue[str]":
+        return self._queue
+
+    def _assert_owner_loop(self) -> None:
+        if asyncio.get_running_loop() is not self._owner_loop:
+            raise RuntimeError("v1 SSE sink touched from a foreign event loop")
+
+    def enqueue_status(self, status: str) -> None:
+        """Enqueue a deduped ``task.status`` frame. Never closes the stream."""
+        self._assert_owner_loop()
+        if self._closing or status == self._last_status:
+            return
+        self._last_status = status
+        self._put_or_overflow(status_frame(status))
+
+    def enqueue_close(self, frame_text: str) -> bool:
+        """Close exactly once; the first caller wins.
+
+        Drains any queued backlog before inserting the close frame so
+        the close frame always has room -- even when called *because*
+        the queue just overflowed. Losing unread backlog on close is
+        intentional: every close reason tells the client to resync
+        (``steps()`` + re-attach) rather than trust the tail of the
+        stream.
+        """
+        self._assert_owner_loop()
+        if self._closing:
+            return False
+        self._closing = True
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        self._queue.put_nowait(frame_text)
+        return True
+
+    def _put_or_overflow(self, frame_text: str) -> None:
+        # Defense in depth: every current caller already checks ``closing``
+        # first, but a closed sink must never grow its queue again no
+        # matter how it's reached, so the guard lives here too.
+        if self._closing:
+            return
+        try:
+            self._queue.put_nowait(frame_text)
+        except asyncio.QueueFull:
+            self.enqueue_close(error_frame("resync_required"))
+
+    async def send_text(self, text: str) -> None:
+        """Receive one broadcast frame. Duck-types ``WebSocket.send_text``.
+
+        Must never raise. ``broadcast_to_task`` (``websocket.py:4504-4532``)
+        catches network errors from a connection's ``send_text`` and drops
+        the connection, but re-raises anything else (``:4525-4532``) --
+        that re-raise happens on the *task's own* outbound event path, so
+        an uncaught exception here would abort the broadcast for every
+        other listener on the task, not just this stream. This is the
+        one deliberate blanket ``except Exception`` in this module;
+        dropped frames are counted, not silent.
+        """
+        try:
+            self._assert_owner_loop()
+            if self._closing:
+                return
+            message = json.loads(text)
+            if not isinstance(message, dict):
+                return
+            if not self._binding_matches(message):
+                return
+            if message.get("type") == "task_completed":
+                # Acceleration signal only: the authoritative completion
+                # frame still comes from the watchdog reading the task
+                # row, just woken up early instead of waiting out its
+                # normal cadence. This keeps the sink itself from ever
+                # touching the database -- no query happens here.
+                self.completion_hint.set()
+                return
+            if _is_versioned_task_event(message):
+                status = message.get("status")
+                if isinstance(status, str):
+                    self.enqueue_status(status)
+        except Exception:
+            self.dropped_frame_count += 1
+            logger.exception(
+                "v1 SSE sink dropped a broadcast frame for task %s", self.task_id
+            )
+
+    def _binding_matches(self, message: dict[str, Any]) -> bool:
+        """Drop frames whose task_id doesn't match this stream's binding
+        (defense in depth -- ``manager`` already scopes delivery to this
+        task's connections, so this only matters if a connection is ever
+        reassigned via ``move_connection``)."""
+        candidate = message.get("task_id")
+        if candidate is None and message.get("type") == "task_completed":
+            task_obj = message.get("task")
+            if isinstance(task_obj, dict):
+                candidate = task_obj.get("id")
+        if candidate is None:
+            return True
+        try:
+            return int(candidate) == self.task_id
+        except (TypeError, ValueError):
+            return False
+
+
+# -- Per-principal concurrency accounting --------------------------------
+
+_principal_stream_counts: dict[str, int] = {}
+
+
+def try_reserve_principal_slot(key_prefix: str) -> bool:
+    current = _principal_stream_counts.get(key_prefix, 0)
+    if current >= PER_PRINCIPAL_STREAM_CAP:
+        return False
+    _principal_stream_counts[key_prefix] = current + 1
+    return True
+
+
+def release_principal_slot(key_prefix: str) -> None:
+    current = _principal_stream_counts.get(key_prefix, 0)
+    if current <= 1:
+        _principal_stream_counts.pop(key_prefix, None)
+    else:
+        _principal_stream_counts[key_prefix] = current - 1
+
+
+def reset_principal_stream_counts_for_testing() -> None:
+    _principal_stream_counts.clear()
+
+
+def count_task_sinks(task_id: int) -> int:
+    """Count only v1 SSE sinks for a task -- WebSocket connections on the
+    same task_id don't share this concurrency cap."""
+    return sum(
+        1
+        for connection in manager.connections_for_task(task_id)
+        if isinstance(connection, V1EventStreamSink)
+    )
+
+
+# -- Watchdog --------------------------------------------------------------
+
+
+def _is_runtime_key_active(key_prefix: str) -> bool:
+    """One indexed lookup, no bcrypt (the handshake already verified the
+    secret; this only re-checks revoked/paused)."""
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        return (
+            db.query(AgentApiKey.id)
+            .filter(*active_runtime_key_filters(key_prefix))
+            .first()
+            is not None
+        )
+
+
+async def watchdog_check_once(
+    sink: V1EventStreamSink,
+    task_id: int,
+    principal: ApiKeyPrincipal,
+    *,
+    read_task_snapshot: TaskSnapshotReader,
+) -> bool:
+    """One watchdog check pass. Returns True iff it closed the stream.
+
+    Order: key validity first (the auth axis, fail closed), then the
+    task row's own state. All reads go through
+    ``run_db_io_cancellation_safe``; none of this runs on the sink's
+    ``send_text`` hot path, so the sink itself still never touches the
+    database.
+    """
+    key_active = await run_db_io_cancellation_safe(
+        lambda: _is_runtime_key_active(sink.principal_key_prefix)
+    )
+    if not key_active:
+        return sink.enqueue_close(error_frame("unauthorized"))
+
+    try:
+        snapshot = await run_db_io_cancellation_safe(
+            lambda: read_task_snapshot(task_id, principal)
+        )
+    except V1ApiError as exc:
+        if exc.code is V1ErrorCode.TASK_NOT_FOUND:
+            return sink.enqueue_close(error_frame("task_deleted"))
+        raise
+
+    status = snapshot.status
+    if status in _TERMINAL_STATUSES:
+        return sink.enqueue_close(
+            completed_frame(
+                status=status.value,
+                output=snapshot.output,
+                error=snapshot.error,
+            )
+        )
+    if (
+        status is TaskStatus.WAITING_FOR_USER
+        and snapshot.control_state != "resume_requested"
+    ):
+        return sink.enqueue_close(input_required_frame(task_id))
+    if status is TaskStatus.PAUSED:
+        # SDK wait() semantics: PAUSED keeps waiting, doesn't close.
+        # A "was this paused by an orphaned process?" check was considered
+        # and rejected: a normal pause and an orphaned one leave identical
+        # values in every lease-tracking column (runner id, lease
+        # expiry, last heartbeat, control state) -- both the normal-pause
+        # and lease-recovery code paths stamp those columns with "now",
+        # so they only measure how long ago the pause happened, not
+        # whether anyone is still managing it. Closing on that signal
+        # would kill legitimately paused streams too. The 1-hour absolute
+        # cap is what actually bounds an orphaned paused stream's lifetime.
+        sink.enqueue_status(status.value)
+        return False
+    return False  # pending/running: keep streaming
+
+
+async def _watchdog_loop(
+    sink: V1EventStreamSink,
+    task_id: int,
+    principal: ApiKeyPrincipal,
+    *,
+    read_task_snapshot: TaskSnapshotReader,
+    interval_seconds: float,
+) -> None:
+    """Runs every ``interval_seconds`` and also wakes early on a
+    ``task_completed`` broadcast hint: same check, just run sooner."""
+    while not sink.closing:
+        try:
+            await asyncio.wait_for(
+                sink.completion_hint.wait(), timeout=interval_seconds
+            )
+        except asyncio.TimeoutError:
+            pass
+        else:
+            sink.completion_hint.clear()
+        if sink.closing:
+            return
+        if await watchdog_check_once(
+            sink, task_id, principal, read_task_snapshot=read_task_snapshot
+        ):
+            return
+
+
+# -- Response assembly ----------------------------------------------------
+
+
+async def _terminal_snapshot_stream(
+    snapshot: "_TaskInfoSnapshot",
+) -> AsyncIterator[str]:
+    """Attach-time fast path for an already-terminal task: emit
+    ``task.status`` + ``task.completed`` and end. No sink, no
+    registration, no watchdog -- there's nothing left to watch."""
+    yield status_frame(snapshot.status.value)
+    yield completed_frame(
+        status=snapshot.status.value, output=snapshot.output, error=snapshot.error
+    )
+
+
+async def _generate(
+    sink: V1EventStreamSink,
+    task_id: int,
+    principal: ApiKeyPrincipal,
+    *,
+    initial_status: str,
+    read_task_snapshot: TaskSnapshotReader,
+    watchdog_interval_seconds: float,
+    stream_max_duration_seconds: float,
+    heartbeat_interval_seconds: float,
+) -> AsyncIterator[str]:
+    deadline = monotonic() + stream_max_duration_seconds
+    watchdog_task = asyncio.create_task(
+        _watchdog_loop(
+            sink,
+            task_id,
+            principal,
+            read_task_snapshot=read_task_snapshot,
+            interval_seconds=watchdog_interval_seconds,
+        )
+    )
+    try:
+        # The initial yield must be inside this ``try`` too: a generator
+        # closed (``aclose()``, e.g. on client disconnect) while suspended
+        # here still has to unregister the sink and cancel the watchdog.
+        yield status_frame(initial_status)
+        while True:
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                # First-to-close-wins: a no-op if the watchdog already
+                # closed the stream first in the same tick.
+                sink.enqueue_close(error_frame("stream_expired"))
+            wait_budget = heartbeat_interval_seconds if remaining > 0 else 1.0
+            try:
+                frame = await asyncio.wait_for(sink.queue.get(), timeout=wait_budget)
+            except asyncio.TimeoutError:
+                yield ": ping\n\n"
+                continue
+            yield frame
+            if sink.closing:
+                return
+    finally:
+        watchdog_task.cancel()
+        with contextlib.suppress(BaseException):
+            await watchdog_task
+        # ``manager`` is typed against a real ``WebSocket``; this sink only
+        # duck-types its ``send_text`` contract (module docstring) -- the
+        # cast documents that intentional narrowing instead of suppressing
+        # the type error blanket-wide.
+        manager.disconnect(cast(WebSocket, sink))
+        release_principal_slot(sink.principal_key_prefix)
+
+
+async def build_event_stream_response(
+    *,
+    task_id: int,
+    principal: ApiKeyPrincipal,
+    initial_snapshot: "_TaskInfoSnapshot",
+    read_task_snapshot: TaskSnapshotReader,
+    watchdog_interval_seconds: float = WATCHDOG_INTERVAL_SECONDS,
+    stream_max_duration_seconds: float = STREAM_MAX_DURATION_SECONDS,
+    heartbeat_interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS,
+) -> StreamingResponse:
+    """Assemble the SSE ``StreamingResponse`` for one attach.
+
+    ``initial_snapshot`` must already be authorized (i.e. come from
+    ``_resolve_task_or_404`` via ``read_task_snapshot``) -- this
+    function does no auth of its own. Concurrency caps (429) are
+    checked here, before any sink is registered, so a rejected attach
+    never touches ``manager`` or the per-principal counter.
+    """
+    if initial_snapshot.status in _TERMINAL_STATUSES:
+        return StreamingResponse(
+            _terminal_snapshot_stream(initial_snapshot),
+            media_type="text/event-stream",
+        )
+
+    if count_task_sinks(task_id) >= PER_TASK_STREAM_CAP:
+        raise V1ApiError(V1ErrorCode.RATE_LIMITED, 429)
+
+    key_prefix = principal.key.key_prefix
+    if not try_reserve_principal_slot(key_prefix):
+        raise V1ApiError(V1ErrorCode.RATE_LIMITED, 429)
+
+    sink = V1EventStreamSink(
+        task_id=task_id,
+        principal_key_prefix=key_prefix,
+        initial_status=initial_snapshot.status.value,
+    )
+    try:
+        manager.register_connection(cast(WebSocket, sink), task_id)
+    except Exception:
+        release_principal_slot(key_prefix)
+        raise
+
+    return StreamingResponse(
+        _generate(
+            sink,
+            task_id,
+            principal,
+            initial_status=initial_snapshot.status.value,
+            read_task_snapshot=read_task_snapshot,
+            watchdog_interval_seconds=watchdog_interval_seconds,
+            stream_max_duration_seconds=stream_max_duration_seconds,
+            heartbeat_interval_seconds=heartbeat_interval_seconds,
+        ),
+        media_type="text/event-stream",
+    )

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -4,8 +4,9 @@ This module owns everything about *moving bytes to the client and
 deciding when to stop* -- registration into the shared connection
 ``manager``, the outbound frame queue, the 30-second watchdog, the
 1-hour absolute duration cap, and per-task / per-principal concurrency
-limits. It emits three lifecycle events -- ``task.status``,
-``task.completed``, and ``stream.error`` -- and nothing else.
+limits. It emits four lifecycle events -- ``task.status``,
+``task.completed``, ``task.input_required``, and ``stream.error`` --
+and nothing else.
 
 Explicitly out of scope here:
   - Projecting ``step.*`` / ``message.*`` content from trace events.
@@ -143,7 +144,16 @@ class V1EventStreamSink:
         self.principal_key_prefix = principal_key_prefix
         self.dropped_frame_count = 0
         self.completion_hint = asyncio.Event()
-        self._queue: "asyncio.Queue[str]" = asyncio.Queue(
+        # Each element is ``(frame_text, is_close)``. ``is_close`` travels
+        # with the frame itself rather than being inferred from
+        # ``self._closing`` at dequeue time -- the generator can be
+        # suspended at ``yield`` on an *earlier*, non-close frame while a
+        # concurrent ``enqueue_close`` flips ``_closing`` and appends the
+        # close frame behind it; reading ``_closing`` after that yield
+        # would wrongly treat the earlier frame as the close and return
+        # without ever delivering the close frame still sitting in the
+        # queue.
+        self._queue: "asyncio.Queue[tuple[str, bool]]" = asyncio.Queue(
             maxsize=OUTBOUND_QUEUE_MAX_SIZE
         )
         self._closing = False
@@ -158,7 +168,7 @@ class V1EventStreamSink:
         return self._closing
 
     @property
-    def queue(self) -> "asyncio.Queue[str]":
+    def queue(self) -> "asyncio.Queue[tuple[str, bool]]":
         return self._queue
 
     def _assert_owner_loop(self) -> None:
@@ -192,7 +202,7 @@ class V1EventStreamSink:
                 self._queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
-        self._queue.put_nowait(frame_text)
+        self._queue.put_nowait((frame_text, True))
         return True
 
     def _put_or_overflow(self, frame_text: str) -> None:
@@ -202,7 +212,7 @@ class V1EventStreamSink:
         if self._closing:
             return
         try:
-            self._queue.put_nowait(frame_text)
+            self._queue.put_nowait((frame_text, False))
         except asyncio.QueueFull:
             self.enqueue_close(error_frame("resync_required"))
 
@@ -274,6 +284,17 @@ def try_reserve_principal_slot(key_prefix: str) -> bool:
         return False
     _principal_stream_counts[key_prefix] = current + 1
     return True
+
+
+def principal_slot_available(key_prefix: str) -> bool:
+    """Read-only capacity check -- would ``try_reserve_principal_slot``
+    currently succeed for this key. Used at response-construction time
+    (``build_event_stream_response``) so a 429 is raised before any
+    stream opens, without mutating the counter yet: the actual
+    reservation happens once the generator starts running (see
+    ``_generate``), so a response that's constructed but never iterated
+    never touches this counter."""
+    return _principal_stream_counts.get(key_prefix, 0) < PER_PRINCIPAL_STREAM_CAP
 
 
 def release_principal_slot(key_prefix: str) -> None:
@@ -383,7 +404,15 @@ async def _watchdog_loop(
     interval_seconds: float,
 ) -> None:
     """Runs every ``interval_seconds`` and also wakes early on a
-    ``task_completed`` broadcast hint: same check, just run sooner."""
+    ``task_completed`` broadcast hint: same check, just run sooner.
+
+    A single failed check (e.g. a transient DB error) must not end
+    watchdog coverage for the rest of the stream's lifetime -- that
+    would leave an orphaned stream open until the 1-hour absolute cap
+    with nobody watching it. So every per-cycle check is wrapped and
+    logged; only cancellation (this loop's own teardown, not a check
+    failure) ends the loop early.
+    """
     while not sink.closing:
         try:
             await asyncio.wait_for(
@@ -395,10 +424,16 @@ async def _watchdog_loop(
             sink.completion_hint.clear()
         if sink.closing:
             return
-        if await watchdog_check_once(
-            sink, task_id, principal, read_task_snapshot=read_task_snapshot
-        ):
-            return
+        try:
+            if await watchdog_check_once(
+                sink, task_id, principal, read_task_snapshot=read_task_snapshot
+            ):
+                return
+        except Exception:
+            logger.exception(
+                "v1 SSE watchdog check failed for task %s; retrying next cycle",
+                task_id,
+            )
 
 
 # -- Response assembly ----------------------------------------------------
@@ -417,27 +452,54 @@ async def _terminal_snapshot_stream(
 
 
 async def _generate(
-    sink: V1EventStreamSink,
     task_id: int,
     principal: ApiKeyPrincipal,
     *,
+    key_prefix: str,
     initial_status: str,
     read_task_snapshot: TaskSnapshotReader,
     watchdog_interval_seconds: float,
     stream_max_duration_seconds: float,
     heartbeat_interval_seconds: float,
 ) -> AsyncIterator[str]:
+    """Build the sink, register it, run the stream, tear it all down.
+
+    Sink construction, ``manager`` registration, and the per-principal
+    slot reservation all happen *inside* this ``try`` -- deliberately
+    not in ``build_event_stream_response`` -- because an async
+    generator's body doesn't run at all until it's first iterated. If
+    registration/reservation happened at response-construction time
+    instead, a ``StreamingResponse`` that gets built but never iterated
+    (e.g. the caller closes it before Starlette ever pulls a chunk)
+    would leak both: this generator's ``finally`` -- the only code that
+    unregisters and releases -- would simply never execute. Deferring
+    both into here means whatever starts this generator (even just one
+    ``aclose()`` with no frames read) is guaranteed to reach the
+    ``finally`` and clean up exactly what it reserved.
+
+    The 429 capacity *checks* still happen earlier, in
+    ``build_event_stream_response`` (read-only, no mutation) -- so a
+    rejected attach still fails before any stream bytes are sent; only
+    the actual counter mutation and registration move here.
+    """
     deadline = monotonic() + stream_max_duration_seconds
-    watchdog_task = asyncio.create_task(
-        _watchdog_loop(
-            sink,
-            task_id,
-            principal,
-            read_task_snapshot=read_task_snapshot,
-            interval_seconds=watchdog_interval_seconds,
-        )
+    sink = V1EventStreamSink(
+        task_id=task_id, principal_key_prefix=key_prefix, initial_status=initial_status
     )
+    principal_slot_reserved = False
+    watchdog_task: "asyncio.Task[None] | None" = None
     try:
+        principal_slot_reserved = try_reserve_principal_slot(key_prefix)
+        manager.register_connection(cast(WebSocket, sink), task_id)
+        watchdog_task = asyncio.create_task(
+            _watchdog_loop(
+                sink,
+                task_id,
+                principal,
+                read_task_snapshot=read_task_snapshot,
+                interval_seconds=watchdog_interval_seconds,
+            )
+        )
         # The initial yield must be inside this ``try`` too: a generator
         # closed (``aclose()``, e.g. on client disconnect) while suspended
         # here still has to unregister the sink and cancel the watchdog.
@@ -450,23 +512,41 @@ async def _generate(
                 sink.enqueue_close(error_frame("stream_expired"))
             wait_budget = heartbeat_interval_seconds if remaining > 0 else 1.0
             try:
-                frame = await asyncio.wait_for(sink.queue.get(), timeout=wait_budget)
+                frame_text, is_close = await asyncio.wait_for(
+                    sink.queue.get(), timeout=wait_budget
+                )
             except asyncio.TimeoutError:
                 yield ": ping\n\n"
                 continue
-            yield frame
-            if sink.closing:
+            yield frame_text
+            # ``is_close`` is the flag recorded on *this* frame at enqueue
+            # time, not ``sink.closing`` re-read now -- see the queue
+            # element's docstring in ``V1EventStreamSink.__init__`` for why
+            # that distinction is load-bearing under concurrent
+            # ``enqueue_close`` calls.
+            if is_close:
                 return
     finally:
-        watchdog_task.cancel()
-        with contextlib.suppress(BaseException):
-            await watchdog_task
+        if watchdog_task is not None:
+            watchdog_task.cancel()
+            # Narrowed to ``CancelledError`` only (not a blanket
+            # ``BaseException``): the watchdog loop itself now catches
+            # and logs every per-cycle ``Exception`` internally (see
+            # ``_watchdog_loop``) and retries rather than dying, so the
+            # only exception this teardown should ever observe here is
+            # the cancellation just requested above. If the watchdog
+            # task raises anything else, that's a real bug and must
+            # propagate instead of being silently swallowed.
+            with contextlib.suppress(asyncio.CancelledError):
+                await watchdog_task
         # ``manager`` is typed against a real ``WebSocket``; this sink only
         # duck-types its ``send_text`` contract (module docstring) -- the
         # cast documents that intentional narrowing instead of suppressing
-        # the type error blanket-wide.
+        # the type error blanket-wide. A safe no-op if registration above
+        # never ran or never completed.
         manager.disconnect(cast(WebSocket, sink))
-        release_principal_slot(sink.principal_key_prefix)
+        if principal_slot_reserved:
+            release_principal_slot(key_prefix)
 
 
 async def build_event_stream_response(
@@ -484,8 +564,9 @@ async def build_event_stream_response(
     ``initial_snapshot`` must already be authorized (i.e. come from
     ``_resolve_task_or_404`` via ``read_task_snapshot``) -- this
     function does no auth of its own. Concurrency caps (429) are
-    checked here, before any sink is registered, so a rejected attach
-    never touches ``manager`` or the per-principal counter.
+    checked here, before the generator (and therefore the sink and the
+    per-principal reservation) ever exists, so a rejected attach never
+    touches ``manager`` or the per-principal counter.
     """
     if initial_snapshot.status in _TERMINAL_STATUSES:
         return StreamingResponse(
@@ -497,25 +578,14 @@ async def build_event_stream_response(
         raise V1ApiError(V1ErrorCode.RATE_LIMITED, 429)
 
     key_prefix = principal.key.key_prefix
-    if not try_reserve_principal_slot(key_prefix):
+    if not principal_slot_available(key_prefix):
         raise V1ApiError(V1ErrorCode.RATE_LIMITED, 429)
-
-    sink = V1EventStreamSink(
-        task_id=task_id,
-        principal_key_prefix=key_prefix,
-        initial_status=initial_snapshot.status.value,
-    )
-    try:
-        manager.register_connection(cast(WebSocket, sink), task_id)
-    except Exception:
-        release_principal_slot(key_prefix)
-        raise
 
     return StreamingResponse(
         _generate(
-            sink,
             task_id,
             principal,
+            key_prefix=key_prefix,
             initial_status=initial_snapshot.status.value,
             read_task_snapshot=read_task_snapshot,
             watchdog_interval_seconds=watchdog_interval_seconds,

--- a/src/xagent/web/api/v1/deps.py
+++ b/src/xagent/web/api/v1/deps.py
@@ -27,7 +27,7 @@ auth flow) and §10 (security considerations).
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import cast
+from typing import Any, cast
 
 from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -146,6 +146,22 @@ def _enum_value(value: object) -> str:
     return str(getattr(value, "value", value))
 
 
+def active_runtime_key_filters(prefix: str) -> tuple[Any, ...]:
+    """Shared "is this runtime key still usable" predicate.
+
+    A key is usable iff its prefix matches, it hasn't been revoked, and
+    it isn't paused. Used both by request-time authentication (below)
+    and by the v1 SSE watchdog's out-of-band key-validity check
+    (``web/api/v1/_events_stream.py``), so the two paths can't drift on
+    what "usable" means.
+    """
+    return (
+        AgentApiKey.key_prefix == prefix,
+        AgentApiKey.revoked_at.is_(None),
+        AgentApiKey.paused_at.is_(None),
+    )
+
+
 def _load_runtime_key_record(prefix: str) -> _RuntimeKeyRecord | None:
     """Load and detach runtime-key state before bcrypt verification."""
 
@@ -157,11 +173,7 @@ def _load_runtime_key_record(prefix: str) -> _RuntimeKeyRecord | None:
                 joinedload(AgentApiKey.agent),
                 joinedload(AgentApiKey.workforce),
             )
-            .filter(
-                AgentApiKey.key_prefix == prefix,
-                AgentApiKey.revoked_at.is_(None),
-                AgentApiKey.paused_at.is_(None),
-            )
+            .filter(*active_runtime_key_filters(prefix))
             .first()
         )
         if key_row is None:

--- a/src/xagent/web/api/v1/errors.py
+++ b/src/xagent/web/api/v1/errors.py
@@ -94,8 +94,8 @@ class V1ErrorCode(str, Enum):
     # clients always switch on ``body.error.code``.
     INVALID_INPUT = "invalid_input"
 
-    # Reserved for rate limiting. The server does not emit this yet, but
-    # it stays in the enum so SDK clients can encode the mapping now.
+    # Emitted when a caller exceeds the v1 SSE stream concurrency caps
+    # (per-task or per-principal).
     RATE_LIMITED = "rate_limited"
 
     # Monthly execution quota exhausted. 402 Payment Required. Two distinct

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1237,13 +1237,21 @@ async def stream_chat_task_events(
         line is sent whenever 15s pass without any other frame going
         out, to keep the connection alive -- not on a fixed 15s
         cadence regardless of activity.
+      - Frame sequence into ``task.completed``: a task that fails emits
+        ``task.status`` (``"failed"``) from the failure broadcast first,
+        then the watchdog's authoritative ``task.completed`` close
+        frame. A task that succeeds has no such intermediate broadcast,
+        so it goes straight to ``task.completed`` with no preceding
+        ``task.status``. Attaching to a task that's already terminal
+        (the fast path below) always sends both frames regardless.
       - Attaching to an already-finished task is not an error: the
         stream opens, emits ``task.status`` then ``task.completed``,
         and closes immediately.
       - The stream force-closes with ``task.input_required``
         (``prompt`` always ``null`` at this stage) if the task is
         found waiting on user input; with ``stream.error`` if the
-        API key is revoked/paused, the task row disappears, the
+        API key is revoked/paused, the task row disappears (within one
+        watchdog cycle, 30s in production, of the delete), the
         client can't keep up (``resync_required``), or the stream has
         been open for the 1-hour maximum (``stream_expired``, emitted
         before the connection closes so it's distinguishable from a
@@ -1279,7 +1287,13 @@ async def stream_chat_task_events(
             it checks before it increments; it's specifically the
             count of open streams that can run ahead of it. No stream
             is aborted once opened; both counts self-heal as open
-            streams close.
+            streams close. Both caps are per-process: a multi-worker
+            deployment counts independently in each worker process, so
+            the effective cluster-wide limit is the per-process cap
+            times the worker count. An attach that takes the terminal
+            or waiting-for-user fast path (see Behavior above) never
+            registers a sink at all, so it never counts toward either
+            cap.
     """
     snapshot = await run_db_io_cancellation_safe(
         lambda: _load_task_info_snapshot(task_id, principal)

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from typing import Any, NoReturn, Optional, cast
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from fastapi.responses import StreamingResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -89,6 +90,7 @@ from ...services.task_orchestrator import (
     _retire_turn_session_best_effort,
     commit_claimed_turn_or_reconcile,
 )
+from . import _events_stream
 from ._step_mapping import map_trace_events_to_public_steps
 from .deps import ApiKeyPrincipal, get_principal_from_api_key, record_key_usage
 from .errors import V1ApiError, V1ErrorCode, raise_for_turn_rejection
@@ -1196,4 +1198,68 @@ async def get_chat_task_steps(
     """
     return await run_db_io_cancellation_safe(
         lambda: _get_chat_task_steps_sync(task_id, principal)
+    )
+
+
+@router.get("/chat/tasks/{task_id}/events")
+async def stream_chat_task_events(
+    task_id: int,
+    principal: ApiKeyPrincipal = Depends(get_principal_from_api_key),
+) -> StreamingResponse:
+    """Stream a task's lifecycle as Server-Sent Events.
+
+    Transport layer only: emits ``task.status``, ``task.completed``, and
+    ``stream.error``. Step-by-step and token-by-token content
+    (``step.*`` / ``message.*``) is not projected onto this stream yet --
+    poll ``GET /v1/chat/tasks/{task_id}/steps`` for that in the meantime.
+
+    Behavior:
+      - Normal attach: opens the stream, emits ``task.status`` for the
+        task's current state, then a status update each time it
+        changes (consecutive duplicates are suppressed), and
+        ``task.completed`` when the task finishes. A ``: ping`` comment
+        line is sent every 15s to keep the connection alive.
+      - Attaching to an already-finished task is not an error: the
+        stream opens, emits ``task.status`` then ``task.completed``,
+        and closes immediately.
+      - The stream force-closes with ``task.input_required``
+        (``prompt`` always ``null`` at this stage) if the task is
+        found waiting on user input; with ``stream.error`` if the
+        API key is revoked/paused, the task row disappears, the
+        client can't keep up (``resync_required``), or the stream has
+        been open for the 1-hour maximum (``stream_expired``, emitted
+        before the connection closes so it's distinguishable from a
+        clean end). After any ``stream.error``, re-attaching is the
+        supported recovery path (no replay -- reconcile via
+        ``steps()`` first).
+      - A task that's ``paused`` does not close the stream (matching
+        SDK ``wait()`` semantics: another process may resume it); the
+        1-hour cap is what eventually ends an orphaned paused stream.
+      - The moment of attach can emit a stale ``task.status`` out of
+        order relative to a concurrent live update -- accepted for
+        this transport-only layer (no attach buffering yet).
+
+    Args:
+        task_id: Path parameter; the target task's primary key.
+        principal: Resolved by the auth dependency; also used (not as
+            an authorization gate) for the per-key concurrency count
+            and the periodic key-validity check.
+
+    Raises:
+        V1ApiError 401: missing / invalid / revoked key (plain JSON;
+            the stream never opens).
+        V1ApiError 404: task missing or not owned by the calling key
+            (plain JSON; the stream never opens).
+        V1ApiError 429 ``rate_limited``: more than 2 concurrent streams
+            already open on this task, or more than 32 concurrent
+            streams already open for this key across all tasks.
+    """
+    snapshot = await run_db_io_cancellation_safe(
+        lambda: _load_task_info_snapshot(task_id, principal)
+    )
+    return await _events_stream.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=_load_task_info_snapshot,
     )

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1252,8 +1252,14 @@ async def stream_chat_task_events(
         V1ApiError 404: task missing or not owned by the calling key
             (plain JSON; the stream never opens).
         V1ApiError 429 ``rate_limited``: more than 2 concurrent streams
-            already open on this task, or more than 32 concurrent
-            streams already open for this key across all tasks.
+            already open on this task. The per-key cap (32 concurrent
+            streams across all tasks) is enforced the same way for a
+            normal attach, but it is best-effort under a concurrent
+            attach burst: several attaches for the same key can pass
+            the check at the same instant, so the count can be
+            exceeded briefly instead of the extra attaches getting a
+            429. No stream is aborted once opened; the count corrects
+            itself as open streams for that key close.
     """
     snapshot = await run_db_io_cancellation_safe(
         lambda: _load_task_info_snapshot(task_id, principal)

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1214,12 +1214,29 @@ async def stream_chat_task_events(
     (``step.*`` / ``message.*``) is not projected onto this stream yet --
     poll ``GET /v1/chat/tasks/{task_id}/steps`` for that in the meantime.
 
+    This endpoint declares no ``responses=`` schema, so the field lists
+    below are the only OpenAPI-visible contract for its four SSE event
+    types (each a ``event: <name>`` / ``data: <json>`` frame pair):
+      - ``task.status``: ``{status}``.
+      - ``task.completed``: ``{status, output, error}``. A failed task
+        also ends the stream with this event rather than a separate
+        one -- ``status`` is ``"failed"`` and ``error`` is set.
+      - ``task.input_required``: ``{task_id, prompt: null}`` -- ``prompt``
+        is always ``null`` at this transport layer (see module docstring
+        for why).
+      - ``stream.error``: ``{code, message}``, a flat shape distinct
+        from the nested error envelope ``V1ApiError`` HTTP responses use
+        elsewhere in this router; the two error-code vocabularies do
+        not overlap.
+
     Behavior:
       - Normal attach: opens the stream, emits ``task.status`` for the
         task's current state, then a status update each time it
         changes (consecutive duplicates are suppressed), and
         ``task.completed`` when the task finishes. A ``: ping`` comment
-        line is sent every 15s to keep the connection alive.
+        line is sent whenever 15s pass without any other frame going
+        out, to keep the connection alive -- not on a fixed 15s
+        cadence regardless of activity.
       - Attaching to an already-finished task is not an error: the
         stream opens, emits ``task.status`` then ``task.completed``,
         and closes immediately.
@@ -1251,15 +1268,18 @@ async def stream_chat_task_events(
             the stream never opens).
         V1ApiError 404: task missing or not owned by the calling key
             (plain JSON; the stream never opens).
-        V1ApiError 429 ``rate_limited``: more than 2 concurrent streams
-            already open on this task. The per-key cap (32 concurrent
-            streams across all tasks) is enforced the same way for a
-            normal attach, but it is best-effort under a concurrent
-            attach burst: several attaches for the same key can pass
-            the check at the same instant, so the count can be
-            exceeded briefly instead of the extra attaches getting a
-            429. No stream is aborted once opened; the count corrects
-            itself as open streams for that key close.
+        V1ApiError 429 ``rate_limited``: 2 or more concurrent streams
+            already open on this task, or 32 or more already open for
+            this key across all tasks (the per-key cap). Both caps are
+            checked once, before the attach's own stream registers, so
+            both are best-effort under a concurrent attach burst:
+            several attaches can pass the check at the same instant,
+            so the number of streams actually open can briefly exceed
+            the cap -- the per-key cap's own counter never does, since
+            it checks before it increments; it's specifically the
+            count of open streams that can run ahead of it. No stream
+            is aborted once opened; both counts self-heal as open
+            streams close.
     """
     snapshot = await run_db_io_cancellation_safe(
         lambda: _load_task_info_snapshot(task_id, principal)

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1240,10 +1240,16 @@ async def stream_chat_task_events(
       - Frame sequence into ``task.completed``: a task that fails emits
         ``task.status`` (``"failed"``) from the failure broadcast first,
         then the watchdog's authoritative ``task.completed`` close
-        frame. A task that succeeds has no such intermediate broadcast,
-        so it goes straight to ``task.completed`` with no preceding
-        ``task.status``. Attaching to a task that's already terminal
-        (the fast path below) always sends both frames regardless.
+        frame. This is best-effort, not guaranteed: closing a stream
+        drains its queued backlog before inserting the close frame, so
+        an already-queued ``task.status`` (``"failed"``) can be dropped
+        rather than delivered. No failure information is lost when that
+        happens -- ``task.completed`` still carries ``status: "failed"``
+        and a populated ``error``. A task that succeeds has no such
+        intermediate broadcast, so it goes straight to ``task.completed``
+        with no preceding ``task.status``. Attaching to a task that's
+        already terminal (the fast path below) always sends both frames
+        regardless.
       - Attaching to an already-finished task is not an error: the
         stream opens, emits ``task.status`` then ``task.completed``,
         and closes immediately.
@@ -1261,9 +1267,12 @@ async def stream_chat_task_events(
       - A task that's ``paused`` does not close the stream (matching
         SDK ``wait()`` semantics: another process may resume it); the
         1-hour cap is what eventually ends an orphaned paused stream.
-      - The moment of attach can emit a stale ``task.status`` out of
-        order relative to a concurrent live update -- accepted for
-        this transport-only layer (no attach buffering yet).
+      - No ``task.status`` frame is guaranteed to be fresh or in order,
+        at any point in the stream's life, not only at attach -- this
+        transport-only layer never buffers or reconciles frame order.
+        Accepted because only the three close frames above are treated
+        as authoritative; each comes from a direct read of the task
+        row, never from frame ordering.
 
     Args:
         task_id: Path parameter; the target task's primary key.
@@ -1293,7 +1302,15 @@ async def stream_chat_task_events(
             times the worker count. An attach that takes the terminal
             or waiting-for-user fast path (see Behavior above) never
             registers a sink at all, so it never counts toward either
-            cap.
+            cap. Broadcast delivery is per-process too: a sink only
+            receives the broadcasts fanned out by its own worker
+            process's connection manager, so a task transition driven
+            by a different worker reaches this stream only once the
+            watchdog's 30s database poll picks it up, not via broadcast.
+            Some transitions -- lease-expiry recovery among them --
+            never broadcast at all, in any deployment shape, so the
+            watchdog poll is their only delivery path regardless of
+            worker count.
     """
     snapshot = await run_db_io_cancellation_safe(
         lambda: _load_task_info_snapshot(task_id, principal)

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1208,8 +1208,9 @@ async def stream_chat_task_events(
 ) -> StreamingResponse:
     """Stream a task's lifecycle as Server-Sent Events.
 
-    Transport layer only: emits ``task.status``, ``task.completed``, and
-    ``stream.error``. Step-by-step and token-by-token content
+    Transport layer only: emits ``task.status``, ``task.completed``,
+    ``task.input_required``, and ``stream.error``. Step-by-step and
+    token-by-token content
     (``step.*`` / ``message.*``) is not projected onto this stream yet --
     poll ``GET /v1/chat/tasks/{task_id}/steps`` for that in the meantime.
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7842,12 +7842,9 @@ async def _execute_durable_task_command(
     # Broadcast-only subscribers (e.g. the v1 SSE sink) never issued this
     # command and must not be mistaken for the originating socket, so they
     # are skipped when picking the target for a personal reply.
-    websocket: Any = (
-        next(
-            (c for c in connections if not getattr(c, "is_broadcast_only", False)),
-            None,
-        )
-        or _DiscardingCommandWebSocket()
+    websocket: Any = next(
+        (c for c in connections if not getattr(c, "is_broadcast_only", False)),
+        _DiscardingCommandWebSocket(),
     )
     message_data = dict(command.payload)
     message_data.update(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7839,7 +7839,16 @@ async def _execute_durable_task_command(
     """
 
     connections = manager.connections_for_task(command.task_id)
-    websocket: Any = connections[0] if connections else _DiscardingCommandWebSocket()
+    # Broadcast-only subscribers (e.g. the v1 SSE sink) never issued this
+    # command and must not be mistaken for the originating socket, so they
+    # are skipped when picking the target for a personal reply.
+    websocket: Any = (
+        next(
+            (c for c in connections if not getattr(c, "is_broadcast_only", False)),
+            None,
+        )
+        or _DiscardingCommandWebSocket()
+    )
     message_data = dict(command.payload)
     message_data.update(
         {

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -2475,6 +2475,114 @@ async def test_durable_control_converts_handler_stale_run_to_terminal_rejection(
     assert "run rotated" in str(exc_info.value)
 
 
+def _durable_pause_command(task: Task, owner: User) -> ClaimedTaskCommand:
+    return ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=int(owner.id),
+        command_id="pause-personal-reply-routing",
+        kind=TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+        target_run_id="run-a",
+        attempt_count=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_durable_command_skips_broadcast_only_connections(db_session) -> None:
+    """A v1 SSE sink registers into the same shared connection list as
+    real WebSocket connections but only understands versioned status
+    events; it must never be selected as the target for a personal reply
+    to a durable command. With a broadcast-only connection ahead of a
+    real one in the list, the real one is still picked."""
+    owner = _user(db_session, "broadcast-skip-owner")
+    task = _task(db_session, owner.id)
+    task.runner_id = None
+    task.run_id = "run-a"
+    db_session.commit()
+    command = _durable_pause_command(task, owner)
+
+    broadcast_only = SimpleNamespace(is_broadcast_only=True)
+    real_connection = SimpleNamespace()  # no `is_broadcast_only` attribute at all
+
+    with (
+        patch.object(
+            websocket_api.manager,
+            "connections_for_task",
+            return_value=[broadcast_only, real_connection],
+        ),
+        patch(
+            "xagent.web.api.websocket._handle_pause_task_unserialized",
+            new=AsyncMock(return_value=None),
+        ) as handler,
+    ):
+        await _execute_durable_task_command(command)
+
+    assert handler.await_args.args[0] is real_connection
+
+
+@pytest.mark.asyncio
+async def test_durable_command_falls_back_to_discarding_websocket_when_all_connections_are_broadcast_only(
+    db_session,
+) -> None:
+    """When every registered connection for the task is broadcast-only
+    (e.g. only v1 SSE streams are attached, no real WebSocket), there is
+    no valid personal-reply target, so the handler gets the discarding
+    sink -- same as when the list is empty."""
+    owner = _user(db_session, "broadcast-only-fallback-owner")
+    task = _task(db_session, owner.id)
+    task.runner_id = None
+    task.run_id = "run-a"
+    db_session.commit()
+    command = _durable_pause_command(task, owner)
+
+    broadcast_only = SimpleNamespace(is_broadcast_only=True)
+
+    with (
+        patch.object(
+            websocket_api.manager,
+            "connections_for_task",
+            return_value=[broadcast_only],
+        ),
+        patch(
+            "xagent.web.api.websocket._handle_pause_task_unserialized",
+            new=AsyncMock(return_value=None),
+        ) as handler,
+    ):
+        await _execute_durable_task_command(command)
+
+    assert isinstance(
+        handler.await_args.args[0], websocket_api._DiscardingCommandWebSocket
+    )
+
+
+@pytest.mark.asyncio
+async def test_durable_command_falls_back_to_discarding_websocket_when_no_connections(
+    db_session,
+) -> None:
+    """An empty connection list still routes to the discarding sink,
+    unchanged by the broadcast-only filter."""
+    owner = _user(db_session, "no-connections-fallback-owner")
+    task = _task(db_session, owner.id)
+    task.runner_id = None
+    task.run_id = "run-a"
+    db_session.commit()
+    command = _durable_pause_command(task, owner)
+
+    with (
+        patch.object(websocket_api.manager, "connections_for_task", return_value=[]),
+        patch(
+            "xagent.web.api.websocket._handle_pause_task_unserialized",
+            new=AsyncMock(return_value=None),
+        ) as handler,
+    ):
+        await _execute_durable_task_command(command)
+
+    assert isinstance(
+        handler.await_args.args[0], websocket_api._DiscardingCommandWebSocket
+    )
+
+
 @pytest.mark.asyncio
 async def test_pause_non_owner_non_admin_is_refused(db_session) -> None:
     owner = _user(db_session, "owner")

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -731,6 +731,37 @@ async def test_absolute_deadline_emits_expired_then_closes():
     assert es.count_task_sinks(task_id) == 0
 
 
+async def test_deadline_wait_budget_shrinks_below_the_heartbeat():
+    """Heartbeat (5s) is deliberately much larger than the deadline
+    (0.05s), so only a ``wait_budget`` that's capped at what's left
+    before the deadline -- not the full heartbeat interval -- closes
+    this stream quickly. The old formula (heartbeat whenever any time
+    remains) would instead wait out the full 5s heartbeat before ever
+    rechecking the deadline; ``wait_for(timeout=1)`` turns that into a
+    hard failure instead of a slow pass."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=0.05,
+        heartbeat_interval_seconds=5.0,
+    )
+
+    async def _drain() -> list[str]:
+        return [frame async for frame in resp.body_iterator]
+
+    frames = await asyncio.wait_for(_drain(), timeout=1)
+    assert "event: stream.error" in frames[-1]
+    assert "stream_expired" in frames[-1]
+
+
 # ===== watchdog vs. deadline race closes exactly once =====
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -1037,6 +1037,25 @@ async def test_task_completed_broadcast_never_enqueues_a_status_frame():
     assert sink.queue.empty()
 
 
+# ===== a terminal-failure broadcast also sets the completion_hint =====
+
+
+async def test_terminal_failure_broadcast_also_sets_completion_hint():
+    """A failed task's broadcast (``task_error``) reaches the sink through
+    the generic versioned-event branch below, not the ``task_completed``
+    short-circuit above -- unlike that short-circuit, it must still do
+    both things: enqueue the ``task.status`` frame *and* set
+    ``completion_hint``, so the watchdog wakes early instead of waiting
+    out its normal cadence to emit the authoritative ``task.completed``
+    close frame."""
+    sink = _make_sink(task_id=1, status="running")
+    await sink.send_text(
+        json.dumps({"type": "task_error", "task_id": 1, "status": "failed"})
+    )
+    assert sink.completion_hint.is_set()
+    assert sink.queue.get_nowait() == (es.status_frame("failed"), False)
+
+
 # ===== the completion_hint wakes the watchdog early, not on its next
 # periodic tick =====
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -389,11 +389,11 @@ async def test_watchdog_missing_task_row_closes_with_task_deleted():
 async def test_watchdog_survives_transient_check_failure_and_still_closes():
     """A single failed watchdog cycle (e.g. a transient DB error reading
     the task row) must not silence the watchdog for the rest of the
-    stream's life. Before this fix, an uncaught exception inside the
-    watchdog loop killed the loop's background task permanently and
-    silently -- the generator's teardown swallowed it via a blanket
-    ``except BaseException``, so nothing was left watching the stream
-    until the 1-hour absolute cap. This injects a ``read_task_snapshot``
+    stream's life: an exception escaping the loop would kill its
+    background task permanently, leaving nothing to close the stream
+    until the 1-hour absolute cap. Each cycle therefore catches and
+    logs its own failures and retries on the next tick. This injects a
+    ``read_task_snapshot``
     that raises on its first call and returns a real, terminal
     snapshot on its second, and asserts the stream still reaches
     ``task.completed`` -- i.e. the watchdog retried instead of dying."""

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -290,6 +290,100 @@ async def test_watchdog_paused_does_not_close():
     assert sink.queue.get_nowait() == es.status_frame("paused")
 
 
+async def test_watchdog_waiting_for_user_closes_with_null_prompt_input_required():
+    """The watchdog is the only trigger this transport layer implements
+    for input_required, and it always sends a null prompt -- populating
+    it from the agent's question text belongs to the content-projection
+    layer."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    _set_task_status(task_id, TaskStatus.WAITING_FOR_USER, control_state="idle")
+
+    sink = es.V1EventStreamSink(
+        task_id=task_id, principal_key_prefix=key_prefix, initial_status="running"
+    )
+    closed = await es.watchdog_check_once(
+        sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
+    )
+    assert closed is True
+    assert sink.closing is True
+    assert sink.queue.get_nowait() == es.input_required_frame(task_id)
+    assert (
+        json.loads(es.input_required_frame(task_id).split("data: ", 1)[1])["prompt"]
+        is None
+    )
+
+
+async def test_watchdog_waiting_for_user_with_resume_requested_does_not_close():
+    """The ``resume_requested`` carve-out: a task about to resume isn't
+    "stuck waiting" even though its status hasn't flipped yet."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    _set_task_status(
+        task_id, TaskStatus.WAITING_FOR_USER, control_state="resume_requested"
+    )
+
+    sink = es.V1EventStreamSink(
+        task_id=task_id, principal_key_prefix=key_prefix, initial_status="running"
+    )
+    closed = await es.watchdog_check_once(
+        sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
+    )
+    assert closed is False
+    assert sink.closing is False
+
+
+async def test_watchdog_terminal_task_row_closes_with_completed():
+    """The watchdog itself is the authoritative source for task.completed,
+    independent of the attach-time fast path for an already-terminal
+    task or the broadcast acceleration hint."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    _set_task_status(task_id, TaskStatus.FAILED, error_message="boom")
+
+    sink = es.V1EventStreamSink(
+        task_id=task_id, principal_key_prefix=key_prefix, initial_status="running"
+    )
+    closed = await es.watchdog_check_once(
+        sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
+    )
+    assert closed is True
+    assert sink.queue.get_nowait() == es.completed_frame(
+        status="failed", output=None, error="boom"
+    )
+
+
+async def test_watchdog_missing_task_row_closes_with_task_deleted():
+    """A task row that vanishes out from under an open stream
+    (hard-deleted) surfaces as task_deleted, not a hang or a 500."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+
+    db = _direct_db_session()
+    try:
+        db.query(Task).filter(Task.id == task_id).delete()
+        db.commit()
+    finally:
+        db.close()
+
+    sink = es.V1EventStreamSink(
+        task_id=task_id, principal_key_prefix=key_prefix, initial_status="running"
+    )
+    closed = await es.watchdog_check_once(
+        sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
+    )
+    assert closed is True
+    assert sink.queue.get_nowait() == es.error_frame("task_deleted")
+
+
 # ===== endpoint signature carries no request-scoped DB dependency =====
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -1,0 +1,508 @@
+"""Tests for the v1 SSE transport layer (``GET /v1/chat/tasks/{id}/events``).
+
+Covers the transport layer only: registration, the sink's frame filter
+and exception discipline, the watchdog, the 1-hour cap, and concurrency
+caps. Step/message content projection isn't part of this layer, so it
+isn't tested here. Tests either drive ``_events_stream`` directly (fast,
+deterministic -- used whenever a test needs injected short intervals or
+precise control over the race between the watchdog and the deadline) or
+go through the real HTTP endpoint (used for the 401/404/429/terminal-
+attach shapes, where the JSON-vs-event-stream distinction actually
+matters).
+"""
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+
+from xagent.web.api.v1 import _events_stream as es
+from xagent.web.api.v1 import tasks as v1_tasks
+from xagent.web.api.v1.deps import ApiKeyPrincipal, _resolve_principal_from_credentials
+from xagent.web.api.v1.errors import V1ApiError, V1ErrorCode
+from xagent.web.models.agent_api_key import AgentApiKey
+from xagent.web.models.task import Task, TaskStatus
+
+from ..conftest import _admin_headers, _direct_db_session, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+# ===== local helpers (mirrors test_tasks.py's pattern) =====
+
+
+@pytest.fixture(autouse=True)
+def mock_start_task():
+    """Every test here creates tasks through the real POST endpoint (so
+    ownership/source="sdk" scoping is authentic) but never wants an
+    actual agent execution to run."""
+    with patch(
+        "xagent.web.services.task_orchestrator._schedule_bg",
+        new=MagicMock(),
+    ) as mocked:
+        yield mocked
+
+
+@pytest.fixture(autouse=True)
+def reset_principal_stream_counts():
+    es.reset_principal_stream_counts_for_testing()
+    yield
+    es.reset_principal_stream_counts_for_testing()
+
+
+def _create_agent_with_key() -> tuple[int, str]:
+    headers = _admin_headers()
+    agent_resp = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "v1 events test agent",
+            "description": "test",
+            "instructions": "you are a test agent",
+            "execution_mode": "balanced",
+        },
+    )
+    assert agent_resp.status_code == 200, agent_resp.text
+    agent_id = agent_resp.json()["id"]
+    key_resp = client.post(f"/api/agents/{agent_id}/api-key", headers=headers)
+    assert key_resp.status_code == 200, key_resp.text
+    return agent_id, key_resp.json()["full_key"]
+
+
+def _bearer(full_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {full_key}"}
+
+
+def _create_task(full_key: str, agent_id: int, content: str = "hello") -> int:
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={"agent_id": agent_id, "message": {"role": "user", "content": content}},
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()["task_id"]
+
+
+def _principal_for(full_key: str) -> ApiKeyPrincipal:
+    """Resolve a real principal through the production auth path (bcrypt
+    included) rather than hand-rolling a snapshot -- keeps tests honest
+    about what ``get_principal_from_api_key`` actually returns."""
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=full_key)
+    return _resolve_principal_from_credentials(creds)
+
+
+def _set_task_status(
+    task_id: int,
+    status: TaskStatus,
+    *,
+    output: str | None = None,
+    error_message: str | None = None,
+    control_state: str | None = None,
+) -> None:
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        task.status = status
+        if output is not None:
+            task.output = output
+        if error_message is not None:
+            task.error_message = error_message
+        if control_state is not None:
+            task.control_state = control_state
+        db.commit()
+    finally:
+        db.close()
+
+
+def _key_prefix_for_agent(agent_id: int) -> str:
+    db = _direct_db_session()
+    try:
+        return str(
+            db.query(AgentApiKey)
+            .filter(AgentApiKey.agent_id == agent_id)
+            .one()
+            .key_prefix
+        )
+    finally:
+        db.close()
+
+
+def _make_sink(task_id: int = 1, status: str = "running") -> es.V1EventStreamSink:
+    return es.V1EventStreamSink(
+        task_id=task_id, principal_key_prefix="pfx-test", initial_status=status
+    )
+
+
+# ===== sink.send_text never raises =====
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not json at all",
+        "42",
+        "null",
+        "[]",
+        json.dumps({"type": "task_completed", "task": "not-a-dict"}),
+        json.dumps(
+            {"type": "task_started", "task_id": "not-an-int", "status": "running"}
+        ),
+    ],
+)
+async def test_sink_send_text_never_raises_on_malformed_input(raw):
+    sink = _make_sink()
+    await sink.send_text(raw)  # must not raise
+
+
+async def test_sink_send_text_never_raises_when_classification_throws(monkeypatch):
+    sink = _make_sink()
+
+    def _boom(message):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(es, "_is_versioned_task_event", _boom)
+    before = sink.dropped_frame_count
+    await sink.send_text(
+        json.dumps(
+            {"type": "task_started", "task_id": sink.task_id, "status": "running"}
+        )
+    )  # must not raise
+    assert sink.dropped_frame_count == before + 1
+
+
+async def test_sink_send_text_never_raises_from_foreign_loop():
+    sink = _make_sink()
+    sink._owner_loop = object()  # simulate a foreign event loop
+    await sink.send_text(
+        json.dumps(
+            {"type": "task_started", "task_id": sink.task_id, "status": "running"}
+        )
+    )  # must not raise
+    assert sink.dropped_frame_count == 1
+    assert sink.queue.empty()
+
+
+# ===== unauthorized / not-owned get plain JSON, no stream bytes =====
+
+
+def test_events_unauthorized_401():
+    resp = client.get("/v1/chat/tasks/1/events")
+    assert resp.status_code == 401
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+def test_events_not_owned_404():
+    _, full_key = _create_agent_with_key()
+    resp = client.get("/v1/chat/tasks/999999/events", headers=_bearer(full_key))
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.json()["error"]["code"] == "task_not_found"
+
+
+# ===== attach on an already-terminal task =====
+
+
+def test_events_terminal_task_immediate_close():
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _set_task_status(task_id, TaskStatus.COMPLETED, output="the answer")
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    body = resp.text
+    assert body.count("event: task.status") == 1
+    assert body.count("event: task.completed") == 1
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    status_data = json.loads(blocks[0].split("data: ", 1)[1])
+    completed_data = json.loads(blocks[1].split("data: ", 1)[1])
+    assert status_data == {"status": "completed"}
+    assert completed_data == {
+        "status": "completed",
+        "output": "the answer",
+        "error": None,
+    }
+    # No sink is registered for the terminal fast path -- nothing to close.
+    assert es.count_task_sinks(task_id) == 0
+
+
+# ===== bounded outbound queue, overflow closes with resync_required =====
+
+
+async def test_slow_consumer_queue_overflow_closes_with_resync_required():
+    sink = _make_sink()
+    for i in range(es.OUTBOUND_QUEUE_MAX_SIZE + 5):
+        sink._put_or_overflow(f"frame-{i}")
+    assert sink.closing is True
+    # Memory doesn't grow past the cap even under sustained overflow --
+    # exactly one frame (the close frame) survives.
+    assert sink.queue.qsize() == 1
+    assert sink.queue.get_nowait() == es.error_frame("resync_required")
+
+
+# ===== key revoked/paused closes within one watchdog cycle =====
+
+
+@pytest.mark.parametrize("field", ["revoked_at", "paused_at"])
+async def test_watchdog_closes_within_one_cycle_on_key_invalidation(field):
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+
+    db = _direct_db_session()
+    try:
+        key_row = db.query(AgentApiKey).filter(AgentApiKey.agent_id == agent_id).one()
+        setattr(key_row, field, datetime.now(UTC))
+        db.commit()
+    finally:
+        db.close()
+
+    sink = es.V1EventStreamSink(
+        task_id=task_id, principal_key_prefix=key_prefix, initial_status="running"
+    )
+    closed = await es.watchdog_check_once(
+        sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
+    )
+    assert closed is True
+    assert sink.closing is True
+    assert sink.queue.get_nowait() == es.error_frame("unauthorized")
+
+
+async def test_watchdog_paused_does_not_close():
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    _set_task_status(task_id, TaskStatus.PAUSED)
+
+    sink = es.V1EventStreamSink(
+        task_id=task_id, principal_key_prefix=key_prefix, initial_status="running"
+    )
+    closed = await es.watchdog_check_once(
+        sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
+    )
+    assert closed is False
+    assert sink.closing is False
+    assert sink.queue.get_nowait() == es.status_frame("paused")
+
+
+# ===== endpoint signature carries no request-scoped DB dependency =====
+
+
+def test_events_endpoint_signature_has_no_db_dependency():
+    import inspect
+
+    sig = inspect.signature(v1_tasks.stream_chat_task_events)
+    assert set(sig.parameters) == {"task_id", "principal"}
+
+
+# ===== generator teardown unregisters the sink =====
+
+
+async def test_sink_unregistered_after_generator_teardown():
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=1000,
+        heartbeat_interval_seconds=1000,
+    )
+    first = await resp.body_iterator.__anext__()
+    assert "event: task.status" in first
+    assert es.count_task_sinks(task_id) == 1
+
+    # Simulate what Starlette does on client disconnect / response teardown.
+    await resp.body_iterator.aclose()
+    assert es.count_task_sinks(task_id) == 0
+
+
+# ===== per-principal stream cap =====
+
+
+async def test_try_reserve_principal_slot_caps_at_limit():
+    key_prefix = "pfx-cap-unit-test"
+    for _ in range(es.PER_PRINCIPAL_STREAM_CAP):
+        assert es.try_reserve_principal_slot(key_prefix) is True
+    assert es.try_reserve_principal_slot(key_prefix) is False
+    for _ in range(es.PER_PRINCIPAL_STREAM_CAP):
+        es.release_principal_slot(key_prefix)
+    assert es.try_reserve_principal_slot(key_prefix) is True
+    es.release_principal_slot(key_prefix)
+
+
+def test_events_principal_cap_returns_429_json():
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    for _ in range(es.PER_PRINCIPAL_STREAM_CAP):
+        assert es.try_reserve_principal_slot(key_prefix)
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
+    assert resp.status_code == 429
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.json()["error"]["code"] == "rate_limited"
+    assert es.count_task_sinks(task_id) == 0  # rejected before registration
+
+
+# ===== absolute deadline emits stream_expired before closing =====
+
+
+async def test_absolute_deadline_emits_expired_then_closes():
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=0.05,
+        heartbeat_interval_seconds=0.01,
+    )
+    frames = [frame async for frame in resp.body_iterator]
+    # Zero or more heartbeats may land before the deadline trips, but the
+    # close frame must be exactly one, and it must be last (nothing is
+    # yielded after it).
+    assert "event: task.status" in frames[0]
+    assert frames.count(": ping\n\n") == len(frames) - 2  # everything but status+close
+    assert "event: stream.error" in frames[-1]
+    assert "stream_expired" in frames[-1]
+    assert es.count_task_sinks(task_id) == 0
+
+
+# ===== watchdog vs. deadline race closes exactly once =====
+
+
+async def test_enqueue_close_is_idempotent_first_writer_wins():
+    sink = _make_sink()
+    first = sink.enqueue_close(es.error_frame("stream_expired"))
+    second = sink.enqueue_close(es.error_frame("task_deleted"))
+    assert first is True
+    assert second is False
+    assert sink.queue.qsize() == 1
+    assert sink.queue.get_nowait() == es.error_frame("stream_expired")
+
+
+async def test_close_exactly_once_under_watchdog_deadline_race():
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)  # non-terminal at attach
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=0.001,
+        stream_max_duration_seconds=0.001,
+        heartbeat_interval_seconds=0.001,
+    )
+    # Flip terminal *after* attach so the watchdog's next tick and the
+    # already-short deadline both want to close the stream.
+    _set_task_status(task_id, TaskStatus.COMPLETED, output="done")
+
+    closing_events = ("event: task.completed", "event: stream.error")
+    frames = []
+    async for frame in resp.body_iterator:
+        frames.append(frame)
+        if len(frames) > 10:
+            break
+    close_frames = [f for f in frames if any(name in f for name in closing_events)]
+    assert len(close_frames) == 1
+    assert close_frames[0] == frames[-1]
+    assert es.count_task_sinks(task_id) == 0
+
+
+# ===== frames bound to a different task_id are discarded =====
+
+
+async def test_sink_discards_foreign_task_frames():
+    sink = _make_sink(task_id=1)
+    await sink.send_text(
+        json.dumps({"type": "task_started", "task_id": 2, "status": "running"})
+    )
+    assert sink.queue.empty()
+    assert sink.dropped_frame_count == 0  # a graceful discard, not an error
+
+
+# ===== per-task concurrency cap =====
+
+
+async def test_events_per_task_cap_third_stream_429():
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    responses = []
+    for _ in range(es.PER_TASK_STREAM_CAP):
+        resp = await es.build_event_stream_response(
+            task_id=task_id,
+            principal=principal,
+            initial_snapshot=snapshot,
+            read_task_snapshot=v1_tasks._load_task_info_snapshot,
+            watchdog_interval_seconds=1000,
+            stream_max_duration_seconds=1000,
+            heartbeat_interval_seconds=1000,
+        )
+        # Real delivery (Starlette) always pulls the first chunk before a
+        # response can close; advance each generator once so its ``finally``
+        # cleanup is reachable, same as it would be in production.
+        await resp.body_iterator.__anext__()
+        responses.append(resp)
+
+    assert es.count_task_sinks(task_id) == es.PER_TASK_STREAM_CAP
+    with pytest.raises(V1ApiError) as exc_info:
+        await es.build_event_stream_response(
+            task_id=task_id,
+            principal=principal,
+            initial_snapshot=snapshot,
+            read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        )
+    assert exc_info.value.code is V1ErrorCode.RATE_LIMITED
+    assert exc_info.value.http_status == 429
+
+    for resp in responses:
+        await resp.body_iterator.aclose()
+    assert es.count_task_sinks(task_id) == 0
+
+
+# ===== the sink never touches the database on its per-frame path =====
+
+
+async def test_sink_send_text_never_queries_db(monkeypatch):
+    sink = _make_sink()
+    calls: list[int] = []
+    original_get_session_local = es.get_session_local
+
+    def _tracking_get_session_local():
+        calls.append(1)
+        return original_get_session_local()
+
+    monkeypatch.setattr(es, "get_session_local", _tracking_get_session_local)
+
+    for i in range(20):
+        await sink.send_text(
+            json.dumps(
+                {"type": "task_started", "task_id": sink.task_id, "status": f"s{i}"}
+            )
+        )
+    await sink.send_text(
+        json.dumps({"type": "task_completed", "task": {"id": sink.task_id}})
+    )
+    assert calls == []

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -230,6 +230,62 @@ def test_events_terminal_task_immediate_close():
     assert es.count_task_sinks(task_id) == 0
 
 
+# ===== attach on a task already waiting for user input =====
+
+
+def test_events_waiting_for_user_attach_takes_the_fast_path():
+    """The attach-time fast path for a task that's already
+    ``waiting_for_user`` (and not mid-resume): emits ``task.status`` +
+    ``task.input_required`` and closes immediately, instead of waiting
+    out the watchdog's first cycle (up to 30s in production) to reach
+    the same conclusion."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _set_task_status(task_id, TaskStatus.WAITING_FOR_USER, control_state="idle")
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
+    assert resp.status_code == 200
+    body = resp.text
+    assert body.count("event: task.status") == 1
+    assert body.count("event: task.input_required") == 1
+    assert body.count("event: task.completed") == 0
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    status_data = json.loads(blocks[0].split("data: ", 1)[1])
+    input_required_data = json.loads(blocks[1].split("data: ", 1)[1])
+    assert status_data == {"status": "waiting_for_user"}
+    assert input_required_data == {"task_id": task_id, "prompt": None}
+    # No sink is registered for this fast path either -- nothing to close.
+    assert es.count_task_sinks(task_id) == 0
+
+
+async def test_events_paused_attach_does_not_take_a_fast_path():
+    """A ``paused`` task is not ``waiting_for_user``, so attach must fall
+    through to the normal streaming path (sink registered, watchdog
+    running) instead of the fast path above -- the two tests pin the
+    fast path's condition from both sides."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    _set_task_status(task_id, TaskStatus.PAUSED)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=1000,
+        heartbeat_interval_seconds=1000,
+    )
+    first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert json.loads(first.split("data: ", 1)[1]) == {"status": "paused"}
+    assert es.count_task_sinks(task_id) == 1
+
+    await resp.body_iterator.aclose()
+    assert es.count_task_sinks(task_id) == 0
+
+
 # ===== bounded outbound queue, overflow closes with resync_required =====
 
 
@@ -441,10 +497,23 @@ async def test_watchdog_survives_transient_check_failure_and_still_closes():
 
 
 def test_events_endpoint_signature_has_no_db_dependency():
+    """No parameter is typed as a SQLAlchemy ``Session``.
+
+    A ``Session``-typed FastAPI dependency is request-scoped: it would be
+    checked out for the entire life of the stream (up to the 1-hour cap)
+    instead of only for the brief, per-check reads that
+    ``_events_stream`` already routes through
+    ``run_db_io_cancellation_safe``. Asserting on the exact parameter
+    *name* set is what used to live here; it broke on any unrelated
+    rename and never actually verified the no-request-scoped-session
+    property it claimed to.
+    """
     import inspect
 
+    from sqlalchemy.orm import Session
+
     sig = inspect.signature(v1_tasks.stream_chat_task_events)
-    assert set(sig.parameters) == {"task_id", "principal"}
+    assert not any(param.annotation is Session for param in sig.parameters.values())
 
 
 # ===== generator teardown unregisters the sink =====
@@ -950,6 +1019,22 @@ async def test_consecutive_same_status_broadcasts_are_deduped_to_one_frame():
         )
     assert sink.queue.qsize() == 1
     assert sink.queue.get_nowait() == (es.status_frame("paused"), False)
+
+
+# ===== a `task_completed` broadcast is acceleration-only, never a status
+# frame =====
+
+
+async def test_task_completed_broadcast_never_enqueues_a_status_frame():
+    """``task_completed`` only sets ``completion_hint`` and returns early
+    -- it must never also reach ``enqueue_status``, or a ``task_completed``
+    broadcast racing the watchdog's own authoritative ``task.completed``
+    frame could emit a spurious extra ``task.status`` right as the stream
+    is closing."""
+    sink = _make_sink(task_id=1, status="running")
+    await sink.send_text(json.dumps({"type": "task_completed", "task": {"id": 1}}))
+    assert sink.completion_hint.is_set()
+    assert sink.queue.empty()
 
 
 # ===== the completion_hint wakes the watchdog early, not on its next

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -17,8 +17,11 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import FastAPI
 from fastapi.security import HTTPAuthorizationCredentials
+from fastapi.testclient import TestClient
 
+from xagent.web.api.chat import chat_router
 from xagent.web.api.v1 import _events_stream as es
 from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.api.v1.deps import ApiKeyPrincipal, _resolve_principal_from_credentials
@@ -29,6 +32,19 @@ from xagent.web.models.task import Task, TaskStatus
 from ..conftest import _admin_headers, _direct_db_session, client
 
 pytestmark = pytest.mark.usefixtures("_test_db")
+
+# ``app_for_tests`` (the shared v1 suite app in ``..conftest``) deliberately
+# doesn't mount ``chat_router`` -- it's scoped to the v1 routers this suite
+# actually tests. The one test here that needs the real production task-
+# delete route (``DELETE /api/chat/task/{task_id}``) gets its own minimal
+# app for just that router instead, mirroring the same narrow-app pattern
+# ``test_chat_task_model_ids.py`` already uses. ``get_db`` needs no override
+# here: the real dependency reads from the same process-global session
+# factory ``_test_db`` initializes, so this app shares the exact DB rows
+# the v1 SSE tests create through ``app_for_tests``.
+_chat_delete_app = FastAPI()
+_chat_delete_app.include_router(chat_router)
+_chat_delete_client = TestClient(_chat_delete_app, raise_server_exceptions=False)
 
 
 # ===== local helpers (mirrors test_tasks.py's pattern) =====
@@ -134,6 +150,19 @@ def _make_sink(task_id: int = 1, status: str = "running") -> es.V1EventStreamSin
     return es.V1EventStreamSink(
         task_id=task_id, principal_key_prefix="pfx-test", initial_status=status
     )
+
+
+def _long_intervals(**overrides: float) -> dict[str, float]:
+    """Defaults for ``build_event_stream_response``/``_generate``'s three
+    tunable intervals (watchdog / absolute deadline / heartbeat): 1000s
+    is long enough that none of them fire within a test's timeout unless
+    a test overrides one explicitly to trigger specific timing behavior."""
+    return {
+        "watchdog_interval_seconds": 1000,
+        "stream_max_duration_seconds": 1000,
+        "heartbeat_interval_seconds": 1000,
+        **overrides,
+    }
 
 
 # ===== sink.send_text never raises =====
@@ -274,9 +303,7 @@ async def test_events_paused_attach_does_not_take_a_fast_path():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=1000,
-        heartbeat_interval_seconds=1000,
+        **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
     assert json.loads(first.split("data: ", 1)[1]) == {"status": "paused"}
@@ -284,6 +311,45 @@ async def test_events_paused_attach_does_not_take_a_fast_path():
 
     await resp.body_iterator.aclose()
     assert es.count_task_sinks(task_id) == 0
+
+
+# ===== all three response-construction sites disable proxy buffering =====
+
+
+@pytest.mark.parametrize(
+    "task_state",
+    ["running_attach", "terminal_fast_path", "waiting_for_user_fast_path"],
+)
+async def test_sse_responses_disable_proxy_buffering(task_state):
+    """``build_event_stream_response`` constructs a ``StreamingResponse``
+    from three different call sites -- the running-attach path (normal
+    streaming, sink + watchdog), the terminal fast path, and the
+    waiting-for-user fast path -- and all three must carry the same
+    anti-buffering headers. nginx buffers proxied responses by default;
+    without ``X-Accel-Buffering: no`` it would hold SSE frames back
+    instead of forwarding them to the client immediately."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+
+    if task_state == "terminal_fast_path":
+        _set_task_status(task_id, TaskStatus.COMPLETED, output="done")
+    elif task_state == "waiting_for_user_fast_path":
+        _set_task_status(task_id, TaskStatus.WAITING_FOR_USER, control_state="idle")
+
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        **_long_intervals(),
+    )
+    try:
+        assert resp.headers["x-accel-buffering"] == "no"
+        assert resp.headers["cache-control"] == "no-cache"
+    finally:
+        await resp.body_iterator.aclose()
 
 
 # ===== bounded outbound queue, overflow closes with resync_required =====
@@ -442,6 +508,44 @@ async def test_watchdog_missing_task_row_closes_with_task_deleted():
     assert sink.queue.get_nowait() == (es.error_frame("task_deleted"), True)
 
 
+async def test_real_delete_route_closes_stream_with_task_deleted():
+    """Same ``task_deleted`` close path as the test above, but the row
+    disappears through the real production delete route
+    (``DELETE /api/chat/task/{task_id}``) instead of a raw DB delete --
+    exercising the actual code path an operator or the SDK would trigger,
+    not just the watchdog's read side of a row that's already gone."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        **_long_intervals(watchdog_interval_seconds=0.01),
+    )
+    first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert "event: task.status" in first
+
+    delete_resp = _chat_delete_client.delete(
+        f"/api/chat/task/{task_id}", headers=_admin_headers()
+    )
+    assert delete_resp.status_code == 200, delete_resp.text
+
+    frames = []
+
+    async def _drain() -> None:
+        async for frame in resp.body_iterator:
+            frames.append(frame)
+
+    await asyncio.wait_for(_drain(), timeout=2)
+    assert "event: stream.error" in frames[-1]
+    assert "task_deleted" in frames[-1]
+    assert es.count_task_sinks(task_id) == 0
+
+
 async def test_watchdog_survives_transient_check_failure_and_still_closes():
     """A single failed watchdog cycle (e.g. a transient DB error reading
     the task row) must not silence the watchdog for the rest of the
@@ -472,9 +576,7 @@ async def test_watchdog_survives_transient_check_failure_and_still_closes():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=flaky_reader,
-        watchdog_interval_seconds=0.01,
-        stream_max_duration_seconds=1000,
-        heartbeat_interval_seconds=1000,
+        **_long_intervals(watchdog_interval_seconds=0.01),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
     assert "event: task.status" in first
@@ -507,6 +609,11 @@ def test_events_endpoint_signature_has_no_db_dependency():
     *name* set is what used to live here; it broke on any unrelated
     rename and never actually verified the no-request-scoped-session
     property it claimed to.
+
+    Signature-only: this can't see whether the function body opens its
+    own ad hoc DB session internally (rather than through
+    ``run_db_io_cancellation_safe``) -- it only rules out a request-scoped
+    ``Session`` dependency injected by FastAPI.
     """
     import inspect
 
@@ -530,9 +637,7 @@ async def test_sink_unregistered_after_generator_teardown():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=1000,
-        heartbeat_interval_seconds=1000,
+        **_long_intervals(),
     )
     first = await resp.body_iterator.__anext__()
     assert "event: task.status" in first
@@ -569,9 +674,7 @@ async def test_unstarted_generator_leaves_no_registration_or_reservation():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=1000,
-        heartbeat_interval_seconds=1000,
+        **_long_intervals(),
     )
     # No __anext__() call at all -- the generator body has never run.
     assert es.count_task_sinks(task_id) == 0
@@ -626,9 +729,7 @@ async def test_principal_slot_released_after_real_stream_teardown():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=1000,
-        heartbeat_interval_seconds=1000,
+        **_long_intervals(),
     )
     await resp.body_iterator.__anext__()
     assert es._principal_stream_counts.get(key_prefix, 0) == 1
@@ -673,9 +774,7 @@ async def test_generate_serves_stream_when_reservation_race_lost(caplog):
             key_prefix=key_prefix,
             initial_status=snapshot.status.value,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
-            watchdog_interval_seconds=1000,
-            stream_max_duration_seconds=1000,
-            heartbeat_interval_seconds=1000,
+            **_long_intervals(),
         )
         first = await agen.__anext__()
 
@@ -716,9 +815,9 @@ async def test_absolute_deadline_emits_expired_then_closes():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=0.05,
-        heartbeat_interval_seconds=0.01,
+        **_long_intervals(
+            stream_max_duration_seconds=0.05, heartbeat_interval_seconds=0.01
+        ),
     )
     frames = [frame async for frame in resp.body_iterator]
     # Zero or more heartbeats may land before the deadline trips, but the
@@ -749,9 +848,9 @@ async def test_deadline_wait_budget_shrinks_below_the_heartbeat():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=0.05,
-        heartbeat_interval_seconds=5.0,
+        **_long_intervals(
+            stream_max_duration_seconds=0.05, heartbeat_interval_seconds=5.0
+        ),
     )
 
     async def _drain() -> list[str]:
@@ -872,18 +971,6 @@ async def test_close_exactly_once_under_watchdog_deadline_race():
     assert es.count_task_sinks(task_id) == 0
 
 
-# ===== frames bound to a different task_id are discarded =====
-
-
-async def test_sink_discards_foreign_task_frames():
-    sink = _make_sink(task_id=1)
-    await sink.send_text(
-        json.dumps({"type": "task_started", "task_id": 2, "status": "running"})
-    )
-    assert sink.queue.empty()
-    assert sink.dropped_frame_count == 0  # a graceful discard, not an error
-
-
 # ===== per-task concurrency cap =====
 
 
@@ -900,9 +987,7 @@ async def test_events_per_task_cap_third_stream_429():
             principal=principal,
             initial_snapshot=snapshot,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
-            watchdog_interval_seconds=1000,
-            stream_max_duration_seconds=1000,
-            heartbeat_interval_seconds=1000,
+            **_long_intervals(),
         )
         # Real delivery (Starlette) always pulls the first chunk before a
         # response can close; advance each generator once so its ``finally``
@@ -974,9 +1059,7 @@ async def test_heartbeat_actually_sent_when_idle():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=1000,
-        heartbeat_interval_seconds=0.01,
+        **_long_intervals(heartbeat_interval_seconds=0.01),
     )
     pings = 0
     try:
@@ -999,12 +1082,24 @@ async def test_heartbeat_actually_sent_when_idle():
 
 
 async def test_broadcast_frame_reaches_generator_output_as_task_status():
-    """Wiring test for the full path: ``sink.send_text`` (what
-    ``broadcast_to_task`` calls) -> ``enqueue_status`` -> the outbound
-    queue -> ``_generate``'s yield. Uses a status distinct from the
-    initial attach status ("running") so the assertion can't pass
-    merely because the *first* frame already says ``task.status`` --
-    it must be *this* broadcast that produced the second frame."""
+    """Wiring test for the full path: a real DB status change ->
+    ``ConnectionManager.broadcast_to_task`` (what production code calls,
+    not a hand-rolled ``sink.send_text``) -> the sink's ``send_text`` ->
+    ``enqueue_status`` -> the outbound queue -> ``_generate``'s yield.
+    Uses a status distinct from the initial attach status ("running") so
+    the assertion can't pass merely because the *first* frame already
+    says ``task.status`` -- it must be *this* broadcast that produced
+    the second frame.
+
+    The task row must be updated *before* broadcasting: ``broadcast_to_task``
+    enriches any versioned event through
+    ``_with_current_task_control_state``, which re-reads the task's
+    current row and overwrites the event's ``status`` field with it
+    whenever the event doesn't already carry a state tuple. Broadcasting
+    a bare ``{"type": "task_paused"}`` while the row is still "running"
+    would get its status field filled in as "running", not "paused",
+    and the second frame would never arrive within the timeout below.
+    """
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)
     principal = _principal_for(full_key)
@@ -1016,21 +1111,13 @@ async def test_broadcast_frame_reaches_generator_output_as_task_status():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=1000,
-        heartbeat_interval_seconds=1000,
+        **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
     assert json.loads(first.split("data: ", 1)[1]) == {"status": "running"}
 
-    sink = next(
-        c
-        for c in es.manager.connections_for_task(task_id)
-        if isinstance(c, es.V1EventStreamSink)
-    )
-    await sink.send_text(
-        json.dumps({"type": "task_paused", "task_id": task_id, "status": "paused"})
-    )
+    _set_task_status(task_id, TaskStatus.PAUSED)
+    await es.manager.broadcast_to_task({"type": "task_paused"}, task_id)
 
     second = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
     assert "event: task.status" in second
@@ -1087,6 +1174,34 @@ async def test_terminal_failure_broadcast_also_sets_completion_hint():
     assert sink.queue.get_nowait() == (es.status_frame("failed"), False)
 
 
+# ===== a waiting-for-user broadcast also sets the completion_hint =====
+
+
+async def test_waiting_for_user_broadcast_also_sets_completion_hint():
+    """A task moving to ``waiting_for_user`` reaches the sink through the
+    same generic versioned-event branch as the terminal-failure case
+    above, not the ``task_completed`` short-circuit -- it must also set
+    ``completion_hint`` (in addition to enqueueing the ``task.status``
+    frame), so the watchdog wakes early instead of waiting out its
+    normal cadence to emit the authoritative ``task.input_required``
+    close frame. Safe because the watchdog re-reads the authoritative
+    row before closing anything, including the ``resume_requested``
+    carve-out -- an early wake never closes a stream a fresh read
+    wouldn't have closed anyway."""
+    sink = _make_sink(task_id=1, status="running")
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "task_waiting_for_user",
+                "task_id": 1,
+                "status": "waiting_for_user",
+            }
+        )
+    )
+    assert sink.completion_hint.is_set()
+    assert sink.queue.get_nowait() == (es.status_frame("waiting_for_user"), False)
+
+
 # ===== the completion_hint wakes the watchdog early, not on its next
 # periodic tick =====
 
@@ -1111,9 +1226,7 @@ async def test_completion_hint_wakes_watchdog_before_its_next_periodic_tick():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
-        watchdog_interval_seconds=1000,
-        stream_max_duration_seconds=1000,
-        heartbeat_interval_seconds=1000,
+        **_long_intervals(),
     )
     await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -240,7 +240,7 @@ async def test_slow_consumer_queue_overflow_closes_with_resync_required():
     # Memory doesn't grow past the cap even under sustained overflow --
     # exactly one frame (the close frame) survives.
     assert sink.queue.qsize() == 1
-    assert sink.queue.get_nowait() == es.error_frame("resync_required")
+    assert sink.queue.get_nowait() == (es.error_frame("resync_required"), True)
 
 
 # ===== key revoked/paused closes within one watchdog cycle =====
@@ -269,7 +269,7 @@ async def test_watchdog_closes_within_one_cycle_on_key_invalidation(field):
     )
     assert closed is True
     assert sink.closing is True
-    assert sink.queue.get_nowait() == es.error_frame("unauthorized")
+    assert sink.queue.get_nowait() == (es.error_frame("unauthorized"), True)
 
 
 async def test_watchdog_paused_does_not_close():
@@ -287,7 +287,7 @@ async def test_watchdog_paused_does_not_close():
     )
     assert closed is False
     assert sink.closing is False
-    assert sink.queue.get_nowait() == es.status_frame("paused")
+    assert sink.queue.get_nowait() == (es.status_frame("paused"), False)
 
 
 async def test_watchdog_waiting_for_user_closes_with_null_prompt_input_required():
@@ -309,7 +309,7 @@ async def test_watchdog_waiting_for_user_closes_with_null_prompt_input_required(
     )
     assert closed is True
     assert sink.closing is True
-    assert sink.queue.get_nowait() == es.input_required_frame(task_id)
+    assert sink.queue.get_nowait() == (es.input_required_frame(task_id), True)
     assert (
         json.loads(es.input_required_frame(task_id).split("data: ", 1)[1])["prompt"]
         is None
@@ -354,8 +354,9 @@ async def test_watchdog_terminal_task_row_closes_with_completed():
         sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
     )
     assert closed is True
-    assert sink.queue.get_nowait() == es.completed_frame(
-        status="failed", output=None, error="boom"
+    assert sink.queue.get_nowait() == (
+        es.completed_frame(status="failed", output=None, error="boom"),
+        True,
     )
 
 
@@ -381,7 +382,7 @@ async def test_watchdog_missing_task_row_closes_with_task_deleted():
         sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
     )
     assert closed is True
-    assert sink.queue.get_nowait() == es.error_frame("task_deleted")
+    assert sink.queue.get_nowait() == (es.error_frame("task_deleted"), True)
 
 
 # ===== endpoint signature carries no request-scoped DB dependency =====
@@ -488,7 +489,7 @@ async def test_enqueue_close_is_idempotent_first_writer_wins():
     assert first is True
     assert second is False
     assert sink.queue.qsize() == 1
-    assert sink.queue.get_nowait() == es.error_frame("stream_expired")
+    assert sink.queue.get_nowait() == (es.error_frame("stream_expired"), True)
 
 
 async def test_close_exactly_once_under_watchdog_deadline_race():

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -11,6 +11,7 @@ attach shapes, where the JSON-vs-event-stream distinction actually
 matters).
 """
 
+import asyncio
 import json
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
@@ -385,6 +386,57 @@ async def test_watchdog_missing_task_row_closes_with_task_deleted():
     assert sink.queue.get_nowait() == (es.error_frame("task_deleted"), True)
 
 
+async def test_watchdog_survives_transient_check_failure_and_still_closes():
+    """A single failed watchdog cycle (e.g. a transient DB error reading
+    the task row) must not silence the watchdog for the rest of the
+    stream's life. Before this fix, an uncaught exception inside the
+    watchdog loop killed the loop's background task permanently and
+    silently -- the generator's teardown swallowed it via a blanket
+    ``except BaseException``, so nothing was left watching the stream
+    until the 1-hour absolute cap. This injects a ``read_task_snapshot``
+    that raises on its first call and returns a real, terminal
+    snapshot on its second, and asserts the stream still reaches
+    ``task.completed`` -- i.e. the watchdog retried instead of dying."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    call_count = 0
+
+    def flaky_reader(task_id_, principal_):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("boom - transient read failure")
+        return v1_tasks._load_task_info_snapshot(task_id_, principal_)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=flaky_reader,
+        watchdog_interval_seconds=0.01,
+        stream_max_duration_seconds=1000,
+        heartbeat_interval_seconds=1000,
+    )
+    first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert "event: task.status" in first
+
+    _set_task_status(task_id, TaskStatus.COMPLETED, output="done")
+
+    frames = []
+
+    async def _drain():
+        async for frame in resp.body_iterator:
+            frames.append(frame)
+
+    await asyncio.wait_for(_drain(), timeout=2)
+    assert call_count >= 2  # the first (failing) cycle and the retry
+    assert any("event: task.completed" in f for f in frames)
+    assert es.count_task_sinks(task_id) == 0
+
+
 # ===== endpoint signature carries no request-scoped DB dependency =====
 
 
@@ -422,6 +474,45 @@ async def test_sink_unregistered_after_generator_teardown():
     assert es.count_task_sinks(task_id) == 0
 
 
+# ===== a generator that's built but never started leaks nothing =====
+
+
+async def test_unstarted_generator_leaves_no_registration_or_reservation():
+    """An async generator's body doesn't run until it's first iterated.
+    Registering the sink and reserving the per-principal slot both
+    happen *inside* ``_generate``'s own ``try`` (not at
+    ``build_event_stream_response`` construction time) specifically so
+    that a ``StreamingResponse`` that's constructed but never iterated
+    -- ``__anext__`` never called even once -- leaves nothing behind:
+    no sink in ``manager``, no held slot in the per-principal counter.
+    Before that fix, registration/reservation ran at construction time,
+    so this exact sequence (build, then ``aclose()`` with zero reads)
+    leaked both forever, since the only code that ever released them
+    lived inside the generator body that never got to run."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=1000,
+        heartbeat_interval_seconds=1000,
+    )
+    # No __anext__() call at all -- the generator body has never run.
+    assert es.count_task_sinks(task_id) == 0
+    assert es._principal_stream_counts.get(key_prefix, 0) == 0
+
+    await resp.body_iterator.aclose()
+    assert es.count_task_sinks(task_id) == 0
+    assert es._principal_stream_counts.get(key_prefix, 0) == 0
+
+
 # ===== per-principal stream cap =====
 
 
@@ -448,6 +539,33 @@ def test_events_principal_cap_returns_429_json():
     assert resp.headers["content-type"].startswith("application/json")
     assert resp.json()["error"]["code"] == "rate_limited"
     assert es.count_task_sinks(task_id) == 0  # rejected before registration
+
+
+async def test_principal_slot_released_after_real_stream_teardown():
+    """A real attach through ``build_event_stream_response`` (not the
+    raw counter functions in isolation) must actually give its slot
+    back on teardown -- otherwise every stream a key ever opens
+    permanently eats one of its 32 concurrent slots."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=1000,
+        heartbeat_interval_seconds=1000,
+    )
+    await resp.body_iterator.__anext__()
+    assert es._principal_stream_counts.get(key_prefix, 0) == 1
+
+    await resp.body_iterator.aclose()
+    assert es._principal_stream_counts.get(key_prefix, 0) == 0
 
 
 # ===== absolute deadline emits stream_expired before closing =====
@@ -490,6 +608,72 @@ async def test_enqueue_close_is_idempotent_first_writer_wins():
     assert second is False
     assert sink.queue.qsize() == 1
     assert sink.queue.get_nowait() == (es.error_frame("stream_expired"), True)
+
+
+# ===== close frame isn't lost when it's enqueued while the generator is
+# suspended mid-yield on an earlier, non-close frame =====
+
+
+async def test_close_frame_delivered_when_enqueued_between_two_yields():
+    """The generator can be suspended at ``yield frame_text`` (Starlette
+    awaiting the socket write) when a concurrent close call lands. The
+    close-ness of the *next* frame the generator delivers must come
+    from that frame's own queue entry, not from re-reading
+    ``sink.closing`` after the unrelated earlier yield resumes -- by
+    then ``closing`` is already true even though the frame just sent
+    wasn't the close frame. Driven by hand via ``asend`` to control
+    exactly where the generator is suspended when the race hits."""
+
+    async def _never_read(task_id, principal):  # pragma: no cover
+        raise AssertionError("watchdog must not run in this test")
+
+    task_id = 987_654_321  # sentinel, not a real DB row -- unused by this test
+    gen = es._generate(
+        task_id,
+        None,
+        key_prefix="pfx-close-frame-race-test",
+        initial_status="running",
+        read_task_snapshot=_never_read,
+        watchdog_interval_seconds=10_000,
+        stream_max_duration_seconds=10_000,
+        heartbeat_interval_seconds=10_000,
+    )
+    try:
+        first = await gen.asend(None)
+        assert "event: task.status" in first
+
+        # ``_generate`` builds and registers the sink internally now (fix
+        # for the double-leak on an unstarted generator) -- fetch the
+        # live instance via the same ``manager`` registry the generator
+        # just registered it into.
+        sink = next(
+            c
+            for c in es.manager.connections_for_task(task_id)
+            if isinstance(c, es.V1EventStreamSink)
+        )
+
+        sink.enqueue_status("paused")
+        second = await gen.asend(None)
+        assert "paused" in second
+        # The generator is now suspended right after yielding ``second``
+        # -- exactly the window in which the real consumer would be
+        # awaiting the socket write while other tasks run.
+
+        won = sink.enqueue_close(
+            es.completed_frame(status="completed", output="done", error=None)
+        )
+        assert won is True
+
+        third = await gen.asend(None)
+        assert "event: task.completed" in third
+        with pytest.raises(StopAsyncIteration):
+            await gen.asend(None)
+    finally:
+        # ``_generate``'s own ``finally`` already released the slot it
+        # reserved once the close frame was delivered above; ``aclose()``
+        # here only matters if an assertion failed earlier and the
+        # generator is still suspended mid-stream.
+        await gen.aclose()
 
 
 async def test_close_exactly_once_under_watchdog_deadline_race():
@@ -601,3 +785,153 @@ async def test_sink_send_text_never_queries_db(monkeypatch):
         json.dumps({"type": "task_completed", "task": {"id": sink.task_id}})
     )
     assert calls == []
+
+
+# ===== the heartbeat comment line actually gets sent while idle =====
+
+
+async def test_heartbeat_actually_sent_when_idle():
+    """The 15s heartbeat comment must actually be emitted while the
+    stream is otherwise idle -- this is a real, non-vacuous assertion
+    that at least one ``: ping`` frame arrives, not a shape check that
+    would pass whether zero or many heartbeats fired (that was the bug
+    in the older deadline test, which only ever asserted a frame-count
+    identity that holds either way). Injects a short heartbeat interval
+    with a long watchdog interval and deadline so a heartbeat is the
+    only thing that can produce a frame here."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=1000,
+        heartbeat_interval_seconds=0.01,
+    )
+    pings = 0
+    try:
+
+        async def _collect() -> None:
+            nonlocal pings
+            async for frame in resp.body_iterator:
+                if frame == ": ping\n\n":
+                    pings += 1
+                    return
+
+        await asyncio.wait_for(_collect(), timeout=2)
+    finally:
+        await resp.body_iterator.aclose()
+    assert pings >= 1
+
+
+# ===== a broadcast-shaped frame reaching the sink ends up as real
+# SSE output text out of the generator, not just in the internal queue =====
+
+
+async def test_broadcast_frame_reaches_generator_output_as_task_status():
+    """Wiring test for the full path: ``sink.send_text`` (what
+    ``broadcast_to_task`` calls) -> ``enqueue_status`` -> the outbound
+    queue -> ``_generate``'s yield. Uses a status distinct from the
+    initial attach status ("running") so the assertion can't pass
+    merely because the *first* frame already says ``task.status`` --
+    it must be *this* broadcast that produced the second frame."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    assert snapshot.status.value == "running"
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=1000,
+        heartbeat_interval_seconds=1000,
+    )
+    first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert json.loads(first.split("data: ", 1)[1]) == {"status": "running"}
+
+    sink = next(
+        c
+        for c in es.manager.connections_for_task(task_id)
+        if isinstance(c, es.V1EventStreamSink)
+    )
+    await sink.send_text(
+        json.dumps({"type": "task_paused", "task_id": task_id, "status": "paused"})
+    )
+
+    second = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert "event: task.status" in second
+    assert json.loads(second.split("data: ", 1)[1]) == {"status": "paused"}
+
+    await resp.body_iterator.aclose()
+
+
+# ===== consecutive identical statuses only produce one frame =====
+
+
+async def test_consecutive_same_status_broadcasts_are_deduped_to_one_frame():
+    sink = _make_sink(task_id=1, status="running")
+    for _ in range(3):
+        await sink.send_text(
+            json.dumps({"type": "task_paused", "task_id": 1, "status": "paused"})
+        )
+    assert sink.queue.qsize() == 1
+    assert sink.queue.get_nowait() == (es.status_frame("paused"), False)
+
+
+# ===== the completion_hint wakes the watchdog early, not on its next
+# periodic tick =====
+
+
+async def test_completion_hint_wakes_watchdog_before_its_next_periodic_tick():
+    """The ``task_completed`` broadcast hint is supposed to be an
+    acceleration path -- the watchdog wakes and checks immediately
+    instead of waiting out its normal interval. This pins that it's a
+    genuine early wake, not something that happens to work because the
+    interval is already short: the watchdog interval here is 1000s, so
+    the only way this test can finish inside its 2s bound is if the
+    hint actually woke it early. If the hint stopped working, this
+    would hang until the bound trips and the test would fail instead of
+    silently passing."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        watchdog_interval_seconds=1000,
+        stream_max_duration_seconds=1000,
+        heartbeat_interval_seconds=1000,
+    )
+    await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+
+    _set_task_status(task_id, TaskStatus.COMPLETED, output="done")
+    sink = next(
+        c
+        for c in es.manager.connections_for_task(task_id)
+        if isinstance(c, es.V1EventStreamSink)
+    )
+    await sink.send_text(
+        json.dumps({"type": "task_completed", "task": {"id": task_id}})
+    )
+
+    frames = []
+
+    async def _drain() -> None:
+        async for frame in resp.body_iterator:
+            frames.append(frame)
+
+    await asyncio.wait_for(_drain(), timeout=2)
+    assert any("event: task.completed" in f for f in frames)

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -29,7 +29,12 @@ from xagent.web.api.v1.errors import V1ApiError, V1ErrorCode
 from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.task import Task, TaskStatus
 
-from ..conftest import _admin_headers, _direct_db_session, client
+from ..conftest import (
+    _admin_headers,
+    _direct_db_session,
+    _install_one_slot_queue_pool,
+    client,
+)
 
 pytestmark = pytest.mark.usefixtures("_test_db")
 
@@ -595,32 +600,58 @@ async def test_watchdog_survives_transient_check_failure_and_still_closes():
     assert es.count_task_sinks(task_id) == 0
 
 
-# ===== endpoint signature carries no request-scoped DB dependency =====
+# ===== a live stream never holds a connection-pool slot open =====
 
 
-def test_events_endpoint_signature_has_no_db_dependency():
-    """No parameter is typed as a SQLAlchemy ``Session``.
+async def test_live_stream_holds_no_connection_pool_slot(monkeypatch):
+    """A live SSE stream must not occupy a pooled DB connection for its
+    lifetime: every read the stream itself does (the periodic watchdog
+    checks) goes through ``run_db_io_cancellation_safe``, which checks a
+    connection out and back in per read, not once for the whole stream.
 
-    A ``Session``-typed FastAPI dependency is request-scoped: it would be
-    checked out for the entire life of the stream (up to the 1-hour cap)
-    instead of only for the brief, per-check reads that
-    ``_events_stream`` already routes through
-    ``run_db_io_cancellation_safe``. Asserting on the exact parameter
-    *name* set is what used to live here; it broke on any unrelated
-    rename and never actually verified the no-request-scoped-session
-    property it claimed to.
+    Calls the route handler ``stream_chat_task_events`` itself (not
+    ``build_event_stream_response``) with ``task_id``/``principal`` passed
+    directly as keyword arguments -- this runs the handler's exact body
+    (its own snapshot read, then the call into ``_events_stream``) without
+    going through FastAPI's HTTP/dependency-injection layer, so a session
+    opened anywhere in that body, not only inside ``_events_stream``,
+    would show up in the assertion below.
 
-    Signature-only: this can't see whether the function body opens its
-    own ad hoc DB session internally (rather than through
-    ``run_db_io_cancellation_safe``) -- it only rules out a request-scoped
-    ``Session`` dependency injected by FastAPI.
+    Proven behaviorally, not by inspecting the endpoint's signature:
+    rebind the test database onto a real one-connection pool
+    (``_install_one_slot_queue_pool``), open a live stream, and -- while
+    it's still open with its first frame already delivered, the moment a
+    held connection would show up -- assert the pool has nothing checked
+    out. A second, independent connection is then actually pulled from
+    the pool to prove the one slot is genuinely free, not merely under
+    some checkout-count threshold that would pass even with a stale
+    reference still pinning it.
+
+    This replaces a signature-only check that asserted no parameter was
+    typed as ``Session``: true, but blind to a session opened inside the
+    function body instead of injected as a dependency.
     """
-    import inspect
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
 
-    from sqlalchemy.orm import Session
+    engine = _install_one_slot_queue_pool(monkeypatch, pool_timeout=0.5)
 
-    sig = inspect.signature(v1_tasks.stream_chat_task_events)
-    assert not any(param.annotation is Session for param in sig.parameters.values())
+    resp = await v1_tasks.stream_chat_task_events(task_id=task_id, principal=principal)
+    first = await resp.body_iterator.__anext__()
+    assert "event: task.status" in first
+    assert es.count_task_sinks(task_id) == 1
+
+    assert engine.pool.checkedout() == 0
+    held = engine.connect()
+    try:
+        assert engine.pool.checkedout() == 1
+    finally:
+        held.close()
+
+    await resp.body_iterator.aclose()
+    assert es.count_task_sinks(task_id) == 0
+    engine.dispose()
 
 
 # ===== generator teardown unregisters the sink =====
@@ -1009,6 +1040,86 @@ async def test_events_per_task_cap_third_stream_429():
     for resp in responses:
         await resp.body_iterator.aclose()
     assert es.count_task_sinks(task_id) == 0
+
+
+# ===== the fast paths are exempt from both concurrency caps =====
+
+
+@pytest.mark.parametrize(
+    ("fast_path_status", "closing_event"),
+    [
+        (TaskStatus.COMPLETED, "event: task.completed"),
+        (TaskStatus.WAITING_FOR_USER, "event: task.input_required"),
+    ],
+)
+async def test_fast_path_attach_exempt_from_both_caps(fast_path_status, closing_event):
+    """``build_event_stream_response`` checks ``_stream_close_reason``
+    before either concurrency cap (see its own docstring): a task that's
+    already terminal or already waiting for user input takes the
+    snapshot-closing fast path and returns before the per-task and
+    per-principal cap checks ever run, so it must succeed even when both
+    caps are already saturated.
+
+    Setup order matters: the per-task cap has to be filled with real
+    streams *while the task is still running*, because the fast path
+    never registers a sink -- once the task row is already terminal
+    there is no way to fill that cap through it. Only after both caps
+    are full does the task row flip to the fast-path status under test.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    running_snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    # Fill the per-task cap with real streams while the task is running.
+    responses = []
+    for _ in range(es.PER_TASK_STREAM_CAP):
+        resp = await es.build_event_stream_response(
+            task_id=task_id,
+            principal=principal,
+            initial_snapshot=running_snapshot,
+            read_task_snapshot=v1_tasks._load_task_info_snapshot,
+            **_long_intervals(),
+        )
+        await resp.body_iterator.__anext__()
+        responses.append(resp)
+    assert es.count_task_sinks(task_id) == es.PER_TASK_STREAM_CAP
+
+    # Fill the rest of the per-principal cap too -- opening the streams
+    # above already reserved one principal slot per stream (`_generate`
+    # reserves on the same key_prefix), so only the remainder needs
+    # filling here.
+    already_reserved = es._principal_stream_counts.get(key_prefix, 0)
+    for _ in range(es.PER_PRINCIPAL_STREAM_CAP - already_reserved):
+        assert es.try_reserve_principal_slot(key_prefix)
+    assert es._principal_stream_counts[key_prefix] == es.PER_PRINCIPAL_STREAM_CAP
+
+    # Now flip the task row to the fast-path status under test.
+    if fast_path_status is TaskStatus.WAITING_FOR_USER:
+        _set_task_status(task_id, fast_path_status, control_state="idle")
+    else:
+        _set_task_status(task_id, fast_path_status, output="done")
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    body = resp.text
+    assert body.count("event: task.status") == 1
+    assert body.count(closing_event) == 1
+
+    # The fast path never registers a sink, so the count above -- entirely
+    # made up of the cap-filling streams -- is unchanged.
+    assert es.count_task_sinks(task_id) == es.PER_TASK_STREAM_CAP
+
+    for resp in responses:
+        await resp.body_iterator.aclose()
+    assert es.count_task_sinks(task_id) == 0
+    # Closing each stream above already released its own reserved slot;
+    # release only the ones this test reserved manually.
+    for _ in range(es.PER_PRINCIPAL_STREAM_CAP - already_reserved):
+        es.release_principal_slot(key_prefix)
+    assert es._principal_stream_counts.get(key_prefix, 0) == 0
 
 
 # ===== the sink never touches the database on its per-frame path =====

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -568,6 +568,71 @@ async def test_principal_slot_released_after_real_stream_teardown():
     assert es._principal_stream_counts.get(key_prefix, 0) == 0
 
 
+# ===== per-principal cap is soft: a lost reservation race doesn't 429 =====
+
+
+async def test_generate_serves_stream_when_reservation_race_lost(caplog):
+    """``build_event_stream_response`` only *checks* the per-principal cap
+    (``principal_slot_available``, read-only) before starting the
+    generator; the actual counter mutation (``try_reserve_principal_slot``)
+    happens once ``_generate`` runs. Between those two moments, enough
+    concurrently-racing attaches for the same key can fill the last slot
+    first, so the reservation inside ``_generate`` can fail even though
+    the earlier check passed. That loss must not abort an attach whose
+    response has already started streaming: the stream is served anyway
+    (soft cap), and because ``principal_slot_reserved`` stays False, the
+    ``finally`` teardown must not release a slot this stream never held --
+    doing so would erroneously free a slot actually owned by one of the
+    other concurrent streams that did win the race."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    # Simulate the losing side of the race: every slot is already held by
+    # other concurrent attaches by the time this stream's own generator
+    # runs `try_reserve_principal_slot`.
+    for _ in range(es.PER_PRINCIPAL_STREAM_CAP):
+        assert es.try_reserve_principal_slot(key_prefix)
+    full_count = es._principal_stream_counts[key_prefix]
+
+    with caplog.at_level("WARNING", logger="xagent.web.api.v1._events_stream"):
+        agen = es._generate(
+            task_id,
+            principal,
+            key_prefix=key_prefix,
+            initial_status=snapshot.status.value,
+            read_task_snapshot=v1_tasks._load_task_info_snapshot,
+            watchdog_interval_seconds=1000,
+            stream_max_duration_seconds=1000,
+            heartbeat_interval_seconds=1000,
+        )
+        first = await agen.__anext__()
+
+    # The stream is served normally despite the lost reservation race.
+    assert "event: task.status" in first
+    assert es.count_task_sinks(task_id) == 1
+    # No extra slot was claimed -- the reservation attempt failed and
+    # nothing was added on top of the already-full count.
+    assert es._principal_stream_counts[key_prefix] == full_count
+    assert any(
+        key_prefix in record.message and "best-effort" in record.message
+        for record in caplog.records
+    )
+
+    await agen.aclose()
+
+    # Teardown must not touch the counter: this stream never held a slot,
+    # so releasing one here would steal it from a stream that did.
+    assert es.count_task_sinks(task_id) == 0
+    assert es._principal_stream_counts.get(key_prefix, 0) == full_count
+    assert es._principal_stream_counts[key_prefix] >= 0
+
+    for _ in range(es.PER_PRINCIPAL_STREAM_CAP):
+        es.release_principal_slot(key_prefix)
+
+
 # ===== absolute deadline emits stream_expired before closing =====
 
 


### PR DESCRIPTION
## Why

Starting a task through the SDK gives no feedback for the first several seconds: `steps()` polls once per second, and until the first step lands there is nothing to report. A stream lets a client learn a task is alive the moment it attaches, and learn it ended the moment it ends.

## What

Adds `GET /v1/chat/tasks/{task_id}/events`, a Server-Sent Events stream of task lifecycle events, authenticated with the same key dependency as the other `/v1/chat/tasks` endpoints (one bcrypt per stream rather than one per poll).

The stream emits four event types — `task.status`, `task.completed`, `task.input_required` (the question text is always `null` at this layer), and `stream.error` (`resync_required` / `unauthorized` / `task_deleted` / `stream_expired`) — plus a `: ping` comment every 15 seconds. Projecting step and message content is a separate layer and is not part of this change; the endpoint docstring documents exactly what it emits.

Lifecycle rules:

- A 30-second watchdog on the task row is the authority for terminal state; broadcast frames only make it react sooner. The same watchdog closes streams on key revocation and on task deletion, and emits `task.input_required` for a task waiting on the user. A paused task keeps its stream open, matching `wait()`, which also keeps waiting through a pause.
- A stream lives at most one hour and always ends with an explicit close event: a frame already in flight can never displace the close frame, so a client can always tell "task ended" from "stream ended".
- The outbound queue is bounded at 256 frames. A consumer too slow to keep up gets `stream.error {resync_required}` and re-syncs through `steps()` before re-attaching. There is no replay; `Last-Event-ID` is ignored.
- Concurrency caps are 2 streams per task and 32 per key. Both are enforced when the response is built and are best-effort under a burst of simultaneous attaches — the count can be exceeded briefly rather than the extra attaches being rejected, and it corrects itself as streams close. No stream is ever aborted for this reason.
- The sink swallows every exception and counts dropped frames: a stream subscriber must never be able to break the task's own broadcast path.

## Verification

38 transport tests covering: fail-closed auth and 404, immediate close when attaching to an already-terminal task, slow-consumer bounding, key revocation closing within one watchdog interval, waiting-for-user close carrying a null prompt, a paused task continuing to stream, absolute-deadline close with `stream_expired`, closing exactly once when the watchdog and the deadline race, heartbeats, a broadcast frame reaching the client as `task.status` with same-status dedup, the completion hint waking the watchdog early, cleanup leaving no registration or quota behind on both disconnect and never-started streams, per-task and per-key caps, no request-scoped DB session on the endpoint, and zero DB reads on the frame path.

Full `tests/web/api/v1` suite green on top of main.
