### PR TITLE
feat: let a new standalone task pick its execution mode

### DIFF
--- a/frontend/src/app/task/page.tsx
+++ b/frontend/src/app/task/page.tsx
@@ -32,7 +32,7 @@ function TaskHomePageContent() {
   const [selectedAgents, setSelectedAgents] = useState<AgentCard[]>([]);
   const [selectedAgentConfig, setSelectedAgentConfig] = useState<{
     model?: string;
-    executionMode?: "flash" | "balanced" | "think";
+    executionMode?: "auto" | "flash" | "balanced" | "think";
   }>();
   const [templates, setTemplates] = useState<Template[]>([]);
   const [templatesLoading, setTemplatesLoading] = useState(false);

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1134,6 +1134,7 @@ describe("ChatInput", () => {
 
   const executionModeLabel = (mode: string) =>
     `builds.configForm.executionMode.${mode}.title`
+  const UNSET_MODE_LABEL = "builds.configForm.executionMode.unset"
 
   it("sends the picked execution mode for a new standalone task", async () => {
     mockDefaultModel()
@@ -1147,7 +1148,7 @@ describe("ChatInput", () => {
       />
     )
 
-    const trigger = await screen.findByText(executionModeLabel("auto"))
+    const trigger = await screen.findByText(UNSET_MODE_LABEL)
     fireEvent.click(trigger)
     fireEvent.click(screen.getByText(executionModeLabel("think")))
     fireEvent.submit(container.querySelector("form") as HTMLFormElement)
@@ -1172,10 +1173,9 @@ describe("ChatInput", () => {
       />
     )
 
-    fireEvent.click(await screen.findByText(executionModeLabel("auto")))
-    const menuItem = screen.getAllByText(executionModeLabel("auto"))
-      .find((node) => node.closest('[role="dialog"]')) as HTMLElement
-    fireEvent.click(menuItem)
+    fireEvent.click(await screen.findByText(UNSET_MODE_LABEL))
+    fireEvent.click(screen.getByText(executionModeLabel("auto")))
+    expect(screen.getByText(executionModeLabel("auto"))).toBeInTheDocument()
     fireEvent.submit(container.querySelector("form") as HTMLFormElement)
 
     await waitFor(() => {
@@ -1198,7 +1198,7 @@ describe("ChatInput", () => {
       />
     )
 
-    await screen.findByText(executionModeLabel("auto"))
+    await screen.findByText(UNSET_MODE_LABEL)
     fireEvent.submit(container.querySelector("form") as HTMLFormElement)
 
     await waitFor(() => expect(onSend).toHaveBeenCalledOnce())
@@ -1217,7 +1217,7 @@ describe("ChatInput", () => {
       />
     )
 
-    expect(screen.queryByText(executionModeLabel("auto"))).not.toBeInTheDocument()
+    expect(screen.queryByText(UNSET_MODE_LABEL)).not.toBeInTheDocument()
   })
 
   it("drops a pick made before the picker was hidden", async () => {
@@ -1231,7 +1231,7 @@ describe("ChatInput", () => {
     }
     const { container, rerender } = render(<ChatInput {...props} />)
 
-    fireEvent.click(await screen.findByText(executionModeLabel("auto")))
+    fireEvent.click(await screen.findByText(UNSET_MODE_LABEL))
     fireEvent.click(screen.getByText(executionModeLabel("think")))
     expect(screen.getByText(executionModeLabel("think"))).toBeInTheDocument()
 
@@ -1240,7 +1240,7 @@ describe("ChatInput", () => {
     )
     rerender(<ChatInput {...props} />)
 
-    expect(screen.getByText(executionModeLabel("auto"))).toBeInTheDocument()
+    expect(screen.getByText(UNSET_MODE_LABEL)).toBeInTheDocument()
     fireEvent.submit(container.querySelector("form") as HTMLFormElement)
 
     await waitFor(() => expect(onSend).toHaveBeenCalledOnce())
@@ -1259,7 +1259,7 @@ describe("ChatInput", () => {
       />
     )
 
-    fireEvent.click(await screen.findByText(executionModeLabel("auto")))
+    fireEvent.click(await screen.findByText(UNSET_MODE_LABEL))
     expect(screen.getByText(executionModeLabel("think"))).toBeInTheDocument()
     fireEvent.submit(container.querySelector("form") as HTMLFormElement)
 
@@ -1281,7 +1281,7 @@ describe("ChatInput", () => {
       />
     )
 
-    expect(screen.queryByText(executionModeLabel("auto"))).not.toBeInTheDocument()
+    expect(screen.queryByText(UNSET_MODE_LABEL)).not.toBeInTheDocument()
   })
 
   it("hides the execution mode picker when composer config is hidden", async () => {
@@ -1296,7 +1296,7 @@ describe("ChatInput", () => {
       />
     )
 
-    expect(screen.queryByText(executionModeLabel("auto"))).not.toBeInTheDocument()
+    expect(screen.queryByText(UNSET_MODE_LABEL)).not.toBeInTheDocument()
   })
 
   it("hides the execution mode picker for an existing task and keeps its mode", async () => {

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1118,7 +1118,7 @@ describe("ChatInput", () => {
     )
   })
 
-  it("sends the picked execution mode for a new standalone task", async () => {
+  const mockDefaultModel = () => {
     apiRequestMock.mockImplementation((url: string) => {
       if (url === "http://api.local/api/models/?category=llm") {
         return Promise.resolve(
@@ -1130,6 +1130,13 @@ describe("ChatInput", () => {
       }
       return Promise.resolve(emptyJsonResponse())
     })
+  }
+
+  const executionModeLabel = (mode: string) =>
+    `builds.configForm.executionMode.${mode}.title`
+
+  it("sends the picked execution mode for a new standalone task", async () => {
+    mockDefaultModel()
     const onSend = vi.fn()
     const { container } = render(
       <ChatInput
@@ -1140,9 +1147,9 @@ describe("ChatInput", () => {
       />
     )
 
-    const trigger = await screen.findByText("builds.configForm.executionMode.auto.title")
+    const trigger = await screen.findByText(executionModeLabel("auto"))
     fireEvent.click(trigger)
-    fireEvent.click(screen.getByText("builds.configForm.executionMode.think.title"))
+    fireEvent.click(screen.getByText(executionModeLabel("think")))
     fireEvent.submit(container.querySelector("form") as HTMLFormElement)
 
     await waitFor(() => {
@@ -1153,18 +1160,8 @@ describe("ChatInput", () => {
     })
   })
 
-  it("omits the execution mode when the picker was never touched", async () => {
-    apiRequestMock.mockImplementation((url: string) => {
-      if (url === "http://api.local/api/models/?category=llm") {
-        return Promise.resolve(
-          new Response(JSON.stringify([{ model_id: "model-1", is_default: true }]), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        )
-      }
-      return Promise.resolve(emptyJsonResponse())
-    })
+  it("sends an explicitly picked auto mode", async () => {
+    mockDefaultModel()
     const onSend = vi.fn()
     const { container } = render(
       <ChatInput
@@ -1175,7 +1172,33 @@ describe("ChatInput", () => {
       />
     )
 
-    await screen.findByText("builds.configForm.executionMode.auto.title")
+    fireEvent.click(await screen.findByText(executionModeLabel("auto")))
+    const menuItem = screen.getAllByText(executionModeLabel("auto"))
+      .find((node) => node.closest('[role="dialog"]')) as HTMLElement
+    fireEvent.click(menuItem)
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        "plan a trip",
+        expect.objectContaining({ executionMode: { mode: "auto" } })
+      )
+    })
+  })
+
+  it("omits the execution mode when the picker was never touched", async () => {
+    mockDefaultModel()
+    const onSend = vi.fn()
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="plan a trip"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+      />
+    )
+
+    await screen.findByText(executionModeLabel("auto"))
     fireEvent.submit(container.querySelector("form") as HTMLFormElement)
 
     await waitFor(() => expect(onSend).toHaveBeenCalledOnce())
@@ -1183,20 +1206,97 @@ describe("ChatInput", () => {
   })
 
   it("hides the execution mode picker for a template-resolved task", async () => {
-    const onSend = vi.fn()
+    mockDefaultModel()
     render(
       <ChatInput
         hideFileUpload
         inputValue="summarize this doc"
         onInputChange={vi.fn()}
-        onSend={onSend}
+        onSend={vi.fn()}
         selectedTemplate={{ id: "doc-summarizer", name: "Doc Summarizer" }}
       />
     )
 
-    expect(
-      screen.queryByText("builds.configForm.executionMode.auto.title")
-    ).not.toBeInTheDocument()
+    expect(screen.queryByText(executionModeLabel("auto"))).not.toBeInTheDocument()
+  })
+
+  it("drops a pick made before the picker was hidden", async () => {
+    mockDefaultModel()
+    const onSend = vi.fn()
+    const props = {
+      hideFileUpload: true,
+      inputValue: "plan a trip",
+      onInputChange: vi.fn(),
+      onSend,
+    }
+    const { container, rerender } = render(<ChatInput {...props} />)
+
+    fireEvent.click(await screen.findByText(executionModeLabel("auto")))
+    fireEvent.click(screen.getByText(executionModeLabel("think")))
+    expect(screen.getByText(executionModeLabel("think"))).toBeInTheDocument()
+
+    rerender(
+      <ChatInput {...props} selectedTemplate={{ id: "doc-summarizer", name: "Doc Summarizer" }} />
+    )
+    rerender(<ChatInput {...props} />)
+
+    expect(screen.getByText(executionModeLabel("auto"))).toBeInTheDocument()
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledOnce())
+    expect(onSend.mock.calls[0][1].executionMode).toBeUndefined()
+  })
+
+  it("closes the execution mode menu after a send", async () => {
+    mockDefaultModel()
+    const onSend = vi.fn()
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="plan a trip"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+      />
+    )
+
+    fireEvent.click(await screen.findByText(executionModeLabel("auto")))
+    expect(screen.getByText(executionModeLabel("think"))).toBeInTheDocument()
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledOnce())
+    await waitFor(() => {
+      expect(screen.queryByText(executionModeLabel("think"))).not.toBeInTheDocument()
+    })
+  })
+
+  it("hides the execution mode picker when the composer config is read-only", async () => {
+    mockDefaultModel()
+    render(
+      <ChatInput
+        hideFileUpload
+        inputValue="hello"
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+        readOnlyConfig
+      />
+    )
+
+    expect(screen.queryByText(executionModeLabel("auto"))).not.toBeInTheDocument()
+  })
+
+  it("hides the execution mode picker when composer config is hidden", async () => {
+    mockDefaultModel()
+    render(
+      <ChatInput
+        hideConfig
+        hideFileUpload
+        inputValue="hello"
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText(executionModeLabel("auto"))).not.toBeInTheDocument()
   })
 
   it("hides the execution mode picker for an existing task and keeps its mode", async () => {

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1118,6 +1118,112 @@ describe("ChatInput", () => {
     )
   })
 
+  it("sends the picked execution mode for a new standalone task", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/models/?category=llm") {
+        return Promise.resolve(
+          new Response(JSON.stringify([{ model_id: "model-1", is_default: true }]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+    const onSend = vi.fn()
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="plan a trip"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+      />
+    )
+
+    const trigger = await screen.findByText("builds.configForm.executionMode.auto.title")
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByText("builds.configForm.executionMode.think.title"))
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        "plan a trip",
+        expect.objectContaining({ executionMode: { mode: "think" } })
+      )
+    })
+  })
+
+  it("omits the execution mode when the picker was never touched", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/models/?category=llm") {
+        return Promise.resolve(
+          new Response(JSON.stringify([{ model_id: "model-1", is_default: true }]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        )
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+    const onSend = vi.fn()
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="plan a trip"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+      />
+    )
+
+    await screen.findByText("builds.configForm.executionMode.auto.title")
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledOnce())
+    expect(onSend.mock.calls[0][1].executionMode).toBeUndefined()
+  })
+
+  it("hides the execution mode picker for a template-resolved task", async () => {
+    const onSend = vi.fn()
+    render(
+      <ChatInput
+        hideFileUpload
+        inputValue="summarize this doc"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+        selectedTemplate={{ id: "doc-summarizer", name: "Doc Summarizer" }}
+      />
+    )
+
+    expect(
+      screen.queryByText("builds.configForm.executionMode.auto.title")
+    ).not.toBeInTheDocument()
+  })
+
+  it("hides the execution mode picker for an existing task and keeps its mode", async () => {
+    const onSend = vi.fn()
+    const { container } = render(
+      <ChatInput
+        hideFileUpload
+        inputValue="continue"
+        onInputChange={vi.fn()}
+        onSend={onSend}
+        taskConfig={{ model: "model-1", executionMode: "flash" }}
+      />
+    )
+
+    expect(
+      screen.queryByText("builds.configForm.executionMode.auto.title")
+    ).not.toBeInTheDocument()
+    fireEvent.submit(container.querySelector("form") as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        "continue",
+        expect.objectContaining({ executionMode: { mode: "flash" } })
+      )
+    })
+  })
+
   it("keeps generic loading input disabled without a live task status", () => {
     const { container } = render(
       <ChatInput

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -595,7 +595,7 @@ export function ChatInput({
   // Only a new standalone task: the backend takes execution_mode at creation
   // only, and an agent (a template resolves into one) overrides it anyway.
   const showExecutionModePicker =
-    !compact && !hideConfig && !readOnlyConfig && !taskConfig && !selectedTemplate;
+    !hideConfig && !readOnlyConfig && !taskConfig && !selectedTemplate;
   const showLocalBrowser = Boolean(user?.is_admin) && !readOnlyConfig && !hideConfig;
   const showTaskRuntimeExtension =
     hasTaskRuntimeComposerExtension && !readOnlyConfig && !hideConfig;
@@ -603,6 +603,12 @@ export function ChatInput({
   const activeTaskRuntimeSelection = showTaskRuntimeExtension
     ? taskRuntimeSelection
     : null;
+  useEffect(() => {
+    if (!showExecutionModePicker) {
+      setPickedExecutionMode(undefined);
+      setExecutionModeMenuOpen(false);
+    }
+  }, [showExecutionModePicker]);
   useEffect(() => {
     if (!showLocalBrowser) setLocalBrowserTarget(null);
   }, [showLocalBrowser]);
@@ -751,6 +757,8 @@ export function ChatInput({
 
       await onSend(messageToSend, configToSend);
       deliveryAttemptRef.current = null;
+      setPickedExecutionMode(undefined);
+      setExecutionModeMenuOpen(false);
       setLocalBrowserTarget(null);
       setTaskRuntimeSelection(null);
       fileMention.resetMention();
@@ -1156,6 +1164,9 @@ export function ChatInput({
                       className="inline-flex h-9 items-center gap-2 rounded-xl px-3 text-xs text-muted-foreground hover:bg-secondary/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
                       disabled={isInputBusy}
                       title={t("builds.configForm.executionMode.label")}
+                      aria-label={`${t("builds.configForm.executionMode.label")}: ${t(
+                        `builds.configForm.executionMode.${pickedExecutionMode ?? "auto"}.title`
+                      )}`}
                     >
                       <Sparkles className="h-4 w-4" />
                       <span className="max-w-[150px] truncate hidden sm:inline-block">
@@ -1167,6 +1178,7 @@ export function ChatInput({
                         <button
                           key={mode}
                           type="button"
+                          aria-pressed={mode === pickedExecutionMode}
                           onClick={() => {
                             setPickedExecutionMode(mode);
                             setExecutionModeMenuOpen(false);

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -596,6 +596,11 @@ export function ChatInput({
   // only, and an agent (a template resolves into one) overrides it anyway.
   const showExecutionModePicker =
     !hideConfig && !readOnlyConfig && !taskConfig && !selectedTemplate;
+  // Unset reads as "Default", not "Auto": the server default is auto only when
+  // XAGENT_AGENT_RUNTIME is unset (config.get_default_task_execution_mode).
+  const executionModeTriggerLabel = pickedExecutionMode
+    ? t(`builds.configForm.executionMode.${pickedExecutionMode}.title`)
+    : t("builds.configForm.executionMode.unset");
   const showLocalBrowser = Boolean(user?.is_admin) && !readOnlyConfig && !hideConfig;
   const showTaskRuntimeExtension =
     hasTaskRuntimeComposerExtension && !readOnlyConfig && !hideConfig;
@@ -1164,13 +1169,11 @@ export function ChatInput({
                       className="inline-flex h-9 items-center gap-2 rounded-xl px-3 text-xs text-muted-foreground hover:bg-secondary/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
                       disabled={isInputBusy}
                       title={t("builds.configForm.executionMode.label")}
-                      aria-label={`${t("builds.configForm.executionMode.label")}: ${t(
-                        `builds.configForm.executionMode.${pickedExecutionMode ?? "auto"}.title`
-                      )}`}
+                      aria-label={`${t("builds.configForm.executionMode.label")}: ${executionModeTriggerLabel}`}
                     >
                       <Sparkles className="h-4 w-4" />
                       <span className="max-w-[150px] truncate hidden sm:inline-block">
-                        {t(`builds.configForm.executionMode.${pickedExecutionMode ?? "auto"}.title`)}
+                        {executionModeTriggerLabel}
                       </span>
                     </PopoverTrigger>
                     <PopoverContent align="start" side="top" className="w-64 space-y-0.5 p-1.5">

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -8,6 +8,7 @@ import { useI18n } from "@/contexts/i18n-context";
 import { useApp } from "@/contexts/app-context-chat";
 import { useAuth } from "@/contexts/auth-context";
 import { ConfigDialog } from "@/components/config-dialog";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { apiRequest, getUploadErrorMessage, isJsonRecord, parseApiResponse, UPLOAD_ERROR_MESSAGES } from "@/lib/api-wrapper";
 import { sanitizeFilesDisabledPresentationText } from "@/lib/files-disabled-presentation";
 import { isPausableTaskStatus, isStoppedTaskStatus, normalizeTaskStatus, type TaskStatus } from "@/lib/task-status";
@@ -106,7 +107,8 @@ interface ChatInputProps {
   deferFileUpload?: boolean;
 }
 
-type ExecutionMode = "flash" | "balanced" | "think";
+type ExecutionMode = "auto" | "flash" | "balanced" | "think";
+const EXECUTION_MODES: ExecutionMode[] = ["auto", "flash", "balanced", "think"];
 type ExecutionModeConfig = ExecutionMode | { mode: ExecutionMode };
 
 interface AgentConfig {
@@ -165,6 +167,9 @@ export function ChatInput({
   const [isFocused, setIsFocused] = useState(false);
   const [showNoModelAlert, setShowNoModelAlert] = useState(false);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  // Undefined until picked, so an untouched composer keeps the server default.
+  const [pickedExecutionMode, setPickedExecutionMode] = useState<ExecutionMode>();
+  const [executionModeMenuOpen, setExecutionModeMenuOpen] = useState(false);
   const [localBrowserTarget, setLocalBrowserTarget] =
     useState<LocalBrowserTarget | null>(null);
   const [taskRuntimeSelection, setTaskRuntimeSelection] =
@@ -587,6 +592,10 @@ export function ChatInput({
     !!isLoading &&
     !allowsLiveGuidanceInput &&
     !isStoppedTaskStatus(normalizedTaskStatus);
+  // Only a new standalone task: the backend takes execution_mode at creation
+  // only, and an agent (a template resolves into one) overrides it anyway.
+  const showExecutionModePicker =
+    !compact && !hideConfig && !readOnlyConfig && !taskConfig && !selectedTemplate;
   const showLocalBrowser = Boolean(user?.is_admin) && !readOnlyConfig && !hideConfig;
   const showTaskRuntimeExtension =
     hasTaskRuntimeComposerExtension && !readOnlyConfig && !hideConfig;
@@ -698,7 +707,9 @@ export function ChatInput({
       isSubmittingRef.current = true;
       const trimmed = message.trim();
       const messageToSend = trimmed;
-      const executionMode = taskConfig?.executionMode;
+      const executionMode = showExecutionModePicker
+        ? pickedExecutionMode
+        : taskConfig?.executionMode;
       const extraRuntimeExtensions = activeLocalBrowserTarget
         ? { local_browser: { ...activeLocalBrowserTarget } }
         : activeTaskRuntimeSelection?.runtimeExtensions;
@@ -1136,6 +1147,45 @@ export function ChatInput({
                       />
                     )}
                   </>
+                )}
+                {showExecutionModePicker && (
+                  // Popover, not ui/select: the form is overflow-hidden and clips it.
+                  <Popover open={executionModeMenuOpen} onOpenChange={setExecutionModeMenuOpen}>
+                    <PopoverTrigger
+                      type="button"
+                      className="inline-flex h-9 items-center gap-2 rounded-xl px-3 text-xs text-muted-foreground hover:bg-secondary/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                      disabled={isInputBusy}
+                      title={t("builds.configForm.executionMode.label")}
+                    >
+                      <Sparkles className="h-4 w-4" />
+                      <span className="max-w-[150px] truncate hidden sm:inline-block">
+                        {t(`builds.configForm.executionMode.${pickedExecutionMode ?? "auto"}.title`)}
+                      </span>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" side="top" className="w-64 space-y-0.5 p-1.5">
+                      {EXECUTION_MODES.map((mode) => (
+                        <button
+                          key={mode}
+                          type="button"
+                          onClick={() => {
+                            setPickedExecutionMode(mode);
+                            setExecutionModeMenuOpen(false);
+                          }}
+                          className={cn(
+                            "flex w-full flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted",
+                            mode === pickedExecutionMode && "bg-muted"
+                          )}
+                        >
+                          <span className="text-sm font-medium">
+                            {t(`builds.configForm.executionMode.${mode}.title`)}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {t(`builds.configForm.executionMode.${mode}.description`)}
+                          </span>
+                        </button>
+                      ))}
+                    </PopoverContent>
+                  </Popover>
                 )}
                 {/* Add files or bind this new task to a local host window. */}
                 {(!hideFileUpload && !filesDisabled)

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -625,7 +625,7 @@ export interface Task {
   smallFastModelName?: string
   visualModelName?: string
   compactModelName?: string
-  executionMode?: "flash" | "balanced" | "think"
+  executionMode?: "auto" | "flash" | "balanced" | "think"
   isDag?: boolean
   agentId?: number
   agentName?: string

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2523,6 +2523,7 @@ Build when you need.`,
       },
       executionMode: {
         label: "Execution Mode",
+        unset: "Default",
         auto: {
           title: "Auto",
           description: "Let the agent pick per request",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2523,6 +2523,10 @@ Build when you need.`,
       },
       executionMode: {
         label: "Execution Mode",
+        auto: {
+          title: "Auto",
+          description: "Let the agent pick per request",
+        },
         flash: {
           title: "Flash",
           description: "Simple, quick tasks",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2523,6 +2523,7 @@ const zh = {
       },
       executionMode: {
         label: "执行模式",
+        unset: "默认",
         auto: {
           title: "自动",
           description: "由智能体按请求自行选择",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2523,6 +2523,10 @@ const zh = {
       },
       executionMode: {
         label: "执行模式",
+        auto: {
+          title: "自动",
+          description: "由智能体按请求自行选择",
+        },
         flash: {
           title: "闪电模式",
           description: "简单快速的任务",


### PR DESCRIPTION
## What

The Agent Builder has an execution-mode selector, but the Task page had none: a
new standalone task always fell back to the server default (`auto`), with no way
to force flash / balanced / think.

This adds a mode picker to the composer toolbar on the Task home page.

## Scope

The picker only shows for a **new standalone task** — no selected agent, no
template, not an existing task's composer:

`!compact && !hideConfig && !readOnlyConfig && !taskConfig && !selectedTemplate`

Everything else is deliberately excluded:

- **Existing task** — the backend takes `execution_mode` at task creation only
  (`POST /api/chat/task/create`); there is no update path, so a control that
  looks live but changes nothing would be worse than no control.
- **Selected agent / agent detail page / widgets / build preview** — the agent's
  own mode wins: `resolve_task_runtime_config_core` overrides the task's mode
  with `agent_config.execution_mode` for any non-workforce agent task.
- **Template quick-access** — `handleSend` resolves the template into an agent,
  so this is the agent case above. Without this exclusion the picker would show
  and silently do nothing.

## Backend

None. `execution_mode` was already accepted at task creation, `ExecutionMode`
already has `AUTO`, and `app-context-chat` already forwarded
`config.executionMode.mode`.

## No default change

The picker starts unset rather than at `auto`, so an untouched composer still
sends no `execution_mode` and `get_default_task_execution_mode` keeps deciding
(which matters for `XAGENT_AGENT_RUNTIME=v1`, where the standalone default is
`think`, not `auto`). The button label reads "Auto" because that is the default
for the standalone runtime.

## UI note

The menu is a `Popover`, not `ui/select`: the composer form is `overflow-hidden`
for its rounded corners and clips a plain absolute dropdown. This matches the
`+` menu already sitting in the same toolbar.

## Tests

Four cases in `ChatInput.test.tsx`, each verified by mutation — dropping
`!taskConfig`, dropping `!selectedTemplate`, or hardcoding the initial mode back
to `auto` each makes one of them fail:

- picks think → sends `{ mode: "think" }`
- untouched picker → no `executionMode` in the payload
- template selected → no picker
- existing task → no picker, still forwards the task's own mode

`frontend`: lint clean, `tsc --noEmit` clean, 595 tests pass across
`components/chat`, `components/task`, `components/widget`, `app`.
