### PR TITLE
Resolve the knowledge-base team layer on the governing agent's team

### DIFF
--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -669,6 +669,12 @@ class AgentService:
                 def get_allowed_collections(self) -> list[Any] | None:
                     return None
 
+                # get_agent_creator_user_id / get_declared_knowledge_bases are
+                # not overridden here: ToolConfig already gives both a
+                # fail-closed ``None`` default (see config.py), which is
+                # exactly what this default, non-team-governed tool config
+                # needs.
+
                 def get_allowed_skills(self) -> list[Any] | None:
                     return None
 

--- a/src/xagent/core/tools/adapters/vibe/config.py
+++ b/src/xagent/core/tools/adapters/vibe/config.py
@@ -333,6 +333,23 @@ class BaseToolConfig(ABC):
         """Get allowed knowledge base collections. None means all collections are allowed."""
         pass
 
+    def get_agent_creator_user_id(self) -> Optional[int]:
+        """Get the governing agent's creator, for the knowledge-base seam.
+
+        Fail-closed default for every config that is not web-backed: without
+        a governing team there is no creator exemption to resolve, so
+        ``None`` is always correct here, not merely convenient.
+        """
+        return None
+
+    def get_declared_knowledge_bases(self) -> Optional[List[str]]:
+        """Get the governing agent's stored knowledge-base declaration.
+
+        Fail-closed default for every config that is not web-backed: see
+        ``get_agent_creator_user_id``.
+        """
+        return None
+
     @abstractmethod
     def get_allowed_skills(self) -> Optional[List[str]]:
         """Get allowed skill names. None means all skills are allowed."""

--- a/src/xagent/core/tools/adapters/vibe/document_search.py
+++ b/src/xagent/core/tools/adapters/vibe/document_search.py
@@ -36,12 +36,16 @@ class ListKnowledgeBasesTool(AbstractBaseTool):
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
+        agent_creator_user_id: Optional[int] = None,
+        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self.allowed_collections = allowed_collections
         self.user_id = user_id
         self.is_admin = is_admin
         self.governing_team_id = governing_team_id
+        self.agent_creator_user_id = agent_creator_user_id
+        self.declared_knowledge_bases = declared_knowledge_bases
 
     @property
     def name(self) -> str:
@@ -79,6 +83,8 @@ class ListKnowledgeBasesTool(AbstractBaseTool):
             user_id=self.user_id,
             is_admin=self.is_admin,
             governing_team_id=self.governing_team_id,
+            agent_creator_user_id=self.agent_creator_user_id,
+            declared_knowledge_bases=self.declared_knowledge_bases,
         )
 
 
@@ -87,6 +93,8 @@ def get_list_knowledge_bases_tool(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[list[str]] = None,
 ) -> ListKnowledgeBasesTool:
     """Create a tool to list all knowledge bases through the tool facade."""
     return _get_tool_compatibility_facade().get_list_knowledge_bases_tool(
@@ -94,6 +102,8 @@ def get_list_knowledge_bases_tool(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
+        agent_creator_user_id=agent_creator_user_id,
+        declared_knowledge_bases=declared_knowledge_bases,
     )
 
 
@@ -102,6 +112,8 @@ def _get_list_knowledge_bases_tool_impl(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[list[str]] = None,
 ) -> ListKnowledgeBasesTool:
     """Create a tool to list all knowledge bases.
 
@@ -110,6 +122,9 @@ def _get_list_knowledge_bases_tool_impl(
         user_id: Optional user ID for multi-tenancy filtering.
         is_admin: Whether the user has admin privileges.
         governing_team_id: The governing agent's owning team, if any.
+        agent_creator_user_id: The governing agent's creator, if any.
+        declared_knowledge_bases: The governing agent's stored knowledge-base
+            declaration, if any.
 
     Returns:
         ListKnowledgeBasesTool instance
@@ -119,6 +134,8 @@ def _get_list_knowledge_bases_tool_impl(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
+        agent_creator_user_id=agent_creator_user_id,
+        declared_knowledge_bases=declared_knowledge_bases,
     )
 
 
@@ -135,6 +152,8 @@ class KnowledgeSearchTool(AbstractBaseTool):
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
+        agent_creator_user_id: Optional[int] = None,
+        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self.embedding_model_id = embedding_model_id
@@ -143,6 +162,8 @@ class KnowledgeSearchTool(AbstractBaseTool):
         self.user_id = user_id
         self.is_admin = is_admin
         self.governing_team_id = governing_team_id
+        self.agent_creator_user_id = agent_creator_user_id
+        self.declared_knowledge_bases = declared_knowledge_bases
 
     @property
     def name(self) -> str:
@@ -195,6 +216,8 @@ class KnowledgeSearchTool(AbstractBaseTool):
             user_id=self.user_id,
             is_admin=self.is_admin,
             governing_team_id=self.governing_team_id,
+            agent_creator_user_id=self.agent_creator_user_id,
+            declared_knowledge_bases=self.declared_knowledge_bases,
         )
 
 
@@ -205,6 +228,8 @@ def get_knowledge_search_tool(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[list[str]] = None,
 ) -> KnowledgeSearchTool:
     """Create a knowledge base search tool through the tool facade."""
     return _get_tool_compatibility_facade().get_knowledge_search_tool(
@@ -214,6 +239,8 @@ def get_knowledge_search_tool(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
+        agent_creator_user_id=agent_creator_user_id,
+        declared_knowledge_bases=declared_knowledge_bases,
     )
 
 
@@ -224,6 +251,8 @@ def _get_knowledge_search_tool_impl(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[list[str]] = None,
 ) -> KnowledgeSearchTool:
     """Create a knowledge base search tool for Vibe agents.
 
@@ -234,6 +263,9 @@ def _get_knowledge_search_tool_impl(
         user_id: Optional user ID for multi-tenancy filtering.
         is_admin: Whether the user has admin privileges.
         governing_team_id: The governing agent's owning team, if any.
+        agent_creator_user_id: The governing agent's creator, if any.
+        declared_knowledge_bases: The governing agent's stored knowledge-base
+            declaration, if any.
 
     Returns:
         KnowledgeSearchTool instance
@@ -245,4 +277,6 @@ def _get_knowledge_search_tool_impl(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
+        agent_creator_user_id=agent_creator_user_id,
+        declared_knowledge_bases=declared_knowledge_bases,
     )

--- a/src/xagent/core/tools/adapters/vibe/document_search.py
+++ b/src/xagent/core/tools/adapters/vibe/document_search.py
@@ -35,11 +35,13 @@ class ListKnowledgeBasesTool(AbstractBaseTool):
         allowed_collections: Optional[list[str]] = None,
         user_id: Optional[int] = None,
         is_admin: bool = False,
+        governing_team_id: Optional[int] = None,
     ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self.allowed_collections = allowed_collections
         self.user_id = user_id
         self.is_admin = is_admin
+        self.governing_team_id = governing_team_id
 
     @property
     def name(self) -> str:
@@ -73,7 +75,10 @@ class ListKnowledgeBasesTool(AbstractBaseTool):
             args.setdefault("allowed_collections", self.allowed_collections)
         tool_args = ListKnowledgeBasesArgs.model_validate(args)
         return await _get_tool_compatibility_facade().list_knowledge_bases(
-            tool_args, user_id=self.user_id, is_admin=self.is_admin
+            tool_args,
+            user_id=self.user_id,
+            is_admin=self.is_admin,
+            governing_team_id=self.governing_team_id,
         )
 
 
@@ -81,12 +86,14 @@ def get_list_knowledge_bases_tool(
     allowed_collections: Optional[list[str]] = None,
     user_id: Optional[int] = None,
     is_admin: bool = False,
+    governing_team_id: Optional[int] = None,
 ) -> ListKnowledgeBasesTool:
     """Create a tool to list all knowledge bases through the tool facade."""
     return _get_tool_compatibility_facade().get_list_knowledge_bases_tool(
         allowed_collections=allowed_collections,
         user_id=user_id,
         is_admin=is_admin,
+        governing_team_id=governing_team_id,
     )
 
 
@@ -94,6 +101,7 @@ def _get_list_knowledge_bases_tool_impl(
     allowed_collections: Optional[list[str]] = None,
     user_id: Optional[int] = None,
     is_admin: bool = False,
+    governing_team_id: Optional[int] = None,
 ) -> ListKnowledgeBasesTool:
     """Create a tool to list all knowledge bases.
 
@@ -101,12 +109,16 @@ def _get_list_knowledge_bases_tool_impl(
         allowed_collections: Optional list of allowed collection names to filter.
         user_id: Optional user ID for multi-tenancy filtering.
         is_admin: Whether the user has admin privileges.
+        governing_team_id: The governing agent's owning team, if any.
 
     Returns:
         ListKnowledgeBasesTool instance
     """
     return ListKnowledgeBasesTool(
-        allowed_collections=allowed_collections, user_id=user_id, is_admin=is_admin
+        allowed_collections=allowed_collections,
+        user_id=user_id,
+        is_admin=is_admin,
+        governing_team_id=governing_team_id,
     )
 
 
@@ -122,6 +134,7 @@ class KnowledgeSearchTool(AbstractBaseTool):
         allowed_collections: Optional[list[str]] = None,
         user_id: Optional[int] = None,
         is_admin: bool = False,
+        governing_team_id: Optional[int] = None,
     ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self.embedding_model_id = embedding_model_id
@@ -129,6 +142,7 @@ class KnowledgeSearchTool(AbstractBaseTool):
         self.allowed_collections = allowed_collections
         self.user_id = user_id
         self.is_admin = is_admin
+        self.governing_team_id = governing_team_id
 
     @property
     def name(self) -> str:
@@ -177,7 +191,10 @@ class KnowledgeSearchTool(AbstractBaseTool):
 
         tool_args = KnowledgeSearchArgs.model_validate(args)
         return await _get_tool_compatibility_facade().search_knowledge_base(
-            tool_args, user_id=self.user_id, is_admin=self.is_admin
+            tool_args,
+            user_id=self.user_id,
+            is_admin=self.is_admin,
+            governing_team_id=self.governing_team_id,
         )
 
 
@@ -187,6 +204,7 @@ def get_knowledge_search_tool(
     allowed_collections: Optional[list[str]] = None,
     user_id: Optional[int] = None,
     is_admin: bool = False,
+    governing_team_id: Optional[int] = None,
 ) -> KnowledgeSearchTool:
     """Create a knowledge base search tool through the tool facade."""
     return _get_tool_compatibility_facade().get_knowledge_search_tool(
@@ -195,6 +213,7 @@ def get_knowledge_search_tool(
         allowed_collections=allowed_collections,
         user_id=user_id,
         is_admin=is_admin,
+        governing_team_id=governing_team_id,
     )
 
 
@@ -204,6 +223,7 @@ def _get_knowledge_search_tool_impl(
     allowed_collections: Optional[list[str]] = None,
     user_id: Optional[int] = None,
     is_admin: bool = False,
+    governing_team_id: Optional[int] = None,
 ) -> KnowledgeSearchTool:
     """Create a knowledge base search tool for Vibe agents.
 
@@ -213,6 +233,7 @@ def _get_knowledge_search_tool_impl(
         allowed_collections: Optional list of allowed collection names. Used as default when collections is not specified.
         user_id: Optional user ID for multi-tenancy filtering.
         is_admin: Whether the user has admin privileges.
+        governing_team_id: The governing agent's owning team, if any.
 
     Returns:
         KnowledgeSearchTool instance
@@ -223,4 +244,5 @@ def _get_knowledge_search_tool_impl(
         allowed_collections=allowed_collections,
         user_id=user_id,
         is_admin=is_admin,
+        governing_team_id=governing_team_id,
     )

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from .....config import get_uploads_dir
 from .....core.task_runtime import FILE_OPERATION_ACCESS_VERSION_KEY
 from .....core.workspace import TaskWorkspace
+from ...core.knowledge_base_scope import KnowledgeBaseScopeError
 from .base import AbstractBaseTool, Tool
 from .config import (
     BaseToolConfig,
@@ -222,10 +223,11 @@ class ToolRegistry:
         dispatched and are responsible for
         short-circuiting internally based on the spec.
 
-        Exception contract for creators: ``ConnectorRuntimeError`` and
-        ``RequiredMCPUnavailableError`` propagate to the caller; any other
-        exception is logged as a warning and that creator contributes no
-        tools. Creators rely on this and must not catch broadly themselves.
+        Exception contract for creators: ``ConnectorRuntimeError``,
+        ``RequiredMCPUnavailableError`` and ``KnowledgeBaseScopeError``
+        propagate to the caller; any other exception is logged as a warning
+        and that creator contributes no tools. Creators rely on this and must
+        not catch broadly themselves.
         """
         # Import tool modules on first call to trigger decorator registration
         cls._import_tool_modules()
@@ -248,6 +250,14 @@ class ToolRegistry:
             except ConnectorRuntimeError:
                 raise
             except RequiredMCPUnavailableError:
+                raise
+            except KnowledgeBaseScopeError:
+                # Defence in depth only (see knowledge_tools.py's own
+                # narrowing): the team hook is never invoked while tools are
+                # being built, so nothing today raises this here. Kept so a
+                # future change that does resolve the team layer during tool
+                # build cannot have the typed error silently swallowed by
+                # the blanket handler below.
                 raise
             except Exception as e:
                 logger.warning(

--- a/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
@@ -3,6 +3,7 @@
 import logging
 from typing import TYPE_CHECKING, Any, List
 
+from ...core.knowledge_base_scope import KnowledgeBaseScopeError
 from .factory import register_tool
 
 if TYPE_CHECKING:
@@ -38,6 +39,18 @@ async def _create_knowledge_tools_impl(config: "BaseToolConfig") -> List[Any]:
         allowed_collections = config.get_allowed_collections()
         user_id = config.get_user_id()
         is_admin = config.is_admin()
+        # The governing agent's team, read the same way the six existing
+        # WebToolConfig-internal call sites already read it: as the private
+        # attribute, defaulting to None for every config that has no such
+        # attribute at all (every non-web config).
+        #
+        # Deliberately not behind a dedicated accessor. The attribute already
+        # has six direct readers inside WebToolConfig (config.py:1593, :1792,
+        # :2078, :3530, :3546, :3592), none of which an accessor added here
+        # would convert; a seventh reader asking the same question a seventh
+        # way is a second convention nothing else adopts, and the next reader
+        # then has to learn which of the two is authoritative.
+        governing_team_id = getattr(config, "_connector_team_id", None)
 
         if allowed_collections is not None and len(allowed_collections) == 0:
             return []
@@ -47,6 +60,7 @@ async def _create_knowledge_tools_impl(config: "BaseToolConfig") -> List[Any]:
                 allowed_collections=allowed_collections,
                 user_id=user_id,
                 is_admin=is_admin,
+                governing_team_id=governing_team_id,
             )
             tools.append(list_tool)
 
@@ -58,8 +72,17 @@ async def _create_knowledge_tools_impl(config: "BaseToolConfig") -> List[Any]:
             allowed_collections=allowed_collections,
             user_id=user_id,
             is_admin=is_admin,
+            governing_team_id=governing_team_id,
         )
         tools.append(knowledge_tool)
+    except KnowledgeBaseScopeError:
+        # Defence in depth only: the team hook is never invoked while tools
+        # are being built (resolution happens per search call, not here), so
+        # nothing today can raise this from inside this try block. Kept so a
+        # future change that does resolve the team layer during tool build
+        # cannot have its typed error silently swallowed by the blanket
+        # handler below.
+        raise
     except Exception as e:
         logger.warning(f"Failed to create knowledge tools: {e}")
 

--- a/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
@@ -49,8 +49,12 @@ async def _create_knowledge_tools_impl(config: "BaseToolConfig") -> List[Any]:
         # :2078, :3530, :3546, :3592), none of which an accessor added here
         # would convert; a seventh reader asking the same question a seventh
         # way is a second convention nothing else adopts, and the next reader
-        # then has to learn which of the two is authoritative.
+        # then has to learn which of the two is authoritative. The two
+        # genuinely new values below get accessors because they have no
+        # existing readers to be inconsistent with.
         governing_team_id = getattr(config, "_connector_team_id", None)
+        agent_creator_user_id = config.get_agent_creator_user_id()
+        declared_knowledge_bases = config.get_declared_knowledge_bases()
 
         if allowed_collections is not None and len(allowed_collections) == 0:
             return []
@@ -61,6 +65,8 @@ async def _create_knowledge_tools_impl(config: "BaseToolConfig") -> List[Any]:
                 user_id=user_id,
                 is_admin=is_admin,
                 governing_team_id=governing_team_id,
+                agent_creator_user_id=agent_creator_user_id,
+                declared_knowledge_bases=declared_knowledge_bases,
             )
             tools.append(list_tool)
 
@@ -73,6 +79,8 @@ async def _create_knowledge_tools_impl(config: "BaseToolConfig") -> List[Any]:
             user_id=user_id,
             is_admin=is_admin,
             governing_team_id=governing_team_id,
+            agent_creator_user_id=agent_creator_user_id,
+            declared_knowledge_bases=declared_knowledge_bases,
         )
         tools.append(knowledge_tool)
     except KnowledgeBaseScopeError:

--- a/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
@@ -72,6 +72,7 @@ class KBToolCompatibilityFacade:
         tool_args: ListKnowledgeBasesArgs,
         user_id: Optional[int] = None,
         is_admin: bool = False,
+        governing_team_id: Optional[int] = None,
     ) -> ListKnowledgeBasesResult:
         from ... import document_search as core_document_search
 
@@ -80,6 +81,7 @@ class KBToolCompatibilityFacade:
                 tool_args,
                 user_id=user_id,
                 is_admin=is_admin,
+                governing_team_id=governing_team_id,
             )
 
     async def find_missing_knowledge_bases(
@@ -102,6 +104,7 @@ class KBToolCompatibilityFacade:
         tool_args: KnowledgeSearchArgs,
         user_id: Optional[int] = None,
         is_admin: bool = False,
+        governing_team_id: Optional[int] = None,
     ) -> KnowledgeSearchResult:
         from ... import document_search as core_document_search
 
@@ -110,6 +113,7 @@ class KBToolCompatibilityFacade:
                 tool_args,
                 user_id=user_id,
                 is_admin=is_admin,
+                governing_team_id=governing_team_id,
             )
 
     def get_list_knowledge_bases_tool(
@@ -117,6 +121,7 @@ class KBToolCompatibilityFacade:
         allowed_collections: Optional[list[str]] = None,
         user_id: Optional[int] = None,
         is_admin: bool = False,
+        governing_team_id: Optional[int] = None,
     ) -> ListKnowledgeBasesTool:
         from ....adapters.vibe import document_search as vibe_document_search
 
@@ -124,6 +129,7 @@ class KBToolCompatibilityFacade:
             allowed_collections=allowed_collections,
             user_id=user_id,
             is_admin=is_admin,
+            governing_team_id=governing_team_id,
         )
 
     def get_knowledge_search_tool(
@@ -133,6 +139,7 @@ class KBToolCompatibilityFacade:
         allowed_collections: Optional[list[str]] = None,
         user_id: Optional[int] = None,
         is_admin: bool = False,
+        governing_team_id: Optional[int] = None,
     ) -> KnowledgeSearchTool:
         from ....adapters.vibe import document_search as vibe_document_search
 
@@ -142,6 +149,7 @@ class KBToolCompatibilityFacade:
             allowed_collections=allowed_collections,
             user_id=user_id,
             is_admin=is_admin,
+            governing_team_id=governing_team_id,
         )
 
     async def create_knowledge_tools(

--- a/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
@@ -73,6 +73,8 @@ class KBToolCompatibilityFacade:
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
+        agent_creator_user_id: Optional[int] = None,
+        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> ListKnowledgeBasesResult:
         from ... import document_search as core_document_search
 
@@ -82,6 +84,8 @@ class KBToolCompatibilityFacade:
                 user_id=user_id,
                 is_admin=is_admin,
                 governing_team_id=governing_team_id,
+                agent_creator_user_id=agent_creator_user_id,
+                declared_knowledge_bases=declared_knowledge_bases,
             )
 
     async def find_missing_knowledge_bases(
@@ -105,6 +109,8 @@ class KBToolCompatibilityFacade:
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
+        agent_creator_user_id: Optional[int] = None,
+        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> KnowledgeSearchResult:
         from ... import document_search as core_document_search
 
@@ -114,6 +120,8 @@ class KBToolCompatibilityFacade:
                 user_id=user_id,
                 is_admin=is_admin,
                 governing_team_id=governing_team_id,
+                agent_creator_user_id=agent_creator_user_id,
+                declared_knowledge_bases=declared_knowledge_bases,
             )
 
     def get_list_knowledge_bases_tool(
@@ -122,6 +130,8 @@ class KBToolCompatibilityFacade:
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
+        agent_creator_user_id: Optional[int] = None,
+        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> ListKnowledgeBasesTool:
         from ....adapters.vibe import document_search as vibe_document_search
 
@@ -130,6 +140,8 @@ class KBToolCompatibilityFacade:
             user_id=user_id,
             is_admin=is_admin,
             governing_team_id=governing_team_id,
+            agent_creator_user_id=agent_creator_user_id,
+            declared_knowledge_bases=declared_knowledge_bases,
         )
 
     def get_knowledge_search_tool(
@@ -140,6 +152,8 @@ class KBToolCompatibilityFacade:
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
+        agent_creator_user_id: Optional[int] = None,
+        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> KnowledgeSearchTool:
         from ....adapters.vibe import document_search as vibe_document_search
 
@@ -150,6 +164,8 @@ class KBToolCompatibilityFacade:
             user_id=user_id,
             is_admin=is_admin,
             governing_team_id=governing_team_id,
+            agent_creator_user_id=agent_creator_user_id,
+            declared_knowledge_bases=declared_knowledge_bases,
         )
 
     async def create_knowledge_tools(

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -192,6 +192,8 @@ async def list_knowledge_bases(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[List[str]] = None,
 ) -> ListKnowledgeBasesResult:
     """List all available knowledge bases through the tool compatibility facade."""
     return await _get_tool_compatibility_facade().list_knowledge_bases(
@@ -199,6 +201,8 @@ async def list_knowledge_bases(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
+        agent_creator_user_id=agent_creator_user_id,
+        declared_knowledge_bases=declared_knowledge_bases,
     )
 
 
@@ -207,6 +211,8 @@ async def _list_knowledge_bases_impl(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[List[str]] = None,
 ) -> ListKnowledgeBasesResult:
     """List all available knowledge bases with their statistics.
 
@@ -218,6 +224,19 @@ async def _list_knowledge_bases_impl(
             affects *which* collections are visible (the team layer resolves
             on this team instead of the runner's own team memberships); see
             ``_list_visible_collections``.
+        agent_creator_user_id: Accepted for signature symmetry with
+            ``_search_knowledge_base_impl`` and never read here.
+            ``knowledge_tools.py`` builds the list tool only when the
+            agent's allowed collections are ``None`` -- a non-empty list
+            builds the search tool alone, and an empty list builds no
+            knowledge tool at all -- and both chat call sites derive that
+            value and the declaration from the same stored field, so on this
+            path there is no declared name to classify at all. See
+            ``declared_knowledge_bases`` below.
+        declared_knowledge_bases: Accepted for signature symmetry and never
+            read here, for the same reason. This function reports "here is
+            what is available" -- an unresolved declared name simply does
+            not appear in the list, with no separate message field.
 
     Returns:
         ListKnowledgeBasesResult containing knowledge base information
@@ -302,6 +321,8 @@ async def search_knowledge_base(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[List[str]] = None,
 ) -> KnowledgeSearchResult:
     """Search across knowledge bases through the tool compatibility facade."""
     return await _get_tool_compatibility_facade().search_knowledge_base(
@@ -309,6 +330,8 @@ async def search_knowledge_base(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
+        agent_creator_user_id=agent_creator_user_id,
+        declared_knowledge_bases=declared_knowledge_bases,
     )
 
 
@@ -317,6 +340,8 @@ async def _search_knowledge_base_impl(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[List[str]] = None,
 ) -> KnowledgeSearchResult:
     """Search across knowledge base collections.
 
@@ -327,6 +352,19 @@ async def _search_knowledge_base_impl(
         governing_team_id: The governing agent's owning team, if any. Only
             affects *which* collections are visible; see
             ``_list_visible_collections``.
+        agent_creator_user_id: The governing agent's creator, if any.
+            Carried to this function but not read by it: the rule that
+            tells the agent's own creator apart from every other runner of
+            a team-governed agent arrives separately.
+        declared_knowledge_bases: The governing agent's STORED
+            ``knowledge_bases`` declaration, if any -- never
+            ``tool_args.allowed_collections`` and never
+            ``tool_args.collections``, both of which are model-authored on
+            every path (a declared schema field the model can overwrite).
+            Carried here but not read yet, for the same reason as
+            ``agent_creator_user_id``; keeping the two apart all the way to
+            this function is what lets the rule land without re-threading
+            anything.
 
     Returns:
         KnowledgeSearchResult with formatted search results

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from ....config import get_kb_search_timeout_seconds
+from .knowledge_base_scope import KnowledgeBaseScopeError
 from .RAG_tools.core.schemas import ListCollectionsResult
 from .RAG_tools.management.collections import list_collections
 from .RAG_tools.pipelines.document_search import run_document_search
@@ -34,29 +35,68 @@ def _get_tool_compatibility_facade() -> "KBToolCompatibilityFacade":
 
 
 async def _list_visible_collections(
-    user_id: Optional[int], is_admin: bool
+    user_id: Optional[int],
+    is_admin: bool,
+    governing_team_id: Optional[int] = None,
 ) -> ListCollectionsResult:
-    """Union personal collections with application-provided team overlays."""
+    """Union personal collections with application-provided team overlays.
+
+    For a team-governed run (``governing_team_id`` set and a team-keyed hook
+    installed), the team layer is the *governing* team's own knowledge
+    bases, resolved through ``resolve_team_knowledge_bases_or_raise`` --
+    never the runner's own team memberships, and never a union of the two.
+    Every other case falls back to the existing runner-keyed overlay through
+    ``visible_team_knowledge_bases``, unchanged.
+
+    This function stays a pure union either way: it decides *whose* team
+    rows are visible, never which of the agent's declared names may search
+    them -- that rule belongs to the callers that read the agent's stored
+    configuration, not here, so a future consumer of this function cannot
+    inherit the declared-name rule by accident.
+    """
     result = await list_collections(user_id=user_id, is_admin=is_admin)
-    if user_id is None or is_admin:
+    # This is not an optimisation: the calls below do int(user_id), so
+    # removing this guard would turn an unauthenticated caller into a
+    # TypeError instead of this well-defined early return. It keeps its
+    # position as the first check for exactly that reason -- the governing
+    # team branch below still needs a real user_id.
+    if user_id is None:
         return result
 
     from ....web.services.db_runtime import run_db_io_cancellation_safe
     from ....web.services.knowledge_base_team_scope import (
         has_knowledge_base_visibility_hook,
+        resolve_team_knowledge_bases_or_raise,
+        team_knowledge_base_hook_installed,
         visible_team_knowledge_bases,
     )
 
-    if not has_knowledge_base_visibility_hook():
+    if governing_team_id is not None and team_knowledge_base_hook_installed():
+        # Selection is on the predicate above, never on an empty return: an
+        # installed hook legitimately answers "this team owns nothing".
+        #
+        # Reached before the is_admin short-circuit below on purpose: for a
+        # team-governed run, an admin's declared names must still resolve
+        # against the governing team, not against the admin's unrestricted
+        # view of every collection on the platform.
+        team_refs = await run_db_io_cancellation_safe(
+            lambda: resolve_team_knowledge_bases_or_raise(
+                None, team_id=governing_team_id, log_subject=user_id
+            )
+        )
+    elif is_admin:
         return result
+    elif not has_knowledge_base_visibility_hook():
+        return result
+    else:
+        team_refs = await run_db_io_cancellation_safe(
+            lambda: visible_team_knowledge_bases(None, int(user_id))
+        )
 
     collections_by_name = {
         collection.name: collection for collection in result.collections
     }
     refs_by_owner: dict[int, list] = {}
-    team_refs = await run_db_io_cancellation_safe(
-        lambda: visible_team_knowledge_bases(None, int(user_id))
-    )
     for ref in team_refs:
         refs_by_owner.setdefault(ref.storage_user_id, []).append(ref)
     for storage_user_id, refs in refs_by_owner.items():
@@ -68,6 +108,10 @@ async def _list_visible_collections(
             collection = owner_collections.get(ref.name)
             if collection is None:
                 continue
+            # The sole source of an ``ownership == "team"`` entry in the
+            # merged map is this loop -- every consumer's "does the
+            # governing team own this name" test (below, and in the two
+            # impls further down) is only trustworthy because of that.
             collections_by_name[ref.name] = collection.model_copy(
                 update={
                     "ownership": "team",
@@ -147,12 +191,14 @@ async def list_knowledge_bases(
     tool_args: ListKnowledgeBasesArgs,
     user_id: Optional[int] = None,
     is_admin: bool = False,
+    governing_team_id: Optional[int] = None,
 ) -> ListKnowledgeBasesResult:
     """List all available knowledge bases through the tool compatibility facade."""
     return await _get_tool_compatibility_facade().list_knowledge_bases(
         tool_args,
         user_id=user_id,
         is_admin=is_admin,
+        governing_team_id=governing_team_id,
     )
 
 
@@ -160,6 +206,7 @@ async def _list_knowledge_bases_impl(
     tool_args: ListKnowledgeBasesArgs,
     user_id: Optional[int] = None,
     is_admin: bool = False,
+    governing_team_id: Optional[int] = None,
 ) -> ListKnowledgeBasesResult:
     """List all available knowledge bases with their statistics.
 
@@ -167,15 +214,25 @@ async def _list_knowledge_bases_impl(
         tool_args: Args with optional allowed_collections filter
         user_id: Optional user ID for multi-tenancy filtering
         is_admin: Whether the user has admin privileges
+        governing_team_id: The governing agent's owning team, if any. Only
+            affects *which* collections are visible (the team layer resolves
+            on this team instead of the runner's own team memberships); see
+            ``_list_visible_collections``.
 
     Returns:
         ListKnowledgeBasesResult containing knowledge base information
 
     Raises:
-        RuntimeError: If listing knowledge bases fails
+        KnowledgeBaseScopeError: If the team-scope hook is installed but
+            fails or returns a malformed answer.
+        RuntimeError: If listing knowledge bases fails for any other reason.
     """
     try:
-        result = await _list_visible_collections(user_id=user_id, is_admin=is_admin)
+        result = await _list_visible_collections(
+            user_id=user_id,
+            is_admin=is_admin,
+            governing_team_id=governing_team_id,
+        )
 
         kb_list = []
         for collection in result.collections:
@@ -199,6 +256,8 @@ async def _list_knowledge_bases_impl(
 
         return ListKnowledgeBasesResult(knowledge_bases=kb_list)
 
+    except KnowledgeBaseScopeError:
+        raise
     except Exception as e:
         logger.error(f"Failed to list knowledge bases: {e}", exc_info=True)
         raise RuntimeError(f"Failed to list knowledge bases: {e}") from e
@@ -222,7 +281,13 @@ async def _find_missing_knowledge_bases_impl(
     user_id: Optional[int] = None,
     is_admin: bool = False,
 ) -> List[str]:
-    """Return requested knowledge base names that are not visible to the user."""
+    """Return requested knowledge base names that are not visible to the user.
+
+    Deliberately stays runner-keyed: this backs the agent-builder's
+    save-time validation of an agent's own collection selection, which must
+    answer against the runner's own visible set, not any governing team --
+    an agent being edited is not yet the governing agent of any run.
+    """
     requested = [name.strip() for name in knowledge_bases if name and name.strip()]
     if not requested:
         return []
@@ -236,12 +301,14 @@ async def search_knowledge_base(
     tool_args: KnowledgeSearchArgs,
     user_id: Optional[int] = None,
     is_admin: bool = False,
+    governing_team_id: Optional[int] = None,
 ) -> KnowledgeSearchResult:
     """Search across knowledge bases through the tool compatibility facade."""
     return await _get_tool_compatibility_facade().search_knowledge_base(
         tool_args,
         user_id=user_id,
         is_admin=is_admin,
+        governing_team_id=governing_team_id,
     )
 
 
@@ -249,6 +316,7 @@ async def _search_knowledge_base_impl(
     tool_args: KnowledgeSearchArgs,
     user_id: Optional[int] = None,
     is_admin: bool = False,
+    governing_team_id: Optional[int] = None,
 ) -> KnowledgeSearchResult:
     """Search across knowledge base collections.
 
@@ -256,17 +324,24 @@ async def _search_knowledge_base_impl(
         tool_args: Search configuration including query, collections, and search parameters
         user_id: Optional user ID for multi-tenancy filtering
         is_admin: Whether the user has admin privileges
+        governing_team_id: The governing agent's owning team, if any. Only
+            affects *which* collections are visible; see
+            ``_list_visible_collections``.
 
     Returns:
         KnowledgeSearchResult with formatted search results
 
     Raises:
-        RuntimeError: If search fails
+        KnowledgeBaseScopeError: If the team-scope hook is installed but
+            fails or returns a malformed answer.
+        RuntimeError: If search fails for any other reason.
     """
     try:
         # List all collections
         collections_result = await _list_visible_collections(
-            user_id=user_id, is_admin=is_admin
+            user_id=user_id,
+            is_admin=is_admin,
+            governing_team_id=governing_team_id,
         )
 
         if not collections_result.collections:
@@ -550,6 +625,8 @@ async def _search_knowledge_base_impl(
 
         return KnowledgeSearchResult(results=formatted_results, summary=summary)
 
+    except KnowledgeBaseScopeError:
+        raise
     except Exception as e:
         logger.error(f"Knowledge base search failed: {e}", exc_info=True)
         raise RuntimeError(f"Knowledge base search failed: {e}") from e

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -76,9 +76,11 @@ async def _list_visible_collections(
         # installed hook legitimately answers "this team owns nothing".
         #
         # Reached before the is_admin short-circuit below on purpose: for a
-        # team-governed run, an admin's declared names must still resolve
-        # against the governing team, not against the admin's unrestricted
-        # view of every collection on the platform.
+        # team-governed run, the team layer's source is the governing team,
+        # not the admin's own team memberships. This changes only where the
+        # team layer's rows come from -- the admin's platform-wide view in
+        # ``result`` is not narrowed by it; matching names are re-stamped
+        # with the team's ownership metadata below, the rest stay as-is.
         team_refs = await run_db_io_cancellation_safe(
             lambda: resolve_team_knowledge_bases_or_raise(
                 None, team_id=governing_team_id, log_subject=user_id

--- a/src/xagent/core/tools/core/knowledge_base_scope.py
+++ b/src/xagent/core/tools/core/knowledge_base_scope.py
@@ -1,0 +1,60 @@
+"""Typed scope error for team-resolved knowledge bases.
+
+MODULE CONSTRAINT: this module must not import any xagent module.
+Zero dependencies outside the standard library.
+
+That is what makes it importable at module level from BOTH sides of the
+core/web boundary -- core/tools/core/document_search.py catches it, and
+web/services/knowledge_base_team_scope.py raises it -- with no possible
+import cycle. A single xagent import here reintroduces the ordering
+problem this module exists to remove.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+class KnowledgeBaseScopeError(RuntimeError):
+    """A team-scoped knowledge-base resolution could not be completed.
+
+    Raised when the application-owned team visibility hook is missing,
+    malformed, or fails, and there is no safe way to fall back to a
+    partial or empty answer -- the caller must be told resolution
+    failed rather than receiving a result that silently omits the
+    team layer. The two run-path handlers that would otherwise
+    re-wrap any exception into a bare ``RuntimeError`` catch this type
+    first and re-raise it unchanged, so its ``status_code`` and
+    ``code`` survive to the caller.
+
+    ``safe_message`` (not ``message``) on purpose: it mirrors
+    ``ConnectorRuntimeError`` (``core/tools/adapters/vibe/connector_runtime.py``),
+    the equivalent typed error on the connector team-scope seam, whose
+    ``.safe_message`` is what its own catch site (``chat.py``) reads to
+    build the HTTP response. Nothing in this codebase currently reads
+    ``code``, ``status_code``, ``details``, or ``safe_message`` off this
+    class -- both run-path handlers re-raise it unchanged rather than
+    unpacking it -- but a future HTTP-facing catch site should find the
+    same attribute name on either error, not two conventions for the same
+    shape.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        details: Optional[Mapping[str, Any]] = None,
+        status_code: int = 503,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.safe_message = message
+        self.details = dict(details) if details is not None else {}
+        self.status_code = status_code
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"{self.__class__.__name__}(code={self.code!r}, "
+            f"message={self.safe_message!r}, status_code={self.status_code!r})"
+        )

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -596,6 +596,8 @@ async def create_default_tools(
     connector_team_id: Optional[int] = None,
     db_task_id: Optional[int] = None,
     file_operation_access_version: Any = None,
+    agent_creator_user_id: Optional[int] = None,
+    declared_knowledge_bases: Optional[List[str]] = None,
 ) -> tuple[list[Any], Any]:
     """Create default tools and tool_config for AgentService using ToolFactory.
 
@@ -614,6 +616,17 @@ async def create_default_tools(
     historical positional signature. Runtime callers pass them by keyword so
     File Operation receives trusted task and rollout authority without shifting
     existing positional integrations.
+
+    ``agent_creator_user_id`` and ``declared_knowledge_bases`` thread the same
+    governing agent's creator and its *stored* ``knowledge_bases`` list
+    alongside ``connector_team_id`` into ``WebToolConfig``, so the
+    knowledge-base search path can resolve a declared name against the
+    governing team, fall back to the creator's own collection, and report a
+    name the team never received rather than reaching for the runner's own
+    same-named collection. ``declared_knowledge_bases`` is read from the same
+    place ``allowed_collections`` already is (the agent's own configuration)
+    and is never the model-supplied value on a search request -- the two stay
+    distinct all the way to the resolution point.
     """
     if not user:
         raise ValueError("User is required for tool creation")
@@ -687,6 +700,8 @@ async def create_default_tools(
         mcp_load_summary_tracer=mcp_load_summary_tracer,
         mcp_load_summary_trace_task_id=mcp_load_summary_trace_task_id,
         connector_team_id=connector_team_id,
+        agent_creator_user_id=agent_creator_user_id,
+        declared_knowledge_bases=declared_knowledge_bases,
     )
 
     # Store excluded_agent_id in tool_config for agent tool filtering
@@ -1945,6 +1960,14 @@ class AgentServiceManager:
                 if task_setup_snapshot.agent is not None
                 else None
             )
+            # Same agent as connector_team_id above -- both are read off the
+            # same frozen AgentRuntimeFields snapshot, so they can never
+            # describe two different agents.
+            agent_creator_user_id = (
+                task_setup_snapshot.agent.agent_creator_user_id
+                if task_setup_snapshot.agent is not None
+                else None
+            )
         else:
             if db is None:
                 raise ValueError("Database session or task snapshot is required")
@@ -1966,6 +1989,12 @@ class AgentServiceManager:
                 int(current_agent.team_id)
                 if current_agent is not None and current_agent.team_id is not None
                 else None
+            )
+            # Captured alongside connector_team_id, for the same reason: both
+            # must describe the agent resolved above, never a preview agent
+            # substituted into ``current_agent`` by a branch further down.
+            agent_creator_user_id = (
+                int(current_agent.user_id) if current_agent is not None else None
             )
             if current_agent and _is_published_agent(current_agent):
                 excluded_agent_id = int(current_agent.id)
@@ -2058,6 +2087,10 @@ class AgentServiceManager:
             mcp_load_summary_tracer=parent_tracer,
             mcp_load_summary_trace_task_id=str(task_id),
             connector_team_id=connector_team_id,
+            agent_creator_user_id=agent_creator_user_id,
+            declared_knowledge_bases=agent_config["knowledge_bases"]
+            if agent_config
+            else None,
         )
 
     async def get_agent_for_task(
@@ -2706,6 +2739,21 @@ class AgentServiceManager:
                         if snapshot is not None and snapshot.agent is not None
                         else None
                     ),
+                    # Same agent as connector_team_id immediately above -- both
+                    # read off the same snapshot, so a governing team is never
+                    # paired with another agent's creator. This is the one of
+                    # the three derivation points that does not have its own
+                    # named local variable; it is folded straight into this
+                    # call because that is how connector_team_id already reads
+                    # here.
+                    agent_creator_user_id=(
+                        snapshot.agent.agent_creator_user_id
+                        if snapshot is not None and snapshot.agent is not None
+                        else None
+                    ),
+                    declared_knowledge_bases=agent_config["knowledge_bases"]
+                    if agent_config
+                    else None,
                 )
 
                 with UserContext(runtime_user_id):

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -5173,6 +5173,11 @@ async def list_collections_api(
         collections_by_name = {
             collection.name: collection for collection in personal_collections
         }
+        # Runner-keyed on purpose: this endpoint answers "what can the
+        # requesting user see", the same question for every user regardless
+        # of which agent (if any) they are about to run, so it stays on the
+        # user-keyed overlay hook and never resolves against a governing
+        # agent's team.
         team_refs = visible_team_knowledge_bases(db, int(_user.id))
         refs_by_owner: dict[int, list[KnowledgeBaseAccess]] = {}
         for ref in team_refs:

--- a/src/xagent/web/services/knowledge_base_team_scope.py
+++ b/src/xagent/web/services/knowledge_base_team_scope.py
@@ -16,6 +16,12 @@ is actually asking. An application that wants to narrow who may run a
 team's agents at all enforces that at its agent-access policy layer, not at
 this seam -- this seam only answers "which knowledge base does this team
 own", never "is the current runner allowed to run this agent".
+
+A visibility hook's answer must set ``can_edit`` and ``can_delete`` to
+exactly ``False`` on every entry: ``KnowledgeBaseAccess`` defaults both to
+``True``, and an answer that leaves either at its default -- or omits it --
+is rejected outright rather than narrowed, which surfaces to every caller
+as the seam's one typed 503.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/knowledge_base_team_scope.py
+++ b/src/xagent/web/services/knowledge_base_team_scope.py
@@ -4,17 +4,37 @@ Standalone xagent keeps collections scoped to the requesting user's id. A
 multi-tenant application can install these hooks to expose a logical team
 collection while its files and vector rows remain in the original storage
 user's namespace.
+
+Every knowledge base a team-keyed hook returns becomes searchable and
+quotable by *any* runner of that team's agents -- not only members, and not
+only interactive ones. A published team agent is meant to serve runners,
+including anonymous end users of a widget or other embedded surface, who are
+not members of the team that owns it. Once such a runner's turn resolves a
+declared collection onto the team's copy, the collection's document text
+becomes part of what that run can retrieve and quote back, regardless of who
+is actually asking. An application that wants to narrow who may run a
+team's agents at all enforces that at its agent-access policy layer, not at
+this seam -- this seam only answers "which knowledge base does this team
+own", never "is the current runner allowed to run this agent".
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import logging
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Protocol
 
 from sqlalchemy.orm import Session
 
+from ...core.tools.core.knowledge_base_scope import KnowledgeBaseScopeError
+
+logger = logging.getLogger(__name__)
+
 KnowledgeBaseAction = Literal["read", "edit", "delete"]
+
+ERROR_KNOWLEDGE_BASE_SCOPE_UNAVAILABLE = "knowledge_base_scope_unavailable"
 
 
 @dataclass(frozen=True)
@@ -32,10 +52,43 @@ KnowledgeBaseAccessHook = Callable[
 ]
 KnowledgeBaseLifecycleHook = Callable[[Session | None, int, str, str | None], None]
 
+
+class TeamKnowledgeBaseVisibilityHook(Protocol):
+    """Resolver for the knowledge bases a team owns.
+
+    Typed as a ``Protocol`` with a keyword-only ``team_id`` so it cannot be
+    bound where ``KnowledgeBaseVisibilityHook`` (user-keyed) is expected, or
+    vice versa. The two shapes would otherwise be easy to confuse -- both
+    take an optional session and return a list of the same element type --
+    and the danger is not symmetric.
+
+    Binding the by-team function into the user-keyed slot is the dangerous
+    direction: ``visible_team_knowledge_bases`` calls that slot
+    *positionally* (``_visibility_hook(db, int(user_id))``), so a by-team
+    function bound there receives a plain ``user_id`` where it expects a
+    team id, and its answer is returned to the caller unvalidated -- it
+    silently resolves against whichever team happens to share that
+    numeric id, or misbehaves in some other way the type checker cannot
+    catch, because both callables type-check as functions from
+    ``(Session | None, int) -> list[KnowledgeBaseAccess]``.
+
+    The reverse swap -- binding the user-keyed function into this
+    protocol's slot -- is caught immediately: this slot is always called
+    with ``team_id=`` as a keyword, and a function whose second parameter
+    is positional-only or differently named raises ``TypeError`` at call
+    time instead of resolving against the wrong tenant.
+    """
+
+    def __call__(
+        self, db: Session | None, *, team_id: int
+    ) -> list[KnowledgeBaseAccess]: ...
+
+
 _visibility_hook: KnowledgeBaseVisibilityHook | None = None
 _access_hook: KnowledgeBaseAccessHook | None = None
 _renamed_hook: KnowledgeBaseLifecycleHook | None = None
 _deleted_hook: KnowledgeBaseLifecycleHook | None = None
+_team_visibility_hook: TeamKnowledgeBaseVisibilityHook | None = None
 
 
 def set_knowledge_base_team_hooks(
@@ -44,14 +97,26 @@ def set_knowledge_base_team_hooks(
     access: KnowledgeBaseAccessHook | None = None,
     renamed: KnowledgeBaseLifecycleHook | None = None,
     deleted: KnowledgeBaseLifecycleHook | None = None,
+    team_visibility: TeamKnowledgeBaseVisibilityHook | None = None,
 ) -> None:
-    """Install or clear application-owned knowledge-base hooks."""
+    """Install application-owned knowledge-base hooks.
+
+    Installs the complete hook set: every hook not supplied to a given call
+    is cleared, even one a previous call installed. This is a reset-all
+    setter, not a merge -- an application that installs hooks across more
+    than one call must pass its complete set each time. A caller that adds
+    a new slot to this function later must audit every existing installer
+    for the same reason: an installer that does not know about the new
+    keyword clears it.
+    """
 
     global _visibility_hook, _access_hook, _renamed_hook, _deleted_hook
+    global _team_visibility_hook
     _visibility_hook = visibility
     _access_hook = access
     _renamed_hook = renamed
     _deleted_hook = deleted
+    _team_visibility_hook = team_visibility
 
 
 def has_knowledge_base_visibility_hook() -> bool:
@@ -72,6 +137,192 @@ def visible_team_knowledge_bases(
     if _visibility_hook is None:
         return []
     return list(_visibility_hook(db, int(user_id)))
+
+
+def _validate_team_knowledge_base_answer(
+    answer: object,
+) -> list[KnowledgeBaseAccess]:
+    """Validate the team-visibility hook's answer shape.
+
+    This is an authorization input, not user-facing data: a malformed
+    answer must fail loudly, never be normalized, coerced, or defaulted to
+    empty.
+
+    Two different classes of rejection are mixed into one list on purpose,
+    and each element below says which class it is:
+
+    - **Fail-open guards.** ``can_edit`` and ``can_delete`` default to
+      ``True`` on ``KnowledgeBaseAccess``, and the consumer that reads a
+      by-team answer copies both flags straight onto the collection object
+      it hands back to the caller. An answer that simply omits them would
+      therefore grant edit *and* delete on the team's knowledge base to
+      every runner who can search it. Rejecting anything other than
+      ``False`` is what closes that gap; nothing about this check is
+      informational.
+    - **Coherence check.** ``team_owned`` is fixed ``True`` for every
+      element a by-team hook may legitimately return, but the consumer
+      that reads a by-team answer never looks at this field -- it sets
+      ``ownership: "team"`` itself once it decides to trust the answer at
+      all. A wrong ``team_owned`` therefore cannot fail open on that path
+      today. The check exists so the answer cannot assert something false
+      that a later consumer might start believing, not because today's
+      consumer is fooled by it.
+    """
+    if not isinstance(answer, Iterable) or isinstance(answer, (str, bytes)):
+        raise ValueError(
+            "team knowledge-base visibility hook returned a malformed answer: "
+            f"expected an iterable of KnowledgeBaseAccess, got {type(answer).__name__}"
+        )
+    validated: list[KnowledgeBaseAccess] = []
+    for element in answer:
+        if not isinstance(element, KnowledgeBaseAccess):
+            # Wrong element type.
+            raise ValueError(
+                "team knowledge-base visibility hook returned a malformed "
+                f"answer: expected KnowledgeBaseAccess elements, got "
+                f"{type(element).__name__}"
+            )
+        if not isinstance(element.name, str) or not element.name:
+            # Empty (or non-string) name.
+            raise ValueError(
+                "team knowledge-base visibility hook returned a malformed "
+                f"answer: name must be a non-empty str, got {element.name!r}"
+            )
+        if isinstance(element.storage_user_id, bool) or not isinstance(
+            element.storage_user_id, int
+        ):
+            # bool storage_user_id, or a non-int storage_user_id.
+            raise ValueError(
+                "team knowledge-base visibility hook returned a malformed "
+                f"answer: storage_user_id must be an int (not bool), got "
+                f"{element.storage_user_id!r} for {element.name!r}"
+            )
+        if element.can_edit is not False or element.can_delete is not False:
+            # Fail-open guard: see the docstring above -- these are copied
+            # onto the collection object unchanged, and the dataclass
+            # defaults are True, so an omitted field grants edit and
+            # delete to every runner who can search the collection.
+            raise ValueError(
+                "team knowledge-base visibility hook returned a malformed "
+                f"answer for {element.name!r}: can_edit and can_delete must "
+                "both be False on a team-owned entry"
+            )
+        if element.team_owned is not True:
+            # Coherence check: see the docstring above -- the consumer
+            # does not read this field, so a wrong value cannot fail open
+            # on today's path, but it would assert something false to a
+            # future reader.
+            raise ValueError(
+                "team knowledge-base visibility hook returned a malformed "
+                f"answer for {element.name!r}: team_owned must be True"
+            )
+        validated.append(element)
+    return validated
+
+
+def team_knowledge_bases(
+    db: Session | None, *, team_id: int
+) -> list[KnowledgeBaseAccess]:
+    """Knowledge bases owned by ``team_id``; empty for no hook installed.
+
+    ``team_id`` is the team that owns the *governing agent*, never the
+    running user's current team. A non-empty answer is shape-validated
+    (see ``_validate_team_knowledge_base_answer``) before it reaches any
+    caller.
+    """
+    if _team_visibility_hook is None:
+        return []
+    answer = _team_visibility_hook(db, team_id=int(team_id))
+    return _validate_team_knowledge_base_answer(answer)
+
+
+def team_knowledge_base_hook_installed() -> bool:
+    """Whether an application installed a team-keyed visibility hook.
+
+    Callers select on this, never on an empty return value: an installed
+    hook legitimately answers with an empty list for a team that owns
+    nothing.
+    """
+    return _team_visibility_hook is not None
+
+
+def resolve_team_knowledge_bases_or_raise(
+    db: Session | None, *, team_id: int, log_subject: int | None
+) -> list[KnowledgeBaseAccess]:
+    """``team_knowledge_bases(db, team_id=team_id)``, with every non-typed
+    failure converted into the seam's one typed 503.
+
+    Mirrors ``resolve_team_connector_ids_or_raise``: a
+    ``KnowledgeBaseScopeError`` passes through unchanged, and any other
+    exception (including a validator ``ValueError``) is logged and
+    converted into ``KnowledgeBaseScopeError`` so a caller can distinguish
+    "the team owns nothing" (an empty list) from "resolution failed" (a
+    raised, typed error) instead of the two collapsing into the same
+    silent empty answer.
+
+    ``log_subject`` is the id that identifies the caller in the warning
+    log line, formatted only, never interpreted.
+    """
+    try:
+        return team_knowledge_bases(db, team_id=team_id)
+    except KnowledgeBaseScopeError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve team knowledge-base scope for team %s (caller %s)",
+            team_id,
+            log_subject,
+            exc_info=True,
+        )
+        raise KnowledgeBaseScopeError(
+            ERROR_KNOWLEDGE_BASE_SCOPE_UNAVAILABLE,
+            "Knowledge base team scope is unavailable.",
+            details={"reason": "team_scope_resolution_failed"},
+            status_code=503,
+        ) from exc
+
+
+@contextmanager
+def snapshot_knowledge_base_team_hooks() -> Iterator[None]:
+    """Save every module-level hook slot, restore it on exit.
+
+    Intended for tests: entering the block, replacing any slot (through
+    ``set_knowledge_base_team_hooks`` or a direct module-attribute
+    monkeypatch), and leaving restores every slot to the exact object it
+    held before the block, including a slot the block never touched. A
+    slot added to this module later must be added here too, or a snapshot
+    taken before that slot exists will silently fail to restore it.
+
+    The connector seam this module otherwise mirrors has no counterpart, and
+    that asymmetry is deliberate rather than a gap to close in either
+    direction. Its tests reset by calling the setter with no arguments,
+    which restores the *empty* state, not the state the test found. Every
+    slot here is process-global, so a test that installs one and resets by
+    clearing leaves any hook the process had installed before it gone, and
+    the next test to depend on that hook fails somewhere else. Saving and
+    restoring lives on the module because the state being saved lives on the
+    module: a test-side helper would have to name and reach these globals
+    from outside, and would go stale the moment a slot is added here.
+    """
+    global _visibility_hook, _access_hook, _renamed_hook, _deleted_hook
+    global _team_visibility_hook
+    saved = (
+        _visibility_hook,
+        _access_hook,
+        _renamed_hook,
+        _deleted_hook,
+        _team_visibility_hook,
+    )
+    try:
+        yield
+    finally:
+        (
+            _visibility_hook,
+            _access_hook,
+            _renamed_hook,
+            _deleted_hook,
+            _team_visibility_hook,
+        ) = saved
 
 
 def resolve_knowledge_base_access(

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -1079,6 +1079,17 @@ class AgentRuntimeFields:
     # ``agent_id``. Read by the team-scope connector-visibility hook seam;
     # a fail-closed default keeps an un-migrated construction site personal.
     team_id: Optional[int] = None
+    # The Agent row's own creator, never the runner of this task. The one
+    # construction site in this module fills it unconditionally from the
+    # Agent row's ``user_id``, for a team agent and a personal one alike -- unlike
+    # ``team_id`` above, a personal agent still has a creator. The ``None``
+    # default is what a task with no Agent row gets (``TaskSetupSnapshot``
+    # leaves ``agent`` unset there) and what an un-migrated future
+    # construction site would get; it is a fail-closed default, not a
+    # description of the personal-agent case. Named for what it is -- the
+    # agent's creator -- not "owner", which this module already uses
+    # elsewhere for the running principal.
+    agent_creator_user_id: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -1305,6 +1316,7 @@ def resolve_task_runtime_config_core(
                 team_id=(
                     int(agent_row.team_id) if agent_row.team_id is not None else None
                 ),
+                agent_creator_user_id=int(agent_row.user_id),
             )
     else:
         # Inline agent_config path: task carries its own agent config

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1190,6 +1190,8 @@ class WebToolConfig(BaseToolConfig):
         mcp_load_summary_tracer: Optional[Any] = None,
         mcp_load_summary_trace_task_id: Optional[str] = None,
         connector_team_id: Optional[int] = None,
+        agent_creator_user_id: Optional[int] = None,
+        declared_knowledge_bases: Optional[List[str]] = None,
     ):
         # ``tool_selection_spec`` accepts :class:`ToolSelectionSpec` from
         # the tools adapter package; typed as ``Any`` here to avoid an
@@ -1205,6 +1207,18 @@ class WebToolConfig(BaseToolConfig):
         # path ever supplies this directly, it is read off a loaded ``Agent``
         # row (or a frozen snapshot of one) by the caller.
         self._connector_team_id = connector_team_id
+        # The governing agent's creator -- always the same agent as
+        # ``_connector_team_id`` above, populated by the same caller. Used by
+        # the knowledge-base resolution path to tell the agent's creator
+        # apart from any other runner of a team-governed agent.
+        self._agent_creator_user_id = agent_creator_user_id
+        # The governing agent's own STORED ``knowledge_bases`` declaration --
+        # never the model-supplied value on a search request. Read from the
+        # same place ``allowed_collections`` above already is; kept as a
+        # separate field because ``allowed_collections`` on a tool_args
+        # object can be overwritten by the model, and this value must not
+        # be confusable with that one at the resolution point.
+        self._declared_knowledge_bases = declared_knowledge_bases
         self._task_runtime_contribution: Any = None
         self._task_runtime_workspace: Any = None
         self._live_db = db
@@ -1891,6 +1905,21 @@ class WebToolConfig(BaseToolConfig):
     def get_allowed_collections(self) -> Optional[List[str]]:
         """Get allowed knowledge base collections. None means all collections are allowed."""
         return self._allowed_collections
+
+    def get_agent_creator_user_id(self) -> Optional[int]:
+        """Get the governing agent's creator, for the knowledge-base seam."""
+        return self._agent_creator_user_id
+
+    def get_declared_knowledge_bases(self) -> Optional[List[str]]:
+        """Get the governing agent's stored knowledge-base declaration.
+
+        Distinct from ``get_allowed_collections()``: both are populated from
+        the same agent configuration today, but this value is threaded
+        through to the knowledge-base resolution point as its own input and
+        must never be conflated with a tool-args field a model can
+        overwrite.
+        """
+        return self._declared_knowledge_bases
 
     def get_allowed_skills(self) -> Optional[List[str]]:
         """Get allowed skill names. None means all skills are allowed."""

--- a/tests/core/tools/adapters/vibe/test_knowledge_tools_team_scope_wiring.py
+++ b/tests/core/tools/adapters/vibe/test_knowledge_tools_team_scope_wiring.py
@@ -1,0 +1,159 @@
+"""The governing-team id, the agent's creator, and its stored knowledge-base
+declaration must actually reach the knowledge-base tool instances that
+``knowledge_tools.py`` builds -- not just exist as parameters somewhere in
+the call chain. Each test here breaks one link of that chain and would go
+red if that link silently dropped its value.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import pytest
+
+from xagent.core.tools.adapters.vibe import knowledge_tools
+from xagent.core.tools.adapters.vibe.document_search import (
+    KnowledgeSearchTool,
+    ListKnowledgeBasesTool,
+)
+from xagent.web.tools.config import WebToolConfig
+
+
+class _FakeConfig:
+    """A minimal ``BaseToolConfig``-shaped stand-in.
+
+    ``_connector_team_id`` is a bare attribute, not a method: this mirrors
+    how ``WebToolConfig`` actually stores it and how ``knowledge_tools.py``
+    reads it (``getattr(config, "_connector_team_id", None)``, the
+    accessor-less option this seam settled on).
+    """
+
+    def __init__(
+        self,
+        *,
+        allowed_collections: Optional[List[str]] = None,
+        user_id: Optional[int] = 7,
+        is_admin: bool = False,
+        connector_team_id: Optional[int] = None,
+        agent_creator_user_id: Optional[int] = None,
+        declared_knowledge_bases: Optional[List[str]] = None,
+    ) -> None:
+        self.allowed_collections = allowed_collections
+        self.user_id = user_id
+        self.is_admin_value = is_admin
+        self._connector_team_id = connector_team_id
+        self._agent_creator_user_id = agent_creator_user_id
+        self._declared_knowledge_bases = declared_knowledge_bases
+
+    def get_allowed_collections(self) -> Optional[List[str]]:
+        return self.allowed_collections
+
+    def get_user_id(self) -> Optional[int]:
+        return self.user_id
+
+    def is_admin(self) -> bool:
+        return self.is_admin_value
+
+    def get_agent_creator_user_id(self) -> Optional[int]:
+        return self._agent_creator_user_id
+
+    def get_declared_knowledge_bases(self) -> Optional[List[str]]:
+        return self._declared_knowledge_bases
+
+
+async def _build_tools(
+    config: Any,
+) -> tuple[ListKnowledgeBasesTool, KnowledgeSearchTool]:
+    tools = await knowledge_tools._create_knowledge_tools_impl(config)
+    list_tool = next(t for t in tools if isinstance(t, ListKnowledgeBasesTool))
+    search_tool = next(t for t in tools if isinstance(t, KnowledgeSearchTool))
+    return list_tool, search_tool
+
+
+@pytest.mark.asyncio
+async def test_missing_governing_team_id_leaves_tools_untouched_by_default() -> None:
+    """Negative control: a config with no team id set (the common,
+    non-team-governed case) must not accidentally acquire one."""
+    config = _FakeConfig()
+    list_tool, search_tool = await _build_tools(config)
+
+    assert list_tool.governing_team_id is None
+    assert search_tool.governing_team_id is None
+    assert list_tool.agent_creator_user_id is None
+    assert search_tool.agent_creator_user_id is None
+
+
+@pytest.mark.asyncio
+async def test_running_the_search_tool_forwards_all_three_values_through_the_real_facade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tests above build tools and inspect their instance attributes,
+    which stops one hop short of proving anything: those attributes still
+    have to survive ``run_json_async`` -> the *real* compatibility facade
+    (not a monkeypatched stand-in) -> the core impl function. This test
+    walks the whole chain by actually invoking the tool and intercepting
+    only the innermost core function, so a facade method that quietly
+    drops one of the three values on its way through is caught here even
+    though it would not be caught by asserting on the tool object alone.
+    """
+    from xagent.core.tools.core import document_search as core_document_search
+
+    captured: dict = {}
+
+    async def _fake_search_impl(tool_args, **kwargs):
+        captured.update(kwargs)
+        return core_document_search.KnowledgeSearchResult(results=[], summary="ok")
+
+    monkeypatch.setattr(
+        core_document_search, "_search_knowledge_base_impl", _fake_search_impl
+    )
+
+    config = WebToolConfig(
+        db=None,
+        request=None,
+        user_id=7,
+        connector_team_id=42,
+        agent_creator_user_id=99,
+        declared_knowledge_bases=["kb1"],
+    )
+    _, search_tool = await _build_tools(config)
+
+    await search_tool.run_json_async({"query": "hello"})
+
+    assert captured.get("governing_team_id") == 42
+    assert captured.get("agent_creator_user_id") == 99
+    assert captured.get("declared_knowledge_bases") == ["kb1"]
+
+
+@pytest.mark.asyncio
+async def test_running_the_list_tool_forwards_all_three_values_through_the_real_facade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.core.tools.core import document_search as core_document_search
+
+    captured: dict = {}
+
+    async def _fake_list_impl(tool_args, **kwargs):
+        captured.update(kwargs)
+        return core_document_search.ListKnowledgeBasesResult(knowledge_bases=[])
+
+    monkeypatch.setattr(
+        core_document_search, "_list_knowledge_bases_impl", _fake_list_impl
+    )
+
+    config = WebToolConfig(
+        db=None,
+        request=None,
+        user_id=7,
+        allowed_collections=None,  # required for the list tool to be built
+        connector_team_id=42,
+        agent_creator_user_id=99,
+        declared_knowledge_bases=["kb1"],
+    )
+    list_tool, _ = await _build_tools(config)
+
+    await list_tool.run_json_async({})
+
+    assert captured.get("governing_team_id") == 42
+    assert captured.get("agent_creator_user_id") == 99
+    assert captured.get("declared_knowledge_bases") == ["kb1"]

--- a/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
@@ -82,7 +82,7 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
     from xagent.core.tools.core import document_search
 
     sentinel = object()
-    calls: list[tuple[object, int, bool]] = []
+    calls: list[tuple] = []
 
     class Facade:
         async def list_knowledge_bases(
@@ -90,8 +90,16 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
             tool_args: object,
             user_id: Optional[int] = None,
             is_admin: bool = False,
+            governing_team_id: Optional[int] = None,
         ) -> object:
-            calls.append((tool_args, user_id or 0, is_admin))
+            calls.append(
+                (
+                    tool_args,
+                    user_id or 0,
+                    is_admin,
+                    governing_team_id,
+                )
+            )
             return sentinel
 
     args = document_search.ListKnowledgeBasesArgs()
@@ -101,10 +109,53 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
         args,
         user_id=7,
         is_admin=True,
+        governing_team_id=42,
     )
 
     assert result is sentinel
-    assert calls == [(args, 7, True)]
+    # The governing team must reach the facade call unmodified -- a
+    # facade-layer bug that drops it would leave a team-governed search
+    # silently resolving as if it were personal.
+    assert calls == [(args, 7, True, 42)]
+
+
+@pytest.mark.asyncio
+async def test_public_search_knowledge_base_routes_through_tool_facade(monkeypatch):
+    from xagent.core.tools.core import document_search
+
+    sentinel = object()
+    calls: list[tuple] = []
+
+    class Facade:
+        async def search_knowledge_base(
+            self,
+            tool_args: object,
+            user_id: Optional[int] = None,
+            is_admin: bool = False,
+            governing_team_id: Optional[int] = None,
+        ) -> object:
+            calls.append(
+                (
+                    tool_args,
+                    user_id or 0,
+                    is_admin,
+                    governing_team_id,
+                )
+            )
+            return sentinel
+
+    args = document_search.KnowledgeSearchArgs(query="q")
+    monkeypatch.setattr(document_search, "_get_tool_compatibility_facade", Facade)
+
+    result = await document_search.search_knowledge_base(
+        args,
+        user_id=7,
+        is_admin=True,
+        governing_team_id=42,
+    )
+
+    assert result is sentinel
+    assert calls == [(args, 7, True, 42)]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
@@ -91,6 +91,8 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
             user_id: Optional[int] = None,
             is_admin: bool = False,
             governing_team_id: Optional[int] = None,
+            agent_creator_user_id: Optional[int] = None,
+            declared_knowledge_bases: Optional[list] = None,
         ) -> object:
             calls.append(
                 (
@@ -98,6 +100,8 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
                     user_id or 0,
                     is_admin,
                     governing_team_id,
+                    agent_creator_user_id,
+                    declared_knowledge_bases,
                 )
             )
             return sentinel
@@ -110,13 +114,15 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
         user_id=7,
         is_admin=True,
         governing_team_id=42,
+        agent_creator_user_id=99,
+        declared_knowledge_bases=["kb1", "kb2"],
     )
 
     assert result is sentinel
-    # The governing team must reach the facade call unmodified -- a
-    # facade-layer bug that drops it would leave a team-governed search
-    # silently resolving as if it were personal.
-    assert calls == [(args, 7, True, 42)]
+    # All three new values must reach the facade call unmodified -- a
+    # facade-layer bug that drops any one of them would leave a
+    # team-governed search silently resolving as if it were personal.
+    assert calls == [(args, 7, True, 42, 99, ["kb1", "kb2"])]
 
 
 @pytest.mark.asyncio
@@ -133,6 +139,8 @@ async def test_public_search_knowledge_base_routes_through_tool_facade(monkeypat
             user_id: Optional[int] = None,
             is_admin: bool = False,
             governing_team_id: Optional[int] = None,
+            agent_creator_user_id: Optional[int] = None,
+            declared_knowledge_bases: Optional[list] = None,
         ) -> object:
             calls.append(
                 (
@@ -140,6 +148,8 @@ async def test_public_search_knowledge_base_routes_through_tool_facade(monkeypat
                     user_id or 0,
                     is_admin,
                     governing_team_id,
+                    agent_creator_user_id,
+                    declared_knowledge_bases,
                 )
             )
             return sentinel
@@ -152,10 +162,12 @@ async def test_public_search_knowledge_base_routes_through_tool_facade(monkeypat
         user_id=7,
         is_admin=True,
         governing_team_id=42,
+        agent_creator_user_id=99,
+        declared_knowledge_bases=["kb1", "kb2"],
     )
 
     assert result is sentinel
-    assert calls == [(args, 7, True, 42)]
+    assert calls == [(args, 7, True, 42, 99, ["kb1", "kb2"])]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/core/RAG_tools/test_multitenancy.py
+++ b/tests/core/tools/core/RAG_tools/test_multitenancy.py
@@ -833,6 +833,58 @@ class TestAPIMultiTenancy:
         assert result.status == "success"
         assert result.total_count == 0
 
+    @patch("xagent.web.api.kb.list_collections")
+    @pytest.mark.asyncio
+    async def test_list_collections_api_stays_runner_keyed_when_a_team_hook_is_installed(
+        self, mock_list_collections
+    ):
+        """The fourth consumer of the team-scope seam: this endpoint answers
+        "what can the requesting user see" and must keep doing that even
+        when an application has installed a team-keyed visibility hook for
+        the knowledge-base search path -- it has no governing agent to key
+        on, so it must go on calling the user-keyed overlay hook
+        (``visible_team_knowledge_bases``) and must never touch the
+        team-keyed one (``team_knowledge_bases`` /
+        ``resolve_team_knowledge_bases_or_raise``).
+        """
+        from xagent.core.tools.core.RAG_tools.core.schemas import ListCollectionsResult
+        from xagent.web.models.user import User
+        from xagent.web.services import knowledge_base_team_scope as kb_scope
+
+        mock_user = MagicMock(spec=User)
+        mock_user.id = 123
+        mock_user.is_admin = False
+
+        mock_list_collections.return_value = ListCollectionsResult(
+            status="success",
+            total_count=0,
+            collections=[],
+            message="No collections found",
+            warnings=[],
+        )
+
+        user_keyed_calls: list[int] = []
+        team_keyed_calls: list[int] = []
+
+        def _user_keyed(db, user_id: int):
+            user_keyed_calls.append(user_id)
+            return []
+
+        def _team_keyed(db, *, team_id: int):
+            team_keyed_calls.append(team_id)
+            return []
+
+        with kb_scope.snapshot_knowledge_base_team_hooks():
+            kb_scope.set_knowledge_base_team_hooks(
+                visibility=_user_keyed, team_visibility=_team_keyed
+            )
+
+            result = await list_collections_api(_user=mock_user)
+
+        assert result.status == "success"
+        assert user_keyed_calls == [123]
+        assert team_keyed_calls == []
+
     @pytest.mark.asyncio
     @patch("xagent.web.api.kb.get_vector_index_store")
     @patch("xagent.web.api.kb._ensure_collection_access", new_callable=AsyncMock)

--- a/tests/core/tools/core/test_document_search_collection_concurrency.py
+++ b/tests/core/tools/core/test_document_search_collection_concurrency.py
@@ -54,9 +54,11 @@ def _install_collections(
     monkeypatch: pytest.MonkeyPatch, *names: str, embeddings: int = 10
 ) -> None:
     async def _list(
-        user_id: int | None = None, is_admin: bool = False
+        user_id: int | None = None,
+        is_admin: bool = False,
+        governing_team_id: int | None = None,
     ) -> ListCollectionsResult:
-        del user_id, is_admin
+        del user_id, is_admin, governing_team_id
         listing = _collections(*names)
         for collection in listing.collections:
             collection.embeddings = embeddings
@@ -163,9 +165,11 @@ async def test_aggregation_order_totals_and_empty_collections_are_preserved(
     """Order follows the collection list and zero-embedding collections are skipped."""
 
     async def _list(
-        user_id: int | None = None, is_admin: bool = False
+        user_id: int | None = None,
+        is_admin: bool = False,
+        governing_team_id: int | None = None,
     ) -> ListCollectionsResult:
-        del user_id, is_admin
+        del user_id, is_admin, governing_team_id
         listing = _collections("alpha", "empty", "beta")
         listing.collections[1].embeddings = 0
         return listing
@@ -331,9 +335,11 @@ async def test_a_broken_collection_object_cannot_escape_into_the_gather(
             raise RuntimeError("rerank binding is corrupt")
 
     async def _list(
-        user_id: int | None = None, is_admin: bool = False
+        user_id: int | None = None,
+        is_admin: bool = False,
+        governing_team_id: int | None = None,
     ) -> ListCollectionsResult:
-        del user_id, is_admin
+        del user_id, is_admin, governing_team_id
         listing = _collections("alpha")
         listing.collections.append(_Exploding())  # type: ignore[arg-type]
         return listing

--- a/tests/core/tools/core/test_document_search_team_layer.py
+++ b/tests/core/tools/core/test_document_search_team_layer.py
@@ -263,6 +263,61 @@ async def test_kb_team_hook_absent_falls_back_to_user_keyed_overlay(
 
 
 # ---------------------------------------------------------------------------
+# Both a team-keyed hook and a runner-keyed hook installed at once: the
+# governing branch must consult only the team-keyed one.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_governing_branch_never_unions_with_runner_keyed_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two invariants pinned together, because either one can regress
+    without the other noticing:
+
+    1. Never a union. With both hooks installed, the governing branch must
+       resolve only through the team-keyed hook. The team-keyed hook here
+       answers ``[]`` for the governing team, while the runner-keyed hook
+       answers a real collection ("runner-owned") for the same runner: if
+       the governing branch ever merged in the runner-keyed hook's answer,
+       "runner-owned" would appear in the result, and the runner-keyed
+       hook's callable would be invoked at all -- both are asserted against.
+    2. Selection is on the predicate, not on the answer. The team-keyed
+       hook's empty answer must not be read as "no team-keyed hook, fall
+       back to the runner-keyed one" -- the governing branch stays selected
+       purely because ``team_knowledge_base_hook_installed()`` is true.
+    """
+    team_calls: list[int] = []
+    runner_calls: list[int] = []
+
+    def _team_visibility(db: Any, *, team_id: int) -> list:
+        team_calls.append(team_id)
+        return []
+
+    def _runner_visibility(db: Any, user_id: int) -> list:
+        runner_calls.append(user_id)
+        return [
+            kb_scope.KnowledgeBaseAccess(
+                name="runner-owned", storage_user_id=CREATOR, team_owned=True
+            )
+        ]
+
+    kb_scope.set_knowledge_base_team_hooks(
+        team_visibility=_team_visibility, visibility=_runner_visibility
+    )
+    _install_collections(monkeypatch, {MEMBER: [], CREATOR: [_kb("runner-owned")]})
+
+    result = await document_search._list_visible_collections(
+        user_id=MEMBER, is_admin=False, governing_team_id=TEAM
+    )
+
+    names = {c.name for c in result.collections}
+    assert "runner-owned" not in names
+    assert team_calls == [TEAM]
+    assert runner_calls == []
+
+
+# ---------------------------------------------------------------------------
 # The typed error survives the run-path re-wrap; the build-frame
 # narrowings are defence in depth only.
 # ---------------------------------------------------------------------------
@@ -428,6 +483,19 @@ def test_list_knowledge_bases_tool_has_exactly_two_construction_sites() -> None:
     import subprocess
 
     repo_root = pathlib.Path(__file__).resolve().parents[4]
+    try:
+        probe = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        pytest.skip("git is not available -- git grep counting is unavailable")
+    if probe.returncode != 0 or probe.stdout.strip() != "true":
+        pytest.skip("not inside a git checkout -- git grep counting is unavailable")
+
     output = subprocess.run(
         ["git", "grep", "-n", "ListKnowledgeBasesTool("],
         cwd=repo_root,

--- a/tests/core/tools/core/test_document_search_team_layer.py
+++ b/tests/core/tools/core/test_document_search_team_layer.py
@@ -1,0 +1,443 @@
+"""Team-governed knowledge-base visibility: the team layer and its seam.
+
+Covers ``_list_visible_collections`` resolving the team layer against the
+*governing* agent's team instead of the runner's own team memberships, the
+typed scope error surviving both re-wrap points, and the governing-team
+values reaching the knowledge tools at build time.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from xagent.core.tools.core import document_search
+from xagent.core.tools.core.knowledge_base_scope import KnowledgeBaseScopeError
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    ListCollectionsResult,
+    SearchPipelineResult,
+)
+from xagent.web.services import knowledge_base_team_scope as kb_scope
+
+CREATOR = 100
+MEMBER = 200
+ADMIN = 400
+TEAM = 1
+
+
+def _collections(*collections: CollectionInfo) -> ListCollectionsResult:
+    return ListCollectionsResult(
+        status="success",
+        collections=list(collections),
+        total_count=len(collections),
+        message="ok",
+    )
+
+
+def _kb(name: str, *, embeddings: int = 5, documents: int = 3) -> CollectionInfo:
+    return CollectionInfo(name=name, embeddings=embeddings, documents=documents)
+
+
+class _ListCollectionsSpy:
+    """Routes ``list_collections(user_id=...)`` by user id and records calls."""
+
+    def __init__(self, by_user: dict[int, list[CollectionInfo]]) -> None:
+        self._by_user = by_user
+        self.calls: list[tuple[Optional[int], Optional[bool]]] = []
+
+    async def __call__(
+        self,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        force_realtime: bool = False,
+    ) -> ListCollectionsResult:
+        self.calls.append((user_id, is_admin))
+        return _collections(*self._by_user.get(user_id, []))
+
+    def calls_for(self, user_id: int) -> int:
+        return sum(1 for called_id, _ in self.calls if called_id == user_id)
+
+
+class _SearchSpy:
+    """Fake ``run_document_search`` recording which (collection, user_id,
+    is_admin) triples were actually searched, and returning one hit for
+    each so ``results`` stays non-empty."""
+
+    def __init__(self) -> None:
+        self.searched: list[tuple[str, Optional[int], bool]] = []
+
+    def __call__(
+        self,
+        collection: str,
+        query_text: str,
+        config: dict,
+        user_id: Optional[int],
+        is_admin: bool,
+    ) -> SearchPipelineResult:
+        self.searched.append((collection, user_id, is_admin))
+        return SearchPipelineResult(
+            status="success",
+            search_type="hybrid",
+            results=[
+                {
+                    "doc_id": f"{collection}-doc",
+                    "chunk_id": f"{collection}-chunk",
+                    "text": f"hit from {collection}",
+                    "score": 0.9,
+                    "parse_hash": "hash",
+                    "model_tag": "model",
+                    "metadata": {},
+                }
+            ],
+            result_count=1,
+            warnings=[],
+            message="ok",
+            used_rerank=False,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hooks():
+    with kb_scope.snapshot_knowledge_base_team_hooks():
+        kb_scope.set_knowledge_base_team_hooks()
+        yield
+
+
+def _install_team(monkeypatch: pytest.MonkeyPatch, teams: dict[int, list]) -> None:
+    def _team_visibility(db: Any, *, team_id: int) -> list:
+        return teams.get(team_id, [])
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=_team_visibility)
+
+
+def _install_collections(
+    monkeypatch: pytest.MonkeyPatch, by_user: dict[int, list[CollectionInfo]]
+) -> _ListCollectionsSpy:
+    spy = _ListCollectionsSpy(by_user)
+    monkeypatch.setattr(document_search, "list_collections", spy)
+    return spy
+
+
+def _install_search(monkeypatch: pytest.MonkeyPatch) -> _SearchSpy:
+    spy = _SearchSpy()
+    monkeypatch.setattr(document_search, "run_document_search", spy)
+    return spy
+
+
+async def _search(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    runner_id: int,
+    is_admin: bool = False,
+    team_id: Optional[int] = TEAM,
+    creator_id: Optional[int] = CREATOR,
+    declared: Optional[list[str]] = None,
+    collections: Optional[list[str]] = None,
+    allowed_collections: Optional[list[str]] = None,
+) -> document_search.KnowledgeSearchResult:
+    tool_args = document_search.KnowledgeSearchArgs(
+        query="q",
+        collections=collections or [],
+        allowed_collections=allowed_collections,
+    )
+    return await document_search._search_knowledge_base_impl(
+        tool_args,
+        user_id=runner_id,
+        is_admin=is_admin,
+        governing_team_id=team_id,
+        agent_creator_user_id=creator_id,
+        declared_knowledge_bases=declared,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A name the governing team owns resolves to the team's storage tenant,
+# for every runner.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runner_id,is_admin",
+    [
+        (MEMBER, False),  # a team member
+        (ADMIN, True),  # a platform admin -- admin status must not bypass this
+    ],
+)
+async def test_kb_resolves_on_governing_team(
+    monkeypatch: pytest.MonkeyPatch, runner_id: int, is_admin: bool
+) -> None:
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="handbook",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    _install_collections(
+        monkeypatch,
+        {
+            runner_id: [],
+            CREATOR: [_kb("handbook")],
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=runner_id,
+        is_admin=is_admin,
+        declared=["handbook"],
+        collections=["handbook"],
+    )
+
+    assert search_spy.searched == [("handbook", CREATOR, False)]
+    assert result.results
+
+
+# ---------------------------------------------------------------------------
+# No governing team => the team-keyed hook is never invoked, and no other
+# tenant's collections are listed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_governing_team_never_touches_team_hook_or_creator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    team_calls: list[int] = []
+
+    def _team_visibility(db: Any, *, team_id: int) -> list:
+        team_calls.append(team_id)
+        return []
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=_team_visibility)
+    spy = _install_collections(monkeypatch, {MEMBER: [_kb("kb1")]})
+    _install_search(monkeypatch)
+
+    await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        team_id=None,
+        creator_id=None,
+        declared=["kb1"],
+    )
+
+    assert team_calls == []
+    assert spy.calls_for(CREATOR) == 0
+
+
+# ---------------------------------------------------------------------------
+# Team hook not installed => legacy runner-keyed overlay, selection
+# on the predicate, never on an empty return.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kb_team_hook_absent_falls_back_to_user_keyed_overlay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scoped narrowly to the TEAM LAYER only: with no team-keyed hook
+    installed, ``_list_visible_collections`` must still resolve the legacy
+    runner-keyed overlay when the (separate) user-keyed hook is installed.
+    A governing team id is passed in deliberately, to show the selection is
+    on the hook predicate rather than on the id being present.
+    """
+    legacy_access = kb_scope.KnowledgeBaseAccess(
+        name="legacy-shared", storage_user_id=CREATOR, team_owned=True
+    )
+    kb_scope.set_knowledge_base_team_hooks(
+        visibility=lambda db, user_id: [legacy_access]
+    )
+    _install_collections(monkeypatch, {MEMBER: [], CREATOR: [_kb("legacy-shared")]})
+
+    result = await document_search._list_visible_collections(
+        user_id=MEMBER, is_admin=False, governing_team_id=TEAM
+    )
+
+    names = {c.name for c in result.collections}
+    assert "legacy-shared" in names
+
+
+# ---------------------------------------------------------------------------
+# The typed error survives the run-path re-wrap; the build-frame
+# narrowings are defence in depth only.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kb_scope_hook_failure_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _broken_team_visibility(db: Any, *, team_id: int):
+        raise RuntimeError("boom")
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=_broken_team_visibility)
+    _install_collections(monkeypatch, {MEMBER: []})
+    _install_search(monkeypatch)
+
+    with pytest.raises(KnowledgeBaseScopeError):
+        await _search(monkeypatch, runner_id=MEMBER, declared=["handbook"])
+
+
+@pytest.mark.asyncio
+async def test_kb_scope_error_survives_tool_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defence in depth: even if a future change made a tool-build frame
+    raise the typed error, the frame's own narrow catch must let it pass
+    through unwrapped. Exercised directly against the narrowing clause's
+    intended shape rather than the real (currently unreachable) call path.
+    """
+    from xagent.core.tools.adapters.vibe import knowledge_tools
+
+    class _RaisingConfig:
+        def get_allowed_collections(self):
+            raise KnowledgeBaseScopeError("x", "boom")
+
+        def get_user_id(self):
+            return MEMBER
+
+        def is_admin(self):
+            return False
+
+        def get_agent_creator_user_id(self):
+            return None
+
+        def get_declared_knowledge_bases(self):
+            return None
+
+    with pytest.raises(KnowledgeBaseScopeError):
+        await knowledge_tools._create_knowledge_tools_impl(_RaisingConfig())
+
+
+# ---------------------------------------------------------------------------
+# user_id is None returns before any team resolution.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_caller_returns_before_team_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+
+    def _team_visibility(db: Any, *, team_id: int) -> list:
+        calls.append(team_id)
+        return []
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=_team_visibility)
+    _install_collections(monkeypatch, {})
+
+    # Must not raise TypeError from int(None), and must not touch the team hook.
+    result = await document_search._list_visible_collections(
+        user_id=None, is_admin=False, governing_team_id=TEAM
+    )
+    assert result.collections == []
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# The save-time validation consumer (find_missing_knowledge_bases) stays
+# runner-keyed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_missing_knowledge_bases_is_runner_keyed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="handbook",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    _install_collections(monkeypatch, {MEMBER: [], CREATOR: [_kb("handbook")]})
+
+    # find_missing_knowledge_bases takes no governing_team_id parameter at
+    # all -- it stays a strictly two-argument (user_id, is_admin) call, so
+    # it cannot see the governing team's rows even though one is installed.
+    missing = await document_search._find_missing_knowledge_bases_impl(
+        ["handbook"], user_id=MEMBER, is_admin=False
+    )
+
+    assert missing == ["handbook"]
+
+
+# ---------------------------------------------------------------------------
+# The knowledge tools read the governing-team values off the config, and
+# there are exactly two ListKnowledgeBasesTool( construction sites.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "allowed_collections,expect_list_tool",
+    [(None, True), (["kb1"], False)],
+)
+async def test_list_tool_built_only_without_declaration(
+    monkeypatch: pytest.MonkeyPatch, allowed_collections, expect_list_tool
+) -> None:
+    from xagent.core.tools.adapters.vibe import knowledge_tools
+
+    class _Config:
+        def get_allowed_collections(self):
+            return allowed_collections
+
+        def get_user_id(self):
+            return MEMBER
+
+        def is_admin(self):
+            return False
+
+        def get_agent_creator_user_id(self):
+            return CREATOR
+
+        def get_declared_knowledge_bases(self):
+            return allowed_collections
+
+    tools = await knowledge_tools._create_knowledge_tools_impl(_Config())
+    tool_names = {t.name for t in tools}
+    assert ("list_knowledge_bases" in tool_names) is expect_list_tool
+
+
+def test_list_knowledge_bases_tool_has_exactly_two_construction_sites() -> None:
+    """Two sites, and the second one is exempt on purpose.
+
+    The first is ``adapters/vibe/document_search.py``, which
+    ``knowledge_tools.py`` calls and which carries the governing-team
+    values. The second is ``web/api/websocket.py``, the agent-builder
+    console: it constructs the tool directly with ``user_id`` and
+    ``is_admin`` and nothing else, has no allowed-collections list, and runs
+    for the person configuring an agent rather than inside any agent's run,
+    so there is no governing team for it to resolve against and it keeps
+    today's runner-keyed behaviour. That is why this count is asserted
+    instead of asserting that every site threads the governing-team values:
+    a third site appearing, or a refactor routing the builder console
+    through ``knowledge_tools.py``, changes which of those two statements
+    holds and should be re-decided rather than silently absorbed.
+    """
+    import pathlib
+    import re
+    import subprocess
+
+    repo_root = pathlib.Path(__file__).resolve().parents[4]
+    output = subprocess.run(
+        ["git", "grep", "-n", "ListKnowledgeBasesTool("],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    construction_sites = [
+        line
+        for line in output.splitlines()
+        if "src/" in line and not re.search(r"class ListKnowledgeBasesTool\(", line)
+    ]
+    assert len(construction_sites) == 2, construction_sites

--- a/tests/core/tools/core/test_document_search_team_visibility_boundary.py
+++ b/tests/core/tools/core/test_document_search_team_visibility_boundary.py
@@ -26,12 +26,20 @@ from xagent.web.services.knowledge_base_team_scope import (
 
 
 @pytest.fixture(autouse=True)
-def _isolate_team_knowledge_base_visibility_hook(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Keep this suite from changing unrelated application hooks."""
+def _isolate_team_knowledge_base_visibility_hook():
+    """Keep this suite from changing unrelated application hooks.
 
-    monkeypatch.setattr(kb_scope, "_visibility_hook", None)
+    Goes through the module's own snapshot/restore primitive rather than
+    monkeypatching ``_visibility_hook`` alone: a direct monkeypatch of that
+    one attribute does not save or restore the team-keyed slot, so a test
+    in this suite that installs a team-keyed hook (or a future test that
+    does) would leak it into whatever runs next. The primitive saves every
+    slot the module has, known or not yet added.
+    """
+
+    with kb_scope.snapshot_knowledge_base_team_hooks():
+        kb_scope.set_knowledge_base_team_hooks()
+        yield
 
 
 @pytest.fixture()
@@ -39,6 +47,11 @@ def install_visibility_hook(
     monkeypatch: pytest.MonkeyPatch,
 ) -> Callable[[KnowledgeBaseVisibilityHook], None]:
     def install(hook: KnowledgeBaseVisibilityHook) -> None:
+        # A direct attribute monkeypatch, not the reset-all setter: this
+        # fixture must not disturb an access/lifecycle hook another part of
+        # the same test installed. The autouse fixture above is what keeps
+        # this suite isolated from the rest of the module's state, including
+        # the team-keyed slot this fixture never touches.
         monkeypatch.setattr(kb_scope, "_visibility_hook", hook)
 
     return install

--- a/tests/web/api/test_chat_team_scope_wiring_behavioral.py
+++ b/tests/web/api/test_chat_team_scope_wiring_behavioral.py
@@ -1,0 +1,179 @@
+"""Behavioral pins for the two ``create_default_tools`` call sites the
+source-level guard (``test_chat_team_scope_wiring_static.py``) cannot
+reach: that guard only proves neither call site passes a literal
+``None``, so it cannot catch a call site that derives the *wrong*
+non-``None`` value (e.g. the running user's id instead of the agent
+creator's), or one that hardcodes an empty list where the agent's own
+declaration belongs.
+
+These tests drive the real methods (``AgentServiceManager._build_tools_for_task``
+and ``AgentServiceManager.get_agent_for_task``) with a fake ``TaskSetupSnapshot``
+and assert the values forwarded to ``create_default_tools`` equal the
+snapshot's own agent fields -- not merely "not None" -- so a swap to the
+runner's id, or a hardcoded ``[]``, fails the assertion.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xagent.web.api.chat import AgentServiceManager
+from xagent.web.models.agent import AgentStatus
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import AgentRuntimeFields
+from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
+    TaskSetupSnapshot,
+    _TaskFields,
+)
+
+# Deliberately distinct from the runner so a mutation that reads the
+# runner's own id instead of the agent's creator id is observable.
+_CREATOR_USER_ID = 4242
+_RUNNER_USER_ID = 1
+_TEAM_ID = 99
+_DECLARED_KBS = ["gov-team-handbook", "gov-team-runbook"]
+
+
+def _make_snapshot() -> TaskSetupSnapshot:
+    return TaskSetupSnapshot(
+        task=_TaskFields(
+            id=42,
+            user_id=_RUNNER_USER_ID,
+            status=TaskStatus.PENDING,
+            agent_id=7,
+            agent_config=None,
+            model_name=None,
+            compact_model_name=None,
+            execution_mode="flash",
+            agent_type="standard",
+        ),
+        runtime_user=RuntimeUserFields(id=_RUNNER_USER_ID, is_admin=False),
+        has_reconstructable_history=False,
+        task_pattern="single_call",
+        task_llm=None,
+        task_fast_llm=None,
+        task_vision_llm=None,
+        task_compact_llm=None,
+        agent=AgentRuntimeFields(
+            id=7,
+            name="gov-agent",
+            status=AgentStatus.PUBLISHED,
+            instructions="be terse",
+            team_id=_TEAM_ID,
+            agent_creator_user_id=_CREATOR_USER_ID,
+        ),
+        agent_config={
+            "llms": (None, None, None, None),
+            "execution_mode": "flash",
+            "instructions": "be terse",
+            "skills": [],
+            "knowledge_bases": list(_DECLARED_KBS),
+            "tool_categories": ["basic"],
+        },
+        excluded_agent_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_tools_for_task_forwards_snapshot_creator_not_runner() -> None:
+    """Pins the snapshot branch inside ``_build_tools_for_task`` (the first
+    of the two ``agent_creator_user_id`` derivation points): the value
+    forwarded to ``create_default_tools`` must be the agent's own creator,
+    never the id of whoever is running the task.
+    """
+    manager = AgentServiceManager()
+    snapshot = _make_snapshot()
+
+    with (
+        patch(
+            "xagent.web.api.chat.create_default_tools",
+            new=AsyncMock(return_value=([], MagicMock())),
+        ) as create_tools_mock,
+        patch.object(
+            manager, "_get_or_create_task_sandbox", AsyncMock(return_value=None)
+        ),
+    ):
+        await manager._build_tools_for_task(
+            task_id=42,
+            task=snapshot.task,
+            db=None,
+            user=snapshot.runtime_user,
+            agent_config=snapshot.agent_config,
+            task_llm=None,
+            task_vision_llm=None,
+            task_setup_snapshot=snapshot,
+        )
+
+    kwargs = create_tools_mock.call_args.kwargs
+    assert kwargs.get("connector_team_id") == _TEAM_ID
+    assert kwargs.get("agent_creator_user_id") == _CREATOR_USER_ID
+    assert kwargs.get("agent_creator_user_id") != _RUNNER_USER_ID
+    assert kwargs.get("declared_knowledge_bases") == _DECLARED_KBS
+
+
+def _make_runner_user() -> User:
+    return User(
+        id=_RUNNER_USER_ID,
+        username="wiring-runner",
+        password_hash="hash",
+        is_admin=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_agent_for_task_forwards_snapshot_declaration_not_empty() -> None:
+    """Pins the second call site, inside ``_get_agent_for_task_unlocked``:
+    the declaration forwarded to ``create_default_tools`` must be the
+    agent's own stored ``knowledge_bases`` list, never a hardcoded empty
+    list standing in for "no declaration".
+    """
+    manager = AgentServiceManager()
+    manager._default_llm = MagicMock()
+    snapshot = _make_snapshot()
+
+    task_row = Task(
+        id=42,
+        user_id=_RUNNER_USER_ID,
+        title="wiring-behavioral",
+        description="wiring-behavioral",
+        status=TaskStatus.PENDING,
+        agent_id=7,
+        agent_type="standard",
+    )
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = task_row
+
+    with (
+        patch(
+            "xagent.web.api.chat.create_default_tools",
+            new=AsyncMock(return_value=([], MagicMock())),
+        ) as create_tools_mock,
+        patch.object(manager, "_load_persisted_conversation_history"),
+        patch.object(manager, "_load_persisted_execution_context", new=AsyncMock()),
+        patch("xagent.web.api.chat.create_task_tracer", return_value=MagicMock()),
+        patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None),
+        patch("xagent.web.api.chat.AgentService"),
+    ):
+        try:
+            await manager.get_agent_for_task(
+                task_id=42,
+                db=db,
+                user=_make_runner_user(),
+                task_setup_snapshot=snapshot,
+            )
+        except Exception:
+            # Downstream construction may raise against the mocked
+            # AgentService; the forwarding assertion below is recorded
+            # before that point (same pattern as the snapshot-passthrough
+            # suite this file sits alongside).
+            pass
+
+    kwargs = create_tools_mock.call_args.kwargs
+    assert kwargs.get("connector_team_id") == _TEAM_ID
+    assert kwargs.get("agent_creator_user_id") == _CREATOR_USER_ID
+    assert kwargs.get("declared_knowledge_bases") == _DECLARED_KBS
+    assert kwargs.get("declared_knowledge_bases") != []

--- a/tests/web/api/test_chat_team_scope_wiring_static.py
+++ b/tests/web/api/test_chat_team_scope_wiring_static.py
@@ -1,0 +1,87 @@
+"""Static, source-level guards for the part of ``chat.py``'s team-governed
+wiring that a fast unit test cannot reach without a real database session,
+task row, and workforce runtime: the three places
+``AgentServiceManager`` derives ``agent_creator_user_id`` for a
+team-governed run, and the two ``create_default_tools`` call sites that
+must forward both ``agent_creator_user_id`` and ``declared_knowledge_bases``
+through.
+
+These are not behavioural pins -- they cannot prove the values resolve to
+the *correct* agent at runtime (the tests against the shared
+``AgentRuntimeFields`` construction site and against
+``create_default_tools``'s own forwarding into ``WebToolConfig`` do that,
+see ``test_agent_runtime_fields_creator.py`` and
+``test_create_default_tools_team_scope_forwarding.py``). What this file
+closes is a narrower, cheaper gap: a derivation point quietly hardcoded to
+``None``, or a call site dropping one of the two keywords, would not raise
+anywhere at runtime, and no test that never drives this exact code path
+would notice. Reading the source with the ``ast`` module is what lets this
+be checked without constructing the session/task/workforce machinery that
+driving the real code path would require.
+
+This file's own blind spot -- a call site that swaps in a *wrong but
+non-``None``* value (the running user's id instead of the agent's
+creator, or a hardcoded empty list instead of the stored declaration) --
+is closed behaviourally instead, in
+``test_chat_team_scope_wiring_behavioral.py``: it drives both call sites
+with a fake ``TaskSetupSnapshot`` and a spy on ``create_default_tools``,
+and asserts the forwarded values equal the snapshot's own agent fields.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import xagent.web.api.chat as chat_module
+
+
+def _tree() -> ast.Module:
+    return ast.parse(inspect.getsource(chat_module))
+
+
+def _is_hardcoded_none(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def _create_default_tools_call_sites() -> list[ast.Call]:
+    calls = []
+    for node in ast.walk(_tree()):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name == "create_default_tools":
+            calls.append(node)
+    return calls
+
+
+def test_there_are_exactly_two_create_default_tools_call_sites() -> None:
+    """A third call site would need this whole file's static guards
+    revisited (it might not thread the two new values at all), the same
+    reason the construction-site count is pinned elsewhere in this design.
+    """
+    calls = _create_default_tools_call_sites()
+    assert len(calls) == 2, [c.lineno for c in calls]
+
+
+def test_exactly_two_local_variable_derivations_of_agent_creator_user_id() -> None:
+    """Two of the three places ``AgentServiceManager`` derives this value
+    are plain local-variable assignments (the snapshot branch and the
+    live-ORM-row branch inside ``_build_tools_for_task``); the third is
+    folded directly into the second ``create_default_tools`` call's own
+    keyword argument and is covered by the call-site check above instead.
+    """
+    assigns = [
+        node
+        for node in ast.walk(_tree())
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "agent_creator_user_id"
+    ]
+    assert len(assigns) == 2, [a.lineno for a in assigns]
+    for assign in assigns:
+        assert not _is_hardcoded_none(assign.value), (
+            f"line {assign.lineno} hardcodes agent_creator_user_id to None"
+        )

--- a/tests/web/services/test_agent_runtime_fields_creator.py
+++ b/tests/web/services/test_agent_runtime_fields_creator.py
@@ -1,0 +1,125 @@
+"""``AgentRuntimeFields.agent_creator_user_id`` always names the same agent
+as ``team_id``, at the single construction site in
+``llm_utils.resolve_task_runtime_config_core`` that both the snapshot
+branch and the stored-snapshot branch of ``chat.py`` read off.
+
+Coverage note, stated plainly rather than left implicit: this file proves
+the shared construction site is correct, which is what makes those two
+``chat.py`` read sites (``task_setup_snapshot.agent.agent_creator_user_id``
+and ``snapshot.agent.agent_creator_user_id``) trustworthy -- but it does
+not call ``chat.py`` itself, so it cannot catch a ``chat.py`` change that
+stops reading this field, or reads it off the wrong object. The third
+``chat.py`` site -- the snapshot-less branch that reads a live ``Agent``
+ORM row directly (``int(current_agent.team_id)`` /
+``int(current_agent.user_id)``), which the design itself documents as not
+reachable from production today -- has no test in this file at all: an
+earlier draft of this file asserted a copy of that expression against
+itself rather than against ``chat.py``'s actual code, which cannot fail no
+matter what ``chat.py`` does, so it was removed rather than left as a
+false-confidence pin. Closing this gap for real requires driving
+``AgentServiceManager._build_tools_for_task`` through its snapshot-less
+branch, which means constructing a real session, task, and workforce
+runtime; that has not been done.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from xagent.web.models.agent import Agent, AgentStatus
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.llm_utils import AgentRuntimeFields
+from xagent.web.services.task_setup_snapshot import load_task_setup_snapshot_sync
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'agent_creator.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+def _create_user(db, username: str) -> User:
+    user = User(username=username, password_hash="hash", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _create_agent(db, user_id: int, **overrides) -> Agent:
+    defaults = dict(
+        user_id=user_id,
+        name="creator-pin-agent",
+        instructions="be terse",
+        status=AgentStatus.PUBLISHED,
+        execution_mode="balanced",
+        models={},
+        knowledge_bases=[],
+        skills=[],
+        tool_categories=["basic"],
+    )
+    defaults.update(overrides)
+    agent = Agent(**defaults)
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def _create_task(db, user_id: int, **overrides) -> Task:
+    defaults = dict(
+        user_id=user_id,
+        title="creator pin test",
+        description="d",
+        status=TaskStatus.PENDING,
+        execution_mode="flash",
+        source="sdk",
+    )
+    defaults.update(overrides)
+    task = Task(**defaults)
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def test_snapshot_carries_agent_creator_alongside_team_id(db_session) -> None:
+    """Derivation points 1 and 3 (both read ``snapshot.agent``): the
+    snapshot's ``team_id`` and ``agent_creator_user_id`` describe the same
+    agent.
+
+    The task owner here is the same user as the agent's creator -- this
+    file's job is to pin that the single ``AgentRuntimeFields`` construction
+    site populates both new-and-old fields off the same loaded ``agent_row``
+    (a wrong binding here would leave ``agent_creator_user_id`` mismatched
+    against ``team_id`` on *every* run, not only a cross-user one); a
+    creator-vs-runner *resolution* scenario, where the two differ, is
+    exercised by the resolution-outcome tests against ``_search_knowledge_base_impl``
+    directly.
+    """
+    creator = _create_user(db_session, "creator-pin-creator")
+    agent = _create_agent(db_session, user_id=int(creator.id), team_id=101)
+    task = _create_task(db_session, user_id=int(creator.id), agent_id=int(agent.id))
+
+    snapshot = load_task_setup_snapshot_sync(
+        task_id=int(task.id), task_owner_user_id=int(creator.id)
+    )
+
+    assert snapshot is not None and snapshot.agent is not None
+    assert isinstance(snapshot.agent, AgentRuntimeFields)
+    assert snapshot.agent.team_id == 101
+    assert snapshot.agent.agent_creator_user_id == int(creator.id)
+
+
+# No test below this point for chat.py's snapshot-less derivation branch
+# (AgentServiceManager._build_tools_for_task's `else` arm, which reads
+# `current_agent.team_id` / `current_agent.user_id` directly off a live
+# ORM row instead of an AgentRuntimeFields snapshot). See the module
+# docstring above for why and what closing this gap would require.

--- a/tests/web/services/test_agent_runtime_fields_creator.py
+++ b/tests/web/services/test_agent_runtime_fields_creator.py
@@ -45,8 +45,8 @@ def db_session(tmp_path):
         Base.metadata.drop_all(bind=get_engine())
 
 
-def _create_user(db, username: str) -> User:
-    user = User(username=username, password_hash="hash", is_admin=False)
+def _create_user(db, username: str, *, is_admin: bool = False) -> User:
+    user = User(username=username, password_hash="hash", is_admin=is_admin)
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -95,27 +95,33 @@ def test_snapshot_carries_agent_creator_alongside_team_id(db_session) -> None:
     snapshot's ``team_id`` and ``agent_creator_user_id`` describe the same
     agent.
 
-    The task owner here is the same user as the agent's creator -- this
-    file's job is to pin that the single ``AgentRuntimeFields`` construction
-    site populates both new-and-old fields off the same loaded ``agent_row``
-    (a wrong binding here would leave ``agent_creator_user_id`` mismatched
-    against ``team_id`` on *every* run, not only a cross-user one); a
-    creator-vs-runner *resolution* scenario, where the two differ, is
-    exercised by the resolution-outcome tests against ``_search_knowledge_base_impl``
-    directly.
+    The agent creator and the task owner are two different users here --
+    a binding that read ``agent_creator_user_id`` off the task owner
+    instead of ``agent_row.user_id`` would still pass against an
+    equal-user fixture, so this fixture keeps the two apart and asserts
+    the field names the creator, not the owner. The owner is an admin
+    only so that ``_load_agent_for_task_runtime`` can load a PUBLISHED
+    agent it does not own and is not team-scoped into -- standalone
+    xagent has no other cross-user visibility path for a published
+    agent, and that access check is incidental to what this test pins.
+    A creator-vs-runner *resolution* scenario, where the two differ, is
+    exercised by the resolution-outcome tests against
+    ``_search_knowledge_base_impl`` directly.
     """
     creator = _create_user(db_session, "creator-pin-creator")
+    owner = _create_user(db_session, "creator-pin-owner", is_admin=True)
     agent = _create_agent(db_session, user_id=int(creator.id), team_id=101)
-    task = _create_task(db_session, user_id=int(creator.id), agent_id=int(agent.id))
+    task = _create_task(db_session, user_id=int(owner.id), agent_id=int(agent.id))
 
     snapshot = load_task_setup_snapshot_sync(
-        task_id=int(task.id), task_owner_user_id=int(creator.id)
+        task_id=int(task.id), task_owner_user_id=int(owner.id)
     )
 
     assert snapshot is not None and snapshot.agent is not None
     assert isinstance(snapshot.agent, AgentRuntimeFields)
     assert snapshot.agent.team_id == 101
     assert snapshot.agent.agent_creator_user_id == int(creator.id)
+    assert snapshot.agent.agent_creator_user_id != int(owner.id)
 
 
 # No test below this point for chat.py's snapshot-less derivation branch

--- a/tests/web/services/test_knowledge_base_team_scope.py
+++ b/tests/web/services/test_knowledge_base_team_scope.py
@@ -1,0 +1,243 @@
+"""Unit tests for the knowledge-base team-scope seam."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.tools.core.knowledge_base_scope import KnowledgeBaseScopeError
+from xagent.web.services import knowledge_base_team_scope as kb_scope
+
+T1 = 11
+T2 = 22
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hooks():
+    with kb_scope.snapshot_knowledge_base_team_hooks():
+        kb_scope.set_knowledge_base_team_hooks()
+        yield
+
+
+def _valid_access(
+    name: str = "handbook", storage_user_id: int = 7
+) -> kb_scope.KnowledgeBaseAccess:
+    return kb_scope.KnowledgeBaseAccess(
+        name=name,
+        storage_user_id=storage_user_id,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The team-keyed Protocol's keyword-only marker: a user-keyed implementation
+# bound into the team-keyed slot raises TypeError instead of resolving
+# against the wrong tenant.
+# ---------------------------------------------------------------------------
+
+
+def test_user_keyed_function_in_team_slot_raises_type_error():
+    """The reverse swap is caught: ``team_knowledge_bases`` always calls
+    the team-keyed slot with ``team_id=`` as a keyword, so a user-keyed
+    implementation whose second parameter is positional-or-keyword under a
+    different name raises ``TypeError`` at call time instead of resolving
+    against the wrong tenant.
+    """
+
+    def user_keyed_shaped(db: Any, user_id: int) -> list:
+        return []
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=user_keyed_shaped)
+
+    with pytest.raises(TypeError):
+        kb_scope.team_knowledge_bases(None, team_id=T1)
+
+
+# ---------------------------------------------------------------------------
+# The validator's seven rejection classes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "answer,description",
+    [
+        (None, "non-iterable"),
+        ([{"name": "x", "storage_user_id": 1}], "wrong element type"),
+        (
+            [
+                kb_scope.KnowledgeBaseAccess(
+                    name="",
+                    storage_user_id=1,
+                    team_owned=True,
+                    can_edit=False,
+                    can_delete=False,
+                )
+            ],
+            "empty name",
+        ),
+        (
+            [
+                kb_scope.KnowledgeBaseAccess(
+                    name="x",
+                    storage_user_id="1",
+                    team_owned=True,
+                    can_edit=False,
+                    can_delete=False,  # type: ignore[arg-type]
+                )
+            ],
+            "non-int storage_user_id",
+        ),
+        (
+            [
+                kb_scope.KnowledgeBaseAccess(
+                    name="x",
+                    storage_user_id=True,
+                    team_owned=True,
+                    can_edit=False,
+                    can_delete=False,  # type: ignore[arg-type]
+                )
+            ],
+            "bool storage_user_id",
+        ),
+        (
+            [
+                kb_scope.KnowledgeBaseAccess(
+                    name="x", storage_user_id=1, team_owned=True
+                )
+            ],
+            "can_edit/can_delete omitted, so the dataclass defaults (True) apply",
+        ),
+        (
+            [
+                kb_scope.KnowledgeBaseAccess(
+                    name="x",
+                    storage_user_id=1,
+                    team_owned=False,
+                    can_edit=False,
+                    can_delete=False,
+                )
+            ],
+            "team_owned not True",
+        ),
+    ],
+)
+def test_kb_team_hook_shape_violation_raises(answer, description) -> None:
+    def _hook(db: Any, *, team_id: int):
+        return answer
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=_hook)
+
+    with pytest.raises(ValueError):
+        kb_scope.team_knowledge_bases(None, team_id=T1)
+
+
+def test_valid_answer_round_trips():
+    kb_scope.set_knowledge_base_team_hooks(
+        team_visibility=lambda db, *, team_id: [_valid_access()]
+    )
+    result = kb_scope.team_knowledge_bases(None, team_id=T1)
+    assert result == [_valid_access()]
+    for entry in result:
+        assert entry.can_edit is False
+        assert entry.can_delete is False
+        assert entry.team_owned is True
+
+
+def test_no_input_for_which_a_malformed_answer_returns_empty_instead_of_raising():
+    """There exists no malformed-answer input for which
+    ``resolve_team_knowledge_bases_or_raise`` returns ``[]`` after an
+    internal failure -- it always raises the typed error instead."""
+
+    kb_scope.set_knowledge_base_team_hooks(
+        team_visibility=lambda db, *, team_id: [
+            kb_scope.KnowledgeBaseAccess(name="", storage_user_id=1)
+        ]
+    )
+    with pytest.raises(KnowledgeBaseScopeError):
+        kb_scope.resolve_team_knowledge_bases_or_raise(None, team_id=T1, log_subject=7)
+
+
+def test_resolve_or_raise_passes_a_typed_error_through_unchanged():
+    def _raising(db: Any, *, team_id: int):
+        raise KnowledgeBaseScopeError("already-typed", "boom")
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=_raising)
+
+    with pytest.raises(KnowledgeBaseScopeError) as excinfo:
+        kb_scope.resolve_team_knowledge_bases_or_raise(None, team_id=T1, log_subject=7)
+    assert excinfo.value.code == "already-typed"
+
+
+def test_resolve_or_raise_wraps_arbitrary_hook_failure():
+    def _raising(db: Any, *, team_id: int):
+        raise RuntimeError("db unavailable")
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=_raising)
+
+    with pytest.raises(KnowledgeBaseScopeError) as excinfo:
+        kb_scope.resolve_team_knowledge_bases_or_raise(None, team_id=T1, log_subject=7)
+    assert excinfo.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# No hook installed -> zero calls, predicate reflects presence.
+# ---------------------------------------------------------------------------
+
+
+def test_team_knowledge_bases_empty_without_hook_installed():
+    assert kb_scope.team_knowledge_base_hook_installed() is False
+    assert kb_scope.team_knowledge_bases(None, team_id=T1) == []
+
+
+def test_team_knowledge_base_hook_installed_reflects_presence():
+    assert kb_scope.team_knowledge_base_hook_installed() is False
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=lambda db, *, team_id: [])
+    assert kb_scope.team_knowledge_base_hook_installed() is True
+
+
+# ---------------------------------------------------------------------------
+# The snapshot/restore primitive restores every slot.
+# ---------------------------------------------------------------------------
+
+
+_SLOT_INSTALLERS = {
+    "visibility": lambda: kb_scope.set_knowledge_base_team_hooks(
+        visibility=lambda db, user_id: []
+    ),
+    "team_visibility": lambda: kb_scope.set_knowledge_base_team_hooks(
+        team_visibility=lambda db, *, team_id: []
+    ),
+}
+
+
+@pytest.mark.parametrize("slot", sorted(_SLOT_INSTALLERS))
+def test_kb_hooks_snapshot_restores_all_slots(slot: str) -> None:
+    kb_scope.set_knowledge_base_team_hooks()  # every slot starts cleared
+
+    with kb_scope.snapshot_knowledge_base_team_hooks():
+        _SLOT_INSTALLERS[slot]()
+        assert kb_scope.team_knowledge_base_hook_installed() == (
+            slot == "team_visibility"
+        )
+
+    # Every slot -- not only the one this iteration touched -- is back to
+    # its pre-entry (cleared) state.
+    assert kb_scope.team_knowledge_base_hook_installed() is False
+    assert kb_scope.has_knowledge_base_visibility_hook() is False
+
+
+def test_kb_hooks_snapshot_restores_object_identity() -> None:
+    sentinel_visibility = lambda db, user_id: []  # noqa: E731
+    kb_scope.set_knowledge_base_team_hooks(visibility=sentinel_visibility)
+
+    with kb_scope.snapshot_knowledge_base_team_hooks():
+        kb_scope.set_knowledge_base_team_hooks(
+            visibility=lambda db, user_id: [_valid_access()]
+        )
+        assert kb_scope._visibility_hook is not sentinel_visibility
+
+    assert kb_scope._visibility_hook is sentinel_visibility
+    kb_scope.set_knowledge_base_team_hooks()

--- a/tests/web/test_team_sharing_hooks.py
+++ b/tests/web/test_team_sharing_hooks.py
@@ -63,17 +63,25 @@ def test_knowledge_base_team_hooks_delegate_with_none_session():
     access = kb_scope.KnowledgeBaseAccess(
         name="shared", storage_user_id=42, team_owned=True
     )
-    kb_scope.set_knowledge_base_team_hooks(
-        visibility=lambda db, user_id: [access],
-        access=lambda db, user_id, name, action: access,
-        renamed=lambda db, user_id, old, new: lifecycle_calls.append(
-            ("rename", db, user_id, old, new)
-        ),
-        deleted=lambda db, user_id, name, new: lifecycle_calls.append(
-            ("delete", db, user_id, name, new)
-        ),
+    team_access = kb_scope.KnowledgeBaseAccess(
+        name="team-doc",
+        storage_user_id=99,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
     )
-    try:
+    with kb_scope.snapshot_knowledge_base_team_hooks():
+        kb_scope.set_knowledge_base_team_hooks(
+            visibility=lambda db, user_id: [access],
+            access=lambda db, user_id, name, action: access,
+            renamed=lambda db, user_id, old, new: lifecycle_calls.append(
+                ("rename", db, user_id, old, new)
+            ),
+            deleted=lambda db, user_id, name, new: lifecycle_calls.append(
+                ("delete", db, user_id, name, new)
+            ),
+            team_visibility=lambda db, *, team_id: [team_access],
+        )
         assert kb_scope.visible_team_knowledge_bases(None, 7) == [access]
         assert kb_scope.resolve_knowledge_base_access(None, 7, "shared") == access
         kb_scope.notify_knowledge_base_renamed(None, 42, "old", "new")
@@ -82,5 +90,12 @@ def test_knowledge_base_team_hooks_delegate_with_none_session():
             ("rename", None, 42, "old", "new"),
             ("delete", None, 42, "new", None),
         ]
-    finally:
+        assert kb_scope.team_knowledge_bases(None, team_id=5) == [team_access]
+        assert kb_scope.team_knowledge_base_hook_installed() is True
+
+        # A reset-all call clears every slot, including the team-keyed one --
+        # this is the property the snapshot primitive above restores after
+        # this block exits.
         kb_scope.set_knowledge_base_team_hooks()
+        assert kb_scope.team_knowledge_base_hook_installed() is False
+        assert kb_scope.visible_team_knowledge_bases(None, 7) == []

--- a/tests/web/tools/test_create_default_tools_team_scope_forwarding.py
+++ b/tests/web/tools/test_create_default_tools_team_scope_forwarding.py
@@ -1,0 +1,100 @@
+"""``create_default_tools`` forwards ``agent_creator_user_id`` and
+``declared_knowledge_bases`` into the ``WebToolConfig`` it builds, the same
+way it already forwards ``connector_team_id``.
+
+Scope: this covers the *definition* -- the signature at
+``create_default_tools(...)`` and its body's construction of
+``WebToolConfig(...)`` -- by calling the function directly with explicit
+values, the way a call site would. It does NOT cover whether either of the
+two real call sites in ``chat.py`` (``_build_tools_for_task`` and the
+snapshot branch inside ``_get_agent_for_task_unlocked``) actually derives
+and passes those values in the first place; that requires the surrounding
+session/task/workforce machinery those methods are embedded in, which is
+out of reach of a fast unit test. ``test_chat_team_scope_wiring_static.py``
+(source-level guards) and ``test_chat_team_scope_wiring_behavioral.py``
+(driving both call sites with a fake ``TaskSetupSnapshot`` and a spy on
+``create_default_tools``) close that gap instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.factory import ToolFactory
+
+
+@pytest.mark.asyncio
+async def test_create_default_tools_forwards_creator_and_declaration_to_web_tool_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.api.chat import create_default_tools
+
+    captured: dict[str, Any] = {}
+
+    class _FakeToolConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        def set_task_runtime_contribution(self, contribution: Any) -> None:
+            pass
+
+    async def create_tools(config: Any) -> list:
+        return []
+
+    monkeypatch.setattr("xagent.web.tools.config.WebToolConfig", _FakeToolConfig)
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local", lambda: object()
+    )
+    monkeypatch.setattr(ToolFactory, "create_all_tools", create_tools)
+
+    await create_default_tools(
+        None,
+        user=SimpleNamespace(id=7, is_admin=False),
+        task_id="web_task_11",
+        connector_team_id=42,
+        agent_creator_user_id=99,
+        declared_knowledge_bases=["kb1", "kb2"],
+    )
+
+    assert captured.get("connector_team_id") == 42
+    assert captured.get("agent_creator_user_id") == 99
+    assert captured.get("declared_knowledge_bases") == ["kb1", "kb2"]
+
+
+@pytest.mark.asyncio
+async def test_create_default_tools_leaves_creator_and_declaration_unset_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative control: the common no-agent case must not accidentally
+    populate either new value."""
+    from xagent.web.api.chat import create_default_tools
+
+    captured: dict[str, Any] = {}
+
+    class _FakeToolConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        def set_task_runtime_contribution(self, contribution: Any) -> None:
+            pass
+
+    async def create_tools(config: Any) -> list:
+        return []
+
+    monkeypatch.setattr("xagent.web.tools.config.WebToolConfig", _FakeToolConfig)
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local", lambda: object()
+    )
+    monkeypatch.setattr(ToolFactory, "create_all_tools", create_tools)
+
+    await create_default_tools(
+        None,
+        user=SimpleNamespace(id=7, is_admin=False),
+        task_id="web_task_11",
+    )
+
+    assert captured.get("agent_creator_user_id") is None
+    assert captured.get("declared_knowledge_bases") is None


### PR DESCRIPTION
### What this changes

A team-owned agent's knowledge bases should be the ones **its own team** owns, not
the ones whoever happens to be running it can see. Today `_list_visible_collections`
unions the runner's personal collections with the runner's *own* team memberships,
which is the right answer for a person browsing their knowledge bases and the wrong
answer for a run governed by someone else's team agent.

This PR builds the seam that makes the right answer possible, in three parts.

**The team layer resolves on the governing team.** `_list_visible_collections` now
takes a `governing_team_id`. When one is set *and* an application has installed a
team-keyed visibility hook, the team layer is the governing team's own knowledge
bases — never the runner's team memberships, and never a union of the two. Every
other input keeps the existing runner-keyed overlay, byte for byte.

Two ordering decisions inside that branch are deliberate:

- The team branch is reached **before** the `is_admin` short-circuit. An admin
  running a team agent must still resolve against that agent's team, not against
  their unrestricted view of every collection on the platform.
- The unauthenticated guard stays the **first** check. The calls below do
  `int(user_id)`, so removing or reordering it turns an unauthenticated caller into
  a `TypeError` instead of a well-defined early return.

Selection is on the hook predicate, never on an empty return value: an installed
hook legitimately answers "this team owns nothing".

**Resolution failure gets a typed channel.** `KnowledgeBaseScopeError` lives in a
module with zero xagent imports, so both sides of the core/web boundary can name it
without an import cycle. `resolve_team_knowledge_bases_or_raise` converts every
non-typed failure into it, and the run-path handlers that otherwise re-wrap
everything into a bare `RuntimeError` now let it through unchanged. Without this,
"the team owns nothing" (an empty list) and "resolution failed" collapse into the
same silent empty answer, and a search quietly returns fewer collections than it
should. The hook's answer is shape-validated before any caller sees it — `can_edit`
and `can_delete` default to `True` on `KnowledgeBaseAccess` and are copied straight
onto the collection handed back, so an answer that omits them would grant edit and
delete on the team's knowledge base to every runner who can search it.

**The governing agent's identity reaches the tool build.** Two more values travel
the existing route to the knowledge-base search entry point: the Agent row's own
creator, and the agent's *stored* `knowledge_bases` declaration. Both are derived at
the same three points that already derive the governing team, off the same frozen
snapshot or the same resolved agent, so a governing team can never be paired with
another agent's creator. The declaration is read from the agent's own configuration
and stays distinct from `tool_args.allowed_collections` and `tool_args.collections`
all the way down; those are model-authored on every path, and `setdefault` lets a
model-supplied value win outright over the agent's configured one.

### Nothing changes for anyone yet

Both new values arrive at `_search_knowledge_base_impl` and are not read there. The
declared-name resolution rule that consumes them arrives separately.

The team layer's own behaviour change is also inert until a deployment opts in:
standalone xagent installs no team-keyed hook, so `team_knowledge_base_hook_installed()`
is `False` and every path falls back to today's runner-keyed overlay. An application
that installs the hook gets the governing-team resolution; one that does not sees no
difference at all. The typed error can only be raised by a hook that exists.

That inertness is the reason this lands on its own: the seam is safe to ship ahead of
any hook installation, and reviewing it does not require holding the resolution rule
in your head at the same time.

### What is pinned

| Test file | What it holds |
|---|---|
| `tests/web/services/test_knowledge_base_team_scope.py` | The team-keyed hook slot, the answer validator (every rejection class), the typed-error conversion, and the snapshot/restore primitive |
| `tests/core/tools/core/test_document_search_team_layer.py` | The team layer resolving on the governing team for a member and for an admin; the runner-keyed fallback when no team hook is installed; the unauthenticated early return; the typed error surviving both re-wrap points; the tool build reading the governing values |
| `tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py` | All three values reaching the facade unmodified, on both the list and search entry points |
| `tests/core/tools/adapters/vibe/test_knowledge_tools_team_scope_wiring.py` | The knowledge tool builder reading them off the config and forwarding them |
| `tests/web/api/test_chat_team_scope_wiring_behavioral.py`, `..._static.py` | All three derivation points reading off one agent, never two |
| `tests/web/services/test_agent_runtime_fields_creator.py` | The snapshot field carrying the creator alongside the team id |
| `tests/web/tools/test_create_default_tools_team_scope_forwarding.py` | The tool-creation entry point forwarding both new values |
| `tests/core/tools/core/RAG_tools/test_multitenancy.py` | The collections endpoint staying runner-keyed even when a team hook is installed |
| `tests/core/tools/core/test_document_search_team_visibility_boundary.py`, `tests/web/test_team_sharing_hooks.py` | Existing suites moved onto the snapshot primitive so they no longer leak hook state |

`find_missing_knowledge_bases` deliberately stays runner-keyed and takes no governing
team: it backs the agent builder's save-time validation of an agent's own collection
selection, and an agent being edited is not yet the governing agent of any run.
