### PR TITLE
feat: let the Get Started video card link out via the home extension point

### DIFF
--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -365,6 +365,7 @@ describe("Home", () => {
   }
 
   beforeEach(() => {
+    delete homeGetStartedDestinationOverridesMock.video
     delete homeGetStartedDestinationOverridesMock.docs
     delete homeGetStartedDestinationOverridesMock.guides
     delete homeGetStartedDestinationOverridesMock.whatsNew
@@ -498,6 +499,29 @@ describe("Home", () => {
     expectLinkedGetStartedCard("home.getStarted.guides.title", "custom-guide:destination")
     expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "  /whats-new  ")
     expect(getStartedCard("home.getStarted.video.title").wrapper.querySelector("a")).toBeNull()
+  })
+
+  it("resolves a configured video destination while keeping the inline tutorial video and canonical siblings", () => {
+    homeGetStartedDestinationOverridesMock.video = "https://help.xagent.co/user-guide/demo-videos.html"
+    render(<Home />)
+
+    expectLinkedGetStartedCard("home.getStarted.video.title", "https://help.xagent.co/user-guide/demo-videos.html")
+    const linkedVideo = getStartedCard("home.getStarted.video.title").card.querySelector("video")
+    if (!(linkedVideo instanceof HTMLVideoElement)) throw new Error("Tutorial video was not eagerly loaded")
+    expect(linkedVideo).toHaveAttribute("src", "/videos/Tutorial.mp4")
+    expectLinkedGetStartedCard("home.getStarted.docs.title", "https://docs.xagent.co/api-reference/introduction")
+    expectLinkedGetStartedCard("home.getStarted.guides.title", "https://docs.xagent.co/models/overview")
+    expectLinkedGetStartedCard("home.getStarted.whatsNew.title", "https://docs.xagent.co/release-notes")
+
+    cleanup()
+    for (const invalid of [null, "", "   "]) {
+      ;(homeGetStartedDestinationOverridesMock as Record<string, unknown>).video = invalid
+      const { unmount } = render(<Home />)
+      expectInertGetStartedCard("home.getStarted.video.title")
+      const inertVideo = getStartedCard("home.getStarted.video.title").card.querySelector("video")
+      if (!(inertVideo instanceof HTMLVideoElement)) throw new Error("Tutorial video was not eagerly loaded")
+      unmount()
+    }
   })
 
   it("rejects pointer, hover, focus, native, inline-style, SVG, and media-control affordances injected into an inert card", () => {
@@ -763,18 +787,19 @@ describe("Home", () => {
     const resolver = sourceSlice(pageSource, "function resolveHomeGetStartedDestination(", "export default function Home()")
     const cardRender = sourceSlice(pageSource, "{[", "          {/* Build agents with templates */}")
 
+    expect(contractInterface).toMatch(/video\?: string \| null/)
     expect(contractInterface).toMatch(/docs\?: string \| null/)
     expect(contractInterface).toMatch(/guides\?: string \| null/)
     expect(contractInterface).toMatch(/whatsNew\?: string \| null/)
-    expect(contractInterface.match(/\?: string \| null/g)).toHaveLength(3)
-    expect(contractInterface.match(/^\s+\w+\??:/gm)).toHaveLength(3)
+    expect(contractInterface.match(/\?: string \| null/g)).toHaveLength(4)
+    expect(contractInterface.match(/^\s+\w+\??:/gm)).toHaveLength(4)
     expect(contractInterface).not.toContain("tutorial")
     expect(extensionSource).toMatch(/export const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides = \{\}/)
     expect(pageSource).toMatch(/import \* as homePageExtensionModule from "@\/lib\/home-page-extension";/)
     expect(pageSource).toMatch(
       /const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =\s*\(homePageExtensionModule as \{ homeGetStartedDestinationOverrides\?: HomeGetStartedDestinationOverrides \}\)\s*\.homeGetStartedDestinationOverrides \?\? \{\}/,
     )
-    expect(pageSource).toMatch(/const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = \{/)
+    expect(pageSource).toMatch(/const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string \| null> = \{/)
     expect(resolver).toContain("configured === undefined")
     expect(resolver).toContain("typeof configured !== \"string\"")
     expect(resolver).toContain("configured.trim().length === 0")
@@ -785,11 +810,11 @@ describe("Home", () => {
     expect(cardRender).toContain("focus-visible:ring-2")
     expect(cardRender).not.toMatch(/\bon[A-Z][A-Za-z]*|\btabIndex\b|\brole\b|\bcontrols\b|\bstyle\b|\bcursor\s*=|\bcontentEditable\b|\bsuppressContentEditableWarning\b|\bdraggable\b|\{\s*\.\.\./)
     const destinationCalls = Array.from(cardRender.matchAll(
-      /resolveHomeGetStartedDestination\(homeGetStartedDestinationOverrides\.(docs|guides|whatsNew), defaultHomeGetStartedDestinations\.\1\)/g,
+      /resolveHomeGetStartedDestination\(homeGetStartedDestinationOverrides\.(video|docs|guides|whatsNew), defaultHomeGetStartedDestinations\.\1\)/g,
     )).map((match) => match[1])
-    expect(destinationCalls).toEqual(["docs", "guides", "whatsNew"])
-    expect(cardRender.match(/resolveHomeGetStartedDestination\(/g)).toHaveLength(3)
-    expect(cardRender.match(/defaultHomeGetStartedDestinations\./g)).toHaveLength(3)
+    expect(destinationCalls).toEqual(["video", "docs", "guides", "whatsNew"])
+    expect(cardRender.match(/resolveHomeGetStartedDestination\(/g)).toHaveLength(4)
+    expect(cardRender.match(/defaultHomeGetStartedDestinations\./g)).toHaveLength(4)
     expect(cardRender).not.toMatch(/https:\/\/docs\.xagent\.co\//)
   })
 

--- a/frontend/src/app/page.test.tsx
+++ b/frontend/src/app/page.test.tsx
@@ -515,7 +515,7 @@ describe("Home", () => {
 
     cleanup()
     for (const invalid of [null, "", "   "]) {
-      ;(homeGetStartedDestinationOverridesMock as Record<string, unknown>).video = invalid
+      homeGetStartedDestinationOverridesMock.video = invalid
       const { unmount } = render(<Home />)
       expectInertGetStartedCard("home.getStarted.video.title")
       const inertVideo = getStartedCard("home.getStarted.video.title").card.querySelector("video")
@@ -799,7 +799,9 @@ describe("Home", () => {
     expect(pageSource).toMatch(
       /const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =\s*\(homePageExtensionModule as \{ homeGetStartedDestinationOverrides\?: HomeGetStartedDestinationOverrides \}\)\s*\.homeGetStartedDestinationOverrides \?\? \{\}/,
     )
-    expect(pageSource).toMatch(/const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string \| null> = \{/)
+    expect(pageSource).toMatch(
+      /const defaultHomeGetStartedDestinations: \{ video: null \} & Record<\s*Exclude<keyof HomeGetStartedDestinationOverrides, "video">,\s*string\s*> = \{/,
+    )
     expect(resolver).toContain("configured === undefined")
     expect(resolver).toContain("typeof configured !== \"string\"")
     expect(resolver).toContain("configured.trim().length === 0")

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -162,7 +162,10 @@ const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =
   (homePageExtensionModule as { homeGetStartedDestinationOverrides?: HomeGetStartedDestinationOverrides })
     .homeGetStartedDestinationOverrides ?? {}
 
-const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string | null> = {
+const defaultHomeGetStartedDestinations: { video: null } & Record<
+  Exclude<keyof HomeGetStartedDestinationOverrides, "video">,
+  string
+> = {
   video: null,
   docs: "https://docs.xagent.co/api-reference/introduction",
   guides: "https://docs.xagent.co/models/overview",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -162,7 +162,8 @@ const homeGetStartedDestinationOverrides: HomeGetStartedDestinationOverrides =
   (homePageExtensionModule as { homeGetStartedDestinationOverrides?: HomeGetStartedDestinationOverrides })
     .homeGetStartedDestinationOverrides ?? {}
 
-const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string> = {
+const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationOverrides, string | null> = {
+  video: null,
   docs: "https://docs.xagent.co/api-reference/introduction",
   guides: "https://docs.xagent.co/models/overview",
   whatsNew: "https://docs.xagent.co/release-notes",
@@ -170,7 +171,7 @@ const defaultHomeGetStartedDestinations: Record<keyof HomeGetStartedDestinationO
 
 function resolveHomeGetStartedDestination(
   configured: unknown,
-  defaultDestination: string,
+  defaultDestination: string | null,
 ): string | null {
   if (configured === undefined) return defaultDestination
   if (typeof configured !== "string" || configured.trim().length === 0) return null
@@ -523,7 +524,7 @@ export default function Home() {
           <h2 className="text-[16px] font-bold mb-4 text-foreground">{t("home.getStarted.title")}</h2>
           <div ref={getStartedSectionRef} className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 mb-10">
             {[
-              { title: t("home.getStarted.video.title"), desc: t("home.getStarted.video.description", { appName: branding.appName }), video: "/videos/Tutorial.mp4", link: null },
+              { title: t("home.getStarted.video.title"), desc: t("home.getStarted.video.description", { appName: branding.appName }), video: "/videos/Tutorial.mp4", link: resolveHomeGetStartedDestination(homeGetStartedDestinationOverrides.video, defaultHomeGetStartedDestinations.video) },
               { title: t("home.getStarted.docs.title"), desc: t("home.getStarted.docs.description"), video: "/videos/Documentation.mp4", link: resolveHomeGetStartedDestination(homeGetStartedDestinationOverrides.docs, defaultHomeGetStartedDestinations.docs) },
               { title: t("home.getStarted.guides.title"), desc: t("home.getStarted.guides.description"), icon: <ListChecks className="w-8 h-8 text-green-500" />, bg: "bg-green-50 dark:bg-green-950/30", link: resolveHomeGetStartedDestination(homeGetStartedDestinationOverrides.guides, defaultHomeGetStartedDestinations.guides) },
               { title: t("home.getStarted.whatsNew.title"), desc: t("home.getStarted.whatsNew.description"), icon: <Sparkles className="w-8 h-8 text-orange-500" />, bg: "bg-orange-50 dark:bg-orange-950/30", link: resolveHomeGetStartedDestination(homeGetStartedDestinationOverrides.whatsNew, defaultHomeGetStartedDestinations.whatsNew) }

--- a/frontend/src/lib/page-extension-contracts.ts
+++ b/frontend/src/lib/page-extension-contracts.ts
@@ -15,15 +15,18 @@ export type HomePageExtensionComponent = ComponentType
  * Each key is resolved independently with three-state semantics:
  * - `undefined` (key omitted, or the whole `homeGetStartedDestinationOverrides`
  *   export is missing from a replacement module): the canonical OSS default
- *   destination is used.
+ *   destination is used. For `video`, the canonical OSS default is itself
+ *   `null` — the card plays its inline tutorial video without linking out.
  * - `null` (or a non-string / blank value): the card renders as a
  *   non-interactive card — no anchor, no tab stop, no pointer cursor, and no
- *   link-only hover styling.
+ *   link-only hover styling. A `video` card still autoplays its inline video
+ *   in this state; only the link wrapper is affected.
  * - a string that is non-empty after trimming: used as the destination
  *   verbatim, including any surrounding whitespace, which is deliberately
  *   not trimmed from the emitted href.
  */
 export interface HomeGetStartedDestinationOverrides {
+  video?: string | null
   docs?: string | null
   guides?: string | null
   whatsNew?: string | null


### PR DESCRIPTION
## Summary
- `HomeGetStartedDestinationOverrides` gains a `video` key, resolved through the same `resolveHomeGetStartedDestination` helper already used for `docs`/`guides`/`whatsNew`.
- The Get Started "Video Tutorial" card's `link` now comes from `resolveHomeGetStartedDestination(homeGetStartedDestinationOverrides.video, defaultHomeGetStartedDestinations.video)` instead of the hardcoded `null`.
- The OSS default for `video` is `null`, so with no override configured the card behaves exactly as before (inline autoplaying video, no link wrapper, no hover/focus affordances).
- When a replacement `home-page-extension` module sets `video` to a URL, the card becomes a link (same `target="_blank"` treatment as the other cards) while still autoplaying its inline tutorial video — the link wraps the existing video, it doesn't replace it.

## Why
Downstream distributions (e.g. the SaaS build) want their own "Video Tutorial" card to point at their own hosted how-to-videos page, without forking `page.tsx`. The existing extension point already supports this pattern for docs/guides/whatsNew; this extends it to video for consistency.

## Test plan
- [x] `npx vitest run src/app/page.test.tsx` (111 passed) — includes a new test asserting the video card links out with the inline video intact, and stays inert for null/blank/undefined overrides
- [x] `tsc --noEmit` — no errors
- [x] `eslint` on changed files — no new warnings