### PR TITLE
fix(mcp): strip all non-tool-name characters from MCP tool names

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from ....utils.encryption import decrypt_value
 from ...core.api_tool import call_api
+from .agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 from .connector_runtime import (
     MISSING_RUNTIME_VALUE,
@@ -134,11 +135,25 @@ class CustomApiTool(AbstractBaseTool):
     ):
         # Format name for LLM (replace spaces/dashes with underscores)
         sanitized_name = name.replace(" ", "_").replace("-", "_")
+        # `name` is free-form user input (CustomApiCreate.name only bounds
+        # length, not charset), so anything the two replacements above
+        # didn't catch -- a `.` in a domain-like name, punctuation, etc. --
+        # would otherwise survive into `function.name` and 400 the whole
+        # LLM call the same way an unsanitized MCP tool name does.
+        sanitized_name = re.sub(r"[^A-Za-z0-9_-]", "_", sanitized_name)
         # Ensure name doesn't start with api_ twice if already prefixed
-        if sanitized_name.startswith("api_"):
-            self._name = f"{sanitized_name}_call"
-        else:
-            self._name = f"api_{sanitized_name}_call"
+        prefix = "" if sanitized_name.startswith("api_") else "api_"
+        suffix = "_call"
+        # Same failure mode as the character check above -- an over-long
+        # name is rejected by the same providers, just on length instead of
+        # charset. Budget the truncation around the fixed prefix/suffix so
+        # `_call` (the part that signals "this is an API call") survives
+        # instead of being cut off by a blind truncation of the whole
+        # string. `MAX_AGENT_TOOL_NAME_LENGTH` is this repo's own record of
+        # that provider limit (agent_tool_names.py), shared here rather than
+        # redeclared so the two adapters can't drift apart on the number.
+        budget = MAX_AGENT_TOOL_NAME_LENGTH - len(prefix) - len(suffix)
+        self._name = f"{prefix}{sanitized_name[:budget]}{suffix}"
 
         # Structured originating-server identity, normalized once through the
         # shared SSOT. A scoped mcp:<server> selector fronts this Custom-API

--- a/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
@@ -1,6 +1,7 @@
 """Custom API Tool Adapter for Agent System."""
 
 import asyncio
+import hashlib
 import json
 import logging
 import re
@@ -153,6 +154,20 @@ class CustomApiTool(AbstractBaseTool):
         # that provider limit (agent_tool_names.py), shared here rather than
         # redeclared so the two adapters can't drift apart on the number.
         budget = MAX_AGENT_TOOL_NAME_LENGTH - len(prefix) - len(suffix)
+        if len(sanitized_name) > budget:
+            # `name` is a free-form, DB-unique string with no server
+            # prefix to squeeze the way the MCP adapter does -- the whole
+            # sanitized name is what a truncation would cut. Two long,
+            # descriptive Custom API names that share a common prefix and
+            # differ only in a trailing qualifier (a normal naming habit,
+            # e.g. two services named for the same team) truncate to the
+            # same string otherwise, and nothing downstream detects that
+            # collision -- mix in a short hash of the *original* name so a
+            # truncated name stays distinct instead of silently dispatching
+            # to whichever of the two tools registers first.
+            digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+            hash_suffix = f"_{digest}"
+            sanitized_name = sanitized_name[: budget - len(hash_suffix)] + hash_suffix
         self._name = f"{prefix}{sanitized_name[:budget]}{suffix}"
 
         # Structured originating-server identity, normalized once through the

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -23,6 +23,7 @@ from ..... import config as _root_config
 from .....sandbox.base import Sandbox
 from ...core.mcp.sessions import Connection, create_session
 from ...core.mcp.tools import load_mcp_tools
+from .agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
 from .base import AbstractBaseTool, ToolVisibility
 from .connector_runtime import (
     ERROR_DELEGATED_AUTHORIZATION_FAILED,
@@ -410,8 +411,7 @@ class MCPToolAdapter(AbstractBaseTool):
     def name(self) -> str:
         """Get tool name with optional prefix, formatted for LLM requirements."""
         raw_name = f"{self._name_prefix}{self.mcp_tool.name}"
-        # Replace spaces and dashes with underscores to match LLM tool naming constraints
-        # This matches the frontend/chat.py filtering logic
+        # Replace spaces and dashes with underscores to match LLM tool naming constraints.
         sanitized = raw_name.replace(" ", "_").replace("-", "_")
         # Some MCP servers namespace tool names with characters (e.g. the
         # `.` in `coding.start`) that OpenAI-compatible APIs reject outright
@@ -420,7 +420,13 @@ class MCPToolAdapter(AbstractBaseTool):
         # LLM call, not just this one tool. Catch anything left over from
         # the two replacements above instead of only handling the specific
         # characters this method happened to have seen so far.
-        return re.sub(r"[^A-Za-z0-9_-]", "_", sanitized)
+        sanitized = re.sub(r"[^A-Za-z0-9_-]", "_", sanitized)
+        # Same failure mode as the character check above -- an over-long
+        # name is rejected by the same providers, just on length instead of
+        # charset. `MAX_AGENT_TOOL_NAME_LENGTH` is this repo's own record of
+        # that provider limit (agent_tool_names.py), shared here rather than
+        # redeclared so the two adapters can't drift apart on the number.
+        return sanitized[:MAX_AGENT_TOOL_NAME_LENGTH]
 
     @property
     def description(self) -> str:

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -410,23 +410,40 @@ class MCPToolAdapter(AbstractBaseTool):
     @property
     def name(self) -> str:
         """Get tool name with optional prefix, formatted for LLM requirements."""
-        raw_name = f"{self._name_prefix}{self.mcp_tool.name}"
-        # Replace spaces and dashes with underscores to match LLM tool naming constraints.
-        sanitized = raw_name.replace(" ", "_").replace("-", "_")
-        # Some MCP servers namespace tool names with characters (e.g. the
-        # `.` in `coding.start`) that OpenAI-compatible APIs reject outright
-        # -- `^[a-zA-Z0-9_-]+$` is the pattern OpenAI/DeepSeek enforce on
-        # `tools[].function.name`, and a name that fails it 400s the whole
-        # LLM call, not just this one tool. Catch anything left over from
-        # the two replacements above instead of only handling the specific
-        # characters this method happened to have seen so far.
-        sanitized = re.sub(r"[^A-Za-z0-9_-]", "_", sanitized)
+
+        def _sanitize(value: str) -> str:
+            # Replace spaces and dashes with underscores to match LLM tool
+            # naming constraints, then catch anything else disallowed --
+            # some MCP servers namespace tool names with characters (e.g.
+            # the `.` in `coding.start`) that OpenAI-compatible APIs reject
+            # outright (`^[a-zA-Z0-9_-]+$` is the pattern OpenAI/DeepSeek
+            # enforce on `tools[].function.name`), and a name that fails it
+            # 400s the whole LLM call, not just this one tool.
+            return re.sub(
+                r"[^A-Za-z0-9_-]", "_", value.replace(" ", "_").replace("-", "_")
+            )
+
+        sanitized_prefix = _sanitize(self._name_prefix)
+        sanitized_tool = _sanitize(self.mcp_tool.name)
         # Same failure mode as the character check above -- an over-long
         # name is rejected by the same providers, just on length instead of
         # charset. `MAX_AGENT_TOOL_NAME_LENGTH` is this repo's own record of
         # that provider limit (agent_tool_names.py), shared here rather than
         # redeclared so the two adapters can't drift apart on the number.
-        return sanitized[:MAX_AGENT_TOOL_NAME_LENGTH]
+        #
+        # The tool name -- not the prefix -- is the only part that tells
+        # two tools on the *same* server apart, so truncating from the end
+        # (i.e. cutting the tool name) can make two distinct tools collide
+        # into one identical name once `prefix + tool_name` exceeds the
+        # limit. `_find_tool` has no duplicate-name detection, so a
+        # collision isn't a loud error like an illegal character is -- it's
+        # a silent wrong-tool dispatch. Squeeze the prefix instead and keep
+        # the tool name whole; `max(0, ...)` covers a tool name alone at or
+        # past the limit, where a negative slice would otherwise wrap
+        # around from the end instead of emptying.
+        budget_for_prefix = max(0, MAX_AGENT_TOOL_NAME_LENGTH - len(sanitized_tool))
+        combined = f"{sanitized_prefix[:budget_for_prefix]}{sanitized_tool}"
+        return combined[:MAX_AGENT_TOOL_NAME_LENGTH]
 
     @property
     def description(self) -> str:

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -412,7 +412,15 @@ class MCPToolAdapter(AbstractBaseTool):
         raw_name = f"{self._name_prefix}{self.mcp_tool.name}"
         # Replace spaces and dashes with underscores to match LLM tool naming constraints
         # This matches the frontend/chat.py filtering logic
-        return raw_name.replace(" ", "_").replace("-", "_")
+        sanitized = raw_name.replace(" ", "_").replace("-", "_")
+        # Some MCP servers namespace tool names with characters (e.g. the
+        # `.` in `coding.start`) that OpenAI-compatible APIs reject outright
+        # -- `^[a-zA-Z0-9_-]+$` is the pattern OpenAI/DeepSeek enforce on
+        # `tools[].function.name`, and a name that fails it 400s the whole
+        # LLM call, not just this one tool. Catch anything left over from
+        # the two replacements above instead of only handling the specific
+        # characters this method happened to have seen so far.
+        return re.sub(r"[^A-Za-z0-9_-]", "_", sanitized)
 
     @property
     def description(self) -> str:

--- a/tests/core/tools/adapters/vibe/test_api_tool_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_api_tool_adapter.py
@@ -1,7 +1,9 @@
+import re
 from unittest.mock import patch
 
 import pytest
 
+from xagent.core.tools.adapters.vibe.agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
 from xagent.core.tools.adapters.vibe.api_tool_adapter import (
     CustomApiTool,
     create_custom_api_tools,
@@ -28,6 +30,55 @@ def test_custom_api_tool_init():
     assert "Configured method: POST" in tool.description
     assert "- API_KEY" in tool.description
     assert "- API_KEY_BACKUP" in tool.description
+
+
+@pytest.mark.parametrize(
+    ("api_name", "expected"),
+    [
+        # A domain-shaped name is the natural thing for a user to type
+        # when naming a custom API after the service it calls -- the `.`
+        # must not survive into `function.name`.
+        ("weather.com", "api_weather_com_call"),
+        ("Foo (v2)", "api_Foo__v2__call"),
+        ("Slack #alerts", "api_Slack__alerts_call"),
+    ],
+)
+def test_custom_api_tool_name_strips_disallowed_characters_for_openai_compatible_apis(
+    api_name, expected
+):
+    """`CustomApiCreate.name` (web/api/custom_api.py) only bounds length,
+    not charset, so this is free-form user input. OpenAI-compatible
+    chat-completions APIs validate `tools[].function.name` against
+    `^[a-zA-Z0-9_-]+$` and 400 the whole call if any tool name fails it
+    -- the same defect `MCPToolAdapter.name` had, just reached through a
+    different, even less constrained input."""
+    tool = CustomApiTool(
+        name=api_name,
+        description="A test API",
+        env={},
+    )
+
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", tool.name)
+    assert tool.name == expected
+
+
+def test_custom_api_tool_name_is_truncated_to_the_provider_length_limit():
+    """Same failure mode as an illegal character -- an over-long name is
+    rejected by the same providers, just on length. `CustomApiCreate.
+    name` only bounds length to 100, well past what fits after the
+    `api_`/`_call` wrapper, so this adapter must enforce the real
+    provider limit itself. The `_call` suffix -- the part that signals
+    "this is an API call" -- must survive a name this long, not just get
+    chopped off by a blind truncation of the whole string."""
+    tool = CustomApiTool(
+        name="x" * 200,
+        description="A test API",
+        env={},
+    )
+
+    assert len(tool.name) == MAX_AGENT_TOOL_NAME_LENGTH
+    assert tool.name.startswith("api_")
+    assert tool.name.endswith("_call")
 
 
 def test_custom_api_tool_replace_secrets():

--- a/tests/core/tools/adapters/vibe/test_api_tool_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_api_tool_adapter.py
@@ -81,6 +81,38 @@ def test_custom_api_tool_name_is_truncated_to_the_provider_length_limit():
     assert tool.name.endswith("_call")
 
 
+def test_custom_api_tool_truncation_keeps_long_shared_prefix_names_distinct():
+    """Regression: unlike the MCP adapter, there is no server prefix to
+    squeeze here -- `name` is one free-form, DB-unique string (`custom_
+    apis.name` is `String(100) unique=True`), so two long, descriptive
+    API names that share everything but a trailing qualifier (a normal
+    naming habit -- e.g. two services named for the same team) truncate
+    to the exact same string once cut to fit `api_<name>_call` within
+    `MAX_AGENT_TOOL_NAME_LENGTH`. Nothing downstream detects that
+    collision, so the model asking for one tool would silently get
+    whichever one happens to register first. The fix mixes a short hash
+    of the original name into a truncated name so it stays distinct.
+    """
+    name_a = "Acme Billing Reconciliation Service For The Payments Team Alpha"
+    name_b = "Acme Billing Reconciliation Service For The Payments Team Beta"
+
+    tool_a = CustomApiTool(name=name_a, description="A test API", env={})
+    tool_b = CustomApiTool(name=name_b, description="A test API", env={})
+
+    assert tool_a.name != tool_b.name
+    assert len(tool_a.name) <= MAX_AGENT_TOOL_NAME_LENGTH
+    assert len(tool_b.name) <= MAX_AGENT_TOOL_NAME_LENGTH
+
+
+def test_custom_api_tool_short_name_truncation_is_unaffected_by_the_hash_suffix():
+    """The hash suffix only kicks in once truncation is actually needed --
+    a short name's `._name` must stay exactly what it was before this
+    fix, byte for byte, not gain a hash suffix it doesn't need."""
+    tool = CustomApiTool(name="my-test api", description="A test API", env={})
+
+    assert tool.name == "api_my_test_api_call"
+
+
 def test_custom_api_tool_replace_secrets():
     # Use unencrypted secrets for simplicity since decrypt_value handles unencrypted fallback or we can mock it
     # We will mock decrypt_value to just return the value for testing replace

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1,4 +1,5 @@
 import json
+import re
 from contextlib import asynccontextmanager
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
@@ -267,6 +268,29 @@ def test_mcp_tool_adapter_source_server_defaults_none():
     )
     assert adapter.source_server is None
     assert adapter.metadata.source_server is None
+
+
+def test_mcp_tool_adapter_name_strips_dots_for_openai_compatible_apis():
+    """OpenAI-compatible chat-completions APIs (and at least DeepSeek's)
+    validate `tools[].function.name` against `^[a-zA-Z0-9_-]+$` and 400
+    the whole call if any tool name fails it. MCP servers commonly
+    namespace tool names with a `.` (e.g. `coding.start`) to avoid
+    collisions between generically-named tools -- that dot must not
+    survive into the LLM-visible name."""
+    mcp_tool = SimpleNamespace(
+        name="coding.start",
+        description="Start a coding run",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = _build_mcp_tool_adapter(
+        "Coding MCP",
+        {"transport": "streamable_http", "url": "http://127.0.0.1:8642/mcp"},
+        mcp_tool,
+    )
+
+    assert "." not in adapter.name
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", adapter.name)
+    assert adapter.name == "mcp_Coding_MCP_coding_start"
 
 
 def test_mcp_tool_adapter_defaults_to_not_concurrency_safe():

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 from xagent.core.tools.adapters.vibe import mcp_adapter as mcp_adapter_module
+from xagent.core.tools.adapters.vibe.agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
 from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPFailurePhase,
     MCPServerLoadFailure,
@@ -270,15 +271,37 @@ def test_mcp_tool_adapter_source_server_defaults_none():
     assert adapter.metadata.source_server is None
 
 
-def test_mcp_tool_adapter_name_strips_dots_for_openai_compatible_apis():
+@pytest.mark.parametrize(
+    ("tool_name", "expected"),
+    [
+        # `.` namespacing, the case the fix was written for.
+        ("coding.start", "mcp_Coding_MCP_coding_start"),
+        # Path-like separator.
+        ("list/items", "mcp_Coding_MCP_list_items"),
+        # Parentheses and a space alongside the version marker.
+        ("run (v2)", "mcp_Coding_MCP_run__v2_"),
+        # Non-ASCII names collapse to underscores rather than raising or
+        # being romanized -- `_semantic_slug` (agent_tool_names.py) makes
+        # the opposite, deliberate choice for agent-delegation tool names
+        # (pinyin-transliterate instead of drop) because it can carry a
+        # unique per-agent id in the suffix; MCP tool names have no such
+        # id to fall back on for uniqueness, so this test pins today's
+        # trade-off (two same-length CJK names collide) rather than
+        # leaving it to be discovered later.
+        ("查询", "mcp_Coding_MCP___"),
+    ],
+)
+def test_mcp_tool_adapter_name_strips_disallowed_characters_for_openai_compatible_apis(
+    tool_name, expected
+):
     """OpenAI-compatible chat-completions APIs (and at least DeepSeek's)
     validate `tools[].function.name` against `^[a-zA-Z0-9_-]+$` and 400
-    the whole call if any tool name fails it. MCP servers commonly
-    namespace tool names with a `.` (e.g. `coding.start`) to avoid
-    collisions between generically-named tools -- that dot must not
-    survive into the LLM-visible name."""
+    the whole call if any tool name fails it. MCP servers namespace tool
+    names with all sorts of characters (e.g. the `.` in `coding.start`)
+    to avoid collisions between generically-named tools -- none of that
+    must survive into the LLM-visible name."""
     mcp_tool = SimpleNamespace(
-        name="coding.start",
+        name=tool_name,
         description="Start a coding run",
         inputSchema={"type": "object", "properties": {}},
     )
@@ -288,9 +311,29 @@ def test_mcp_tool_adapter_name_strips_dots_for_openai_compatible_apis():
         mcp_tool,
     )
 
-    assert "." not in adapter.name
     assert re.fullmatch(r"[A-Za-z0-9_-]+", adapter.name)
-    assert adapter.name == "mcp_Coding_MCP_coding_start"
+    assert adapter.name == expected
+
+
+def test_mcp_tool_adapter_name_is_truncated_to_the_provider_length_limit():
+    """Same failure mode as an illegal character -- an over-long name is
+    rejected by the same providers, just on length. Nothing upstream
+    (MCP server name, MCP tool name) is length-bounded, so this adapter
+    must enforce the limit itself instead of assuming it never comes up.
+    """
+    mcp_tool = SimpleNamespace(
+        name="x" * 200,
+        description="A tool with an absurdly long name",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    adapter = _build_mcp_tool_adapter(
+        "Coding MCP",
+        {"transport": "streamable_http", "url": "http://127.0.0.1:8642/mcp"},
+        mcp_tool,
+    )
+
+    assert len(adapter.name) == MAX_AGENT_TOOL_NAME_LENGTH
+    assert adapter.name.startswith("mcp_Coding_MCP_")
 
 
 def test_mcp_tool_adapter_defaults_to_not_concurrency_safe():

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -320,6 +320,9 @@ def test_mcp_tool_adapter_name_is_truncated_to_the_provider_length_limit():
     rejected by the same providers, just on length. Nothing upstream
     (MCP server name, MCP tool name) is length-bounded, so this adapter
     must enforce the limit itself instead of assuming it never comes up.
+    A tool name alone at or past the limit squeezes the prefix down to
+    nothing rather than wrapping around from the end (a negative slice
+    on the *tool* name would otherwise do exactly that).
     """
     mcp_tool = SimpleNamespace(
         name="x" * 200,
@@ -333,7 +336,40 @@ def test_mcp_tool_adapter_name_is_truncated_to_the_provider_length_limit():
     )
 
     assert len(adapter.name) == MAX_AGENT_TOOL_NAME_LENGTH
-    assert adapter.name.startswith("mcp_Coding_MCP_")
+    assert adapter.name == "x" * MAX_AGENT_TOOL_NAME_LENGTH
+
+
+def test_mcp_tool_adapter_truncation_keeps_same_server_tools_distinct():
+    """Regression: truncating the *tool name* end of `prefix + tool_name`
+    can make two distinct tools on one long-named server collapse into
+    one identical LLM-visible name once the combined length passes
+    `MAX_AGENT_TOOL_NAME_LENGTH` -- `_find_tool` (react.py) has no
+    duplicate-name detection, so the model asking for one tool would
+    silently get whichever tool happens to register first instead. MCP
+    server names are bounded at 100 (web/api/mcp.py), so 59 characters
+    -- long enough that `mcp_<server>_` alone already reaches the limit
+    -- is a length a real deployment can produce, not a contrived one.
+    The fix keeps the tool name whole and squeezes the prefix instead.
+    """
+    server = "s" * 59
+
+    def _adapter(tool_name: str) -> MCPToolAdapter:
+        return _build_mcp_tool_adapter(
+            server,
+            {"transport": "streamable_http", "url": "http://127.0.0.1:8642/mcp"},
+            SimpleNamespace(
+                name=tool_name,
+                description=tool_name,
+                inputSchema={"type": "object", "properties": {}},
+            ),
+        )
+
+    read_name = _adapter("read_file").name
+    delete_name = _adapter("delete_all_files").name
+
+    assert read_name != delete_name
+    assert read_name.endswith("read_file")
+    assert delete_name.endswith("delete_all_files")
 
 
 def test_mcp_tool_adapter_defaults_to_not_concurrency_safe():


### PR DESCRIPTION
## Summary

- `MCPToolAdapter.name` only replaced spaces and dashes when building the LLM-visible tool name, so any other disallowed character (most notably a `.` used for namespacing, e.g. `coding.start`) survived into the final name.
- OpenAI-compatible chat-completions APIs (reproduced with DeepSeek) validate `tools[].function.name` against `^[a-zA-Z0-9_-]+$` and reject the whole call with a 400 if any single tool name fails it — one bad tool name breaks every tool call in that request, not just the one tool.
- Fix: after the existing space/dash replacement, run the remaining name through `re.sub(r"[^A-Za-z0-9_-]", "_", ...)` so any other character an MCP server puts in a tool name gets sanitized the same way, without changing existing space/dash behavior.

Fixes #1340.

## Test plan

- [x] Added `test_mcp_tool_adapter_name_strips_dots_for_openai_compatible_apis` covering a dot-namespaced tool name (`coding.start`), asserting the final name matches `^[A-Za-z0-9_-]+$`.
- [x] `pytest tests/core/tools/adapters/vibe/test_mcp_adapter.py` — 69 passed.
- [x] `ruff check` / `ruff format --check` / `mypy` on the touched files — clean.
- [x] `pre-commit run --files src/xagent/core/tools/adapters/vibe/mcp_adapter.py tests/core/tools/adapters/vibe/test_mcp_adapter.py` — all hooks passed.