### PR TITLE
fix(files): send region cookies for public downloads

### DIFF
--- a/frontend/src/components/file/pptx-preview-renderer.test.tsx
+++ b/frontend/src/components/file/pptx-preview-renderer.test.tsx
@@ -50,7 +50,7 @@ describe("PptxPreviewRenderer public file access", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalled())
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/files/public/preview/presentation-id?token=pptx-guest-token",
-      expect.objectContaining({ credentials: "omit" }),
+      expect.objectContaining({ credentials: "same-origin" }),
     )
     expect(fetchMock.mock.calls.every(([url]) => !String(url).includes("preview-pdf"))).toBe(true)
   })

--- a/frontend/src/contexts/file-access-context.test.tsx
+++ b/frontend/src/contexts/file-access-context.test.tsx
@@ -113,12 +113,12 @@ describe("FileAccessProvider", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining("token=first-token"),
-      expect.objectContaining({ credentials: "omit" }),
+      expect.objectContaining({ credentials: "same-origin" }),
     )
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       expect.stringContaining("token=second-token"),
-      expect.objectContaining({ credentials: "omit" }),
+      expect.objectContaining({ credentials: "same-origin" }),
     )
   })
 
@@ -148,12 +148,12 @@ describe("FileAccessProvider", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("token=surviving-token"),
-      expect.objectContaining({ credentials: "omit" }),
+      expect.objectContaining({ credentials: "same-origin" }),
     )
     expect(sessionStorage.getItem("xagent_public_access_token")).toBeNull()
   })
 
-  it("forces public file requests to omit cookies and ambient Authorization", async () => {
+  it("allows same-origin routing cookies but strips ambient Authorization", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response())
     vi.stubGlobal("fetch", fetchMock)
     const policy = createPublicFileAccessPolicy("guest-token")
@@ -164,7 +164,7 @@ describe("FileAccessProvider", () => {
     })
 
     const [, options] = fetchMock.mock.calls[0] as [string, RequestInit]
-    expect(options.credentials).toBe("omit")
+    expect(options.credentials).toBe("same-origin")
     expect(new Headers(options.headers).get("Authorization")).toBeNull()
     expect(new Headers(options.headers).get("X-Trace")).toBe("request")
   })

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -121,7 +121,9 @@ export function createPublicFileAccessPolicy(accessToken: string): FileAccessPol
     request: (url, options = {}) => {
       const headers = new Headers(options.headers)
       headers.delete("Authorization")
-      return fetch(url, { ...options, headers, credentials: "omit" })
+      // Same-origin cookies carry deployment routing state, not file authority;
+      // the scoped query token remains the public endpoint's credential.
+      return fetch(url, { ...options, headers, credentials: "same-origin" })
     },
     // The guest token rides the query string, so media elements can load
     // previewUrl directly — no headers needed, and range requests work.

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -126,8 +126,9 @@ export function createPublicFileAccessPolicy(accessToken: string): FileAccessPol
       const headers = new Headers(options.headers)
       headers.delete("Authorization")
       // Same-origin requests carry ambient cookies, including the edge's
-      // selected_region routing cookie. Public routes authorize on the scoped
-      // query token alone, never on cookies.
+      // selected_region routing cookie. Cookies are not an authorization input.
+      // Task-bound configured files validate the scoped query token; taskless
+      // and legacy paths use their file ID or path capability.
       return fetch(url, { ...options, headers, credentials: "same-origin" })
     },
     // The guest token rides the query string, so media elements can load

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -121,8 +121,9 @@ export function createPublicFileAccessPolicy(accessToken: string): FileAccessPol
     request: (url, options = {}) => {
       const headers = new Headers(options.headers)
       headers.delete("Authorization")
-      // Same-origin cookies carry deployment routing state, not file authority;
-      // the scoped query token remains the public endpoint's credential.
+      // Same-origin requests carry ambient cookies, including the edge's
+      // selected_region routing cookie. Public routes authorize on the scoped
+      // query token alone, never on cookies.
       return fetch(url, { ...options, headers, credentials: "same-origin" })
     },
     // The guest token rides the query string, so media elements can load

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -18,8 +18,10 @@ export interface FileAccessPolicy {
   relativePreviewUrl: (fileId: string, relativePath: string) => string
   pdfPreviewUrl?: (fileId: string) => string
   /**
-   * Execute under this policy's credential boundary. Implementations may
-   * override caller credentials and remove or attach authorization headers.
+   * Execute under this policy's credential boundary. The built-in default
+   * attaches Bearer authorization. The public policy forces same-origin
+   * credentials, strips caller Authorization, and leaves its scoped query
+   * token on the URL. Custom policies must define an equivalent boundary.
    */
   request: FileAccessRequest
   listFiles?: (query: string) => Promise<Response>

--- a/frontend/src/contexts/file-access-context.tsx
+++ b/frontend/src/contexts/file-access-context.tsx
@@ -17,6 +17,10 @@ export interface FileAccessPolicy {
   inlineDownloadUrl: (fileId: string) => string
   relativePreviewUrl: (fileId: string, relativePath: string) => string
   pdfPreviewUrl?: (fileId: string) => string
+  /**
+   * Execute under this policy's credential boundary. Implementations may
+   * override caller credentials and remove or attach authorization headers.
+   */
   request: FileAccessRequest
   listFiles?: (query: string) => Promise<Response>
   /**


### PR DESCRIPTION
## Summary

- send same-origin cookies with public file fetches so the canonical edge can read `selected_region`
- continue stripping ambient `Authorization` and prevent callers from broadening credentials to cross-origin requests
- update public file policy and PPTX preview coverage

Follow-up to #1276.

## Verification

- `npm test -- --run src/contexts/file-access-context.test.tsx src/components/file/inline-file-preview.test.tsx src/components/file/pptx-preview-renderer.test.tsx src/components/chat/chat-input-public-file-access.test.tsx`
- `.venv/bin/pre-commit run --all-files`