### PR TITLE
enh: remove assistant avatar icon from chat messages

### DIFF
--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { Bot, ChevronDown, ChevronUp, Copy, Check, Laptop } from "lucide-react";
+import { ChevronDown, ChevronUp, Copy, Check, Laptop } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { TraceEventRenderer, type AgentExecutionSummary } from "./TraceEventRenderer";
@@ -448,7 +448,7 @@ export function ChatMessage({
   return (
     <div className="w-full space-y-2 animate-fade-in group">
       {shouldShowProcess && !isUser && (
-        <div className={cn("pl-7")}>
+        <div>
           <TraceEventRenderer
             events={traceEvents}
             taskStatus={resolvedProcessStatus}
@@ -473,17 +473,6 @@ export function ChatMessage({
                 : "bg-transparent p-0 w-full max-w-full"
             )}
           >
-            {/* Avatar */}
-            {!isUser && (
-              <div
-                className={cn(
-                  "flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center shadow-md bg-transparent"
-                )}
-              >
-                <Bot className="w-5 h-5 text-muted-foreground" />
-              </div>
-            )}
-
             {/* Message content */}
             <div className={cn("flex-1 min-w-0")}>
               {isAssistantFailure ? (
@@ -558,7 +547,7 @@ export function ChatMessage({
         <div
           className={cn(
             "flex items-center gap-1.5 text-xs text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity duration-200",
-            isUser ? "justify-end mr-1" : "justify-start ml-14"
+            isUser ? "justify-end mr-1" : "justify-start"
           )}
         >
           <button

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -448,14 +448,12 @@ export function ChatMessage({
   return (
     <div className="w-full space-y-2 animate-fade-in group">
       {shouldShowProcess && !isUser && (
-        <div>
-          <TraceEventRenderer
-            events={traceEvents}
-            taskStatus={resolvedProcessStatus}
-            onOpenExecutionPlan={onOpenExecutionPlan}
-            onAgentExecutionClick={onAgentExecutionClick}
-          />
-        </div>
+        <TraceEventRenderer
+          events={traceEvents}
+          taskStatus={resolvedProcessStatus}
+          onOpenExecutionPlan={onOpenExecutionPlan}
+          onAgentExecutionClick={onAgentExecutionClick}
+        />
       )}
 
       {!isProcessOnlyMessage && (

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -465,14 +465,13 @@ export function ChatMessage({
         >
           <div
             className={cn(
-              "flex gap-4 transition-all duration-300",
               isUser
-                ? "max-w-[85%] bg-secondary text-secondary-foreground p-3 rounded-2xl flex-row-reverse items-center"
+                ? "max-w-[85%] bg-secondary text-secondary-foreground p-3 rounded-2xl"
                 : "bg-transparent p-0 w-full max-w-full"
             )}
           >
             {/* Message content */}
-            <div className={cn("flex-1 min-w-0")}>
+            <div>
               {isAssistantFailure ? (
                 <div className="py-3 text-sm leading-relaxed text-red-500 break-words [overflow-wrap:anywhere]">
                   {displayCopyableContent}


### PR DESCRIPTION
## Summary
- Remove the Bot avatar icon shown to the left of assistant chat replies
- Drop the compensating layout offsets (`pl-7` on the trace view, `ml-14` on the action row) that were sized for the removed avatar column, so the trace/text/action row now align to the message's left edge

## Test plan
- [x] `npx vitest run src/components/chat/ChatMessage.process-view.test.tsx src/components/chat/ChatMessage.test.tsx` — 32 tests pass
- [x] `npx tsc --noEmit` — no type errors