### PR TITLE
Add a team-keyed shared MCP env hook, separate from the user-keyed one

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -1160,6 +1160,14 @@ class ToolFactory:
                     UserMCPServer, MCPServer.id == UserMCPServer.mcpserver_id
                 ).filter(UserMCPServer.user_id == user_id, UserMCPServer.is_active)
 
+            # This shared layer is resolved purely on user_id and is
+            # outside team governance: the query above is already
+            # restricted to the user's own active links, so no team-owned
+            # server reaches it today, and this classmethod has no
+            # production caller. Broadening either of those -- a caller in
+            # src/, or a query that admits team-owned servers -- means this
+            # path must first re-key the shared layer onto the governing
+            # team the way the web tool-config loader does.
             user_env_overrides = load_user_env_overrides(db, user_id)
             shared_env_overrides = load_shared_env_overrides(db, user_id)
             env_source_overrides = load_user_env_sources(db, user_id)

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -72,7 +72,14 @@ class TeamConnectorVisibilityHook(Protocol):
     MCP transports, a team-owned server with no personal link for the
     running user executes using the shared definition row's own stored
     credentials, not the runner's. (OAuth transports fail closed instead,
-    for lack of a token to resolve.) Custom APIs are starker: there is no
+    for lack of a token to resolve.) For stdio specifically, the shared env
+    layer a team-owned server resolves is keyed on the team this hook
+    answers for -- the team that owns the *governing agent* -- never on any
+    other team, including one the running user happens to belong to: when
+    the governing team has no stored row for that server, there is no
+    shared layer at all, and a runner whose own env-source pick is
+    "shared" falls back to their own stored key instead of silently
+    borrowing another team's row. Custom APIs are starker: there is no
     per-member credential override layer at all, and no transport-level
     exception either -- every custom API always executes with whatever is
     stored on its shared definition row (headers, a static API key, and so

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -72,14 +72,25 @@ class TeamConnectorVisibilityHook(Protocol):
     MCP transports, a team-owned server with no personal link for the
     running user executes using the shared definition row's own stored
     credentials, not the runner's. (OAuth transports fail closed instead,
-    for lack of a token to resolve.) For stdio specifically, the shared env
-    layer a team-owned server resolves is keyed on the team this hook
-    answers for -- the team that owns the *governing agent* -- never on any
-    other team, including one the running user happens to belong to: when
-    the governing team has no stored row for that server, there is no
-    shared layer at all, and a runner whose own env-source pick is
-    "shared" falls back to their own stored key instead of silently
-    borrowing another team's row. Custom APIs are starker: there is no
+    for lack of a token to resolve.) For stdio specifically, **once an
+    application has also installed the separate, credential-side hook**
+    (``mcp_runtime.set_mcp_team_env_hook`` -- a different socket from this
+    one, installed independently), the shared env layer a team-owned
+    server resolves is keyed on the team this hook answers for -- the team
+    that owns the *governing agent* -- never on any other team, including
+    one the running user happens to belong to: when the governing team has
+    no stored row for that server, there is no shared layer at all, and a
+    runner whose own env-source pick is "shared" falls back to their own
+    stored key instead of silently borrowing another team's row. An
+    application that installs only this visibility hook, without also
+    installing ``set_mcp_team_env_hook``, gets none of that: the shared env
+    layer then still resolves however the pre-existing, user-keyed
+    ``set_mcp_shared_env_hook`` was wired, which can and typically does key
+    on the *running user's own* team rather than the governing one --
+    exactly the cross-team leak the paragraph above describes as closed.
+    Deciding to share a team-owned MCP server through this hook is a
+    visibility decision only; closing the credential leak is a second,
+    separate installation step. Custom APIs are starker: there is no
     per-member credential override layer at all, and no transport-level
     exception either -- every custom API always executes with whatever is
     stored on its shared definition row (headers, a static API key, and so

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import logging
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Iterator, Protocol
 
+from ...core.tools.adapters.vibe.connector_runtime import (
+    ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+    ConnectorRuntimeError,
+)
 from .mcp_oauth import MCPOAuthRuntimeError, resolve_mcp_oauth_runtime_auth
 
 HTTP_MCP_TRANSPORTS = frozenset({"sse", "websocket", "streamable_http"})
@@ -96,6 +102,139 @@ def load_shared_env_overrides(db: Any, user_id: int | None) -> dict[int, dict]:
 
         logging.getLogger(__name__).exception("shared env hook failed")
         return {}
+
+
+class TeamMCPEnvHook(Protocol):
+    """Resolver for a team's own shared MCP env overrides, keyed by server id.
+
+    Typed as a ``Protocol`` with a keyword-only ``team_id`` for the same
+    reason ``TeamConnectorVisibilityHook`` (the visibility twin in
+    connector_team_scope.py) is: this hook and the user-keyed
+    ``_get_mcp_shared_env_hook`` above are otherwise structurally
+    identical -- ``(db, id) -> {mcpserver_id: {env}}`` -- and a swapped
+    install would type-check while resolving an unrelated team's or
+    user's env.
+    """
+
+    def __call__(self, db: Any, *, team_id: int) -> dict[int, dict]: ...
+
+
+# Hook signature: (db, *, team_id) -> {mcpserver_id: {env}}. Deliberately a
+# separate module-global slot from _get_mcp_shared_env_hook, not a keyword on
+# set_mcp_shared_env_hook: the two hooks answer different questions -- "did
+# the application register anything shared at all" (user-keyed, default:
+# none) versus "does THIS SPECIFIC governing team have a row" (team-keyed,
+# authorization-relevant) -- and load_shared_env_overrides's failure policy
+# (degrade to no shared layer) would hide a signature TypeError or a
+# malformed answer from this hook instead of surfacing it.
+_get_mcp_team_env_hook: TeamMCPEnvHook | None = None
+
+
+def set_mcp_team_env_hook(hook: TeamMCPEnvHook | None) -> None:
+    global _get_mcp_team_env_hook
+    _get_mcp_team_env_hook = hook
+
+
+def team_env_hook_installed() -> bool:
+    """Whether an application installed a team-keyed env hook.
+
+    Callers select on this, never on an empty return value: an installed
+    hook legitimately answers empty for a team that stored nothing for any
+    server (see load_team_env_overrides).
+    """
+    return _get_mcp_team_env_hook is not None
+
+
+def _validate_team_mcp_env_answer(answer: Any) -> dict[int, dict]:
+    """Validate the team-env hook's answer shape.
+
+    This is an authorization input, not user-facing data: a malformed
+    answer must fail loudly, never be normalized, coerced, or defaulted to
+    empty -- the same stance connector_team_scope's
+    ``_validate_team_connector_answer`` takes for the visibility twin. The
+    hook must return a ``dict`` whose keys are all ``int`` server ids
+    (``bool`` is a subclass of ``int`` in Python but is rejected here -- a
+    truthy/falsy value is never a legitimate server id) and whose values
+    are all ``dict`` env mappings.
+    """
+    if not isinstance(answer, dict):
+        raise ValueError(
+            "team env hook returned a malformed answer: expected a dict, "
+            f"got {type(answer).__name__}"
+        )
+    for key, value in answer.items():
+        if isinstance(key, bool) or not isinstance(key, int):
+            raise ValueError(
+                "team env hook returned a malformed answer: key "
+                f"{key!r} is not a server id (must be int, not bool)"
+            )
+        if not isinstance(value, dict):
+            raise ValueError(
+                "team env hook returned a malformed answer: value for key "
+                f"{key!r} must be a dict, got {type(value).__name__}"
+            )
+    # Defensive copy at the authorization boundary: the caller must not be
+    # able to mutate the installing application's own answer object (or
+    # vice versa). Shallow is sufficient -- every downstream consumer only
+    # ever reads the inner per-server env dicts, never mutates them in
+    # place (see the shallow-copy note in config.py's wiring block).
+    return dict(answer)
+
+
+def load_team_env_overrides(db: Any, team_id: int | None) -> dict[int, dict]:
+    """Batch-load a governing team's own shared MCP env overrides, keyed by
+    server id.
+
+    Unlike load_shared_env_overrides, this loader's failure policy is
+    raise, not degrade: any hook exception and any answer shape violation
+    becomes a typed ConnectorRuntimeError instead of silently falling back
+    to no shared layer. A misbehaving hook here must not be
+    indistinguishable from "the governing team legitimately has no row" --
+    the caller (config.py's wiring) already treats the latter as a
+    deliberate, signal-losing degrade of its own; collapsing hook failure
+    into the same outcome would double that loss silently.
+    """
+    if team_id is None or _get_mcp_team_env_hook is None:
+        return {}
+    try:
+        answer = _get_mcp_team_env_hook(db, team_id=team_id)
+        return _validate_team_mcp_env_answer(answer)
+    except ConnectorRuntimeError:
+        raise
+    except Exception as exc:
+        logging.getLogger(__name__).warning("team env hook failed", exc_info=True)
+        raise ConnectorRuntimeError(
+            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+            "Team MCP env is unavailable.",
+            details={"reason": "team_env_resolution_failed"},
+            status_code=503,
+        ) from exc
+
+
+@contextmanager
+def mcp_env_hooks_snapshot() -> Iterator[None]:
+    """Save every env hook slot in this module on entry, restore all of
+    them on exit.
+
+    Covers both the pre-existing shared (user-keyed) slot and the
+    team-keyed slot above, so a test that installs either hook is
+    restored to the pre-entry state deterministically without reaching
+    past the public setters. A hook slot added to this module later,
+    following the same ``_get_mcp_*_hook`` naming pattern as the two
+    above, that is not added here as well fails the coverage test in
+    tests/web/services/test_mcp_team_env_hook.py, by design -- see that
+    module's docstring rule. A slot that breaks the naming pattern is
+    outside what that coverage test can discover and must be added here
+    by hand.
+    """
+    global _get_mcp_shared_env_hook, _get_mcp_team_env_hook
+    saved_shared = _get_mcp_shared_env_hook
+    saved_team = _get_mcp_team_env_hook
+    try:
+        yield
+    finally:
+        _get_mcp_shared_env_hook = saved_shared
+        _get_mcp_team_env_hook = saved_team
 
 
 CALLER_ID_ENV_VAR = "XAGENT_MCP_CALLER_ID"

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -75,7 +75,10 @@ def load_user_env_sources(db: Any, user_id: int | None) -> dict[int, str]:
 # Hook signature: (db, user_id) -> {mcpserver_id: {env}}. An application layer
 # (e.g. a multi-tenant deployment) can inject a shared env layer that sits between
 # the global and per-user env via set_mcp_shared_env_hook(). The core is agnostic
-# to what "shared" means (team, org, ...); default: no shared layer.
+# to what "shared" means (team, org, ...); default: no shared layer. For team
+# semantics specifically -- keying the shared layer on the team that owns the
+# governing agent, rather than on the running user -- install the separate,
+# team-keyed socket below instead: see set_mcp_team_env_hook.
 _get_mcp_shared_env_hook: Callable[[Any, int | None], dict[int, dict]] | None = None
 
 
@@ -163,10 +166,16 @@ def _validate_team_mcp_env_answer(answer: Any) -> dict[int, dict]:
             f"got {type(answer).__name__}"
         )
     for key, value in answer.items():
-        if isinstance(key, bool) or not isinstance(key, int):
+        if isinstance(key, bool):
             raise ValueError(
                 "team env hook returned a malformed answer: key "
                 f"{key!r} is not a server id (must be int, not bool)"
+            )
+        if not isinstance(key, int):
+            raise ValueError(
+                "team env hook returned a malformed answer: key "
+                f"{key!r} is not a server id (must be int, got "
+                f"{type(key).__name__})"
             )
         if not isinstance(value, dict):
             raise ValueError(
@@ -197,12 +206,14 @@ def load_team_env_overrides(db: Any, team_id: int | None) -> dict[int, dict]:
     if team_id is None or _get_mcp_team_env_hook is None:
         return {}
     try:
-        answer = _get_mcp_team_env_hook(db, team_id=team_id)
+        answer = _get_mcp_team_env_hook(db, team_id=int(team_id))
         return _validate_team_mcp_env_answer(answer)
     except ConnectorRuntimeError:
         raise
     except Exception as exc:
-        logging.getLogger(__name__).warning("team env hook failed", exc_info=True)
+        logging.getLogger(__name__).warning(
+            "team env hook failed for team %s", team_id, exc_info=True
+        )
         raise ConnectorRuntimeError(
             ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
             "Team MCP env is unavailable.",

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -158,7 +158,14 @@ def _validate_team_mcp_env_answer(answer: Any) -> dict[int, dict]:
     hook must return a ``dict`` whose keys are all ``int`` server ids
     (``bool`` is a subclass of ``int`` in Python but is rejected here -- a
     truthy/falsy value is never a legitimate server id) and whose values
-    are all ``dict`` env mappings.
+    are all ``dict`` env mappings whose own keys and values are all
+    ``str``: this env eventually becomes a subprocess environment, where a
+    non-string surfaces as an unclassified failure at spawn time rather
+    than as the typed error this boundary promises. There is no ``bool``
+    special case on the inner side, unlike the server-id keys above,
+    because ``bool`` is not a ``str`` subclass and is already rejected.
+    A malformed env value's own content is never formatted into the error
+    message -- these are credentials.
     """
     if not isinstance(answer, dict):
         raise ValueError(
@@ -182,6 +189,19 @@ def _validate_team_mcp_env_answer(answer: Any) -> dict[int, dict]:
                 "team env hook returned a malformed answer: value for key "
                 f"{key!r} must be a dict, got {type(value).__name__}"
             )
+        for env_key, env_value in value.items():
+            if not isinstance(env_key, str):
+                raise ValueError(
+                    "team env hook returned a malformed answer: env key "
+                    f"{env_key!r} under server id {key!r} is not a string "
+                    f"(got {type(env_key).__name__})"
+                )
+            if not isinstance(env_value, str):
+                raise ValueError(
+                    "team env hook returned a malformed answer: env value "
+                    f"for env key {env_key!r} under server id {key!r} is "
+                    f"not a string (got {type(env_value).__name__})"
+                )
     # Defensive copy at the authorization boundary: the caller must not be
     # able to mutate the installing application's own answer object (or
     # vice versa). Shallow is sufficient -- every downstream consumer only
@@ -202,12 +222,26 @@ def load_team_env_overrides(db: Any, team_id: int | None) -> dict[int, dict]:
     the caller (config.py's wiring) already treats the latter as a
     deliberate, signal-losing degrade of its own; collapsing hook failure
     into the same outcome would double that loss silently.
+
+    A row whose env mapping is empty is dropped here rather than passed on:
+    an empty mapping carries nothing, and letting it through as "the team
+    has a row" would make storing an empty row strictly worse for the
+    runner than storing nothing at all -- the caller's row-present branch
+    keeps a "shared" pick that then merges nothing, pinning the run to the
+    global env, whereas a missing row degrades that pick and lets the
+    runner's own key through. load_user_env_overrides above applies the
+    same convention to a per-user override that decrypts to an empty
+    mapping.
     """
-    if team_id is None or _get_mcp_team_env_hook is None:
+    if db is None or team_id is None or _get_mcp_team_env_hook is None:
         return {}
     try:
         answer = _get_mcp_team_env_hook(db, team_id=int(team_id))
-        return _validate_team_mcp_env_answer(answer)
+        validated = _validate_team_mcp_env_answer(answer)
+        # Validate first, then drop rows whose env mapping is empty. The
+        # order matters: dropping first would let a malformed server-id key
+        # with an empty value escape the shape check entirely.
+        return {server_id: env for server_id, env in validated.items() if env}
     except ConnectorRuntimeError:
         raise
     except Exception as exc:

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -148,6 +148,40 @@ def team_env_hook_installed() -> bool:
     return _get_mcp_team_env_hook is not None
 
 
+_team_env_hook_missing_warned = False
+
+
+def warn_team_env_hook_missing_once(*, team_id: int, connector_count: int) -> None:
+    """Warn, once per process, that team-owned connectors are in scope while
+    no team-keyed env hook is installed.
+
+    An application that installed the connector visibility hook but not
+    set_mcp_team_env_hook keeps the pre-existing, user-keyed shared env
+    layer for team-owned servers, which resolves on whatever that hook was
+    wired to -- typically the running user's own team, not the team that
+    owns the governing agent. That is a half-installed state, and it is the
+    only state this warns about: an application that installs neither hook
+    never reaches this call, because without the visibility hook no server
+    is ever team-owned and the caller's own scope check is already empty.
+
+    Once per process rather than once per run: the condition is an
+    installation fact that cannot change while the process is up, so
+    repeating it per run would add volume without adding signal.
+    """
+    global _team_env_hook_missing_warned
+    if _team_env_hook_missing_warned:
+        return
+    _team_env_hook_missing_warned = True
+    logging.getLogger(__name__).warning(
+        "Team-owned MCP connectors are in scope (team_id=%s, %s connector(s)) "
+        "but no team-keyed env hook is installed: their shared env layer "
+        "stays keyed on the running user, not on the team that owns the "
+        "governing agent (see set_mcp_team_env_hook)",
+        team_id,
+        connector_count,
+    )
+
+
 def _validate_team_mcp_env_answer(answer: Any) -> dict[int, dict]:
     """Validate the team-env hook's answer shape.
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3513,6 +3513,7 @@ class WebToolConfig(BaseToolConfig):
                 load_user_env_overrides,
                 load_user_env_sources,
                 team_env_hook_installed,
+                warn_team_env_hook_missing_once,
             )
 
             servers = self._visible_mcp_server_query(team_mcp_ids).all()
@@ -3531,50 +3532,55 @@ class WebToolConfig(BaseToolConfig):
 
             # Re-key the shared env layer, for team-owned ids only, onto the
             # governing team's own row -- never the run owner's team, and
-            # never any other team's. Guarded on all three of
-            # connector_team_id, the installed predicate, and a non-empty
-            # team_mcp_ids so a run that touches none of this pays no team
-            # query at all.
-            if (
-                self._connector_team_id is not None
-                and team_env_hook_installed()
-                and team_mcp_ids
-            ):
-                team_env_by_id = load_team_env_overrides(
-                    self.db, self._connector_team_id
-                )
-                # Never mutate the loader-returned mappings in place: either
-                # may be the object a hook keeps its own reference to.
-                # Shallow copies of the outer dict are sufficient because
-                # every downstream consumer only reads the inner per-server
-                # values -- resolve_stdio_env's lookups, and this file's own
-                # per-server env merge in _build_mcp_server_config's stdio
-                # branch (an unconditional-overwrite `{**a, **b}` merge) --
-                # neither assigns back into shared_env_by_id or
-                # env_source_by_id. (mcp_runtime.build_mcp_runtime_connection
-                # has its own caller-id merge, but this method's own call to
-                # it, in the delegated/OAuth branch above, never passes these
-                # two maps, so it never reads them at all here.)
-                shared_env_by_id = dict(shared_env_by_id)
-                env_source_by_id = dict(env_source_by_id)
-                for server_id in team_mcp_ids:
-                    if server_id in team_env_by_id:
-                        shared_env_by_id[server_id] = team_env_by_id[server_id]
-                    else:
-                        shared_env_by_id.pop(server_id, None)
-                        if env_source_by_id.get(server_id) == "shared":
-                            # Unconditional, not only when the pop above
-                            # removed something: firing it only on an actual
-                            # removal would make a non-member runner's
-                            # outcome depend on whether the RUNNER'S OWN team
-                            # happens to hold a row for this server -- the
-                            # exact cross-team influence this seam forbids,
-                            # re-entering through a side door. Unconditional,
-                            # the outcome depends on exactly three inputs:
-                            # the governing team's row, the runner's own key,
-                            # and this pick -- the runner's own team's rows
-                            # never enter the computation.
-                            del env_source_by_id[server_id]
+            # never any other team's. The outer condition is the scope test:
+            # a run with no governing team, or one whose governing team owns
+            # nothing visible here, pays no team query at all. The inner
+            # condition then decides between re-keying and reporting that
+            # the credential-side hook was never installed -- the shared
+            # layer stays user-keyed in that state, which is exactly the
+            # cross-team influence this block exists to remove.
+            if self._connector_team_id is not None and team_mcp_ids:
+                if not team_env_hook_installed():
+                    warn_team_env_hook_missing_once(
+                        team_id=self._connector_team_id,
+                        connector_count=len(team_mcp_ids),
+                    )
+                else:
+                    team_env_by_id = load_team_env_overrides(
+                        self.db, self._connector_team_id
+                    )
+                    # Never mutate the loader-returned mappings in place: either
+                    # may be the object a hook keeps its own reference to.
+                    # Shallow copies of the outer dict are sufficient because
+                    # every downstream consumer only reads the inner per-server
+                    # values -- resolve_stdio_env's lookups, and this file's own
+                    # per-server env merge in _build_mcp_server_config's stdio
+                    # branch (an unconditional-overwrite `{**a, **b}` merge) --
+                    # neither assigns back into shared_env_by_id or
+                    # env_source_by_id. (mcp_runtime.build_mcp_runtime_connection
+                    # has its own caller-id merge, but this method's own call to
+                    # it, in the delegated/OAuth branch above, never passes these
+                    # two maps, so it never reads them at all here.)
+                    shared_env_by_id = dict(shared_env_by_id)
+                    env_source_by_id = dict(env_source_by_id)
+                    for server_id in team_mcp_ids:
+                        if server_id in team_env_by_id:
+                            shared_env_by_id[server_id] = team_env_by_id[server_id]
+                        else:
+                            shared_env_by_id.pop(server_id, None)
+                            if env_source_by_id.get(server_id) == "shared":
+                                # Unconditional, not only when the pop above
+                                # removed something: firing it only on an actual
+                                # removal would make a non-member runner's
+                                # outcome depend on whether the RUNNER'S OWN team
+                                # happens to hold a row for this server -- the
+                                # exact cross-team influence this seam forbids,
+                                # re-entering through a side door. Unconditional,
+                                # the outcome depends on exactly three inputs:
+                                # the governing team's row, the runner's own key,
+                                # and this pick -- the runner's own team's rows
+                                # never enter the computation.
+                                del env_source_by_id[server_id]
         except ConnectorRuntimeError:
             raise
         except Exception as error:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3547,12 +3547,14 @@ class WebToolConfig(BaseToolConfig):
                 # may be the object a hook keeps its own reference to.
                 # Shallow copies of the outer dict are sufficient because
                 # every downstream consumer only reads the inner per-server
-                # values -- resolve_stdio_env's lookups, this file's own
+                # values -- resolve_stdio_env's lookups, and this file's own
                 # per-server env merge in _build_mcp_server_config's stdio
-                # branch, and mcp_runtime.build_mcp_runtime_connection's
-                # caller-id env merge (both of the latter two are
-                # unconditional-overwrite `{**a, **b}` merges) -- none of
-                # them assign back into shared_env_by_id or env_source_by_id.
+                # branch (an unconditional-overwrite `{**a, **b}` merge) --
+                # neither assigns back into shared_env_by_id or
+                # env_source_by_id. (mcp_runtime.build_mcp_runtime_connection
+                # has its own caller-id merge, but this method's own call to
+                # it, in the delegated/OAuth branch above, never passes these
+                # two maps, so it never reads them at all here.)
                 shared_env_by_id = dict(shared_env_by_id)
                 env_source_by_id = dict(env_source_by_id)
                 for server_id in team_mcp_ids:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3485,7 +3485,11 @@ class WebToolConfig(BaseToolConfig):
     async def _load_mcp_server_configs(self) -> List[Dict[str, Any]]:
         """Load MCP server configurations visible to this run: the user's
         personal servers, unioned with the governing agent's team-owned
-        servers when a team-scope hook is installed."""
+        servers when a team-scope hook is installed. For each team-owned
+        server id, this method also re-keys the shared env layer onto the
+        governing team's own row -- see the team-env block below -- instead
+        of leaving the shared layer keyed on the run owner's personal
+        shared-env hook answer."""
         self._mcp_oauth_diagnostics = []
         self._reset_mcp_config_load_cache_state()
 
@@ -3505,8 +3509,10 @@ class WebToolConfig(BaseToolConfig):
         try:
             from ..services.mcp_runtime import (
                 load_shared_env_overrides,
+                load_team_env_overrides,
                 load_user_env_overrides,
                 load_user_env_sources,
+                team_env_hook_installed,
             )
 
             servers = self._visible_mcp_server_query(team_mcp_ids).all()
@@ -3522,6 +3528,51 @@ class WebToolConfig(BaseToolConfig):
             user_env_by_id = load_user_env_overrides(self.db, self._user_id)
             shared_env_by_id = load_shared_env_overrides(self.db, self._user_id)
             env_source_by_id = load_user_env_sources(self.db, self._user_id)
+
+            # Re-key the shared env layer, for team-owned ids only, onto the
+            # governing team's own row -- never the run owner's team, and
+            # never any other team's. Guarded on all three of
+            # connector_team_id, the installed predicate, and a non-empty
+            # team_mcp_ids so a run that touches none of this pays no team
+            # query at all.
+            if (
+                self._connector_team_id is not None
+                and team_env_hook_installed()
+                and team_mcp_ids
+            ):
+                team_env_by_id = load_team_env_overrides(
+                    self.db, self._connector_team_id
+                )
+                # Never mutate the loader-returned mappings in place: either
+                # may be the object a hook keeps its own reference to.
+                # Shallow copies of the outer dict are sufficient because
+                # every downstream consumer only reads the inner per-server
+                # values -- resolve_stdio_env's lookups, this file's own
+                # per-server env merge in _build_mcp_server_config's stdio
+                # branch, and mcp_runtime.build_mcp_runtime_connection's
+                # caller-id env merge (both of the latter two are
+                # unconditional-overwrite `{**a, **b}` merges) -- none of
+                # them assign back into shared_env_by_id or env_source_by_id.
+                shared_env_by_id = dict(shared_env_by_id)
+                env_source_by_id = dict(env_source_by_id)
+                for server_id in team_mcp_ids:
+                    if server_id in team_env_by_id:
+                        shared_env_by_id[server_id] = team_env_by_id[server_id]
+                    else:
+                        shared_env_by_id.pop(server_id, None)
+                        if env_source_by_id.get(server_id) == "shared":
+                            # Unconditional, not only when the pop above
+                            # removed something: firing it only on an actual
+                            # removal would make a non-member runner's
+                            # outcome depend on whether the RUNNER'S OWN team
+                            # happens to hold a row for this server -- the
+                            # exact cross-team influence this seam forbids,
+                            # re-entering through a side door. Unconditional,
+                            # the outcome depends on exactly three inputs:
+                            # the governing team's row, the runner's own key,
+                            # and this pick -- the runner's own team's rows
+                            # never enter the computation.
+                            del env_source_by_id[server_id]
         except ConnectorRuntimeError:
             raise
         except Exception as error:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3549,18 +3549,20 @@ class WebToolConfig(BaseToolConfig):
                     team_env_by_id = load_team_env_overrides(
                         self.db, self._connector_team_id
                     )
-                    # Never mutate the loader-returned mappings in place: either
-                    # may be the object a hook keeps its own reference to.
-                    # Shallow copies of the outer dict are sufficient because
-                    # every downstream consumer only reads the inner per-server
-                    # values -- resolve_stdio_env's lookups, and this file's own
-                    # per-server env merge in _build_mcp_server_config's stdio
-                    # branch (an unconditional-overwrite `{**a, **b}` merge) --
-                    # neither assigns back into shared_env_by_id or
-                    # env_source_by_id. (mcp_runtime.build_mcp_runtime_connection
-                    # has its own caller-id merge, but this method's own call to
-                    # it, in the delegated/OAuth branch above, never passes these
-                    # two maps, so it never reads them at all here.)
+                    # Both copies are load-bearing, for different reasons.
+                    # shared_env_by_id: load_shared_env_overrides hands back the
+                    # installing application's own object unwrapped, so writing
+                    # into it below would mutate the hook's dict.
+                    # env_source_by_id: load_user_env_sources always builds a
+                    # fresh dict, so no hook holds it -- but the degrade below
+                    # removes entries from it in place (`del ...[server_id]`),
+                    # and the loader's result is not this block's to shrink.
+                    # Shallow outer copies suffice for both: every downstream
+                    # consumer only reads the inner per-server values --
+                    # resolve_stdio_env's lookups and this file's own per-server
+                    # env merge in _build_mcp_server_config's stdio branch (an
+                    # unconditional-overwrite `{**a, **b}` merge) -- and neither
+                    # assigns back into either map.
                     shared_env_by_id = dict(shared_env_by_id)
                     env_source_by_id = dict(env_source_by_id)
                     for server_id in team_mcp_ids:

--- a/tests/web/services/test_mcp_team_env_hook.py
+++ b/tests/web/services/test_mcp_team_env_hook.py
@@ -1,0 +1,302 @@
+"""Tests for the team-keyed MCP env hook slot: loader, validator, installed
+predicate, and the hook-snapshot primitive.
+
+This slot is deliberately separate from the pre-existing user-keyed shared
+env hook (set_mcp_shared_env_hook / load_shared_env_overrides, pinned in
+test_mcp_shared_env_hook.py): the two resolve unrelated grouping keys and
+must never be interchangeable. Wiring-level pins -- how the two layers
+combine inside WebToolConfig, the cross-team-borrowing prohibition, and the
+env-source degrade -- live in tests/web/tools/test_mcp_team_env_wiring.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from xagent.web.services import mcp_runtime
+
+T1 = 101
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks() -> Iterator[None]:
+    yield
+    mcp_runtime.set_mcp_team_env_hook(None)
+    mcp_runtime.set_mcp_shared_env_hook(None)
+
+
+# ---------------------------------------------------------------------------
+# Default (no hook installed) is closed, and free: no call, no query.
+# ---------------------------------------------------------------------------
+
+
+def test_team_env_hook_default_not_installed():
+    assert mcp_runtime.team_env_hook_installed() is False
+
+
+def test_load_team_env_overrides_default_is_empty_and_uncalled():
+    # No hook installed at all -- the loader must not reach for one.
+    assert mcp_runtime.load_team_env_overrides("db", T1) == {}
+
+
+def test_load_team_env_overrides_none_team_id_never_calls_installed_hook():
+    calls: list[tuple] = []
+
+    def hook(db, *, team_id):
+        calls.append((db, team_id))
+        return {}
+
+    mcp_runtime.set_mcp_team_env_hook(hook)
+    assert mcp_runtime.load_team_env_overrides("db", None) == {}
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Installed predicate and the positive path.
+# ---------------------------------------------------------------------------
+
+
+def test_team_env_hook_installed_true_once_set():
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})
+    assert mcp_runtime.team_env_hook_installed() is True
+
+
+def test_team_env_hook_installed_selects_on_predicate_not_empty_answer():
+    """An installed hook that legitimately answers empty for a team that
+    stored nothing is still 'installed' -- callers must select on the
+    predicate, never infer absence from an empty return."""
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})
+    assert mcp_runtime.team_env_hook_installed() is True
+    assert mcp_runtime.load_team_env_overrides("db", T1) == {}
+
+
+def test_load_team_env_overrides_returns_hook_answer():
+    calls = {}
+
+    def hook(db, *, team_id):
+        calls["args"] = (db, team_id)
+        return {5: {"KEY": "team-value"}}
+
+    mcp_runtime.set_mcp_team_env_hook(hook)
+    assert mcp_runtime.load_team_env_overrides("db", T1) == {5: {"KEY": "team-value"}}
+    assert calls["args"] == ("db", T1)
+
+
+# The hook is always invoked with team_id passed as a keyword. A hook
+# declared keyword-only (as the Protocol requires) would raise TypeError if
+# the call site ever regressed to passing team_id positionally, and that
+# TypeError would surface here as a ConnectorRuntimeError instead of the
+# expected return value -- failing this test.
+def test_team_env_hook_call_uses_keyword_team_id():
+    def strict_hook(db, *, team_id):
+        assert team_id == T1
+        return {}
+
+    mcp_runtime.set_mcp_team_env_hook(strict_hook)
+    assert mcp_runtime.load_team_env_overrides("db", T1) == {}
+
+
+# ---------------------------------------------------------------------------
+# Loader level: hook failure raises the typed error, never degrades.
+# ---------------------------------------------------------------------------
+
+
+def test_load_team_env_overrides_hook_failure_raises_connector_runtime_error():
+    def boom(db, *, team_id):
+        raise RuntimeError("hook exploded")
+
+    mcp_runtime.set_mcp_team_env_hook(boom)
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        mcp_runtime.load_team_env_overrides("db", T1)
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.details["reason"] == "team_env_resolution_failed"
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+
+def test_load_team_env_overrides_passes_through_planted_connector_runtime_error():
+    """A hook that already raises the typed error reaches the caller as
+    that exact object -- not re-wrapped, not given a new cause."""
+    planted = ConnectorRuntimeError(
+        "planted_code", "planted", details={"reason": "planted_reason"}
+    )
+
+    def raising_hook(db, *, team_id):
+        raise planted
+
+    mcp_runtime.set_mcp_team_env_hook(raising_hook)
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        mcp_runtime.load_team_env_overrides("db", T1)
+    assert excinfo.value is planted
+
+
+# ---------------------------------------------------------------------------
+# Loader level: malformed answer shapes raise, one case each.
+# There exists no input for which an internal failure returns {}.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "malformed_answer",
+    [
+        None,
+        "not-a-dict",
+        {"5": {"K": "v"}},  # string key, not int
+        {True: {"K": "v"}},  # bool key, not accepted as int
+        {5: "not-a-dict"},  # value is not a dict
+    ],
+    ids=[
+        "none",
+        "non-dict-answer",
+        "string-key",
+        "bool-key",
+        "non-dict-value",
+    ],
+)
+def test_load_team_env_overrides_raises_on_malformed_answer(malformed_answer):
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: malformed_answer)
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        mcp_runtime.load_team_env_overrides("db", T1)
+    assert excinfo.value.status_code == 503
+
+
+@pytest.mark.parametrize(
+    "malformed_answer",
+    [
+        None,
+        "not-a-dict",
+        {"5": {"K": "v"}},
+        {True: {"K": "v"}},
+        {5: "not-a-dict"},
+    ],
+    ids=[
+        "none",
+        "non-dict-answer",
+        "string-key",
+        "bool-key",
+        "non-dict-value",
+    ],
+)
+def test_validate_team_mcp_env_answer_raises_value_error(malformed_answer):
+    with pytest.raises(ValueError):
+        mcp_runtime._validate_team_mcp_env_answer(malformed_answer)
+
+
+def test_validate_team_mcp_env_answer_accepts_empty_dict():
+    assert mcp_runtime._validate_team_mcp_env_answer({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# Loader level: the answer object is never handed back unwrapped.
+# ---------------------------------------------------------------------------
+
+
+def test_load_team_env_overrides_defensive_copy_of_outer_dict():
+    hook_owned = {5: {"KEY": "v"}}
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: hook_owned)
+
+    result = mcp_runtime.load_team_env_overrides("db", T1)
+    result[999] = {"INJECTED": "x"}
+
+    assert 999 not in hook_owned
+
+
+# ---------------------------------------------------------------------------
+# The two hook slots are independent: installing/using one never reads,
+# calls, or is affected by the other, in either direction.
+# ---------------------------------------------------------------------------
+
+
+def test_team_and_shared_hooks_are_independent_slots():
+    shared_calls = []
+    team_calls = []
+
+    mcp_runtime.set_mcp_shared_env_hook(
+        lambda db, user_id: (shared_calls.append((db, user_id)), {})[1]
+    )
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (team_calls.append((db, team_id)), {})[1]
+    )
+
+    mcp_runtime.load_team_env_overrides("db", T1)
+    assert team_calls == [("db", T1)]
+    assert shared_calls == []
+
+    mcp_runtime.load_shared_env_overrides("db", 7)
+    assert shared_calls == [("db", 7)]
+    assert team_calls == [("db", T1)]  # unchanged
+
+
+def test_setting_team_hook_does_not_install_shared_hook():
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})
+    assert mcp_runtime.load_shared_env_overrides("db", 7) == {}
+
+
+def test_setting_shared_hook_does_not_install_team_hook():
+    mcp_runtime.set_mcp_shared_env_hook(lambda db, user_id: {})
+    assert mcp_runtime.team_env_hook_installed() is False
+
+
+# ---------------------------------------------------------------------------
+# The snapshot/restore primitive covers every hook slot in the module,
+# not just the two known today. Enumerating slots by name (rather than
+# hard-coding "the shared one and the team one") is what makes a slot added
+# later, and not added to mcp_env_hooks_snapshot, fail this test instead of
+# silently escaping coverage.
+# ---------------------------------------------------------------------------
+
+
+def _hook_slot_names() -> list[str]:
+    return [
+        name
+        for name in vars(mcp_runtime)
+        if name.startswith("_get_mcp_") and name.endswith("_hook")
+    ]
+
+
+def test_hook_slot_names_are_discoverable():
+    # Sanity check the enumeration itself finds both known slots, so the
+    # coverage test below is not vacuously true.
+    names = _hook_slot_names()
+    assert "_get_mcp_shared_env_hook" in names
+    assert "_get_mcp_team_env_hook" in names
+
+
+def test_snapshot_restores_every_hook_slot_by_identity():
+    names = _hook_slot_names()
+    originals = {name: getattr(mcp_runtime, name) for name in names}
+
+    with mcp_runtime.mcp_env_hooks_snapshot():
+        for name in names:
+            setattr(mcp_runtime, name, lambda *a, **k: None)
+        for name in names:
+            assert getattr(mcp_runtime, name) is not originals[name]
+
+    for name in names:
+        assert getattr(mcp_runtime, name) is originals[name]
+
+
+def test_snapshot_restores_on_exception():
+    names = _hook_slot_names()
+    originals = {name: getattr(mcp_runtime, name) for name in names}
+
+    with pytest.raises(RuntimeError):
+        with mcp_runtime.mcp_env_hooks_snapshot():
+            for name in names:
+                setattr(mcp_runtime, name, lambda *a, **k: None)
+            raise RuntimeError("boom inside the block")
+
+    for name in names:
+        assert getattr(mcp_runtime, name) is originals[name]
+
+
+def test_snapshot_leaves_untouched_state_alone_when_nothing_changes_inside():
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})
+    installed_hook = mcp_runtime._get_mcp_team_env_hook
+
+    with mcp_runtime.mcp_env_hooks_snapshot():
+        pass
+
+    assert mcp_runtime._get_mcp_team_env_hook is installed_hook

--- a/tests/web/services/test_mcp_team_env_hook.py
+++ b/tests/web/services/test_mcp_team_env_hook.py
@@ -23,9 +23,12 @@ T1 = 101
 
 @pytest.fixture(autouse=True)
 def _reset_hooks() -> Iterator[None]:
-    yield
-    mcp_runtime.set_mcp_team_env_hook(None)
-    mcp_runtime.set_mcp_shared_env_hook(None)
+    # Through the module's own snapshot primitive rather than by resetting
+    # each slot by hand: a slot added to the module later is then covered
+    # by this fixture automatically, which is the whole point of the
+    # primitive being slot-complete.
+    with mcp_runtime.mcp_env_hooks_snapshot():
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -138,23 +141,27 @@ def test_load_team_env_overrides_passes_through_planted_connector_runtime_error(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "malformed_answer",
-    [
-        None,
-        "not-a-dict",
-        {"5": {"K": "v"}},  # string key, not int
-        {True: {"K": "v"}},  # bool key, not accepted as int
-        {5: "not-a-dict"},  # value is not a dict
-    ],
-    ids=[
-        "none",
-        "non-dict-answer",
-        "string-key",
-        "bool-key",
-        "non-dict-value",
-    ],
-)
+# Both malformed-answer tests below consume this one table: the loader
+# level (which must convert every case into the typed 503) and the
+# validator level (which must raise ValueError for every case). A case
+# added here is automatically exercised at both levels.
+_MALFORMED_TEAM_ENV_ANSWERS = [
+    pytest.param(None, id="none"),
+    pytest.param("not-a-dict", id="non-dict-answer"),
+    pytest.param({"5": {"K": "v"}}, id="string-key"),
+    pytest.param({True: {"K": "v"}}, id="bool-key"),
+    pytest.param({5: "not-a-dict"}, id="non-dict-value"),
+    pytest.param({5: {1: "v"}}, id="non-str-env-key"),
+    pytest.param({5: {"K": 1}}, id="non-str-env-value"),
+    pytest.param({5: {"K": None}}, id="none-env-value"),
+    # A bad server-id key whose env mapping is empty: the loader drops
+    # empty rows, and this pins that it drops them only AFTER the shape
+    # check, so a malformed key cannot ride an empty row past validation.
+    pytest.param({"5": {}}, id="string-key-with-empty-env"),
+]
+
+
+@pytest.mark.parametrize("malformed_answer", _MALFORMED_TEAM_ENV_ANSWERS)
 def test_load_team_env_overrides_raises_on_malformed_answer(malformed_answer):
     mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: malformed_answer)
     with pytest.raises(ConnectorRuntimeError) as excinfo:
@@ -162,23 +169,7 @@ def test_load_team_env_overrides_raises_on_malformed_answer(malformed_answer):
     assert excinfo.value.status_code == 503
 
 
-@pytest.mark.parametrize(
-    "malformed_answer",
-    [
-        None,
-        "not-a-dict",
-        {"5": {"K": "v"}},
-        {True: {"K": "v"}},
-        {5: "not-a-dict"},
-    ],
-    ids=[
-        "none",
-        "non-dict-answer",
-        "string-key",
-        "bool-key",
-        "non-dict-value",
-    ],
-)
+@pytest.mark.parametrize("malformed_answer", _MALFORMED_TEAM_ENV_ANSWERS)
 def test_validate_team_mcp_env_answer_raises_value_error(malformed_answer):
     with pytest.raises(ValueError):
         mcp_runtime._validate_team_mcp_env_answer(malformed_answer)
@@ -186,6 +177,33 @@ def test_validate_team_mcp_env_answer_raises_value_error(malformed_answer):
 
 def test_validate_team_mcp_env_answer_accepts_empty_dict():
     assert mcp_runtime._validate_team_mcp_env_answer({}) == {}
+
+
+def test_validate_keeps_an_empty_row_but_loader_drops_it():
+    """The validator's job is shape, the loader's job is normalization.
+    An empty env mapping is a well-shaped row, so the validator keeps it;
+    the loader then drops it so no consumer ever sees the two states."""
+    assert mcp_runtime._validate_team_mcp_env_answer({5: {}}) == {5: {}}
+
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {5: {}})
+    assert mcp_runtime.load_team_env_overrides("db", T1) == {}
+
+
+def test_loader_drops_only_the_empty_rows():
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {5: {}, 6: {"KEY": "v"}})
+    assert mcp_runtime.load_team_env_overrides("db", T1) == {6: {"KEY": "v"}}
+
+
+def test_load_team_env_overrides_none_db_never_calls_installed_hook():
+    calls: list[object] = []
+
+    def hook(db, *, team_id):
+        calls.append(team_id)
+        return {}
+
+    mcp_runtime.set_mcp_team_env_hook(hook)
+    assert mcp_runtime.load_team_env_overrides(None, T1) == {}
+    assert calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/tools/test_mcp_team_env_wiring.py
+++ b/tests/web/tools/test_mcp_team_env_wiring.py
@@ -1,0 +1,590 @@
+"""Wiring pins for the team-keyed shared env layer inside
+``WebToolConfig._load_mcp_server_configs``.
+
+Companion to tests/web/tools/test_mcp_team_visibility.py, which pins *which*
+servers a team-governed run can see. This file pins what env each
+team-owned server resolves to: for a team-owned id, the shared env layer
+comes from the *governing* team's own row (``mcp_runtime.set_mcp_team_env_hook``)
+and from nothing else -- never the running user's own team, never any
+other team, never a degraded/partial mix -- while ids outside the team's
+visible set and runs with no governing team keep the pre-existing
+personal/legacy behaviour unchanged.
+
+Loader-level unit pins for the hook slot itself (predicate, validator,
+snapshot primitive) live in
+tests/web/services/test_mcp_team_env_hook.py; this file only pins how
+config.py's wiring block consumes that loader.
+
+Fixture seed (one stdio MCP row reachable only through the team hook, one
+stdio MCP row owned personally by the run owner, run owner ``C``
+throughout):
+
+    team_server      -- reachable only through a team-visibility hook keyed
+                         on T1 (the governing team in every test below)
+    personal_server   -- C holds an active personal link, never surfaced by
+                         any team-visibility hook
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
+from xagent.core.tools.adapters.vibe.mcp_tools import create_mcp_tools
+from xagent.web.models import Base, MCPServer, User, UserMCPServer
+from xagent.web.services import agent_team_scope, connector_team_scope, mcp_runtime
+from xagent.web.tools.config import WebToolConfig
+
+T1 = 301  # the governing team throughout this file
+T2 = 302  # a team the runner might also belong to, never the governing one
+
+
+class _ProbeError(RuntimeError):
+    """Distinguishable failure raised by a broken team-env hook."""
+
+
+@pytest.fixture()
+def db_session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks() -> Iterator[None]:
+    yield
+    connector_team_scope.set_connector_team_hooks()
+    agent_team_scope.set_agent_team_scope_hook(None)
+    mcp_runtime.set_mcp_team_env_hook(None)
+    mcp_runtime.set_mcp_shared_env_hook(None)
+
+
+def _create_user(db: Session, username: str) -> User:
+    user = User(username=username, password_hash="hash")
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _create_stdio_mcp(
+    db: Session,
+    name: str,
+    *,
+    owner: User | None = None,
+    env: dict | None = None,
+) -> MCPServer:
+    server = MCPServer(
+        name=name,
+        description=f"{name} description",
+        managed="external",
+        transport="stdio",
+        command="python",
+        args=["-m", "probe"],
+        env=env,
+    )
+    db.add(server)
+    db.flush()
+    if owner is not None:
+        db.add(
+            UserMCPServer(
+                user_id=owner.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=True,
+            )
+        )
+        db.flush()
+    return server
+
+
+def _link_own_env(
+    db: Session,
+    *,
+    user: User,
+    server: MCPServer,
+    env: dict | None,
+    env_source: str | None,
+) -> None:
+    """Give ``user`` an ACTIVE personal env link to ``server``. The
+    cross-team-borrowing test below needs this, otherwise it would pass
+    under the pre-PR rule for reasons unrelated to the invariant under
+    test."""
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            can_edit=False,
+            can_delete=False,
+            is_active=True,
+            env=env,
+            env_source=env_source,
+        )
+    )
+    db.flush()
+
+
+@pytest.fixture()
+def seed(db_session: Session):
+    c = _create_user(db_session, "run-owner")
+    team_server = _create_stdio_mcp(
+        db_session, "team-server", env={"GLOBAL": "global-value"}
+    )
+    personal_server = _create_stdio_mcp(
+        db_session, "personal-server", owner=c, env={"GLOBAL": "global-value"}
+    )
+    return SimpleNamespace(
+        c=c, team_server=team_server, personal_server=personal_server
+    )
+
+
+def _install_visibility(*, ids_by_team: dict[int, set[int]]) -> None:
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda db, *, team_id: {
+            "mcp": ids_by_team.get(team_id, set()),
+            "custom_api": set(),
+        }
+    )
+
+
+def _cfg(db_session: Session, seed, *, connector_team_id: int | None) -> WebToolConfig:
+    return WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        connector_team_id=connector_team_id,
+        include_mcp_tools=True,
+    )
+
+
+async def _env_for(db_session, seed, server, *, connector_team_id) -> dict:
+    cfg = _cfg(db_session, seed, connector_team_id=connector_team_id)
+    configs = await cfg._load_mcp_server_configs()
+    (config,) = [c for c in configs if c["id"] == int(server.id)]
+    env = dict(config["config"].get("env") or {})
+    env.pop("XAGENT_MCP_CALLER_ID", None)
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Team-owned id + governing-team row => that row is the shared layer,
+# for a runner the agent-team-scope hook calls a member and one it doesn't
+# -- the resolution never consults that hook at all, so the outcome
+# must be identical either way.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runner_is_member", [True, False], ids=["member", "non-member"]
+)
+async def test_team_env_layer_keyed_on_governing_team(
+    db_session, seed, runner_is_member
+):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (
+            {seed.team_server.id: {"TEAM_KEY": "team-value"}} if team_id == T1 else {}
+        )
+    )
+    agent_team_scope.set_agent_team_scope_hook(
+        lambda db, user_id: (
+            agent_team_scope.AgentTeamScope(team_id=T1, is_team_admin=False)
+            if runner_is_member and user_id == int(seed.c.id)
+            else None
+        )
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+    assert env.get("TEAM_KEY") == "team-value"
+
+
+# ---------------------------------------------------------------------------
+# The hook is never invoked -- not merely "invoked and answers
+# empty" -- when connector_team_id is None, or when team_mcp_ids is empty.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connector_team_id_none_never_invokes_team_env_hook(
+    db_session, seed, monkeypatch
+):
+    """In practice team_mcp_ids is already empty whenever connector_team_id
+    is None (resolve_team_connector_ids_or_raise short-circuits on
+    ``team_id is None`` before ever calling the visibility hook), and
+    load_team_env_overrides has its own ``team_id is None`` guard too, so
+    this forces team_mcp_ids non-empty AND spies on the loader call itself
+    (rather than the hook) to isolate config.py's own
+    ``connector_team_id is not None`` condition from both of those other
+    guards: it must gate the wiring block on its own terms, not only rely
+    on either guard beneath it."""
+    from xagent.web.services import connector_team_scope
+    from xagent.web.services import mcp_runtime as mcp_runtime_module
+
+    monkeypatch.setattr(
+        connector_team_scope,
+        "resolve_team_connector_ids_or_raise",
+        lambda db, *, team_id, log_subject: {
+            "mcp": {int(seed.team_server.id)},
+            "custom_api": set(),
+        },
+    )
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})
+    calls: list[object] = []
+    real_loader = mcp_runtime_module.load_team_env_overrides
+
+    def spy_loader(db, team_id):
+        calls.append(team_id)
+        return real_loader(db, team_id)
+
+    monkeypatch.setattr(mcp_runtime_module, "load_team_env_overrides", spy_loader)
+
+    cfg = _cfg(db_session, seed, connector_team_id=None)
+    await cfg._load_mcp_server_configs()
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_empty_team_mcp_ids_never_invokes_team_env_hook(db_session, seed):
+    _install_visibility(ids_by_team={})  # T1 resolves to no ids at all
+    calls: list[int] = []
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (calls.append(team_id), {})[1]
+    )
+
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+    await cfg._load_mcp_server_configs()
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Governing team has NO row => no shared layer at all for that id --
+# in particular never the row of a DIFFERENT team (T2) that also holds one
+# for the same server, even though the code never even asks T2 for it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_cross_team_env_borrowing(db_session, seed):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    # T1 (governing) has no row; T2 (a different team) does -- this must
+    # never surface, and production code never even calls the hook with
+    # team_id=T2 for this run.
+    calls: list[int] = []
+
+    def hook(db, *, team_id):
+        calls.append(team_id)
+        if team_id == T2:
+            return {seed.team_server.id: {"STOLEN": "stolen-value"}}
+        return {}
+
+    mcp_runtime.set_mcp_team_env_hook(hook)
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"},
+        env_source=None,
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert "STOLEN" not in env
+    assert env.get("OWN_KEY") == "own-value"
+    assert calls == [T1]  # only ever asked for the governing team
+
+
+@pytest.mark.asyncio
+async def test_governing_team_no_row_scrubs_legacy_shared_value(db_session, seed):
+    """The mechanism behind test_no_cross_team_env_borrowing: even a value
+    that already made it into shared_env_by_id through the pre-existing
+    user-keyed shared-env hook (the only way a "wrong team's row" could
+    reach this map before this PR, since that hook's application-side
+    wiring is what used to resolve "shared" for a team-owned connector) is
+    scrubbed once a governing team is known and has no row of its own --
+    not merely never fetched from elsewhere. This is the direct pin for
+    the ``shared_env_by_id.pop(server_id, None)`` line."""
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    # Simulates what the legacy, user-keyed-only resolution could already
+    # have put in shared_env_by_id for this server, before the team-env
+    # block ever runs.
+    mcp_runtime.set_mcp_shared_env_hook(
+        lambda db, user_id: {seed.team_server.id: {"STOLEN": "legacy-shared-value"}}
+    )
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})  # T1 has no row
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"},
+        env_source=None,
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert "STOLEN" not in env
+    assert env.get("OWN_KEY") == "own-value"
+
+
+# ---------------------------------------------------------------------------
+# An explicit "shared" pick degrades to the legacy default
+# (global < user) when the governing team has no row -- own key merges if
+# present, global-only if it does not -- and never a foreign row.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "has_own_key", [True, False], ids=["own-key-present", "own-key-absent"]
+)
+async def test_shared_pick_degrades_when_owning_team_has_no_row(
+    db_session, seed, has_own_key
+):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (
+            {seed.team_server.id: {"STOLEN": "stolen-value"}} if team_id == T2 else {}
+        )
+    )
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"} if has_own_key else None,
+        env_source="shared",
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert "STOLEN" not in env
+    if has_own_key:
+        assert env.get("OWN_KEY") == "own-value"
+    else:
+        assert "OWN_KEY" not in env
+        assert env.get("GLOBAL") == "global-value"
+
+
+# ---------------------------------------------------------------------------
+# The substituted team layer occupies the *shared* slot of
+# resolve_stdio_env -- the user layer still wins on an overlapping key, and
+# a team-only key still passes through.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_env_occupies_shared_slot_user_still_wins(db_session, seed):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (
+            {seed.team_server.id: {"SHARED_KEY": "from-team", "ONLY_TEAM": "team-only"}}
+            if team_id == T1
+            else {}
+        )
+    )
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"SHARED_KEY": "own-wins", "ONLY_OWN": "own-only"},
+        env_source=None,  # legacy fallback: global < shared < user
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert env["SHARED_KEY"] == "own-wins"
+    assert env["ONLY_TEAM"] == "team-only"
+    assert env["ONLY_OWN"] == "own-only"
+    assert env["GLOBAL"] == "global-value"
+
+
+# ---------------------------------------------------------------------------
+# Team hook absent (not installed at all) => legacy behaviour, byte for
+# byte -- including that a pre-existing user-keyed shared-env hook, if
+# installed, is left completely untouched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_env_hook_absent_falls_back_to_user_keyed_layer(db_session, seed):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    # No mcp_runtime.set_mcp_team_env_hook call at all in this test.
+    mcp_runtime.set_mcp_shared_env_hook(
+        lambda db, user_id: (
+            {seed.team_server.id: {"LEGACY_SHARED": "legacy-value"}}
+            if user_id == int(seed.c.id)
+            else {}
+        )
+    )
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"},
+        env_source=None,
+    )
+
+    assert mcp_runtime.team_env_hook_installed() is False
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert env.get("LEGACY_SHARED") == "legacy-value"
+    assert env.get("OWN_KEY") == "own-value"
+
+
+@pytest.mark.asyncio
+async def test_installed_hook_answering_empty_still_applies_degrade(db_session, seed):
+    """The wiring selects on team_env_hook_installed(), never on whether
+    load_team_env_overrides(...) happens to return {} for this team: an
+    installed hook legitimately answers empty for a team that owns
+    nothing (mirrors team_connector_hook_installed's own rule), and the
+    degrade below must still fire in that case -- selecting on an empty
+    *answer* instead would wrongly skip the whole block and leave a
+    "shared" pick undegraded, silently pinning the tool to global-only
+    even though the runner has an own key on file."""
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})  # installed, empty
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"},
+        env_source="shared",
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert env.get("OWN_KEY") == "own-value"
+
+
+# ---------------------------------------------------------------------------
+# Ids not in team_mcp_ids are untouched -- even if a hook installed for
+# this run would (incorrectly, if consulted) answer for them too.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ids_outside_team_mcp_ids_untouched(db_session, seed):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (
+            {
+                seed.team_server.id: {"TEAM_KEY": "team-value"},
+                seed.personal_server.id: {"SHOULD_NOT_APPEAR": "leak"},
+            }
+            if team_id == T1
+            else {}
+        )
+    )
+
+    env = await _env_for(db_session, seed, seed.personal_server, connector_team_id=T1)
+
+    assert "SHOULD_NOT_APPEAR" not in env
+    assert env == {"GLOBAL": "global-value"}
+
+
+# ---------------------------------------------------------------------------
+# Wiring level: a broken team-env hook raises the typed error from
+# _load_mcp_server_configs, and that error survives the create_mcp_tools
+# boundary instead of being dropped into a silently env-less/empty tool set.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_env_hook_failure_raises_connector_runtime_error(db_session, seed):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+
+    def boom(db, *, team_id):
+        raise _ProbeError("boom")
+
+    mcp_runtime.set_mcp_team_env_hook(boom)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        await cfg._load_mcp_server_configs()
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.details["reason"] == "team_env_resolution_failed"
+    assert isinstance(excinfo.value.__cause__, _ProbeError)
+
+
+@pytest.mark.asyncio
+async def test_team_env_hook_failure_survives_create_mcp_tools_boundary(
+    db_session, seed
+):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+
+    def boom(db, *, team_id):
+        raise _ProbeError("boom")
+
+    mcp_runtime.set_mcp_team_env_hook(boom)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+
+    assert cfg.get_tool_selection_spec() is None
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        await create_mcp_tools(cfg)
+    assert excinfo.value.details["reason"] == "team_env_resolution_failed"
+
+
+# ---------------------------------------------------------------------------
+# Wiring level: a malformed hook answer raises the same typed error.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_env_hook_shape_violation_raises(db_session, seed):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: "not-a-dict")
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        await cfg._load_mcp_server_configs()
+
+    assert excinfo.value.status_code == 503
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Wiring level: neither loader-owned mapping is mutated in place by
+# the re-key block -- a hook that keeps a reference to its own returned
+# dict observes it unchanged after a build. This is the direct pin for the
+# `shared_env_by_id = dict(shared_env_by_id)` copy: load_shared_env_overrides
+# hands back the hook's own object unwrapped, so removing that copy would
+# mutate it here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hook_owned_mappings_not_mutated_by_team_rekey(db_session, seed):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    shared_hook_owned = {seed.team_server.id: {"OLD_SHARED": "old-value"}}
+    team_hook_owned = {seed.team_server.id: {"TEAM_KEY": "team-value"}}
+    mcp_runtime.set_mcp_shared_env_hook(lambda db, user_id: shared_hook_owned)
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: team_hook_owned if team_id == T1 else {}
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert env.get("TEAM_KEY") == "team-value"  # the re-key did take effect
+    assert shared_hook_owned == {seed.team_server.id: {"OLD_SHARED": "old-value"}}
+    assert team_hook_owned == {seed.team_server.id: {"TEAM_KEY": "team-value"}}

--- a/tests/web/tools/test_mcp_team_env_wiring.py
+++ b/tests/web/tools/test_mcp_team_env_wiring.py
@@ -27,6 +27,7 @@ throughout):
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterator
 from types import SimpleNamespace
 
@@ -69,11 +70,13 @@ def db_session() -> Iterator[Session]:
 
 @pytest.fixture(autouse=True)
 def _reset_hooks() -> Iterator[None]:
-    yield
-    connector_team_scope.set_connector_team_hooks()
-    agent_team_scope.set_agent_team_scope_hook(None)
-    mcp_runtime.set_mcp_team_env_hook(None)
-    mcp_runtime.set_mcp_shared_env_hook(None)
+    # The env hook slots restore through the module's own snapshot
+    # primitive; the two team-scope hooks below live in other modules and
+    # have no such primitive, so they are still reset by hand.
+    with mcp_runtime.mcp_env_hooks_snapshot():
+        yield
+        connector_team_scope.set_connector_team_hooks()
+        agent_team_scope.set_agent_team_scope_hook(None)
 
 
 def _create_user(db: Session, username: str) -> User:
@@ -183,6 +186,28 @@ async def _env_for(db_session, seed, server, *, connector_team_id) -> dict:
     env = dict(config["config"].get("env") or {})
     env.pop("XAGENT_MCP_CALLER_ID", None)
     return env
+
+
+def _create_http_mcp(db: Session, name: str) -> MCPServer:
+    """A team-owned server on a non-stdio transport. The env layers are a
+    stdio-only concept, so this exists to pin that they stay there."""
+    server = MCPServer(
+        name=name,
+        description=f"{name} description",
+        managed="external",
+        transport="streamable_http",
+        url="https://example.com/mcp",
+    )
+    db.add(server)
+    db.flush()
+    return server
+
+
+async def _config_for(db_session, seed, server, *, connector_team_id) -> dict:
+    cfg = _cfg(db_session, seed, connector_team_id=connector_team_id)
+    configs = await cfg._load_mcp_server_configs()
+    (config,) = [c for c in configs if c["id"] == int(server.id)]
+    return config
 
 
 # ---------------------------------------------------------------------------
@@ -588,3 +613,197 @@ async def test_hook_owned_mappings_not_mutated_by_team_rekey(db_session, seed):
     assert env.get("TEAM_KEY") == "team-value"  # the re-key did take effect
     assert shared_hook_owned == {seed.team_server.id: {"OLD_SHARED": "old-value"}}
     assert team_hook_owned == {seed.team_server.id: {"TEAM_KEY": "team-value"}}
+
+
+# ---------------------------------------------------------------------------
+# The four picks/transport cells the suite was missing: a "shared" pick
+# with the team row present, "own" and "platform" picks on a team-owned
+# server, and a team-owned server on a non-stdio transport.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shared_pick_with_team_row_uses_the_team_row(db_session, seed):
+    """The pick="shared" + row-PRESENT combination: the team row is the
+    shared layer and the runner's own key is not merged at all. The
+    row-ABSENT half of this pick is pinned separately above."""
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (
+            {seed.team_server.id: {"TEAM_KEY": "team-value"}} if team_id == T1 else {}
+        )
+    )
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"},
+        env_source="shared",
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert env.get("TEAM_KEY") == "team-value"
+    assert "OWN_KEY" not in env
+    assert env.get("GLOBAL") == "global-value"
+
+
+@pytest.mark.asyncio
+async def test_own_pick_on_a_team_server_ignores_the_team_row(db_session, seed):
+    """Removing the `== "shared"` condition from the degrade in the wiring
+    block would flip this pick to the legacy fallback and leak the team row
+    into an "own" run; nothing else in this file would notice."""
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (
+            {seed.team_server.id: {"TEAM_KEY": "team-value"}} if team_id == T1 else {}
+        )
+    )
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"},
+        env_source="own",
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert env.get("OWN_KEY") == "own-value"
+    assert "TEAM_KEY" not in env
+    assert env.get("GLOBAL") == "global-value"
+
+
+@pytest.mark.asyncio
+async def test_platform_pick_on_a_team_server_stays_global_only(db_session, seed):
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (
+            {seed.team_server.id: {"TEAM_KEY": "team-value"}} if team_id == T1 else {}
+        )
+    )
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"},
+        env_source="platform",
+    )
+
+    env = await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert env == {"GLOBAL": "global-value"}
+
+
+@pytest.mark.asyncio
+async def test_non_stdio_team_server_never_receives_an_env_layer(db_session):
+    """The env layers are stdio-only. The re-key block itself is transport
+    agnostic -- it rewrites the map for every team-owned id -- so this pins
+    the other end: for an HTTP-transport server the map is never read, and
+    the produced config carries no env key at all."""
+    c = _create_user(db_session, "run-owner")
+    http_server = _create_http_mcp(db_session, "team-http-server")
+    seed = SimpleNamespace(c=c, team_server=http_server, personal_server=http_server)
+
+    _install_visibility(ids_by_team={T1: {int(http_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(
+        lambda db, *, team_id: (
+            {http_server.id: {"TEAM_KEY": "team-value"}} if team_id == T1 else {}
+        )
+    )
+
+    config = await _config_for(db_session, seed, http_server, connector_team_id=T1)
+
+    assert config["transport"] == "streamable_http"
+    assert "env" not in config["config"]
+
+
+# ---------------------------------------------------------------------------
+# A stored row carrying an empty env mapping must be indistinguishable
+# from no row at all.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_team_row_behaves_exactly_like_no_row(db_session, seed):
+    """A stored row carrying an empty env mapping must be indistinguishable
+    from no row at all. Both are run here and their outcomes compared
+    directly, so the two states cannot drift apart later."""
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    _link_own_env(
+        db_session,
+        user=seed.c,
+        server=seed.team_server,
+        env={"OWN_KEY": "own-value"},
+        env_source="shared",
+    )
+
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {seed.team_server.id: {}})
+    env_empty_row = await _env_for(
+        db_session, seed, seed.team_server, connector_team_id=T1
+    )
+
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})
+    env_no_row = await _env_for(
+        db_session, seed, seed.team_server, connector_team_id=T1
+    )
+
+    assert env_empty_row == env_no_row
+    # And the shared outcome is the degrade, not a global-only pin.
+    assert env_empty_row == {"GLOBAL": "global-value", "OWN_KEY": "own-value"}
+
+
+# ---------------------------------------------------------------------------
+# The half-installed state: connectors are shared to a team, but no
+# credential-side hook was installed, so the shared layer silently stays
+# keyed on the running user. Warns once per process.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warns_once_when_team_connectors_exist_without_the_env_hook(
+    db_session, seed, monkeypatch, caplog
+):
+    """The half-installed state: connectors are shared to a team, but no
+    credential-side hook was installed, so the shared layer silently stays
+    keyed on the running user. The flag is reset here because it is
+    process-wide and another test in this file reaches the same state."""
+    monkeypatch.setattr(mcp_runtime, "_team_env_hook_missing_warned", False)
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+
+    with caplog.at_level(logging.WARNING, logger=mcp_runtime.__name__):
+        await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+        first = [r for r in caplog.records if "team-keyed env hook" in r.message]
+        await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+        second = [r for r in caplog.records if "team-keyed env hook" in r.message]
+
+    assert len(first) == 1
+    assert len(second) == 1  # once per process, not once per run
+
+
+@pytest.mark.asyncio
+async def test_no_warning_when_the_env_hook_is_installed(
+    db_session, seed, monkeypatch, caplog
+):
+    monkeypatch.setattr(mcp_runtime, "_team_env_hook_missing_warned", False)
+    _install_visibility(ids_by_team={T1: {int(seed.team_server.id)}})
+    mcp_runtime.set_mcp_team_env_hook(lambda db, *, team_id: {})
+
+    with caplog.at_level(logging.WARNING, logger=mcp_runtime.__name__):
+        await _env_for(db_session, seed, seed.team_server, connector_team_id=T1)
+
+    assert not [r for r in caplog.records if "team-keyed env hook" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_no_warning_when_the_team_owns_no_visible_connector(
+    db_session, seed, monkeypatch, caplog
+):
+    """The condition a deployment that uses none of the team features can
+    never reach: with no visibility hook there are no team-owned ids."""
+    monkeypatch.setattr(mcp_runtime, "_team_env_hook_missing_warned", False)
+
+    with caplog.at_level(logging.WARNING, logger=mcp_runtime.__name__):
+        await _env_for(db_session, seed, seed.personal_server, connector_team_id=T1)
+
+    assert not [r for r in caplog.records if "team-keyed env hook" in r.message]


### PR DESCRIPTION
For a run governed by a team-owned agent, each team-owned MCP server's shared env
layer now resolves from the governing team's own row — never from the runner's
current team, and never from any other team. When the governing team has no row
for a server, that server has no shared layer at all, and a runner whose
env-source pick is `shared` degrades unconditionally to the legacy default
(global env, then the runner's own key).

## What changes

- **`mcp_runtime.py`** gains `set_mcp_team_env_hook`, `load_team_env_overrides`
  and `team_env_hook_installed`, deliberately separate from
  `set_mcp_shared_env_hook`. That older loader degrades to "no layer" on any
  failure, which would hide a signature error or a malformed answer on this new,
  authorization-relevant seam. The failure policy here is the opposite: raise,
  through the same typed `ConnectorRuntimeError` channel `connector_team_scope`
  already uses, with strict shape validation on the answer. A snapshot/restore
  contextmanager covers every hook slot in the module so a fixture cannot
  silently clear one.
- **`config.py`**: `_load_mcp_server_configs` re-keys the shared env layer for
  team-owned ids, immediately after the existing prefetch and inside the same
  guarded region. The block is gated on a governing team being known, its hook
  being installed, and at least one team-owned id in scope, so an ungoverned run
  pays no extra query.
- **`connector_team_scope.py`**: the accepted-risk docstring now also states the
  credential rule.

## Behaviour with no hook installed

Selection is on the installed predicate, never on an empty return — an empty
answer is a legitimate answer, not a missing implementation. With no hook
installed the whole block is skipped. Verified by serialising the full
`_load_mcp_server_configs` result and counting emitted queries against this
branch's base: identical output, identical query count.

## Cost

One extra query per config-cache miss, not per task. The MCP config build is
cached per instance; this adds a query only when that cache misses.

## Tests

Fourteen invariants are pinned across `tests/web/services/test_mcp_team_env_hook.py`
and `tests/web/tools/test_mcp_team_env_wiring.py`, each verified by breaking the
implementation and confirming the intended test — and only that test — fails:

- the shared layer keys on the governing team, for a runner who is a member and
  for one who is not;
- no row for the governing team means no shared layer, and any legacy shared
  value for that id is scrubbed rather than left in place;
- a `shared` pick degrades unconditionally, whether or not the runner has an own
  key, and whether or not the scrub removed anything;
- the runner's own key still wins over the team layer;
- the hook is never consulted when there is no governing team, or when no
  team-owned id is in scope;
- an installed hook answering with an empty mapping still applies the degrade
  (the predicate, not the answer, decides);
- hook failure and every malformed answer shape raise the typed error rather
  than degrading, including the `bool`-as-`int` key case;
- ids outside the team-owned set are untouched;
- the mappings owned by the hook are never mutated in place;
- the hook is always invoked with `team_id` passed as a keyword;
- the snapshot primitive restores every slot in the module by identity.
