### PR TITLE
fix(steps): project dag step failures instead of reporting completion

### DIFF
--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -56,7 +56,10 @@ Pairing rule:
         but has no current producer. A per-invocation id is the only
         safe key when the same tool is called twice in the same step.
       - ``react_action_*`` events pair on ``step_id``.
-      - ``dag_step_*`` events pair on ``step_id``.
+      - ``dag_step_*`` events pair on ``step_id``. Both families'
+        end events project their own ``data['status']``: ``"failed"``
+        stays failed, anything else (including a missing key)
+        becomes ``"completed"``.
       - ``dag_plan_*`` events pair on ``task_id`` (single planning
         phase per task; no per-plan identifier available).
       - ``dag_execution`` events pair on ``data['phase']``: a
@@ -285,12 +288,17 @@ class PublicStepProjector:
                 self._pending[("thinking", key)] = step
                 return [step]
             if event_type.endswith("_end"):
+                # dag_step_end always carries its own data['status']
+                # ("failed" or "completed"); react_action_end has no
+                # current producer but is covered by the same rule for
+                # when one appears. A missing key defaults to
+                # "completed" -- see _terminal_status_from_event.
                 finalized = _finalize_pending(
                     self._pending,
                     self._finished,
                     ("thinking", key),
                     end_event=event,
-                    status="completed",
+                    status=_terminal_status_from_event(event),
                 )
                 return [finalized] if finalized is not None else []
             # Events in these families that are neither a start nor an
@@ -642,6 +650,20 @@ def _build_message_step(event: Any, *, role: str) -> Dict[str, Any]:
 
 
 # ===== shared finalization =====
+
+
+def _terminal_status_from_event(event: Any) -> str:
+    """Project a thinking-family end event's own ``data['status']``.
+
+    ``dag_step_end`` (and, theoretically, ``react_action_end``) carries
+    the step's own terminal status: ``"failed"`` or ``"completed"``. We
+    surface it as-is, mapping anything other than the literal string
+    ``"failed"`` -- including a missing key -- to ``"completed"``. Every
+    current ``dag_step_end`` producer sets the field explicitly; the
+    completed fallback only guards a malformed or legacy event, not a
+    real failure being swallowed.
+    """
+    return "failed" if _data_get(event, "status") == "failed" else "completed"
 
 
 def _finalize_pending(

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -55,11 +55,20 @@ Pairing rule:
         ``tool_execution_id`` is accepted ahead of it for compatibility
         but has no current producer. A per-invocation id is the only
         safe key when the same tool is called twice in the same step.
-      - ``react_action_*`` events pair on ``step_id``.
-      - ``dag_step_*`` events pair on ``step_id``. Both families'
-        end events project their own ``data['status']``: ``"failed"``
-        stays failed, anything else (including a missing key)
-        becomes ``"completed"``.
+      - ``react_action_*`` events pair on ``step_id``. ``react_action_end``
+        has no current producer -- the (ACTION, END, REACT) combination
+        is unreachable in this codebase today -- so the rule below is
+        untested for this family, not an observed fact.
+      - ``dag_step_*`` events pair on ``step_id``. Its end events
+        project their own ``data['status']``: ``"failed"`` stays
+        failed, anything else (including a missing key) becomes
+        ``"completed"``. ``react_action_end`` would be folded through
+        this same rule if one were ever emitted, but the rest of the
+        ACTION family (``tool_execution_end``, below) instead reads
+        ``data['success']`` -- so a future ``react_action_end``
+        producer that follows that existing sibling convention rather
+        than ``dag_step_*``'s would have its failures silently
+        projected as ``"completed"``.
       - ``dag_plan_*`` events pair on ``task_id`` (single planning
         phase per task; no per-plan identifier available).
       - ``dag_execution`` events pair on ``data['phase']``: a
@@ -293,6 +302,10 @@ class PublicStepProjector:
                 # current producer but is covered by the same rule for
                 # when one appears. A missing key defaults to
                 # "completed" -- see _terminal_status_from_event.
+                # No extra_data_fn here on purpose: a failed thinking
+                # step doesn't carry an "error" field. Its data shape
+                # is the existing contract ({"phase": ...} only), unlike
+                # the tool family below, which does attach "error".
                 finalized = _finalize_pending(
                     self._pending,
                     self._finished,

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -678,7 +678,9 @@ class PublicStep(BaseModel):
         description=(
             "running while the corresponding end event has not yet "
             "fired, completed on a normal end event, failed when the "
-            "end event carries success=false. A task in a terminal "
+            "end event reports failure (success=false or a dedicated "
+            "*_failed event for tool events, status='failed' for step "
+            "events). A task in a terminal "
             "state can still contain running steps: interrupted or "
             "cancelled steps never get an end event, so terminal "
             "state is judged from the task's own status, not from "

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -634,8 +634,11 @@ PublicStepType = Literal["thinking", "tool_call", "agent_delegation", "message"]
 
 # ``running`` means a start event was seen with no matching end; a
 # terminal task can still contain running steps (interrupted/cancelled
-# steps never get an end event). ``completed`` / ``failed`` reflect
-# the end event's success flag.
+# steps never get an end event). ``completed`` / ``failed`` are read
+# off the end event, but the field that carries the outcome differs by
+# family: tool events use ``success`` (or a dedicated ``*_failed``
+# event), step events use their own ``data['status']``. See the
+# ``PublicStep.status`` field description below for the full rule.
 PublicStepStatus = Literal["running", "completed", "failed"]
 
 

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -145,6 +145,32 @@ def test_dag_step_end_missing_status_key_defaults_to_completed():
     assert steps[0]["status"] == "completed"
 
 
+@pytest.mark.parametrize("raw_status", ["interrupted", "cancelled", None])
+def test_dag_step_end_unrecognized_status_falls_back_to_completed(raw_status):
+    """Any ``data['status']`` other than the literal ``"failed"`` must
+    fold to ``"completed"`` -- not pass through verbatim. This pins the
+    fallback against a refactor that swaps the dedicated helper for a
+    direct ``_data_get(event, "status", "completed")`` passthrough:
+    the three existing status tests above (``"failed"``, ``"completed"``,
+    missing key) all coincide with a passthrough's output and would
+    stay green even if an unrecognized value like ``"interrupted"``
+    leaked straight into ``PublicStepStatus``, which does not accept it.
+    """
+    data = {} if raw_status is None else {"status": raw_status}
+    events = [
+        _ev("dag_step_start", step_id="s2"),
+        _ev(
+            "dag_step_end",
+            step_id="s2",
+            data=data,
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 1
+    assert steps[0]["status"] == "completed"
+
+
 def test_dag_plan_pair_becomes_thinking_planning():
     events = [
         _ev("dag_plan_start", task_id="t1"),

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -101,6 +101,50 @@ def test_dag_step_pair_becomes_thinking_step():
     assert steps[0]["data"]["phase"] == "step"
 
 
+def test_dag_step_end_with_failed_status_projects_failed():
+    events = [
+        _ev("dag_step_start", step_id="s2"),
+        _ev(
+            "dag_step_end",
+            step_id="s2",
+            data={"status": "failed", "error": "boom"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 1
+    assert steps[0]["status"] == "failed"
+
+
+def test_dag_step_end_with_completed_status_projects_completed():
+    events = [
+        _ev("dag_step_start", step_id="s2"),
+        _ev(
+            "dag_step_end",
+            step_id="s2",
+            data={"status": "completed"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 1
+    assert steps[0]["status"] == "completed"
+
+
+def test_dag_step_end_missing_status_key_defaults_to_completed():
+    events = [
+        _ev("dag_step_start", step_id="s2"),
+        _ev(
+            "dag_step_end",
+            step_id="s2",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ]
+    steps = map_trace_events_to_public_steps(events)
+    assert len(steps) == 1
+    assert steps[0]["status"] == "completed"
+
+
 def test_dag_plan_pair_becomes_thinking_planning():
     events = [
         _ev("dag_plan_start", task_id="t1"),
@@ -727,6 +771,15 @@ _PROJECTOR_EQUIVALENCE_CASES: Dict[str, List[SimpleNamespace]] = {
             timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
         ),
     ],
+    "dag_step_failed": [
+        _ev("dag_step_start", step_id="s2f"),
+        _ev(
+            "dag_step_end",
+            step_id="s2f",
+            data={"status": "failed", "error": "boom"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ],
     "dag_plan_pair": [
         _ev("dag_plan_start", task_id="t1"),
         _ev(
@@ -1071,10 +1124,10 @@ def test_projector_equivalent_to_batch(events):
     stays a pure driver over the projector, never a second copy of
     the folding logic.
 
-    Literal output shapes per event family are already pinned by this
-    file's 23 direct-call tests above, which now exercise the
-    projector itself. What this test guards instead is that the batch
-    driver never grows a second, independent folding implementation.
+    Literal output shapes per event family are already pinned by the
+    direct-call tests above, which now exercise the projector itself.
+    What this test guards instead is that the batch driver never grows
+    a second, independent folding implementation.
     """
     expected = map_trace_events_to_public_steps(events)
     projected = PublicStepProjector.from_history(events).materialized_steps()


### PR DESCRIPTION
## Why

`dag_step_end` carries the step's own terminal status in `data['status']` — `'failed'` or `'completed'` — but the public step projector's thinking-family end branch hardcoded `status='completed'`. A DAG step that actually failed was reported to SDK and API consumers as completed.

## What

The end branch now projects the status the event itself reports. Anything other than the literal `'failed'`, including a missing key, maps to `completed`: every current producer sets the field explicitly, so the fallback only guards a malformed or legacy row rather than swallowing a real failure. The `status` field description is updated to name both failure signals — `success=false` (or a dedicated `*_failed` event) for tool events, `status='failed'` for step events.

## Backfill note

Existing tasks are affected too, since `steps()` replays the same projection. A task whose DAG step took a failure path will read `failed` instead of `completed` once the response cache (30s by default) expires. This is not a contract change: `failed` has always been part of `PublicStepStatus`; DAG steps simply never produced it before.

## Verification

Three cases added to `test_steps_mapping.py`: `status='failed'` projects failed, `status='completed'` projects completed, and a missing `status` key projects completed (pinning the fallback direction). A failed-step fixture was added to the projector/batch equivalence set so the new behavior is pinned on both the incremental and batch paths. Full `tests/web/api/v1` suite green.
