### PR TITLE
enh: guide send_message toward plain-language progress narration

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -90,8 +90,11 @@ DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_WORK_TOOL_CALLS = 10
 # Live testing showed the model rarely reaches for send_message on its own
 # even with schema-level guidance: a 5-round web_search task sent zero
 # progress updates. This threshold drives a deterministic system-message
-# nudge instead of relying solely on prompt persuasion.
-DEFAULT_PROGRESS_NARRATION_NUDGE_AFTER_CONSECUTIVE_TOOL_CALLS = 2
+# nudge instead of relying solely on prompt persuasion. It backstops a
+# single sustained phase (e.g. several searches in a row); a tool-group
+# change is its own, more responsive trigger (see _maybe_nudge_progress_
+# narration), so this can afford to be a little looser than that.
+DEFAULT_PROGRESS_NARRATION_NUDGE_AFTER_CONSECUTIVE_TOOL_CALLS = 3
 # Tool calls that already deliver a message to the user; encountering one
 # resets the progress-narration nudge counter.
 MESSAGE_TOOL_NAMES = frozenset({"send_message", "ask_user_question"})
@@ -239,6 +242,19 @@ class ReActPattern(AgentPattern):
         # streak that stays past the threshold doesn't get re-nudged every
         # single subsequent tool call; only when it grows further.
         self._progress_narration_last_nudged_count = 0
+        # The tool-decision group active as of the last message to the user,
+        # and whether we've already checked the first tool call of the
+        # current streak against it. Lets a genuine phase change (e.g.
+        # web_search -> write_file) nudge immediately instead of waiting for
+        # the count threshold, without re-checking every call in a streak.
+        self._progress_narration_group_at_last_message: str | None = None
+        self._progress_narration_group_change_checked = False
+        # Identity of the most recent send_message/ask_user_question ledger
+        # record we've already accounted for. Comparing this (rather than
+        # waiting to observe a consecutive-call count of 0, which this
+        # method's call site never actually produces) is what detects that a
+        # fresh message just landed and the per-streak state should reset.
+        self._progress_narration_last_message_id: str | None = None
         self.status = "idle"
         self.current_iteration = 0
         self.last_response: Any = None
@@ -1205,6 +1221,15 @@ class ReActPattern(AgentPattern):
             "progress_narration_last_nudged_count": (
                 self._progress_narration_last_nudged_count
             ),
+            "progress_narration_group_at_last_message": (
+                self._progress_narration_group_at_last_message
+            ),
+            "progress_narration_group_change_checked": (
+                self._progress_narration_group_change_checked
+            ),
+            "progress_narration_last_message_id": (
+                self._progress_narration_last_message_id
+            ),
             "force_final_answer_next": self.force_final_answer_next,
             "repeated_tool_decision": self.repeated_tool_decision,
             "waiting_for_user_request": self.waiting_for_user_request,
@@ -1262,6 +1287,17 @@ class ReActPattern(AgentPattern):
             )
         self._progress_narration_last_nudged_count = int(
             state.get("progress_narration_last_nudged_count", 0) or 0
+        )
+        raw_group = state.get("progress_narration_group_at_last_message")
+        self._progress_narration_group_at_last_message = (
+            str(raw_group) if isinstance(raw_group, str) else None
+        )
+        self._progress_narration_group_change_checked = bool(
+            state.get("progress_narration_group_change_checked", False)
+        )
+        raw_message_id = state.get("progress_narration_last_message_id")
+        self._progress_narration_last_message_id = (
+            str(raw_message_id) if isinstance(raw_message_id, str) else None
         )
         self.force_final_answer_next = bool(state.get("force_final_answer_next", False))
         repeated_tool_decision = state.get("repeated_tool_decision")
@@ -2559,10 +2595,15 @@ class ReActPattern(AgentPattern):
                 successful_tool_result = True
             if requested_decision:
                 successful_tool_result = False
-            else:
                 # A pending repeated-tool decision will settle continue-vs-
                 # finish on its own next turn; layering a progress nudge on
-                # top of that would just be redundant noise.
+                # top of that would just be redundant noise. But the nudge's
+                # own reset bookkeeping must still run this segment — it
+                # keys off message identity, not off whether a nudge fires,
+                # and skipping it here would leave last_nudged_count stuck
+                # at a stale pre-message value for the rest of the run.
+                self._sync_progress_narration_message_state()
+            else:
                 self._maybe_nudge_progress_narration(context=context)
 
         if (
@@ -2937,44 +2978,149 @@ class ReActPattern(AgentPattern):
             count += 1
         return count
 
+    def _latest_work_tool_group(self) -> str | None:
+        """The tool-decision group of the most recent completed work-tool call.
+
+        Skips every control tool transparently (send_message included) —
+        this asks "what kind of work was the agent last actually doing",
+        not "what was the last thing recorded at all".
+        """
+        control_tool_names = self._control_tool_names()
+        for record in reversed(list(self.tool_ledger.values())):
+            if record.tool_name in control_tool_names:
+                continue
+            return self._tool_decision_group_for_name(record.tool_name)
+        return None
+
+    def _latest_message_record_id(self) -> str | None:
+        for record in reversed(list(self.tool_ledger.values())):
+            if record.tool_name in MESSAGE_TOOL_NAMES:
+                return record.tool_call_id
+        return None
+
+    def _work_tool_group_before_message(self, message_tool_call_id: str) -> str | None:
+        """The work-tool group active right before the given message record.
+
+        This method may run well after that message was actually sent —
+        the ledger can already hold newer work-tool calls by the time we
+        get to evaluate — so it can't just ask "what's the most recent
+        work-tool call" (that would answer for whatever ran *after* the
+        message, not before it). Scan forward and stop exactly at the
+        message instead, so later entries in the ledger can't leak in.
+        """
+        control_tool_names = self._control_tool_names()
+        group: str | None = None
+        for record in self.tool_ledger.values():
+            if record.tool_call_id == message_tool_call_id:
+                break
+            if record.tool_name in control_tool_names:
+                continue
+            group = self._tool_decision_group_for_name(record.tool_name)
+        return group
+
+    def _sync_progress_narration_message_state(self) -> None:
+        """Reset per-streak nudge bookkeeping once a new message has landed.
+
+        Must run on *every* work-tool segment regardless of whether a nudge
+        will actually be considered this turn — including a segment the
+        repeated-tool decision preempts (see the call site). Skipping it
+        there was a real bug: a run whose search/fetch calls share a tool
+        group can reach the repeated-tool-decision's own (group-based,
+        message-transparent) threshold right on the first work-tool call
+        after a message, preempting that exact turn. If this sync only ran
+        from inside the nudge check, it would never get a chance to fire —
+        last_nudged_count would stay stuck at its pre-message value and
+        every later threshold comparison for the rest of the run would be
+        wrong.
+        """
+        latest_message_id = self._latest_message_record_id()
+        if latest_message_id != self._progress_narration_last_message_id:
+            self._progress_narration_last_message_id = latest_message_id
+            self._progress_narration_last_nudged_count = 0
+            self._progress_narration_group_change_checked = False
+            self._progress_narration_group_at_last_message = (
+                self._work_tool_group_before_message(latest_message_id)
+                if latest_message_id is not None
+                else None
+            )
+
     def _maybe_nudge_progress_narration(self, *, context: Any) -> None:
         """Push the model toward send_message when it has gone quiet.
 
         Schema-level guidance on send_message alone proved too weak in
         practice — a real multi-round search task made zero progress-update
-        calls. This adds a deterministic backstop: once enough consecutive
-        tool calls pass without any message to the user, inject a system
-        reminder before the next LLM call.
+        calls, and once it did narrate, it stayed silent through several
+        later tool calls of a visibly different kind (fetching a page,
+        writing a file) before narrating again. Two independent triggers
+        fix that, both funneled through the same "already nudged this
+        streak" throttle:
+
+        - the first tool call after the last message belongs to a
+          different tool group than the one just reported on — a new
+          phase started, worth narrating regardless of raw count;
+        - N consecutive tool calls pass with no message at all, for
+          sustained work within a single phase (e.g. several searches).
         """
-        threshold = self.progress_narration_nudge_after_consecutive_tool_calls
-        if threshold is None or threshold <= 0:
-            return
+        self._sync_progress_narration_message_state()
 
         count = self._consecutive_work_tool_calls_since_last_message()
         if count == 0:
-            self._progress_narration_last_nudged_count = 0
             return
-        if count < threshold:
-            return
+
+        threshold = self.progress_narration_nudge_after_consecutive_tool_calls
+
+        # Checked once per streak, whichever tool call this method first
+        # gets to evaluate (not necessarily count==1: the repeated-tool
+        # decision can preempt this method for the streak's actual first
+        # call, so "first call we get to look at" is the only count we can
+        # rely on). Repeating this on every later call would fire on
+        # ordinary alternation (search, fetch, search, ...) instead of just
+        # the one genuine transition away from what was last reported.
+        group_changed = False
+        if not self._progress_narration_group_change_checked:
+            self._progress_narration_group_change_checked = True
+            current_group = self._latest_work_tool_group()
+            previous_group = self._progress_narration_group_at_last_message
+            group_changed = (
+                current_group is not None
+                and previous_group is not None
+                and current_group != previous_group
+            )
+
         # Only re-nudge once the streak has grown by another full threshold
         # since the last reminder — otherwise every subsequent tool call
         # past the threshold would re-fire it (count strictly increases by
         # one each call, so a plain "count > last nudged" check nags on
         # every single one).
-        if count - self._progress_narration_last_nudged_count < threshold:
+        threshold_crossed = (
+            threshold is not None
+            and threshold > 0
+            and count >= threshold
+            and count - self._progress_narration_last_nudged_count >= threshold
+        )
+
+        if not group_changed and not threshold_crossed:
             return
 
         self._progress_narration_last_nudged_count = count
+        reason = (
+            "You just switched to a different kind of action since your last update."
+            if group_changed
+            else (
+                f"You have made {count} consecutive tool calls without "
+                "sending the user any update."
+            )
+        )
         context.add_system_message(
-            "Progress narration reminder:\n"
-            f"You have made {count} consecutive tool calls without sending "
-            "the user any update. Before your next tool call, call "
-            "send_message with message_type='progress' to briefly tell "
-            "them what you're doing or what you just found, in plain "
-            "language and in their own language — then continue the task.",
+            f"Progress narration reminder:\n{reason} Before your next tool "
+            "call, call send_message with message_type='progress' to "
+            "briefly tell them what you're doing or what you just found, "
+            "in plain language and in their own language — then continue "
+            "the task.",
             metadata={
                 "source": "progress_narration_nudge",
                 "consecutive_tool_calls": count,
+                "trigger": "group_change" if group_changed else "consecutive_count",
             },
         )
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1720,11 +1720,22 @@ class ReActPattern(AgentPattern):
                 "type": "function",
                 "function": {
                     "name": "send_message",
-                    "description": "Send a message to the user, optionally waiting for a response.",
+                    "description": (
+                        "Send a message to the user, optionally waiting for a "
+                        "response. Use message_type='progress' to narrate a "
+                        "longer task as it moves through meaningful phases, "
+                        "not before every tool call."
+                    ),
                     "parameters": {
                         "type": "object",
                         "properties": {
-                            "message": {"type": "string"},
+                            "message": {
+                                "type": "string",
+                                "description": (
+                                    "The message text, in the same language "
+                                    "as the user's request."
+                                ),
+                            },
                             "message_type": {
                                 "type": "string",
                                 "enum": [
@@ -1734,6 +1745,19 @@ class ReActPattern(AgentPattern):
                                     "progress",
                                     "warning",
                                 ],
+                                "description": (
+                                    "progress: a brief, plain-language "
+                                    "narration of what you are doing right "
+                                    "now or what you just found — describe "
+                                    "it the way the user themselves would, "
+                                    "never by naming the tool, model, file "
+                                    "path, or raw arguments involved. info: "
+                                    "a one-off notification. "
+                                    "question/confirmation: expects a "
+                                    "response — set expect_response=true. "
+                                    "warning: something the user should "
+                                    "know may affect the outcome."
+                                ),
                             },
                             "expect_response": {"type": "boolean"},
                             "visible": {"type": "boolean"},

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1722,9 +1722,10 @@ class ReActPattern(AgentPattern):
                     "name": "send_message",
                     "description": (
                         "Send a message to the user, optionally waiting for a "
-                        "response. Use message_type='progress' to narrate a "
-                        "longer task as it moves through meaningful phases, "
-                        "not before every tool call."
+                        "response (by setting expect_response=true). Use "
+                        "message_type='progress' to narrate a longer task as "
+                        "it moves through meaningful phases, not before "
+                        "every tool call."
                     ),
                     "parameters": {
                         "type": "object",
@@ -1732,8 +1733,11 @@ class ReActPattern(AgentPattern):
                             "message": {
                                 "type": "string",
                                 "description": (
-                                    "The message text, in the same language "
-                                    "as the user's request."
+                                    "The message text, in the target "
+                                    "response language (matching the user's "
+                                    "request language unless they "
+                                    "explicitly asked to answer in another "
+                                    "language)."
                                 ),
                             },
                             "message_type": {
@@ -1746,17 +1750,19 @@ class ReActPattern(AgentPattern):
                                     "warning",
                                 ],
                                 "description": (
-                                    "progress: a brief, plain-language "
-                                    "narration of what you are doing right "
-                                    "now or what you just found — describe "
-                                    "it the way the user themselves would, "
-                                    "never by naming the tool, model, file "
-                                    "path, or raw arguments involved. info: "
-                                    "a one-off notification. "
-                                    "question/confirmation: expects a "
-                                    "response — set expect_response=true. "
-                                    "warning: something the user should "
-                                    "know may affect the outcome."
+                                    "The type of message (defaults to "
+                                    "'info'). progress: a brief, "
+                                    "plain-language narration of what you "
+                                    "are doing right now or what you just "
+                                    "found — describe it the way the user "
+                                    "themselves would, never by naming the "
+                                    "tool, model, file path, or raw "
+                                    "arguments involved. info: a one-off "
+                                    "notification. question/confirmation: "
+                                    "expects a response — you must set "
+                                    "expect_response=true. warning: "
+                                    "something the user should know that "
+                                    "may affect the outcome."
                                 ),
                             },
                             "expect_response": {"type": "boolean"},

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -87,6 +87,14 @@ class ReActReasoningMode(str, Enum):
 REPEATED_TOOL_DECISION_REQUESTED_STATUS = "repeated_tool_decision_requested"
 DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_TOOL_CALLS = 4
 DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_WORK_TOOL_CALLS = 10
+# Live testing showed the model rarely reaches for send_message on its own
+# even with schema-level guidance: a 5-round web_search task sent zero
+# progress updates. This threshold drives a deterministic system-message
+# nudge instead of relying solely on prompt persuasion.
+DEFAULT_PROGRESS_NARRATION_NUDGE_AFTER_CONSECUTIVE_TOOL_CALLS = 2
+# Tool calls that already deliver a message to the user; encountering one
+# resets the progress-narration nudge counter.
+MESSAGE_TOOL_NAMES = frozenset({"send_message", "ask_user_question"})
 REACT_DECISION_TOOL_NAME = "react_decision"
 REACT_DECISION_FINAL_ANSWER = "final_answer"
 REACT_DECISION_TOOL_CALL = "tool_call"
@@ -202,6 +210,9 @@ class ReActPattern(AgentPattern):
         repeated_tool_decision_after_consecutive_work_tool_calls: int | None = (
             DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_WORK_TOOL_CALLS
         ),
+        progress_narration_nudge_after_consecutive_tool_calls: int | None = (
+            DEFAULT_PROGRESS_NARRATION_NUDGE_AFTER_CONSECUTIVE_TOOL_CALLS
+        ),
         tool_parallel_enabled: bool = False,
         tool_max_concurrency: int = 3,
     ) -> None:
@@ -221,6 +232,13 @@ class ReActPattern(AgentPattern):
         self.repeated_tool_decision_after_consecutive_work_tool_calls = (
             repeated_tool_decision_after_consecutive_work_tool_calls
         )
+        self.progress_narration_nudge_after_consecutive_tool_calls = (
+            progress_narration_nudge_after_consecutive_tool_calls
+        )
+        # Consecutive-tool-call count at which we last injected a nudge, so a
+        # streak that stays past the threshold doesn't get re-nudged every
+        # single subsequent tool call; only when it grows further.
+        self._progress_narration_last_nudged_count = 0
         self.status = "idle"
         self.current_iteration = 0
         self.last_response: Any = None
@@ -1181,6 +1199,12 @@ class ReActPattern(AgentPattern):
             "repeated_tool_decision_after_consecutive_work_tool_calls": (
                 self.repeated_tool_decision_after_consecutive_work_tool_calls
             ),
+            "progress_narration_nudge_after_consecutive_tool_calls": (
+                self.progress_narration_nudge_after_consecutive_tool_calls
+            ),
+            "progress_narration_last_nudged_count": (
+                self._progress_narration_last_nudged_count
+            ),
             "force_final_answer_next": self.force_final_answer_next,
             "repeated_tool_decision": self.repeated_tool_decision,
             "waiting_for_user_request": self.waiting_for_user_request,
@@ -1229,6 +1253,16 @@ class ReActPattern(AgentPattern):
             self.repeated_tool_decision_after_consecutive_work_tool_calls = (
                 int(raw_work_threshold) if raw_work_threshold is not None else None
             )
+        if "progress_narration_nudge_after_consecutive_tool_calls" in state:
+            raw_nudge_threshold = state[
+                "progress_narration_nudge_after_consecutive_tool_calls"
+            ]
+            self.progress_narration_nudge_after_consecutive_tool_calls = (
+                int(raw_nudge_threshold) if raw_nudge_threshold is not None else None
+            )
+        self._progress_narration_last_nudged_count = int(
+            state.get("progress_narration_last_nudged_count", 0) or 0
+        )
         self.force_final_answer_next = bool(state.get("force_final_answer_next", False))
         repeated_tool_decision = state.get("repeated_tool_decision")
         self.repeated_tool_decision = (
@@ -2525,6 +2559,11 @@ class ReActPattern(AgentPattern):
                 successful_tool_result = True
             if requested_decision:
                 successful_tool_result = False
+            else:
+                # A pending repeated-tool decision will settle continue-vs-
+                # finish on its own next turn; layering a progress nudge on
+                # top of that would just be redundant noise.
+                self._maybe_nudge_progress_narration(context=context)
 
         if (
             self.finalize_after_tool_result
@@ -2877,6 +2916,67 @@ class ReActPattern(AgentPattern):
                 continue
             count += 1
         return count
+
+    def _consecutive_work_tool_calls_since_last_message(self) -> int:
+        """Work-tool calls made since the model last sent the user anything.
+
+        Unlike ``_consecutive_work_tool_call_count`` (which treats every
+        control tool as transparent), a send_message/ask_user_question call
+        here breaks the streak: it is the one signal that the user actually
+        heard from the agent.
+        """
+        count = 0
+        control_tool_names = self._control_tool_names()
+        for record in reversed(list(self.tool_ledger.values())):
+            if record.tool_name in MESSAGE_TOOL_NAMES:
+                break
+            if record.tool_name in control_tool_names:
+                continue
+            if record.status not in {"completed", "failed"}:
+                continue
+            count += 1
+        return count
+
+    def _maybe_nudge_progress_narration(self, *, context: Any) -> None:
+        """Push the model toward send_message when it has gone quiet.
+
+        Schema-level guidance on send_message alone proved too weak in
+        practice — a real multi-round search task made zero progress-update
+        calls. This adds a deterministic backstop: once enough consecutive
+        tool calls pass without any message to the user, inject a system
+        reminder before the next LLM call.
+        """
+        threshold = self.progress_narration_nudge_after_consecutive_tool_calls
+        if threshold is None or threshold <= 0:
+            return
+
+        count = self._consecutive_work_tool_calls_since_last_message()
+        if count == 0:
+            self._progress_narration_last_nudged_count = 0
+            return
+        if count < threshold:
+            return
+        # Only re-nudge once the streak has grown by another full threshold
+        # since the last reminder — otherwise every subsequent tool call
+        # past the threshold would re-fire it (count strictly increases by
+        # one each call, so a plain "count > last nudged" check nags on
+        # every single one).
+        if count - self._progress_narration_last_nudged_count < threshold:
+            return
+
+        self._progress_narration_last_nudged_count = count
+        context.add_system_message(
+            "Progress narration reminder:\n"
+            f"You have made {count} consecutive tool calls without sending "
+            "the user any update. Before your next tool call, call "
+            "send_message with message_type='progress' to briefly tell "
+            "them what you're doing or what you just found, in plain "
+            "language and in their own language — then continue the task.",
+            metadata={
+                "source": "progress_narration_nudge",
+                "consecutive_tool_calls": count,
+            },
+        )
 
     async def _finalize_success(
         self,

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -43,6 +43,10 @@ class SearchArgs(BaseModel):
     count: int = 10
 
 
+class FetchWebContentArgs(BaseModel):
+    url: str
+
+
 class FakeTool:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
@@ -117,6 +121,24 @@ class FakeSearchTool:
                 },
             ]
         }
+
+
+class FakeFetchWebContentTool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+        class Metadata:
+            name = "fetch_web_content"
+            description = "Fetch and extract a web page's content."
+
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[BaseModel]:
+        return FetchWebContentArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        return {"success": True, "content": f"content of {args['url']}"}
 
 
 class FakeTraceSanitizingTool:
@@ -2845,6 +2867,497 @@ def test_progress_narration_nudge_survives_checkpoint_resume() -> None:
     resumed_context = ExecutionContext(execution_id="task-1")
     resumed._maybe_nudge_progress_narration(context=resumed_context)
     assert not any(m.role == "system" for m in resumed_context.messages)
+
+
+def test_progress_narration_nudge_fires_immediately_on_a_tool_group_change() -> None:
+    # Live testing showed the model narrated once after two web_search
+    # calls, then stayed silent through fetch_web_content, two more
+    # searches, and write_file before narrating again — a raw count
+    # threshold alone let four calls of visibly different work pass
+    # unremarked. A tool-group change should nudge right away instead of
+    # waiting for the count to catch up.
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=3)
+    context = ExecutionContext(execution_id="task-1")
+
+    # The model narrated on its own initiative (not necessarily in
+    # response to a nudge — threshold=3 hasn't been crossed by these two
+    # calls yet), reporting on the web_search group.
+    _record_work_tool_call(pattern, "call-1", tool_name="web_search")
+    _record_work_tool_call(pattern, "call-2", tool_name="web_search")
+    _record_send_message_call(pattern, "call-3")
+    pattern._maybe_nudge_progress_narration(context=context)
+    assert not any(m.role == "system" for m in context.messages)
+
+    # First tool call after the message is a different tool entirely —
+    # should nudge immediately even though the count (1) is well under
+    # the threshold (3).
+    _record_work_tool_call(pattern, "call-4", tool_name="fetch_web_content")
+    pattern._maybe_nudge_progress_narration(context=context)
+    system_messages = [m for m in context.messages if m.role == "system"]
+    assert len(system_messages) == 1
+    assert "switched to a different kind of action" in system_messages[-1].content
+
+
+def test_progress_narration_nudge_checks_group_change_only_once_per_streak() -> None:
+    # Real runs alternate tools within what is really one phase (search,
+    # open a result, search again). Re-checking the group on every call
+    # would nudge on every alternation instead of just the one genuine
+    # transition away from what was last reported.
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=5)
+    context = ExecutionContext(execution_id="task-1")
+
+    _record_work_tool_call(pattern, "call-1", tool_name="web_search")
+    pattern._maybe_nudge_progress_narration(context=context)
+    _record_send_message_call(pattern, "call-2")
+    pattern._maybe_nudge_progress_narration(context=context)
+
+    _record_work_tool_call(pattern, "call-3", tool_name="fetch_web_content")
+    pattern._maybe_nudge_progress_narration(context=context)  # group change, count=1
+    _record_work_tool_call(pattern, "call-4", tool_name="web_search")
+    pattern._maybe_nudge_progress_narration(context=context)  # back to search, count=2
+    _record_work_tool_call(pattern, "call-5", tool_name="fetch_web_content")
+    pattern._maybe_nudge_progress_narration(
+        context=context
+    )  # count=3, still < threshold
+
+    # Only the one nudge from the initial group change — the alternation
+    # afterward (fetch -> search -> fetch) must not each fire their own.
+    assert sum(1 for m in context.messages if m.role == "system") == 1
+
+
+def test_progress_narration_nudge_ignores_group_change_on_the_very_first_streak() -> (
+    None
+):
+    # With no prior message, there is no "last reported" group to compare
+    # against — a fresh run's first tool call must not be treated as a
+    # change (there's nothing to change from).
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=3)
+    context = ExecutionContext(execution_id="task-1")
+
+    _record_work_tool_call(pattern, "call-1", tool_name="fetch_web_content")
+    pattern._maybe_nudge_progress_narration(context=context)
+
+    assert not any(m.role == "system" for m in context.messages)
+
+
+def test_progress_narration_nudge_does_not_treat_same_group_as_a_change() -> None:
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=3)
+    context = ExecutionContext(execution_id="task-1")
+
+    _record_work_tool_call(pattern, "call-1", tool_name="web_search")
+    pattern._maybe_nudge_progress_narration(context=context)
+    _record_send_message_call(pattern, "call-2")
+    pattern._maybe_nudge_progress_narration(context=context)
+
+    # Same tool group as what was just reported on — not a change, and
+    # under the count threshold, so no nudge yet.
+    _record_work_tool_call(pattern, "call-3", tool_name="web_search")
+    pattern._maybe_nudge_progress_narration(context=context)
+
+    assert not any(m.role == "system" for m in context.messages)
+
+
+def test_progress_narration_nudge_detects_group_change_without_a_mid_flight_check() -> (
+    None
+):
+    # The real dispatch loop never calls _maybe_nudge_progress_narration
+    # right after send_message itself — that's its own "control" segment,
+    # which skips this entirely — so the very first evaluation after a
+    # message always already has at least one newer work-tool call sitting
+    # in the ledger ahead of it. An earlier version of this reset keyed off
+    # "the most recent work-tool call" for the pre-message group too, which
+    # is wrong once a newer call already exists: it would end up comparing
+    # the new call's group against itself. Exercise that exact shape here
+    # (no evaluation between the message and the next call) to pin the fix.
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=3)
+    context = ExecutionContext(execution_id="task-1")
+
+    _record_work_tool_call(pattern, "call-1", tool_name="web_search")
+    _record_work_tool_call(pattern, "call-2", tool_name="web_search")
+    _record_send_message_call(pattern, "call-3")
+    _record_work_tool_call(pattern, "call-4", tool_name="fetch_web_content")
+    pattern._maybe_nudge_progress_narration(context=context)
+
+    system_messages = [m for m in context.messages if m.role == "system"]
+    assert len(system_messages) == 1
+    assert "switched to a different kind of action" in system_messages[-1].content
+
+
+@pytest.mark.asyncio
+async def test_progress_narration_nudges_fire_through_the_real_dispatch_loop() -> None:
+    # All the unit tests above call _maybe_nudge_progress_narration directly,
+    # bypassing the real per-segment dispatch loop entirely (the "requested
+    # decision" gate, control-vs-work segment routing, etc.). Live testing
+    # kept showing a single narration for an entire multi-phase run despite
+    # those unit tests passing, so drive the actual loop end to end here:
+    # two searches, a fetch (crosses the count threshold), a narration, a
+    # write (different group — should nudge immediately), another
+    # narration, one more search (group changes again), a third narration,
+    # then the final answer.
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": json.dumps({"query": "LangChain pricing"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": json.dumps({"query": "CrewAI pricing"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_3",
+                        "function": {
+                            "name": "fetch_web_content",
+                            "arguments": json.dumps({"url": "https://crewai.com"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_4",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Checked pricing pages, digging into search results now.",
+                                    "message_type": "progress",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_5",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": json.dumps(
+                                {
+                                    "file_path": "comparison.md",
+                                    "content": "draft",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_6",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Wrote a first draft, double-checking a few sources.",
+                                    "message_type": "progress",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_7",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": json.dumps({"query": "LangSmith pricing"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_8",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Confirmed the last details, finishing up now.",
+                                    "message_type": "progress",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_9",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": json.dumps(
+                                {
+                                    "response_language": "English",
+                                    "answer": "Here is the comparison.",
+                                    "outcome": "completed",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+        ]
+    )
+    pattern = ReActPattern(
+        max_iterations=12,
+        progress_narration_nudge_after_consecutive_tool_calls=3,
+    )
+    # In production, zhipu_web_search and fetch_web_content both declare
+    # category=ToolCategory.WEB_SEARCH — they share one tool-decision group.
+    # A generic per-name FakeTool (its own name as its own group) hides
+    # this and made an earlier version of this test pass for the wrong
+    # reason; use FakeGroupedTool to reproduce the real category sharing.
+    tools = [
+        FakeGroupedTool("zhipu_web_search", "web_search"),
+        FakeGroupedTool("fetch_web_content", "web_search"),
+        FakeWriteFileTool(),
+    ]
+    context = ExecutionContext(execution_id="task-1")
+    context.add_user_message(
+        "Compare LangChain and CrewAI pricing and write up the findings."
+    )
+
+    result = await pattern.run(context=context, tools=tools, llm=llm)
+
+    assert result["success"] is True
+
+    nudges = [
+        m
+        for m in context.messages
+        if m.role == "system" and "Progress narration reminder" in (m.content or "")
+    ]
+    # Nudge 1: count threshold (search, search, fetch — all web_search).
+    # Nudge 2: write_file is the *first* call after message 1, and its
+    # group (file) differs from web_search — group-change fires
+    # immediately at count 1, without waiting for the threshold.
+    # Nudge 3: web_search is the first call after message 2, and its group
+    # differs from write_file's — group-change fires again at count 1.
+    # (fetch_web_content sharing web_search's category with zhipu_web_search
+    # means a search-after-fetch transition would NOT get its own
+    # group-change nudge — that's exactly what the live run showed — but
+    # this sequence never puts search directly after fetch within one
+    # streak, so it isn't exercised here.)
+    assert len(nudges) == 3
+    assert nudges[0].metadata["trigger"] == "consecutive_count"
+    assert nudges[1].metadata["trigger"] == "group_change"
+    assert nudges[2].metadata["trigger"] == "group_change"
+
+
+@pytest.mark.asyncio
+async def test_progress_narration_nudge_catches_up_when_group_change_is_masked() -> (
+    None
+):
+    # The exact shape from the live run that motivated this whole nudge
+    # mechanism: search, search, fetch_web_content (nudge — count
+    # threshold), a narration, then search, search, write_file.
+    #
+    # zhipu_web_search and fetch_web_content share the web_search category,
+    # so search+search+fetch also happens to cross the *repeated-tool*
+    # decision's own (group-based, message-transparent) threshold of 4
+    # right on the first search after the narration — which preempts that
+    # exact segment's progress-nudge check entirely. This pins the fix for
+    # that interaction: the nudge's reset bookkeeping must still run on a
+    # preempted segment, and the group-change check must still fire on
+    # whatever segment it first gets to look at (not require count==1
+    # exactly), so write_file two calls later still gets recognized as a
+    # genuine phase change instead of the state staying stuck for the rest
+    # of the run.
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": json.dumps({"query": "LangChain pricing"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": json.dumps({"query": "CrewAI pricing"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_3",
+                        "function": {
+                            "name": "fetch_web_content",
+                            "arguments": json.dumps({"url": "https://crewai.com"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_4",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Checked pricing pages, searching a bit more.",
+                                    "message_type": "progress",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_5",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": json.dumps({"query": "LangSmith pricing"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_6",
+                        "function": {
+                            "name": "zhipu_web_search",
+                            "arguments": json.dumps({"query": "LangChain vs CrewAI"}),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_7",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": json.dumps(
+                                {
+                                    "file_path": "comparison.md",
+                                    "content": "draft",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_8",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": json.dumps(
+                                {
+                                    "response_language": "English",
+                                    "answer": "Here is the comparison.",
+                                    "outcome": "completed",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+        ]
+    )
+    pattern = ReActPattern(
+        max_iterations=12,
+        progress_narration_nudge_after_consecutive_tool_calls=3,
+    )
+    tools = [
+        FakeGroupedTool("zhipu_web_search", "web_search"),
+        FakeGroupedTool("fetch_web_content", "web_search"),
+        FakeWriteFileTool(),
+    ]
+    context = ExecutionContext(execution_id="task-1")
+    context.add_user_message(
+        "Compare LangChain and CrewAI pricing and write up the findings."
+    )
+
+    result = await pattern.run(context=context, tools=tools, llm=llm)
+
+    assert result["success"] is True
+
+    nudges = [
+        m
+        for m in context.messages
+        if m.role == "system" and "Progress narration reminder" in (m.content or "")
+    ]
+    assert len(nudges) == 2
+    assert nudges[0].metadata["trigger"] == "consecutive_count"
+    # write_file's group differs from the search streak's, so the (now
+    # preemption-robust) group-change check catches it before the raw
+    # count would have.
+    assert nudges[1].metadata["trigger"] == "group_change"
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -2722,6 +2722,131 @@ async def test_react_pattern_streams_final_answer_after_repeated_guard() -> None
     assert outbound.events[-1]["content"] == "Fallback answer."
 
 
+def _record_work_tool_call(
+    pattern: ReActPattern, call_id: str, tool_name: str = "web_search"
+) -> None:
+    pattern.tool_ledger[call_id] = ToolCallRecord(
+        tool_call_id=call_id,
+        tool_name=tool_name,
+        args={"query": "x"},
+        args_hash="hash",
+        status="completed",
+        result={"success": True},
+    )
+
+
+def _record_send_message_call(pattern: ReActPattern, call_id: str) -> None:
+    pattern.tool_ledger[call_id] = ToolCallRecord(
+        tool_call_id=call_id,
+        tool_name="send_message",
+        args={"message": "update", "message_type": "progress"},
+        args_hash="hash",
+        status="completed",
+        result={"message": "update", "status": "sent"},
+    )
+
+
+def test_progress_narration_nudge_fires_once_a_streak_crosses_the_threshold() -> None:
+    # Live testing showed the model can go a whole multi-round search task
+    # (5 tool calls) without ever calling send_message on its own; this
+    # nudge is the deterministic backstop for that silence.
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=2)
+    context = ExecutionContext(execution_id="task-1")
+
+    _record_work_tool_call(pattern, "call-1")
+    pattern._maybe_nudge_progress_narration(context=context)
+    assert not any(m.role == "system" for m in context.messages)
+
+    _record_work_tool_call(pattern, "call-2")
+    pattern._maybe_nudge_progress_narration(context=context)
+    system_messages = [m for m in context.messages if m.role == "system"]
+    assert len(system_messages) == 1
+    assert "send_message" in system_messages[0].content
+    assert "message_type='progress'" in system_messages[0].content
+
+
+def test_progress_narration_nudge_does_not_repeat_for_the_same_streak() -> None:
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=2)
+    context = ExecutionContext(execution_id="task-1")
+
+    for i in range(1, 4):
+        _record_work_tool_call(pattern, f"call-{i}")
+        pattern._maybe_nudge_progress_narration(context=context)
+
+    # Threshold (2) was crossed once and the streak kept growing (3), so the
+    # nudge should not have fired again in between — only when the count
+    # actually exceeds the last-nudged value.
+    assert sum(1 for m in context.messages if m.role == "system") == 1
+
+
+def test_progress_narration_nudge_renudges_once_the_streak_grows_further() -> None:
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=2)
+    context = ExecutionContext(execution_id="task-1")
+
+    for i in range(1, 5):
+        _record_work_tool_call(pattern, f"call-{i}")
+        pattern._maybe_nudge_progress_narration(context=context)
+        if i == 2:
+            # First crossing: exactly one nudge so far.
+            assert sum(1 for m in context.messages if m.role == "system") == 1
+
+    # The model kept ignoring it past the first nudge (4 consecutive calls,
+    # last nudged at 2) — that "still not narrating" state deserves a second
+    # reminder rather than staying silent for the rest of the run.
+    assert sum(1 for m in context.messages if m.role == "system") == 2
+
+
+def test_progress_narration_nudge_resets_after_a_send_message_call() -> None:
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=2)
+    context = ExecutionContext(execution_id="task-1")
+
+    _record_work_tool_call(pattern, "call-1")
+    _record_work_tool_call(pattern, "call-2")
+    pattern._maybe_nudge_progress_narration(context=context)
+    assert sum(1 for m in context.messages if m.role == "system") == 1
+
+    _record_send_message_call(pattern, "call-3")
+    pattern._maybe_nudge_progress_narration(context=context)
+    assert sum(1 for m in context.messages if m.role == "system") == 1
+
+    # New streak after the model finally narrated — should be able to nudge
+    # again once it goes quiet for another full threshold.
+    _record_work_tool_call(pattern, "call-4")
+    _record_work_tool_call(pattern, "call-5")
+    pattern._maybe_nudge_progress_narration(context=context)
+    assert sum(1 for m in context.messages if m.role == "system") == 2
+
+
+def test_progress_narration_nudge_disabled_when_threshold_is_none() -> None:
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=None)
+    context = ExecutionContext(execution_id="task-1")
+
+    for i in range(1, 6):
+        _record_work_tool_call(pattern, f"call-{i}")
+        pattern._maybe_nudge_progress_narration(context=context)
+
+    assert not any(m.role == "system" for m in context.messages)
+
+
+def test_progress_narration_nudge_survives_checkpoint_resume() -> None:
+    pattern = ReActPattern(progress_narration_nudge_after_consecutive_tool_calls=2)
+    context = ExecutionContext(execution_id="task-1")
+    _record_work_tool_call(pattern, "call-1")
+    _record_work_tool_call(pattern, "call-2")
+    pattern._maybe_nudge_progress_narration(context=context)
+    assert sum(1 for m in context.messages if m.role == "system") == 1
+
+    resumed = ReActPattern()
+    resumed.load_state(pattern.get_state())
+    assert resumed.progress_narration_nudge_after_consecutive_tool_calls == 2
+    # The streak hasn't grown past what was already nudged, so resuming
+    # must not immediately re-nudge for the same unchanged state.
+    resumed.tool_ledger = dict(pattern.tool_ledger)
+    resumed_context = ExecutionContext(execution_id="task-1")
+    resumed._maybe_nudge_progress_narration(context=resumed_context)
+    assert not any(m.role == "system" for m in resumed_context.messages)
+
+
 @pytest.mark.asyncio
 async def test_react_pattern_supports_plain_function_tools(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
Third layer of the friendlier-agent-status work (follow-up to #1356, which handled trace-label copy and tool-name friendliness on the frontend). This one is behavioral: get the agent to actually narrate its own progress in plain language, since the trace UI's event labels were otherwise the user's only signal of what's happening.

**Update after a live smoke test on this branch:** schema-level guidance on `send_message` alone proved too weak — a real task ("compare LangChain vs CrewAI pricing/features") ran 5 rounds of `zhipu_web_search` over ~2 minutes and never called `send_message` once. So this PR now has two parts:

1. **Schema wording** — documented `message_type='progress'` on the `send_message` tool: narrate what's happening the way the user themselves would (never naming the tool, model, file path, or raw arguments), at meaningful phase transitions rather than before every tool call. Also documented the other enum values, the `message` field's language rule (matching `REACT_RESPONSE_LANGUAGE_DESCRIPTION`'s existing convention), and `message_type`'s default.
2. **Deterministic backstop** (new, based on the live-test finding) — reuses the same consecutive-tool-call ledger scanning already used for `repeated_tool_decision`: once N consecutive work-tool calls pass with no message sent to the user (`send_message`/`ask_user_question`), inject a system reminder before the next LLM call telling the model to narrate now. Threshold defaults to 2, is configurable and checkpoint-persisted the same way as the existing `repeated_tool_decision_after_consecutive_*` thresholds, and is skipped when a repeated-tool decision is already pending for that segment (which settles continue-vs-finish on its own next turn, so a progress nudge there would just be noise).

No change to the `send_message`/tool-dispatch handlers themselves beyond the new nudge injection point; shared by both the ReAct (`balanced`) and DAG plan-execute (`think`) patterns since DAG steps run through `ReActPattern`.

## Test plan
- [x] `pytest tests/core/agent/` (all tests, including 6 new ones covering the nudge: fires once past threshold, doesn't repeat mid-streak, re-fires once the streak grows another full threshold, resets after a send_message call, disabled when threshold is None, and survives checkpoint resume without re-nudging)
- [x] `ruff check` / `ruff format --check` / `mypy` — all clean
- [x] Live smoke test on this branch surfaced the original gap (0 progress messages across a 5-round search task) that motivated part 2
- [ ] Re-run the same live smoke test with the nudge in place to confirm it actually gets the model to narrate, and that the resulting cadence isn't spammy — worth doing once more before merge