### PR TITLE
feat(interactions): add the interaction lifecycle service's answer-side entry point

### DIFF
--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -385,11 +385,7 @@ def classify_task_command_conflict(
     deleted concurrently with the insert (TASK_MISSING), and a conflict on
     neither -- the row references two foreign keys, so absence of a duplicate
     does not prove the task caused it: a concurrently deleted actor fails the
-    users FK while the task is still present (UNRELATED). Rolling back to a
-    savepoint opened before the failing insert is equivalent to rolling back
-    the whole transaction for this purpose, as long as that savepoint
-    predates the insert: either way, the post-rollback state this function
-    queries no longer contains the failed statement's own effects.
+    users FK while the task is still present (UNRELATED).
 
     RACED_DUPLICATE means the command survived the race, not that the
     caller's work did: the rollback that had to precede this call also undid

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -385,7 +385,11 @@ def classify_task_command_conflict(
     deleted concurrently with the insert (TASK_MISSING), and a conflict on
     neither -- the row references two foreign keys, so absence of a duplicate
     does not prove the task caused it: a concurrently deleted actor fails the
-    users FK while the task is still present (UNRELATED).
+    users FK while the task is still present (UNRELATED). Rolling back to a
+    savepoint opened before the failing insert is equivalent to rolling back
+    the whole transaction for this purpose, as long as that savepoint
+    predates the insert: either way, the post-rollback state this function
+    queries no longer contains the failed statement's own effects.
 
     RACED_DUPLICATE means the command survived the race, not that the
     caller's work did: the rollback that had to precede this call also undid

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -78,6 +78,7 @@ the scanned package tree).
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -122,6 +123,8 @@ from .task_lease_service import TASK_RUN_ID_TRACE_FIELD
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Principal and the shared public-chat ownership predicate
@@ -1616,9 +1619,6 @@ def _retire_respond_session_best_effort(db: "Session") -> None:
     helper is named for.
     """
 
-    import logging
-
-    logger = logging.getLogger(__name__)
     try:
         db.close()
         return
@@ -1868,9 +1868,7 @@ def respond(
     documented above as unreachable and is in this same category.
     """
 
-    if not isinstance(envelope.kind, str):
-        return RespondValidationRejected(reason="unknown_kind")
-    if envelope.kind not in _KIND_VOCABULARY:
+    if not isinstance(envelope.kind, str) or envelope.kind not in _KIND_VOCABULARY:
         return RespondValidationRejected(reason="unknown_kind")
     if (
         not isinstance(envelope.protocol_version, int)
@@ -2051,9 +2049,7 @@ def respond(
             # under the same idempotency key resolves the ambiguity by
             # itself. The classification this build does not compute is
             # exactly the set of fields logged here.
-            import logging
-
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "answer fence matched zero rows for interaction %s on task "
                 "%s; reread status=%s active_slot=%s terminal_reason=%s "
                 "run_id=%s responder_identity=%s",
@@ -2147,9 +2143,7 @@ def respond(
             # against the durable graph (that reconciliation is not
             # delivered here): it retires its session and reports the
             # ambiguity, leaving the caller to re-check.
-            import logging
-
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "commit failed while answering interaction %s on task %s; "
                 "the write may or may not be durable -- a retry under the "
                 "same idempotency key resolves which",
@@ -2180,9 +2174,7 @@ def respond(
             # purpose: this wraps one post-commit best-effort notification
             # and nothing else -- no statement above the commit is inside
             # it.
-            import logging
-
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "failed to notify the task command dispatcher after "
                 "committing the answer for interaction %s on task %s; "
                 "the dispatcher's idle poll will still pick the command up",

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1357,14 +1357,27 @@ def _answer_fence_task_predicate(principal: InteractionPrincipal) -> list[Any]:
     row the fence statement joins in via ``Task.id == task_id`` (see
     ``_answer_fence_stmt``), not a second, independently-scoped read.
 
-    The ownership terms are redundant on PostgreSQL -- step 2 of
-    ``respond()`` already holds this row's ``FOR NO KEY UPDATE`` lock -- and
-    load-bearing on SQLite, where the dialect drops every locking clause
-    silently and nothing serializes a caller until this statement, the
-    transaction's first write (see ``respond()``'s own docstring for the
-    two backends' different serialization points). Enforcing ownership at
-    the write point rather than only in ``respond()``'s step 3 is what
-    makes the two backends agree on what a successful answer proves.
+    The ``Task.user_id`` term requires the owner in person, on both
+    backends: step 3's authorization admits an admin acting on another
+    user's task, and the guest ownership predicate never reads
+    ``principal.user_id`` (see ``task_is_owned_by_public_principal``), so
+    for both of those callers this term is the only ownership constraint
+    in the path and the fence misses. Answering on another user's behalf
+    is not delivered in this build; whether an admin may do so is a policy
+    decision left to the change that wires the first production caller. A
+    ``principal.user_id`` of ``None`` compiles to ``tasks.user_id IS
+    NULL`` and matches nothing (the column is ``nullable=False``), so such
+    a caller fails closed here rather than matching another user's row.
+
+    Against a *concurrent* ownership change the term is redundant on
+    PostgreSQL -- step 2 of ``respond()`` already holds this row's
+    ``FOR NO KEY UPDATE`` lock -- and load-bearing on SQLite, where the
+    dialect drops every locking clause silently and nothing serializes a
+    caller until this statement, the transaction's first write (see
+    ``respond()``'s own docstring for the two backends' different
+    serialization points). Enforcing ownership at the write point rather
+    than only in ``respond()``'s step 3 is what makes the two backends
+    agree on what a successful answer proves.
 
     ``Task.status`` is compared through ``TaskStatusPredicate.eq``, never a
     raw string literal beside the column -- this module's own convention
@@ -1696,9 +1709,10 @@ def respond(
        from under this transaction's own row lock, then reports
        ``OutcomeUnknown`` without further classifying why the fence missed
        (a fine-grained classification -- already-answered replay/conflict,
-       three terminated reasons, wrong task state, foreign run, or --
-       reachable only on SQLite, see ``_answer_fence_task_predicate`` -- an
-       ownership change -- is not delivered in this build); ``rowcount > 1``
+       three terminated reasons, wrong task state, foreign run, or an
+       ownership miss, reachable on both backends (see
+       ``_answer_fence_task_predicate``) -- is not delivered in this build);
+       ``rowcount > 1``
        is a schema invariant violation (``uq_task_interaction_active_slot``)
        and raises.
     7. The Task CAS via ``apply_task_control_transition``, called with no

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1545,8 +1545,26 @@ def _respond_receipt(
     table's audit-authoritative record of who answered (see ``respond()``'s
     own docstring for why ``responder_user_id`` cannot be used for the same
     purpose).
+
+    The only caller is ``respond()``'s idempotent-replay branch, whose
+    precondition -- a staged RESUME command this service itself committed
+    in the same transaction as the answer fence UPDATE -- implies an
+    answered row, and the paired CHECK constraints
+    (``ck_task_interaction_requests_responded_at_pairs_status`` and
+    ``ck_task_interaction_requests_responder_pairs_responded_at``) make an
+    answered row with a NULL ``responded_at`` or ``responder_identity``
+    impossible. That reasoning spans two modules, so the guard below turns
+    it into a loud failure instead of trusting it silently: a receipt must
+    never carry a coerced ``'None'`` identity or a ``None`` timestamp.
     """
 
+    if interaction.responded_at is None or interaction.responder_identity is None:
+        raise RuntimeError(
+            f"interaction {interaction.id} on task {interaction.task_id} "
+            "matched a staged RESUME command but carries no answer; "
+            "ck_task_interaction_requests_responder_pairs_responded_at "
+            "makes this impossible"
+        )
     return InteractionResponseReceipt(
         interaction_id=int(interaction.id),
         task_id=int(interaction.task_id),
@@ -1688,9 +1706,18 @@ def respond(
     3. Pure Python authorization against the row step 2 loaded: a
        ``"user"`` principal must own the task or be an admin; a
        ``"guest"`` principal must satisfy the shared
-       ``task_is_owned_by_public_principal`` predicate. Runs before the
-       idempotency pre-read (step 5) so an unauthorized caller can never use
-       a guessed idempotency key to read back someone else's receipt.
+       ``task_is_owned_by_public_principal`` predicate. A principal whose
+       ``kind`` is neither ``"user"`` nor ``"guest"`` is always
+       unauthorized -- there is no third branch that defaults to allow. A
+       malformed guest principal that populates zero or more than one
+       entity-binding field makes the ownership predicate raise
+       ``ValueError``; this function catches only that one exception type
+       from that one call and treats it as unauthorized -- the same
+       fail-closed-on-a-malformed-caller behavior the predicate itself
+       documents and ``create()`` applies to the same two cases. Runs
+       before the idempotency pre-read (step 5) so an unauthorized caller
+       can never use a guessed idempotency key to read back someone else's
+       receipt.
     4. Load the interaction row by ``(id, task_id)`` -- absent,
        ``Unavailable(interaction_missing)``. Present but its own ``kind`` /
        ``protocol_version`` columns disagree with ``envelope``'s,

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1873,7 +1873,7 @@ def respond(
     if not isinstance(envelope.values, dict):
         return RespondValidationRejected(reason="invalid_values")
     try:
-        json.dumps(envelope.values, allow_nan=False)
+        json.dumps(envelope.values, allow_nan=False, sort_keys=True)
     except (TypeError, ValueError):
         # The same probe ``_render_request_payload`` runs on the question
         # side (see its own docstring), applied here for the two failure
@@ -1889,6 +1889,13 @@ def respond(
         # case into the ``ValueError`` caught here. Structural, like every
         # other check in step 1 -- it asks whether these values can be
         # stored at all, not whether they answer this particular question.
+        # ``sort_keys=True`` matches ``_canonical_payload``
+        # (``task_command_transport.py``), which sorts keys recursively: a
+        # dict mixing int and str keys passes an unsorted dump (int keys
+        # are silently coerced to strings -- the same silent-corruption
+        # class as the nan case) and then raises ``TypeError`` inside the
+        # replay comparison. The probe has to be a strict superset of every
+        # serializer downstream of step 1.
         return RespondValidationRejected(reason="invalid_values")
 
     from ..models.database import get_session_local

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1822,7 +1822,10 @@ def respond(
        retires its session and reports ``OutcomeUnknown`` unconditionally,
        leaving the caller to re-check.
     10. After a successful commit, outside any transaction:
-        ``notify_task_command_dispatcher()``.
+        ``notify_task_command_dispatcher()``. Best-effort: a raise here
+        would turn a committed answer into a reported failure, so it is
+        caught, logged as a warning, and the dispatcher's idle poll
+        delivers the command instead.
 
     What this function lets escape, deliberately, and what it does not.
     The eight ``RespondOutcome`` variants cover every outcome this build
@@ -1833,9 +1836,10 @@ def respond(
 
     - Database-level failures outside the two units caught above --
       a deadlock, a lost connection, a pool checkout timeout -- raised by
-      any statement from step 2 onward. The two catches are narrow on
+      any statement from step 2 onward. The three catches are narrow on
       purpose: step 8's is ``IntegrityError`` only, step 9's covers the
-      commit only.
+      commit only, and step 10's wraps one post-commit best-effort
+      notification whose failure is logged and swallowed.
     - ``TaskCommandOwnerStateError`` and ``TaskCommandTaskMissing`` from
       ``stage_task_command``. Neither is an ``IntegrityError`` subclass, so
       step 8's catch does not see them, and both mean a precondition this

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -2028,13 +2028,15 @@ def respond(
                 )
             # The reread above already has the row in hand, so recording
             # what it found costs no extra statement. Without this line a
-            # fence miss is the one path out of this function that leaves
-            # nothing at all behind: the caller is told ``OutcomeUnknown``,
-            # and a retry against a terminated, superseded, or
-            # foreign-owned row produces the same miss and the same
-            # ``OutcomeUnknown`` every time, so no amount of retrying ever
-            # reveals which of them it was. The classification this build
-            # does not compute is exactly the set of fields logged here.
+            # fence miss is the one exit a retry cannot clarify on its
+            # own: the caller is told ``OutcomeUnknown``, and a retry
+            # against a terminated, superseded, or foreign-owned row
+            # produces the same miss and the same ``OutcomeUnknown`` every
+            # time, so no amount of retrying ever reveals which of them it
+            # was -- unlike the commit-exception door below, where a retry
+            # under the same idempotency key resolves the ambiguity by
+            # itself. The classification this build does not compute is
+            # exactly the set of fields logged here.
             import logging
 
             logging.getLogger(__name__).warning(
@@ -2128,6 +2130,16 @@ def respond(
             # against the durable graph (that reconciliation is not
             # delivered here): it retires its session and reports the
             # ambiguity, leaving the caller to re-check.
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "commit failed while answering interaction %s on task %s; "
+                "the write may or may not be durable -- a retry under the "
+                "same idempotency key resolves which",
+                interaction_id,
+                task_id,
+                exc_info=True,
+            )
             session_retired = True
             _retire_respond_session_best_effort(db)
             return RespondOutcomeUnknown()

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -59,9 +59,10 @@ either); and the response-conflict counter
 Not delivered here, and named so a reader does not go looking for them in
 this module: the compatibility seam that routes the existing resume
 coordinator (``websocket.py``'s ``_handle_resume_task_unserialized``)
-through ``_active_native_row_criteria()`` ships as its own change in this
-same series and is not part of this one -- nothing in ``websocket.py``
-references this module today. ``create()``'s own call body -- the write
+through ``_active_native_row_criteria()`` shipped as its own change in this
+same series and has already merged -- ``websocket.py`` now imports
+``_active_native_row_criteria`` from this module -- but is not part of this
+change. ``create()``'s own call body -- the write
 that actually stages a row -- is not delivered here either; its own
 zero-production-caller gate
 (``tests/web/services/test_task_interaction_service_create_gate.py``)
@@ -483,13 +484,12 @@ def public_chat_identity_matches(task: "Task", principal: InteractionPrincipal) 
 
 
 # ---------------------------------------------------------------------------
-# RespondOutcome: the answer-side discriminated union. Types only in this
-# delivery -- respond() itself, and every branch that could actually
-# produce most of these variants, lands with a later change (see the module
-# docstring). Defining the full union now, rather than growing it
-# incrementally alongside respond()'s call body, is what lets the reason
-# vocabulary be pinned once and the counting below be a real guard instead
-# of a moving target.
+# RespondOutcome: the answer-side discriminated union. respond() itself,
+# and the call body that produces every one of these variants, are both
+# delivered in this module (see the module docstring). Defining the full
+# union up front, rather than growing it incrementally alongside that call
+# body, is what lets the reason vocabulary be pinned once and the counting
+# below be a real guard instead of a moving target.
 # ---------------------------------------------------------------------------
 
 
@@ -1526,7 +1526,7 @@ def _respond_command_payload(
     *, interaction_id: int, principal: InteractionPrincipal, values: Any
 ) -> dict[str, Any]:
     """The RESUME command payload ``respond()`` stages in step 8, and the
-    payload it re-derives at steps 5 and 6 to look an existing command up by
+    payload it re-derives at steps 5 and 8 to look an existing command up by
     the same shape.
 
     Carries ``responder_identity`` alongside the answer ``values`` so that
@@ -1563,7 +1563,15 @@ def _respond_receipt(
     a caller's ``principal`` -- that column, not ``principal``, is this
     table's audit-authoritative record of who answered (see ``respond()``'s
     own docstring for why ``responder_user_id`` cannot be used for the same
-    purpose).
+    purpose). This is not the only receipt this module builds: the accept
+    path builds ``RespondAccepted``'s receipt from plain locals captured in
+    the same transaction before the commit below, including
+    ``principal.identity_string()`` for ``responder_identity`` rather than
+    a read of this row's column. The two are not competing sources of
+    truth -- the answer fence this function's own precondition depends on
+    is the statement that wrote the column from that same
+    ``principal.identity_string()`` value, so the column and the local are
+    equal by the fence write's own semantics, not by coincidence.
 
     The only caller is ``respond()``'s idempotent-replay branch, whose
     precondition -- a staged RESUME command this service itself committed
@@ -1679,12 +1687,18 @@ def respond(
     the module docstring's audit-identity paragraph for why
     `responder_identity` and not this column is this table's audit source
     of truth. `actor_user_id` (written on the staged command, step 8)
-    records whose identity the resulting RESUME command executes as, which
-    is always the task's owning user for both principal kinds -- a guest's
-    turn already runs as that owner, matching the existing
-    `public_chat_access.py` precedent of dispatching guest-originated work
-    under the owner's identity. Do not "fix" this into agreement; they are
-    answers to different questions.
+    records whose identity the resulting RESUME command executes as. For a
+    guest principal, and for a non-admin `"user"` principal, that is always
+    the task's owning user: a guest's turn already runs as the entity owner
+    it is chatting through, matching the existing `public_chat_access.py`
+    precedent of dispatching guest-originated work under the owner's
+    identity, and step 3's non-admin branch requires `task.user_id ==
+    principal.user_id` to even reach here. The admin branch carries no such
+    requirement -- `principal.is_admin` authorizes on its own -- so an
+    admin's `actor_user_id` is the admin's own `principal.user_id` (which
+    can be absent, or belong to someone other than the task's owner), not
+    the task owner's. Do not "fix" this into agreement; they are answers to
+    different questions.
 
     Of the two audit-relevant columns this function fills on the interaction
     row, `responder_identity` is the one a reader can trust to stay
@@ -1730,7 +1744,7 @@ def respond(
        A dict whose contents cannot be rendered as JSON -- a ``datetime``,
        a ``set``, ``bytes``, or a ``nan``/infinite float -- is rejected
        here too, by the same ``json.dumps(..., allow_nan=False)`` probe
-       the question side runs (see ``_render_request_payload``). Without
+       the question side runs (see ``build_v1_request_payload``). Without
        it the first two would surface as a ``StatementError`` raised
        inside step 6's fence UPDATE, outside the ``RespondOutcome``
        contract entirely, and the third would be stored silently as a
@@ -1875,7 +1889,7 @@ def respond(
     try:
         json.dumps(envelope.values, allow_nan=False, sort_keys=True)
     except (TypeError, ValueError):
-        # The same probe ``_render_request_payload`` runs on the question
+        # The same probe ``build_v1_request_payload`` runs on the question
         # side (see its own docstring), applied here for the two failure
         # modes this side has. A ``values`` dict holding a ``datetime``,
         # ``set``, ``bytes``, or any other object the JSON encoder does not
@@ -2068,11 +2082,14 @@ def respond(
         # on ``ir``/``task`` the instant ``db.commit()`` returns -- reading
         # ``ir.run_id`` or ``task.state_version`` afterward would silently
         # re-issue a SELECT against a session this function is about to
-        # decide whether to keep or retire. The fence UPDATE and the CAS
-        # above are Core statements, so ``ir``/``task``'s in-memory
-        # attributes were never updated by them either; these locals are
-        # the values this call itself just wrote, not a read of what those
-        # statements left behind.
+        # decide whether to keep or retire. The fence UPDATE above is a
+        # Core statement, so ``ir``'s in-memory attributes are not synced
+        # by it; ``task``'s, by contrast, already are --
+        # ``apply_task_control_transition`` re-reads it with its own
+        # ``session.refresh(task)`` right after its atomic UPDATE. Either
+        # way these locals still have to be captured now: ``expire_on_commit``
+        # is what invalidates them the instant ``db.commit()`` returns, not
+        # whether this transaction has kept them current up to this point.
         answered_run_id = str(ir.run_id)
         answered_responder_identity = principal.identity_string()
         answered_responded_at = now

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -48,27 +48,30 @@ value object and the shared public-chat ownership predicate extracted from
 discriminated unions; the ``create()`` typed seam (validates and returns,
 does not stage a row); ``get()``/``list_active()``; the three-tier
 compatibility materialization view; the answer fence and its active-row
-predicate; ``respond()``'s own call body (validation, authorization,
-anchor resolution, the idempotency pre-read, the answer fence, the task
+predicate; ``respond()``'s own call body (validation, authorization, the
+idempotency pre-read, anchor resolution, the answer fence, the task
 control-state transition, staging the resume command, and committing --
 this delivery reports an unresolved fence miss or a failed commit as
 ``RespondOutcomeUnknown`` rather than further classifying or reconciling
-either; the response-conflict counter
-(``COUNTER_LIFECYCLE_RESPONSE_CONFLICT``); and the compatibility seam that
-routes the existing resume coordinator through this service
-(``websocket.py``'s ``_handle_resume_task_unserialized``). ``create()``'s
-own call body -- the write that actually stages a row -- is still not
-delivered here; its own zero-production-caller gate
+either); and the response-conflict counter
+(``COUNTER_LIFECYCLE_RESPONSE_CONFLICT``).
+
+Not delivered here, and named so a reader does not go looking for them in
+this module: the compatibility seam that routes the existing resume
+coordinator (``websocket.py``'s ``_handle_resume_task_unserialized``)
+through ``_active_native_row_criteria()`` ships as its own change in this
+same series and is not part of this one -- nothing in ``websocket.py``
+references this module today. ``create()``'s own call body -- the write
+that actually stages a row -- is not delivered here either; its own
+zero-production-caller gate
 (``tests/web/services/test_task_interaction_service_create_gate.py``)
-now watches ``create()`` alone. ``respond()`` left that gate not because
-it gained a caller -- the compatibility seam only reads
-``_active_native_row_criteria()`` and never calls it, and zero production
-code does today -- but because gating and callers are independent facts;
-the gate's own docstring states this and the seam's role. The gate gives
-that boundary a regression guard against import bindings, not an absolute
-one -- its docstring lists what it cannot see (dynamic access,
-alias/re-export chains, filename-stem exclusion, and code outside the
-scanned package tree).
+watches ``create()`` alone. ``respond()`` is not under that gate, and that
+is a statement about the gate, not about callers: zero production code
+calls ``respond()`` today, and the gate simply does not watch it. The gate
+gives ``create()``'s boundary a regression guard against import bindings,
+not an absolute one -- its docstring lists what it cannot see (dynamic
+access, alias/re-export chains, filename-stem exclusion, and code outside
+the scanned package tree).
 """
 
 from __future__ import annotations
@@ -619,12 +622,21 @@ RespondOutcome = (
 
 # ---------------------------------------------------------------------------
 # CreateOutcome: the create() seam's own discriminated union. Same family,
-# same style as RespondOutcome, but a separate set of classes -- the two
-# unions are not reused between each other even where a reason string
-# happens to be spelled the same way (e.g. "not_task_principal" appears in
-# both vocabularies below because both seams reuse the shared ownership
-# predicate's verdict, not because the two outcome types share a base
-# class).
+# same style as RespondOutcome, but two different mechanisms, and the
+# asymmetry is intentional rather than unfinished cleanup. Respond's
+# outcomes declare each reason as a ``Literal`` on the dataclass field, so
+# the type is the vocabulary. Create's still carry ``reason: str`` beside
+# the runtime dictionaries below, which record something a ``Literal``
+# cannot: which reasons are *producible* in this delivery as opposed to
+# merely declared, a distinction that exists only because create()'s call
+# body is not delivered yet. The two vocabularies overlap in nine strings
+# and are deliberately not shared -- ``"not_task_principal"`` appears in
+# both because both seams reuse the shared ownership predicate's verdict,
+# not because the two outcome types share a base class, and a change to
+# one side's word list must never silently move the other's. When
+# create()'s call body lands and the producible/declared distinction
+# disappears with it, that side converts to the Literal mechanism and this
+# note goes away.
 # ---------------------------------------------------------------------------
 
 
@@ -1389,7 +1401,15 @@ def _answer_fence_task_predicate(principal: InteractionPrincipal) -> list[Any]:
     ``respond()``'s own docstring for the two backends' different
     serialization points). Enforcing ownership at the write point rather
     than only in ``respond()``'s step 3 is what makes the two backends
-    agree on what a successful answer proves.
+    agree on the terms this statement actually carries -- which is not
+    every term step 3 evaluated. Three are re-asserted here: the task is
+    still ``WAITING_FOR_USER``, ``Task.user_id`` is still the principal's,
+    and, for a guest, the ``guest_id`` in ``agent_config`` still matches.
+    The rest of the guest conjunction -- ``auth_mode``, the entity binding,
+    and the channel binding -- is evaluated once in Python at step 3 and
+    not re-checked in SQL. A successful answer therefore proves the three
+    terms above held at write time and that the other three held at read
+    time, not that all six held at write time.
 
     ``Task.status`` is compared through ``TaskStatusPredicate.eq``, never a
     raw string literal beside the column -- this module's own convention
@@ -1641,16 +1661,28 @@ def respond(
     hold.
 
     `_handle_resume_task_unserialized` re-issues the same
-    `RESUME_REQUESTED` transition when it applies
-    the command this call staged. `apply_task_control_transition` has no
-    legality table, so that second transition succeeds and bumps
-    `state_version` again. Post-commit verification must therefore be
-    monotone in `state_version` and must not compare `control_state`. One
-    concrete consequence, recorded here because a future reader who treats
-    `state_version` as an operation counter will be surprised by it:
-    answering one interaction bumps `state_version` twice -- once in step 7
-    below, once when the coordinator re-applies the transition -- so a
-    consumer that expects "one answer, one version bump" will observe +2.
+    `RESUME_REQUESTED` transition when it applies the command this call
+    staged (`websocket.py`, reached from `_execute_durable_task_command`).
+    `apply_task_control_transition` has no legality table, so that second
+    transition succeeds and bumps `state_version` again. Post-commit
+    verification must therefore be monotone in `state_version` and must not
+    compare `control_state`. One concrete consequence, recorded here
+    because a future reader who treats `state_version` as an operation
+    counter will be surprised by it: answering one interaction bumps
+    `state_version` twice -- once in step 7 below, once when the
+    coordinator re-applies the transition -- so a consumer that expects
+    "one answer, one version bump" will observe +2.
+
+    That second bump is not reachable today: nothing in production calls
+    `respond()`, so no RESUME command carrying this function's payload is
+    ever staged or executed. It becomes reachable with the change that
+    gives `respond()` its first production caller, and deciding which of
+    the two writers owns the transition belongs to that change, not this
+    one. Making the transition single-writer here is not an option this
+    change can take on its own: `apply_task_control_transition` is shared
+    by eight direct call sites across five modules plus five more through
+    `transition_task_control_state_sync`, and adding a legality table to it
+    is a change to the task state machine, not to this service.
 
     `responder_user_id` and `actor_user_id` answer two different questions
     and are allowed to disagree. `responder_user_id` (written on the

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -65,11 +65,11 @@ references this module today. ``create()``'s own call body -- the write
 that actually stages a row -- is not delivered here either; its own
 zero-production-caller gate
 (``tests/web/services/test_task_interaction_service_create_gate.py``)
-watches ``create()`` alone. ``respond()`` is not under that gate, and that
-is a statement about the gate, not about callers: zero production code
-calls ``respond()`` today, and the gate simply does not watch it. The gate
-gives ``create()``'s boundary a regression guard against import bindings,
-not an absolute one -- its docstring lists what it cannot see (dynamic
+watches both ``create()`` and ``respond()``: zero production code calls
+either name today, and the change that wires a caller is the change that
+takes the corresponding name out of the gated set. The gate gives
+``create()``'s boundary a regression guard against import bindings, not
+an absolute one -- its docstring lists what it cannot see (dynamic
 access, alias/re-export chains, filename-stem exclusion, and code outside
 the scanned package tree).
 """

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -10,9 +10,7 @@ both live on the ask side, and both require the caller to already hold the
 transaction they run inside. This module's ``respond()`` is the opposite
 shape on every one of those points: it owns its own session end to end
 (opens it, commits or rolls it back, retires it) and never nests inside a
-caller's transaction -- the one savepoint it opens
-(``db.begin_nested()``, around staging its own resume command) is its
-own, not a caller's. ``create()``, by contrast, takes a caller-owned
+caller's transaction. ``create()``, by contrast, takes a caller-owned
 session and only reads through it, never opening or committing one of its
 own. Putting ``respond()`` in the same file as the staging primitive would
 make that staging module's merge-reason docstring false. What this module
@@ -52,8 +50,10 @@ does not stage a row); ``get()``/``list_active()``; the three-tier
 compatibility materialization view; the answer fence and its active-row
 predicate; ``respond()``'s own call body (validation, authorization,
 anchor resolution, the idempotency pre-read, the answer fence, the task
-control-state transition, staging the resume command, and committing or
-reconciling an ambiguous acknowledgment); the response-conflict counter
+control-state transition, staging the resume command, and committing --
+this delivery reports an unresolved fence miss or a failed commit as
+``RespondOutcomeUnknown`` rather than further classifying or reconciling
+either; the response-conflict counter
 (``COUNTER_LIFECYCLE_RESPONSE_CONFLICT``); and the compatibility seam that
 routes the existing resume coordinator through this service
 (``websocket.py``'s ``_handle_resume_task_unserialized``). ``create()``'s
@@ -74,7 +74,6 @@ scanned package tree).
 from __future__ import annotations
 
 import json
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -103,12 +102,9 @@ from .ops_signals import (
     register_degradation,
 )
 from .task_command_transport import (
-    TaskCommandConflictKind,
     TaskCommandKind,
-    _canonical_payload,
     _matches_existing,
     _normalize_command_id,
-    classify_task_command_conflict,
     notify_task_command_dispatcher,
     stage_task_command,
 )
@@ -542,15 +538,8 @@ RespondUnauthorizedReason = Literal["not_task_principal"]
 RespondUnavailableReason = Literal[
     "task_missing", "interaction_missing", "checkpoint_unavailable"
 ]
-RespondConflictReason = Literal["already_answered", "idempotency_key_reused"]
-RespondStaleReason = Literal[
-    "expired",
-    "run_superseded",
-    "answered_via_chat",
-    "run_ended",
-    "foreign_run",
-    "anchor_dangling",
-]
+RespondConflictReason = Literal["idempotency_key_reused"]
+RespondStaleReason = Literal["anchor_dangling"]
 
 
 @dataclass(frozen=True)
@@ -590,11 +579,18 @@ class RespondStale:
 
 @dataclass(frozen=True)
 class RespondOutcomeUnknown:
-    """A commit whose acknowledgment was ambiguous, reconciled against the
-    durable graph, and still unresolved after every reconciliation attempt.
-    Not an exception this service lets escape -- a stable, typed result a
-    caller can act on (e.g. surface "we could not confirm this went
-    through" rather than crash)."""
+    """A call this function could not resolve to one of the specific
+    outcomes above, for either of two reasons this build does not further
+    distinguish: the answer fence's UPDATE matched zero rows and this
+    build does not classify why (step 6 -- a future delivery may reread
+    and classify that miss the way the fence classification build does),
+    or committing raised and this build does not attempt to reconcile the
+    durable graph afterward (steps 8/9) -- the acknowledgment could have
+    been lost after the server applied the write, or a racing writer could
+    have taken the idempotency key first; either way this build reports
+    the ambiguity rather than guessing. Not an exception this service lets
+    escape -- a stable, typed result a caller can act on (e.g. surface "we
+    could not confirm this went through" rather than crash)."""
 
 
 RespondOutcome = (
@@ -1552,10 +1548,6 @@ def _respond_receipt(
     )
 
 
-_RESPOND_DURABLE_GRAPH_ATTEMPTS = 3
-_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS = 0.01
-
-
 def _retire_respond_session_best_effort(db: "Session") -> None:
     """Release an owned Session without letting a close/invalidate failure
     replace the transaction error that is already in flight. Same shape as
@@ -1578,119 +1570,6 @@ def _retire_respond_session_best_effort(db: "Session") -> None:
         db.invalidate()
     except Exception:
         logger.warning("failed to invalidate respond() session", exc_info=True)
-
-
-def _verify_respond_durable_graph(
-    *,
-    task_id: int,
-    interaction_id: int,
-    expected_run_id: str,
-    expected_state_version_after: int,
-    principal: InteractionPrincipal,
-    canonical_submitted_values: str,
-    command_id: str,
-    command_kind: TaskCommandKind,
-    command_payload: dict[str, Any],
-    actor_user_id: int | None,
-) -> InteractionResponseReceipt | None:
-    """Check the complete accepted answer graph in a fresh, owned Session,
-    up to three times with a short sleep between attempts. Same retry shape
-    as ``task_orchestrator._reconcile_claimed_turn_after_commit_ack_failure``:
-    a new ``SessionLocal()`` per attempt, ``time.sleep(0.01)`` between
-    failures, the session retired in every case before the next attempt or
-    return.
-
-    Three independent facts must all hold -- the row's key, the answer's
-    hash, and the answering principal's identity: (1) the
-    ``tasks`` row has advanced past ``expected_state_version_after - 1`` on
-    the same ``run_id`` -- ``>=``, not ``==``, and ``control_state`` is not
-    compared at all, because the resume coordinator re-issues the same
-    ``RESUME_REQUESTED`` transition when it applies the command this call
-    staged (see ``respond()``'s own docstring for the verbatim reasoning);
-    (2) the interaction row is answered, by this identity, with a
-    ``response_payload`` that canonicalizes to the same string as the
-    answer ``values`` the caller submitted (``canonical_submitted_values``
-    -- the interaction row stores the answer values alone, not the wrapping
-    command payload the third check below compares); (3) exactly one
-    command row exists for this idempotency key and it matches what this
-    call staged. Returns the receipt on success, ``None`` if every attempt
-    fails to confirm all three.
-    """
-
-    from ..models.database import get_session_local
-
-    SessionLocal = get_session_local()
-    for attempt in range(_RESPOND_DURABLE_GRAPH_ATTEMPTS):
-        reconcile_db: "Session | None" = None
-        try:
-            reconcile_db = SessionLocal()
-            task = (
-                reconcile_db.query(Task)
-                .filter(
-                    Task.id == task_id,
-                    Task.run_id == expected_run_id,
-                    Task.state_version >= expected_state_version_after,
-                )
-                .first()
-            )
-            if task is not None:
-                ir = (
-                    reconcile_db.query(TaskInteractionRequest)
-                    .filter(
-                        TaskInteractionRequest.id == interaction_id,
-                        TaskInteractionRequest.task_id == task_id,
-                        TaskInteractionRequest.status == "answered",
-                        TaskInteractionRequest.responder_identity
-                        == principal.identity_string(),
-                    )
-                    .first()
-                )
-                if (
-                    ir is not None
-                    and _canonical_payload(
-                        ir.response_payload
-                        if isinstance(ir.response_payload, dict)
-                        else {}
-                    )
-                    == canonical_submitted_values
-                ):
-                    commands = (
-                        reconcile_db.query(TaskExecutionCommand)
-                        .filter(
-                            TaskExecutionCommand.task_id == task_id,
-                            TaskExecutionCommand.command_id == command_id,
-                        )
-                        .all()
-                    )
-                    if len(commands) == 1 and _matches_existing(
-                        commands[0],
-                        actor_user_id=actor_user_id,
-                        kind=command_kind,
-                        payload=command_payload,
-                    ):
-                        return _respond_receipt(
-                            interaction=ir,
-                            task=task,
-                            command_db_id=int(commands[0].id),
-                            idempotency_key=command_id,
-                        )
-        except Exception:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                "respond() durable-graph reconciliation attempt %s failed for "
-                "task %s interaction %s",
-                attempt + 1,
-                task_id,
-                interaction_id,
-                exc_info=True,
-            )
-        finally:
-            if reconcile_db is not None:
-                _retire_respond_session_best_effort(reconcile_db)
-        if attempt < _RESPOND_DURABLE_GRAPH_ATTEMPTS - 1:
-            time.sleep(_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS)
-    return None
 
 
 def respond(
@@ -1813,12 +1692,15 @@ def respond(
        row state); a hit that does not match is
        ``Conflict(idempotency_key_reused)``.
     6. The answer fence UPDATE. ``rowcount == 1`` continues; ``rowcount == 0``
-       rereads the interaction row and classifies the miss (already-answered
-       replay/conflict, three terminated reasons, wrong task state, foreign
-       run, or -- reachable only on SQLite, see
-       ``_answer_fence_task_predicate`` -- an ownership change);
-       ``rowcount > 1`` is a schema invariant violation
-       (``uq_task_interaction_active_slot``) and raises.
+       rereads the interaction row only to confirm it did not disappear out
+       from under this transaction's own row lock, then reports
+       ``OutcomeUnknown`` without further classifying why the fence missed
+       (a fine-grained classification -- already-answered replay/conflict,
+       three terminated reasons, wrong task state, foreign run, or --
+       reachable only on SQLite, see ``_answer_fence_task_predicate`` -- an
+       ownership change -- is not delivered in this build); ``rowcount > 1``
+       is a schema invariant violation (``uq_task_interaction_active_slot``)
+       and raises.
     7. The Task CAS via ``apply_task_control_transition``, called with no
        ``expected_run_id`` / ``expected_state_version`` -- this function
        takes no caller-supplied optimistic-concurrency token, so neither of
@@ -1832,17 +1714,19 @@ def respond(
        WHERE clause cannot fail to match. This call is therefore left
        uncaught; ``StaleTaskRunError`` surfacing here would mean that
        invariant broke, not a normal stale-answer outcome.
-    8. Stage the RESUME command inside this function's own
-       ``db.begin_nested()``. An ``IntegrityError`` there is classified via
-       ``classify_task_command_conflict`` after rolling back to that
-       savepoint (not the whole transaction) -- see that function's own
-       docstring for why a savepoint rollback is equivalent to the "the
-       caller has rolled back the transaction" precondition it documents.
+    8. Stage the RESUME command. An ``IntegrityError`` there -- a second
+       writer raced this call's own insert for the same idempotency key --
+       is not classified in this build (a fine-grained classification via
+       ``classify_task_command_conflict``, distinguishing a genuine replay
+       from a real conflict, is not delivered here): the whole transaction
+       rolls back, undoing this call's own fence UPDATE and CAS along with
+       it, and this call reports ``OutcomeUnknown``.
     9. Commit. A raised exception here does not mean the write failed --
        the acknowledgment could have been lost after the server applied it
-       -- so this function retires its session and checks the durable graph
-       in a fresh one (``_verify_respond_durable_graph``) before deciding
-       between ``Accepted`` and ``OutcomeUnknown``.
+       -- but this build does not attempt to reconcile that against the
+       durable graph (that reconciliation is not delivered here): it
+       retires its session and reports ``OutcomeUnknown`` unconditionally,
+       leaving the caller to re-check.
     10. After a successful commit, outside any transaction:
         ``notify_task_command_dispatcher()``.
     """
@@ -1913,7 +1797,6 @@ def respond(
         command_payload = _respond_command_payload(
             interaction_id=interaction_id, principal=principal, values=envelope.values
         )
-        canonical_submitted_values = _canonical_payload(envelope.values)
         actor_user_id = principal.user_id
 
         existing_command = (
@@ -1968,7 +1851,12 @@ def respond(
             # changed since step 4's read); without expiring first, the
             # ORM would hand this query's result back through the same
             # already-loaded, now-stale Python object instead of the fresh
-            # row this reread exists to see.
+            # row this reread exists to see. This build does not classify
+            # why the fence missed -- a fine-grained classification against
+            # the reread row's status is not delivered here -- it only
+            # confirms the row did not disappear out from under this
+            # transaction's own row lock, then reports the miss as
+            # ``OutcomeUnknown`` (see that outcome's own docstring).
             db.expire_all()
             reread = get(db, task_id=task_id, interaction_id=interaction_id)
             if reread is None:
@@ -1976,58 +1864,7 @@ def respond(
                     f"interaction {interaction_id} on task {task_id} disappeared "
                     "while this transaction held the tasks row lock"
                 )
-            if reread.status == "answered":
-                fresh_command = (
-                    db.query(TaskExecutionCommand)
-                    .filter(
-                        TaskExecutionCommand.task_id == task_id,
-                        TaskExecutionCommand.command_id == normalized_key,
-                    )
-                    .first()
-                )
-                if fresh_command is not None and _matches_existing(
-                    fresh_command,
-                    actor_user_id=actor_user_id,
-                    kind=TaskCommandKind.RESUME,
-                    payload=command_payload,
-                ):
-                    return RespondReplayed(
-                        receipt=_respond_receipt(
-                            interaction=reread,
-                            task=task,
-                            command_db_id=int(fresh_command.id),
-                            idempotency_key=normalized_key,
-                        )
-                    )
-                increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
-                return RespondConflict(reason="already_answered")
-            if reread.status == "terminated":
-                terminal_reason_map: dict[str, RespondStaleReason] = {
-                    "deadline_elapsed": "expired",
-                    "run_superseded": "run_superseded",
-                    "answered_via_legacy_resume": "answered_via_chat",
-                }
-                mapped_reason = terminal_reason_map.get(
-                    str(reread.terminal_reason or "")
-                )
-                if mapped_reason is None:
-                    raise RuntimeError(
-                        f"interaction {interaction_id} on task {task_id} is "
-                        f"terminated with an unrecognized terminal_reason "
-                        f"{reread.terminal_reason!r}"
-                    )
-                return RespondStale(reason=mapped_reason)
-            if reread.status == "active":
-                if task.status != TaskStatus.WAITING_FOR_USER:
-                    return RespondStale(reason="run_ended")
-                if task.run_id != reread.run_id:
-                    return RespondStale(reason="foreign_run")
-                return RespondUnauthorized(reason="not_task_principal")
-            raise RuntimeError(
-                f"interaction {interaction_id} on task {task_id} has an "
-                f"unrecognized status {reread.status!r} after a zero-rowcount "
-                "answer fence"
-            )
+            return RespondOutcomeUnknown()
 
         # No expected_run_id/expected_state_version to pass: this function
         # takes no caller-supplied optimistic-concurrency token, so
@@ -2038,9 +1875,6 @@ def respond(
         # docstring, step 7).
         apply_task_control_transition(task, TaskControlState.RESUME_REQUESTED)
 
-        expected_state_version_after = int(task.state_version)
-        run_id_for_verification = str(task.run_id)
-        savepoint = db.begin_nested()
         # Capture every receipt value this transaction can still commit as
         # plain Python locals now, before the commit below. SQLAlchemy's
         # default ``expire_on_commit=True`` invalidates every ORM attribute
@@ -2068,63 +1902,29 @@ def respond(
                 payload=command_payload,
             )
         except IntegrityError:
-            savepoint.rollback()
-            classification = classify_task_command_conflict(
-                db,
-                task_id=task_id,
-                command_id=normalized_key,
-                actor_user_id=actor_user_id,
-                kind=TaskCommandKind.RESUME,
-                payload=command_payload,
-            )
-            if classification.kind == TaskCommandConflictKind.RACED_DUPLICATE:
-                assert classification.raced is not None
-                if classification.raced.payload_matches:
-                    db.commit()
-                    return RespondReplayed(
-                        receipt=InteractionResponseReceipt(
-                            interaction_id=interaction_id,
-                            task_id=task_id,
-                            run_id=answered_run_id,
-                            status="answered",
-                            responded_at=answered_responded_at,
-                            responder_identity=answered_responder_identity,
-                            idempotency_key=normalized_key,
-                            command_db_id=classification.raced.command_db_id,
-                            task_state_version=committed_state_version,
-                            task_control_state=committed_control_state,
-                        )
-                    )
-                db.rollback()
-                increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
-                return RespondConflict(reason="idempotency_key_reused")
-            if classification.kind == TaskCommandConflictKind.TASK_MISSING:
-                db.rollback()
-                return RespondUnavailable(reason="task_missing")
+            # A second writer raced this call's own insert for the same
+            # idempotency key. This build does not classify what that
+            # means (a fine-grained classification via
+            # ``classify_task_command_conflict``, distinguishing a genuine
+            # replay from a real conflict, is not delivered here): the
+            # whole transaction rolls back, undoing this call's own fence
+            # UPDATE and CAS along with it, and this call reports the
+            # ambiguity rather than guessing which case it was.
             db.rollback()
-            raise
+            return RespondOutcomeUnknown()
 
         command_db_id = staged.staged_db_id
         try:
             db.commit()
         except Exception:
+            # A raised exception here does not mean the write failed -- the
+            # acknowledgment could have been lost after the server applied
+            # it -- but this build does not attempt to reconcile that
+            # against the durable graph (that reconciliation is not
+            # delivered here): it retires its session and reports the
+            # ambiguity, leaving the caller to re-check.
             session_retired = True
             _retire_respond_session_best_effort(db)
-            receipt = _verify_respond_durable_graph(
-                task_id=task_id,
-                interaction_id=interaction_id,
-                expected_run_id=run_id_for_verification,
-                expected_state_version_after=expected_state_version_after,
-                principal=principal,
-                canonical_submitted_values=canonical_submitted_values,
-                command_id=normalized_key,
-                command_kind=TaskCommandKind.RESUME,
-                command_payload=command_payload,
-                actor_user_id=actor_user_id,
-            )
-            if receipt is not None:
-                notify_task_command_dispatcher()
-                return RespondAccepted(receipt=receipt)
             return RespondOutcomeUnknown()
 
         notify_task_command_dispatcher()

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1494,7 +1494,7 @@ class RespondEnvelope:
     caller today (#1079's own AC) never hands one back, and the only thing
     an echoed locator could prove -- "this is the same value the server
     handed out" -- is already proven by ``interaction_id`` plus the row and
-    anchor checks ``respond()`` runs on its own account (steps 4 and 4.5).
+    anchor checks ``respond()`` runs on its own account (steps 4 and 5.5).
     """
 
     kind: str
@@ -1722,15 +1722,17 @@ def respond(
        ``Unavailable(interaction_missing)``. Present but its own ``kind`` /
        ``protocol_version`` columns disagree with ``envelope``'s,
        ``ValidationRejected(kind_version_mismatch)``.
-    4.5. Resolve the row's resume anchor via
+    5. Idempotency pre-read against ``task_execution_commands``: a hit
+       matching this call's payload is ``Replayed`` (built from the current
+       row state); a hit that does not match is
+       ``Conflict(idempotency_key_reused)``. Runs before anchor resolution:
+       an answered row's anchor is prunable, and replay recognition must
+       not depend on one.
+    5.5. Resolve the row's resume anchor via
        ``_resolve_read_direction_anchor`` -- ``checkpoint_unavailable`` maps
        to ``Unavailable``, ``anchor_dangling`` to ``Stale``. Never falls back
        to a legacy scan on failure (see that resolver's own docstring for
        why).
-    5. Idempotency pre-read against ``task_execution_commands``: a hit
-       matching this call's payload is ``Replayed`` (built from the current
-       row state); a hit that does not match is
-       ``Conflict(idempotency_key_reused)``.
     6. The answer fence UPDATE. ``rowcount == 1`` continues; ``rowcount == 0``
        rereads the interaction row only to confirm it did not disappear out
        from under this transaction's own row lock, then reports
@@ -1840,17 +1842,25 @@ def respond(
         if ir.kind != envelope.kind or ir.protocol_version != envelope.protocol_version:
             return RespondValidationRejected(reason="kind_version_mismatch")
 
-        unresolved = _resolve_read_direction_anchor(db, ir)
-        if unresolved is not None:
-            if unresolved.reason == "checkpoint_unavailable":
-                return RespondUnavailable(reason="checkpoint_unavailable")
-            return RespondStale(reason="anchor_dangling")
-
         command_payload = _respond_command_payload(
             interaction_id=interaction_id, principal=principal, values=envelope.values
         )
         actor_user_id = principal.user_id
 
+        # Runs before anchor resolution below, not after it. Answering
+        # clears ``active_slot``, and the checkpoint retention pruner only
+        # protects rows whose ``active_slot`` is still set
+        # (``trace_handlers.py``), so an answered row's anchor becomes
+        # prunable the moment this service answers it and the foreign key's
+        # ``ON DELETE SET NULL`` then empties the pointer. With anchor
+        # resolution first, a retry arriving after that pruning would be
+        # told ``Stale(anchor_dangling)`` about an answer that was in fact
+        # accepted, and would never reach the replay branch below. Replay
+        # recognition is a question about this call's idempotency key and
+        # the row it already wrote; it does not need a live anchor, and
+        # must not be gated on one. Still after step 3's authorization, so
+        # an unauthorized caller can never use a guessed idempotency key to
+        # read back someone else's receipt.
         existing_command = (
             db.query(TaskExecutionCommand)
             .filter(
@@ -1876,6 +1886,12 @@ def respond(
                 )
             increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
             return RespondConflict(reason="idempotency_key_reused")
+
+        unresolved = _resolve_read_direction_anchor(db, ir)
+        if unresolved is not None:
+            if unresolved.reason == "checkpoint_unavailable":
+                return RespondUnavailable(reason="checkpoint_unavailable")
+            return RespondStale(reason="anchor_dangling")
 
         now = datetime.now(timezone.utc)
         responder_user_id = principal.user_id if principal.kind == "user" else None

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1362,19 +1362,6 @@ def materialize_compatibility_view(
 # ---------------------------------------------------------------------------
 
 
-def _rowcount(result: Any) -> int:
-    """Same idiom as ``task_lease_service._rowcount``: a session double used
-    in a unit test (``MagicMock()``, or a plain object with no ``rowcount``
-    attribute at all) must fall through to zero, not raise ``AttributeError``
-    from a bare ``result.rowcount`` read. Every rowcount-based branch below
-    goes through this instead of reading the attribute directly, so a test
-    double that never bothered to set ``rowcount`` lands on the ``0``
-    classification branch rather than an unrelated crash.
-    """
-
-    return int(getattr(result, "rowcount", 0) or 0)
-
-
 def _answer_fence_task_predicate(principal: InteractionPrincipal) -> list[Any]:
     """The task-side terms of the answer fence: is this task still waiting,
     and does ``principal`` own it -- evaluated against the same ``tasks``
@@ -2002,7 +1989,7 @@ def respond(
                 responder_identity=principal.identity_string(),
             )
         )
-        rowcount = _rowcount(fence_result)
+        rowcount = int(getattr(fence_result, "rowcount", 0) or 0)
         if rowcount > 1:
             raise RuntimeError(
                 f"answer fence updated {rowcount} rows for interaction "

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -590,7 +590,19 @@ class RespondOutcomeUnknown:
     have taken the idempotency key first; either way this build reports
     the ambiguity rather than guessing. Not an exception this service lets
     escape -- a stable, typed result a caller can act on (e.g. surface "we
-    could not confirm this went through" rather than crash)."""
+    could not confirm this went through" rather than crash).
+
+    Retrying under the same idempotency key resolves the second reason and
+    not the first, and a caller should not be told otherwise. A retry
+    after an ambiguous commit finds the command this call staged and
+    returns ``Replayed``, and a retry after a rolled-back staging race
+    simply runs again. A retry after a fence miss re-evaluates the same
+    predicate against the same row and misses again: a terminated,
+    superseded, foreign-run, or foreign-owned row stays that way, so the
+    second ``OutcomeUnknown`` is as final as the first. Step 6 logs the
+    reread row's state for that reason -- until the fence classification
+    build lands, that log line is the only place the distinction exists.
+    """
 
 
 RespondOutcome = (
@@ -1984,6 +1996,29 @@ def respond(
                     f"interaction {interaction_id} on task {task_id} disappeared "
                     "while this transaction held the tasks row lock"
                 )
+            # The reread above already has the row in hand, so recording
+            # what it found costs no extra statement. Without this line a
+            # fence miss is the one path out of this function that leaves
+            # nothing at all behind: the caller is told ``OutcomeUnknown``,
+            # and a retry against a terminated, superseded, or
+            # foreign-owned row produces the same miss and the same
+            # ``OutcomeUnknown`` every time, so no amount of retrying ever
+            # reveals which of them it was. The classification this build
+            # does not compute is exactly the set of fields logged here.
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "answer fence matched zero rows for interaction %s on task "
+                "%s; reread status=%s active_slot=%s terminal_reason=%s "
+                "run_id=%s responder_identity=%s",
+                interaction_id,
+                task_id,
+                reread.status,
+                reread.active_slot,
+                reread.terminal_reason,
+                reread.run_id,
+                reread.responder_identity,
+            )
             return RespondOutcomeUnknown()
 
         # No expected_run_id/expected_state_version to pass: this function

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1755,13 +1755,24 @@ def respond(
        WHERE clause cannot fail to match. This call is therefore left
        uncaught; ``StaleTaskRunError`` surfacing here would mean that
        invariant broke, not a normal stale-answer outcome.
-    8. Stage the RESUME command. An ``IntegrityError`` there -- a second
-       writer raced this call's own insert for the same idempotency key --
-       is not classified in this build (a fine-grained classification via
-       ``classify_task_command_conflict``, distinguishing a genuine replay
-       from a real conflict, is not delivered here): the whole transaction
-       rolls back, undoing this call's own fence UPDATE and CAS along with
-       it, and this call reports ``OutcomeUnknown``.
+    8. Stage the RESUME command, and require the result to be a row this
+       call itself created carrying this call's own payload. Two different
+       signals report the same race -- a second writer took this
+       idempotency key between step 5's pre-read and this statement -- and
+       both get the same conservative answer. An ``IntegrityError`` is
+       raised when that writer's row lands on the unique constraint;
+       ``created=False`` is returned instead when the row was already
+       committed and visible, because ``stage_task_command`` checks for an
+       existing row before inserting and returns it rather than raising. A
+       ``created=False`` result whose ``payload_matches`` is also true is
+       treated the same way rather than as a replay: step 5 is where a
+       replay is recognized, and a hit that only becomes visible after it
+       is a race. Neither case is classified further in this build (a
+       fine-grained classification via ``classify_task_command_conflict``,
+       distinguishing a genuine replay from a real conflict, is not
+       delivered here): the whole transaction rolls back, undoing this
+       call's own fence UPDATE and CAS along with it, and this call reports
+       ``OutcomeUnknown``.
     9. Commit. A raised exception here does not mean the write failed --
        the acknowledgment could have been lost after the server applied it
        -- but this build does not attempt to reconcile that against the
@@ -1951,6 +1962,26 @@ def respond(
             # whole transaction rolls back, undoing this call's own fence
             # UPDATE and CAS along with it, and this call reports the
             # ambiguity rather than guessing which case it was.
+            db.rollback()
+            return RespondOutcomeUnknown()
+
+        if not (staged.created and staged.payload_matches):
+            # The same race the IntegrityError branch above catches,
+            # arriving through the other door. ``stage_task_command`` does
+            # not raise when a row for this ``(task_id, command_id)``
+            # already exists -- it returns that row with ``created=False``
+            # -- so a writer that committed one between step 5's pre-read
+            # and this call would otherwise leave this transaction
+            # committing the fence and the CAS while the RESUME carrying
+            # this answer was never staged at all, and returning
+            # ``RespondAccepted`` naming the other writer's row. Both doors
+            # get this build's one conservative answer: roll the whole
+            # transaction back, undoing this call's own fence UPDATE and
+            # CAS, and report the ambiguity. ``created=False`` with a
+            # matching payload is folded in here rather than reported as
+            # ``Replayed`` on purpose -- step 5 is where a replay is
+            # recognized, and a hit that only appears after it is a race,
+            # not a replay.
             db.rollback()
             return RespondOutcomeUnknown()
 

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -7,26 +7,26 @@ docstring pins its merge reason to a fact this module does not share: its
 two entry points exist in one file because they share every exception type
 and one nesting invariant that must never be split across a file boundary,
 both live on the ask side, and both require the caller to already hold the
-transaction they run inside. This module's future ``respond()`` -- not
-implemented in this delivery, see below for what is -- is designed to be
-the opposite shape on every one of those points: it will own its own
-session and its own commit, and will not nest inside anyone else's
-savepoint. Nothing in this delivery opens a session or commits anything;
-``create()`` takes a caller-owned session and only reads through it. Putting
-the future seam in the same file as the staging primitive would make that
-staging module's merge-reason docstring false the day it lands. What this
-delivery reuses from the staging module
-instead of duplicating is narrow and one-directional: the private kind
-vocabulary (``_KIND_VOCABULARY``), imported by name. ``create()`` never
-calls ``stage_interaction_request`` in this delivery and therefore never
-raises or catches any of that module's nine exception classes, and this
-module's own read-direction anchor resolver validates a real
-``trace_events`` row against a stored interaction row's fields -- a
-different check from the staging module's ``_validate_anchor_fields``,
-which validates an ``InteractionAnchor`` value object before an INSERT --
-so it is not reused here either. See ``create()``'s own docstring for the
-exception-family accounting, and ``_resolve_read_direction_anchor``'s for
-the anchor-check distinction.
+transaction they run inside. This module's ``respond()`` is the opposite
+shape on every one of those points: it owns its own session end to end
+(opens it, commits or rolls it back, retires it) and never nests inside a
+caller's transaction -- the one savepoint it opens
+(``db.begin_nested()``, around staging its own resume command) is its
+own, not a caller's. ``create()``, by contrast, takes a caller-owned
+session and only reads through it, never opening or committing one of its
+own. Putting ``respond()`` in the same file as the staging primitive would
+make that staging module's merge-reason docstring false. What this module
+reuses from the staging module instead of duplicating is narrow and
+one-directional: the private kind vocabulary (``_KIND_VOCABULARY``),
+imported by name. Neither ``create()`` nor ``respond()`` calls
+``stage_interaction_request`` and neither raises or catches any of that
+module's nine exception classes, and this module's own read-direction
+anchor resolver validates a real ``trace_events`` row against a stored
+interaction row's fields -- a different check from the staging module's
+``_validate_anchor_fields``, which validates an ``InteractionAnchor``
+value object before an INSERT -- so it is not reused here either. See
+``create()``'s own docstring for the exception-family accounting, and
+``_resolve_read_direction_anchor``'s for the anchor-check distinction.
 
 Concurrency precondition, stated once here because every rowcount-based
 branch this service will grow depends on it: every rowcount-based branch
@@ -44,29 +44,44 @@ records who answered a request must treat ``responder_identity`` as
 authoritative and ``responder_user_id`` as a convenience join that can go
 missing under normal account deletion, not a corruption signal.
 
-Delivered here: the ``InteractionPrincipal`` value object and the shared
-public-chat ownership predicate extracted from ``public_chat_access.py``;
-the ``RespondOutcome`` and ``CreateOutcome`` discriminated unions and their
-reason vocabularies; the ``create()`` typed seam (validates and returns,
-does not stage a row); ``get()``/``list_active()``; and the three-tier compatibility
-materialization view. Not delivered here: ``respond()``'s call body, the
-answer fence, the compatibility seam into the existing resume coordinator,
-and any new counter. Those land with later changes; this module's own
-zero-production-caller gate
-(``tests/web/services/test_task_interaction_service_production_gate.py``)
-gives that boundary a regression guard against import bindings, not an
-absolute one -- the gate's own docstring lists what it cannot see
-(dynamic access, alias/re-export chains, filename-stem exclusion, and
-code outside the scanned package tree).
+This module now delivers the full answer side: the ``InteractionPrincipal``
+value object and the shared public-chat ownership predicate extracted from
+``public_chat_access.py``; the ``RespondOutcome`` and ``CreateOutcome``
+discriminated unions; the ``create()`` typed seam (validates and returns,
+does not stage a row); ``get()``/``list_active()``; the three-tier
+compatibility materialization view; the answer fence and its active-row
+predicate; ``respond()``'s own call body (validation, authorization,
+anchor resolution, the idempotency pre-read, the answer fence, the task
+control-state transition, staging the resume command, and committing or
+reconciling an ambiguous acknowledgment); the response-conflict counter
+(``COUNTER_LIFECYCLE_RESPONSE_CONFLICT``); and the compatibility seam that
+routes the existing resume coordinator through this service
+(``websocket.py``'s ``_handle_resume_task_unserialized``). ``create()``'s
+own call body -- the write that actually stages a row -- is still not
+delivered here; its own zero-production-caller gate
+(``tests/web/services/test_task_interaction_service_create_gate.py``)
+now watches ``create()`` alone. ``respond()`` left that gate not because
+it gained a caller -- the compatibility seam only reads
+``_active_native_row_criteria()`` and never calls it, and zero production
+code does today -- but because gating and callers are independent facts;
+the gate's own docstring states this and the seam's role. The gate gives
+that boundary a regression guard against import bindings, not an absolute
+one -- its docstring lists what it cannot see (dynamic access,
+alias/re-export chains, filename-stem exclusion, and code outside the
+scanned package tree).
 """
 
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Literal, cast
 
+import sqlalchemy as sa
 from pydantic import ValidationError as _PydanticValidationError
+from sqlalchemy.exc import IntegrityError
 
 from ...core.agent.checkpoint import (
     CHECKPOINT_EVENT_TYPE,
@@ -74,25 +89,38 @@ from ...core.agent.checkpoint import (
     checkpoint_execution_id,
 )
 from ...core.tools.adapters.vibe.ask_user_tool import AskUserQuestionArgs
-from ..models.task import Task, TraceEvent
+from ..models.task import Task, TaskStatus, TaskStatusPredicate, TraceEvent
+from ..models.task_command import TaskExecutionCommand
 from ..models.task_interaction import (
     INTERACTION_PROTOCOL_VERSION,
     TaskInteractionRequest,
 )
 from .chat_history_service import get_latest_waiting_question
+from .interaction_rollout import COUNTER_LIFECYCLE_RESPONSE_CONFLICT, increment_counter
 from .ops_signals import (
     CHECKPOINT_LOAD_UNAVAILABLE,
     CHECKPOINT_PK_ANCHOR_DANGLING,
     register_degradation,
 )
-from .task_command_transport import _normalize_command_id
+from .task_command_transport import (
+    TaskCommandConflictKind,
+    TaskCommandKind,
+    _canonical_payload,
+    _matches_existing,
+    _normalize_command_id,
+    classify_task_command_conflict,
+    notify_task_command_dispatcher,
+    stage_task_command,
+)
+from .task_execution_controller import (
+    TaskControlState,
+    apply_task_control_transition,
+)
 from .task_interaction_schema import interaction_requests_table_exists
 from .task_interaction_staging import _KIND_VOCABULARY
 from .task_lease_service import TASK_RUN_ID_TRACE_FIELD
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from sqlalchemy.orm import Session
 
 # ---------------------------------------------------------------------------
@@ -492,6 +520,39 @@ class InteractionResponseReceipt:
     task_control_state: str
 
 
+# Each outcome that carries a reason declares its own closed word list as a
+# ``Literal``, so the vocabulary is the type itself rather than a separate
+# dict a reader has to trust stays in sync with the dataclasses below. A
+# reason string outside its outcome's Literal is a static type error at
+# every construction site; it is not a runtime check (dataclasses do not
+# validate their field types at construction), the same limitation a
+# runtime membership check against a dict would not have removed either,
+# since nothing in this module ever constructed one of these outcomes with
+# an unvalidated, caller-supplied reason string to begin with -- every
+# reason literal below is written by this module's own code, at a call
+# site a type checker already sees.
+RespondValidationRejectedReason = Literal[
+    "unknown_kind",
+    "unknown_protocol_version",
+    "malformed_idempotency_key",
+    "invalid_values",
+    "kind_version_mismatch",
+]
+RespondUnauthorizedReason = Literal["not_task_principal"]
+RespondUnavailableReason = Literal[
+    "task_missing", "interaction_missing", "checkpoint_unavailable"
+]
+RespondConflictReason = Literal["already_answered", "idempotency_key_reused"]
+RespondStaleReason = Literal[
+    "expired",
+    "run_superseded",
+    "answered_via_chat",
+    "run_ended",
+    "foreign_run",
+    "anchor_dangling",
+]
+
+
 @dataclass(frozen=True)
 class RespondAccepted:
     receipt: InteractionResponseReceipt
@@ -499,17 +560,17 @@ class RespondAccepted:
 
 @dataclass(frozen=True)
 class RespondValidationRejected:
-    reason: str
+    reason: RespondValidationRejectedReason
 
 
 @dataclass(frozen=True)
 class RespondUnauthorized:
-    reason: str
+    reason: RespondUnauthorizedReason
 
 
 @dataclass(frozen=True)
 class RespondUnavailable:
-    reason: str
+    reason: RespondUnavailableReason
 
 
 @dataclass(frozen=True)
@@ -519,12 +580,12 @@ class RespondReplayed:
 
 @dataclass(frozen=True)
 class RespondConflict:
-    reason: str
+    reason: RespondConflictReason
 
 
 @dataclass(frozen=True)
 class RespondStale:
-    reason: str
+    reason: RespondStaleReason
 
 
 @dataclass(frozen=True)
@@ -546,48 +607,6 @@ RespondOutcome = (
     | RespondStale
     | RespondOutcomeUnknown
 )
-
-# The (outcome type, reason) pairs RespondOutcome can produce once
-# respond() is implemented, keyed by outcome class name. ``None`` in the
-# reason set stands for the reason-less variants (Accepted / Replayed /
-# OutcomeUnknown carry no reason code). This is the vocabulary guard: it
-# proves the reason word list stays closed at exactly the pairs enumerated
-# here, nothing more -- it does NOT prove every pair has a test written
-# against it (several reasons are reachable from more than one triggering
-# condition, e.g. every "A" row of the design's failure matrix collapses to
-# the single (Unauthorized, not_task_principal) pair here; a guard over
-# this dict cannot and does not distinguish which condition produced a
-# given pair). Do not read "count matches" as "coverage complete".
-RESPOND_OUTCOME_REASON_VOCABULARY: dict[str, frozenset[str | None]] = {
-    "RespondAccepted": frozenset({None}),
-    "RespondValidationRejected": frozenset(
-        {
-            "unknown_kind",
-            "unknown_protocol_version",
-            "malformed_idempotency_key",
-            "invalid_values",
-            "kind_version_mismatch",
-        }
-    ),
-    "RespondUnauthorized": frozenset({"not_task_principal"}),
-    "RespondUnavailable": frozenset(
-        {"task_missing", "interaction_missing", "checkpoint_unavailable"}
-    ),
-    "RespondReplayed": frozenset({None}),
-    "RespondConflict": frozenset({"already_answered", "idempotency_key_reused"}),
-    "RespondStale": frozenset(
-        {
-            "expired",
-            "run_superseded",
-            "answered_via_chat",
-            "run_ended",
-            "foreign_run",
-            "state_version_advanced",
-            "anchor_dangling",
-        }
-    ),
-    "RespondOutcomeUnknown": frozenset({None}),
-}
 
 
 # ---------------------------------------------------------------------------
@@ -1314,3 +1333,815 @@ def materialize_compatibility_view(
             interaction.model_dump(mode="json") for interaction in parsed.interactions
         ],
     )
+
+
+# ---------------------------------------------------------------------------
+# The answer fence: the one write this module makes to an active interaction
+# row, and the shared active-row predicate's write-side counterpart the
+# module docstring on ``_active_native_row_criteria`` already commits to.
+# ---------------------------------------------------------------------------
+
+
+def _rowcount(result: Any) -> int:
+    """Same idiom as ``task_lease_service._rowcount``: a session double used
+    in a unit test (``MagicMock()``, or a plain object with no ``rowcount``
+    attribute at all) must fall through to zero, not raise ``AttributeError``
+    from a bare ``result.rowcount`` read. Every rowcount-based branch below
+    goes through this instead of reading the attribute directly, so a test
+    double that never bothered to set ``rowcount`` lands on the ``0``
+    classification branch rather than an unrelated crash.
+    """
+
+    return int(getattr(result, "rowcount", 0) or 0)
+
+
+def _answer_fence_task_predicate(principal: InteractionPrincipal) -> list[Any]:
+    """The task-side terms of the answer fence: is this task still waiting,
+    and does ``principal`` own it -- evaluated against the same ``tasks``
+    row the fence statement joins in via ``Task.id == task_id`` (see
+    ``_answer_fence_stmt``), not a second, independently-scoped read.
+
+    The ownership terms are redundant on PostgreSQL -- step 2 of
+    ``respond()`` already holds this row's ``FOR NO KEY UPDATE`` lock -- and
+    load-bearing on SQLite, where the dialect drops every locking clause
+    silently and nothing serializes a caller until this statement, the
+    transaction's first write (see ``respond()``'s own docstring for the
+    two backends' different serialization points). Enforcing ownership at
+    the write point rather than only in ``respond()``'s step 3 is what
+    makes the two backends agree on what a successful answer proves.
+
+    ``Task.status`` is compared through ``TaskStatusPredicate.eq``, never a
+    raw string literal beside the column -- this module's own convention
+    (see ``TaskStatusPredicate``'s docstring for why a raw literal is a
+    query-time failure waiting to happen, not merely a style preference).
+
+    The two entity-binding backends disagree on how a JSON key read
+    compiles (``->>`` on PostgreSQL, ``json_extract`` on SQLite) -- both are
+    exercised by ``test_task_interaction_service_postgresql.py`` and this
+    module's SQLite unit tests, deliberately, rather than assumed
+    equivalent from one compiled form.
+    """
+
+    terms: list[Any] = [
+        TaskStatusPredicate.eq(TaskStatus.WAITING_FOR_USER),
+        Task.user_id == principal.user_id,
+    ]
+    if principal.kind == "guest":
+        terms.append(Task.agent_config["guest_id"].as_string() == principal.guest_id)
+    return terms
+
+
+def _answer_fence_stmt(
+    *,
+    interaction_id: int,
+    task_id: int,
+    principal: InteractionPrincipal,
+    response_payload: dict[str, Any],
+    now: "datetime",
+    responder_user_id: int | None,
+    responder_identity: str,
+) -> Any:
+    """The Core UPDATE that is this module's one and only write to an active
+    interaction row: a compare-and-swap on row status, task state, and
+    ownership, all evaluated in the same statement's WHERE clause so that a
+    concurrent change to any one of them is what makes ``rowcount`` land on
+    zero rather than one.
+
+    ``Task.id == task_id`` pins the implicit ``FROM tasks`` join this
+    statement needs (both for the reused active-row predicate's own
+    ``Task.run_id`` comparison and for ``_answer_fence_task_predicate``'s
+    terms) to exactly one row. The ownership terms are deliberately a flat
+    conjunction here, not their own correlated ``EXISTS(...)``: a subquery
+    correlated against this UPDATE's target table auto-correlates every
+    table the two queries have in common, including
+    ``TaskInteractionRequest`` itself, which either raises
+    ``InvalidRequestError`` or -- if correlation is pinned away from
+    ``TaskInteractionRequest`` -- leaves the outer join unpinned to a
+    specific ``tasks`` row (verified empirically against both backends'
+    compiled SQL). A flat conjunction against a ``tasks`` row already pinned
+    by primary key has no such ambiguity and compiles to one join, not a
+    join plus a subquery.
+
+    The three active-row criteria (``status``, ``active_slot``, and the
+    ``run_id`` comparison against this same joined ``tasks`` row) are
+    imported from ``_active_native_row_criteria`` rather than rewritten --
+    that function's own docstring already commits every future caller
+    needing "the live row" to changing together with it.
+
+    Writes exactly the columns the model's paired CHECK constraints require
+    for an answered row: ``status``, ``active_slot`` (cleared), and,
+    together, ``response_payload`` / ``responded_at`` / responder identity.
+    Never writes ``terminated_at`` or ``terminal_reason`` -- doing so on a
+    row this statement is simultaneously marking ``answered`` trips
+    ``ck_task_interaction_requests_terminal_pairs_status`` /
+    ``ck_task_interaction_requests_terminated_at_pairs_status``, the
+    database refusing a row that claims to be both answered and
+    terminated. ``responder_user_id`` is the caller's to set correctly:
+    populated only for a ``"user"`` principal, left ``None`` for a guest
+    (see ``respond()``'s own docstring for why that column and
+    ``responder_identity`` are allowed to disagree).
+    """
+
+    return (
+        sa.update(TaskInteractionRequest)
+        .where(
+            TaskInteractionRequest.id == interaction_id,
+            TaskInteractionRequest.task_id == task_id,
+            Task.id == task_id,
+            *_active_native_row_criteria(),
+            *_answer_fence_task_predicate(principal),
+        )
+        .values(
+            status="answered",
+            active_slot=None,
+            response_payload=response_payload,
+            responded_at=now,
+            responder_user_id=responder_user_id,
+            responder_identity=responder_identity,
+            updated_at=now,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# respond(): the answer-side entry point. Everything above this point in the
+# module either already shipped (the principal, the outcome unions, create(),
+# the shared active-row predicate, the anchor resolver, the compatibility
+# view) or is this function's own supporting statement (the fence, just
+# above). What follows is the function this module was always building
+# toward, per its own docstring's "not delivered here" list -- which this
+# change retires.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RespondEnvelope:
+    """The caller-supplied answer for ``respond()``: what interaction this
+    answers, with what values, and under which idempotency key -- not yet
+    validated.
+
+    Deliberately carries no resume-locator field mirroring
+    ``CreateInteractionEnvelope``'s absence of one: the only documented
+    caller today (#1079's own AC) never hands one back, and the only thing
+    an echoed locator could prove -- "this is the same value the server
+    handed out" -- is already proven by ``interaction_id`` plus the row and
+    anchor checks ``respond()`` runs on its own account (steps 4 and 4.5).
+    """
+
+    kind: str
+    protocol_version: int
+    values: Any
+    idempotency_key: str
+
+
+def _respond_command_payload(
+    *, interaction_id: int, principal: InteractionPrincipal, values: Any
+) -> dict[str, Any]:
+    """The RESUME command payload ``respond()`` stages in step 8, and the
+    payload it re-derives at steps 5 and 6 to look an existing command up by
+    the same shape.
+
+    Carries ``responder_identity`` alongside the answer ``values`` so that
+    two different principals submitting the same idempotency key with the
+    same ``values`` are *not* treated as the same idempotent request: step
+    7's ``actor_user_id`` is the task owner for both a ``"user"`` and a
+    ``"guest"`` principal (see ``respond()``'s own docstring), so
+    ``_matches_existing``'s ``actor_user_id`` comparison alone cannot tell
+    them apart -- putting ``responder_identity`` in the payload that
+    ``_canonical_payload`` hashes is what does: two principals reusing one
+    key now canonicalize to two different payloads, which
+    ``_matches_existing`` reports as ``idempotency_key_reused``, not a
+    replay.
+    """
+
+    return {
+        "interaction_id": interaction_id,
+        "responder_identity": principal.identity_string(),
+        "values": values,
+    }
+
+
+def _respond_receipt(
+    *,
+    interaction: "TaskInteractionRequest",
+    task: "Task",
+    command_db_id: int,
+    idempotency_key: str,
+) -> InteractionResponseReceipt:
+    """Build the receipt from already-loaded, already-committed-or-about-to-
+    commit rows, never from a lazy relationship read after commit (see
+    ``InteractionResponseReceipt``'s own docstring). ``responder_identity``
+    is read from the interaction row's own column, never reconstructed from
+    a caller's ``principal`` -- that column, not ``principal``, is this
+    table's audit-authoritative record of who answered (see ``respond()``'s
+    own docstring for why ``responder_user_id`` cannot be used for the same
+    purpose).
+    """
+
+    return InteractionResponseReceipt(
+        interaction_id=int(interaction.id),
+        task_id=int(interaction.task_id),
+        run_id=str(interaction.run_id),
+        status=str(interaction.status),
+        responded_at=cast("datetime", interaction.responded_at),
+        responder_identity=str(interaction.responder_identity),
+        idempotency_key=idempotency_key,
+        command_db_id=command_db_id,
+        task_state_version=int(task.state_version),
+        task_control_state=str(task.control_state),
+    )
+
+
+_RESPOND_DURABLE_GRAPH_ATTEMPTS = 3
+_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS = 0.01
+
+
+def _retire_respond_session_best_effort(db: "Session") -> None:
+    """Release an owned Session without letting a close/invalidate failure
+    replace the transaction error that is already in flight. Same shape as
+    ``task_orchestrator._retire_turn_session_best_effort`` -- a different
+    copy because that helper is private to its own module and this
+    service's session lifecycle (see the module docstring: ``respond()``
+    owns and retires its own session) is not the turn-commit lifecycle that
+    helper is named for.
+    """
+
+    import logging
+
+    logger = logging.getLogger(__name__)
+    try:
+        db.close()
+        return
+    except Exception:
+        logger.warning("failed to close respond() session", exc_info=True)
+    try:
+        db.invalidate()
+    except Exception:
+        logger.warning("failed to invalidate respond() session", exc_info=True)
+
+
+def _verify_respond_durable_graph(
+    *,
+    task_id: int,
+    interaction_id: int,
+    expected_run_id: str,
+    expected_state_version_after: int,
+    principal: InteractionPrincipal,
+    canonical_submitted_values: str,
+    command_id: str,
+    command_kind: TaskCommandKind,
+    command_payload: dict[str, Any],
+    actor_user_id: int | None,
+) -> InteractionResponseReceipt | None:
+    """Check the complete accepted answer graph in a fresh, owned Session,
+    up to three times with a short sleep between attempts. Same retry shape
+    as ``task_orchestrator._reconcile_claimed_turn_after_commit_ack_failure``:
+    a new ``SessionLocal()`` per attempt, ``time.sleep(0.01)`` between
+    failures, the session retired in every case before the next attempt or
+    return.
+
+    Three independent facts must all hold -- the row's key, the answer's
+    hash, and the answering principal's identity: (1) the
+    ``tasks`` row has advanced past ``expected_state_version_after - 1`` on
+    the same ``run_id`` -- ``>=``, not ``==``, and ``control_state`` is not
+    compared at all, because the resume coordinator re-issues the same
+    ``RESUME_REQUESTED`` transition when it applies the command this call
+    staged (see ``respond()``'s own docstring for the verbatim reasoning);
+    (2) the interaction row is answered, by this identity, with a
+    ``response_payload`` that canonicalizes to the same string as the
+    answer ``values`` the caller submitted (``canonical_submitted_values``
+    -- the interaction row stores the answer values alone, not the wrapping
+    command payload the third check below compares); (3) exactly one
+    command row exists for this idempotency key and it matches what this
+    call staged. Returns the receipt on success, ``None`` if every attempt
+    fails to confirm all three.
+    """
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    for attempt in range(_RESPOND_DURABLE_GRAPH_ATTEMPTS):
+        reconcile_db: "Session | None" = None
+        try:
+            reconcile_db = SessionLocal()
+            task = (
+                reconcile_db.query(Task)
+                .filter(
+                    Task.id == task_id,
+                    Task.run_id == expected_run_id,
+                    Task.state_version >= expected_state_version_after,
+                )
+                .first()
+            )
+            if task is not None:
+                ir = (
+                    reconcile_db.query(TaskInteractionRequest)
+                    .filter(
+                        TaskInteractionRequest.id == interaction_id,
+                        TaskInteractionRequest.task_id == task_id,
+                        TaskInteractionRequest.status == "answered",
+                        TaskInteractionRequest.responder_identity
+                        == principal.identity_string(),
+                    )
+                    .first()
+                )
+                if (
+                    ir is not None
+                    and _canonical_payload(
+                        ir.response_payload
+                        if isinstance(ir.response_payload, dict)
+                        else {}
+                    )
+                    == canonical_submitted_values
+                ):
+                    commands = (
+                        reconcile_db.query(TaskExecutionCommand)
+                        .filter(
+                            TaskExecutionCommand.task_id == task_id,
+                            TaskExecutionCommand.command_id == command_id,
+                        )
+                        .all()
+                    )
+                    if len(commands) == 1 and _matches_existing(
+                        commands[0],
+                        actor_user_id=actor_user_id,
+                        kind=command_kind,
+                        payload=command_payload,
+                    ):
+                        return _respond_receipt(
+                            interaction=ir,
+                            task=task,
+                            command_db_id=int(commands[0].id),
+                            idempotency_key=command_id,
+                        )
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "respond() durable-graph reconciliation attempt %s failed for "
+                "task %s interaction %s",
+                attempt + 1,
+                task_id,
+                interaction_id,
+                exc_info=True,
+            )
+        finally:
+            if reconcile_db is not None:
+                _retire_respond_session_best_effort(reconcile_db)
+        if attempt < _RESPOND_DURABLE_GRAPH_ATTEMPTS - 1:
+            time.sleep(_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS)
+    return None
+
+
+def respond(
+    *,
+    interaction_id: int,
+    task_id: int,
+    principal: InteractionPrincipal,
+    envelope: RespondEnvelope,
+) -> RespondOutcome:
+    """Answer one active interaction row and stage the RESUME command that
+    lets the task's execution resume with that answer, in one all-or-
+    nothing transaction on a session this function owns end to end (opens
+    it, commits or rolls it back, and retires it -- the caller never passes
+    one in, because step 9 below needs to be able to retire it on an
+    ambiguous commit and start a fresh one to verify what actually landed).
+
+    Every rowcount-based branch below assumes READ COMMITTED (PostgreSQL's
+    default, and what this deployment uses; see the module docstring for
+    the general statement). The branch that actually depends on it is step
+    6's zero-rowcount reread: a blocked fence UPDATE re-evaluates its WHERE
+    clause once the lock holder's transaction ends, so a second caller's
+    UPDATE naturally resolves to a `rowcount` of zero that this function can
+    then classify against the row's now-current state. Under REPEATABLE
+    READ or stricter the same conflict surfaces as a serialization failure
+    instead of a rowcount of zero, and step 6's classification does not
+    hold.
+
+    `_handle_resume_task_unserialized` re-issues the same
+    `RESUME_REQUESTED` transition when it applies
+    the command this call staged. `apply_task_control_transition` has no
+    legality table, so that second transition succeeds and bumps
+    `state_version` again. Post-commit verification must therefore be
+    monotone in `state_version` and must not compare `control_state`. One
+    concrete consequence, recorded here because a future reader who treats
+    `state_version` as an operation counter will be surprised by it:
+    answering one interaction bumps `state_version` twice -- once in step 7
+    below, once when the coordinator re-applies the transition -- so a
+    consumer that expects "one answer, one version bump" will observe +2.
+
+    `responder_user_id` and `actor_user_id` answer two different questions
+    and are allowed to disagree. `responder_user_id` (written on the
+    interaction row) records who actually answered; for a guest principal
+    it stays `NULL`, and it can also be cleared for a `"user"` principal
+    later by that user account's own deletion (`ON DELETE SET NULL`) -- see
+    the module docstring's audit-identity paragraph for why
+    `responder_identity` and not this column is this table's audit source
+    of truth. `actor_user_id` (written on the staged command, step 8)
+    records whose identity the resulting RESUME command executes as, which
+    is always the task's owning user for both principal kinds -- a guest's
+    turn already runs as that owner, matching the existing
+    `public_chat_access.py` precedent of dispatching guest-originated work
+    under the owner's identity. Do not "fix" this into agreement; they are
+    answers to different questions.
+
+    Of the two audit-relevant columns this function fills on the interaction
+    row, `responder_identity` is the one a reader can trust to stay
+    populated across account deletion; `responder_user_id` is a convenience
+    join that account deletion can silently null out from under it. Every
+    branch below that has to report `responder_identity` (the receipt
+    builder, the durable-graph check) reads it back off the interaction
+    row's own column rather than recomputing it from `principal`.
+
+    Step 2 loads `task` as a mapped entity, not a column tuple, specifically
+    so `apply_task_control_transition` (step 7) can call `object_session(task)`
+    on it. The cost of that choice: `task` is now a live object in this
+    session's identity map, and `apply_task_control_transition` flushes it
+    (`session.flush([task])`) before issuing its own Core UPDATE. This
+    function must not assign any attribute on `task` between step 2 and
+    step 7 -- doing so would be picked up by that flush and written out
+    alongside the CAS whether or not that was intended. Nothing between
+    those two steps needs to set an attribute on `task` at all: the fence
+    (step 6) and the CAS (step 7) are both Core statements operating on
+    ``Task``/``TaskInteractionRequest`` directly, not on this loaded
+    instance's attributes.
+
+    Statement order, each step's position load-bearing:
+
+    1. Pure Python validation against ``envelope`` alone: ``kind`` checked
+       for ``str`` before it is compared against the shared vocabulary (a
+       non-``str`` -- a ``list``, a ``dict`` -- is rejected outright rather
+       than reaching a membership test that would raise ``TypeError`` on an
+       unhashable value), ``protocol_version`` checked for ``int`` and not
+       ``bool`` before it is compared against the current version (``bool``
+       is excluded explicitly because it is a subclass of ``int`` and
+       ``True == 1`` would otherwise pass; a ``float`` like ``1.0`` is
+       rejected by the ``isinstance`` check for the same reason it would
+       otherwise compare equal), ``idempotency_key`` through
+       ``_normalize_command_id``, and ``values`` required to be a ``dict``.
+       This mirrors ``stage_interaction_request``'s own type-before-value
+       order (``task_interaction_staging.py``) for the identical reason.
+       ``values``'s dict check is a structural check
+       only, not the question-side ``parse_v1_request_payload`` contract --
+       an answer's ``values`` shape is keyed by the *question's own*
+       interaction fields, which are only known once the row is read in
+       step 4, not from ``envelope`` alone. Validating an answer against
+       those per-field types (its ``InteractionArg.type`` /
+       ``InteractionArg.field`` definitions) is not implemented in this
+       change; a malformed-but-dict-shaped answer reaches the fence and is
+       stored as submitted.
+    2. The first SQL statement: load ``tasks`` by id with
+       ``with_for_update(key_share=True)`` (``FOR NO KEY UPDATE`` on
+       PostgreSQL) -- absent on the given id, ``Unavailable(task_missing)``.
+    3. Pure Python authorization against the row step 2 loaded: a
+       ``"user"`` principal must own the task or be an admin; a
+       ``"guest"`` principal must satisfy the shared
+       ``task_is_owned_by_public_principal`` predicate. Runs before the
+       idempotency pre-read (step 5) so an unauthorized caller can never use
+       a guessed idempotency key to read back someone else's receipt.
+    4. Load the interaction row by ``(id, task_id)`` -- absent,
+       ``Unavailable(interaction_missing)``. Present but its own ``kind`` /
+       ``protocol_version`` columns disagree with ``envelope``'s,
+       ``ValidationRejected(kind_version_mismatch)``.
+    4.5. Resolve the row's resume anchor via
+       ``_resolve_read_direction_anchor`` -- ``checkpoint_unavailable`` maps
+       to ``Unavailable``, ``anchor_dangling`` to ``Stale``. Never falls back
+       to a legacy scan on failure (see that resolver's own docstring for
+       why).
+    5. Idempotency pre-read against ``task_execution_commands``: a hit
+       matching this call's payload is ``Replayed`` (built from the current
+       row state); a hit that does not match is
+       ``Conflict(idempotency_key_reused)``.
+    6. The answer fence UPDATE. ``rowcount == 1`` continues; ``rowcount == 0``
+       rereads the interaction row and classifies the miss (already-answered
+       replay/conflict, three terminated reasons, wrong task state, foreign
+       run, or -- reachable only on SQLite, see
+       ``_answer_fence_task_predicate`` -- an ownership change);
+       ``rowcount > 1`` is a schema invariant violation
+       (``uq_task_interaction_active_slot``) and raises.
+    7. The Task CAS via ``apply_task_control_transition``, called with no
+       ``expected_run_id`` / ``expected_state_version`` -- this function
+       takes no caller-supplied optimistic-concurrency token, so neither of
+       that helper's own staleness checks can fire. ``status`` is
+       deliberately never passed either; flipping ``Task.status`` is the
+       resume coordinator's job, not this function's. The one remaining way
+       ``apply_task_control_transition`` can raise ``StaleTaskRunError`` --
+       its own atomic UPDATE matching zero rows -- is unreachable here: step
+       2's ``FOR NO KEY UPDATE`` already holds this exact ``tasks`` row for
+       the rest of the transaction, so the CAS's ``Task.id == task_id``
+       WHERE clause cannot fail to match. This call is therefore left
+       uncaught; ``StaleTaskRunError`` surfacing here would mean that
+       invariant broke, not a normal stale-answer outcome.
+    8. Stage the RESUME command inside this function's own
+       ``db.begin_nested()``. An ``IntegrityError`` there is classified via
+       ``classify_task_command_conflict`` after rolling back to that
+       savepoint (not the whole transaction) -- see that function's own
+       docstring for why a savepoint rollback is equivalent to the "the
+       caller has rolled back the transaction" precondition it documents.
+    9. Commit. A raised exception here does not mean the write failed --
+       the acknowledgment could have been lost after the server applied it
+       -- so this function retires its session and checks the durable graph
+       in a fresh one (``_verify_respond_durable_graph``) before deciding
+       between ``Accepted`` and ``OutcomeUnknown``.
+    10. After a successful commit, outside any transaction:
+        ``notify_task_command_dispatcher()``.
+    """
+
+    if not isinstance(envelope.kind, str):
+        return RespondValidationRejected(reason="unknown_kind")
+    if envelope.kind not in _KIND_VOCABULARY:
+        return RespondValidationRejected(reason="unknown_kind")
+    if (
+        not isinstance(envelope.protocol_version, int)
+        or isinstance(envelope.protocol_version, bool)
+        or envelope.protocol_version != INTERACTION_PROTOCOL_VERSION
+    ):
+        return RespondValidationRejected(reason="unknown_protocol_version")
+    if not isinstance(envelope.idempotency_key, str):
+        return RespondValidationRejected(reason="malformed_idempotency_key")
+    try:
+        normalized_key = _normalize_command_id(envelope.idempotency_key)
+    except ValueError:
+        return RespondValidationRejected(reason="malformed_idempotency_key")
+    if not isinstance(envelope.values, dict):
+        return RespondValidationRejected(reason="invalid_values")
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    db: "Session" = SessionLocal()
+    session_retired = False
+    try:
+        task = (
+            db.execute(
+                sa.select(Task)
+                .where(Task.id == task_id)
+                .with_for_update(key_share=True)
+            )
+            .scalars()
+            .first()
+        )
+        if task is None:
+            return RespondUnavailable(reason="task_missing")
+
+        if principal.kind == "user":
+            authorized = principal.is_admin or (
+                principal.user_id is not None and task.user_id == principal.user_id
+            )
+        elif principal.kind == "guest":
+            try:
+                authorized = task_is_owned_by_public_principal(task, principal)
+            except ValueError:
+                authorized = False
+        else:
+            authorized = False
+        if not authorized:
+            return RespondUnauthorized(reason="not_task_principal")
+
+        ir = get(db, task_id=task_id, interaction_id=interaction_id)
+        if ir is None:
+            return RespondUnavailable(reason="interaction_missing")
+        if ir.kind != envelope.kind or ir.protocol_version != envelope.protocol_version:
+            return RespondValidationRejected(reason="kind_version_mismatch")
+
+        unresolved = _resolve_read_direction_anchor(db, ir)
+        if unresolved is not None:
+            if unresolved.reason == "checkpoint_unavailable":
+                return RespondUnavailable(reason="checkpoint_unavailable")
+            return RespondStale(reason="anchor_dangling")
+
+        command_payload = _respond_command_payload(
+            interaction_id=interaction_id, principal=principal, values=envelope.values
+        )
+        canonical_submitted_values = _canonical_payload(envelope.values)
+        actor_user_id = principal.user_id
+
+        existing_command = (
+            db.query(TaskExecutionCommand)
+            .filter(
+                TaskExecutionCommand.task_id == task_id,
+                TaskExecutionCommand.command_id == normalized_key,
+            )
+            .first()
+        )
+        if existing_command is not None:
+            if _matches_existing(
+                existing_command,
+                actor_user_id=actor_user_id,
+                kind=TaskCommandKind.RESUME,
+                payload=command_payload,
+            ):
+                return RespondReplayed(
+                    receipt=_respond_receipt(
+                        interaction=ir,
+                        task=task,
+                        command_db_id=int(existing_command.id),
+                        idempotency_key=normalized_key,
+                    )
+                )
+            increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
+            return RespondConflict(reason="idempotency_key_reused")
+
+        now = datetime.now(timezone.utc)
+        responder_user_id = principal.user_id if principal.kind == "user" else None
+        fence_result = db.execute(
+            _answer_fence_stmt(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                principal=principal,
+                response_payload=envelope.values,
+                now=now,
+                responder_user_id=responder_user_id,
+                responder_identity=principal.identity_string(),
+            )
+        )
+        rowcount = _rowcount(fence_result)
+        if rowcount > 1:
+            raise RuntimeError(
+                f"answer fence updated {rowcount} rows for interaction "
+                f"{interaction_id} on task {task_id}; "
+                "uq_task_interaction_active_slot makes this impossible"
+            )
+        if rowcount == 0:
+            # The fence UPDATE's own re-evaluation just proved this session's
+            # identity map is stale for this row (rowcount 0 means the row
+            # changed since step 4's read); without expiring first, the
+            # ORM would hand this query's result back through the same
+            # already-loaded, now-stale Python object instead of the fresh
+            # row this reread exists to see.
+            db.expire_all()
+            reread = get(db, task_id=task_id, interaction_id=interaction_id)
+            if reread is None:
+                raise RuntimeError(
+                    f"interaction {interaction_id} on task {task_id} disappeared "
+                    "while this transaction held the tasks row lock"
+                )
+            if reread.status == "answered":
+                fresh_command = (
+                    db.query(TaskExecutionCommand)
+                    .filter(
+                        TaskExecutionCommand.task_id == task_id,
+                        TaskExecutionCommand.command_id == normalized_key,
+                    )
+                    .first()
+                )
+                if fresh_command is not None and _matches_existing(
+                    fresh_command,
+                    actor_user_id=actor_user_id,
+                    kind=TaskCommandKind.RESUME,
+                    payload=command_payload,
+                ):
+                    return RespondReplayed(
+                        receipt=_respond_receipt(
+                            interaction=reread,
+                            task=task,
+                            command_db_id=int(fresh_command.id),
+                            idempotency_key=normalized_key,
+                        )
+                    )
+                increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
+                return RespondConflict(reason="already_answered")
+            if reread.status == "terminated":
+                terminal_reason_map: dict[str, RespondStaleReason] = {
+                    "deadline_elapsed": "expired",
+                    "run_superseded": "run_superseded",
+                    "answered_via_legacy_resume": "answered_via_chat",
+                }
+                mapped_reason = terminal_reason_map.get(
+                    str(reread.terminal_reason or "")
+                )
+                if mapped_reason is None:
+                    raise RuntimeError(
+                        f"interaction {interaction_id} on task {task_id} is "
+                        f"terminated with an unrecognized terminal_reason "
+                        f"{reread.terminal_reason!r}"
+                    )
+                return RespondStale(reason=mapped_reason)
+            if reread.status == "active":
+                if task.status != TaskStatus.WAITING_FOR_USER:
+                    return RespondStale(reason="run_ended")
+                if task.run_id != reread.run_id:
+                    return RespondStale(reason="foreign_run")
+                return RespondUnauthorized(reason="not_task_principal")
+            raise RuntimeError(
+                f"interaction {interaction_id} on task {task_id} has an "
+                f"unrecognized status {reread.status!r} after a zero-rowcount "
+                "answer fence"
+            )
+
+        # No expected_run_id/expected_state_version to pass: this function
+        # takes no caller-supplied optimistic-concurrency token, so
+        # apply_task_control_transition's own staleness checks never fire.
+        # StaleTaskRunError from its atomic UPDATE matching zero rows is
+        # provably unreachable here -- step 2's row lock is still held --
+        # and is deliberately left uncaught (see this function's own
+        # docstring, step 7).
+        apply_task_control_transition(task, TaskControlState.RESUME_REQUESTED)
+
+        expected_state_version_after = int(task.state_version)
+        run_id_for_verification = str(task.run_id)
+        savepoint = db.begin_nested()
+        # Capture every receipt value this transaction can still commit as
+        # plain Python locals now, before the commit below. SQLAlchemy's
+        # default ``expire_on_commit=True`` invalidates every ORM attribute
+        # on ``ir``/``task`` the instant ``db.commit()`` returns -- reading
+        # ``ir.run_id`` or ``task.state_version`` afterward would silently
+        # re-issue a SELECT against a session this function is about to
+        # decide whether to keep or retire. The fence UPDATE and the CAS
+        # above are Core statements, so ``ir``/``task``'s in-memory
+        # attributes were never updated by them either; these locals are
+        # the values this call itself just wrote, not a read of what those
+        # statements left behind.
+        answered_run_id = str(ir.run_id)
+        answered_responder_identity = principal.identity_string()
+        answered_responded_at = now
+        committed_state_version = int(task.state_version)
+        committed_control_state = str(task.control_state)
+
+        try:
+            staged = stage_task_command(
+                db,
+                task_id=task_id,
+                actor_user_id=actor_user_id,
+                command_id=normalized_key,
+                kind=TaskCommandKind.RESUME,
+                payload=command_payload,
+            )
+        except IntegrityError:
+            savepoint.rollback()
+            classification = classify_task_command_conflict(
+                db,
+                task_id=task_id,
+                command_id=normalized_key,
+                actor_user_id=actor_user_id,
+                kind=TaskCommandKind.RESUME,
+                payload=command_payload,
+            )
+            if classification.kind == TaskCommandConflictKind.RACED_DUPLICATE:
+                assert classification.raced is not None
+                if classification.raced.payload_matches:
+                    db.commit()
+                    return RespondReplayed(
+                        receipt=InteractionResponseReceipt(
+                            interaction_id=interaction_id,
+                            task_id=task_id,
+                            run_id=answered_run_id,
+                            status="answered",
+                            responded_at=answered_responded_at,
+                            responder_identity=answered_responder_identity,
+                            idempotency_key=normalized_key,
+                            command_db_id=classification.raced.command_db_id,
+                            task_state_version=committed_state_version,
+                            task_control_state=committed_control_state,
+                        )
+                    )
+                db.rollback()
+                increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
+                return RespondConflict(reason="idempotency_key_reused")
+            if classification.kind == TaskCommandConflictKind.TASK_MISSING:
+                db.rollback()
+                return RespondUnavailable(reason="task_missing")
+            db.rollback()
+            raise
+
+        command_db_id = staged.staged_db_id
+        try:
+            db.commit()
+        except Exception:
+            session_retired = True
+            _retire_respond_session_best_effort(db)
+            receipt = _verify_respond_durable_graph(
+                task_id=task_id,
+                interaction_id=interaction_id,
+                expected_run_id=run_id_for_verification,
+                expected_state_version_after=expected_state_version_after,
+                principal=principal,
+                canonical_submitted_values=canonical_submitted_values,
+                command_id=normalized_key,
+                command_kind=TaskCommandKind.RESUME,
+                command_payload=command_payload,
+                actor_user_id=actor_user_id,
+            )
+            if receipt is not None:
+                notify_task_command_dispatcher()
+                return RespondAccepted(receipt=receipt)
+            return RespondOutcomeUnknown()
+
+        notify_task_command_dispatcher()
+        return RespondAccepted(
+            receipt=InteractionResponseReceipt(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                run_id=answered_run_id,
+                status="answered",
+                responded_at=answered_responded_at,
+                responder_identity=answered_responder_identity,
+                idempotency_key=normalized_key,
+                command_db_id=command_db_id,
+                task_state_version=committed_state_version,
+                task_control_state=committed_control_state,
+            )
+        )
+    finally:
+        if not session_retired:
+            _retire_respond_session_best_effort(db)

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1695,7 +1695,16 @@ def respond(
        only, not the question-side ``parse_v1_request_payload`` contract --
        an answer's ``values`` shape is keyed by the *question's own*
        interaction fields, which are only known once the row is read in
-       step 4, not from ``envelope`` alone. Validating an answer against
+       step 4, not from ``envelope`` alone.
+       A dict whose contents cannot be rendered as JSON -- a ``datetime``,
+       a ``set``, ``bytes``, or a ``nan``/infinite float -- is rejected
+       here too, by the same ``json.dumps(..., allow_nan=False)`` probe
+       the question side runs (see ``_render_request_payload``). Without
+       it the first two would surface as a ``StatementError`` raised
+       inside step 6's fence UPDATE, outside the ``RespondOutcome``
+       contract entirely, and the third would be stored silently as a
+       non-JSON token.
+       Validating an answer against
        those per-field types (its ``InteractionArg.type`` /
        ``InteractionArg.field`` definitions) is not implemented in this
        change; a malformed-but-dict-shaped answer reaches the fence and is
@@ -1783,6 +1792,31 @@ def respond(
        leaving the caller to re-check.
     10. After a successful commit, outside any transaction:
         ``notify_task_command_dispatcher()``.
+
+    What this function lets escape, deliberately, and what it does not.
+    The eight ``RespondOutcome`` variants cover every outcome this build
+    classifies; they do not cover operational failure. Three families are
+    left to propagate rather than folded into ``OutcomeUnknown``, because
+    a caller that cannot tell "the database is down" from "your answer was
+    ambiguous" will retry the first one forever:
+
+    - Database-level failures outside the two units caught above --
+      a deadlock, a lost connection, a pool checkout timeout -- raised by
+      any statement from step 2 onward. The two catches are narrow on
+      purpose: step 8's is ``IntegrityError`` only, step 9's covers the
+      commit only.
+    - ``TaskCommandOwnerStateError`` and ``TaskCommandTaskMissing`` from
+      ``stage_task_command``. Neither is an ``IntegrityError`` subclass, so
+      step 8's catch does not see them, and both mean a precondition this
+      function already checked has changed underneath it.
+    - ``RuntimeError`` from the two structural invariants asserted above:
+      a fence rowcount above one, and an interaction row that disappeared
+      while this transaction held the tasks row lock.
+
+    On every one of those paths the ``finally`` below retires the session,
+    which rolls back an uncommitted transaction, so an escaping exception
+    leaves no partial write behind. ``StaleTaskRunError`` from step 7 is
+    documented above as unreachable and is in this same category.
     """
 
     if not isinstance(envelope.kind, str):
@@ -1802,6 +1836,24 @@ def respond(
     except ValueError:
         return RespondValidationRejected(reason="malformed_idempotency_key")
     if not isinstance(envelope.values, dict):
+        return RespondValidationRejected(reason="invalid_values")
+    try:
+        json.dumps(envelope.values, allow_nan=False)
+    except (TypeError, ValueError):
+        # The same probe ``_render_request_payload`` runs on the question
+        # side (see its own docstring), applied here for the two failure
+        # modes this side has. A ``values`` dict holding a ``datetime``,
+        # ``set``, ``bytes``, or any other object the JSON encoder does not
+        # know raises ``TypeError`` at bind time, inside the fence UPDATE
+        # -- far past every typed return above, so it would leave this
+        # function through ``sqlalchemy.exc.StatementError`` instead of one
+        # of the eight ``RespondOutcome`` variants. A float that is ``nan``
+        # or an infinity is worse because it is silent: the default encoder
+        # renders it as the bare ``NaN`` / ``Infinity`` tokens, which are
+        # not JSON, and stores them. ``allow_nan=False`` turns that second
+        # case into the ``ValueError`` caught here. Structural, like every
+        # other check in step 1 -- it asks whether these values can be
+        # stored at all, not whether they answer this particular question.
         return RespondValidationRejected(reason="invalid_values")
 
     from ..models.database import get_session_local
@@ -2015,7 +2067,35 @@ def respond(
             _retire_respond_session_best_effort(db)
             return RespondOutcomeUnknown()
 
-        notify_task_command_dispatcher()
+        try:
+            notify_task_command_dispatcher()
+        except Exception:
+            # Post-commit, and the only statement here that runs after the
+            # answer is already durable. ``notify_task_command_dispatcher``
+            # reads two module globals and calls
+            # ``loop.call_soon_threadsafe`` after checking
+            # ``loop.is_closed()``; the loop can close between that check
+            # and that call, raising ``RuntimeError``. Letting it out would
+            # turn a committed answer into a raised exception -- the caller
+            # would read it as a failure, retry, land on the replay branch,
+            # and get a receipt without a second notify anyway. Skipping
+            # the wakeup costs at most ``DISPATCHER_IDLE_SECONDS`` of
+            # latency because the dispatcher's idle poll still finds the
+            # staged command; that is the documented fallback (see
+            # ``stage_task_command``'s caller obligation (a)). Narrow on
+            # purpose: this wraps one post-commit best-effort notification
+            # and nothing else -- no statement above the commit is inside
+            # it.
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "failed to notify the task command dispatcher after "
+                "committing the answer for interaction %s on task %s; "
+                "the dispatcher's idle poll will still pick the command up",
+                interaction_id,
+                task_id,
+                exc_info=True,
+            )
         return RespondAccepted(
             receipt=InteractionResponseReceipt(
                 interaction_id=interaction_id,

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1668,6 +1668,7 @@ def test_respond_rejects_answer_values_that_are_not_a_dict(_respond_db) -> None:
         pytest.param({"a": {1, 2}}, id="set"),
         pytest.param({"a": b"x"}, id="bytes"),
         pytest.param({"a": float("nan")}, id="nan_float"),
+        pytest.param({"a": "x", 1: "y"}, id="mixed_int_str_keys"),
     ],
 )
 def test_respond_rejects_values_that_cannot_be_rendered_as_json(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -2310,6 +2310,72 @@ def test_respond_reports_outcome_unknown_when_staging_the_command_raises_and_lea
     assert _conflict_counter() == before_counter
 
 
+def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_and_leaves_no_residue(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from xagent.web.services.task_command_transport import StagedTaskCommand
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    def _racing_stage_task_command(*args: Any, **kwargs: Any) -> StagedTaskCommand:
+        return StagedTaskCommand(
+            staged_db_id=4242,
+            client_command_id=kwargs.get("command_id", "staging-race"),
+            created=False,
+            payload_matches=False,
+            status="pending",
+        )
+
+    monkeypatch.setattr(svc, "stage_task_command", _racing_stage_task_command)
+
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(idempotency_key="staging-race"),
+        )
+
+        assert isinstance(outcome, svc.RespondOutcomeUnknown)
+
+
+def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_with_a_matching_payload(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from xagent.web.services.task_command_transport import StagedTaskCommand
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    def _racing_stage_task_command(*args: Any, **kwargs: Any) -> StagedTaskCommand:
+        return StagedTaskCommand(
+            staged_db_id=4242,
+            client_command_id=kwargs.get("command_id", "staging-race-match"),
+            created=False,
+            payload_matches=True,
+            status="pending",
+        )
+
+    monkeypatch.setattr(svc, "stage_task_command", _racing_stage_task_command)
+
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(idempotency_key="staging-race-match"),
+        )
+
+        assert isinstance(outcome, svc.RespondOutcomeUnknown)
+
+
 # ---------------------------------------------------------------------------
 # The mapping meta-test. For every one of the 20 (outcome, reason) pairs in
 # the vocabulary, at least one test above must produce it. This is

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -19,14 +19,19 @@ reasons plus ``Conflict(already_answered)`` collapse onto this build's
 single ``(OutcomeUnknown, None)`` pair instead, alongside the two other
 triggers (an unclassified staging ``IntegrityError`` and an unreconciled
 commit exception) this build already reports the same way. The matrix
-below enumerates this build's own 16 triggering cells, producing 14
-distinct (outcome type, reason) pairs -- fewer than 16 because several
-cells share a pair (two "principal does not own this task" cells both
+below enumerates this build's own 22 triggering cells, producing 14
+distinct (outcome type, reason) pairs -- fewer than 22 because several
+cells share a pair (six "principal does not own this task" cells both
 produce ``(RespondUnauthorized, not_task_principal)``; two "same
 idempotency key, different actor" cells both produce ``(RespondConflict,
 idempotency_key_reused)``; four distinct triggers collapse onto
 ``(OutcomeUnknown, None)``; one cell, kind/version validation, is
 parametrized over two reasons on its own). The full cell-to-pair mapping:
+
+    (Cell ids are this build's subset of the full matrix an end-to-end
+    delivery would enumerate; the gaps -- there is no V4, C1, or S1-S5
+    here -- are cells only a build that stages rows and classifies fence
+    misses can reach.)
 
     OK        -> (Accepted, None)                                    1
     V1        -> (ValidationRejected, unknown_kind)                  }  2
@@ -34,7 +39,13 @@ parametrized over two reasons on its own). The full cell-to-pair mapping:
     V2        -> (ValidationRejected, malformed_idempotency_key)     1
     V3        -> (ValidationRejected, invalid_values)                1
     V5        -> (ValidationRejected, kind_version_mismatch)         1
-    A1,A2     -> (Unauthorized, not_task_principal)      1 (2 cells share it)
+    A1..A6    -> (Unauthorized, not_task_principal)      1 (6 cells share
+                 it -- a user principal that does not own the task, the
+                 authorization-before-idempotency ordering guard, a guest
+                 principal on a non-matching task, a guest principal with
+                 two populated entity-binding directions, an unknown
+                 principal kind, and a guest principal with zero
+                 populated entity-binding directions)
     U1        -> (Unavailable, task_missing)                         1
     U2        -> (Unavailable, interaction_missing)                  1
     U3        -> (Unavailable, checkpoint_unavailable)                1
@@ -46,7 +57,7 @@ parametrized over two reasons on its own). The full cell-to-pair mapping:
                  fence-level mismatch this build cannot label, a staging
                  IntegrityError, and a commit exception)
     -----------------------------------------------------------------
-    16 cells; 14 distinct pairs (12 single-reason cells + V1's own 2)
+    22 cells; 14 distinct pairs (12 single-reason cells + V1's own 2)
 
 The cell-by-cell tests this matrix implies, and the mapping meta-test that
 checks their coverage against the vocabulary, are both in this file now,
@@ -60,8 +71,8 @@ layers:
 | Assertion | Checks | Catches | Misses |
 |---|---|---|---|
 | Union-membership guard (this file, written) | ``RespondOutcome`` has exactly its eight known member classes | A variant added or removed without updating this list | Reason-level coverage |
-| Cell-by-cell tests (this file, written) | One test per of the 16 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
-| Mapping meta-test (this file, written) | Each of the 14 pairs is produced by >= 1 cell's test (12 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a third not_task_principal scenario) -- caught by review, not this meta-test |
+| Cell-by-cell tests (this file, written) | One test per of the 22 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
+| Mapping meta-test (this file, written) | Each of the 14 pairs is produced by >= 1 cell's test (12 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a seventh not_task_principal scenario) -- caught by review, not this meta-test |
 """
 
 from __future__ import annotations
@@ -133,7 +144,7 @@ def _clean_degradation_registry():
 # The two assertions below read that type back rather than duplicating it:
 # the first confirms the Union has exactly the eight known member classes,
 # the second (further down, next to the mapping meta-test) confirms the
-# 20 (outcome, reason) pairs it derives from those classes' own Literal
+# 14 (outcome, reason) pairs it derives from those classes' own Literal
 # annotations still match what every test in this file actually produces.
 
 
@@ -255,7 +266,7 @@ def test_create_rejects_nan_default_value_as_invalid_values(
 
 
 # ---------------------------------------------------------------------------
-# create(): the six (outcome, reason) pairs producible in this delivery.
+# create(): the seven (outcome, reason) pairs producible in this delivery.
 # CC1 (slot_taken / idempotency_key_reused), CS1 (anchor_dangling /
 # run_ended), and CU2 (checkpoint_unavailable / anchor_run_mismatch) are not
 # producible -- create() never stages a row, so nothing that requires one
@@ -1821,6 +1832,140 @@ def test_respond_rejects_a_guest_whose_bindings_match_but_principal_user_id_does
         assert isinstance(outcome, svc.RespondOutcomeUnknown)
 
 
+def test_respond_rejects_a_guest_principal_on_a_non_matching_task(
+    _respond_db,
+) -> None:
+    """Same owner, same auth_mode, but a different widget_workforce_id --
+    the entity-binding conjunct must reject this at step 3, not the
+    (correctly matching) owner or auth_mode conjuncts. Mirrors
+    ``test_ca1_guest_principal_is_rejected_on_a_non_matching_task`` on the
+    create() side."""
+
+    owner_id, task_id = _waiting_task(
+        _respond_db,
+        agent_config={
+            "auth_mode": "widget",
+            "guest_id": "guest-1",
+            "widget_workforce_id": 10,
+        },
+    )
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    guest = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=owner_id,
+        is_admin=False,
+        auth_mode="widget",
+        widget_workforce_id=999,
+        guest_id="guest-1",
+    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=guest,
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+def test_respond_rejects_a_guest_principal_with_two_populated_directions(
+    _respond_db,
+) -> None:
+    """A malformed principal that populates more than one of the four
+    entity-binding fields makes ``task_is_owned_by_public_principal`` raise
+    ``ValueError``; respond() must catch exactly that and translate it to
+    ``Unauthorized(not_task_principal)``, not let it escape. Mirrors
+    ``test_ca1_guest_principal_with_two_populated_directions_is_unauthorized_not_raised``
+    on the create() side."""
+
+    owner_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    guest = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=owner_id,
+        is_admin=False,
+        auth_mode="widget",
+        widget_agent_id=1,
+        widget_workforce_id=1,
+        guest_id="guest-1",
+    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=guest,
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+def test_respond_rejects_an_unknown_principal_kind(
+    _respond_db,
+) -> None:
+    """A principal.kind that is neither "user" nor "guest" must be
+    rejected -- there is no third branch that defaults to allow. Mirrors
+    ``test_ca1_unknown_principal_kind_is_always_unauthorized`` on the
+    create() side."""
+
+    owner_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = svc.InteractionPrincipal(
+        kind="robot",
+        user_id=owner_id,
+        is_admin=True,
+        auth_mode=None,
+    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+def test_respond_rejects_a_guest_principal_with_zero_populated_directions(
+    _respond_db,
+) -> None:
+    """Mirrors
+    ``test_ca1_guest_principal_with_zero_populated_directions_is_unauthorized_not_raised``
+    on the create() side: a guest principal that populates none of the
+    four entity-binding fields makes the ownership predicate raise
+    ``ValueError``, which respond() must translate to
+    ``Unauthorized(not_task_principal)`` rather than let escape."""
+
+    owner_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    guest = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=owner_id,
+        is_admin=False,
+        auth_mode="widget",
+        guest_id="guest-1",
+    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=guest,
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
 def test_respond_reports_unavailable_when_the_task_row_does_not_exist(
     _respond_db,
 ) -> None:
@@ -2508,11 +2653,11 @@ def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_with_a_m
 
 
 # ---------------------------------------------------------------------------
-# The mapping meta-test. For every one of the 20 (outcome, reason) pairs in
+# The mapping meta-test. For every one of the 14 (outcome, reason) pairs in
 # the vocabulary, at least one test above must produce it. This is
 # deliberately not an arithmetic comparison against the total cell count
 # (see the module docstring's three-way division of labor table) -- several
-# triggering conditions collapse onto the same pair (five distinct
+# triggering conditions collapse onto the same pair (six distinct
 # "principal does not own this task" scenarios all produce
 # ``not_task_principal``; two distinct "same idempotency key, different
 # submitter" scenarios both produce ``idempotency_key_reused``), and one
@@ -2551,7 +2696,7 @@ def test_every_vocabulary_pair_is_produced_by_at_least_one_cell_test() -> None:
     every ``isinstance(outcome, svc.Respond<Type>)`` check the cell tests
     above use, and cross-checks the resulting (type, reason) set against
     the vocabulary. Deliberately not ``len(produced) == len(vocabulary)`` or
-    any other arithmetic against the 24-cell count -- five
+    any other arithmetic against the 22-cell count -- six
     not_task_principal cells and two idempotency_key_reused cells
     legitimately collapse onto one pair each; this only asserts that no
     vocabulary pair is left with zero producing cells."""

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -16,28 +16,33 @@ commit against the durable graph would need (see ``RespondOutcomeUnknown``
 's own docstring in ``task_interaction_service.py``) -- six triggering
 scenarios that such a build would classify into five distinct ``Stale``
 reasons plus ``Conflict(already_answered)`` collapse onto this build's
-single ``(OutcomeUnknown, None)`` pair instead, alongside the two other
-triggers (an unclassified staging ``IntegrityError`` and an unreconciled
-commit exception) this build already reports the same way. The matrix
-below enumerates this build's own 22 triggering cells, producing 14
-distinct (outcome type, reason) pairs -- fewer than 22 because several
-cells share a pair (six "principal does not own this task" cells both
+single ``(OutcomeUnknown, None)`` pair instead, alongside the four other
+triggers (an unclassified staging ``IntegrityError``, the two
+staging-race doors, and an unreconciled commit exception) this build
+already reports the same way. The matrix
+below enumerates this build's own 27 triggering cells, producing 14
+distinct (outcome type, reason) pairs -- fewer than 27 because several
+cells share a pair (six "principal does not own this task" cells all
 produce ``(RespondUnauthorized, not_task_principal)``; two "same
 idempotency key, different actor" cells both produce ``(RespondConflict,
-idempotency_key_reused)``; four distinct triggers collapse onto
+idempotency_key_reused)``; six distinct triggers collapse onto
 ``(OutcomeUnknown, None)``; one cell, kind/version validation, is
 parametrized over two reasons on its own). The full cell-to-pair mapping:
 
     (Cell ids are this build's subset of the full matrix an end-to-end
-    delivery would enumerate; the gaps -- there is no V4, C1, or S1-S5
+    delivery would enumerate; the gaps -- there is no C1 or S1-S5
     here -- are cells only a build that stages rows and classifies fence
     misses can reach.)
 
-    OK        -> (Accepted, None)                                    1
+    OK,OK2    -> (Accepted, None)      1 (2 cells share it -- the plain
+                 accepted path, and a commit that succeeds but whose
+                 post-commit dispatcher notify raises)
     V1        -> (ValidationRejected, unknown_kind)                  }  2
                  (ValidationRejected, unknown_protocol_version)      }
     V2        -> (ValidationRejected, malformed_idempotency_key)     1
-    V3        -> (ValidationRejected, invalid_values)                1
+    V3,V4     -> (ValidationRejected, invalid_values)      1 (2 cells share
+                 it -- a non-dict ``values`` payload, and a dict
+                 ``values`` payload that cannot be rendered as JSON)
     V5        -> (ValidationRejected, kind_version_mismatch)         1
     A1..A6    -> (Unauthorized, not_task_principal)      1 (6 cells share
                  it -- a user principal that does not own the task, the
@@ -49,15 +54,20 @@ parametrized over two reasons on its own). The full cell-to-pair mapping:
     U1        -> (Unavailable, task_missing)                         1
     U2        -> (Unavailable, interaction_missing)                  1
     U3        -> (Unavailable, checkpoint_unavailable)                1
-    R1        -> (Replayed, None)                                    1
+    R1,R2     -> (Replayed, None)      1 (2 cells share it -- the plain
+                 replay, and a replay of an already-answered row whose
+                 resume anchor was pruned before the retry)
     C2,C3     -> (Conflict, idempotency_key_reused)      1 (2 cells share it)
     S6        -> (Stale, anchor_dangling)                             1
-    X1..X4    -> (OutcomeUnknown, None)      1 (4 cells share it -- a
+    X1..X6    -> (OutcomeUnknown, None)      1 (6 cells share it -- a
                  fence miss with no further classification, a guest whose
                  fence-level mismatch this build cannot label, a staging
-                 IntegrityError, and a commit exception)
+                 IntegrityError, a commit exception, and two staging-race
+                 doors -- a raced row found already staged with a
+                 mismatched payload, and one found with a matching
+                 payload)
     -----------------------------------------------------------------
-    22 cells; 14 distinct pairs (12 single-reason cells + V1's own 2)
+    27 cells; 14 distinct pairs (12 single-reason cells + V1's own 2)
 
 The cell-by-cell tests this matrix implies, and the mapping meta-test that
 checks their coverage against the vocabulary, are both in this file now,
@@ -71,7 +81,7 @@ layers:
 | Assertion | Checks | Catches | Misses |
 |---|---|---|---|
 | Union-membership guard (this file, written) | ``RespondOutcome`` has exactly its eight known member classes | A variant added or removed without updating this list | Reason-level coverage |
-| Cell-by-cell tests (this file, written) | One test per of the 22 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
+| Cell-by-cell tests (this file, written) | One test per of the 27 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
 | Mapping meta-test (this file, written) | Each of the 14 pairs is produced by >= 1 cell's test (12 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a seventh not_task_principal scenario) -- caught by review, not this meta-test |
 """
 
@@ -1432,8 +1442,11 @@ def _answered_row_with_valid_anchor(
 ) -> int:
     """A row this service already answered in some earlier, successful call
     -- its resume anchor is still valid (nothing has pruned the checkpoint
-    it points at), which is what makes it reachable past step 5.5 for the
-    already-answered replay and fence-miss tests below."""
+    it points at). A live anchor is still what makes the fence-miss tests
+    below reachable past step 5.5; the already-answered replay tests no
+    longer need it, since step 5's pre-read now recognizes the replay
+    before anchor resolution runs (the pruned-anchor replay test below is
+    what pins that down)."""
 
     db = session_factory()
     try:
@@ -2205,10 +2218,10 @@ def test_respond_logs_the_reread_row_state_when_the_fence_misses(
     matching = [
         record
         for record in caplog.records
-        if "answer fence matched zero rows" in record.message
+        if "answer fence matched zero rows" in record.getMessage()
     ]
     assert len(matching) == 1
-    assert "status=answered" in matching[0].message
+    assert "status=answered" in matching[0].getMessage()
 
 
 def test_respond_reports_conflict_for_the_same_key_with_a_different_payload(
@@ -2549,9 +2562,26 @@ def test_respond_reports_outcome_unknown_when_staging_the_command_raises_and_lea
     assert _conflict_counter() == before_counter
 
 
-def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_and_leaves_no_residue(
-    _respond_db, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    "payload_matches",
+    [False, True],
+    ids=["payload-mismatch", "payload-matches"],
+)
+def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row(
+    _respond_db, monkeypatch: pytest.MonkeyPatch, payload_matches: bool
 ) -> None:
+    """A ``created=False`` staging result -- the row was already committed
+    and visible by the time this call's own staging statement ran -- is
+    reported as ``OutcomeUnknown`` and leaves no residue, regardless of
+    whether the raced row's payload happens to match this call's own
+    envelope. A matching payload is deliberately not treated as a replay:
+    replay recognition happens once, at step 5's idempotency pre-read,
+    before the staging statement runs. A raced hit that only becomes
+    visible after that pre-read is a race this build cannot distinguish
+    from a genuine conflict, not a replay it missed, so both the
+    mismatched and the matching case collapse onto the same conservative
+    outcome."""
+
     from xagent.web.services.task_command_transport import StagedTaskCommand
 
     user_id, task_id = _waiting_task(_respond_db)
@@ -2563,7 +2593,7 @@ def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_and_leav
             staged_db_id=4242,
             client_command_id=kwargs.get("command_id", "staging-race"),
             created=False,
-            payload_matches=False,
+            payload_matches=payload_matches,
             status="pending",
         )
 
@@ -2577,39 +2607,6 @@ def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_and_leav
             task_id=task_id,
             principal=principal,
             envelope=_respond_envelope(idempotency_key="staging-race"),
-        )
-
-        assert isinstance(outcome, svc.RespondOutcomeUnknown)
-
-
-def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_with_a_matching_payload(
-    _respond_db, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from xagent.web.services.task_command_transport import StagedTaskCommand
-
-    user_id, task_id = _waiting_task(_respond_db)
-    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_principal(user_id)
-
-    def _racing_stage_task_command(*args: Any, **kwargs: Any) -> StagedTaskCommand:
-        return StagedTaskCommand(
-            staged_db_id=4242,
-            client_command_id=kwargs.get("command_id", "staging-race-match"),
-            created=False,
-            payload_matches=True,
-            status="pending",
-        )
-
-    monkeypatch.setattr(svc, "stage_task_command", _racing_stage_task_command)
-
-    with _asserts_no_side_effects(
-        _respond_db, task_id=task_id, interaction_id=interaction_id
-    ):
-        outcome = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=principal,
-            envelope=_respond_envelope(idempotency_key="staging-race-match"),
         )
 
         assert isinstance(outcome, svc.RespondOutcomeUnknown)
@@ -2659,7 +2656,7 @@ def test_every_vocabulary_pair_is_produced_by_at_least_one_cell_test() -> None:
     every ``isinstance(outcome, svc.Respond<Type>)`` check the cell tests
     above use, and cross-checks the resulting (type, reason) set against
     the vocabulary. Deliberately not ``len(produced) == len(vocabulary)`` or
-    any other arithmetic against the 22-cell count -- six
+    any other arithmetic against the 27-cell count -- six
     not_task_principal cells and two idempotency_key_reused cells
     legitimately collapse onto one pair each; this only asserts that no
     vocabulary pair is left with zero producing cells."""

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1766,7 +1766,11 @@ def test_respond_rejects_a_guest_whose_bindings_match_but_principal_user_id_does
         },
     )
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    wrong_user_id = make_user(_respond_db())
+    setup_db = _respond_db()
+    try:
+        wrong_user_id = make_user(setup_db)
+    finally:
+        setup_db.close()
     guest = svc.InteractionPrincipal(
         kind="guest",
         user_id=wrong_user_id,

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1661,6 +1661,33 @@ def test_respond_rejects_answer_values_that_are_not_a_dict(_respond_db) -> None:
         assert outcome == svc.RespondValidationRejected(reason="invalid_values")
 
 
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param({"a": datetime.now(timezone.utc)}, id="datetime"),
+        pytest.param({"a": {1, 2}}, id="set"),
+        pytest.param({"a": b"x"}, id="bytes"),
+        pytest.param({"a": float("nan")}, id="nan_float"),
+    ],
+)
+def test_respond_rejects_values_that_cannot_be_rendered_as_json(
+    _respond_db, values: dict[str, Any]
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(values=values),
+        )
+
+        assert outcome == svc.RespondValidationRejected(reason="invalid_values")
+
+
 def test_respond_rejects_when_the_stored_row_disagrees_with_the_envelope_on_protocol_version(
     _respond_db,
 ) -> None:
@@ -2207,6 +2234,32 @@ def test_respond_accepts_a_fully_valid_answer_and_fills_every_receipt_field(
     assert after["ir_response_payload"] == {"env": "prod"}
     assert after["task_state_version"] == 6
     assert after["commands_count"] == 1
+
+
+def test_respond_returns_accepted_when_the_dispatcher_notify_fails(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    def _raising_notify() -> None:
+        raise RuntimeError("Event loop is closed")
+
+    monkeypatch.setattr(svc, "notify_task_command_dispatcher", _raising_notify)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="notify-fails-key"),
+    )
+
+    assert isinstance(outcome, svc.RespondAccepted)
+
+    after = _graph_snapshot(_respond_db, task_id=task_id, interaction_id=interaction_id)
+    assert after["ir_status"] == "answered"
+    assert after["ir_response_payload"] == {"env": "prod"}
 
 
 def test_respond_receipt_fields_do_not_touch_the_session_after_commit(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1397,7 +1397,7 @@ def _active_row_ready_for_respond(
     anchor_run_partition: str | None = None,
 ) -> int:
     """An active interaction row with a resolvable anchor -- the state every
-    respond() test that expects to reach the fence (steps 5 onward) starts
+    respond() test that expects to reach the fence (step 6 onward) starts
     from. ``anchor_run_partition``, when different from ``run_id``, is what
     ``test_respond_reports_stale_when_the_anchor_points_at_a_different_run_partition``
     below uses to force the anchor resolver's own partition check to fail
@@ -1435,7 +1435,7 @@ def _answered_row_with_valid_anchor(
 ) -> int:
     """A row this service already answered in some earlier, successful call
     -- its resume anchor is still valid (nothing has pruned the checkpoint
-    it points at), which is what makes it reachable past step 4.5 for the
+    it points at), which is what makes it reachable past step 5.5 for the
     already-answered replay and fence-miss tests below."""
 
     db = session_factory()
@@ -1580,7 +1580,7 @@ def _conflict_counter() -> int:
 
 # ---------------------------------------------------------------------------
 # The pure-read path: envelope validation, task/interaction existence,
-# authorization, and anchor resolution -- steps 1 through 4.5. Twelve cells,
+# authorization, and anchor resolution -- steps 1 through 5.5. Twelve cells,
 # each asserting outcome, reason, and zero side effects.
 # ---------------------------------------------------------------------------
 
@@ -1916,6 +1916,53 @@ def test_respond_returns_the_original_receipt_for_a_matching_replay(
         assert isinstance(outcome, svc.RespondReplayed)
         assert outcome.receipt.responder_identity == principal.identity_string()
         assert outcome.receipt.idempotency_key == command_id
+
+
+def test_respond_replays_an_answered_row_whose_anchor_was_pruned(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    principal = _owning_user_principal(user_id)
+    values = {"env": "prod"}
+    command_id = "replay-key-pruned-anchor"
+    interaction_id = _answered_row_with_valid_anchor(
+        _respond_db,
+        task_id=task_id,
+        run_id="run-a",
+        responder_identity=principal.identity_string(),
+        response_payload=values,
+    )
+    payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values=values
+    )
+    _stage_matching_command(
+        _respond_db,
+        task_id=task_id,
+        actor_user_id=principal.user_id,
+        command_id=command_id,
+        payload=payload,
+    )
+
+    # Simulate the checkpoint retention pruner: the row's anchor is gone,
+    # the way ON DELETE SET NULL leaves it once the checkpoint it pointed
+    # at is pruned.
+    db = _respond_db()
+    try:
+        row = db.get(TaskInteractionRequest, interaction_id)
+        row.resume_trace_event_id = None
+        db.commit()
+    finally:
+        db.close()
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key=command_id, values=values),
+    )
+
+    assert isinstance(outcome, svc.RespondReplayed)
+    assert outcome.receipt.idempotency_key == command_id
 
 
 def test_respond_receipt_refuses_a_row_that_carries_no_answer() -> None:

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -337,10 +337,10 @@ def _valid_envelope(**overrides: Any) -> svc.CreateInteractionEnvelope:
     return svc.CreateInteractionEnvelope(**defaults)
 
 
-def _owning_principal(task_user_id: int) -> svc.InteractionPrincipal:
+def _owning_principal(user_id: int) -> svc.InteractionPrincipal:
     return svc.InteractionPrincipal(
         kind="user",
-        user_id=task_user_id,
+        user_id=user_id,
         is_admin=False,
         auth_mode=None,
     )
@@ -1215,12 +1215,6 @@ def test_get_scopes_by_task_id_not_by_interaction_id_alone(
 # ---------------------------------------------------------------------------
 
 
-def _owning_principal_for_fence(user_id: int) -> svc.InteractionPrincipal:
-    return svc.InteractionPrincipal(
-        kind="user", user_id=user_id, is_admin=False, auth_mode=None
-    )
-
-
 # ---------------------------------------------------------------------------
 # TaskStatusPredicate structural assertion. The active-row query
 # ``_active_native_row_criteria()`` builds never references ``Task.status``
@@ -1278,7 +1272,7 @@ def test_active_row_query_uses_zero_taskstatus_bind_parameters() -> None:
 def test_answer_fence_predicate_compiles_without_any_taskstatus_literal_string() -> (
     None
 ):
-    principal = _owning_principal_for_fence(1)
+    principal = _owning_principal(1)
     stmt = sa.select(TaskInteractionRequest).where(
         TaskInteractionRequest.id == 1,
         TaskInteractionRequest.task_id == 1,
@@ -1300,7 +1294,7 @@ def test_answer_fence_predicate_compiles_without_any_taskstatus_literal_string()
 
 
 def test_answer_fence_predicate_guest_branch_adds_a_json_lookup_term() -> None:
-    user_terms = svc._answer_fence_task_predicate(_owning_principal_for_fence(1))
+    user_terms = svc._answer_fence_task_predicate(_owning_principal(1))
     guest_principal = svc.InteractionPrincipal(
         kind="guest",
         user_id=1,
@@ -1490,15 +1484,6 @@ def _stage_matching_command(
         db.close()
 
 
-def _owning_user_principal(user_id: int) -> svc.InteractionPrincipal:
-    return svc.InteractionPrincipal(
-        kind="user",
-        user_id=user_id,
-        is_admin=False,
-        auth_mode=None,
-    )
-
-
 def _respond_envelope(**overrides: Any) -> svc.RespondEnvelope:
     defaults: dict[str, Any] = {
         "kind": "clarification",
@@ -1617,7 +1602,7 @@ def test_respond_rejects_an_envelope_outside_the_known_kind_or_version_vocabular
         outcome = svc.respond(
             interaction_id=interaction_id,
             task_id=task_id,
-            principal=_owning_user_principal(user_id),
+            principal=_owning_principal(user_id),
             envelope=_respond_envelope(**overrides),
         )
 
@@ -1638,7 +1623,7 @@ def test_respond_rejects_an_idempotency_key_that_is_not_url_safe(_respond_db) ->
         outcome = svc.respond(
             interaction_id=interaction_id,
             task_id=task_id,
-            principal=_owning_user_principal(user_id),
+            principal=_owning_principal(user_id),
             envelope=_respond_envelope(idempotency_key="has a space"),
         )
 
@@ -1656,7 +1641,7 @@ def test_respond_rejects_answer_values_that_are_not_a_dict(_respond_db) -> None:
         outcome = svc.respond(
             interaction_id=interaction_id,
             task_id=task_id,
-            principal=_owning_user_principal(user_id),
+            principal=_owning_principal(user_id),
             envelope=_respond_envelope(values="not-a-dict"),
         )
 
@@ -1683,7 +1668,7 @@ def test_respond_rejects_values_that_cannot_be_rendered_as_json(
         outcome = svc.respond(
             interaction_id=interaction_id,
             task_id=task_id,
-            principal=_owning_user_principal(user_id),
+            principal=_owning_principal(user_id),
             envelope=_respond_envelope(values=values),
         )
 
@@ -1736,7 +1721,7 @@ def test_respond_rejects_when_the_stored_row_disagrees_with_the_envelope_on_prot
         outcome = svc.respond(
             interaction_id=interaction_id,
             task_id=task_id,
-            principal=_owning_user_principal(user_id),
+            principal=_owning_principal(user_id),
             envelope=_respond_envelope(protocol_version=1),
         )
 
@@ -1962,7 +1947,7 @@ def test_respond_reports_unavailable_when_the_task_row_does_not_exist(
     outcome = svc.respond(
         interaction_id=1,
         task_id=999_999_999,
-        principal=_owning_user_principal(1),
+        principal=_owning_principal(1),
         envelope=_respond_envelope(),
     )
 
@@ -1977,7 +1962,7 @@ def test_respond_reports_unavailable_when_the_interaction_row_does_not_exist(
         outcome = svc.respond(
             interaction_id=999_999,
             task_id=task_id,
-            principal=_owning_user_principal(user_id),
+            principal=_owning_principal(user_id),
             envelope=_respond_envelope(),
         )
 
@@ -2008,7 +1993,7 @@ def test_respond_reports_unavailable_when_the_anchor_row_fetch_raises(
         outcome = svc.respond(
             interaction_id=interaction_id,
             task_id=task_id,
-            principal=_owning_user_principal(user_id),
+            principal=_owning_principal(user_id),
             envelope=_respond_envelope(),
         )
 
@@ -2028,7 +2013,7 @@ def test_respond_reports_stale_when_the_anchor_points_at_a_different_run_partiti
         outcome = svc.respond(
             interaction_id=interaction_id,
             task_id=task_id,
-            principal=_owning_user_principal(user_id),
+            principal=_owning_principal(user_id),
             envelope=_respond_envelope(),
         )
 
@@ -2046,7 +2031,7 @@ def test_respond_returns_the_original_receipt_for_a_matching_replay(
     _respond_db,
 ) -> None:
     user_id, task_id = _waiting_task(_respond_db)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
     values = {"env": "prod"}
     command_id = "replay-key-1"
     interaction_id = _answered_row_with_valid_anchor(
@@ -2085,7 +2070,7 @@ def test_respond_replays_an_answered_row_whose_anchor_was_pruned(
     _respond_db,
 ) -> None:
     user_id, task_id = _waiting_task(_respond_db)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
     values = {"env": "prod"}
     command_id = "replay-key-pruned-anchor"
     interaction_id = _answered_row_with_valid_anchor(
@@ -2173,7 +2158,7 @@ def test_respond_reports_outcome_unknown_when_the_fence_misses_and_leaves_no_res
     one."""
 
     user_id, task_id = _waiting_task(_respond_db)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
     interaction_id = _answered_row_with_valid_anchor(
         _respond_db,
         task_id=task_id,
@@ -2200,7 +2185,7 @@ def test_respond_logs_the_reread_row_state_when_the_fence_misses(
     _respond_db, caplog: pytest.LogCaptureFixture
 ) -> None:
     user_id, task_id = _waiting_task(_respond_db)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
     interaction_id = _answered_row_with_valid_anchor(
         _respond_db,
         task_id=task_id,
@@ -2230,7 +2215,7 @@ def test_respond_reports_conflict_for_the_same_key_with_a_different_payload(
     _respond_db,
 ) -> None:
     user_id, task_id = _waiting_task(_respond_db)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
     command_id = "shared-key-1"
     staged_payload = svc._respond_command_payload(
@@ -2292,7 +2277,7 @@ def test_respond_reports_conflict_when_a_guest_and_the_owner_share_one_key(
         command_id=command_id,
         payload=guest_payload,
     )
-    owner = _owning_user_principal(owner_id)
+    owner = _owning_principal(owner_id)
     before_counter = _conflict_counter()
     with _asserts_no_side_effects(
         _respond_db, task_id=task_id, interaction_id=interaction_id
@@ -2315,7 +2300,7 @@ def test_respond_checks_authorization_before_the_idempotency_prequery(
     idempotency key to read back someone else's receipt."""
 
     owner_id, task_id = _waiting_task(_respond_db)
-    principal = _owning_user_principal(owner_id)
+    principal = _owning_principal(owner_id)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
     command_id = "someone-elses-key"
     values = {"env": "prod"}
@@ -2357,7 +2342,7 @@ def test_respond_accepts_a_fully_valid_answer_and_fills_every_receipt_field(
 ) -> None:
     user_id, task_id = _waiting_task(_respond_db, state_version=5)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
 
     dispatched: list[bool] = []
     import xagent.web.services.task_interaction_service as svc_module
@@ -2405,7 +2390,7 @@ def test_respond_returns_accepted_when_the_dispatcher_notify_fails(
 ) -> None:
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
 
     def _raising_notify() -> None:
         raise RuntimeError("Event loop is closed")
@@ -2435,7 +2420,7 @@ def test_respond_receipt_fields_do_not_touch_the_session_after_commit(
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
 
     outcome = svc.respond(
         interaction_id=interaction_id,
@@ -2494,7 +2479,7 @@ def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residu
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
 
     from sqlalchemy.orm import Session as OrmSession
 
@@ -2537,7 +2522,7 @@ def test_respond_reports_outcome_unknown_when_staging_the_command_raises_and_lea
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
 
     def _raising_stage_task_command(*args: Any, **kwargs: Any) -> Any:
         raise _IntegrityError(
@@ -2571,7 +2556,7 @@ def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_and_leav
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
 
     def _racing_stage_task_command(*args: Any, **kwargs: Any) -> StagedTaskCommand:
         return StagedTaskCommand(
@@ -2604,7 +2589,7 @@ def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row_with_a_m
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
+    principal = _owning_principal(user_id)
 
     def _racing_stage_task_command(*args: Any, **kwargs: Any) -> StagedTaskCommand:
         return StagedTaskCommand(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1376,7 +1376,6 @@ def _respond_db(monkeypatch: pytest.MonkeyPatch, _session_factory):
 def _waiting_task(
     session_factory,
     *,
-    state_version: int = 5,
     agent_config: dict[str, Any] | None = None,
 ) -> tuple[int, int]:
     """A task parked in WAITING_FOR_USER, the state every respond() test
@@ -1390,7 +1389,7 @@ def _waiting_task(
         task.status = TaskStatus.WAITING_FOR_USER
         task.control_state = TaskControlState.WAITING_FOR_USER.value
         task.run_id = "run-a"
-        task.state_version = state_version
+        task.state_version = 5
         task.channel_id = None
         task.agent_id = None
         if agent_config is not None:
@@ -2352,30 +2351,24 @@ def test_respond_checks_authorization_before_the_idempotency_prequery(
 
 
 def test_respond_accepts_a_fully_valid_answer_and_fills_every_receipt_field(
-    _respond_db,
+    _respond_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    user_id, task_id = _waiting_task(_respond_db, state_version=5)
+    user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
     principal = _owning_principal(user_id)
 
     dispatched: list[bool] = []
-    import xagent.web.services.task_interaction_service as svc_module
-
-    monkeypatch_target = svc_module.notify_task_command_dispatcher
 
     def _record_dispatch() -> None:
         dispatched.append(True)
 
-    svc_module.notify_task_command_dispatcher = _record_dispatch
-    try:
-        outcome = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=principal,
-            envelope=_respond_envelope(idempotency_key="ok-path-key"),
-        )
-    finally:
-        svc_module.notify_task_command_dispatcher = monkeypatch_target
+    monkeypatch.setattr(svc, "notify_task_command_dispatcher", _record_dispatch)
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="ok-path-key"),
+    )
 
     assert isinstance(outcome, svc.RespondAccepted)
     receipt = outcome.receipt

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -5,18 +5,21 @@ This module accumulates coverage across every deliverable this service
 ships except the shared public-chat ownership predicate (covered directly
 by ``tests/web/api/test_public_chat_ownership_helper.py``, since it is
 extracted from and tested alongside ``public_chat_access.py``) and the
-production-caller gate (its own file,
-``test_task_interaction_service_production_gate.py``).
+``create()`` zero-production-caller gate (its own file,
+``test_task_interaction_service_create_gate.py``).
 
 RespondOutcome's failure matrix, and what this delivery does and does not
-do with it: the matrix enumerates 25 triggering cells across
-``respond()``'s not-yet-implemented logic, producing 21 distinct (outcome
-type, reason) pairs -- fewer than 25 because several cells share a pair
+do with it: the matrix enumerates 24 triggering cells across
+``respond()``'s not-yet-implemented logic, producing 20 distinct (outcome
+type, reason) pairs -- fewer than 24 because several cells share a pair
 (five different "principal does not own this task" cells all produce
 ``(RespondUnauthorized, not_task_principal)``; two "same idempotency key,
 different actor" cells both produce ``(RespondConflict,
 idempotency_key_reused)``; one cell, kind/version validation, is
-parametrized over two reasons on its own). The full cell-to-pair mapping:
+parametrized over two reasons on its own). ``respond()`` takes no
+caller-supplied optimistic-concurrency token, so there is no cell for a
+stale one -- the matrix's ``Stale`` row has six pairs, not seven, for that
+reason. The full cell-to-pair mapping:
 
     OK        -> (Accepted, None)                                    1
     V1        -> (ValidationRejected, unknown_kind)                  }  2
@@ -31,29 +34,30 @@ parametrized over two reasons on its own). The full cell-to-pair mapping:
     R1        -> (Replayed, None)                                    1
     C1        -> (Conflict, already_answered)                        1
     C2,C3     -> (Conflict, idempotency_key_reused)      1 (2 cells share it)
-    S1..S7    -> seven distinct (Stale, *) pairs                     7
+    S1..S6    -> six distinct (Stale, *) pairs                       6
     X1        -> (OutcomeUnknown, None)                              1
     -----------------------------------------------------------------
-    25 cells; 21 distinct pairs (19 single-reason cells + V1's own 2)
+    24 cells; 20 distinct pairs (18 single-reason cells + V1's own 2)
 
-This delivery does **not** write the 25 cell-by-cell tests this matrix
-implies -- ``respond()`` itself is not implemented here (see the module
-docstring in ``task_interaction_service.py``), so there is no behavior yet
-for those tests to pin. What this delivery does write is the vocabulary
-guard below (``test_respond_outcome_vocabulary_has_exactly_21_pairs``),
-which is a different assertion from either the cell-by-cell tests or a
-mapping meta-test, per the three-way division of labor between the
-assertion layers:
+The cell-by-cell tests this matrix implies, and the mapping meta-test that
+checks their coverage against the vocabulary, are both in this file now,
+alongside ``respond()``'s own implementation. The vocabulary itself is
+enforced by the type system -- each outcome's reason is its own
+``Literal`` -- backed by a union-membership test confirming
+``RespondOutcome`` still has exactly its eight known variants, which
+leaves a two-way division of labor between the remaining assertion
+layers:
 
 | Assertion | Checks | Catches | Misses |
 |---|---|---|---|
-| Vocabulary closure (this file, written) | The set of (outcome, reason) pairs RespondOutcome can produce == the 21-pair vocabulary | A new reason constant or outcome variant added without updating the vocabulary | Cell-level coverage |
-| Cell-by-cell tests (not written here; land with respond()) | One test per of the 25 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
-| Mapping meta-test (not written here; lands with respond()) | Each of the 21 pairs is produced by >= 1 cell's test (19 singles + V1's 2) | A new cell that produces a new pair with no test written for it; V1's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a sixth not_task_principal scenario) -- caught by review, not this meta-test |
+| Union-membership guard (this file, written) | ``RespondOutcome`` has exactly its eight known member classes | A variant added or removed without updating this list | Reason-level coverage |
+| Cell-by-cell tests (this file, written) | One test per of the 24 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
+| Mapping meta-test (this file, written) | Each of the 20 pairs is produced by >= 1 cell's test (18 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a sixth not_task_principal scenario) -- caught by review, not this meta-test |
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
@@ -61,6 +65,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -68,7 +73,7 @@ from tests.web.services.task_interaction_schema_shared import make_task, make_us
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.models.database import Base
-from xagent.web.models.task import Task, TraceEvent
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import task_interaction_service as svc
 from xagent.web.services.ops_signals import (
@@ -93,30 +98,39 @@ def _clean_degradation_registry():
 
 
 # ---------------------------------------------------------------------------
-# Vocabulary guards (three pinned numbers -- do not recompute them here):
+# CreateOutcome's vocabulary guards (two pinned numbers, still plain dicts
+# in the source -- do not recompute them here):
 #
-#   - RespondOutcome: 21 (outcome type, reason) pairs.
 #   - CreateOutcome reason word list: 13 words total, across both delivery
 #     periods.
 #   - CreateOutcome pairs producible in this delivery specifically: 7.
 #
-# These guards prove the vocabulary stays closed at exactly these counts.
-# They do NOT prove every pair has a test written against it -- several
-# reasons are reachable from more than one triggering condition and are
-# indistinguishable at the (type, reason) level alone (see each dict's own
-# comment in the source for which ones collapse).
+# These guards prove CreateOutcome's vocabulary stays closed at exactly
+# these counts. They do NOT prove every pair has a test written against
+# it -- several reasons are reachable from more than one triggering
+# condition and are indistinguishable at the (type, reason) level alone
+# (see each dict's own comment in the source for which ones collapse).
+# RespondOutcome has no equivalent dict -- see the comment immediately
+# below this one for how its vocabulary is guarded instead.
 # ---------------------------------------------------------------------------
 
 
-def test_respond_outcome_vocabulary_has_exactly_21_pairs() -> None:
-    total = sum(
-        len(reasons) for reasons in svc.RESPOND_OUTCOME_REASON_VOCABULARY.values()
-    )
-    assert total == 21
+# RespondOutcome's reason vocabulary has no separate dict guard: each
+# outcome that carries a reason declares it as a ``Literal`` directly on
+# the dataclass field (see task_interaction_service.py), so the type
+# itself is the single source of the word list -- there is nothing left
+# for a count-guard test to protect against drifting out of sync with.
+# The two assertions below read that type back rather than duplicating it:
+# the first confirms the Union has exactly the eight known member classes,
+# the second (further down, next to the mapping meta-test) confirms the
+# 20 (outcome, reason) pairs it derives from those classes' own Literal
+# annotations still match what every test in this file actually produces.
 
 
-def test_respond_outcome_vocabulary_covers_all_eight_variants() -> None:
-    assert set(svc.RESPOND_OUTCOME_REASON_VOCABULARY) == {
+def test_respond_outcome_union_has_exactly_the_eight_known_variants() -> None:
+    import typing
+
+    assert {cls.__name__ for cls in typing.get_args(svc.RespondOutcome)} == {
         "RespondAccepted",
         "RespondValidationRejected",
         "RespondUnauthorized",
@@ -1172,6 +1186,112 @@ def test_get_scopes_by_task_id_not_by_interaction_id_alone(
 
 
 # ---------------------------------------------------------------------------
+# The answer fence: compile-time assertions against the predicate alone,
+# independent of ``respond()`` (the fence statement's own execution is
+# covered end to end by the full accepted-path and durable-graph-landed
+# tests further down, not by a standalone execution test here -- see the
+# fence functions' own docstrings for what they are reused by).
+# ---------------------------------------------------------------------------
+
+
+def _owning_principal_for_fence(user_id: int) -> svc.InteractionPrincipal:
+    return svc.InteractionPrincipal(
+        kind="user", user_id=user_id, is_admin=False, auth_mode=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# TaskStatusPredicate structural assertion. The active-row query
+# ``_active_native_row_criteria()`` builds never references ``Task.status``
+# at all (see that function's own docstring for why -- "is the task
+# WAITING_FOR_USER" is a concern the answer fence adds, not part of "which
+# row is the live one"), so this is the tripwire for the change that does
+# add a ``Task.status`` conjunct to a query built from this same predicate
+# (the answer fence, or the write-side reclaim statement): whichever lands
+# must keep this passing only because its new conjunct goes through
+# ``TaskStatusPredicate`` rather than a bare ``TaskStatus`` member-name
+# string.
+#
+# Walks the statement's own bind parameters rather than comparing
+# substrings of its compiled SQL text. A substring check here is
+# satisfiable by construction -- there is nothing in this query for it to
+# ever have found, since the query never touches ``Task.status`` at all --
+# so a version of this test written that way could never actually go red
+# on a real regression: it would still pass even if ``TaskStatusPredicate``
+# were dropped entirely and every ``Task.status`` comparison were rewritten
+# to compare bare enum members directly, because that comparison still
+# would not appear as a substring of *this* unrelated query's SQL text.
+# Reading the actual TaskStatus-typed bind values out of the unbuilt
+# ClauseElement tree instead means a future author who adds a TaskStatus
+# literal to this exact query turns this test red regardless of how
+# SQLAlchemy renders it. Verified with a real mutation: adding
+# ``Task.status == TaskStatus.WAITING_FOR_USER`` to the statement below
+# turns up one offending bind parameter; reverting it returns to zero.
+#
+# Needs no database connection -- unlike the fence-predicate compile test
+# just below, which needs a SQLite dialect object to compile against but
+# not an actual database either.
+# ---------------------------------------------------------------------------
+
+
+def test_active_row_query_uses_zero_taskstatus_bind_parameters() -> None:
+    from sqlalchemy.sql.elements import BindParameter
+    from sqlalchemy.sql.visitors import iterate
+
+    stmt = (
+        sa.select(TaskInteractionRequest)
+        .join(Task, Task.id == TaskInteractionRequest.task_id)
+        .where(
+            TaskInteractionRequest.task_id == 1,
+            *svc._active_native_row_criteria(),
+        )
+    )
+    taskstatus_binds = [
+        node
+        for node in iterate(stmt)
+        if isinstance(node, BindParameter) and isinstance(node.value, TaskStatus)
+    ]
+    assert taskstatus_binds == []
+
+
+def test_answer_fence_predicate_compiles_without_any_taskstatus_literal_string() -> (
+    None
+):
+    principal = _owning_principal_for_fence(1)
+    stmt = sa.select(TaskInteractionRequest).where(
+        TaskInteractionRequest.id == 1,
+        TaskInteractionRequest.task_id == 1,
+        Task.id == 1,
+        *svc._active_native_row_criteria(),
+        *svc._answer_fence_task_predicate(principal),
+    )
+    import sqlalchemy.dialects.sqlite
+
+    compiled = str(
+        stmt.compile(
+            dialect=sqlalchemy.dialects.sqlite.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    for member in TaskStatus:
+        assert member.name.lower() not in compiled
+    assert "WAITING_FOR_USER" in compiled
+
+
+def test_answer_fence_predicate_guest_branch_adds_a_json_lookup_term() -> None:
+    user_terms = svc._answer_fence_task_predicate(_owning_principal_for_fence(1))
+    guest_principal = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=1,
+        is_admin=False,
+        auth_mode="widget",
+        guest_id="guest-1",
+    )
+    guest_terms = svc._answer_fence_task_predicate(guest_principal)
+    assert len(guest_terms) == len(user_terms) + 1
+
+
+# ---------------------------------------------------------------------------
 # Structural guards: raw SQL and the _rowcount idiom.
 # ---------------------------------------------------------------------------
 
@@ -1184,10 +1304,10 @@ def test_module_issues_zero_sa_text_calls() -> None:
     match this assertion's own docstring and any future prose mention of
     ``sa.text`` in a comment.
 
-    This module does not perform any rowcount-based writes in this
-    delivery (create() validates and returns; it does not stage a row), so
-    there is no ``_rowcount``-idiom call to guard here yet -- that
-    obligation applies once a write path lands."""
+    ``respond()``'s answer fence and its rowcount-based classification are
+    both Core statements too (``sa.update(...)``, ``.with_for_update(...)``)
+    -- their absence from this scan is what proves them clean, not an
+    exemption."""
 
     import ast
     import inspect
@@ -1204,3 +1324,1455 @@ def test_module_issues_zero_sa_text_calls() -> None:
         elif isinstance(func, ast.Attribute) and func.attr == "text":
             text_calls.append(node)
     assert text_calls == []
+
+
+# ---------------------------------------------------------------------------
+# respond(): the answer-side entry point. respond() owns and retires its own
+# session (see its docstring), so every test below patches
+# ``xagent.web.models.database.get_session_local`` to hand back this file's
+# own file-backed SQLite session factory -- a bare ``:memory:`` database
+# cannot be shared across the separate connections respond()'s own session
+# and this test's setup/verification sessions each open.
+# ---------------------------------------------------------------------------
+
+import xagent.web.models.database as _database_module  # noqa: E402
+from xagent.web.models.task_command import TaskExecutionCommand  # noqa: E402
+from xagent.web.services.task_execution_controller import (  # noqa: E402
+    TaskControlState,
+)
+
+
+@pytest.fixture
+def _respond_db(monkeypatch: pytest.MonkeyPatch, _session_factory):
+    monkeypatch.setattr(_database_module, "get_session_local", lambda: _session_factory)
+    return _session_factory
+
+
+def _waiting_task(
+    session_factory,
+    *,
+    run_id: str = "run-a",
+    state_version: int = 5,
+    agent_config: dict[str, Any] | None = None,
+    channel_id: int | None = None,
+    agent_id: int | None = None,
+) -> tuple[int, int]:
+    """A task parked in WAITING_FOR_USER, the state every respond() test
+    starts from -- the answer fence's task-side predicate requires it."""
+
+    db = session_factory()
+    try:
+        user_id = make_user(db)
+        task_id = make_task(db, user_id=user_id)
+        task = db.query(Task).filter(Task.id == task_id).first()
+        task.status = TaskStatus.WAITING_FOR_USER
+        task.control_state = TaskControlState.WAITING_FOR_USER.value
+        task.run_id = run_id
+        task.state_version = state_version
+        task.channel_id = channel_id
+        task.agent_id = agent_id
+        if agent_config is not None:
+            task.agent_config = agent_config
+        db.commit()
+        return user_id, task_id
+    finally:
+        db.close()
+
+
+def _active_row_ready_for_respond(
+    session_factory,
+    *,
+    task_id: int,
+    run_id: str = "run-a",
+    idempotency_key: str | None = None,
+    anchor_run_partition: str | None = None,
+) -> int:
+    """An active interaction row with a resolvable anchor -- the state every
+    respond() test that expects to reach the fence (steps 5 onward) starts
+    from. ``anchor_run_partition``, when different from ``run_id``, is what
+    ``test_respond_reports_stale_when_the_anchor_points_at_a_different_run_partition``
+    below uses to force the anchor resolver's own partition check to fail
+    without touching the interaction row's ``run_id`` (the fence's own,
+    separate run comparison)."""
+
+    db = session_factory()
+    try:
+        trace_event_id = _make_trace_event(
+            db, task_id=task_id, run_partition=anchor_run_partition or run_id
+        )
+        row = _make_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id=run_id,
+            resume_trace_event_id=trace_event_id,
+            resume_run_partition=run_id,
+        )
+        if idempotency_key is not None:
+            row.request_idempotency_key = idempotency_key
+            db.commit()
+        return int(row.id)
+    finally:
+        db.close()
+
+
+def _answered_row_with_valid_anchor(
+    session_factory,
+    *,
+    task_id: int,
+    run_id: str,
+    responder_identity: str,
+    response_payload: dict[str, Any],
+    idempotency_key: str = "prior-answer-key",
+) -> int:
+    """A row this service already answered in some earlier, successful call
+    -- its resume anchor is still valid (nothing has pruned the checkpoint
+    it points at), which is what makes it reachable past step 4.5 for the
+    already-answered classification tests below."""
+
+    db = session_factory()
+    try:
+        trace_event_id = _make_trace_event(db, task_id=task_id, run_partition=run_id)
+        row = _make_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id=run_id,
+            resume_trace_event_id=trace_event_id,
+            resume_run_partition=run_id,
+        )
+        now = _now()
+        row.status = "answered"
+        row.active_slot = None
+        row.response_payload = response_payload
+        row.responded_at = now
+        row.responder_identity = responder_identity
+        row.request_idempotency_key = idempotency_key
+        db.commit()
+        return int(row.id)
+    finally:
+        db.close()
+
+
+def _terminated_row_with_valid_anchor(
+    session_factory,
+    *,
+    task_id: int,
+    run_id: str,
+    terminal_reason: str,
+    idempotency_key: str = "terminated-row-key",
+) -> int:
+    db = session_factory()
+    try:
+        trace_event_id = _make_trace_event(db, task_id=task_id, run_partition=run_id)
+        row = _make_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id=run_id,
+            resume_trace_event_id=trace_event_id,
+            resume_run_partition=run_id,
+        )
+        now = _now()
+        row.status = "terminated"
+        row.active_slot = None
+        row.terminal_reason = terminal_reason
+        row.terminated_at = now
+        row.request_idempotency_key = idempotency_key
+        db.commit()
+        return int(row.id)
+    finally:
+        db.close()
+
+
+def _stage_matching_command(
+    session_factory,
+    *,
+    task_id: int,
+    actor_user_id: int | None,
+    command_id: str,
+    payload: dict[str, Any],
+    status: str = "completed",
+) -> int:
+    db = session_factory()
+    try:
+        command = TaskExecutionCommand(
+            task_id=task_id,
+            actor_user_id=actor_user_id,
+            command_id=command_id,
+            kind=svc.TaskCommandKind.RESUME.value,
+            payload=payload,
+            status=status,
+        )
+        db.add(command)
+        db.commit()
+        db.refresh(command)
+        return int(command.id)
+    finally:
+        db.close()
+
+
+def _owning_user_principal(user_id: int) -> svc.InteractionPrincipal:
+    return svc.InteractionPrincipal(
+        kind="user",
+        user_id=user_id,
+        is_admin=False,
+        auth_mode=None,
+    )
+
+
+def _respond_envelope(**overrides: Any) -> svc.RespondEnvelope:
+    defaults: dict[str, Any] = {
+        "kind": "clarification",
+        "protocol_version": 1,
+        "values": {"env": "prod"},
+        "idempotency_key": "respond-key-1",
+    }
+    defaults.update(overrides)
+    return svc.RespondEnvelope(**defaults)
+
+
+def _graph_snapshot(
+    session_factory, *, task_id: int, interaction_id: int
+) -> dict[str, Any]:
+    """A comparable snapshot of the three tables respond() can touch, for
+    the "zero side effects" half of every rejection-path assertion below."""
+
+    db = session_factory()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        ir = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == interaction_id)
+            .first()
+        )
+        commands = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.task_id == task_id)
+            .count()
+        )
+        return {
+            "task_state_version": task.state_version if task is not None else None,
+            "task_control_state": task.control_state if task is not None else None,
+            "task_run_id": task.run_id if task is not None else None,
+            "ir_status": ir.status if ir is not None else None,
+            "ir_active_slot": ir.active_slot if ir is not None else None,
+            "ir_response_payload": ir.response_payload if ir is not None else None,
+            "ir_responder_identity": ir.responder_identity if ir is not None else None,
+            "ir_responder_user_id": ir.responder_user_id if ir is not None else None,
+            "ir_responded_at": ir.responded_at if ir is not None else None,
+            "ir_updated_at": ir.updated_at if ir is not None else None,
+            "commands_count": commands,
+        }
+    finally:
+        db.close()
+
+
+@contextlib.contextmanager
+def _asserts_no_side_effects(
+    session_factory, *, task_id: int, interaction_id: int
+) -> Any:
+    """Wrap a rejection-path ``respond()`` call and confirm it left the
+    task/interaction/command graph exactly as it found it. Snapshots on
+    entry, yields to the body (which calls ``svc.respond()`` and asserts on
+    its outcome), and compares snapshots on exit -- the "zero side effects"
+    half of every rejection-path test below, previously written out as a
+    repeated ``before = _graph_snapshot(...)`` / ``assert ... == before``
+    pair at each call site."""
+
+    before = _graph_snapshot(
+        session_factory, task_id=task_id, interaction_id=interaction_id
+    )
+    yield
+    after = _graph_snapshot(
+        session_factory, task_id=task_id, interaction_id=interaction_id
+    )
+    assert after == before
+
+
+def _conflict_counter() -> int:
+    """The current value of the response-conflict counter, the same
+    process-local registry ``respond()`` itself increments through
+    (``xagent.web.services.interaction_rollout``)."""
+
+    from xagent.web.services import interaction_rollout as rollout_module
+
+    return rollout_module.counters_snapshot().get(
+        svc.COUNTER_LIFECYCLE_RESPONSE_CONFLICT, 0
+    )
+
+
+# ---------------------------------------------------------------------------
+# The pure-read path: envelope validation, task/interaction existence,
+# authorization, and anchor resolution -- steps 1 through 4.5. Twelve cells,
+# each asserting outcome, reason, and zero side effects.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"kind": "not_a_real_kind"}, id="unknown_kind"),
+        pytest.param({"protocol_version": 2}, id="unknown_protocol_version"),
+        # Type-before-value: a non-str kind must be rejected by an isinstance
+        # check before it ever reaches the vocabulary membership test, which
+        # raises TypeError on an unhashable value (a list, a dict) instead of
+        # returning a typed outcome if the type check is skipped.
+        pytest.param({"kind": ["clarification"]}, id="kind_is_a_list"),
+        pytest.param({"kind": {"clarification": 1}}, id="kind_is_a_dict"),
+        # Type-before-value: bool is a subclass of int (True == 1) and a
+        # float compares equal to an int of the same value (1.0 == 1), so
+        # both must be rejected by an isinstance check before the equality
+        # comparison, or they would silently pass validation.
+        pytest.param({"protocol_version": True}, id="protocol_version_is_a_bool"),
+        pytest.param({"protocol_version": 1.0}, id="protocol_version_is_a_float"),
+    ],
+)
+def test_respond_rejects_an_envelope_outside_the_known_kind_or_version_vocabulary(
+    _respond_db, overrides: dict[str, Any]
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(**overrides),
+        )
+
+        if "kind" in overrides:
+            assert outcome == svc.RespondValidationRejected(reason="unknown_kind")
+        else:
+            assert outcome == svc.RespondValidationRejected(
+                reason="unknown_protocol_version"
+            )
+
+
+def test_respond_rejects_an_idempotency_key_that_is_not_url_safe(_respond_db) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(idempotency_key="has a space"),
+        )
+
+        assert outcome == svc.RespondValidationRejected(
+            reason="malformed_idempotency_key"
+        )
+
+
+def test_respond_rejects_answer_values_that_are_not_a_dict(_respond_db) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(values="not-a-dict"),
+        )
+
+        assert outcome == svc.RespondValidationRejected(reason="invalid_values")
+
+
+def test_respond_rejects_when_the_stored_row_disagrees_with_the_envelope_on_protocol_version(
+    _respond_db,
+) -> None:
+    """The row's own protocol_version can only differ from 1 once it is no
+    longer active (``ck_task_interaction_requests_active_protocol`` pins an
+    active row's protocol_version to 1), so this cell is built on a row that
+    has already reached a terminal state under an older protocol."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    now = _now()
+    db = _respond_db()
+    try:
+        row = TaskInteractionRequest(
+            task_id=task_id,
+            run_id="run-a",
+            kind="clarification",
+            protocol_version=2,
+            status="terminated",
+            active_slot=None,
+            origin="internal",
+            request_payload={"message": "q", "interactions": []},
+            request_idempotency_key="protocol-mismatch-key",
+            resume_trace_event_id=None,
+            resume_event_id="resume-event-1",
+            resume_execution_id="exec-1",
+            resume_locator_format="trace_event_pk_v1",
+            resume_checkpoint_type="agent_execution_checkpoint",
+            resume_run_partition="run-a",
+            terminal_reason="deadline_elapsed",
+            terminated_at=now,
+            created_at=now,
+            expires_at=now + timedelta(minutes=15),
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        interaction_id = int(row.id)
+    finally:
+        db.close()
+
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(protocol_version=1),
+        )
+
+        assert outcome == svc.RespondValidationRejected(reason="kind_version_mismatch")
+
+
+def test_respond_rejects_a_user_principal_that_does_not_own_the_task(
+    _respond_db,
+) -> None:
+    owner_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    intruder = svc.InteractionPrincipal(
+        kind="user",
+        user_id=owner_id + 987654,
+        is_admin=False,
+        auth_mode=None,
+    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=intruder,
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+def test_respond_rejects_a_guest_whose_bindings_match_but_principal_user_id_does_not(
+    _respond_db,
+) -> None:
+    """A guest principal whose ``guest_id`` and entity binding both match
+    the task -- so step 3's ``task_is_owned_by_public_principal`` passes,
+    since that predicate never reads ``principal.user_id`` at all -- but
+    whose ``user_id`` field does not match the task's real owner. Step 3
+    has nothing to catch this with; the fence's own ``Task.user_id ==
+    principal.user_id`` term (present for both principal kinds, not only
+    the guest-specific JSON check) is what refuses it, on both backends,
+    since this is a plain mismatch present from the start, not a
+    concurrent change to catch only via SQLite's missing lock."""
+
+    owner_id, task_id = _waiting_task(
+        _respond_db,
+        agent_config={
+            "auth_mode": "widget",
+            "guest_id": "guest-1",
+            "widget_workforce_id": 10,
+        },
+    )
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    wrong_user_id = make_user(_respond_db())
+    guest = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=wrong_user_id,
+        is_admin=False,
+        auth_mode="widget",
+        widget_workforce_id=10,
+        guest_id="guest-1",
+    )
+    assert wrong_user_id != owner_id
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=guest,
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+def test_respond_reports_unavailable_when_the_task_row_does_not_exist(
+    _respond_db,
+) -> None:
+    outcome = svc.respond(
+        interaction_id=1,
+        task_id=999_999_999,
+        principal=_owning_user_principal(1),
+        envelope=_respond_envelope(),
+    )
+
+    assert outcome == svc.RespondUnavailable(reason="task_missing")
+
+
+def test_respond_reports_unavailable_when_the_interaction_row_does_not_exist(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    with _asserts_no_side_effects(_respond_db, task_id=task_id, interaction_id=999_999):
+        outcome = svc.respond(
+            interaction_id=999_999,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnavailable(reason="interaction_missing")
+
+
+def test_respond_reports_unavailable_when_the_anchor_row_fetch_raises(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        from sqlalchemy.orm import Session as OrmSession
+
+        original_get = OrmSession.get
+
+        def _raising_get(
+            self: Any, model: Any, pk: Any, *args: Any, **kwargs: Any
+        ) -> Any:
+            if model is TraceEvent:
+                raise RuntimeError("simulated session failure")
+            return original_get(self, model, pk, *args, **kwargs)
+
+        monkeypatch.setattr(OrmSession, "get", _raising_get)
+
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnavailable(reason="checkpoint_unavailable")
+
+
+def test_respond_reports_stale_when_the_anchor_points_at_a_different_run_partition(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(
+        _respond_db, task_id=task_id, anchor_run_partition="a-different-partition"
+    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondStale(reason="anchor_dangling")
+
+
+# ---------------------------------------------------------------------------
+# Idempotency, the version short-circuit, and the answer fence's
+# zero-rowcount classification -- steps 5, 5.5, and 6. Eleven cells plus the
+# authorization-before-idempotency ordering guard.
+# ---------------------------------------------------------------------------
+
+
+def test_respond_returns_the_original_receipt_for_a_matching_replay(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    principal = _owning_user_principal(user_id)
+    values = {"env": "prod"}
+    command_id = "replay-key-1"
+    interaction_id = _answered_row_with_valid_anchor(
+        _respond_db,
+        task_id=task_id,
+        run_id="run-a",
+        responder_identity=principal.identity_string(),
+        response_payload=values,
+    )
+    payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values=values
+    )
+    _stage_matching_command(
+        _respond_db,
+        task_id=task_id,
+        actor_user_id=principal.user_id,
+        command_id=command_id,
+        payload=payload,
+    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(idempotency_key=command_id, values=values),
+        )
+
+        assert isinstance(outcome, svc.RespondReplayed)
+        assert outcome.receipt.responder_identity == principal.identity_string()
+        assert outcome.receipt.idempotency_key == command_id
+
+
+def test_respond_reports_conflict_for_an_already_answered_row_under_a_fresh_key(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    principal = _owning_user_principal(user_id)
+    interaction_id = _answered_row_with_valid_anchor(
+        _respond_db,
+        task_id=task_id,
+        run_id="run-a",
+        responder_identity=principal.identity_string(),
+        response_payload={"env": "prod"},
+    )
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(idempotency_key="never-seen-before"),
+        )
+
+        assert outcome == svc.RespondConflict(reason="already_answered")
+    assert _conflict_counter() == before_counter + 1
+
+
+def test_respond_reports_conflict_for_the_same_key_with_a_different_payload(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    principal = _owning_user_principal(user_id)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    command_id = "shared-key-1"
+    staged_payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values={"env": "staging"}
+    )
+    _stage_matching_command(
+        _respond_db,
+        task_id=task_id,
+        actor_user_id=principal.user_id,
+        command_id=command_id,
+        payload=staged_payload,
+    )
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(
+                idempotency_key=command_id, values={"env": "prod"}
+            ),
+        )
+
+        assert outcome == svc.RespondConflict(reason="idempotency_key_reused")
+    assert _conflict_counter() == before_counter + 1
+
+
+def test_respond_reports_conflict_when_a_guest_and_the_owner_share_one_key(
+    _respond_db,
+) -> None:
+    """The same idempotency key and the same answer values, submitted once
+    as a guest and once as the owning user. Without ``responder_identity``
+    in the staged payload this would misclassify as a replay -- see
+    ``_respond_command_payload``'s own docstring."""
+
+    values = {"env": "prod"}
+    owner_id, task_id = _waiting_task(
+        _respond_db, agent_config={"auth_mode": "widget", "guest_id": "guest-1"}
+    )
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    command_id = "shared-key-guest-owner"
+    guest = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=owner_id,
+        is_admin=False,
+        auth_mode="widget",
+        widget_agent_id=None,
+        guest_id="guest-1",
+    )
+    guest_payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=guest, values=values
+    )
+    _stage_matching_command(
+        _respond_db,
+        task_id=task_id,
+        actor_user_id=guest.user_id,
+        command_id=command_id,
+        payload=guest_payload,
+    )
+    owner = _owning_user_principal(owner_id)
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=owner,
+            envelope=_respond_envelope(idempotency_key=command_id, values=values),
+        )
+
+        assert outcome == svc.RespondConflict(reason="idempotency_key_reused")
+    assert _conflict_counter() == before_counter + 1
+
+
+@pytest.mark.parametrize(
+    "terminal_reason,expected_reason",
+    [
+        pytest.param("deadline_elapsed", "expired", id="expired"),
+        pytest.param("run_superseded", "run_superseded", id="run_superseded"),
+        pytest.param(
+            "answered_via_legacy_resume", "answered_via_chat", id="answered_via_chat"
+        ),
+    ],
+)
+def test_respond_reports_stale_for_a_terminated_row(
+    _respond_db, terminal_reason: str, expected_reason: str
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _terminated_row_with_valid_anchor(
+        _respond_db, task_id=task_id, run_id="run-a", terminal_reason=terminal_reason
+    )
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(idempotency_key="never-seen-before-terminal"),
+        )
+
+        if expected_reason == "expired":
+            assert outcome == svc.RespondStale(reason="expired")
+        elif expected_reason == "run_superseded":
+            assert outcome == svc.RespondStale(reason="run_superseded")
+        else:
+            assert outcome == svc.RespondStale(reason="answered_via_chat")
+    # Reverse assertion: a Stale outcome must never increment the
+    # response-conflict counter -- only the three Conflict cells do.
+    assert _conflict_counter() == before_counter
+
+
+def test_respond_reports_stale_when_the_task_has_moved_on_from_waiting(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    db = _respond_db()
+    try:
+        db.query(Task).filter(Task.id == task_id).update({"status": TaskStatus.RUNNING})
+        db.commit()
+    finally:
+        db.close()
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondStale(reason="run_ended")
+    assert _conflict_counter() == before_counter
+
+
+def test_respond_reports_stale_when_the_task_is_waiting_on_a_different_run(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db, run_id="run-current")
+    interaction_id = _active_row_ready_for_respond(
+        _respond_db, task_id=task_id, run_id="run-old"
+    )
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_user_principal(user_id),
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondStale(reason="foreign_run")
+    assert _conflict_counter() == before_counter
+
+
+def _racing_fence_stmt_that_changes_ownership(
+    session_factory, *, task_id: int, intruder_owner_id: int
+) -> Any:
+    """Build a monkeypatch replacement for ``svc._answer_fence_stmt`` that
+    races a concurrent ownership change onto the task row between step 2's
+    read and the fence statement's own execution -- the SQLite-only TOCTOU
+    window (SQLite's dialect drops ``FOR UPDATE`` entirely; PostgreSQL's row
+    lock closes it, see ``_answer_fence_task_predicate``'s own docstring) the
+    test below needs to reproduce it."""
+
+    real_fence_stmt = svc._answer_fence_stmt
+
+    def _racing_fence_stmt(*args: Any, **kwargs: Any) -> Any:
+        race_db = session_factory()
+        try:
+            race_db.query(Task).filter(Task.id == task_id).update(
+                {"user_id": intruder_owner_id}
+            )
+            race_db.commit()
+        finally:
+            race_db.close()
+        return real_fence_stmt(*args, **kwargs)
+
+    return _racing_fence_stmt
+
+
+def test_respond_reports_unauthorized_when_ownership_changes_between_the_check_and_the_write(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The SQLite-only TOCTOU window between step 3's authorization read and
+    step 6's write-point fence (see ``_answer_fence_task_predicate``'s own
+    docstring for why PostgreSQL's row lock closes this window and SQLite's
+    dialect does not)."""
+
+    owner_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    intruder_owner_id = make_user(_respond_db())
+
+    monkeypatch.setattr(
+        svc,
+        "_answer_fence_stmt",
+        _racing_fence_stmt_that_changes_ownership(
+            _respond_db, task_id=task_id, intruder_owner_id=intruder_owner_id
+        ),
+    )
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=_owning_user_principal(owner_id),
+        envelope=_respond_envelope(),
+    )
+
+    assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+def test_respond_checks_authorization_before_the_idempotency_prequery(
+    _respond_db,
+) -> None:
+    """An unauthorized caller must never be able to use a guessed
+    idempotency key to read back someone else's receipt."""
+
+    owner_id, task_id = _waiting_task(_respond_db)
+    principal = _owning_user_principal(owner_id)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    command_id = "someone-elses-key"
+    values = {"env": "prod"}
+    payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values=values
+    )
+    _stage_matching_command(
+        _respond_db,
+        task_id=task_id,
+        actor_user_id=owner_id,
+        command_id=command_id,
+        payload=payload,
+    )
+    intruder = svc.InteractionPrincipal(
+        kind="user",
+        user_id=owner_id + 42_424_242,
+        is_admin=False,
+        auth_mode=None,
+    )
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=intruder,
+        envelope=_respond_envelope(idempotency_key=command_id, values=values),
+    )
+
+    assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+# ---------------------------------------------------------------------------
+# The write path: the Task CAS, staging the command, commit-or-reconcile,
+# and dispatcher notification -- steps 7 through 10.
+# ---------------------------------------------------------------------------
+
+
+def test_respond_accepts_a_fully_valid_answer_and_fills_every_receipt_field(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db, state_version=5)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    dispatched: list[bool] = []
+    import xagent.web.services.task_interaction_service as svc_module
+
+    monkeypatch_target = svc_module.notify_task_command_dispatcher
+
+    def _record_dispatch() -> None:
+        dispatched.append(True)
+
+    svc_module.notify_task_command_dispatcher = _record_dispatch
+    try:
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(idempotency_key="ok-path-key"),
+        )
+    finally:
+        svc_module.notify_task_command_dispatcher = monkeypatch_target
+
+    assert isinstance(outcome, svc.RespondAccepted)
+    receipt = outcome.receipt
+    assert receipt.interaction_id == interaction_id
+    assert receipt.task_id == task_id
+    assert receipt.run_id == "run-a"
+    assert receipt.status == "answered"
+    assert receipt.responded_at is not None
+    assert receipt.responder_identity == principal.identity_string()
+    assert receipt.idempotency_key == "ok-path-key"
+    assert receipt.command_db_id > 0
+    assert receipt.task_state_version == 6
+    assert receipt.task_control_state == TaskControlState.RESUME_REQUESTED.value
+    assert dispatched == [True]
+
+    after = _graph_snapshot(_respond_db, task_id=task_id, interaction_id=interaction_id)
+    assert after["ir_status"] == "answered"
+    assert after["ir_active_slot"] is None
+    assert after["ir_response_payload"] == {"env": "prod"}
+    assert after["task_state_version"] == 6
+    assert after["commands_count"] == 1
+
+
+def test_respond_receipt_fields_do_not_touch_the_session_after_commit(
+    _respond_db,
+) -> None:
+    """Every value on a returned receipt is a plain Python value captured
+    before commit -- reading it after the caller (here, the test itself)
+    expires every object on the session must not re-issue any SQL."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="expire-all-check"),
+    )
+    assert isinstance(outcome, svc.RespondAccepted)
+    receipt = outcome.receipt
+
+    verify_db = _respond_db()
+    try:
+        verify_db.expire_all()
+        query_count = 0
+
+        def _count_queries(*_args: Any, **_kwargs: Any) -> None:
+            nonlocal query_count
+            query_count += 1
+
+        from sqlalchemy import event
+
+        event.listen(verify_db.get_bind(), "before_cursor_execute", _count_queries)
+        try:
+            _ = (
+                receipt.interaction_id,
+                receipt.task_id,
+                receipt.run_id,
+                receipt.status,
+                receipt.responded_at,
+                receipt.responder_identity,
+                receipt.idempotency_key,
+                receipt.command_db_id,
+                receipt.task_state_version,
+                receipt.task_control_state,
+            )
+        finally:
+            event.remove(verify_db.get_bind(), "before_cursor_execute", _count_queries)
+        assert query_count == 0
+    finally:
+        verify_db.close()
+
+
+def test_rowcount_helper_does_not_raise_on_a_bare_test_double() -> None:
+    from unittest.mock import MagicMock
+
+    class _NoRowcount:
+        pass
+
+    assert svc._rowcount(_NoRowcount()) == 0
+    assert svc._rowcount(MagicMock(rowcount=3)) == 3
+
+
+def test_respond_reports_outcome_unknown_when_commit_ack_is_lost_and_the_graph_never_lands(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Injects a commit failure and never lets the durable-graph
+    reconciliation find a matching command row (by using a task_id the
+    reconciliation query cannot see any command for), forcing all three
+    reconciliation attempts to fail."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+
+    def _failing_commit(self: Any) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
+
+    monkeypatch.setattr(OrmSession, "commit", _failing_commit)
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="ambiguous-commit-no-graph"),
+    )
+
+    assert isinstance(outcome, svc.RespondOutcomeUnknown)
+
+
+def test_respond_reports_accepted_when_commit_ack_is_lost_but_the_graph_landed(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same injected failure as the OutcomeUnknown case above, except this
+    time the underlying commit genuinely succeeded at the database layer
+    (only the acknowledgment back to this process was lost) -- proving the
+    reconciliation path returns Accepted, not a false negative, once the
+    complete graph is actually there to find."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+
+    def _lost_ack_but_committed(self: Any) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            original_commit(self)
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
+
+    monkeypatch.setattr(OrmSession, "commit", _lost_ack_but_committed)
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="ambiguous-commit-landed"),
+    )
+
+    assert isinstance(outcome, svc.RespondAccepted)
+    assert outcome.receipt.responder_identity == principal.identity_string()
+
+
+def test_respond_durable_graph_check_is_monotone_when_the_coordinator_has_already_advanced_state(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The resume coordinator re-issues the same RESUME_REQUESTED
+    transition once it applies the command this call staged, bumping
+    state_version a second time -- the durable-graph check must still
+    report Accepted against a state_version that has moved past what this
+    call itself wrote, and must not compare control_state (see respond()'s
+    own docstring)."""
+
+    user_id, task_id = _waiting_task(_respond_db, state_version=5)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+
+    def _lost_ack_then_coordinator_advances(self: Any) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            original_commit(self)
+            # Simulate the coordinator re-applying its own transition on a
+            # separate connection before this call's reconciliation runs.
+            side_db = _respond_db()
+            try:
+                side_db.query(Task).filter(Task.id == task_id).update(
+                    {
+                        "state_version": Task.state_version + 1,
+                        "control_state": "running",
+                    }
+                )
+                side_db.commit()
+            finally:
+                side_db.close()
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
+
+    monkeypatch.setattr(OrmSession, "commit", _lost_ack_then_coordinator_advances)
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="monotone-check"),
+    )
+
+    assert isinstance(outcome, svc.RespondAccepted)
+
+
+def test_respond_reports_outcome_unknown_when_the_landed_row_answers_a_different_identity(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same lost-commit-acknowledgment injection as the two cases above, but
+    this time the row the durable-graph check reads back was answered under
+    a *different* ``responder_identity`` than the one this call's own
+    principal carries. A mismatched identity, not an absent one, is the
+    only way an answered row can fail to attest to this call: two CHECK
+    constraints chain to rule out a null identity on an answered row --
+    ``ck_task_interaction_requests_responded_at_pairs_status`` ties
+    ``status = 'answered'`` to ``responded_at IS NOT NULL``, and
+    ``ck_task_interaction_requests_responder_pairs_responded_at`` ties
+    ``responded_at IS NOT NULL`` to ``responder_identity IS NOT NULL`` --
+    so an answered row always carries *some* identity, just not
+    necessarily this call's own. See ``_verify_respond_durable_graph``'s
+    own docstring for why the comparison exists. The reconciliation must
+    not treat "an answer landed" as "my answer landed": with nothing tying
+    the row to this principal, every attempt has to keep failing and the
+    call must report OutcomeUnknown, never Accepted.
+    """
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_user_principal(user_id)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+
+    def _lost_ack_but_landed_under_another_identity(self: Any) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            original_commit(self)
+            # The row genuinely committed (columns and all), but stamped
+            # with a different identity than this call's own principal --
+            # standing in for the row this call's ambiguous commit might
+            # have raced against, not a corruption of this call's own
+            # write.
+            side_db = _respond_db()
+            try:
+                side_db.query(TaskInteractionRequest).filter(
+                    TaskInteractionRequest.id == interaction_id
+                ).update({"responder_identity": "user:999999"})
+                side_db.commit()
+            finally:
+                side_db.close()
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
+
+    monkeypatch.setattr(
+        OrmSession, "commit", _lost_ack_but_landed_under_another_identity
+    )
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="ambiguous-commit-wrong-identity"),
+    )
+
+    assert isinstance(outcome, svc.RespondOutcomeUnknown)
+
+
+# ---------------------------------------------------------------------------
+# classify_task_command_conflict's IntegrityError branch (step 8), reached
+# when stage_task_command's own insert (inside this call's own
+# `db.begin_nested()`) collides with a UNIQUE or FOREIGN KEY constraint.
+# This repo already has real coverage for classify_task_command_conflict
+# itself (test_task_command_transport.py) and for the pre-existing-command
+# shortcut at step 5 (the idempotency_key_reused cells above), but never for
+# this specific call site -- respond() reaching an IntegrityError on its own
+# insert has no test anywhere in the repo before this delivery.
+#
+# Of TaskCommandConflictKind's three values, only RACED_DUPLICATE is
+# reachable here, and only on PostgreSQL. The other two are not reachable
+# through respond() at all, verified against the real code rather than
+# assumed:
+#
+# - UNRELATED needs the staged row's actor_user_id foreign key to fail --
+#   the referenced user deleted out from under a still-pending insert. In
+#   respond(), actor_user_id is always `principal.user_id`, and the answer
+#   fence's own task-side predicate (`_answer_fence_task_predicate`)
+#   requires `Task.user_id == principal.user_id` unconditionally for
+#   *both* principal kinds (guest included -- its "owning user" is the
+#   value in this same term) as a condition of the fence UPDATE actually
+#   matching a row. Confirmed by running an admin principal whose user_id
+#   does not equal the task's owner through respond(): the fence's own
+#   ownership term rejects it before step 8, at rowcount=0's
+#   `not_task_principal` classification, in the *reread* branch (`if
+#   reread.status == "active": ... return RespondUnauthorized(...)`) --
+#   `principal.is_admin` only bypasses the earlier, separate Python check
+#   at step 3, never the fence's own SQL. So the only user_id that can ever
+#   reach step 8 is the task's actual owner, and that user cannot be
+#   deleted while this same transaction still holds the task row it owns
+#   (`tasks.user_id` has no `ondelete`, i.e. FK `RESTRICT` -- deleting it
+#   while a referencing task row exists is rejected at the database level,
+#   independent of any lock this transaction holds). UNRELATED gets no
+#   test.
+# - TASK_MISSING needs the task to disappear between step 2 and step 8.
+#   respond() holds the tasks row through step 2's `with_for_update` for
+#   the whole transaction, and by step 8 has already written on this same
+#   connection at steps 6 and 7 -- on PostgreSQL that is the row lock
+#   itself blocking a concurrent DELETE; on SQLite (where `with_for_update`
+#   compiles to nothing, see
+#   `test_every_with_for_update_call_passes_key_share_true`'s own
+#   docstring) it is SQLite's whole-database writer lock, already held by
+#   this connection since step 6's fence UPDATE. Either way a concurrent
+#   delete of this task cannot land before this call's own insert attempt,
+#   so classify_task_command_conflict can never observe the task gone
+#   here. TASK_MISSING gets no test either.
+#
+# RACED_DUPLICATE needs a second writer to commit a row for the same
+# (task_id, command_id) strictly between stage_task_command's own
+# existing-row check and its own insert flush -- a real second connection
+# genuinely open at that instant, not a pre-committed row (which either of
+# respond()'s own two earlier existing-command checks, at step 5 and inside
+# stage_task_command itself, would catch first and never reach the flush
+# at all). SQLite cannot reproduce this: by the time respond() reaches
+# step 8 it has already written the fence UPDATE (step 6) and the CAS
+# (step 7) on this same connection, which already holds SQLite's one
+# whole-database writer lock (the same fact
+# `postgres_task_command_sessions`'s own docstring in
+# test_task_command_transport.py documents for the sibling raced-insert
+# test on enqueue_task_command) -- a second writer's commit cannot land
+# inside that window until this transaction ends. PostgreSQL's row lock,
+# held by step 2's `with_for_update` only on the specific `tasks` row,
+# does not extend to the `task_execution_commands` table, so a second
+# writer can complete there while this transaction is still open. Both of
+# RACED_DUPLICATE's sub-branches (payload_matches True and False -- they
+# produce different RespondOutcomes and only one increments the conflict
+# counter) live in test_task_interaction_service_postgresql.py for that
+# reason; nothing in this file exercises this call site.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# The mapping meta-test. For every one of the 20 (outcome, reason) pairs in
+# the vocabulary, at least one test above must produce it. This is
+# deliberately not an arithmetic comparison against the total cell count
+# (see the module docstring's three-way division of labor table) -- several
+# triggering conditions collapse onto the same pair (five distinct
+# "principal does not own this task" scenarios all produce
+# ``not_task_principal``; two distinct "same idempotency key, different
+# submitter" scenarios both produce ``idempotency_key_reused``), and one
+# validation scenario is parametrized over two reasons on its own.
+# ---------------------------------------------------------------------------
+
+
+def _expected_respond_outcome_vocabulary() -> set[tuple[str, str | None]]:
+    """The (outcome type, reason) pairs ``RespondOutcome`` can produce,
+    read directly off each member class's own ``reason`` field -- a
+    ``Literal`` for the five outcomes that carry one, absent entirely for
+    the three that do not (``RespondAccepted`` / ``RespondReplayed`` /
+    ``RespondOutcomeUnknown``, which contribute the reason-less pair
+    instead). This is the vocabulary itself, not a copy of it: there is no
+    separate dict for this function, or the tests that use it, to drift
+    out of sync with.
+    """
+
+    import typing
+
+    expected: set[tuple[str, str | None]] = set()
+    for cls in typing.get_args(svc.RespondOutcome):
+        hints = typing.get_type_hints(cls)
+        reason_hint = hints.get("reason")
+        if reason_hint is None:
+            expected.add((cls.__name__, None))
+            continue
+        for literal_value in typing.get_args(reason_hint):
+            expected.add((cls.__name__, literal_value))
+    return expected
+
+
+def test_every_vocabulary_pair_is_produced_by_at_least_one_cell_test() -> None:
+    """AST-based, not a hand-maintained checklist: scans this module's own
+    source for every ``svc.Respond<Type>(reason=...)`` construction and
+    every ``isinstance(outcome, svc.Respond<Type>)`` check the cell tests
+    above use, and cross-checks the resulting (type, reason) set against
+    the vocabulary. Deliberately not ``len(produced) == len(vocabulary)`` or
+    any other arithmetic against the 24-cell count -- five
+    not_task_principal cells and two idempotency_key_reused cells
+    legitimately collapse onto one pair each; this only asserts that no
+    vocabulary pair is left with zero producing cells."""
+
+    import ast
+    import inspect
+
+    module = inspect.getmodule(
+        test_every_vocabulary_pair_is_produced_by_at_least_one_cell_test
+    )
+    tree = ast.parse(inspect.getsource(module))
+
+    reasonless_types = {"RespondAccepted", "RespondReplayed", "RespondOutcomeUnknown"}
+    produced: set[tuple[str, str | None]] = set()
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "svc"
+            and node.func.attr.startswith("Respond")
+        ):
+            reason_value: str | None = None
+            for kw in node.keywords:
+                if kw.arg == "reason" and isinstance(kw.value, ast.Constant):
+                    reason_value = kw.value.value
+            produced.add((node.func.attr, reason_value))
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "isinstance"
+            and len(node.args) == 2
+        ):
+            type_arg = node.args[1]
+            if (
+                isinstance(type_arg, ast.Attribute)
+                and isinstance(type_arg.value, ast.Name)
+                and type_arg.value.id == "svc"
+                and type_arg.attr in reasonless_types
+            ):
+                produced.add((type_arg.attr, None))
+
+    expected = _expected_respond_outcome_vocabulary()
+    missing = expected - produced
+    assert not missing, f"vocabulary pairs with no covering test: {sorted(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# The lock-strength static guard: every `with_for_update(...)` call this
+# module issues against `tasks` must pass `key_share=True`. Writing a bare
+# `with_for_update()` here compiles and passes every SQLite test in this
+# file (the dialect drops the clause entirely -- see
+# `_answer_fence_task_predicate`'s own docstring), so nothing short of an
+# AST scan of the source itself would ever catch the regression: it is a
+# production deadlock waiting for the first concurrent PostgreSQL writer,
+# invisible to this module's entire SQLite-backed unit suite.
+# ---------------------------------------------------------------------------
+
+
+def _with_for_update_calls_missing_key_share(source: str | None = None) -> list:
+    """AST-scan ``source`` (the real module's own source by default) for
+    every ``with_for_update(...)`` call missing ``key_share=True``. Takes an
+    optional source string so the guard test below can exercise this exact
+    function against a fabricated snippet, as its own positive verification,
+    instead of re-implementing its walk inline against a hardcoded string --
+    a second copy of the walk logic could drift from this one and still
+    pass its own test while the real guard silently stopped working.
+    """
+
+    import ast as ast_module
+    import inspect
+
+    if source is None:
+        source = inspect.getsource(svc)
+    tree = ast_module.parse(source)
+    offenders = []
+    for node in ast_module.walk(tree):
+        if (
+            isinstance(node, ast_module.Call)
+            and isinstance(node.func, ast_module.Attribute)
+            and node.func.attr == "with_for_update"
+        ):
+            has_true_key_share = any(
+                kw.arg == "key_share"
+                and isinstance(kw.value, ast_module.Constant)
+                and kw.value.value is True
+                for kw in node.keywords
+            )
+            if not has_true_key_share:
+                offenders.append(node)
+    return offenders
+
+
+def test_every_with_for_update_call_passes_key_share_true() -> None:
+    """`key_share=True` compiles to PostgreSQL's `FOR NO KEY UPDATE`, which
+    lets a concurrent child-row insert still take its required `KEY SHARE`
+    lock on the same `tasks` row. A bare `with_for_update()` compiles to the
+    stronger `FOR UPDATE`, which blocks that insert and closes a lock cycle
+    with any concurrent stager -- a real `DeadlockDetected` on PostgreSQL.
+    This is the static half of that regression's coverage; the dynamic half
+    is the PostgreSQL concurrency test this same mutation also turns red.
+
+    The zero-offenders assertion below, against the real module, would also
+    pass vacuously if the scanner itself were broken -- either its node
+    matching never recognizing a ``with_for_update`` call at all, or its
+    ``key_share=True`` check being vacuously true regardless of what a call
+    actually passes -- since a scanner that never flags anything reports
+    zero offenders on real, compliant code too. The second and third
+    assertions below rule both failure modes out by calling
+    ``_with_for_update_calls_missing_key_share`` itself (not a second,
+    reimplemented copy of its walk, which could drift from the scanner it
+    is supposed to be verifying and still pass on its own) against two
+    fabricated snippets: one missing ``key_share=True`` and one carrying
+    it. Confirmed by mutation: breaking the scanner's node match, or
+    hardcoding ``has_true_key_share = True``, turns either assertion red."""
+
+    offenders = _with_for_update_calls_missing_key_share()
+    assert offenders == []
+
+    bare_source = (
+        "import sqlalchemy as sa\n"
+        "stmt = sa.select(Task).where(Task.id == 1).with_for_update()\n"
+    )
+    assert len(_with_for_update_calls_missing_key_share(bare_source)) == 1
+
+    guarded_source = (
+        "import sqlalchemy as sa\n"
+        "stmt = sa.select(Task).where(Task.id == 1)"
+        ".with_for_update(key_share=True)\n"
+    )
+    assert _with_for_update_calls_missing_key_share(guarded_source) == []

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -9,17 +9,24 @@ extracted from and tested alongside ``public_chat_access.py``) and the
 ``test_task_interaction_service_create_gate.py``).
 
 RespondOutcome's failure matrix, and what this delivery does and does not
-do with it: the matrix enumerates 24 triggering cells across
-``respond()``'s not-yet-implemented logic, producing 20 distinct (outcome
-type, reason) pairs -- fewer than 24 because several cells share a pair
-(five different "principal does not own this task" cells all produce
-``(RespondUnauthorized, not_task_principal)``; two "same idempotency key,
-different actor" cells both produce ``(RespondConflict,
-idempotency_key_reused)``; one cell, kind/version validation, is
-parametrized over two reasons on its own). ``respond()`` takes no
-caller-supplied optimistic-concurrency token, so there is no cell for a
-stale one -- the matrix's ``Stale`` row has six pairs, not seven, for that
-reason. The full cell-to-pair mapping:
+do with it: this build's ``RespondConflictReason``/``RespondStaleReason``
+``Literal``s are narrower than a build that also classifies why the
+answer fence's UPDATE matched zero rows and reconciles an ambiguous
+commit against the durable graph would need (see ``RespondOutcomeUnknown``
+'s own docstring in ``task_interaction_service.py``) -- six triggering
+scenarios that such a build would classify into five distinct ``Stale``
+reasons plus ``Conflict(already_answered)`` collapse onto this build's
+single ``(OutcomeUnknown, None)`` pair instead, alongside the two other
+triggers (an unclassified staging ``IntegrityError`` and an unreconciled
+commit exception) this build already reports the same way. The matrix
+below enumerates this build's own 16 triggering cells, producing 14
+distinct (outcome type, reason) pairs -- fewer than 16 because several
+cells share a pair (two "principal does not own this task" cells both
+produce ``(RespondUnauthorized, not_task_principal)``; two "same
+idempotency key, different actor" cells both produce ``(RespondConflict,
+idempotency_key_reused)``; four distinct triggers collapse onto
+``(OutcomeUnknown, None)``; one cell, kind/version validation, is
+parametrized over two reasons on its own). The full cell-to-pair mapping:
 
     OK        -> (Accepted, None)                                    1
     V1        -> (ValidationRejected, unknown_kind)                  }  2
@@ -27,17 +34,19 @@ reason. The full cell-to-pair mapping:
     V2        -> (ValidationRejected, malformed_idempotency_key)     1
     V3        -> (ValidationRejected, invalid_values)                1
     V5        -> (ValidationRejected, kind_version_mismatch)         1
-    A1..A5    -> (Unauthorized, not_task_principal)      1 (5 cells share it)
+    A1,A2     -> (Unauthorized, not_task_principal)      1 (2 cells share it)
     U1        -> (Unavailable, task_missing)                         1
     U2        -> (Unavailable, interaction_missing)                  1
     U3        -> (Unavailable, checkpoint_unavailable)                1
     R1        -> (Replayed, None)                                    1
-    C1        -> (Conflict, already_answered)                        1
     C2,C3     -> (Conflict, idempotency_key_reused)      1 (2 cells share it)
-    S1..S6    -> six distinct (Stale, *) pairs                       6
-    X1        -> (OutcomeUnknown, None)                              1
+    S6        -> (Stale, anchor_dangling)                             1
+    X1..X4    -> (OutcomeUnknown, None)      1 (4 cells share it -- a
+                 fence miss with no further classification, a guest whose
+                 fence-level mismatch this build cannot label, a staging
+                 IntegrityError, and a commit exception)
     -----------------------------------------------------------------
-    24 cells; 20 distinct pairs (18 single-reason cells + V1's own 2)
+    16 cells; 14 distinct pairs (12 single-reason cells + V1's own 2)
 
 The cell-by-cell tests this matrix implies, and the mapping meta-test that
 checks their coverage against the vocabulary, are both in this file now,
@@ -51,8 +60,8 @@ layers:
 | Assertion | Checks | Catches | Misses |
 |---|---|---|---|
 | Union-membership guard (this file, written) | ``RespondOutcome`` has exactly its eight known member classes | A variant added or removed without updating this list | Reason-level coverage |
-| Cell-by-cell tests (this file, written) | One test per of the 24 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
-| Mapping meta-test (this file, written) | Each of the 20 pairs is produced by >= 1 cell's test (18 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a sixth not_task_principal scenario) -- caught by review, not this meta-test |
+| Cell-by-cell tests (this file, written) | One test per of the 16 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
+| Mapping meta-test (this file, written) | Each of the 14 pairs is produced by >= 1 cell's test (12 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a third not_task_principal scenario) -- caught by review, not this meta-test |
 """
 
 from __future__ import annotations
@@ -1427,7 +1436,7 @@ def _answered_row_with_valid_anchor(
     """A row this service already answered in some earlier, successful call
     -- its resume anchor is still valid (nothing has pruned the checkpoint
     it points at), which is what makes it reachable past step 4.5 for the
-    already-answered classification tests below."""
+    already-answered replay and fence-miss tests below."""
 
     db = session_factory()
     try:
@@ -1445,36 +1454,6 @@ def _answered_row_with_valid_anchor(
         row.response_payload = response_payload
         row.responded_at = now
         row.responder_identity = responder_identity
-        row.request_idempotency_key = idempotency_key
-        db.commit()
-        return int(row.id)
-    finally:
-        db.close()
-
-
-def _terminated_row_with_valid_anchor(
-    session_factory,
-    *,
-    task_id: int,
-    run_id: str,
-    terminal_reason: str,
-    idempotency_key: str = "terminated-row-key",
-) -> int:
-    db = session_factory()
-    try:
-        trace_event_id = _make_trace_event(db, task_id=task_id, run_partition=run_id)
-        row = _make_active_interaction_row(
-            db,
-            task_id=task_id,
-            run_id=run_id,
-            resume_trace_event_id=trace_event_id,
-            resume_run_partition=run_id,
-        )
-        now = _now()
-        row.status = "terminated"
-        row.active_slot = None
-        row.terminal_reason = terminal_reason
-        row.terminated_at = now
         row.request_idempotency_key = idempotency_key
         db.commit()
         return int(row.id)
@@ -1770,7 +1749,13 @@ def test_respond_rejects_a_guest_whose_bindings_match_but_principal_user_id_does
     principal.user_id`` term (present for both principal kinds, not only
     the guest-specific JSON check) is what refuses it, on both backends,
     since this is a plain mismatch present from the start, not a
-    concurrent change to catch only via SQLite's missing lock."""
+    concurrent change to catch only via SQLite's missing lock. The refusal
+    lands as a zero-rowcount fence miss, which this build reports as
+    ``OutcomeUnknown`` rather than the fine-grained ``Unauthorized`` a more
+    detailed classification would give it (see respond()'s own docstring,
+    step 6) -- the security property this test exists to pin (the guest
+    never gets an answer accepted) holds either way; only the label does
+    not."""
 
     owner_id, task_id = _waiting_task(
         _respond_db,
@@ -1801,7 +1786,7 @@ def test_respond_rejects_a_guest_whose_bindings_match_but_principal_user_id_does
             envelope=_respond_envelope(),
         )
 
-        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+        assert isinstance(outcome, svc.RespondOutcomeUnknown)
 
 
 def test_respond_reports_unavailable_when_the_task_row_does_not_exist(
@@ -1929,9 +1914,23 @@ def test_respond_returns_the_original_receipt_for_a_matching_replay(
         assert outcome.receipt.idempotency_key == command_id
 
 
-def test_respond_reports_conflict_for_an_already_answered_row_under_a_fresh_key(
+def test_respond_reports_outcome_unknown_when_the_fence_misses_and_leaves_no_residue(
     _respond_db,
 ) -> None:
+    """This build does not classify why the answer fence's UPDATE matched
+    zero rows (see ``RespondOutcomeUnknown``'s own docstring) -- every
+    fine-grained fence-miss scenario (already answered, terminated, wrong
+    task state, foreign run, a concurrent ownership change) collapses onto
+    this single conservative outcome instead of the outcome/reason such a
+    build's more detailed sibling would report. Picks one concrete trigger
+    -- the row already answered by someone else, under a fresh idempotency
+    key this call has never seen -- and proves both the collapse and the
+    safety property that makes it acceptable: this call changes nothing.
+    The pre-existing answer, its already-staged command, and the conflict
+    counter are all untouched -- a conservative miss must never be
+    misreported as a conflict, since this build never confirmed it was
+    one."""
+
     user_id, task_id = _waiting_task(_respond_db)
     principal = _owning_user_principal(user_id)
     interaction_id = _answered_row_with_valid_anchor(
@@ -1952,8 +1951,8 @@ def test_respond_reports_conflict_for_an_already_answered_row_under_a_fresh_key(
             envelope=_respond_envelope(idempotency_key="never-seen-before"),
         )
 
-        assert outcome == svc.RespondConflict(reason="already_answered")
-    assert _conflict_counter() == before_counter + 1
+        assert isinstance(outcome, svc.RespondOutcomeUnknown)
+    assert _conflict_counter() == before_counter
 
 
 def test_respond_reports_conflict_for_the_same_key_with_a_different_payload(
@@ -2036,149 +2035,6 @@ def test_respond_reports_conflict_when_a_guest_and_the_owner_share_one_key(
 
         assert outcome == svc.RespondConflict(reason="idempotency_key_reused")
     assert _conflict_counter() == before_counter + 1
-
-
-@pytest.mark.parametrize(
-    "terminal_reason,expected_reason",
-    [
-        pytest.param("deadline_elapsed", "expired", id="expired"),
-        pytest.param("run_superseded", "run_superseded", id="run_superseded"),
-        pytest.param(
-            "answered_via_legacy_resume", "answered_via_chat", id="answered_via_chat"
-        ),
-    ],
-)
-def test_respond_reports_stale_for_a_terminated_row(
-    _respond_db, terminal_reason: str, expected_reason: str
-) -> None:
-    user_id, task_id = _waiting_task(_respond_db)
-    interaction_id = _terminated_row_with_valid_anchor(
-        _respond_db, task_id=task_id, run_id="run-a", terminal_reason=terminal_reason
-    )
-    before_counter = _conflict_counter()
-    with _asserts_no_side_effects(
-        _respond_db, task_id=task_id, interaction_id=interaction_id
-    ):
-        outcome = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=_owning_user_principal(user_id),
-            envelope=_respond_envelope(idempotency_key="never-seen-before-terminal"),
-        )
-
-        if expected_reason == "expired":
-            assert outcome == svc.RespondStale(reason="expired")
-        elif expected_reason == "run_superseded":
-            assert outcome == svc.RespondStale(reason="run_superseded")
-        else:
-            assert outcome == svc.RespondStale(reason="answered_via_chat")
-    # Reverse assertion: a Stale outcome must never increment the
-    # response-conflict counter -- only the three Conflict cells do.
-    assert _conflict_counter() == before_counter
-
-
-def test_respond_reports_stale_when_the_task_has_moved_on_from_waiting(
-    _respond_db,
-) -> None:
-    user_id, task_id = _waiting_task(_respond_db)
-    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    db = _respond_db()
-    try:
-        db.query(Task).filter(Task.id == task_id).update({"status": TaskStatus.RUNNING})
-        db.commit()
-    finally:
-        db.close()
-    before_counter = _conflict_counter()
-    with _asserts_no_side_effects(
-        _respond_db, task_id=task_id, interaction_id=interaction_id
-    ):
-        outcome = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=_owning_user_principal(user_id),
-            envelope=_respond_envelope(),
-        )
-
-        assert outcome == svc.RespondStale(reason="run_ended")
-    assert _conflict_counter() == before_counter
-
-
-def test_respond_reports_stale_when_the_task_is_waiting_on_a_different_run(
-    _respond_db,
-) -> None:
-    user_id, task_id = _waiting_task(_respond_db, run_id="run-current")
-    interaction_id = _active_row_ready_for_respond(
-        _respond_db, task_id=task_id, run_id="run-old"
-    )
-    before_counter = _conflict_counter()
-    with _asserts_no_side_effects(
-        _respond_db, task_id=task_id, interaction_id=interaction_id
-    ):
-        outcome = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=_owning_user_principal(user_id),
-            envelope=_respond_envelope(),
-        )
-
-        assert outcome == svc.RespondStale(reason="foreign_run")
-    assert _conflict_counter() == before_counter
-
-
-def _racing_fence_stmt_that_changes_ownership(
-    session_factory, *, task_id: int, intruder_owner_id: int
-) -> Any:
-    """Build a monkeypatch replacement for ``svc._answer_fence_stmt`` that
-    races a concurrent ownership change onto the task row between step 2's
-    read and the fence statement's own execution -- the SQLite-only TOCTOU
-    window (SQLite's dialect drops ``FOR UPDATE`` entirely; PostgreSQL's row
-    lock closes it, see ``_answer_fence_task_predicate``'s own docstring) the
-    test below needs to reproduce it."""
-
-    real_fence_stmt = svc._answer_fence_stmt
-
-    def _racing_fence_stmt(*args: Any, **kwargs: Any) -> Any:
-        race_db = session_factory()
-        try:
-            race_db.query(Task).filter(Task.id == task_id).update(
-                {"user_id": intruder_owner_id}
-            )
-            race_db.commit()
-        finally:
-            race_db.close()
-        return real_fence_stmt(*args, **kwargs)
-
-    return _racing_fence_stmt
-
-
-def test_respond_reports_unauthorized_when_ownership_changes_between_the_check_and_the_write(
-    _respond_db, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The SQLite-only TOCTOU window between step 3's authorization read and
-    step 6's write-point fence (see ``_answer_fence_task_predicate``'s own
-    docstring for why PostgreSQL's row lock closes this window and SQLite's
-    dialect does not)."""
-
-    owner_id, task_id = _waiting_task(_respond_db)
-    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    intruder_owner_id = make_user(_respond_db())
-
-    monkeypatch.setattr(
-        svc,
-        "_answer_fence_stmt",
-        _racing_fence_stmt_that_changes_ownership(
-            _respond_db, task_id=task_id, intruder_owner_id=intruder_owner_id
-        ),
-    )
-
-    outcome = svc.respond(
-        interaction_id=interaction_id,
-        task_id=task_id,
-        principal=_owning_user_principal(owner_id),
-        envelope=_respond_envelope(),
-    )
-
-    assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
 
 
 def test_respond_checks_authorization_before_the_idempotency_prequery(
@@ -2335,268 +2191,90 @@ def test_rowcount_helper_does_not_raise_on_a_bare_test_double() -> None:
     assert svc._rowcount(MagicMock(rowcount=3)) == 3
 
 
-def test_respond_reports_outcome_unknown_when_commit_ack_is_lost_and_the_graph_never_lands(
+def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residue(
     _respond_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Injects a commit failure and never lets the durable-graph
-    reconciliation find a matching command row (by using a task_id the
-    reconciliation query cannot see any command for), forcing all three
-    reconciliation attempts to fail."""
+    """A raised exception at commit does not, by itself, mean the write
+    failed -- the acknowledgment could have been lost after the server
+    applied it -- but this build does not attempt to reconcile that
+    against the durable graph (a fine-grained reconciliation via a fresh
+    session's own read, distinguishing a landed write from a lost one, is
+    not delivered here; see respond()'s own docstring, step 9): it reports
+    the ambiguity unconditionally. Simulates a commit that never actually
+    reaches the database and proves that in this build's conservative
+    handling nothing landed either -- the interaction row, the task row,
+    and the command table are all exactly as they were before the call."""
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
     principal = _owning_user_principal(user_id)
 
     from sqlalchemy.orm import Session as OrmSession
-
-    original_commit = OrmSession.commit
-    call_count = {"n": 0}
 
     def _failing_commit(self: Any) -> None:
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            raise RuntimeError("simulated lost commit acknowledgment")
-        return original_commit(self)
+        raise RuntimeError("simulated lost commit acknowledgment")
 
     monkeypatch.setattr(OrmSession, "commit", _failing_commit)
-    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
 
-    outcome = svc.respond(
-        interaction_id=interaction_id,
-        task_id=task_id,
-        principal=principal,
-        envelope=_respond_envelope(idempotency_key="ambiguous-commit-no-graph"),
-    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(idempotency_key="commit-raises"),
+        )
 
-    assert isinstance(outcome, svc.RespondOutcomeUnknown)
+        assert isinstance(outcome, svc.RespondOutcomeUnknown)
 
 
-def test_respond_reports_accepted_when_commit_ack_is_lost_but_the_graph_landed(
+# ---------------------------------------------------------------------------
+# Step 8's own IntegrityError catch, reached when stage_task_command's own
+# insert collides with a UNIQUE or FOREIGN KEY constraint (the real trigger
+# is a second writer racing this call for the same idempotency key -- only
+# reproducible against a real PostgreSQL server, see
+# test_task_interaction_service_postgresql.py; simulated directly here).
+# This build does not classify what an IntegrityError there means (a
+# fine-grained classification via classify_task_command_conflict,
+# distinguishing a genuine replay from a real conflict, is not delivered --
+# see respond()'s own docstring, step 8): the whole transaction rolls back
+# and this call reports the ambiguity.
+# ---------------------------------------------------------------------------
+
+
+def test_respond_reports_outcome_unknown_when_staging_the_command_raises_and_leaves_no_residue(
     _respond_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Same injected failure as the OutcomeUnknown case above, except this
-    time the underlying commit genuinely succeeded at the database layer
-    (only the acknowledgment back to this process was lost) -- proving the
-    reconciliation path returns Accepted, not a false negative, once the
-    complete graph is actually there to find."""
+    from sqlalchemy.exc import IntegrityError as _IntegrityError
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
     principal = _owning_user_principal(user_id)
 
-    from sqlalchemy.orm import Session as OrmSession
+    def _raising_stage_task_command(*args: Any, **kwargs: Any) -> Any:
+        raise _IntegrityError(
+            "INSERT", {}, Exception("simulated raced duplicate command_id")
+        )
 
-    original_commit = OrmSession.commit
-    call_count = {"n": 0}
+    monkeypatch.setattr(svc, "stage_task_command", _raising_stage_task_command)
 
-    def _lost_ack_but_committed(self: Any) -> None:
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            original_commit(self)
-            raise RuntimeError("simulated lost commit acknowledgment")
-        return original_commit(self)
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(idempotency_key="staging-raises"),
+        )
 
-    monkeypatch.setattr(OrmSession, "commit", _lost_ack_but_committed)
-    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
-
-    outcome = svc.respond(
-        interaction_id=interaction_id,
-        task_id=task_id,
-        principal=principal,
-        envelope=_respond_envelope(idempotency_key="ambiguous-commit-landed"),
-    )
-
-    assert isinstance(outcome, svc.RespondAccepted)
-    assert outcome.receipt.responder_identity == principal.identity_string()
-
-
-def test_respond_durable_graph_check_is_monotone_when_the_coordinator_has_already_advanced_state(
-    _respond_db, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The resume coordinator re-issues the same RESUME_REQUESTED
-    transition once it applies the command this call staged, bumping
-    state_version a second time -- the durable-graph check must still
-    report Accepted against a state_version that has moved past what this
-    call itself wrote, and must not compare control_state (see respond()'s
-    own docstring)."""
-
-    user_id, task_id = _waiting_task(_respond_db, state_version=5)
-    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
-
-    from sqlalchemy.orm import Session as OrmSession
-
-    original_commit = OrmSession.commit
-    call_count = {"n": 0}
-
-    def _lost_ack_then_coordinator_advances(self: Any) -> None:
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            original_commit(self)
-            # Simulate the coordinator re-applying its own transition on a
-            # separate connection before this call's reconciliation runs.
-            side_db = _respond_db()
-            try:
-                side_db.query(Task).filter(Task.id == task_id).update(
-                    {
-                        "state_version": Task.state_version + 1,
-                        "control_state": "running",
-                    }
-                )
-                side_db.commit()
-            finally:
-                side_db.close()
-            raise RuntimeError("simulated lost commit acknowledgment")
-        return original_commit(self)
-
-    monkeypatch.setattr(OrmSession, "commit", _lost_ack_then_coordinator_advances)
-    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
-
-    outcome = svc.respond(
-        interaction_id=interaction_id,
-        task_id=task_id,
-        principal=principal,
-        envelope=_respond_envelope(idempotency_key="monotone-check"),
-    )
-
-    assert isinstance(outcome, svc.RespondAccepted)
-
-
-def test_respond_reports_outcome_unknown_when_the_landed_row_answers_a_different_identity(
-    _respond_db, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Same lost-commit-acknowledgment injection as the two cases above, but
-    this time the row the durable-graph check reads back was answered under
-    a *different* ``responder_identity`` than the one this call's own
-    principal carries. A mismatched identity, not an absent one, is the
-    only way an answered row can fail to attest to this call: two CHECK
-    constraints chain to rule out a null identity on an answered row --
-    ``ck_task_interaction_requests_responded_at_pairs_status`` ties
-    ``status = 'answered'`` to ``responded_at IS NOT NULL``, and
-    ``ck_task_interaction_requests_responder_pairs_responded_at`` ties
-    ``responded_at IS NOT NULL`` to ``responder_identity IS NOT NULL`` --
-    so an answered row always carries *some* identity, just not
-    necessarily this call's own. See ``_verify_respond_durable_graph``'s
-    own docstring for why the comparison exists. The reconciliation must
-    not treat "an answer landed" as "my answer landed": with nothing tying
-    the row to this principal, every attempt has to keep failing and the
-    call must report OutcomeUnknown, never Accepted.
-    """
-
-    user_id, task_id = _waiting_task(_respond_db)
-    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
-    principal = _owning_user_principal(user_id)
-
-    from sqlalchemy.orm import Session as OrmSession
-
-    original_commit = OrmSession.commit
-    call_count = {"n": 0}
-
-    def _lost_ack_but_landed_under_another_identity(self: Any) -> None:
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            original_commit(self)
-            # The row genuinely committed (columns and all), but stamped
-            # with a different identity than this call's own principal --
-            # standing in for the row this call's ambiguous commit might
-            # have raced against, not a corruption of this call's own
-            # write.
-            side_db = _respond_db()
-            try:
-                side_db.query(TaskInteractionRequest).filter(
-                    TaskInteractionRequest.id == interaction_id
-                ).update({"responder_identity": "user:999999"})
-                side_db.commit()
-            finally:
-                side_db.close()
-            raise RuntimeError("simulated lost commit acknowledgment")
-        return original_commit(self)
-
-    monkeypatch.setattr(
-        OrmSession, "commit", _lost_ack_but_landed_under_another_identity
-    )
-    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
-
-    outcome = svc.respond(
-        interaction_id=interaction_id,
-        task_id=task_id,
-        principal=principal,
-        envelope=_respond_envelope(idempotency_key="ambiguous-commit-wrong-identity"),
-    )
-
-    assert isinstance(outcome, svc.RespondOutcomeUnknown)
-
-
-# ---------------------------------------------------------------------------
-# classify_task_command_conflict's IntegrityError branch (step 8), reached
-# when stage_task_command's own insert (inside this call's own
-# `db.begin_nested()`) collides with a UNIQUE or FOREIGN KEY constraint.
-# This repo already has real coverage for classify_task_command_conflict
-# itself (test_task_command_transport.py) and for the pre-existing-command
-# shortcut at step 5 (the idempotency_key_reused cells above), but never for
-# this specific call site -- respond() reaching an IntegrityError on its own
-# insert has no test anywhere in the repo before this delivery.
-#
-# Of TaskCommandConflictKind's three values, only RACED_DUPLICATE is
-# reachable here, and only on PostgreSQL. The other two are not reachable
-# through respond() at all, verified against the real code rather than
-# assumed:
-#
-# - UNRELATED needs the staged row's actor_user_id foreign key to fail --
-#   the referenced user deleted out from under a still-pending insert. In
-#   respond(), actor_user_id is always `principal.user_id`, and the answer
-#   fence's own task-side predicate (`_answer_fence_task_predicate`)
-#   requires `Task.user_id == principal.user_id` unconditionally for
-#   *both* principal kinds (guest included -- its "owning user" is the
-#   value in this same term) as a condition of the fence UPDATE actually
-#   matching a row. Confirmed by running an admin principal whose user_id
-#   does not equal the task's owner through respond(): the fence's own
-#   ownership term rejects it before step 8, at rowcount=0's
-#   `not_task_principal` classification, in the *reread* branch (`if
-#   reread.status == "active": ... return RespondUnauthorized(...)`) --
-#   `principal.is_admin` only bypasses the earlier, separate Python check
-#   at step 3, never the fence's own SQL. So the only user_id that can ever
-#   reach step 8 is the task's actual owner, and that user cannot be
-#   deleted while this same transaction still holds the task row it owns
-#   (`tasks.user_id` has no `ondelete`, i.e. FK `RESTRICT` -- deleting it
-#   while a referencing task row exists is rejected at the database level,
-#   independent of any lock this transaction holds). UNRELATED gets no
-#   test.
-# - TASK_MISSING needs the task to disappear between step 2 and step 8.
-#   respond() holds the tasks row through step 2's `with_for_update` for
-#   the whole transaction, and by step 8 has already written on this same
-#   connection at steps 6 and 7 -- on PostgreSQL that is the row lock
-#   itself blocking a concurrent DELETE; on SQLite (where `with_for_update`
-#   compiles to nothing, see
-#   `test_every_with_for_update_call_passes_key_share_true`'s own
-#   docstring) it is SQLite's whole-database writer lock, already held by
-#   this connection since step 6's fence UPDATE. Either way a concurrent
-#   delete of this task cannot land before this call's own insert attempt,
-#   so classify_task_command_conflict can never observe the task gone
-#   here. TASK_MISSING gets no test either.
-#
-# RACED_DUPLICATE needs a second writer to commit a row for the same
-# (task_id, command_id) strictly between stage_task_command's own
-# existing-row check and its own insert flush -- a real second connection
-# genuinely open at that instant, not a pre-committed row (which either of
-# respond()'s own two earlier existing-command checks, at step 5 and inside
-# stage_task_command itself, would catch first and never reach the flush
-# at all). SQLite cannot reproduce this: by the time respond() reaches
-# step 8 it has already written the fence UPDATE (step 6) and the CAS
-# (step 7) on this same connection, which already holds SQLite's one
-# whole-database writer lock (the same fact
-# `postgres_task_command_sessions`'s own docstring in
-# test_task_command_transport.py documents for the sibling raced-insert
-# test on enqueue_task_command) -- a second writer's commit cannot land
-# inside that window until this transaction ends. PostgreSQL's row lock,
-# held by step 2's `with_for_update` only on the specific `tasks` row,
-# does not extend to the `task_execution_commands` table, so a second
-# writer can complete there while this transaction is still open. Both of
-# RACED_DUPLICATE's sub-branches (payload_matches True and False -- they
-# produce different RespondOutcomes and only one increments the conflict
-# counter) live in test_task_interaction_service_postgresql.py for that
-# reason; nothing in this file exercises this call site.
-# ---------------------------------------------------------------------------
+        assert isinstance(outcome, svc.RespondOutcomeUnknown)
+    # A conservative miss must not be misreported as a conflict either --
+    # the counter only increments for an outcome this build actually
+    # confirmed was a conflict.
+    assert _conflict_counter() == before_counter
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1313,7 +1313,7 @@ def test_answer_fence_predicate_guest_branch_adds_a_json_lookup_term() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Structural guards: raw SQL and the _rowcount idiom.
+# Structural guards: raw SQL.
 # ---------------------------------------------------------------------------
 
 
@@ -1372,11 +1372,8 @@ def _respond_db(monkeypatch: pytest.MonkeyPatch, _session_factory):
 def _waiting_task(
     session_factory,
     *,
-    run_id: str = "run-a",
     state_version: int = 5,
     agent_config: dict[str, Any] | None = None,
-    channel_id: int | None = None,
-    agent_id: int | None = None,
 ) -> tuple[int, int]:
     """A task parked in WAITING_FOR_USER, the state every respond() test
     starts from -- the answer fence's task-side predicate requires it."""
@@ -1388,10 +1385,10 @@ def _waiting_task(
         task = db.query(Task).filter(Task.id == task_id).first()
         task.status = TaskStatus.WAITING_FOR_USER
         task.control_state = TaskControlState.WAITING_FOR_USER.value
-        task.run_id = run_id
+        task.run_id = "run-a"
         task.state_version = state_version
-        task.channel_id = channel_id
-        task.agent_id = agent_id
+        task.channel_id = None
+        task.agent_id = None
         if agent_config is not None:
             task.agent_config = agent_config
         db.commit()
@@ -1404,8 +1401,6 @@ def _active_row_ready_for_respond(
     session_factory,
     *,
     task_id: int,
-    run_id: str = "run-a",
-    idempotency_key: str | None = None,
     anchor_run_partition: str | None = None,
 ) -> int:
     """An active interaction row with a resolvable anchor -- the state every
@@ -1419,18 +1414,15 @@ def _active_row_ready_for_respond(
     db = session_factory()
     try:
         trace_event_id = _make_trace_event(
-            db, task_id=task_id, run_partition=anchor_run_partition or run_id
+            db, task_id=task_id, run_partition=anchor_run_partition or "run-a"
         )
         row = _make_active_interaction_row(
             db,
             task_id=task_id,
-            run_id=run_id,
+            run_id="run-a",
             resume_trace_event_id=trace_event_id,
-            resume_run_partition=run_id,
+            resume_run_partition="run-a",
         )
-        if idempotency_key is not None:
-            row.request_idempotency_key = idempotency_key
-            db.commit()
         return int(row.id)
     finally:
         db.close()
@@ -1443,7 +1435,6 @@ def _answered_row_with_valid_anchor(
     run_id: str,
     responder_identity: str,
     response_payload: dict[str, Any],
-    idempotency_key: str = "prior-answer-key",
 ) -> int:
     """A row this service already answered in some earlier, successful call
     -- its resume anchor is still valid (nothing has pruned the checkpoint
@@ -1466,7 +1457,7 @@ def _answered_row_with_valid_anchor(
         row.response_payload = response_payload
         row.responded_at = now
         row.responder_identity = responder_identity
-        row.request_idempotency_key = idempotency_key
+        row.request_idempotency_key = "prior-answer-key"
         db.commit()
         return int(row.id)
     finally:
@@ -1480,7 +1471,6 @@ def _stage_matching_command(
     actor_user_id: int | None,
     command_id: str,
     payload: dict[str, Any],
-    status: str = "completed",
 ) -> int:
     db = session_factory()
     try:
@@ -1490,7 +1480,7 @@ def _stage_matching_command(
             command_id=command_id,
             kind=svc.TaskCommandKind.RESUME.value,
             payload=payload,
-            status=status,
+            status="completed",
         )
         db.add(command)
         db.commit()
@@ -2152,8 +2142,6 @@ def test_respond_receipt_refuses_a_row_that_carries_no_answer() -> None:
     unanswered = SimpleNamespace(
         id=7,
         task_id=11,
-        run_id="run-a",
-        status="active",
         responded_at=None,
         responder_identity=None,
     )
@@ -2488,16 +2476,6 @@ def test_respond_receipt_fields_do_not_touch_the_session_after_commit(
         assert query_count == 0
     finally:
         verify_db.close()
-
-
-def test_rowcount_helper_does_not_raise_on_a_bare_test_double() -> None:
-    from unittest.mock import MagicMock
-
-    class _NoRowcount:
-        pass
-
-    assert svc._rowcount(_NoRowcount()) == 0
-    assert svc._rowcount(MagicMock(rowcount=3)) == 3
 
 
 def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residue(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -2478,7 +2478,7 @@ def test_respond_receipt_fields_do_not_touch_the_session_after_commit(
 
 
 def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residue(
-    _respond_db, monkeypatch: pytest.MonkeyPatch
+    _respond_db, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A raised exception at commit does not, by itself, mean the write
     failed -- the acknowledgment could have been lost after the server
@@ -2489,7 +2489,9 @@ def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residu
     the ambiguity unconditionally. Simulates a commit that never actually
     reaches the database and proves that in this build's conservative
     handling nothing landed either -- the interaction row, the task row,
-    and the command table are all exactly as they were before the call."""
+    and the command table are all exactly as they were before the call.
+    Also asserts the ambiguity is logged: unlike the fence-miss branch,
+    this door used to leave no trace for an operator to find."""
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
@@ -2505,14 +2507,22 @@ def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residu
     with _asserts_no_side_effects(
         _respond_db, task_id=task_id, interaction_id=interaction_id
     ):
-        outcome = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=principal,
-            envelope=_respond_envelope(idempotency_key="commit-raises"),
-        )
+        with caplog.at_level(logging.WARNING):
+            outcome = svc.respond(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                principal=principal,
+                envelope=_respond_envelope(idempotency_key="commit-raises"),
+            )
 
         assert isinstance(outcome, svc.RespondOutcomeUnknown)
+        matching = [
+            record
+            for record in caplog.records
+            if "commit failed while answering" in record.getMessage()
+        ]
+        assert len(matching) == 1
+        assert matching[0].levelno == logging.WARNING
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -2060,6 +2061,36 @@ def test_respond_reports_outcome_unknown_when_the_fence_misses_and_leaves_no_res
 
         assert isinstance(outcome, svc.RespondOutcomeUnknown)
     assert _conflict_counter() == before_counter
+
+
+def test_respond_logs_the_reread_row_state_when_the_fence_misses(
+    _respond_db, caplog: pytest.LogCaptureFixture
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    principal = _owning_user_principal(user_id)
+    interaction_id = _answered_row_with_valid_anchor(
+        _respond_db,
+        task_id=task_id,
+        run_id="run-a",
+        responder_identity=principal.identity_string(),
+        response_payload={"env": "prod"},
+    )
+    with caplog.at_level(logging.WARNING):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_respond_envelope(idempotency_key="never-seen-before-logged"),
+        )
+
+    assert isinstance(outcome, svc.RespondOutcomeUnknown)
+    matching = [
+        record
+        for record in caplog.records
+        if "answer fence matched zero rows" in record.message
+    ]
+    assert len(matching) == 1
+    assert "status=answered" in matching[0].message
 
 
 def test_respond_reports_conflict_for_the_same_key_with_a_different_payload(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -2670,7 +2670,10 @@ def test_every_vocabulary_pair_is_produced_by_at_least_one_cell_test() -> None:
     any other arithmetic against the 27-cell count -- six
     not_task_principal cells and two idempotency_key_reused cells
     legitimately collapse onto one pair each; this only asserts that no
-    vocabulary pair is left with zero producing cells."""
+    vocabulary pair is left with zero producing cells. Its blind spot: a
+    new cell that produces no *new* pair -- for example a seventh
+    not_task_principal scenario -- adds nothing this scan would notice
+    missing, so that gap is caught by review, not by this test."""
 
     import ast
     import inspect

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1918,6 +1918,35 @@ def test_respond_returns_the_original_receipt_for_a_matching_replay(
         assert outcome.receipt.idempotency_key == command_id
 
 
+def test_respond_receipt_refuses_a_row_that_carries_no_answer() -> None:
+    """``_respond_receipt`` may only ever see an answered row: its one
+    caller is the idempotent-replay branch, and the paired CHECK
+    constraints make an answered row with a NULL ``responded_at`` or
+    ``responder_identity`` impossible. That reasoning spans two modules
+    with nothing else pinning it, so the builder raises loudly on a row
+    with no answer rather than coercing ``None`` into the string
+    ``'None'`` (or a falsy ``""``) inside an audit-bearing receipt."""
+
+    from types import SimpleNamespace
+
+    unanswered = SimpleNamespace(
+        id=7,
+        task_id=11,
+        run_id="run-a",
+        status="active",
+        responded_at=None,
+        responder_identity=None,
+    )
+    task = SimpleNamespace(state_version=1, control_state="waiting_for_user")
+    with pytest.raises(RuntimeError, match="carries no answer"):
+        svc._respond_receipt(
+            interaction=unanswered,  # type: ignore[arg-type]
+            task=task,  # type: ignore[arg-type]
+            command_db_id=1,
+            idempotency_key="key-1",
+        )
+
+
 def test_respond_reports_outcome_unknown_when_the_fence_misses_and_leaves_no_residue(
     _respond_db,
 ) -> None:

--- a/tests/web/services/test_task_interaction_service_create_gate.py
+++ b/tests/web/services/test_task_interaction_service_create_gate.py
@@ -5,11 +5,13 @@ Replaces the two-name gate this file's predecessor enforced, keeping both
 names under watch. The predecessor named its retirement condition as "the
 change that routes the existing resume coordinator through this module's
 compatibility seam" -- the change meant to give ``respond()`` its first
-production caller. That change has not landed: it ships separately in this
-same series, and nothing in ``websocket.py`` references this module today.
-Zero production code anywhere in this package calls either name, and this
-gate is what keeps that true until the change that wires a caller retires
-the name it wires.
+production caller. That compatibility seam has since landed: ``websocket.py``
+now imports ``_active_native_row_criteria`` from this module. It does not,
+though, give ``respond()`` a caller -- the seam only reads that filter
+predicate, it never calls ``respond()`` -- so this gate's retirement
+condition is still open. Zero production code anywhere in this package
+calls either name, and this gate is what keeps that true until the change
+that wires a caller retires the name it wires.
 
 ``create()``'s production call body -- the write that actually calls
 ``stage_interaction_request`` -- arrives with the change that wires

--- a/tests/web/services/test_task_interaction_service_create_gate.py
+++ b/tests/web/services/test_task_interaction_service_create_gate.py
@@ -1,19 +1,15 @@
-"""Zero-production-caller gate for ``task_interaction_service.create`` alone.
+"""Zero-production-caller gate for ``task_interaction_service.create`` and
+``respond``.
 
-Replaces the two-name gate this file's predecessor enforced: that gate
-locked both ``create`` and ``respond`` against any production caller, and
-its own docstring named its retirement condition as "the change that routes
-the existing resume coordinator through this module's compatibility seam" --
-the change meant to give ``respond()`` its first production caller. That
-change has landed, but not that way: the compatibility seam in
-``websocket.py`` only reads ``_active_native_row_criteria()`` to decide
-whether an active native row exists, and rejects the legacy resume path
-outright when one does -- it never calls ``respond()`` itself. Zero
-production code anywhere in this package calls ``respond()`` today.
-Locking it under this gate anyway would be conflating "no gate" with "no
-caller"; the two are independent facts, and the former is what this file
-narrows to. ``create()`` still has no caller either, so this narrower gate
-takes over guarding it alone.
+Replaces the two-name gate this file's predecessor enforced, keeping both
+names under watch. The predecessor named its retirement condition as "the
+change that routes the existing resume coordinator through this module's
+compatibility seam" -- the change meant to give ``respond()`` its first
+production caller. That change has not landed: it ships separately in this
+same series, and nothing in ``websocket.py`` references this module today.
+Zero production code anywhere in this package calls either name, and this
+gate is what keeps that true until the change that wires a caller retires
+the name it wires.
 
 ``create()``'s production call body -- the write that actually calls
 ``stage_interaction_request`` -- arrives with the change that wires
@@ -70,7 +66,7 @@ from xagent.web.services import (  # noqa: F401 -- negative control import
     task_interaction_service as service,
 )
 
-GATED_NAMES = frozenset({"create"})
+GATED_NAMES = frozenset({"create", "respond"})
 SERVICE_MODULE = "task_interaction_service"
 
 
@@ -169,7 +165,7 @@ def _production_modules() -> list[Path]:
 # --------------------------------------------------------------------------
 
 
-def test_no_production_module_calls_create() -> None:
+def test_no_production_module_calls_create_or_respond() -> None:
     offenders: dict[str, set[str]] = {}
     for path in _production_modules():
         try:
@@ -283,13 +279,12 @@ def test_importing_unrelated_name_is_not_flagged() -> None:
     assert _production_uses(source) == set()
 
 
-def test_a_production_call_to_respond_is_not_flagged() -> None:
-    """A hypothetical production call to ``respond()`` -- something this
-    package does not actually have today (see this file's own module
-    docstring) -- must not trip this narrower gate either: retiring the
-    predecessor's two-name gate dropped the watch over ``respond`` entirely,
-    not merely relaxed it, so nothing calling ``respond()`` is this gate's
-    concern regardless of whether such a caller exists yet."""
+def test_detects_a_production_call_to_respond() -> None:
+    """``respond()`` is under this gate for the same reason ``create()``
+    is: it has no production caller, and the change that gives it one is
+    the change that takes it out of here. This is the positive control for
+    that half of the gate -- a hypothetical production call must be
+    detected, or the gate would be watching a name it cannot see."""
 
     source = textwrap.dedent(
         """
@@ -299,7 +294,7 @@ def test_a_production_call_to_respond_is_not_flagged() -> None:
             return respond(**kwargs)
         """
     )
-    assert _production_uses(source) == set()
+    assert _production_uses(source) == {"respond"}
 
 
 def test_same_named_call_on_an_unrelated_object_is_not_flagged() -> None:

--- a/tests/web/services/test_task_interaction_service_create_gate.py
+++ b/tests/web/services/test_task_interaction_service_create_gate.py
@@ -1,52 +1,38 @@
-"""Zero-production-caller gate for ``task_interaction_service.create`` and
-``task_interaction_service.respond``.
+"""Zero-production-caller gate for ``task_interaction_service.create`` alone.
 
-Both names are typed seams with no call body wired to them yet: ``create()``
-validates and returns a typed outcome without ever staging a row, and
-``respond()`` does not exist as a callable at all in this delivery. A static
-test asserts that no production module calls either name through this
-module, so the seam cannot grow a caller before its production behavior is
-actually implemented and tested.
+Replaces the two-name gate this file's predecessor enforced: that gate
+locked both ``create`` and ``respond`` against any production caller, and
+its own docstring named its retirement condition as "the change that routes
+the existing resume coordinator through this module's compatibility seam" --
+the change meant to give ``respond()`` its first production caller. That
+change has landed, but not that way: the compatibility seam in
+``websocket.py`` only reads ``_active_native_row_criteria()`` to decide
+whether an active native row exists, and rejects the legacy resume path
+outright when one does -- it never calls ``respond()`` itself. Zero
+production code anywhere in this package calls ``respond()`` today.
+Locking it under this gate anyway would be conflating "no gate" with "no
+caller"; the two are independent facts, and the former is what this file
+narrows to. ``create()`` still has no caller either, so this narrower gate
+takes over guarding it alone.
 
-Retired by the change that routes the existing resume coordinator through
-this module's compatibility seam. That change is what makes ``respond()``
-reachable in production: the seam refuses a legacy resume on a task that
-holds an active native interaction row, so from that change on the only way
-such a task can be answered is a caller that goes through ``respond()``. The
-first HTTP caller arrives separately, with the endpoint issue, and that
-change must explicitly retire this gate rather than merely satisfy it: an
-endpoint that reaches ``create``/``respond`` only in value position
-(``Depends(create)``, ``functools.partial(respond, ...)`` -- blind spot (e)
-above) leaves this gate passing without ever being seen by the AST walk
-below, so a still-green gate after that change lands is not evidence that
-nothing calls these names in production. ``create()`` is not covered by
-this gate's retirement at all: its production call body arrives with the
-change that wires interaction creation end-to-end and fills in
-``stage_interaction_request``'s caller obligations -- the change that
-deletes this gate file must add a replacement guard that locks
-``create()`` alone, or the seam stops being a statically enforced seam
-the moment this file goes away.
+``create()``'s production call body -- the write that actually calls
+``stage_interaction_request`` -- arrives with the change that wires
+interaction creation end-to-end and fills in that primitive's caller
+obligations. Retiring this gate is that change's job, not this one's: the
+change that deletes this file must add whatever replacement guard it needs,
+the same way this file replaced its own predecessor.
 
 AST-based, module-qualified matching -- not a bare-name or substring scan.
-``create`` and ``respond`` are ordinary English verbs already used as method
-names elsewhere in this codebase (``docker_client.containers.create(...)``,
-unrelated ``.respond(...)`` calls); a scanner that flagged every call named
-``create`` or ``respond`` would be red on day one. This gate only counts a
-call when the callee name is resolved -- through an import binding recorded
-in the same module -- to ``task_interaction_service.create`` or
-``task_interaction_service.respond`` specifically. This is a different scan
-shape from the staging primitive's own gate
-(``test_interaction_staging_production_gate.py``), which gates on two names
-that are unique enough in this codebase for a bare attribute match to be
-safe. ``create`` and ``respond`` are not unique, so this gate additionally
-tracks which local names are bound to this module before it will count a
-call against them; merely importing this module, or importing some other
-name from it (``InteractionPrincipal``, an outcome type, the shared
-ownership predicate), never trips this gate on its own.
+``create`` is an ordinary English verb already used as a method name
+elsewhere in this codebase (``docker_client.containers.create(...)``); a
+scanner that flagged every call named ``create`` would be red on day one.
+This gate only counts a call when the callee name is resolved -- through an
+import binding recorded in the same module -- to
+``task_interaction_service.create`` specifically.
 
 Known blind spots, not fixed here because closing them is out of scope for a
-static AST scan of one package tree (the staging gate documents the same
-class of gaps for the same reason):
+static AST scan of one package tree (identical to the predecessor gate's own
+list, for the identical reasons):
 
 (a) Dynamic access: ``importlib.import_module(...)`` plus ``getattr(...)``
     matches none of the node shapes below.
@@ -77,12 +63,14 @@ import ast
 import textwrap
 from pathlib import Path
 
+import pytest
+
 import xagent
 from xagent.web.services import (  # noqa: F401 -- negative control import
     task_interaction_service as service,
 )
 
-GATED_NAMES = frozenset({"create", "respond"})
+GATED_NAMES = frozenset({"create"})
 SERVICE_MODULE = "task_interaction_service"
 
 
@@ -177,11 +165,11 @@ def _production_modules() -> list[Path]:
 
 
 # --------------------------------------------------------------------------
-# T-GATE-1: the gate itself
+# The gate itself
 # --------------------------------------------------------------------------
 
 
-def test_no_production_module_calls_create_or_respond() -> None:
+def test_no_production_module_calls_create() -> None:
     offenders: dict[str, set[str]] = {}
     for path in _production_modules():
         try:
@@ -197,8 +185,8 @@ def test_no_production_module_calls_create_or_respond() -> None:
 
 
 # --------------------------------------------------------------------------
-# T-GATE-2: positive controls -- each call shape must be individually
-# detected once it is bound to this module
+# Positive controls -- each call shape must be individually detected once it
+# is bound to this module
 # --------------------------------------------------------------------------
 
 
@@ -232,10 +220,10 @@ def test_detects_module_attribute_call() -> None:
         from xagent.web.services import task_interaction_service
 
         def handler(db, **kwargs):
-            return task_interaction_service.respond(db, **kwargs)
+            return task_interaction_service.create(db, **kwargs)
         """
     )
-    assert _production_uses(source) == {"respond"}
+    assert _production_uses(source) == {"create"}
 
 
 def test_detects_aliased_module_attribute_call() -> None:
@@ -256,24 +244,28 @@ def test_detects_star_import_call() -> None:
         from xagent.web.services.task_interaction_service import *
 
         def handler(db, **kwargs):
-            return respond(db, **kwargs)
+            return create(db, **kwargs)
         """
     )
-    assert _production_uses(source) == {"respond"}
+    assert _production_uses(source) == {"create"}
 
 
 # --------------------------------------------------------------------------
-# T-GATE-3: negative controls -- the whole reason this gate cannot reuse the
-# staging gate's bare-name shape
+# Negative controls -- the whole reason this gate cannot reuse the staging
+# gate's bare-name shape
 # --------------------------------------------------------------------------
 
 
 def test_bare_module_import_alone_is_not_flagged() -> None:
-    """Unlike the staging gate, merely referencing this module -- with no
-    call to ``create``/``respond`` bound through it -- must not trip the
-    gate: production code (the shared ownership predicate's consumer in
-    ``public_chat_access.py``) legitimately imports other names from this
-    module in this same delivery."""
+    """Merely referencing this module -- with no call to ``create`` bound
+    through it -- must not trip the gate: production code (the shared
+    ownership predicate's consumer in ``public_chat_access.py``, which
+    imports ``InteractionPrincipal``, ``public_chat_identity_matches``, and
+    ``task_is_owned_by_public_principal``) legitimately imports other names
+    from this module. This gate no longer watches ``respond`` at all, so
+    a caller importing it too would not be flagged either -- see this
+    file's own module docstring for why: no production code calls
+    ``respond()`` today."""
 
     source = "from xagent.web.services import task_interaction_service\n"
     assert _production_uses(source) == set()
@@ -291,16 +283,34 @@ def test_importing_unrelated_name_is_not_flagged() -> None:
     assert _production_uses(source) == set()
 
 
-def test_same_named_call_on_an_unrelated_object_is_not_flagged() -> None:
-    """The whole point of module-qualified matching: a call named
-    ``create`` or ``respond`` on an object with no binding to this module
-    must not match, or this gate would be red against half the codebase."""
+def test_a_production_call_to_respond_is_not_flagged() -> None:
+    """A hypothetical production call to ``respond()`` -- something this
+    package does not actually have today (see this file's own module
+    docstring) -- must not trip this narrower gate either: retiring the
+    predecessor's two-name gate dropped the watch over ``respond`` entirely,
+    not merely relaxed it, so nothing calling ``respond()`` is this gate's
+    concern regardless of whether such a caller exists yet."""
 
     source = textwrap.dedent(
         """
-        def handler(docker_client, ticket):
+        from xagent.web.services.task_interaction_service import respond
+
+        def handler(**kwargs):
+            return respond(**kwargs)
+        """
+    )
+    assert _production_uses(source) == set()
+
+
+def test_same_named_call_on_an_unrelated_object_is_not_flagged() -> None:
+    """The whole point of module-qualified matching: a call named
+    ``create`` on an object with no binding to this module must not match,
+    or this gate would be red against half the codebase."""
+
+    source = textwrap.dedent(
+        """
+        def handler(docker_client):
             docker_client.containers.create(image="x")
-            return ticket.respond(status=200)
         """
     )
     assert _production_uses(source) == set()
@@ -308,7 +318,7 @@ def test_same_named_call_on_an_unrelated_object_is_not_flagged() -> None:
 
 def test_test_module_consumers_are_not_flagged() -> None:
     """Test consumers are allowed: this file, and any other test module
-    that imports the gated names, live under ``tests/``, which
+    that imports the gated name, live under ``tests/``, which
     ``_production_modules`` never walks -- it starts from
     ``xagent.__path__`` (``src/xagent``), not the repository root."""
 
@@ -321,3 +331,41 @@ def test_test_module_consumers_are_not_flagged() -> None:
 def test_service_module_itself_is_excluded_from_the_scan_set() -> None:
     modules = _production_modules()
     assert all(path.stem != SERVICE_MODULE for path in modules)
+
+
+# --------------------------------------------------------------------------
+# Forward-verification: adding a real production caller of ``create`` must
+# turn this gate red, not just its unit-level ``_production_uses`` checks
+# above. ``_production_modules`` walks ``xagent.__path__`` rather than a
+# hardcoded root, so pointing that at a scratch directory for the duration
+# of this one test exercises the exact same scan code the real gate runs,
+# without writing a canary file into the actual ``src/xagent`` tree -- a
+# crash between planting and cleanup there would leave a stray file behind
+# and make every later run of the real gate red for an unrelated reason.
+# --------------------------------------------------------------------------
+
+
+def test_gate_turns_red_when_a_production_caller_is_added(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(xagent, "__path__", [str(tmp_path)])
+    planted = tmp_path / "_zzz_test_task_interaction_service_create_gate_canary.py"
+    planted.write_text(
+        textwrap.dedent(
+            """
+            from xagent.web.services.task_interaction_service import create
+
+
+            def handler(db, **kwargs):
+                return create(db, **kwargs)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    offenders: dict[str, set[str]] = {}
+    for path in _production_modules():
+        uses = _production_uses(path.read_text(encoding="utf-8"))
+        if uses:
+            offenders[str(path)] = uses
+    assert offenders == {str(planted): {"create"}}

--- a/tests/web/services/test_task_interaction_service_create_gate.py
+++ b/tests/web/services/test_task_interaction_service_create_gate.py
@@ -23,8 +23,8 @@ AST-based, module-qualified matching -- not a bare-name or substring scan.
 elsewhere in this codebase (``docker_client.containers.create(...)``); a
 scanner that flagged every call named ``create`` would be red on day one.
 This gate only counts a call when the callee name is resolved -- through an
-import binding recorded in the same module -- to
-``task_interaction_service.create`` specifically.
+import binding recorded in the same module -- to one of the gated names,
+``task_interaction_service.create`` or ``respond``.
 
 Known blind spots, not fixed here because closing them is out of scope for a
 static AST scan of one package tree (identical to the predecessor gate's own

--- a/tests/web/services/test_task_interaction_service_create_gate.py
+++ b/tests/web/services/test_task_interaction_service_create_gate.py
@@ -258,10 +258,10 @@ def test_bare_module_import_alone_is_not_flagged() -> None:
     ownership predicate's consumer in ``public_chat_access.py``, which
     imports ``InteractionPrincipal``, ``public_chat_identity_matches``, and
     ``task_is_owned_by_public_principal``) legitimately imports other names
-    from this module. This gate no longer watches ``respond`` at all, so
-    a caller importing it too would not be flagged either -- see this
-    file's own module docstring for why: no production code calls
-    ``respond()`` today."""
+    from this module. The same holds for both gated names: importing the
+    module, or even binding ``create`` or ``respond`` without calling
+    either, is not a call -- only a call expression through a traced
+    binding trips the gate."""
 
     source = "from xagent.web.services import task_interaction_service\n"
     assert _production_uses(source) == set()

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -503,7 +503,18 @@ def test_concurrent_ownership_change_is_blocked_until_respond_commits(
     # process patched.
     real_fence_stmt = svc._answer_fence_stmt
 
+    # The holder signals here rather than letting the racer guess with a
+    # wall-clock stagger. This function runs after respond()'s step 2 has
+    # taken the tasks row lock and before its fence write, so setting the
+    # event here is the exact moment the racer's UPDATE must start blocking
+    # from. With a fixed 0.1s stagger instead, the test could fail in both
+    # directions on a loaded runner: a holder more than 0.1s late to reach
+    # step 2 lets the racer's UPDATE through unblocked, and a racer late to
+    # issue its UPDATE measures less than the full hold.
+    lock_taken = threading.Event()
+
     def _slow_fence_stmt(*args, **kwargs):
+        lock_taken.set()
         time.sleep(1.0)
         return real_fence_stmt(*args, **kwargs)
 
@@ -520,7 +531,7 @@ def test_concurrent_ownership_change_is_blocked_until_respond_commits(
         results["holder_outcome"] = outcome
 
     def racer() -> None:
-        time.sleep(0.1)
+        assert lock_taken.wait(timeout=30.0), "holder never reached the fence"
         t0 = time.monotonic()
         db = _respond_pg()
         try:

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -486,7 +486,11 @@ def test_concurrent_ownership_change_is_blocked_until_respond_commits(
 
     owner_id, task_id = _pg_waiting_task(_respond_pg)
     interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
-    intruder_id = make_user(_respond_pg())
+    setup_db = _respond_pg()
+    try:
+        intruder_id = make_user(setup_db)
+    finally:
+        setup_db.close()
 
     results: dict = {}
 
@@ -647,7 +651,7 @@ def test_respond_vs_purge_both_interleavings_leave_no_residue(_respond_pg) -> No
 # ---------------------------------------------------------------------------
 
 
-def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg) -> None:
+def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg, engine) -> None:
     import time
 
     import psycopg2.extras
@@ -655,9 +659,11 @@ def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg) -> None:
     user_id, task_id = _pg_waiting_task(_respond_pg)
     interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
     principal = _pg_owning_principal(user_id)
-    replacement_trace_event_id = _make_trace_event(_respond_pg(), task_id=task_id)
-
-    engine = _respond_pg().get_bind()
+    setup_db = _respond_pg()
+    try:
+        replacement_trace_event_id = _make_trace_event(setup_db, task_id=task_id)
+    finally:
+        setup_db.close()
 
     # Through the same engine's connection pool's raw DBAPI connection,
     # rather than a fresh psycopg2.connect(...) built from the URL, so the
@@ -766,13 +772,12 @@ def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_respond_vs_concurrent_purge_does_not_deadlock(_respond_pg) -> None:
+def test_respond_vs_concurrent_purge_does_not_deadlock(_respond_pg, engine) -> None:
     import time
 
     user_id, task_id = _pg_waiting_task(_respond_pg)
     interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
     principal = _pg_owning_principal(user_id)
-    engine = _respond_pg().get_bind()
 
     update_issued = threading.Event()
     results: dict = {}

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -1,8 +1,31 @@
-"""PostgreSQL-only coverage for ``materialize_compatibility_view``'s two
-backend-sensitive facts: the schema-presence gate (A5-P1) and the
-four-field active-row predicate's tiering (A5-P2), both first established
-as ad hoc probes against a disposable database during this delivery's own
-fact audit and pinned here as real, repeatable assertions.
+"""PostgreSQL-only coverage for ``task_interaction_service``, for everything
+in this delivery that a SQLite-backed test cannot actually exercise:
+
+- ``materialize_compatibility_view``'s two backend-sensitive facts, first
+  established as ad hoc probes against a disposable database during this
+  delivery's own fact audit: the schema-presence gate (A5-P1) and the
+  four-field active-row predicate's tiering (A5-P2).
+- The answer fence's guest entity-binding JSON lookup, which compiles to
+  different SQL on PostgreSQL (``->>``) than on SQLite
+  (``json_extract``) and needs a real PostgreSQL server to prove the two
+  backends agree. (The TaskStatus-bind-parameter structural guard this
+  bullet used to also cover needs no database at all and lives in the
+  sibling SQLite-backed file instead.)
+- ``respond()``'s six non-active-row rowcount=0 classifications and the
+  three answered-row CHECK constraints, run against a real PostgreSQL
+  server rather than as a second copy of the SQLite-backed cell tests --
+  the point here is the backend, not new behavior coverage.
+- Four genuinely concurrent tests, each opening a second real connection:
+  the ownership-change TOCTOU window that PostgreSQL's row lock closes
+  (which SQLite's single-writer model cannot reproduce), two
+  ``respond()`` calls serializing on the same ``tasks`` row, and two
+  lock-order deadlock regressions (``respond()`` racing a staging
+  reclaim, and ``respond()`` racing a concurrent purge).
+- One sequential (not concurrent) test running both
+  ``respond()``-vs-``purge_task_rows`` orderings one after another --
+  each ordering runs to completion and commits before the next
+  statement starts, so nothing here actually contends on a lock -- and
+  confirming neither ordering leaves residue.
 
 Fixture pattern follows ``test_interaction_staging_postgresql.py``: a
 disposable, uniquely-named schema inside whatever database
@@ -14,6 +37,7 @@ for why (a shared ``alembic_version`` row contended across worktrees).
 from __future__ import annotations
 
 import os
+import threading
 import uuid
 from datetime import datetime, timedelta, timezone
 from itertools import count
@@ -22,16 +46,28 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import sessionmaker
 
-from tests.web.services.task_interaction_schema_shared import make_task, make_user
+import xagent.web.models.database as database_module
+from tests.web.services.task_interaction_schema_shared import (
+    assert_rejected,
+    make_row,
+    make_task,
+    make_user,
+)
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import task_interaction_service as svc
+from xagent.web.services.interaction_rollout import counters_snapshot
 from xagent.web.services.ops_signals import (
     CHECKPOINT_LOAD_UNAVAILABLE,
     CHECKPOINT_PK_ANCHOR_DANGLING,
     clear_degradation,
+)
+from xagent.web.services.task_command_transport import (
+    TaskCommandKind,
+    enqueue_task_command,
 )
 from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD
 
@@ -267,34 +303,873 @@ def test_active_row_predicate_three_way_tiering(db_session) -> None:
 
 
 # ---------------------------------------------------------------------------
-# TaskStatusPredicate compile-time assertion. Necessarily green today, not
-# aspirationally green: the active-row query this delivery ships never
-# references Task.status at all (see _active_native_row_criteria's own
-# docstring for why -- "is the task WAITING_FOR_USER" is a concern the
-# future answer fence adds, not part of "which row is the live one"), so
-# there is no TaskStatus literal for this assertion to ever have caught in
-# this delivery. It stays here anyway, not deleted, as the tripwire for the
-# change that does add a Task.status conjunct to a query built from this
-# same predicate (the answer fence, or the write-side reclaim statement):
-# when either lands, this assertion must go on compiling their query too,
-# and it must keep passing only because that new conjunct goes through
-# TaskStatusPredicate rather than a bare TaskStatus member-name string. A
-# future author who adds a literal instead of using TaskStatusPredicate
-# should see this assertion turn red, not stay silently green because
-# nobody pointed it at the new query.
+# The TaskStatusPredicate structural assertion (zero TaskStatus bind
+# parameters in the active-row query) needs no database at all -- it lives
+# in the sibling SQLite-backed file (test_task_interaction_service.py) so
+# it runs by default instead of skipping whenever XAGENT_TEST_POSTGRES_URL
+# is unset.
 # ---------------------------------------------------------------------------
 
 
-def test_active_row_query_compiles_with_zero_taskstatus_literals(engine) -> None:
-    stmt = (
-        sa.select(TaskInteractionRequest)
-        .join(Task, Task.id == TaskInteractionRequest.task_id)
-        .where(
-            TaskInteractionRequest.task_id == 1,
-            *svc._active_native_row_criteria(),
+# ---------------------------------------------------------------------------
+# The guest entity-binding JSON term compiles differently on
+# each backend (``->>`` on PostgreSQL, ``json_extract`` on SQLite -- see
+# ``_answer_fence_task_predicate``'s own docstring) and must still agree on
+# every case. The SQLite half of this same assertion lives in
+# ``test_task_interaction_service.py``.
+# ---------------------------------------------------------------------------
+
+
+def test_answer_fence_guest_entity_binding_matches_on_postgresql(db_session) -> None:
+    db = db_session
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    task = db.query(Task).filter(Task.id == task_id).first()
+    task.agent_config = {"auth_mode": "widget", "guest_id": "guest-abc"}
+    task.status = TaskStatus.WAITING_FOR_USER
+    db.commit()
+
+    def matches(guest_id: str) -> bool:
+        principal = svc.InteractionPrincipal(
+            kind="guest",
+            user_id=user_id,
+            is_admin=False,
+            auth_mode="widget",
+            guest_id=guest_id,
         )
+        terms = svc._answer_fence_task_predicate(principal)
+        stmt = sa.select(
+            sa.exists(
+                sa.select(sa.literal(1))
+                .select_from(Task)
+                .where(Task.id == task_id, *terms)
+            )
+        )
+        return bool(db.execute(stmt).scalar())
+
+    assert matches("guest-abc") is True
+    assert matches("guest-WRONG") is False
+
+
+# ---------------------------------------------------------------------------
+# The six rowcount=0 classification cells, exercised through a real
+# svc.respond() call against PostgreSQL, plus the CHECK-guarded answered-row
+# shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _respond_pg(monkeypatch: pytest.MonkeyPatch, session_factory):
+    import xagent.web.models.database as database_module
+
+    monkeypatch.setattr(database_module, "get_session_local", lambda: session_factory)
+    return session_factory
+
+
+def _pg_waiting_task(
+    session_factory,
+    *,
+    run_id: str = "run-a",
+    state_version: int = 5,
+) -> tuple[int, int]:
+    db = session_factory()
+    try:
+        user_id = make_user(db)
+        task_id = make_task(db, user_id=user_id)
+        task = db.query(Task).filter(Task.id == task_id).first()
+        task.status = TaskStatus.WAITING_FOR_USER
+        task.control_state = "waiting_for_user"
+        task.run_id = run_id
+        task.state_version = state_version
+        db.commit()
+        return user_id, task_id
+    finally:
+        db.close()
+
+
+def _pg_active_row(session_factory, *, task_id: int, run_id: str = "run-a") -> int:
+    db = session_factory()
+    try:
+        trace_event_id = _make_trace_event(db, task_id=task_id, run_partition=run_id)
+        row = _make_active_row(
+            db,
+            task_id=task_id,
+            run_id=run_id,
+            resume_trace_event_id=trace_event_id,
+            resume_run_partition=run_id,
+        )
+        return int(row.id)
+    finally:
+        db.close()
+
+
+def _pg_owning_principal(user_id: int) -> svc.InteractionPrincipal:
+    """The one principal shape every ``respond()`` call in this file uses
+    except the guest binding test above, which needs a distinct
+    ``kind``/``auth_mode``/``guest_id`` shape of its own."""
+
+    return svc.InteractionPrincipal(
+        kind="user", user_id=user_id, is_admin=False, auth_mode=None
     )
-    compiled = str(stmt.compile(bind=engine, compile_kwargs={"literal_binds": True}))
-    for member in TaskStatus:
-        assert member.name not in compiled
-        assert member.name.lower() not in compiled
+
+
+def _pg_envelope(idempotency_key: str) -> svc.RespondEnvelope:
+    """Every ``RespondEnvelope`` in this file carries the same
+    ``kind``/``protocol_version``/``values`` and differs only by
+    ``idempotency_key``."""
+
+    return svc.RespondEnvelope(
+        kind="clarification",
+        protocol_version=1,
+        values={"env": "prod"},
+        idempotency_key=idempotency_key,
+    )
+
+
+def test_answer_fence_rowcount_across_six_non_active_states(_respond_pg) -> None:
+    """Each of the six ways the fence UPDATE can land on rowcount=0,
+    exercised sequentially (one ``svc.respond()`` call after another, no
+    concurrent writer) against a real PostgreSQL server rather than SQLite --
+    the point of running this here instead of in the SQLite-backed sibling
+    file is the backend, not concurrency. Each case runs through
+    ``svc.respond()`` end to end rather than the fence statement in
+    isolation. Actual concurrent-writer coverage lives in the dedicated
+    tests below this one (``test_concurrent_ownership_change_is_blocked...``,
+    ``test_two_concurrent_respond_calls_serialize...``, and the
+    deadlock/residue tests), which do open a second connection."""
+
+    # 1. Already answered, fresh key -> Conflict(already_answered).
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    db = _respond_pg()
+    try:
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == interaction_id)
+            .first()
+        )
+        row.status = "answered"
+        row.active_slot = None
+        row.response_payload = {"env": "prod"}
+        row.responded_at = _now()
+        row.responder_identity = _pg_owning_principal(user_id).identity_string()
+        db.commit()
+    finally:
+        db.close()
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=_pg_owning_principal(user_id),
+        envelope=_pg_envelope("pg-already-answered"),
+    )
+    assert outcome == svc.RespondConflict(reason="already_answered")
+
+    # 2/3/4. Terminated, three reasons.
+    for terminal_reason, expected in (
+        ("deadline_elapsed", "expired"),
+        ("run_superseded", "run_superseded"),
+        ("answered_via_legacy_resume", "answered_via_chat"),
+    ):
+        user_id, task_id = _pg_waiting_task(_respond_pg)
+        interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+        db = _respond_pg()
+        try:
+            row = (
+                db.query(TaskInteractionRequest)
+                .filter(TaskInteractionRequest.id == interaction_id)
+                .first()
+            )
+            row.status = "terminated"
+            row.active_slot = None
+            row.terminal_reason = terminal_reason
+            row.terminated_at = _now()
+            db.commit()
+        finally:
+            db.close()
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_pg_owning_principal(user_id),
+            envelope=_pg_envelope(f"pg-terminated-{terminal_reason}"),
+        )
+        assert outcome == svc.RespondStale(reason=expected)
+
+    # 5. Still active, task not WAITING.
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    db = _respond_pg()
+    try:
+        db.query(Task).filter(Task.id == task_id).update({"status": TaskStatus.RUNNING})
+        db.commit()
+    finally:
+        db.close()
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=_pg_owning_principal(user_id),
+        envelope=_pg_envelope("pg-not-waiting"),
+    )
+    assert outcome == svc.RespondStale(reason="run_ended")
+
+    # 6. Still active, waiting, but a foreign run.
+    user_id, task_id = _pg_waiting_task(_respond_pg, run_id="run-current")
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id, run_id="run-old")
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=_pg_owning_principal(user_id),
+        envelope=_pg_envelope("pg-foreign-run"),
+    )
+    assert outcome == svc.RespondStale(reason="foreign_run")
+
+
+# ---------------------------------------------------------------------------
+# The answered-row shape is CHECK-guarded, exact constraint names.
+# ---------------------------------------------------------------------------
+
+
+def test_answered_row_cannot_also_carry_terminated_at(db_session) -> None:
+    db = db_session
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    row = make_row(
+        task_id=task_id,
+        resume_trace_event_id=None,
+        status="answered",
+        terminated_at=_now(),
+    )
+    assert_rejected(db, row, "ck_task_interaction_requests_terminated_at_pairs_status")
+
+
+def test_answered_row_requires_responder_identity(db_session) -> None:
+    db = db_session
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    row = make_row(
+        task_id=task_id,
+        resume_trace_event_id=None,
+        status="answered",
+        responder_identity=None,
+    )
+    assert_rejected(
+        db, row, "ck_task_interaction_requests_responder_pairs_responded_at"
+    )
+
+
+def test_answered_row_cannot_keep_its_active_slot(db_session) -> None:
+    db = db_session
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    row = make_row(
+        task_id=task_id,
+        resume_trace_event_id=None,
+        status="answered",
+        active_slot=1,
+    )
+    assert_rejected(db, row, "ck_task_interaction_requests_active_slot_pairs_status")
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: two real connections, real locks. The reverse assertion that
+# the ownership predicate is redundant on PostgreSQL because the row lock
+# closes the ownership-change TOCTOU window (see
+# ``_answer_fence_task_predicate``'s own docstring), two concurrent
+# respond() calls serializing on the tasks row, and the two
+# respond()-vs-purge interleavings.
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_ownership_change_is_blocked_until_respond_commits(
+    _respond_pg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import threading
+    import time
+
+    owner_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    intruder_id = make_user(_respond_pg())
+
+    results: dict = {}
+
+    # Sleep injected between step 2's lock and the fence write, standing in
+    # for step 3's authorization work, by wrapping the fence statement
+    # builder. Patched via monkeypatch (not a manual assign-then-restore)
+    # so the module-global attribute is restored at fixture teardown no
+    # matter what happens on the holder thread below -- a raise before its
+    # own restore code ran would otherwise leave every later test in this
+    # process patched.
+    real_fence_stmt = svc._answer_fence_stmt
+
+    def _slow_fence_stmt(*args, **kwargs):
+        time.sleep(1.0)
+        return real_fence_stmt(*args, **kwargs)
+
+    monkeypatch.setattr(svc, "_answer_fence_stmt", _slow_fence_stmt)
+
+    def holder() -> None:
+        principal = _pg_owning_principal(owner_id)
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_pg_envelope("pg-a5-holder"),
+        )
+        results["holder_outcome"] = outcome
+
+    def racer() -> None:
+        time.sleep(0.1)
+        t0 = time.monotonic()
+        db = _respond_pg()
+        try:
+            db.query(Task).filter(Task.id == task_id).update({"user_id": intruder_id})
+            db.commit()
+        finally:
+            db.close()
+        results["racer_wait_s"] = time.monotonic() - t0
+
+    t1 = threading.Thread(target=holder)
+    t2 = threading.Thread(target=racer)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert isinstance(results["holder_outcome"], svc.RespondAccepted), results
+    assert results["racer_wait_s"] >= 0.8, results
+
+
+def test_two_concurrent_respond_calls_serialize_on_the_tasks_row(_respond_pg) -> None:
+    import threading
+
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    principal = _pg_owning_principal(user_id)
+
+    outcomes: list = []
+
+    def call(idempotency_key: str) -> None:
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=_pg_envelope(idempotency_key),
+        )
+        outcomes.append(outcome)
+
+    t1 = threading.Thread(target=call, args=("pg-concurrent-1",))
+    t2 = threading.Thread(target=call, args=("pg-concurrent-2",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    accepted = [o for o in outcomes if isinstance(o, svc.RespondAccepted)]
+    stale_or_conflict = [
+        o for o in outcomes if isinstance(o, (svc.RespondStale, svc.RespondConflict))
+    ]
+    assert len(accepted) == 1, outcomes
+    assert len(stale_or_conflict) == 1, outcomes
+
+
+def test_respond_vs_purge_both_interleavings_leave_no_residue(_respond_pg) -> None:
+    from xagent.web.services.task_deletion import purge_task_rows
+
+    for order in ("purge_first", "respond_first"):
+        user_id, task_id = _pg_waiting_task(_respond_pg)
+        interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+        principal = _pg_owning_principal(user_id)
+
+        if order == "purge_first":
+            db = _respond_pg()
+            try:
+                purge_task_rows(db, task_id=task_id)
+                db.commit()
+            finally:
+                db.close()
+            outcome = svc.respond(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                principal=principal,
+                envelope=_pg_envelope(f"pg-{order}"),
+            )
+            assert outcome == svc.RespondUnavailable(reason="task_missing")
+        else:
+            outcome = svc.respond(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                principal=principal,
+                envelope=_pg_envelope(f"pg-{order}"),
+            )
+            assert isinstance(outcome, svc.RespondAccepted)
+            db = _respond_pg()
+            try:
+                purge_task_rows(db, task_id=task_id)
+                db.commit()
+            finally:
+                db.close()
+
+        verify_db = _respond_pg()
+        try:
+            remaining_task = verify_db.query(Task).filter(Task.id == task_id).count()
+            remaining_ir = (
+                verify_db.query(TaskInteractionRequest)
+                .filter(TaskInteractionRequest.task_id == task_id)
+                .count()
+            )
+            assert remaining_task == 0, order
+            assert remaining_ir == 0, order
+        finally:
+            verify_db.close()
+
+
+# ---------------------------------------------------------------------------
+# The lock-strength mutation's real witness: respond() racing a staging-side
+# reclaim. The reclaim UPDATE takes the interaction row first and its
+# replacement INSERT then needs a KEY SHARE lock on the tasks parent row --
+# a `FOR UPDATE` step 2 (instead of `FOR NO KEY UPDATE`) closes a cycle with
+# that INSERT and deadlocks; a `FOR NO KEY UPDATE` step 2 does not, because
+# `NO KEY UPDATE` and `KEY SHARE` do not conflict. This does not go through
+# svc.respond() for the staging side -- the interaction staging primitive's
+# own reclaim/replace sequence is reproduced directly in SQL, since
+# exercising real production code for both sides is not required to pin
+# the lock mechanics this guards.
+# ---------------------------------------------------------------------------
+
+
+def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg) -> None:
+    import threading
+    import time
+
+    import psycopg2.extras
+
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    principal = _pg_owning_principal(user_id)
+    replacement_trace_event_id = _make_trace_event(_respond_pg(), task_id=task_id)
+
+    engine = _respond_pg().get_bind()
+
+    # Through the same engine's connection pool's raw DBAPI connection,
+    # rather than a fresh psycopg2.connect(...) built from the URL, so the
+    # search_path (the disposable per-test schema) carries over identically
+    # to every other query in this test module.
+    def _raw_conn():
+        raw = engine.raw_connection()
+        raw.autocommit = False
+        return raw
+
+    results: dict = {}
+
+    def reclaim_then_insert() -> None:
+        conn = _raw_conn()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE task_interaction_requests SET "
+                "status = 'terminated', terminal_reason = 'run_superseded', "
+                "active_slot = NULL, terminated_at = now(), updated_at = now() "
+                "WHERE task_id = %s AND active_slot IS NOT NULL",
+                (task_id,),
+            )
+            update_issued.set()
+            time.sleep(0.3)
+            cur.execute(
+                "INSERT INTO task_interaction_requests ("
+                "task_id, run_id, kind, protocol_version, status, active_slot, "
+                "origin, request_payload, request_idempotency_key, "
+                "resume_trace_event_id, resume_event_id, resume_execution_id, "
+                "resume_locator_format, resume_checkpoint_type, "
+                "resume_run_partition, created_at, expires_at"
+                ") VALUES (%s, %s, 'clarification', 1, 'active', 1, 'internal', "
+                "%s, %s, %s, 'resume-event-x', 'exec-x', 'trace_event_pk_v1', "
+                "'agent_execution_checkpoint', %s, now(), now() + interval '15 minutes')",
+                (
+                    task_id,
+                    "run-a",
+                    psycopg2.extras.Json({"message": "new", "interactions": []}),
+                    "pg-reclaim-key",
+                    replacement_trace_event_id,
+                    "run-a",
+                ),
+            )
+            conn.commit()
+            results["reclaim_outcome"] = "ok"
+        except Exception as exc:  # noqa: BLE001
+            conn.rollback()
+            results["reclaim_outcome"] = f"error: {exc}"
+        finally:
+            conn.close()
+
+    def respond_call() -> None:
+        update_issued.wait(timeout=5)
+        try:
+            outcome = svc.respond(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                principal=principal,
+                envelope=_pg_envelope("pg-reclaim-race"),
+            )
+            results["respond_outcome"] = outcome
+        except Exception as exc:  # noqa: BLE001
+            results["respond_outcome"] = f"error: {exc}"
+
+    # Deterministic ordering, not a fixed sleep: respond() must not start
+    # until the reclaim's UPDATE has genuinely been issued (even though
+    # still uncommitted) on the reclaim thread's own connection, or the two
+    # threads' actual DB statement order -- the fact this test exists to
+    # pin -- would be left to OS scheduling.
+    update_issued = threading.Event()
+    t1 = threading.Thread(target=reclaim_then_insert)
+    t2 = threading.Thread(target=respond_call)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert results.get("reclaim_outcome") == "ok", results
+    # The reclaim's UPDATE lands, uncommitted, before respond()'s own fence
+    # UPDATE reaches the same row; respond() blocks on it (a plain row lock,
+    # not the tasks lock this test is about), resumes once the reclaim
+    # commits, and correctly reports the row as superseded rather than
+    # timing out or raising -- the interesting fact this test pins is that
+    # neither thread deadlocks getting there, not which of them "wins".
+    assert results.get("respond_outcome") == svc.RespondStale(
+        reason="run_superseded"
+    ), results
+
+
+# ---------------------------------------------------------------------------
+# The lock-order mutation's real witness: respond() genuinely racing
+# purge_task_rows on two threads, not the sequential two-orderings test
+# above (which never contends on a lock at all -- each ordering there runs
+# to completion and commits before the next statement starts). purge's own
+# lock order is tasks-first, same as respond()'s: purge's checkpoint-
+# pointer UPDATE takes the tasks row before its interaction-row DELETE runs.
+# If respond()'s own order were ever reversed, this is the concrete cycle
+# that would deadlock -- reproduced here with purge's two statements issued
+# directly, since exercising purge_task_rows itself on a second thread has
+# no seam to inject the delay this test needs between its two statements.
+# ---------------------------------------------------------------------------
+
+
+def test_respond_vs_concurrent_purge_does_not_deadlock(_respond_pg) -> None:
+    import threading
+    import time
+
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    principal = _pg_owning_principal(user_id)
+    engine = _respond_pg().get_bind()
+
+    update_issued = threading.Event()
+    results: dict = {}
+
+    def purge_sequence() -> None:
+        conn = engine.raw_connection()
+        conn.autocommit = False
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE tasks SET last_checkpoint_event_id = NULL, "
+                "last_checkpoint_trace_event_id = NULL WHERE id = %s",
+                (task_id,),
+            )
+            update_issued.set()
+            time.sleep(0.3)
+            cur.execute(
+                "DELETE FROM task_interaction_requests WHERE task_id = %s", (task_id,)
+            )
+            # Not a full purge_task_rows reproduction (trace_events and the
+            # tasks row itself are left alone) -- only the two statements
+            # whose relative order determines whether this races respond()
+            # into a lock cycle: the checkpoint-pointer UPDATE on tasks
+            # above, and this DELETE on the interaction row.
+            conn.commit()
+            results["purge_outcome"] = "ok"
+        except Exception as exc:  # noqa: BLE001
+            conn.rollback()
+            results["purge_outcome"] = f"error: {exc}"
+        finally:
+            conn.close()
+
+    def respond_call() -> None:
+        update_issued.wait(timeout=5)
+        try:
+            outcome = svc.respond(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                principal=principal,
+                envelope=_pg_envelope("pg-purge-race"),
+            )
+            results["respond_outcome"] = outcome
+        except Exception as exc:  # noqa: BLE001
+            results["respond_outcome"] = f"error: {exc}"
+
+    t1 = threading.Thread(target=purge_sequence)
+    t2 = threading.Thread(target=respond_call)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert results.get("purge_outcome") == "ok", results
+    # respond()'s own step 2 blocks on purge's tasks-row UPDATE (same lock
+    # order, so this is ordinary serialization, not a cycle); by the time it
+    # unblocks, the interaction row is already gone, so respond() correctly
+    # reports that rather than deadlocking or hanging.
+    assert results.get("respond_outcome") == svc.RespondUnavailable(
+        reason="interaction_missing"
+    ), results
+
+
+# ---------------------------------------------------------------------------
+# classify_task_command_conflict's IntegrityError branch (step 8), reached
+# from svc.respond() when stage_task_command's own insert -- inside this
+# call's own ``db.begin_nested()`` -- collides with the
+# ``uq_task_command_identity`` unique constraint. See
+# test_task_interaction_service.py's own section by this name for the full
+# reachability audit of all three TaskCommandConflictKind values against
+# the real code: UNRELATED and TASK_MISSING are both provably unreachable
+# through respond() on either backend (actor_user_id is always the task's
+# own owner, which the fence's ownership predicate requires and which
+# cannot be deleted out from under a task row this transaction still
+# references; the task row itself cannot disappear before this call's own
+# insert either). RACED_DUPLICATE is the only reachable one, and only here
+# on PostgreSQL: a second writer must commit a row for the same
+# (task_id, command_id) strictly between stage_task_command's own
+# existing-row check and its own insert flush, a window SQLite's single
+# whole-database writer lock closes (respond() has already written the
+# fence UPDATE and the CAS on its own connection by the time it reaches
+# step 8, so that connection already holds SQLite's one writer lock).
+# PostgreSQL's row lock from step 2 is scoped to the specific ``tasks`` row
+# alone, so a second writer can complete an insert into the unrelated
+# ``task_execution_commands`` table while this transaction is still open.
+#
+# Both of RACED_DUPLICATE's sub-branches are pinned below -- they produce
+# different RespondOutcomes and only one touches the response-conflict
+# counter (the same counter the idempotency_key_reused cells in the
+# SQLite-backed file exercise through the earlier, pre-existing-command
+# shortcut at step 5; this is the same counter's other, previously
+# untested, wiring point at step 8):
+#
+# - payload_matches=True: the second writer's row carries the identical
+#   actor/kind/payload this call would itself have staged. respond()
+#   replays the winning row (``RespondReplayed``) rather than treating the
+#   loss as a failure, and does not touch the counter.
+# - payload_matches=False: the second writer's row carries different
+#   ``values``, so it canonicalizes to a different payload.
+#   classify_task_command_conflict still finds it (it does not compare
+#   payloads to decide whether a row raced -- only to decide what to do
+#   once one has), and respond() reports ``RespondConflict`` and does
+#   increment the counter, rolling back the whole transaction -- including
+#   the fence UPDATE and the CAS this call had already issued -- since none
+#   of that write was this call's own to keep.
+# ---------------------------------------------------------------------------
+
+
+def _pg_conflict_counter() -> int:
+    return counters_snapshot().get(svc.COUNTER_LIFECYCLE_RESPONSE_CONFLICT, 0)
+
+
+def _pause_command_add_session_factory(
+    base_session_factory, *, precheck_done, release_event
+):
+    """A session factory wrapping ``base_session_factory`` whose returned
+    session pauses the instant something calls ``.add()`` with a
+    ``TaskExecutionCommand`` -- the exact point stage_task_command reaches
+    right after its own existing-row check has already found nothing and
+    right before the insert flush this test needs a second writer to beat.
+    Only ``get_session_local`` is repointed at this wrapper, and only after
+    every setup call already used the plain ``_respond_pg`` factory
+    directly, so only respond()'s own internally-created session is
+    instrumented -- the racing writer below opens its own, unpatched
+    session straight off the base factory."""
+
+    def factory():
+        db = base_session_factory()
+        real_add = db.add
+
+        def paused_add(instance):
+            if isinstance(instance, TaskExecutionCommand):
+                precheck_done.set()
+                assert release_event.wait(timeout=10)
+            real_add(instance)
+
+        db.add = paused_add
+        return db
+
+    return factory
+
+
+def test_respond_races_a_committed_duplicate_command_and_replays_on_matching_payload(
+    _respond_pg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second, independent writer commits a TaskExecutionCommand row for
+    the same (task_id, command_id) with the identical actor/kind/payload
+    while respond() is paused right after its own stage_task_command's
+    existing-row check already found nothing. respond()'s own insert then
+    collides on the unique constraint; classify_task_command_conflict
+    reports RACED_DUPLICATE with payload_matches=True, and respond() commits
+    and replays the winning row instead of treating this as a failure."""
+
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    principal = _pg_owning_principal(user_id)
+    envelope = _pg_envelope("pg-raced-duplicate-match")
+    matching_payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values=envelope.values
+    )
+
+    precheck_done = threading.Event()
+    release_respond = threading.Event()
+    results: dict = {}
+
+    monkeypatch.setattr(
+        database_module,
+        "get_session_local",
+        lambda: _pause_command_add_session_factory(
+            _respond_pg, precheck_done=precheck_done, release_event=release_respond
+        ),
+    )
+
+    def call_respond() -> None:
+        results["outcome"] = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=envelope,
+        )
+
+    t_respond = threading.Thread(target=call_respond)
+    t_respond.start()
+    assert precheck_done.wait(timeout=10)
+
+    db_racer = _respond_pg()
+    try:
+        winner = enqueue_task_command(
+            db_racer,
+            task_id=task_id,
+            actor_user_id=principal.user_id,
+            command_id=envelope.idempotency_key,
+            kind=TaskCommandKind.RESUME,
+            payload=matching_payload,
+        )
+    finally:
+        db_racer.close()
+
+    before_counter = _pg_conflict_counter()
+    release_respond.set()
+    t_respond.join(timeout=10)
+
+    outcome = results["outcome"]
+    assert isinstance(outcome, svc.RespondReplayed), outcome
+    assert outcome.receipt.command_db_id == winner.command_id
+    assert _pg_conflict_counter() == before_counter
+
+    verify_db = _respond_pg()
+    try:
+        commands = (
+            verify_db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.task_id == task_id)
+            .all()
+        )
+        assert len(commands) == 1, commands
+        assert commands[0].id == winner.command_id
+        assert commands[0].actor_user_id == principal.user_id
+    finally:
+        verify_db.close()
+
+
+def test_respond_races_a_committed_duplicate_command_and_conflicts_on_mismatched_payload(
+    _respond_pg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same race as above, except the second writer's row carries different
+    answer values -- a different canonicalized payload.
+    classify_task_command_conflict still classifies this as
+    RACED_DUPLICATE (it finds the row purely by (task_id, command_id), not
+    by payload), but with payload_matches=False; respond() reports
+    RespondConflict, increments the response-conflict counter, and rolls
+    back the whole transaction -- undoing its own fence UPDATE and CAS,
+    since none of that write is this call's to keep once its own command
+    lost the race."""
+
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    principal = _pg_owning_principal(user_id)
+    envelope = _pg_envelope("pg-raced-duplicate-mismatch")
+    mismatched_payload = svc._respond_command_payload(
+        interaction_id=interaction_id,
+        principal=principal,
+        values={"env": "a-different-answer-than-this-call-submits"},
+    )
+
+    precheck_done = threading.Event()
+    release_respond = threading.Event()
+    results: dict = {}
+
+    monkeypatch.setattr(
+        database_module,
+        "get_session_local",
+        lambda: _pause_command_add_session_factory(
+            _respond_pg, precheck_done=precheck_done, release_event=release_respond
+        ),
+    )
+
+    def call_respond() -> None:
+        results["outcome"] = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=envelope,
+        )
+
+    t_respond = threading.Thread(target=call_respond)
+    t_respond.start()
+    assert precheck_done.wait(timeout=10)
+
+    db_racer = _respond_pg()
+    try:
+        winner = enqueue_task_command(
+            db_racer,
+            task_id=task_id,
+            actor_user_id=principal.user_id,
+            command_id=envelope.idempotency_key,
+            kind=TaskCommandKind.RESUME,
+            payload=mismatched_payload,
+        )
+    finally:
+        db_racer.close()
+
+    before_counter = _pg_conflict_counter()
+    release_respond.set()
+    t_respond.join(timeout=10)
+
+    outcome = results["outcome"]
+    assert outcome == svc.RespondConflict(reason="idempotency_key_reused"), outcome
+    assert _pg_conflict_counter() == before_counter + 1
+
+    verify_db = _respond_pg()
+    try:
+        commands = (
+            verify_db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.task_id == task_id)
+            .all()
+        )
+        assert len(commands) == 1, commands
+        assert commands[0].id == winner.command_id
+        assert commands[0].payload == mismatched_payload
+
+        row = (
+            verify_db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == interaction_id)
+            .first()
+        )
+        assert row.status == "active"
+        assert row.active_slot == 1
+        assert row.responded_at is None
+
+        task = verify_db.query(Task).filter(Task.id == task_id).first()
+        assert task.state_version == 5
+        assert task.control_state == "waiting_for_user"
+    finally:
+        verify_db.close()

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -11,16 +11,19 @@ in this delivery that a SQLite-backed test cannot actually exercise:
   backends agree. (The TaskStatus-bind-parameter structural guard this
   bullet used to also cover needs no database at all and lives in the
   sibling SQLite-backed file instead.)
-- ``respond()``'s six non-active-row rowcount=0 classifications and the
-  three answered-row CHECK constraints, run against a real PostgreSQL
-  server rather than as a second copy of the SQLite-backed cell tests --
-  the point here is the backend, not new behavior coverage.
+- The three answered-row CHECK constraints. (This build does not classify
+  a rowcount=0 fence miss -- see ``RespondOutcomeUnknown``'s own
+  docstring -- so the six non-active-row classification cells a more
+  detailed build would need proven against a real PostgreSQL server are
+  not delivered here either.)
 - Four genuinely concurrent tests, each opening a second real connection:
   the ownership-change TOCTOU window that PostgreSQL's row lock closes
   (which SQLite's single-writer model cannot reproduce), two
   ``respond()`` calls serializing on the same ``tasks`` row, and two
   lock-order deadlock regressions (``respond()`` racing a staging
-  reclaim, and ``respond()`` racing a concurrent purge).
+  reclaim, and ``respond()`` racing a concurrent purge) -- both
+  deadlock regressions assert this build's own conservative outcome
+  where their more detailed sibling would assert a specific reason.
 - One sequential (not concurrent) test running both
   ``respond()``-vs-``purge_task_rows`` orderings one after another --
   each ordering runs to completion and commits before the next
@@ -46,7 +49,6 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import sessionmaker
 
-import xagent.web.models.database as database_module
 from tests.web.services.task_interaction_schema_shared import (
     assert_rejected,
     make_row,
@@ -56,18 +58,12 @@ from tests.web.services.task_interaction_schema_shared import (
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
-from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import task_interaction_service as svc
-from xagent.web.services.interaction_rollout import counters_snapshot
 from xagent.web.services.ops_signals import (
     CHECKPOINT_LOAD_UNAVAILABLE,
     CHECKPOINT_PK_ANCHOR_DANGLING,
     clear_degradation,
-)
-from xagent.web.services.task_command_transport import (
-    TaskCommandKind,
-    enqueue_task_command,
 )
 from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD
 
@@ -352,9 +348,10 @@ def test_answer_fence_guest_entity_binding_matches_on_postgresql(db_session) -> 
 
 
 # ---------------------------------------------------------------------------
-# The six rowcount=0 classification cells, exercised through a real
-# svc.respond() call against PostgreSQL, plus the CHECK-guarded answered-row
-# shape.
+# Fixtures shared by every real svc.respond() call in this file, plus the
+# CHECK-guarded answered-row shape. (The six rowcount=0 classification
+# cells this build does not classify are not exercised here -- see this
+# file's own module docstring.)
 # ---------------------------------------------------------------------------
 
 
@@ -426,103 +423,6 @@ def _pg_envelope(idempotency_key: str) -> svc.RespondEnvelope:
     )
 
 
-def test_answer_fence_rowcount_across_six_non_active_states(_respond_pg) -> None:
-    """Each of the six ways the fence UPDATE can land on rowcount=0,
-    exercised sequentially (one ``svc.respond()`` call after another, no
-    concurrent writer) against a real PostgreSQL server rather than SQLite --
-    the point of running this here instead of in the SQLite-backed sibling
-    file is the backend, not concurrency. Each case runs through
-    ``svc.respond()`` end to end rather than the fence statement in
-    isolation. Actual concurrent-writer coverage lives in the dedicated
-    tests below this one (``test_concurrent_ownership_change_is_blocked...``,
-    ``test_two_concurrent_respond_calls_serialize...``, and the
-    deadlock/residue tests), which do open a second connection."""
-
-    # 1. Already answered, fresh key -> Conflict(already_answered).
-    user_id, task_id = _pg_waiting_task(_respond_pg)
-    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
-    db = _respond_pg()
-    try:
-        row = (
-            db.query(TaskInteractionRequest)
-            .filter(TaskInteractionRequest.id == interaction_id)
-            .first()
-        )
-        row.status = "answered"
-        row.active_slot = None
-        row.response_payload = {"env": "prod"}
-        row.responded_at = _now()
-        row.responder_identity = _pg_owning_principal(user_id).identity_string()
-        db.commit()
-    finally:
-        db.close()
-    outcome = svc.respond(
-        interaction_id=interaction_id,
-        task_id=task_id,
-        principal=_pg_owning_principal(user_id),
-        envelope=_pg_envelope("pg-already-answered"),
-    )
-    assert outcome == svc.RespondConflict(reason="already_answered")
-
-    # 2/3/4. Terminated, three reasons.
-    for terminal_reason, expected in (
-        ("deadline_elapsed", "expired"),
-        ("run_superseded", "run_superseded"),
-        ("answered_via_legacy_resume", "answered_via_chat"),
-    ):
-        user_id, task_id = _pg_waiting_task(_respond_pg)
-        interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
-        db = _respond_pg()
-        try:
-            row = (
-                db.query(TaskInteractionRequest)
-                .filter(TaskInteractionRequest.id == interaction_id)
-                .first()
-            )
-            row.status = "terminated"
-            row.active_slot = None
-            row.terminal_reason = terminal_reason
-            row.terminated_at = _now()
-            db.commit()
-        finally:
-            db.close()
-        outcome = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=_pg_owning_principal(user_id),
-            envelope=_pg_envelope(f"pg-terminated-{terminal_reason}"),
-        )
-        assert outcome == svc.RespondStale(reason=expected)
-
-    # 5. Still active, task not WAITING.
-    user_id, task_id = _pg_waiting_task(_respond_pg)
-    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
-    db = _respond_pg()
-    try:
-        db.query(Task).filter(Task.id == task_id).update({"status": TaskStatus.RUNNING})
-        db.commit()
-    finally:
-        db.close()
-    outcome = svc.respond(
-        interaction_id=interaction_id,
-        task_id=task_id,
-        principal=_pg_owning_principal(user_id),
-        envelope=_pg_envelope("pg-not-waiting"),
-    )
-    assert outcome == svc.RespondStale(reason="run_ended")
-
-    # 6. Still active, waiting, but a foreign run.
-    user_id, task_id = _pg_waiting_task(_respond_pg, run_id="run-current")
-    interaction_id = _pg_active_row(_respond_pg, task_id=task_id, run_id="run-old")
-    outcome = svc.respond(
-        interaction_id=interaction_id,
-        task_id=task_id,
-        principal=_pg_owning_principal(user_id),
-        envelope=_pg_envelope("pg-foreign-run"),
-    )
-    assert outcome == svc.RespondStale(reason="foreign_run")
-
-
 # ---------------------------------------------------------------------------
 # The answered-row shape is CHECK-guarded, exact constraint names.
 # ---------------------------------------------------------------------------
@@ -582,7 +482,6 @@ def test_answered_row_cannot_keep_its_active_slot(db_session) -> None:
 def test_concurrent_ownership_change_is_blocked_until_respond_commits(
     _respond_pg, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    import threading
     import time
 
     owner_id, task_id = _pg_waiting_task(_respond_pg)
@@ -639,7 +538,15 @@ def test_concurrent_ownership_change_is_blocked_until_respond_commits(
 
 
 def test_two_concurrent_respond_calls_serialize_on_the_tasks_row(_respond_pg) -> None:
-    import threading
+    """Two real connections answering the same row with different
+    idempotency keys must never both win: step 2's row lock serializes
+    them, and the loser's fence UPDATE matches zero rows once the winner
+    commits. This build does not classify why the loser's fence missed
+    (see ``RespondOutcomeUnknown``'s own docstring) -- a more detailed
+    build's loser would land on ``Stale`` or ``Conflict``, this build's
+    lands on ``OutcomeUnknown`` -- so the loser is accepted here as any
+    non-``Accepted`` outcome; the invariant this test exists to pin is
+    "never both win", not which label the loser gets."""
 
     user_id, task_id = _pg_waiting_task(_respond_pg)
     interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
@@ -665,7 +572,11 @@ def test_two_concurrent_respond_calls_serialize_on_the_tasks_row(_respond_pg) ->
 
     accepted = [o for o in outcomes if isinstance(o, svc.RespondAccepted)]
     stale_or_conflict = [
-        o for o in outcomes if isinstance(o, (svc.RespondStale, svc.RespondConflict))
+        o
+        for o in outcomes
+        if isinstance(
+            o, (svc.RespondStale, svc.RespondConflict, svc.RespondOutcomeUnknown)
+        )
     ]
     assert len(accepted) == 1, outcomes
     assert len(stale_or_conflict) == 1, outcomes
@@ -737,7 +648,6 @@ def test_respond_vs_purge_both_interleavings_leave_no_residue(_respond_pg) -> No
 
 
 def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg) -> None:
-    import threading
     import time
 
     import psycopg2.extras
@@ -830,12 +740,16 @@ def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg) -> None:
     # The reclaim's UPDATE lands, uncommitted, before respond()'s own fence
     # UPDATE reaches the same row; respond() blocks on it (a plain row lock,
     # not the tasks lock this test is about), resumes once the reclaim
-    # commits, and correctly reports the row as superseded rather than
-    # timing out or raising -- the interesting fact this test pins is that
-    # neither thread deadlocks getting there, not which of them "wins".
-    assert results.get("respond_outcome") == svc.RespondStale(
-        reason="run_superseded"
-    ), results
+    # commits, and correctly reports the miss rather than timing out or
+    # raising -- the interesting fact this test pins is that neither thread
+    # deadlocks getting there, not which of them "wins". This build does
+    # not classify why the fence missed (a more detailed build's sibling
+    # asserts the specific ``Stale(run_superseded)`` this scenario produces
+    # -- see ``RespondOutcomeUnknown``'s own docstring for why this build
+    # reports the ambiguity instead).
+    assert isinstance(results.get("respond_outcome"), svc.RespondOutcomeUnknown), (
+        results
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -853,7 +767,6 @@ def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg) -> None:
 
 
 def test_respond_vs_concurrent_purge_does_not_deadlock(_respond_pg) -> None:
-    import threading
     import time
 
     user_id, task_id = _pg_waiting_task(_respond_pg)
@@ -920,256 +833,3 @@ def test_respond_vs_concurrent_purge_does_not_deadlock(_respond_pg) -> None:
     assert results.get("respond_outcome") == svc.RespondUnavailable(
         reason="interaction_missing"
     ), results
-
-
-# ---------------------------------------------------------------------------
-# classify_task_command_conflict's IntegrityError branch (step 8), reached
-# from svc.respond() when stage_task_command's own insert -- inside this
-# call's own ``db.begin_nested()`` -- collides with the
-# ``uq_task_command_identity`` unique constraint. See
-# test_task_interaction_service.py's own section by this name for the full
-# reachability audit of all three TaskCommandConflictKind values against
-# the real code: UNRELATED and TASK_MISSING are both provably unreachable
-# through respond() on either backend (actor_user_id is always the task's
-# own owner, which the fence's ownership predicate requires and which
-# cannot be deleted out from under a task row this transaction still
-# references; the task row itself cannot disappear before this call's own
-# insert either). RACED_DUPLICATE is the only reachable one, and only here
-# on PostgreSQL: a second writer must commit a row for the same
-# (task_id, command_id) strictly between stage_task_command's own
-# existing-row check and its own insert flush, a window SQLite's single
-# whole-database writer lock closes (respond() has already written the
-# fence UPDATE and the CAS on its own connection by the time it reaches
-# step 8, so that connection already holds SQLite's one writer lock).
-# PostgreSQL's row lock from step 2 is scoped to the specific ``tasks`` row
-# alone, so a second writer can complete an insert into the unrelated
-# ``task_execution_commands`` table while this transaction is still open.
-#
-# Both of RACED_DUPLICATE's sub-branches are pinned below -- they produce
-# different RespondOutcomes and only one touches the response-conflict
-# counter (the same counter the idempotency_key_reused cells in the
-# SQLite-backed file exercise through the earlier, pre-existing-command
-# shortcut at step 5; this is the same counter's other, previously
-# untested, wiring point at step 8):
-#
-# - payload_matches=True: the second writer's row carries the identical
-#   actor/kind/payload this call would itself have staged. respond()
-#   replays the winning row (``RespondReplayed``) rather than treating the
-#   loss as a failure, and does not touch the counter.
-# - payload_matches=False: the second writer's row carries different
-#   ``values``, so it canonicalizes to a different payload.
-#   classify_task_command_conflict still finds it (it does not compare
-#   payloads to decide whether a row raced -- only to decide what to do
-#   once one has), and respond() reports ``RespondConflict`` and does
-#   increment the counter, rolling back the whole transaction -- including
-#   the fence UPDATE and the CAS this call had already issued -- since none
-#   of that write was this call's own to keep.
-# ---------------------------------------------------------------------------
-
-
-def _pg_conflict_counter() -> int:
-    return counters_snapshot().get(svc.COUNTER_LIFECYCLE_RESPONSE_CONFLICT, 0)
-
-
-def _pause_command_add_session_factory(
-    base_session_factory, *, precheck_done, release_event
-):
-    """A session factory wrapping ``base_session_factory`` whose returned
-    session pauses the instant something calls ``.add()`` with a
-    ``TaskExecutionCommand`` -- the exact point stage_task_command reaches
-    right after its own existing-row check has already found nothing and
-    right before the insert flush this test needs a second writer to beat.
-    Only ``get_session_local`` is repointed at this wrapper, and only after
-    every setup call already used the plain ``_respond_pg`` factory
-    directly, so only respond()'s own internally-created session is
-    instrumented -- the racing writer below opens its own, unpatched
-    session straight off the base factory."""
-
-    def factory():
-        db = base_session_factory()
-        real_add = db.add
-
-        def paused_add(instance):
-            if isinstance(instance, TaskExecutionCommand):
-                precheck_done.set()
-                assert release_event.wait(timeout=10)
-            real_add(instance)
-
-        db.add = paused_add
-        return db
-
-    return factory
-
-
-def test_respond_races_a_committed_duplicate_command_and_replays_on_matching_payload(
-    _respond_pg, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A second, independent writer commits a TaskExecutionCommand row for
-    the same (task_id, command_id) with the identical actor/kind/payload
-    while respond() is paused right after its own stage_task_command's
-    existing-row check already found nothing. respond()'s own insert then
-    collides on the unique constraint; classify_task_command_conflict
-    reports RACED_DUPLICATE with payload_matches=True, and respond() commits
-    and replays the winning row instead of treating this as a failure."""
-
-    user_id, task_id = _pg_waiting_task(_respond_pg)
-    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
-    principal = _pg_owning_principal(user_id)
-    envelope = _pg_envelope("pg-raced-duplicate-match")
-    matching_payload = svc._respond_command_payload(
-        interaction_id=interaction_id, principal=principal, values=envelope.values
-    )
-
-    precheck_done = threading.Event()
-    release_respond = threading.Event()
-    results: dict = {}
-
-    monkeypatch.setattr(
-        database_module,
-        "get_session_local",
-        lambda: _pause_command_add_session_factory(
-            _respond_pg, precheck_done=precheck_done, release_event=release_respond
-        ),
-    )
-
-    def call_respond() -> None:
-        results["outcome"] = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=principal,
-            envelope=envelope,
-        )
-
-    t_respond = threading.Thread(target=call_respond)
-    t_respond.start()
-    assert precheck_done.wait(timeout=10)
-
-    db_racer = _respond_pg()
-    try:
-        winner = enqueue_task_command(
-            db_racer,
-            task_id=task_id,
-            actor_user_id=principal.user_id,
-            command_id=envelope.idempotency_key,
-            kind=TaskCommandKind.RESUME,
-            payload=matching_payload,
-        )
-    finally:
-        db_racer.close()
-
-    before_counter = _pg_conflict_counter()
-    release_respond.set()
-    t_respond.join(timeout=10)
-
-    outcome = results["outcome"]
-    assert isinstance(outcome, svc.RespondReplayed), outcome
-    assert outcome.receipt.command_db_id == winner.command_id
-    assert _pg_conflict_counter() == before_counter
-
-    verify_db = _respond_pg()
-    try:
-        commands = (
-            verify_db.query(TaskExecutionCommand)
-            .filter(TaskExecutionCommand.task_id == task_id)
-            .all()
-        )
-        assert len(commands) == 1, commands
-        assert commands[0].id == winner.command_id
-        assert commands[0].actor_user_id == principal.user_id
-    finally:
-        verify_db.close()
-
-
-def test_respond_races_a_committed_duplicate_command_and_conflicts_on_mismatched_payload(
-    _respond_pg, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Same race as above, except the second writer's row carries different
-    answer values -- a different canonicalized payload.
-    classify_task_command_conflict still classifies this as
-    RACED_DUPLICATE (it finds the row purely by (task_id, command_id), not
-    by payload), but with payload_matches=False; respond() reports
-    RespondConflict, increments the response-conflict counter, and rolls
-    back the whole transaction -- undoing its own fence UPDATE and CAS,
-    since none of that write is this call's to keep once its own command
-    lost the race."""
-
-    user_id, task_id = _pg_waiting_task(_respond_pg)
-    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
-    principal = _pg_owning_principal(user_id)
-    envelope = _pg_envelope("pg-raced-duplicate-mismatch")
-    mismatched_payload = svc._respond_command_payload(
-        interaction_id=interaction_id,
-        principal=principal,
-        values={"env": "a-different-answer-than-this-call-submits"},
-    )
-
-    precheck_done = threading.Event()
-    release_respond = threading.Event()
-    results: dict = {}
-
-    monkeypatch.setattr(
-        database_module,
-        "get_session_local",
-        lambda: _pause_command_add_session_factory(
-            _respond_pg, precheck_done=precheck_done, release_event=release_respond
-        ),
-    )
-
-    def call_respond() -> None:
-        results["outcome"] = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=principal,
-            envelope=envelope,
-        )
-
-    t_respond = threading.Thread(target=call_respond)
-    t_respond.start()
-    assert precheck_done.wait(timeout=10)
-
-    db_racer = _respond_pg()
-    try:
-        winner = enqueue_task_command(
-            db_racer,
-            task_id=task_id,
-            actor_user_id=principal.user_id,
-            command_id=envelope.idempotency_key,
-            kind=TaskCommandKind.RESUME,
-            payload=mismatched_payload,
-        )
-    finally:
-        db_racer.close()
-
-    before_counter = _pg_conflict_counter()
-    release_respond.set()
-    t_respond.join(timeout=10)
-
-    outcome = results["outcome"]
-    assert outcome == svc.RespondConflict(reason="idempotency_key_reused"), outcome
-    assert _pg_conflict_counter() == before_counter + 1
-
-    verify_db = _respond_pg()
-    try:
-        commands = (
-            verify_db.query(TaskExecutionCommand)
-            .filter(TaskExecutionCommand.task_id == task_id)
-            .all()
-        )
-        assert len(commands) == 1, commands
-        assert commands[0].id == winner.command_id
-        assert commands[0].payload == mismatched_payload
-
-        row = (
-            verify_db.query(TaskInteractionRequest)
-            .filter(TaskInteractionRequest.id == interaction_id)
-            .first()
-        )
-        assert row.status == "active"
-        assert row.active_slot == 1
-        assert row.responded_at is None
-
-        task = verify_db.query(Task).filter(Task.id == task_id).first()
-        assert task.state_version == 5
-        assert task.control_state == "waiting_for_user"
-    finally:
-        verify_db.close()

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -365,9 +365,6 @@ def _respond_pg(monkeypatch: pytest.MonkeyPatch, session_factory):
 
 def _pg_waiting_task(
     session_factory,
-    *,
-    run_id: str = "run-a",
-    state_version: int = 5,
 ) -> tuple[int, int]:
     db = session_factory()
     try:
@@ -376,24 +373,24 @@ def _pg_waiting_task(
         task = db.query(Task).filter(Task.id == task_id).first()
         task.status = TaskStatus.WAITING_FOR_USER
         task.control_state = "waiting_for_user"
-        task.run_id = run_id
-        task.state_version = state_version
+        task.run_id = "run-a"
+        task.state_version = 5
         db.commit()
         return user_id, task_id
     finally:
         db.close()
 
 
-def _pg_active_row(session_factory, *, task_id: int, run_id: str = "run-a") -> int:
+def _pg_active_row(session_factory, *, task_id: int) -> int:
     db = session_factory()
     try:
-        trace_event_id = _make_trace_event(db, task_id=task_id, run_partition=run_id)
+        trace_event_id = _make_trace_event(db, task_id=task_id, run_partition="run-a")
         row = _make_active_row(
             db,
             task_id=task_id,
-            run_id=run_id,
+            run_id="run-a",
             resume_trace_event_id=trace_event_id,
-            resume_run_partition=run_id,
+            resume_run_partition="run-a",
         )
         return int(row.id)
     finally:


### PR DESCRIPTION
## Summary

Adds `respond()` to the task interaction lifecycle service: the entry point that answers one active native interaction row and stages the command that resumes the task's execution with that answer, in one all-or-nothing transaction.

This is the core of a four-part series. The resume-coordinator seam ships separately (it reads only the active-row criteria that already exist on main — a coverage run proved it never executes this function). Two follow-up changes, staged on top of this one, restore precision that this change deliberately trades for size: fine-grained classification of a missed answer fence, and reconciliation after a lost commit acknowledgment.

## What's here

- The answer fence: one UPDATE that flips the active row to `answered` only if it is still active, still owned by the caller's principal, and the task is still waiting — ownership is enforced at the write, not only in a prior read.
- `RespondEnvelope` validation with type-before-value checks (a list-typed kind or a boolean protocol version is rejected as invalid input, not crashed on or coerced).
- The outcome vocabulary as `Literal` types: each outcome's reason field is typed by the exact set of reasons this change can produce, and a meta-test derives the required test cells from the type — "this change only produces these outcomes" is checked by the type system, not claimed in prose.
- Idempotent replay: a repeat of the same answer under the same content-derived key returns the original receipt instead of double-staging.
- Conservative failure handling (see below), with three tests proving the conservative paths leave zero residue: no orphaned row state, no staged command, no task-state change.
- The zero-production-caller gate watches both `create` and `respond`; neither has a production caller, and the gate is the regression guard for that fact. The change that wires a caller is the change that takes the corresponding name out of the gated set.

## Deliberately conservative in this change

Two failure paths return `OutcomeUnknown` here rather than a precise classification:

- **Fence miss**: when the fence UPDATE matches no row, this change reports the outcome as unknown instead of rereading the row to distinguish "already answered" from "superseded run" and friends. The reread-and-classify block arrives in a follow-up; a test here proves the miss path rolls back cleanly.
- **Commit-ack loss and staging conflict**: when the final commit raises, or staging the resume command hits a concurrent duplicate, this change rolls back and reports unknown instead of reconciling against the durable state. The reconciliation (a fresh-session verification of what actually landed) arrives in the other follow-up; tests here prove both paths leave no residue.

Unknown is conservative in both cases and zero-residue in all of them. Retrying under the same idempotency key converges for an ambiguous commit (the replay check finds the staged command) and for a rolled-back staging race (it simply runs again). A fence miss does not converge — the same predicate misses the same row every time — so the fence-miss path logs the reread row's state, and classifying that miss is the fence classification change's job.

## Why this ships at this size

The series was split four ways, and this change is the part that cannot shrink further without moving safety evidence out of the change that needs it:

- The fence, the envelope validation, the outcome types, and the vocabulary checks live in one module and reference each other directly; any cut separates a definition from its only callers. (Three names are imported rather than defined here — the kind vocabulary and command-id normalizer from the staging and transport modules, and the protocol-version constant from the models package — so "one module" describes where the answer-side logic lives, not a closed import graph.)
- The shared test fixtures, the vocabulary meta-test, the repo-level lock-strength guard, and the gate change all have to land with the first change that contains `respond()`.
- The tests that prove this change is safe to merge — per-cell mutation-verified, including real two-connection PostgreSQL races for the locking claims — stay here by policy. What could move out without weakening that proof has moved out: the classification and reconciliation follow-ups, and this change also drops (not defers — drops, with the rationale in the docstrings) an optimistic-concurrency parameter pair that had no caller and no settled contract.


