### PR TITLE
Resolve an agent's declared knowledge bases against its own team

### DIFF
--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -250,15 +250,21 @@ async def _list_knowledge_bases_impl(
             ``knowledge_tools.py`` builds the list tool only when the
             agent's allowed collections are ``None`` -- a non-empty list
             builds the search tool alone, and an empty list builds no
-            knowledge tool at all -- and both chat call sites derive that
-            value and the declaration from the same stored field, so on this
-            path there is no declared name to classify as "unshared" versus
-            "missing". See ``declared_knowledge_bases`` below.
+            knowledge tool at all -- and both chat call sites derive the
+            allowed collections and the declaration from the same stored
+            field, so in production a list tool is built with no declared
+            name to classify as "unshared" versus "missing". A test may
+            still hand this function a declaration alongside ``None``
+            allowed collections; that combination is constructed to isolate
+            forwarding, not something a call site produces. See
+            ``declared_knowledge_bases`` below.
         declared_knowledge_bases: Accepted for signature symmetry and never
             read here, for the same reason. This function reports "here is
             what is available" -- an unresolved declared name simply does
             not appear in the list, with no separate message field, and
-            never triggers the creator-existence probe.
+            never triggers the creator-existence probe. That holds whatever
+            is passed, so an artificially constructed declaration changes
+            nothing about the answer.
 
     Returns:
         ListKnowledgeBasesResult containing knowledge base information
@@ -522,6 +528,11 @@ async def _search_knowledge_base_impl(
             ``tool_args.allowed_collections`` and never
             ``tool_args.collections``, both of which are model-authored on
             every path (a declared schema field the model can overwrite).
+            Both chat call sites derive this and the tool's allowed
+            collections from that one stored field, so in production the
+            two are equal by construction; a test that pairs a declaration
+            with different allowed collections is isolating forwarding, and
+            this function's behaviour is defined for that pairing too.
 
     Returns:
         KnowledgeSearchResult with formatted search results

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -537,7 +537,6 @@ class _CreatorCollectionProbe:
                 # restore exactly the misclassification this call exists to
                 # remove.
                 team_hosted = await _team_names_hosted_on(self._agent_creator_user_id)
-                self._names = {c.name for c in creator_result.collections} - team_hosted
             except Exception:
                 logger.warning(
                     "Failed to resolve creator's personal collections while "
@@ -546,6 +545,28 @@ class _CreatorCollectionProbe:
                 )
                 self._names = set()
                 self.lookup_failed = True
+            else:
+                if creator_result.status == "success":
+                    self._names = {
+                        c.name for c in creator_result.collections
+                    } - team_hosted
+                else:
+                    # The listing reports an infrastructure failure by
+                    # returning status="error" with an empty collection list
+                    # instead of raising (RAG_tools/management/collections).
+                    # Read as a plain answer, that empty list says "the
+                    # creator holds nothing", and the caller would assert
+                    # the certain "does not exist" wording off a lookup that
+                    # never completed. Same treatment as a raised failure:
+                    # nothing is established, so the report must hedge.
+                    logger.warning(
+                        "Creator collection listing reported status=%s while "
+                        "classifying an unshared knowledge base: %s",
+                        creator_result.status,
+                        creator_result.message,
+                    )
+                    self._names = set()
+                    self.lookup_failed = True
         return name in self._names
 
 
@@ -619,9 +640,16 @@ async def _search_knowledge_base_impl(
         # Team-governed run WITH a declaration, on a deployment that has
         # actually installed the team-keyed hook: the declaration is the
         # authority for both what may be searched and what gets reported.
-        # Gated on this three-way conjunction, not merely on
-        # governing_team_id being set, for two independent reasons:
+        # Gated on this four-way conjunction, not merely on
+        # governing_team_id being set, for three independent reasons:
         #
+        # - an unauthenticated call (``user_id`` is None) never had a team
+        #   layer resolved for it at all: ``_list_visible_collections``
+        #   returns before any team resolution when the runner id is absent,
+        #   so the visible set it produced is the plain listing. Running the
+        #   rule on top of that would classify every declared name through a
+        #   creator probe made on nobody's behalf. Both chat call sites carry
+        #   a real runner id today; this conjunct keeps it that way;
         # - an empty declaration (the case where agent_config carried no
         #   agent at all) has nothing to authorise or verdict-derive against,
         #   so the declared-name rule does not apply and the search falls
@@ -655,15 +683,17 @@ async def _search_knowledge_base_impl(
         # This gate and the team layer's own gate in
         # ``_list_visible_collections`` are not the same predicate: they
         # share ``governing_team_id is not None and
-        # team_knowledge_base_hook_installed()``, but this one adds a third
-        # conjunct (``declared_names_for_this_run``) that the team layer's
-        # gate does not read. That is intentional, not a mismatch to close --
+        # team_knowledge_base_hook_installed()``, but this one adds two more
+        # conjuncts (``user_id is not None`` and
+        # ``declared_names_for_this_run``) that the team layer's gate does
+        # not read. That is intentional, not a mismatch to close --
         # the team layer's job is only "resolve onto the governing team",
         # which an empty declaration does not change; this gate's job is
         # "does the declared-name rule apply at all", which an empty
         # declaration answers no to.
         declared_name_rule_applies = (
-            governing_team_id is not None
+            user_id is not None
+            and governing_team_id is not None
             and team_knowledge_base_hook_installed()
             and bool(declared_names_for_this_run)
         )
@@ -817,37 +847,76 @@ async def _search_knowledge_base_impl(
                 ]
 
                 if unresolvable_names:
-                    # The creator-collection lookup raised during this call,
-                    # so every unresolved declared name is unclassified, not
-                    # established absent. Reported as one undifferentiated
-                    # outcome for all of them -- a lookup failure is not
+                    # The creator-collection lookup did not complete during
+                    # this call, so every unresolved declared name is
+                    # unclassified, not established absent. Reported as one
+                    # undifferentiated outcome -- a lookup failure is not
                     # per-name, so this sentence still says nothing about
-                    # which names the creator holds. The other two report
-                    # sets are necessarily empty here: the first failure
-                    # caches the creator's name set as empty and marks the
-                    # probe failed, so every later unresolved name takes
-                    # this same classification, and a name reaches the
-                    # missing set only on a run whose runner is the creator
-                    # -- which never calls the probe at all.
-                    summary = _TERMINAL_UNRESOLVABLE_MESSAGE.format(
-                        names=", ".join(unresolvable_names)
-                    )
+                    # which names the creator holds -- and scoped like the
+                    # other two report sets, so an explicit request is
+                    # answered about the names it asked for.
+                    #
+                    # The narrowed list cannot come out empty: with an
+                    # explicit request, reaching this branch means every
+                    # requested name was unresolved, because a requested
+                    # name the verdict loop admitted would have survived the
+                    # narrowing and left the search set non-empty; without
+                    # one, the scope is the whole declaration.
+                    #
+                    # The other two report sets are necessarily empty here:
+                    # the first failure caches the creator's name set as
+                    # empty and marks the probe failed, so every later
+                    # unresolved name takes this same classification, and a
+                    # name reaches the missing set only on a run whose
+                    # runner is the creator -- which never calls the probe
+                    # at all.
+                    #
+                    # The admitted clause renders on the same condition as
+                    # the mixed branch below, so a request narrowed away to
+                    # nothing still says what could have been asked for.
+                    failed_unresolvable_names = [
+                        name for name in unresolvable_names if name in reported_scope
+                    ]
+                    unresolvable_segments = [
+                        _TERMINAL_UNRESOLVABLE_MESSAGE.format(
+                            names=", ".join(failed_unresolvable_names)
+                        )
+                    ]
+                    if admitted_names:
+                        unresolvable_segments.append(
+                            "Available collections: "
+                            f"{', '.join(sorted(admitted_names))}."
+                        )
+                    summary = " ".join(unresolvable_segments)
                 elif not failed_unshared_names:
                     # Nothing in scope is the creator's own collection, so
                     # the two inherited terminal sentences are true as
                     # written and each renders byte for byte on its own
-                    # call style.
+                    # call style. The availability clause they carry is
+                    # dropped when the verdict loop admitted nothing, the
+                    # same as the mixed branch below: its source is the
+                    # admitted set, which this rule can empty where the
+                    # visible union it replaced never could, and a label
+                    # with an empty list after it tells the model nothing.
                     if explicit_request is not None:
                         summary = (
-                            f"Error: The following collections do not exist: {', '.join(sorted(explicit_request))}. "
-                            f"Available collections: {', '.join(sorted(admitted_names))}"
+                            "Error: The following collections do not exist: "
+                            f"{', '.join(sorted(explicit_request))}."
                         )
+                        if admitted_names:
+                            summary += (
+                                " Available collections: "
+                                f"{', '.join(sorted(admitted_names))}"
+                            )
                     else:
                         summary = (
-                            f"Error: None of the allowed collections exist. "
-                            f"Allowed: {', '.join(sorted(authorised))}. "
-                            f"Available: {', '.join(sorted(admitted_names))}"
+                            "Error: None of the allowed collections exist. "
+                            f"Allowed: {', '.join(sorted(authorised))}."
                         )
+                        if admitted_names:
+                            summary += (
+                                f" Available: {', '.join(sorted(admitted_names))}"
+                            )
                 else:
                     # At least one failed name is the creator's own
                     # collection, which does exist. Neither inherited

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -164,7 +164,7 @@ class KnowledgeSearchArgs(BaseModel):
     query: str = Field(description="The search query or question")
     collections: List[str] = Field(
         default=[],
-        description="Specific knowledge base collection names to search. Empty list uses allowed_collections if set, otherwise searches all collections.",
+        description="Specific knowledge base collection names to search. Empty list searches every knowledge base this agent is configured with: allowed_collections when set, all collections when not, and for an agent owned by a team, that agent's own stored knowledge base list.",
     )
     search_type: str = Field(
         default="hybrid",
@@ -183,7 +183,7 @@ class KnowledgeSearchArgs(BaseModel):
     )
     allowed_collections: Optional[List[str]] = Field(
         default=None,
-        description="Optional list of allowed collection names. Used as default when collections is empty.",
+        description="Optional list of allowed collection names. Used as default when collections is empty. Ignored for an agent owned by a team, whose own stored knowledge base list is the authority.",
     )
 
 
@@ -695,6 +695,11 @@ async def _search_knowledge_base_impl(
         if tool_args.allowed_collections:
             logger.info(f"   - Allowed collections: {tool_args.allowed_collections}")
 
+        # Collected by whichever branch below resolves the search set; a
+        # partial failure warns without stopping the rest of the agent's
+        # knowledge bases from being searched normally.
+        partial_failure_notes = []
+
         if declared_name_rule_applies:
             resolved_by_name = {c.name: c for c in collections_result.collections}
             authorised = set(declared_names_for_this_run)
@@ -872,8 +877,7 @@ async def _search_knowledge_base_impl(
                     summary = "Error: " + " ".join(segments)
                 return KnowledgeSearchResult(results=[], summary=summary)
 
-            collections_to_iterate: List[CollectionInfo] = to_search
-            partial_failure_notes = []
+            collections_to_iterate = to_search
             if unshared_names:
                 partial_failure_notes.append(_render_unshared_names(unshared_names))
             if missing_names or unresolvable_names:
@@ -912,7 +916,6 @@ async def _search_knowledge_base_impl(
             collections_to_iterate = [
                 c for c in collections_result.collections if c.name in collections_set
             ]
-            partial_failure_notes = []
             logger.info(f"Searching specific collections: {sorted(collections_set)}")
         elif tool_args.allowed_collections is not None:
             allowed_set = set(tool_args.allowed_collections)
@@ -935,11 +938,9 @@ async def _search_knowledge_base_impl(
             collections_to_iterate = [
                 c for c in collections_result.collections if c.name in valid_collections
             ]
-            partial_failure_notes = []
             logger.info(f"Searching allowed collections: {sorted(valid_collections)}")
         else:
             collections_to_iterate = collections_result.collections
-            partial_failure_notes = []
             logger.info("Searching all collections")
 
         # Build base search config (per-collection overrides happen below)

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -36,9 +36,10 @@ _PARTIAL_FAILURE_NOTE = (
     "bases were searched normally."
 )
 # The terminal counterpart of the note above, for the one case the certainty
-# wording would be a falsehood: the creator-collection lookup raised, so
-# nothing established that these names are absent -- only that they could not
-# be classified. Reuses the note's hedge; nothing was searched, so it does not
+# wording would be a falsehood: the creator-collection lookup did not
+# complete -- it raised, or returned a result whose status reports failure --
+# so nothing established that these names are absent, only that they could
+# not be classified. Reuses the note's hedge; nothing was searched, so it does not
 # borrow the note's second sentence.
 _TERMINAL_UNRESOLVABLE_MESSAGE = "Error: {names} could not be resolved for this agent."
 
@@ -532,7 +533,8 @@ class _CreatorCollectionProbe:
     def __init__(self, agent_creator_user_id: Optional[int]) -> None:
         self._agent_creator_user_id = agent_creator_user_id
         self._names: Optional[set] = None
-        # Whether the one lookup this probe makes raised. Read by the caller
+        # Whether the one lookup this probe makes failed -- raised, or
+        # returned a result whose status reports failure. Read by the caller
         # to tell "the creator does not hold this name" apart from "nobody
         # asked" -- the failure degrades to "not held" for the search
         # decision (unchanged), but the report must not claim an absence
@@ -821,7 +823,8 @@ async def _search_knowledge_base_impl(
                         unshared_names.append(name)
                     elif creator_probe.lookup_failed:
                         # Not "missing": the lookup that would have decided
-                        # raised. The search outcome is the same either way
+                        # did not complete (raised, or reported failure
+                        # through its status). The search outcome is the same either way
                         # (nothing resolves), only the report differs.
                         unresolvable_names.append(name)
                     else:

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -435,13 +435,59 @@ def _resolve_declared_name(
     return _UNRESOLVED
 
 
+async def _team_names_hosted_on(storage_user_id: int) -> set:
+    """Names on ``storage_user_id``'s tenant that a team owns, not the user.
+
+    A team's knowledge base lives in some member's storage namespace, so a
+    raw ``list_collections`` for that member returns the team's rows
+    alongside their own, and nothing on the row itself separates them:
+    ``CollectionInfo.ownership`` is ``"personal"`` on every row
+    ``list_collections`` produces -- the one place it becomes ``"team"`` is
+    the overlay in ``_list_visible_collections``, which reads the very hook
+    this function reads.
+
+    Asked through the runner-keyed visibility hook, called with the
+    tenant's own id, because it is the only seam that answers "which
+    knowledge bases does a team own" for a team other than the governing
+    one. The answer only ever narrows what may be called this user's own,
+    and is never rendered: a name it removes is reported as absent instead
+    of as the creator's, so the report can say less about the creator than
+    before, never more.
+
+    Bounded by what the seam can answer: it reports the teams this user is
+    a member of *now*, so a team's row hosted on the tenant of someone who
+    has since left that team still counts as personal. Closing that would
+    need a "which team owns this name" question the hook contract does not
+    have, and answering it would widen what a run can learn.
+    """
+    from ....web.services.db_runtime import run_db_io_cancellation_safe
+    from ....web.services.knowledge_base_team_scope import (
+        has_knowledge_base_visibility_hook,
+        visible_team_knowledge_bases,
+    )
+
+    if not has_knowledge_base_visibility_hook():
+        # Standalone xagent, and any deployment that installed only the
+        # team-keyed hook: no team owns anything here, so every row on the
+        # tenant is the user's own.
+        return set()
+    refs = await run_db_io_cancellation_safe(
+        lambda: visible_team_knowledge_bases(None, int(storage_user_id))
+    )
+    # Only the rows physically hosted on this tenant. A team row stored
+    # elsewhere never appeared in this tenant's listing, and excluding its
+    # name would drop a same-named collection this user really does own.
+    return {ref.name for ref in refs if ref.storage_user_id == storage_user_id}
+
+
 class _CreatorCollectionProbe:
     """Memoised lookup of the agent creator's own collection names.
 
-    At most one ``list_collections`` call for the creator's id per search
-    call, regardless of how many declared names need classifying -- the
-    lookup result is cached after the first call, including a failure
-    (cached as "nothing"). A failure degrades to "not held" and never
+    At most one creator lookup per search call -- one collection listing
+    and one team-ownership question, both memoised together -- regardless
+    of how many declared names need classifying. The lookup result is
+    cached after the first call, including a failure (cached as
+    "nothing"). A failure degrades to "not held" and never
     raises: a probe that cannot complete must not block the search, and
     must not be distinguishable from "the creator does not have this
     collection" (see the module docstring's identity-disclosure limits).
@@ -484,7 +530,14 @@ class _CreatorCollectionProbe:
                 creator_result = await list_collections(
                     user_id=self._agent_creator_user_id, is_admin=False
                 )
-                self._names = {c.name for c in creator_result.collections}
+                # Inside the same try on purpose: if the team lookup fails,
+                # which of these rows are the creator's own is unknown, and
+                # the caller must hedge rather than assert the creator
+                # holds them. Falling back to the unfiltered listing would
+                # restore exactly the misclassification this call exists to
+                # remove.
+                team_hosted = await _team_names_hosted_on(self._agent_creator_user_id)
+                self._names = {c.name for c in creator_result.collections} - team_hosted
             except Exception:
                 logger.warning(
                     "Failed to resolve creator's personal collections while "
@@ -660,7 +713,14 @@ async def _search_knowledge_base_impl(
                     return KnowledgeSearchResult(
                         results=[],
                         summary=f"Error: The following collections are not allowed: {', '.join(sorted(disallowed))}. "
-                        f"Allowed collections: {', '.join(sorted(authorised & available_names))}",
+                        # The clause lists the declaration itself, not its
+                        # intersection with the visible union: that union
+                        # seeds the runner's own same-named personal
+                        # collections, which the verdict loop below then
+                        # refuses to search -- advertising them here as
+                        # allowed and rejecting them one step later is the
+                        # same contradiction the terminal branch avoids.
+                        f"Allowed collections: {', '.join(sorted(authorised))}",
                     )
                 explicit_request = requested_set
                 logger.info(f"Searching specific collections: {sorted(requested_set)}")
@@ -727,68 +787,89 @@ async def _search_knowledge_base_impl(
                 # which would fall through to the generic search-miss text
                 # below instead of the two outcomes this branch exists to
                 # report.
-                # Both branches list "Available" from the verdict-admitted
-                # names, never from ``authorised & available_names``. That
-                # intersection reports two sets of names it must not: the
-                # governing team's collections the agent never declared
-                # (``_list_visible_collections`` merges the team's full
-                # catalogue in before any declared-name filter runs), and --
-                # on this branch specifically -- the runner's own same-named
-                # personal copies, which seed the union and are precisely the
-                # collections the rule refuses to search. On the no-explicit
-                # branch nothing was admitted, so the clause renders empty;
-                # on the explicit branch the admitted set is the one taken
-                # before the narrowing above, so a run whose requested names
-                # all failed still tells the model what it may ask for.
+                # The summary is derived from the verdicts, one report set
+                # per verdict class, so no name is described twice and none
+                # is described as both absent and held. "Available" is
+                # always the verdict-admitted set, never
+                # ``authorised & available_names``: that intersection
+                # reports two sets of names it must not -- the governing
+                # team's collections the agent never declared, and the
+                # runner's own same-named personal copies, which seed the
+                # visible union and are precisely what the rule refuses to
+                # search. The admitted set is the one taken before the
+                # narrowing above, so a run whose requested names all
+                # failed still tells the model what it may ask for.
+                reported_scope = (
+                    explicit_request
+                    if explicit_request is not None
+                    else set(declared_names_for_this_run)
+                )
+                failed_unshared_names = [
+                    name for name in unshared_names if name in reported_scope
+                ]
+                failed_missing_names = [
+                    name for name in missing_names if name in reported_scope
+                ]
+
                 if unresolvable_names:
                     # The creator-collection lookup raised during this call,
                     # so every unresolved declared name is unclassified, not
                     # established absent. Reported as one undifferentiated
                     # outcome for all of them -- a lookup failure is not
                     # per-name, so this sentence still says nothing about
-                    # which names the creator holds. ``unshared_names`` is
-                    # necessarily empty here: the first failure caches the
-                    # creator's name set as empty, so no later name can be
-                    # classified as held.
+                    # which names the creator holds. The other two report
+                    # sets are necessarily empty here: the first failure
+                    # caches the creator's name set as empty and marks the
+                    # probe failed, so every later unresolved name takes
+                    # this same classification, and a name reaches the
+                    # missing set only on a run whose runner is the creator
+                    # -- which never calls the probe at all.
                     summary = _TERMINAL_UNRESOLVABLE_MESSAGE.format(
                         names=", ".join(unresolvable_names)
                     )
-                    failed_unshared_names: List[str] = []
-                elif explicit_request is not None:
-                    summary = (
-                        f"Error: The following collections do not exist: {', '.join(sorted(explicit_request))}. "
-                        f"Available collections: {', '.join(sorted(admitted_names))}"
-                    )
-                    failed_unshared_names = [
-                        name for name in unshared_names if name in explicit_request
-                    ]
+                elif not failed_unshared_names:
+                    # Nothing in scope is the creator's own collection, so
+                    # the two inherited terminal sentences are true as
+                    # written and each renders byte for byte on its own
+                    # call style.
+                    if explicit_request is not None:
+                        summary = (
+                            f"Error: The following collections do not exist: {', '.join(sorted(explicit_request))}. "
+                            f"Available collections: {', '.join(sorted(admitted_names))}"
+                        )
+                    else:
+                        summary = (
+                            f"Error: None of the allowed collections exist. "
+                            f"Allowed: {', '.join(sorted(authorised))}. "
+                            f"Available: {', '.join(sorted(admitted_names))}"
+                        )
                 else:
-                    summary = (
-                        f"Error: None of the allowed collections exist. "
-                        f"Allowed: {', '.join(sorted(authorised))}. "
-                        f"Available: {', '.join(sorted(admitted_names))}"
-                    )
-                    failed_unshared_names = unshared_names
-                # A total failure keeps the existing terminal wording
-                # unchanged (above) -- this branch does not decide whether
-                # a failed name happened to be the creator's own unshared
-                # collection, it only decides that nothing is searchable.
-                # Whichever of the failed names the verdict loop already
-                # classified as the creator's own unshared collection still
-                # gets that message appended, with the "Error:" prefix and
-                # the empty result set both preserved: this is the terminal
-                # path, not the partial-failure warnings channel, so it
-                # does not fold through collection_warnings.
-                if failed_unshared_names:
-                    # A bare space here would leave the appended sentence
-                    # reading like one more entry in the comma-separated
-                    # "Available: ..." list the base text ends with -- both
-                    # to a human reader and to the model consuming this
-                    # summary. The period closes that list before the new
-                    # sentence starts.
-                    summary = (
-                        summary + ". " + _render_unshared_names(failed_unshared_names)
-                    )
+                    # At least one failed name is the creator's own
+                    # collection, which does exist. Neither inherited
+                    # sentence can carry that: one is a statement about
+                    # every allowed collection, the other enumerates the
+                    # whole request, and both would assert the absence of a
+                    # name this same summary goes on to say the creator
+                    # holds. The absence sentence therefore enumerates only
+                    # the names actually classified missing and is dropped
+                    # when there are none; the availability clause is
+                    # dropped when nothing was admitted rather than
+                    # rendering an empty list. Same shape on both call
+                    # styles: each report set lists only its own names, and
+                    # a name appears in exactly one of them.
+                    segments: List[str] = []
+                    if failed_missing_names:
+                        segments.append(
+                            "The following collections do not exist: "
+                            f"{', '.join(sorted(failed_missing_names))}."
+                        )
+                    segments.append(_render_unshared_names(failed_unshared_names))
+                    if admitted_names:
+                        segments.append(
+                            "Available collections: "
+                            f"{', '.join(sorted(admitted_names))}."
+                        )
+                    summary = "Error: " + " ".join(segments)
                 return KnowledgeSearchResult(results=[], summary=summary)
 
             collections_to_iterate: List[CollectionInfo] = to_search

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from ....config import get_kb_search_timeout_seconds
 from .knowledge_base_scope import KnowledgeBaseScopeError
-from .RAG_tools.core.schemas import ListCollectionsResult
+from .RAG_tools.core.schemas import CollectionInfo, ListCollectionsResult
 from .RAG_tools.management.collections import list_collections
 from .RAG_tools.pipelines.document_search import run_document_search
 
@@ -22,6 +22,25 @@ logger = logging.getLogger(__name__)
 # filter silently stops matching - the readonly notice reappears in summaries,
 # which the readonly tests in test_document_search_collection_concurrency catch.
 _READONLY_WARNING_PREFIX = "READONLY_MODE:"
+
+# The fixed, unparaphrasable strings a team-governed search reports through.
+# See the module's callers for when each one is used; the wording itself is
+# a reviewed user-facing contract and must not be edited casually.
+_UNSHARED_CREATOR_KB_MESSAGE = (
+    "{name} is a personal knowledge base belonging to this agent's creator and has not "
+    "been shared with the team. Ask the agent's owner to share it with the team to make "
+    "it available here."
+)
+_PARTIAL_FAILURE_NOTE = (
+    "Note: {names} could not be resolved for this agent. The agent's other knowledge "
+    "bases were searched normally."
+)
+# The terminal counterpart of the note above, for the one case the certainty
+# wording would be a falsehood: the creator-collection lookup raised, so
+# nothing established that these names are absent -- only that they could not
+# be classified. Reuses the note's hedge; nothing was searched, so it does not
+# borrow the note's second sentence.
+_TERMINAL_UNRESOLVABLE_MESSAGE = "Error: {names} could not be resolved for this agent."
 
 if TYPE_CHECKING:
     from .RAG_tools.kb import KBToolCompatibilityFacade
@@ -233,12 +252,13 @@ async def _list_knowledge_bases_impl(
             builds the search tool alone, and an empty list builds no
             knowledge tool at all -- and both chat call sites derive that
             value and the declaration from the same stored field, so on this
-            path there is no declared name to classify at all. See
-            ``declared_knowledge_bases`` below.
+            path there is no declared name to classify as "unshared" versus
+            "missing". See ``declared_knowledge_bases`` below.
         declared_knowledge_bases: Accepted for signature symmetry and never
             read here, for the same reason. This function reports "here is
             what is available" -- an unresolved declared name simply does
-            not appear in the list, with no separate message field.
+            not appear in the list, with no separate message field, and
+            never triggers the creator-existence probe.
 
     Returns:
         ListKnowledgeBasesResult containing knowledge base information
@@ -337,6 +357,148 @@ async def search_knowledge_base(
     )
 
 
+class _Unresolved:
+    """Sentinel: a declared name the governing team does not own, and the
+    runner is not the agent's creator.
+
+    Distinguishes "needs the creator-existence probe" from "resolved to a
+    collection" (any other object) and from "give up, report missing"
+    (``None``), without conflating either with a real ``CollectionInfo``.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<unresolved>"
+
+
+_UNRESOLVED = _Unresolved()
+
+
+def _resolve_declared_name(
+    name: str,
+    resolved: Dict[str, CollectionInfo],
+    *,
+    governing_team_id: Optional[int],
+    agent_creator_user_id: Optional[int],
+    runner_id: Optional[int],
+    declared_names: "set[str] | frozenset[str]",
+) -> "CollectionInfo | _Unresolved | None":
+    """Governing team, then creator, then declared-name membership, in that
+    order. Returns a collection, ``_UNRESOLVED`` (needs the
+    creator-existence probe), or ``None`` (nothing to search).
+
+    ``declared_names`` is the agent's STORED ``knowledge_bases`` list, never
+    ``allowed_collections`` and never ``tool_args.collections`` -- both of
+    those live on the model-supplied ``tool_args`` and can be overwritten by
+    the model itself, so neither can be trusted as the boundary of what may
+    be probed. See the ``name not in declared_names`` check below.
+    """
+    if governing_team_id is None:
+        # No governing team: today's behaviour, untouched.
+        return resolved.get(name)
+
+    entry = resolved.get(name)
+    if entry is not None and entry.ownership == "team":
+        # A name the governing team owns is resolved here and never reaches
+        # the creator check below. This test is trustworthy only because
+        # ``_list_visible_collections`` guarantees the sole source of an
+        # ``ownership == "team"`` entry is the governing team resolved
+        # above -- never the runner's own team memberships.
+        return entry
+
+    if runner_id is not None and runner_id == agent_creator_user_id:
+        # The team does not own this name, but the runner is the agent's
+        # creator: their own personal collection (if any) still resolves,
+        # exactly as it would with no governing team at all.
+        return entry
+
+    if name not in declared_names:
+        # On the one caller today, this is always False: the caller's loop
+        # iterates ``declared_names_for_this_run`` itself, so ``name`` is
+        # already a member of ``declared_names`` (built from that same
+        # list) by construction -- the iteration source is what actually
+        # binds the probe to the agent's stored configuration here. This
+        # check is a second guard for any future caller that classifies a
+        # name from somewhere else: without it, a model-supplied name could
+        # reach the probe below, and the two distinct outcomes it produces
+        # would become an enumeration oracle over the creator's private
+        # collection names.
+        return None
+
+    return _UNRESOLVED
+
+
+class _CreatorCollectionProbe:
+    """Memoised lookup of the agent creator's own collection names.
+
+    At most one ``list_collections`` call for the creator's id per search
+    call, regardless of how many declared names need classifying -- the
+    lookup result is cached after the first call, including a failure
+    (cached as "nothing"). A failure degrades to "not held" and never
+    raises: a probe that cannot complete must not block the search, and
+    must not be distinguishable from "the creator does not have this
+    collection" (see the module docstring's identity-disclosure limits).
+
+    A failure is still not distinguishable per name -- it hits every name
+    this run classifies alike -- so the enumeration oracle stays closed;
+    what the caller does with ``lookup_failed`` is choose a report that does
+    not assert an absence, not reveal one.
+
+    This still leaves a costlier existence-only side channel open to
+    anyone who can edit the agent, not only the creator: the stored
+    ``knowledge_bases`` declaration this probe classifies against is
+    itself editable by any same-team member, not just the creator --
+    ``agent_store.get_owned_agent`` (via ``owned_agent_clause``) lets a
+    non-admin team member update any team agent whose ``visibility ==
+    'team'``, including its ``knowledge_bases`` list. A team member can
+    therefore add a personal-collection-shaped name of their choosing to
+    the declaration, run the agent, and read the sharing-gap sentence
+    versus the generic "does not exist" outcome off the summary to learn
+    whether the creator holds a same-named private collection -- at the
+    cost of an agent edit per name probed, and revealing only that
+    existence, never the collection's contents.
+    """
+
+    def __init__(self, agent_creator_user_id: Optional[int]) -> None:
+        self._agent_creator_user_id = agent_creator_user_id
+        self._names: Optional[set] = None
+        # Whether the one lookup this probe makes raised. Read by the caller
+        # to tell "the creator does not hold this name" apart from "nobody
+        # asked" -- the failure degrades to "not held" for the search
+        # decision (unchanged), but the report must not claim an absence
+        # that was never established.
+        self.lookup_failed = False
+
+    async def holds(self, name: str) -> bool:
+        if self._agent_creator_user_id is None:
+            return False
+        if self._names is None:
+            try:
+                creator_result = await list_collections(
+                    user_id=self._agent_creator_user_id, is_admin=False
+                )
+                self._names = {c.name for c in creator_result.collections}
+            except Exception:
+                logger.warning(
+                    "Failed to resolve creator's personal collections while "
+                    "classifying an unshared knowledge base",
+                    exc_info=True,
+                )
+                self._names = set()
+                self.lookup_failed = True
+        return name in self._names
+
+
+def _render_unshared_names(names: List[str]) -> str:
+    """One sentence per name, space-joined, in declaration order."""
+    return " ".join(_UNSHARED_CREATOR_KB_MESSAGE.format(name=name) for name in names)
+
+
+def _render_missing_names_note(names: List[str]) -> str:
+    return _PARTIAL_FAILURE_NOTE.format(names=", ".join(names))
+
+
 async def _search_knowledge_base_impl(
     tool_args: KnowledgeSearchArgs,
     user_id: Optional[int] = None,
@@ -351,22 +513,15 @@ async def _search_knowledge_base_impl(
         tool_args: Search configuration including query, collections, and search parameters
         user_id: Optional user ID for multi-tenancy filtering
         is_admin: Whether the user has admin privileges
-        governing_team_id: The governing agent's owning team, if any. Only
-            affects *which* collections are visible; see
-            ``_list_visible_collections``.
-        agent_creator_user_id: The governing agent's creator, if any.
-            Carried to this function but not read by it: the rule that
-            tells the agent's own creator apart from every other runner of
-            a team-governed agent arrives separately.
+        governing_team_id: The governing agent's owning team, if any.
+        agent_creator_user_id: The governing agent's creator, if any. Used
+            to tell the agent's own creator apart from every other runner
+            of a team-governed agent.
         declared_knowledge_bases: The governing agent's STORED
             ``knowledge_bases`` declaration, if any -- never
             ``tool_args.allowed_collections`` and never
             ``tool_args.collections``, both of which are model-authored on
             every path (a declared schema field the model can overwrite).
-            Carried here but not read yet, for the same reason as
-            ``agent_creator_user_id``; keeping the two apart all the way to
-            this function is what lets the rule land without re-threading
-            anything.
 
     Returns:
         KnowledgeSearchResult with formatted search results
@@ -384,7 +539,81 @@ async def _search_knowledge_base_impl(
             governing_team_id=governing_team_id,
         )
 
-        if not collections_result.collections:
+        # The agent's stored declaration, de-duplicated with insertion order
+        # kept (a stored declaration may legitimately contain a name twice --
+        # nothing normalises Agent.knowledge_bases into a set -- and an
+        # un-de-duplicated iteration would probe, and report, a duplicate
+        # name twice).
+        declared_names_for_this_run = list(
+            dict.fromkeys(declared_knowledge_bases or [])
+        )
+
+        from ....web.services.knowledge_base_team_scope import (
+            team_knowledge_base_hook_installed,
+        )
+
+        # Team-governed run WITH a declaration, on a deployment that has
+        # actually installed the team-keyed hook: the declaration is the
+        # authority for both what may be searched and what gets reported.
+        # Gated on this three-way conjunction, not merely on
+        # governing_team_id being set, for two independent reasons:
+        #
+        # - an empty declaration (the case where agent_config carried no
+        #   agent at all) has nothing to authorise or verdict-derive against,
+        #   so the declared-name rule does not apply and the search falls
+        #   through to the existing "search everything visible" branch
+        #   below. The governing team's own knowledge bases stay in that
+        #   visible set -- ``_list_visible_collections`` resolves the team
+        #   layer onto the governing team whenever one is set and the hook
+        #   is installed, independently of whether anything was declared --
+        #   so an empty declaration still searches the runner's own
+        #   material *and* the governing team's, the same as it always has;
+        #   only which team the team layer resolves against changes. This
+        #   conjunct is defensive rather than a live production case:
+        #   knowledge_tools.py builds no knowledge tool at all when the
+        #   agent's allowed collections are an empty list, and the two chat
+        #   call sites derive that list and this declaration from the same
+        #   expression, so a declaring-nothing agent never reaches a search;
+        #   the remaining way in is an absent declaration, which on those
+        #   call sites also means an absent governing team. Kept so a future
+        #   caller that does supply a governing team without a declaration
+        #   inherits today's behaviour instead of an empty search set;
+        # - a deployment that has not installed the team-keyed hook must
+        #   stay on today's behaviour byte for byte, the same way the team
+        #   layer itself falls back in ``_list_visible_collections``. An
+        #   upstream change must be safe to ship ahead of any downstream
+        #   hook installation: selecting on "is a governing team id present"
+        #   instead of "is the hook actually installed" would turn on the
+        #   declared-name rule (and its two new report messages) for a
+        #   deployment whose team layer still resolves the old, runner-keyed
+        #   way -- a half-migrated state nothing asked for.
+        #
+        # This gate and the team layer's own gate in
+        # ``_list_visible_collections`` are not the same predicate: they
+        # share ``governing_team_id is not None and
+        # team_knowledge_base_hook_installed()``, but this one adds a third
+        # conjunct (``declared_names_for_this_run``) that the team layer's
+        # gate does not read. That is intentional, not a mismatch to close --
+        # the team layer's job is only "resolve onto the governing team",
+        # which an empty declaration does not change; this gate's job is
+        # "does the declared-name rule apply at all", which an empty
+        # declaration answers no to.
+        declared_name_rule_applies = (
+            governing_team_id is not None
+            and team_knowledge_base_hook_installed()
+            and bool(declared_names_for_this_run)
+        )
+
+        # The inherited empty-visible-set guard, now skipped for exactly the
+        # runs the declared-name rule owns the reporting of. With a governing
+        # team, an installed hook and a non-empty declaration, every declared
+        # name must still get its own verdict and its own sentence even when
+        # nothing at all is visible: a team that owns nothing plus a runner
+        # who owns nothing is a legitimate answer, and returning here would
+        # make it indistinguishable from a platform with no knowledge bases.
+        # Every other input -- no governing team, hook not installed, empty
+        # declaration -- keeps this guard exactly as it is today.
+        if not collections_result.collections and not declared_name_rule_applies:
             return KnowledgeSearchResult(
                 results=[],
                 summary="No knowledge bases available. Please create a knowledge base and upload documents first.",
@@ -402,11 +631,169 @@ async def _search_knowledge_base_impl(
         if tool_args.allowed_collections:
             logger.info(f"   - Allowed collections: {tool_args.allowed_collections}")
 
-        if tool_args.collections:
-            # User specified collections - validate against allowed_collections
+        if declared_name_rule_applies:
+            resolved_by_name = {c.name: c for c in collections_result.collections}
+            authorised = set(declared_names_for_this_run)
+
+            explicit_request: Optional[set] = None
+            if tool_args.collections:
+                requested_set = set(tool_args.collections)
+                # The re-based "not allowed" gate (wording unchanged): the
+                # authority is the agent's stored declaration, not
+                # tool_args.allowed_collections, because that field is
+                # model-authored on every path and setdefault lets a
+                # model-supplied value win outright over the agent's own
+                # configured one.
+                disallowed = requested_set - authorised
+                if disallowed:
+                    return KnowledgeSearchResult(
+                        results=[],
+                        summary=f"Error: The following collections are not allowed: {', '.join(sorted(disallowed))}. "
+                        f"Allowed collections: {', '.join(sorted(authorised & available_names))}",
+                    )
+                explicit_request = requested_set
+                logger.info(f"Searching specific collections: {sorted(requested_set)}")
+
+            to_search: List[CollectionInfo] = []
+            unshared_names: List[str] = []
+            missing_names: List[str] = []
+            unresolvable_names: List[str] = []
+            creator_probe = _CreatorCollectionProbe(agent_creator_user_id)
+
+            # One pass over the agent's stored declaration; every declared
+            # name gets exactly one verdict, and the two report sets plus
+            # the search set are all built from the verdicts -- never from
+            # an intersection with available_names. That expression is what
+            # would let the runner's own same-named personal collection back
+            # in: available_names already contains it (the base union seeds
+            # the runner's own collections), so a rule hung off its
+            # complement would never see the very name it exists to reject.
+            for name in declared_names_for_this_run:
+                verdict = _resolve_declared_name(
+                    name,
+                    resolved_by_name,
+                    governing_team_id=governing_team_id,
+                    agent_creator_user_id=agent_creator_user_id,
+                    runner_id=user_id,
+                    declared_names=authorised,
+                )
+                if verdict is None:
+                    missing_names.append(name)
+                elif isinstance(verdict, _Unresolved):
+                    if await creator_probe.holds(name):
+                        unshared_names.append(name)
+                    elif creator_probe.lookup_failed:
+                        # Not "missing": the lookup that would have decided
+                        # raised. The search outcome is the same either way
+                        # (nothing resolves), only the report differs.
+                        unresolvable_names.append(name)
+                    else:
+                        missing_names.append(name)
+                else:
+                    to_search.append(verdict)
+
+            # Every name the verdict loop admitted, captured before the
+            # explicit-request narrowing below. This -- never the visible
+            # union ``available_names`` -- is what the terminal messages
+            # report as available. A name only lands here after resolving to
+            # a collection this run may actually search, so the runner's own
+            # same-named personal copy (which the union does carry, and which
+            # the rule exists to reject) can never be reported as available.
+            admitted_names = {c.name for c in to_search}
+
+            if explicit_request is not None:
+                # The model may narrow the search to a subset of what the
+                # verdicts admitted; it may never widen it past that set.
+                to_search = [c for c in to_search if c.name in explicit_request]
+
+            if not to_search:
+                # Every declared name failed to resolve. Reached through
+                # this guard, not one keyed on the raw requested/allowed
+                # set: a guard keyed on the requested/allowed names alone
+                # stays non-empty even when every one of them failed to
+                # resolve to a real collection, as long as the runner
+                # happens to hold a same-named personal copy of each one --
+                # which would fall through to the generic search-miss text
+                # below instead of the two outcomes this branch exists to
+                # report.
+                # Both branches list "Available" from the verdict-admitted
+                # names, never from ``authorised & available_names``. That
+                # intersection reports two sets of names it must not: the
+                # governing team's collections the agent never declared
+                # (``_list_visible_collections`` merges the team's full
+                # catalogue in before any declared-name filter runs), and --
+                # on this branch specifically -- the runner's own same-named
+                # personal copies, which seed the union and are precisely the
+                # collections the rule refuses to search. On the no-explicit
+                # branch nothing was admitted, so the clause renders empty;
+                # on the explicit branch the admitted set is the one taken
+                # before the narrowing above, so a run whose requested names
+                # all failed still tells the model what it may ask for.
+                if unresolvable_names:
+                    # The creator-collection lookup raised during this call,
+                    # so every unresolved declared name is unclassified, not
+                    # established absent. Reported as one undifferentiated
+                    # outcome for all of them -- a lookup failure is not
+                    # per-name, so this sentence still says nothing about
+                    # which names the creator holds. ``unshared_names`` is
+                    # necessarily empty here: the first failure caches the
+                    # creator's name set as empty, so no later name can be
+                    # classified as held.
+                    summary = _TERMINAL_UNRESOLVABLE_MESSAGE.format(
+                        names=", ".join(unresolvable_names)
+                    )
+                    failed_unshared_names: List[str] = []
+                elif explicit_request is not None:
+                    summary = (
+                        f"Error: The following collections do not exist: {', '.join(sorted(explicit_request))}. "
+                        f"Available collections: {', '.join(sorted(admitted_names))}"
+                    )
+                    failed_unshared_names = [
+                        name for name in unshared_names if name in explicit_request
+                    ]
+                else:
+                    summary = (
+                        f"Error: None of the allowed collections exist. "
+                        f"Allowed: {', '.join(sorted(authorised))}. "
+                        f"Available: {', '.join(sorted(admitted_names))}"
+                    )
+                    failed_unshared_names = unshared_names
+                # A total failure keeps the existing terminal wording
+                # unchanged (above) -- this branch does not decide whether
+                # a failed name happened to be the creator's own unshared
+                # collection, it only decides that nothing is searchable.
+                # Whichever of the failed names the verdict loop already
+                # classified as the creator's own unshared collection still
+                # gets that message appended, with the "Error:" prefix and
+                # the empty result set both preserved: this is the terminal
+                # path, not the partial-failure warnings channel, so it
+                # does not fold through collection_warnings.
+                if failed_unshared_names:
+                    # A bare space here would leave the appended sentence
+                    # reading like one more entry in the comma-separated
+                    # "Available: ..." list the base text ends with -- both
+                    # to a human reader and to the model consuming this
+                    # summary. The period closes that list before the new
+                    # sentence starts.
+                    summary = (
+                        summary + ". " + _render_unshared_names(failed_unshared_names)
+                    )
+                return KnowledgeSearchResult(results=[], summary=summary)
+
+            collections_to_iterate: List[CollectionInfo] = to_search
+            partial_failure_notes = []
+            if unshared_names:
+                partial_failure_notes.append(_render_unshared_names(unshared_names))
+            if missing_names or unresolvable_names:
+                partial_failure_notes.append(
+                    _render_missing_names_note(missing_names + unresolvable_names)
+                )
+        elif tool_args.collections:
+            # No governing team, and the empty-declaration fallback, share
+            # this branch: byte-for-byte today's behaviour, including its
+            # allowed_collections-is-None skip below.
             requested_set = set(tool_args.collections)
 
-            # If allowed_collections is set, verify requested is a subset
             if tool_args.allowed_collections is not None:
                 allowed_set = set(tool_args.allowed_collections)
                 disallowed = requested_set - allowed_set
@@ -422,7 +809,6 @@ async def _search_knowledge_base_impl(
             else:
                 collections_set = requested_set
 
-            # Check if collections exist
             invalid_names = collections_set - available_names
             if invalid_names:
                 return KnowledgeSearchResult(
@@ -434,9 +820,9 @@ async def _search_knowledge_base_impl(
             collections_to_iterate = [
                 c for c in collections_result.collections if c.name in collections_set
             ]
+            partial_failure_notes = []
             logger.info(f"Searching specific collections: {sorted(collections_set)}")
         elif tool_args.allowed_collections is not None:
-            # Use allowed_collections as default
             allowed_set = set(tool_args.allowed_collections)
 
             if not allowed_set:
@@ -457,9 +843,11 @@ async def _search_knowledge_base_impl(
             collections_to_iterate = [
                 c for c in collections_result.collections if c.name in valid_collections
             ]
+            partial_failure_notes = []
             logger.info(f"Searching allowed collections: {sorted(valid_collections)}")
         else:
             collections_to_iterate = collections_result.collections
+            partial_failure_notes = []
             logger.info("Searching all collections")
 
         # Build base search config (per-collection overrides happen below)
@@ -493,7 +881,7 @@ async def _search_knowledge_base_impl(
         # Search across collections and aggregate results
         all_results = []
         collection_errors: list[str] = []
-        collection_warnings: list[str] = []
+        collection_warnings: list[str] = list(partial_failure_notes)
         total_searched = 0
         search_timeout_seconds = get_kb_search_timeout_seconds()
 

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -164,7 +164,7 @@ class KnowledgeSearchArgs(BaseModel):
     query: str = Field(description="The search query or question")
     collections: List[str] = Field(
         default=[],
-        description="Specific knowledge base collection names to search. Empty list searches every knowledge base this agent is configured with: allowed_collections when set, all collections when not, and for an agent owned by a team, that agent's own stored knowledge base list.",
+        description="Specific knowledge base collection names to search. Empty list searches the agent's default set: its own stored knowledge base list when the agent is owned by a team and that list is non-empty, otherwise allowed_collections when set, and every collection visible to this run when not.",
     )
     search_type: str = Field(
         default="hybrid",
@@ -183,7 +183,7 @@ class KnowledgeSearchArgs(BaseModel):
     )
     allowed_collections: Optional[List[str]] = Field(
         default=None,
-        description="Optional list of allowed collection names. Used as default when collections is empty. Ignored for an agent owned by a team, whose own stored knowledge base list is the authority.",
+        description="Optional list of allowed collection names. Used as default when collections is empty. Ignored when the agent is owned by a team and its stored knowledge base list is non-empty, which is then the authority.",
     )
 
 
@@ -467,9 +467,17 @@ async def _team_names_hosted_on(storage_user_id: int) -> set:
     )
 
     if not has_knowledge_base_visibility_hook():
-        # Standalone xagent, and any deployment that installed only the
-        # team-keyed hook: no team owns anything here, so every row on the
-        # tenant is the user's own.
+        # Without the runner-keyed hook this question cannot be asked, so
+        # every row on the tenant is treated as the user's own. Exact on
+        # standalone xagent, where no team owns anything at all. On a
+        # deployment that installed only the team-keyed hook it is not:
+        # teams do exist there, and a team's row hosted on the creator's
+        # tenant is classified as the creator's personal collection, so the
+        # sharing-gap sentence can name a knowledge base another team owns.
+        # Search decisions are unaffected -- the name is not searched under
+        # either classification -- and the ask stops here rather than
+        # falling back to the team-keyed hook, which answers only for the
+        # governing team and so cannot answer this question.
         return set()
     refs = await run_db_io_cancellation_safe(
         lambda: visible_team_knowledge_bases(None, int(storage_user_id))
@@ -490,15 +498,17 @@ class _CreatorCollectionProbe:
     "nothing"). A failure degrades to "not held" and never
     raises: a probe that cannot complete must not block the search, and
     must not be distinguishable from "the creator does not have this
-    collection" (see the module docstring's identity-disclosure limits).
+    collection"; what that costs, and where the guarantee stops, is stated
+    in the two paragraphs below.
 
     A failure is still not distinguishable per name -- it hits every name
     this run classifies alike -- so the enumeration oracle stays closed;
     what the caller does with ``lookup_failed`` is choose a report that does
     not assert an absence, not reveal one.
 
-    This still leaves a costlier existence-only side channel open to
-    anyone who can edit the agent, not only the creator: the stored
+    On a deployment that does not install the save-time knowledge-base
+    validator, this still leaves a costlier existence-only side channel
+    open to anyone who can edit the agent, not only the creator: the stored
     ``knowledge_bases`` declaration this probe classifies against is
     itself editable by any same-team member, not just the creator --
     ``agent_store.get_owned_agent`` (via ``owned_agent_clause``) lets a
@@ -509,7 +519,14 @@ class _CreatorCollectionProbe:
     versus the generic "does not exist" outcome off the summary to learn
     whether the creator holds a same-named private collection -- at the
     cost of an agent edit per name probed, and revealing only that
-    existence, never the collection's contents.
+    existence, never the collection's contents. The reference deployment
+    does install that validator, and the edit this channel needs never
+    lands there: an update whose declaration names a knowledge base the
+    team does not own is rejected at save time (``agent_store`` ->
+    ``validate_team_agent_knowledge_bases`` ->
+    ``UnsharedKnowledgeBasesError``). With no validator installed that
+    call returns an empty list and the edit is accepted, which is the
+    configuration the paragraph above describes.
     """
 
     def __init__(self, agent_creator_user_id: Optional[int]) -> None:
@@ -538,6 +555,20 @@ class _CreatorCollectionProbe:
                 # remove.
                 team_hosted = await _team_names_hosted_on(self._agent_creator_user_id)
             except Exception:
+                # Deliberately blanket, the seam's typed
+                # KnowledgeBaseScopeError included. Nothing inside this try
+                # produces that type today: the listing reports failure
+                # through its status instead of raising, and the
+                # runner-keyed hook is called directly, without the wrapper
+                # that mints it. If a typed producer is ever added here,
+                # swallowing stays right for this one site: the probe's
+                # answer chooses how a failure is worded and never what is
+                # searched or by whom, and its contract is to degrade to
+                # "not held" rather than abort a search that can still
+                # succeed for the agent's other knowledge bases. Every
+                # other handler of that type re-raises it; this one must
+                # not, and a change of mind here is a change to the probe's
+                # documented never-raise contract above.
                 logger.warning(
                     "Failed to resolve creator's personal collections while "
                     "classifying an unshared knowledge base",

--- a/src/xagent/core/tools/core/knowledge_base_scope.py
+++ b/src/xagent/core/tools/core/knowledge_base_scope.py
@@ -31,12 +31,13 @@ class KnowledgeBaseScopeError(RuntimeError):
     ``ConnectorRuntimeError`` (``core/tools/adapters/vibe/connector_runtime.py``),
     the equivalent typed error on the connector team-scope seam, whose
     ``.safe_message`` is what its own catch site (``chat.py``) reads to
-    build the HTTP response. Nothing in this codebase currently reads
-    ``code``, ``status_code``, ``details``, or ``safe_message`` off this
-    class -- both run-path handlers re-raise it unchanged rather than
-    unpacking it -- but a future HTTP-facing catch site should find the
-    same attribute name on either error, not two conventions for the same
-    shape.
+    build the HTTP response. This error is unpacked the same way, at the
+    same place: the ``create_task`` handler in ``web/api/chat.py`` answers
+    ``status_code`` with ``safe_message`` as the detail, directly alongside
+    its ``ConnectorRuntimeError`` arm, and logs ``code``/``details`` rather
+    than returning them. Every other handler -- the two run-path ones and
+    the two tool-build ones -- re-raises it unchanged so those attributes
+    survive to that single HTTP-facing site.
     """
 
     def __init__(

--- a/src/xagent/core/tools/core/knowledge_base_scope.py
+++ b/src/xagent/core/tools/core/knowledge_base_scope.py
@@ -35,9 +35,15 @@ class KnowledgeBaseScopeError(RuntimeError):
     same place: the ``create_task`` handler in ``web/api/chat.py`` answers
     ``status_code`` with ``safe_message`` as the detail, directly alongside
     its ``ConnectorRuntimeError`` arm, and logs ``code``/``details`` rather
-    than returning them. Every other handler -- the two run-path ones and
-    the two tool-build ones -- re-raises it unchanged so those attributes
-    survive to that single HTTP-facing site.
+    than returning them. The other handlers re-raise it unchanged rather
+    than unpacking it: the two on the run path hand it to run orchestration
+    and the two on the tool-build path hand it to whoever is building the
+    tools, so in each case the status and code reach that caller instead of
+    being flattened into a bare ``RuntimeError``. The creator-collection
+    probe in ``document_search`` is the one deliberate exception -- it
+    catches every exception, this type included, because its answer chooses
+    how a report is worded and never what is searched or by whom, so a
+    failure there must hedge rather than abort the search.
     """
 
     def __init__(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -47,6 +47,7 @@ from ...core.tools.adapters.vibe.config import (
 )
 from ...core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from ...core.tools.adapters.vibe.selection_spec import should_load_mcp_server_configs
+from ...core.tools.core.knowledge_base_scope import KnowledgeBaseScopeError
 from ...sandbox import SandboxMountIntent
 from ..auth_dependencies import get_current_user
 from ..dynamic_memory_store import get_memory_store
@@ -4208,6 +4209,30 @@ async def create_task(
     except HTTPException:
         raise
     except ConnectorRuntimeError as exc:
+        raise HTTPException(
+            status_code=exc.status_code, detail=exc.safe_message
+        ) from exc
+    except KnowledgeBaseScopeError as exc:
+        # Symmetric with the ConnectorRuntimeError arm above, and the only
+        # place anything reads this error's status_code/safe_message: the
+        # typed knowledge-base scope error already carries the status it
+        # wants (503, "resolution failed", retryable) and a message that is
+        # safe to hand a caller, so map both through rather than let the
+        # blanket handler below flatten it into a 500 built from str(exc).
+        # ``exc.code``/``exc.details`` are diagnostic and go to the log only.
+        #
+        # No step inside this endpoint resolves the team knowledge-base
+        # layer today (resolution happens per search call, on the run path),
+        # so this arm mirrors the two typed re-raises on the tool-build path
+        # in ``factory.py`` and ``knowledge_tools.py``: it exists so that a
+        # future in-request resolution surfaces the seam's own 503 instead
+        # of being silently reclassified as an internal error.
+        logger.warning(
+            "Knowledge base scope unavailable during task creation "
+            "(code=%s, details=%s)",
+            exc.code,
+            exc.details,
+        )
         raise HTTPException(
             status_code=exc.status_code, detail=exc.safe_message
         ) from exc

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -4227,6 +4227,20 @@ async def create_task(
         # in ``factory.py`` and ``knowledge_tools.py``: it exists so that a
         # future in-request resolution surfaces the seam's own 503 instead
         # of being silently reclassified as an internal error.
+        #
+        # The asymmetry with the ConnectorRuntimeError arm above is real
+        # and deliberate: that arm has a live producer inside this endpoint
+        # (``prepare_connector_runtime_selection_snapshot``), this one has
+        # none. It is kept because what the two arms share is the
+        # failure-path contract, not the producer: both errors carry their
+        # own status and a caller-safe message, and the blanket handler
+        # below turns anything it does not name into a 500 built from
+        # ``str(exc)``. Dropping this arm would make the first in-request
+        # producer -- the run-path resolution moving earlier, or a
+        # save-time validation added here -- answer 500 with a raw
+        # exception string, silently. The test beside it injects the raise
+        # for the same reason: what is pinned is this funnel's
+        # classification, not any particular producer.
         logger.warning(
             "Knowledge base scope unavailable during task creation "
             "(code=%s, details=%s)",

--- a/tests/core/tools/core/test_document_search_team_declared_names.py
+++ b/tests/core/tools/core/test_document_search_team_declared_names.py
@@ -1,0 +1,1137 @@
+"""Team-governed knowledge-base resolution: the declared-name rule.
+
+Covers a run whose governing agent is team-owned. A declared name the
+governing team owns resolves to the team's copy for every runner; a
+declared name the team does not own resolves to the creator's own personal
+collection only when the runner *is* the creator, and to one of two
+distinguishable, non-identity-leaking outcomes for every other runner.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from xagent.core.tools.core import document_search
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    CollectionInfo,
+    ListCollectionsResult,
+    SearchPipelineResult,
+)
+from xagent.web.services import knowledge_base_team_scope as kb_scope
+
+CREATOR = 100
+MEMBER = 200
+NON_MEMBER = 300
+TEAM = 1
+OTHER_TEAM = 2
+
+
+def _collections(*collections: CollectionInfo) -> ListCollectionsResult:
+    return ListCollectionsResult(
+        status="success",
+        collections=list(collections),
+        total_count=len(collections),
+        message="ok",
+    )
+
+
+def _kb(name: str, *, embeddings: int = 5, documents: int = 3) -> CollectionInfo:
+    return CollectionInfo(name=name, embeddings=embeddings, documents=documents)
+
+
+class _ListCollectionsSpy:
+    """Routes ``list_collections(user_id=...)`` by user id and records calls."""
+
+    def __init__(self, by_user: dict[int, list[CollectionInfo]]) -> None:
+        self._by_user = by_user
+        self.calls: list[tuple[Optional[int], Optional[bool]]] = []
+
+    async def __call__(
+        self,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        force_realtime: bool = False,
+    ) -> ListCollectionsResult:
+        self.calls.append((user_id, is_admin))
+        return _collections(*self._by_user.get(user_id, []))
+
+    def calls_for(self, user_id: int) -> int:
+        return sum(1 for called_id, _ in self.calls if called_id == user_id)
+
+
+class _SearchSpy:
+    """Fake ``run_document_search`` recording which (collection, user_id,
+    is_admin) triples were actually searched, and returning one hit for
+    each so ``results`` stays non-empty."""
+
+    def __init__(self) -> None:
+        self.searched: list[tuple[str, Optional[int], bool]] = []
+
+    def __call__(
+        self,
+        collection: str,
+        query_text: str,
+        config: dict,
+        user_id: Optional[int],
+        is_admin: bool,
+    ) -> SearchPipelineResult:
+        self.searched.append((collection, user_id, is_admin))
+        return SearchPipelineResult(
+            status="success",
+            search_type="hybrid",
+            results=[
+                {
+                    "doc_id": f"{collection}-doc",
+                    "chunk_id": f"{collection}-chunk",
+                    "text": f"hit from {collection}",
+                    "score": 0.9,
+                    "parse_hash": "hash",
+                    "model_tag": "model",
+                    "metadata": {},
+                }
+            ],
+            result_count=1,
+            warnings=[],
+            message="ok",
+            used_rerank=False,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hooks():
+    with kb_scope.snapshot_knowledge_base_team_hooks():
+        kb_scope.set_knowledge_base_team_hooks()
+        yield
+
+
+def _install_team(monkeypatch: pytest.MonkeyPatch, teams: dict[int, list]) -> None:
+    def _team_visibility(db: Any, *, team_id: int) -> list:
+        return teams.get(team_id, [])
+
+    kb_scope.set_knowledge_base_team_hooks(team_visibility=_team_visibility)
+
+
+def _install_collections(
+    monkeypatch: pytest.MonkeyPatch, by_user: dict[int, list[CollectionInfo]]
+) -> _ListCollectionsSpy:
+    spy = _ListCollectionsSpy(by_user)
+    monkeypatch.setattr(document_search, "list_collections", spy)
+    return spy
+
+
+def _install_search(monkeypatch: pytest.MonkeyPatch) -> _SearchSpy:
+    spy = _SearchSpy()
+    monkeypatch.setattr(document_search, "run_document_search", spy)
+    return spy
+
+
+async def _search(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    runner_id: int,
+    team_id: Optional[int] = TEAM,
+    creator_id: Optional[int] = CREATOR,
+    declared: Optional[list[str]] = None,
+    collections: Optional[list[str]] = None,
+    allowed_collections: Optional[list[str]] = None,
+) -> document_search.KnowledgeSearchResult:
+    tool_args = document_search.KnowledgeSearchArgs(
+        query="q",
+        collections=collections or [],
+        allowed_collections=allowed_collections,
+    )
+    return await document_search._search_knowledge_base_impl(
+        tool_args,
+        user_id=runner_id,
+        is_admin=False,
+        governing_team_id=team_id,
+        agent_creator_user_id=creator_id,
+        declared_knowledge_bases=declared,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A name the governing team owns resolves to the team's storage tenant,
+# for every runner.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# A same-named row of the runner's OTHER team never participates.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_cross_team_kb_borrowing(monkeypatch: pytest.MonkeyPatch) -> None:
+    governing_team_kb = kb_scope.KnowledgeBaseAccess(
+        name="other-doc",
+        storage_user_id=999,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    other_team_kb = kb_scope.KnowledgeBaseAccess(
+        name="handbook",
+        storage_user_id=555,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [governing_team_kb], OTHER_TEAM: [other_team_kb]})
+    _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [],
+            CREATOR: [],
+            999: [_kb("other-doc")],  # T's real (differently-named) collection
+            555: [_kb("handbook")],  # the OTHER team's storage tenant
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook"],
+    )
+
+    assert search_spy.searched == []
+    assert result.results == []
+    assert "handbook" in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The runner's own team membership never merges into the governing team's
+# layer -- the module docstring's promise that a team-governed run resolves
+# "never the runner's own team memberships, and never a union of the two"
+# has no other pin.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_own_team_membership_never_unions_with_governing_team(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MEMBER belongs to their own team (not the governing one), and that
+    team owns ``my-team-kb`` through the runner-keyed visibility hook. The
+    governing team owns ``gov-kb`` through the team-keyed hook. The agent
+    declares both. Only ``gov-kb`` may resolve: ``my-team-kb`` must fail to
+    resolve exactly as it would if MEMBER had no team at all -- never
+    silently pass because a merge gave it ``ownership == "team"`` too.
+    """
+    gov_kb = kb_scope.KnowledgeBaseAccess(
+        name="gov-kb",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    my_team_kb = kb_scope.KnowledgeBaseAccess(
+        name="my-team-kb",
+        storage_user_id=777,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+
+    def _member_own_team_visibility(
+        db: Any, user_id: int
+    ) -> list[kb_scope.KnowledgeBaseAccess]:
+        # The runner-keyed overlay (MEMBER's own team membership), never
+        # consulted for a team-governed run's declared-name resolution.
+        return [my_team_kb] if user_id == MEMBER else []
+
+    def _governing_team_visibility(
+        db: Any, *, team_id: int
+    ) -> list[kb_scope.KnowledgeBaseAccess]:
+        return [gov_kb] if team_id == TEAM else []
+
+    kb_scope.set_knowledge_base_team_hooks(
+        team_visibility=_governing_team_visibility,
+        visibility=_member_own_team_visibility,
+    )
+    _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [],
+            CREATOR: [_kb("gov-kb")],
+            777: [_kb("my-team-kb")],
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["gov-kb", "my-team-kb"],
+    )
+
+    assert search_spy.searched == [("gov-kb", CREATOR, False)]
+    assert "my-team-kb" in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The team's copy outranks the creator's own copy: even the creator gets
+# T's copy over their own same-named personal collection.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_copy_wins_over_creator_personal_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="handbook",
+        storage_user_id=999,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    _install_collections(
+        monkeypatch,
+        {
+            CREATOR: [_kb("handbook")],  # creator's OWN copy, must lose
+            999: [_kb("handbook")],  # the team's storage tenant
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=CREATOR,
+        declared=["handbook"],
+    )
+
+    assert search_spy.searched == [("handbook", 999, False)]
+    assert result.results
+
+
+# ---------------------------------------------------------------------------
+# The team does not own the declared name, and the runner IS the agent's
+# creator: their own collection resolves unchanged. Applies equally to an
+# interactive creator and to an external/widget end user whose passed-in
+# runner id happens to equal the creator id.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_creator_keeps_own_unshared_knowledge_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """This is an accepted-exposure ruling, not a gap: an external or
+    anonymous runner is indistinguishable from the agent's creator at this
+    layer, because no real end-user identity is carried to the resolution
+    point. When the runner id passed in happens to equal the creator id --
+    which is what an external/widget surface's identity substitution
+    produces -- the creator's own collection resolves exactly as it would
+    for the creator's own interactive session. No pin anywhere may assert
+    that the declared name is instead rejected on that surface.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    _install_collections(monkeypatch, {CREATOR: [_kb("handbook")]})
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(monkeypatch, runner_id=CREATOR, declared=["handbook"])
+
+    assert search_spy.searched == [("handbook", CREATOR, False)]
+    assert result.results
+
+
+# ---------------------------------------------------------------------------
+# The team does not own the declared name, the runner is not the creator,
+# and the name IS the creator's own personal collection => the new
+# sharing-gap message, no collection resolves. Parametrised over call style
+# and partial failure.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [False, True])
+async def test_unshared_creator_kb_reports_sharing_gap(
+    monkeypatch: pytest.MonkeyPatch, explicit: bool
+) -> None:
+    # T owns the two "good" names -- they resolve and are actually
+    # searched. "private-notes" is the creator's own, never shared with T;
+    # since the runner is not the creator this must degrade to the NEW
+    # message, not a search.
+    team_kbs = [
+        kb_scope.KnowledgeBaseAccess(
+            name=name,
+            storage_user_id=CREATOR,
+            team_owned=True,
+            can_edit=False,
+            can_delete=False,
+        )
+        for name in ("good-one", "also-good")
+    ]
+    _install_team(monkeypatch, {TEAM: team_kbs})
+    _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [_kb("unrelated-own-doc")],
+            CREATOR: [_kb("private-notes"), _kb("good-one"), _kb("also-good")],
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    declared = ["private-notes", "good-one", "also-good"]
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=declared,
+        collections=declared if explicit else None,
+    )
+
+    assert "private-notes" in result.summary
+    assert "has not" in result.summary and "shared with the team" in result.summary
+    searched_names = {name for name, owner, _ in search_spy.searched}
+    # The two team-owned names were still searched, against T's storage
+    # tenant -- a partial failure does not stop the rest of the agent's
+    # knowledge bases from being searched normally.
+    assert searched_names == {"good-one", "also-good"}
+    assert all(owner == CREATOR for _, owner, _ in search_spy.searched)
+    assert result.results
+    assert not result.summary.startswith("Error:")
+
+
+# ---------------------------------------------------------------------------
+# Same shape, but the declared name is NOT the creator's collection either
+# => the branch's generic "does not exist" outcome. A further variant:
+# every declared name fails to resolve while the runner holds a same-named
+# personal copy of each one.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [False, True])
+async def test_absent_kb_reports_does_not_exist(
+    monkeypatch: pytest.MonkeyPatch, explicit: bool
+) -> None:
+    _install_team(monkeypatch, {TEAM: []})
+    _install_collections(monkeypatch, {MEMBER: [_kb("unrelated-own-doc")], CREATOR: []})
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["ghost"],
+        collections=["ghost"] if explicit else None,
+    )
+
+    assert result.results == []
+    assert "Error:" in result.summary
+    if explicit:
+        assert "do not exist" in result.summary
+    else:
+        assert "None of the allowed collections exist" in result.summary
+    # Negative control: the failed name is not the creator's collection
+    # either, so the sharing-gap sentence must not appear.
+    assert "shared with the team" not in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The "Available collections:" clause is captured before the
+# explicit-request narrowing, not after.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_total_narrowing_still_reports_what_the_verdict_loop_admitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The agent declares two names: "handbook", which the governing team
+    owns and which the verdict loop therefore admits, and "ghost", which
+    resolves to nothing. The model's explicit request names only "ghost" --
+    so the narrowing step (applied after ``admitted_names`` is captured)
+    empties ``to_search`` entirely, even though "handbook" was genuinely
+    admitted. If ``admitted_names`` were captured after the narrowing
+    instead of before, this fully-narrowed-away request would report
+    "Available collections:" as empty, leaving the model with no way to
+    learn what it could have asked for.
+    """
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="handbook",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    _install_collections(
+        monkeypatch,
+        {MEMBER: [], CREATOR: [_kb("handbook")]},
+    )
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook", "ghost"],
+        collections=["ghost"],
+    )
+
+    assert result.results == []
+    assert "Error:" in result.summary and "do not exist" in result.summary
+    assert "ghost" in result.summary
+    available_clause = result.summary.split("Available collections:", 1)[1]
+    assert "handbook" in available_clause
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [False, True])
+async def test_total_failure_never_reports_undeclared_team_kb_names(
+    monkeypatch: pytest.MonkeyPatch, explicit: bool
+) -> None:
+    """The governing team owns several knowledge bases the agent never
+    declared. A non-member runner declares one unrelated name that fails
+    to resolve entirely. The terminal "Available"/"Available collections"
+    listing must only ever include names the agent itself declared --
+    never the team's other, undeclared knowledge bases, which this runner
+    has no other way to learn the names of. Before this pin, both terminal
+    branches printed the full visible-union names, including the four
+    undeclared ones below.
+    """
+    hidden_names = (
+        "board-minutes",
+        "layoff-plan-q3",
+        "ma-target-list",
+        "salary-bands",
+    )
+    hidden_kbs = [
+        kb_scope.KnowledgeBaseAccess(
+            name=name,
+            storage_user_id=CREATOR,
+            team_owned=True,
+            can_edit=False,
+            can_delete=False,
+        )
+        for name in hidden_names
+    ]
+    _install_team(monkeypatch, {TEAM: hidden_kbs})
+    _install_collections(
+        monkeypatch,
+        {
+            NON_MEMBER: [],
+            CREATOR: [_kb(name) for name in hidden_names],
+        },
+    )
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=NON_MEMBER,
+        declared=["hr-private"],
+        collections=["hr-private"] if explicit else None,
+    )
+
+    assert result.results == []
+    assert "Error:" in result.summary
+    for hidden_name in hidden_names:
+        assert hidden_name not in result.summary
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [False, True])
+async def test_total_failure_of_a_single_unshared_name_still_reports_the_gap(
+    monkeypatch: pytest.MonkeyPatch, explicit: bool
+) -> None:
+    """Every declared name fails to resolve (``to_search`` ends up empty),
+    and the one declared name is the creator's own unshared collection.
+    The terminal summary must keep its existing ``Error:`` prefix and
+    empty result set (this is the total-failure path, not the
+    partial-failure warnings channel), but it must still say the failed
+    name belongs to the creator and was never shared -- not just that it
+    "does not exist", which would be true of a name nobody owns and false
+    of this one.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    _install_collections(
+        monkeypatch,
+        {MEMBER: [_kb("unrelated-own-doc")], CREATOR: [_kb("private-notes")]},
+    )
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["private-notes"],
+        collections=["private-notes"] if explicit else None,
+    )
+
+    assert result.results == []
+    assert result.summary.startswith("Error:")
+    assert "has not" in result.summary and "shared with the team" in result.summary
+    assert "private-notes" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_total_kb_failure_with_same_named_personal_copies_reports_generic_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The runner holds a same-named personal copy of every declared name,
+    and the governing team owns none of them. A guard keyed on the raw
+    requested/allowed names (instead of on the actual search set) would
+    stay non-empty here -- the personal copies land in the visible
+    union's ``available_names`` -- and fall through to the generic
+    search-miss text instead of this branch's own terminal summary.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [_kb("handbook"), _kb("policies")],
+            CREATOR: [],
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch, runner_id=MEMBER, declared=["handbook", "policies"]
+    )
+
+    assert search_spy.searched == []
+    assert result.results == []
+    assert "Error:" in result.summary
+    assert "None of the allowed collections exist" in result.summary
+    assert "shared with the team" not in result.summary
+    # The runner holds a personal "handbook" and "policies"; both are in the
+    # pre-verdict visible union and neither is searchable. Reporting either
+    # as available would tell the model the exact opposite of what the rule
+    # just decided.
+    available_clause = result.summary.split("Available:", 1)[1]
+    assert "handbook" not in available_clause
+    assert "policies" not in available_clause
+    # The declared names still appear -- in the "Allowed:" clause, which is
+    # what the agent configured, not what resolved.
+    assert "Allowed: handbook, policies" in result.summary
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("creator_holds", [False, True])
+async def test_empty_visible_set_still_reports_a_verdict_per_declared_name(
+    monkeypatch: pytest.MonkeyPatch, creator_holds: bool
+) -> None:
+    """The runner owns nothing and the governing team owns nothing, so the
+    visible union is empty -- but the agent did declare a name. The generic
+    "no knowledge bases exist on this platform" text would be wrong and
+    would swallow the per-name verdict: this run has a specific answer
+    (either the creator's unshared collection, or a name nobody holds), and
+    the rule promises the response says which.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [],
+            CREATOR: [_kb("handbook")] if creator_holds else [],
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(monkeypatch, runner_id=MEMBER, declared=["handbook"])
+
+    assert search_spy.searched == []
+    assert result.results == []
+    assert "No knowledge bases available" not in result.summary
+    assert result.summary.startswith("Error:")
+    assert "handbook" in result.summary
+    if creator_holds:
+        assert "has not" in result.summary and "shared with the team" in result.summary
+    else:
+        assert "None of the allowed collections exist" in result.summary
+        assert "shared with the team" not in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The "not allowed" gate, re-based conditionally on whether the run is
+# team-governed with a declaration.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("allowed_collections", [None, ["kb1"]])
+async def test_team_governed_empty_declaration_keeps_legacy_not_allowed_gate(
+    monkeypatch: pytest.MonkeyPatch, allowed_collections
+) -> None:
+    """The same gate, but on a team-governed run whose agent declares no
+    knowledge bases at all, rather than on a run with no governing team.
+    The two paths share one branch on purpose and must behave identically:
+    applying the stored-declaration basis here regardless would either
+    reject a model-named collection the agent never restricted in the
+    first place, or -- as the empty ``authorised`` set would render it --
+    reject with an ``Allowed collections:`` list that is always empty.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    _install_collections(monkeypatch, {MEMBER: [_kb("kb1"), _kb("kb2")]})
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=[],
+        collections=["kb2"],
+        allowed_collections=allowed_collections,
+    )
+
+    if allowed_collections is None:
+        assert result.results
+    else:
+        assert "Error:" in result.summary and "not allowed" in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The model may narrow an explicit request to a subset of what the
+# verdict loop admitted; only the narrowing half is pinned here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explicit_request_narrows_the_search_to_what_it_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The governing team owns all three declared names, so the verdict
+    loop admits all three -- but the model's explicit ``collections``
+    argument names only one of them. Only that one collection should
+    actually be searched, not all three admitted ones: this pins the
+    narrowing half of "the model may narrow the search but never widen
+    it," which the widening half (the "not allowed" gate above) does not
+    cover.
+    """
+    team_kbs = [
+        kb_scope.KnowledgeBaseAccess(
+            name=name,
+            storage_user_id=CREATOR,
+            team_owned=True,
+            can_edit=False,
+            can_delete=False,
+        )
+        for name in ("alpha", "beta", "gamma")
+    ]
+    _install_team(monkeypatch, {TEAM: team_kbs})
+    _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [],
+            CREATOR: [_kb("alpha"), _kb("beta"), _kb("gamma")],
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["alpha", "beta", "gamma"],
+        collections=["beta"],
+    )
+
+    assert search_spy.searched == [("beta", CREATOR, False)]
+    assert result.results
+
+
+# ---------------------------------------------------------------------------
+# Both report outcomes in one response, each listing only its own names, on
+# both call styles.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [False, True])
+async def test_mixed_missing_and_unshared_names_report_separately(
+    monkeypatch: pytest.MonkeyPatch, explicit: bool
+) -> None:
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="good",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [_kb("unrelated-own-doc")],
+            CREATOR: [_kb("unshared-one"), _kb("good")],
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    declared = ["unshared-one", "ghost-one", "good"]
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=declared,
+        collections=declared if explicit else None,
+    )
+
+    assert "unshared-one" in result.summary
+    assert "has not" in result.summary and "shared with the team" in result.summary
+    assert "ghost-one" in result.summary
+    assert "could not be resolved" in result.summary
+    assert result.results
+    assert not result.summary.startswith("Error:")
+    # The resolved name ("good") was actually searched, against T's
+    # storage tenant -- the two failing names did not stop it.
+    assert search_spy.searched == [("good", CREATOR, False)]
+    # The note lists only the names that failed to resolve -- "good"
+    # resolved successfully and must not appear alongside them.
+    import re
+
+    note_names = re.search(r"Note: (.+?) could not be resolved", result.summary)
+    assert note_names is not None
+    assert "good" not in note_names.group(1)
+
+
+# ---------------------------------------------------------------------------
+# The sharing-gap message never discloses the creator's identity.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sharing_gap_message_has_no_creator_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="good",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    _install_collections(
+        monkeypatch, {MEMBER: [], CREATOR: [_kb("secret"), _kb("good")]}
+    )
+    _install_search(monkeypatch)
+
+    result = await _search(monkeypatch, runner_id=MEMBER, declared=["secret", "good"])
+
+    # The message actually rendered (not the unrelated early-empty-union
+    # summary), and it still names no identity.
+    assert "has not" in result.summary and "shared with the team" in result.summary
+    assert str(CREATOR) not in result.summary
+    assert (
+        "creator" not in result.summary.lower()
+        or "this agent's creator" in result.summary
+    )
+    assert "@" not in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The creator-existence probe never runs for a name outside the agent's
+# stored declaration. Two fixtures that discriminate a correct binding
+# from a wrong one: the explicit call style and the default call style.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_creator_probe_ignores_undeclared_name_even_when_creator_really_owns_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The discriminating fixture: the creator genuinely owns
+    "victim", but it is not in the agent's stored declaration. The model
+    names it via BOTH ``collections`` and its own ``allowed_collections``
+    (which ``setdefault`` would not override). The probe must never run,
+    and the response must not distinguish this from the creator not
+    owning "victim" at all.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    spy = _install_collections(
+        monkeypatch,
+        {MEMBER: [_kb("unrelated-own-doc")], CREATOR: [_kb("victim")]},
+    )
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook"],
+        collections=["victim"],
+        allowed_collections=["victim"],
+    )
+
+    assert spy.calls_for(CREATOR) == 0
+    assert result.results == []
+    assert "Error:" in result.summary and "not allowed" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_creator_probe_ignores_undeclared_name_even_when_creator_really_owns_it_default_style(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same discriminating shape as the fixture above, but on the default
+    call style: the model supplies no explicit ``collections``, only its
+    own ``allowed_collections=["victim"]`` -- so this exercises the verdict
+    loop's own iteration source directly, not the "not allowed" gate (which
+    only runs when the model names collections explicitly). If the loop
+    iterated ``allowed_collections`` instead of the agent's stored
+    declaration, "victim" would be visited and probed even though it was
+    never declared.
+
+    "handbook" (the agent's real, declared name) legitimately reaches the
+    probe here -- the memoised call for it is not the leak. What must not
+    happen is the outcome depending on whether the creator happens to own
+    "victim": the two runs below (creator does / does not own "victim")
+    must produce byte-identical responses, since "victim" is never
+    declared and so must never be classified at all.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+
+    _install_collections(
+        monkeypatch,
+        {MEMBER: [_kb("unrelated-own-doc")], CREATOR: [_kb("victim")]},
+    )
+    _install_search(monkeypatch)
+    with_victim = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook"],
+        allowed_collections=["victim"],
+    )
+
+    _install_collections(monkeypatch, {MEMBER: [_kb("unrelated-own-doc")], CREATOR: []})
+    _install_search(monkeypatch)
+    without_victim = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook"],
+        allowed_collections=["victim"],
+    )
+
+    assert with_victim.summary == without_victim.summary
+    assert with_victim.results == without_victim.results
+    assert "victim" not in with_victim.summary
+
+
+@pytest.mark.asyncio
+async def test_creator_probe_memoised_at_most_once_per_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three declared names all need classifying; the probe must be called
+    at most once for the whole search, not once per name. The
+    de-duplication of the stored declaration is exercised too, via a
+    duplicated name in it.
+    """
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="anchor",
+        storage_user_id=999,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    spy = _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [_kb("unrelated-own-doc")],
+            999: [_kb("anchor")],
+            CREATOR: [],  # creator holds NONE of "one/two/three"
+        },
+    )
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["anchor", "one", "two", "three", "one"],  # "one" duplicated
+    )
+
+    assert spy.calls_for(CREATOR) <= 1
+    # The duplicate is reported once, not twice, in the missing-names list.
+    import re
+
+    missing_list = re.search(r"Note: (.+?) could not be resolved", result.summary)
+    assert missing_list is not None
+    names = [n.strip() for n in missing_list.group(1).split(",")]
+    assert names.count("one") == 1
+
+
+# ---------------------------------------------------------------------------
+# No governing team => the team-keyed hook is never invoked and the
+# creator check never runs.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Team hook not installed => legacy runner-keyed overlay, selection
+# on the predicate, never on an empty return.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_declared_name_rule_inert_until_hook_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The three-way gate: a governing team id and a non-empty declaration
+    are not enough on their own -- the team-keyed hook must actually be
+    installed, or the whole declared-name rule (verdict derivation, the
+    re-based "not allowed" gate, and both new report messages) must stay
+    off and the run must behave exactly as it does with no governing team
+    at all.
+
+    This is deliberately a *different* pin from the team-layer fallback
+    test above: that one only checks which collections are visible; this
+    one checks that the naming rule does not half-apply while the layer
+    is still falling back. A change that lets the rule apply even though
+    the socket is not installed would leave the team-layer pin green
+    (visibility still falls back correctly) while this one goes red.
+    """
+    # No team_visibility hook installed at all -- team_knowledge_base_hook_installed()
+    # is False. The runner has their own same-named personal collection,
+    # which the declared-name rule (if it ran) would have to reject.
+    _install_collections(monkeypatch, {MEMBER: [_kb("handbook")], CREATOR: []})
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(monkeypatch, runner_id=MEMBER, declared=["handbook"])
+
+    # Byte-for-byte legacy behaviour: the runner's own personal collection
+    # searches normally, no sharing-gap or missing-name message, no rejection.
+    assert search_spy.searched == [("handbook", MEMBER, False)]
+    assert result.results
+    assert "shared with the team" not in result.summary
+    assert "could not be resolved" not in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The typed error survives the run-path re-wrap; the build-frame
+# narrowings are defence in depth only.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# The creator-collection lookup failing degrades to the generic
+# outcome and never raises.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_creator_listing_failure_reports_unresolved_not_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The creator-collection lookup raises. The search decision is
+    unchanged -- nothing resolves, nothing is searched -- but the report
+    must not claim the name does not exist: no lookup ever established
+    that. The hedged wording is accurate whether or not the creator holds
+    it, which is also what keeps the two outcomes indistinguishable.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+
+    async def _broken_list_collections(
+        user_id=None, is_admin=None, force_realtime=False
+    ):
+        if user_id == CREATOR:
+            raise RuntimeError("storage unavailable")
+        if user_id == MEMBER:
+            return _collections(_kb("unrelated-own-doc"))
+        return _collections()
+
+    monkeypatch.setattr(document_search, "list_collections", _broken_list_collections)
+    _install_search(monkeypatch)
+
+    result = await _search(monkeypatch, runner_id=MEMBER, declared=["handbook"])
+
+    assert result.results == []
+    assert "Error:" in result.summary
+    assert "shared with the team" not in result.summary
+    assert "handbook could not be resolved for this agent" in result.summary
+    # The certainty wording is exactly what must not appear.
+    assert "None of the allowed collections exist" not in result.summary
+    assert "do not exist" not in result.summary
+
+
+@pytest.mark.asyncio
+async def test_creator_listing_failure_hedges_on_the_explicit_call_style_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_team(monkeypatch, {TEAM: []})
+
+    async def _broken_list_collections(
+        user_id=None, is_admin=None, force_realtime=False
+    ):
+        if user_id == CREATOR:
+            raise RuntimeError("storage unavailable")
+        if user_id == MEMBER:
+            return _collections(_kb("unrelated-own-doc"))
+        return _collections()
+
+    monkeypatch.setattr(document_search, "list_collections", _broken_list_collections)
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook"],
+        collections=["handbook"],
+    )
+
+    assert result.results == []
+    assert "handbook could not be resolved for this agent" in result.summary
+    assert "do not exist" not in result.summary
+
+
+# ---------------------------------------------------------------------------
+# user_id is None returns before any team resolution.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# The save-time validation consumer (find_missing_knowledge_bases) stays
+# runner-keyed.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Governing team set, but the agent declares no knowledge bases at all.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_governed_run_without_agent_config_uses_governing_team_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="handbook",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    spy = _install_collections(
+        monkeypatch,
+        {
+            MEMBER: [_kb("own-material")],
+            CREATOR: [_kb("handbook")],
+        },
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(monkeypatch, runner_id=MEMBER, declared=[])
+
+    # The team layer is still visible, resolved against T, and gets
+    # searched alongside the runner's own material -- an empty declaration
+    # falls through to "search everything visible", and the visible set's
+    # contents are still resolved on the governing team.
+    searched_names = {name for name, _, _ in search_spy.searched}
+    assert searched_names == {"own-material", "handbook"}
+
+    # Holds trivially: exactly one creator-directed call, and it is the
+    # team-ref resolution's owner scan inside _list_visible_collections --
+    # not the creator-existence probe, which never runs for an empty
+    # declaration.
+    assert spy.calls_for(CREATOR) == 1
+    assert "shared with the team" not in result.summary
+    assert "could not be resolved" not in result.summary
+
+    # The targeted-confirmation addition: the runner's own material is
+    # still searched (the fallback, not an empty verdict-derived set).
+    assert ("own-material", MEMBER, False) in search_spy.searched
+
+
+# ---------------------------------------------------------------------------
+# The list tool is built only when the agent declares nothing, and
+# there are exactly two ListKnowledgeBasesTool( construction sites.
+# ---------------------------------------------------------------------------

--- a/tests/core/tools/core/test_document_search_team_declared_names.py
+++ b/tests/core/tools/core/test_document_search_team_declared_names.py
@@ -131,6 +131,7 @@ async def _search(
     monkeypatch: pytest.MonkeyPatch,
     *,
     runner_id: int,
+    is_admin: bool = False,
     team_id: Optional[int] = TEAM,
     creator_id: Optional[int] = CREATOR,
     declared: Optional[list[str]] = None,
@@ -145,7 +146,7 @@ async def _search(
     return await document_search._search_knowledge_base_impl(
         tool_args,
         user_id=runner_id,
-        is_admin=False,
+        is_admin=is_admin,
         governing_team_id=team_id,
         agent_creator_user_id=creator_id,
         declared_knowledge_bases=declared,
@@ -565,6 +566,173 @@ async def test_total_failure_of_a_single_unshared_name_still_reports_the_gap(
     assert result.summary.startswith("Error:")
     assert "has not" in result.summary and "shared with the team" in result.summary
     assert "private-notes" in result.summary
+    # The sharing-gap sentence says the creator holds this collection; the
+    # same summary must not also assert it is absent.
+    assert "do not exist" not in result.summary
+    assert "None of the allowed collections exist" not in result.summary
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [False, True])
+async def test_mixed_terminal_failure_lists_each_name_once(
+    monkeypatch: pytest.MonkeyPatch, explicit: bool
+) -> None:
+    """Two declared names fail for different reasons and nothing resolves:
+    "private-notes" is the creator's own unshared collection, "ghost" is
+    nobody's. The absence sentence may name only "ghost" -- naming
+    "private-notes" there would contradict the sharing-gap sentence in the
+    same summary, and the default call style's blanket "None of the allowed
+    collections exist" would assert the same falsehood about both.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    _install_collections(monkeypatch, {MEMBER: [], CREATOR: [_kb("private-notes")]})
+    search_spy = _install_search(monkeypatch)
+
+    declared = ["private-notes", "ghost"]
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=declared,
+        collections=declared if explicit else None,
+    )
+
+    assert search_spy.searched == []
+    assert result.results == []
+    assert result.summary.startswith("Error:")
+    assert "has not" in result.summary and "shared with the team" in result.summary
+    assert "None of the allowed collections exist" not in result.summary
+    absence_clause = result.summary.split("do not exist:", 1)[1].split(".", 1)[0]
+    assert "ghost" in absence_clause
+    assert "private-notes" not in absence_clause
+
+
+@pytest.mark.asyncio
+async def test_all_unshared_terminal_still_reports_what_was_admitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The team owns "good", so the verdict loop admits it, but the model's
+    explicit request names only the creator's unshared "private-notes" --
+    the narrowing empties the search set. The summary must still say what
+    the run could have searched, which is the whole reason the admitted set
+    is captured before the narrowing.
+    """
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="good",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+    _install_collections(
+        monkeypatch, {MEMBER: [], CREATOR: [_kb("good"), _kb("private-notes")]}
+    )
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["private-notes", "good"],
+        collections=["private-notes"],
+    )
+
+    assert result.results == []
+    assert result.summary.startswith("Error:")
+    assert "shared with the team" in result.summary
+    assert "do not exist" not in result.summary
+    assert "Available collections: good" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_other_teams_kb_hosted_on_creator_tenant_is_not_personal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A team the creator belongs to -- not the governing one -- owns
+    "otherteam-kb", physically stored in the creator's own namespace. A raw
+    listing of that namespace returns it next to the creator's real
+    personal collection, so classifying off the listing alone calls a whole
+    other team's knowledge base "a personal knowledge base belonging to
+    this agent's creator" and aims the remediation at the wrong person.
+    """
+    otherteam_kb = kb_scope.KnowledgeBaseAccess(
+        name="otherteam-kb",
+        storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+
+    def _governing_team_visibility(db: Any, *, team_id: int) -> list:
+        return []
+
+    def _creator_own_team_visibility(db: Any, user_id: int) -> list:
+        return [otherteam_kb] if user_id == CREATOR else []
+
+    kb_scope.set_knowledge_base_team_hooks(
+        team_visibility=_governing_team_visibility,
+        visibility=_creator_own_team_visibility,
+    )
+    _install_collections(
+        monkeypatch,
+        {MEMBER: [], CREATOR: [_kb("otherteam-kb"), _kb("really-mine")]},
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["otherteam-kb", "really-mine"],
+    )
+
+    assert search_spy.searched == []
+    gap_clause = result.summary.split("Error:", 1)[1]
+    assert "otherteam-kb is a personal knowledge base" not in gap_clause
+    assert "otherteam-kb" in result.summary  # reported, as absent
+    # The creator's genuine personal collection is still classified as one:
+    # the filter must remove the team's row, not everything on the tenant.
+    assert "really-mine is a personal knowledge base" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_not_allowed_clause_lists_the_declaration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The clause tells the model what it may ask for, so it must be the
+    agent's declaration -- not the declaration intersected with what is
+    visible right now. "offsite-notes" is declared and currently resolves
+    to nothing; dropping it from the clause tells the model it may not ask
+    for a name the agent is configured with. The governing team's other,
+    undeclared knowledge bases must not appear either.
+    """
+    team_kbs = [
+        kb_scope.KnowledgeBaseAccess(
+            name=name,
+            storage_user_id=CREATOR,
+            team_owned=True,
+            can_edit=False,
+            can_delete=False,
+        )
+        for name in ("handbook", "board-minutes")
+    ]
+    _install_team(monkeypatch, {TEAM: team_kbs})
+    _install_collections(
+        monkeypatch,
+        {MEMBER: [], CREATOR: [_kb("handbook"), _kb("board-minutes")]},
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook", "offsite-notes"],
+        collections=["victim"],
+    )
+
+    assert search_spy.searched == []
+    assert "not allowed" in result.summary
+    clause = result.summary.split("Allowed collections:", 1)[1].strip()
+    assert clause == "handbook, offsite-notes"
+    assert "board-minutes" not in result.summary
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/core/test_document_search_team_declared_names.py
+++ b/tests/core/tools/core/test_document_search_team_declared_names.py
@@ -647,10 +647,24 @@ async def test_other_teams_kb_hosted_on_creator_tenant_is_not_personal(
     personal collection, so classifying off the listing alone calls a whole
     other team's knowledge base "a personal knowledge base belonging to
     this agent's creator" and aims the remediation at the wrong person.
+
+    That same other team also owns "really-mine", which lives in a
+    different member's namespace and shares its name with a collection the
+    creator genuinely owns. Only the rows physically hosted on the
+    creator's tenant may be discounted: a name-only exclusion would take
+    the creator's own collection with it and report it as absent.
     """
+    other_member_tenant = 500
     otherteam_kb = kb_scope.KnowledgeBaseAccess(
         name="otherteam-kb",
         storage_user_id=CREATOR,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    same_name_on_another_tenant = kb_scope.KnowledgeBaseAccess(
+        name="really-mine",
+        storage_user_id=other_member_tenant,
         team_owned=True,
         can_edit=False,
         can_delete=False,
@@ -660,7 +674,9 @@ async def test_other_teams_kb_hosted_on_creator_tenant_is_not_personal(
         return []
 
     def _creator_own_team_visibility(db: Any, user_id: int) -> list:
-        return [otherteam_kb] if user_id == CREATOR else []
+        if user_id != CREATOR:
+            return []
+        return [otherteam_kb, same_name_on_another_tenant]
 
     kb_scope.set_knowledge_base_team_hooks(
         team_visibility=_governing_team_visibility,
@@ -683,7 +699,9 @@ async def test_other_teams_kb_hosted_on_creator_tenant_is_not_personal(
     assert "otherteam-kb is a personal knowledge base" not in gap_clause
     assert "otherteam-kb" in result.summary  # reported, as absent
     # The creator's genuine personal collection is still classified as one:
-    # the filter must remove the team's row, not everything on the tenant.
+    # the team owns a row by that name too, but it is hosted elsewhere, so
+    # discounting it here would describe a collection the creator really
+    # does hold as absent.
     assert "really-mine is a personal knowledge base" in result.summary
 
 

--- a/tests/core/tools/core/test_document_search_team_declared_names.py
+++ b/tests/core/tools/core/test_document_search_team_declared_names.py
@@ -154,12 +154,6 @@ async def _search(
 
 
 # ---------------------------------------------------------------------------
-# A name the governing team owns resolves to the team's storage tenant,
-# for every runner.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
 # A same-named row of the runner's OTHER team never participates.
 # ---------------------------------------------------------------------------
 
@@ -1118,12 +1112,6 @@ async def test_creator_probe_memoised_at_most_once_per_search(
 
 
 # ---------------------------------------------------------------------------
-# No governing team => the team-keyed hook is never invoked and the
-# creator check never runs.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
 # Team hook not installed => legacy runner-keyed overlay, selection
 # on the predicate, never on an empty return.
 # ---------------------------------------------------------------------------
@@ -1164,56 +1152,23 @@ async def test_declared_name_rule_inert_until_hook_installed(
 
 
 # ---------------------------------------------------------------------------
-# The typed error survives the run-path re-wrap; the build-frame
-# narrowings are defence in depth only.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
 # The creator-collection lookup failing degrades to the generic
 # outcome and never raises.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [False, True])
 async def test_creator_listing_failure_reports_unresolved_not_absent(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, explicit: bool
 ) -> None:
     """The creator-collection lookup raises. The search decision is
     unchanged -- nothing resolves, nothing is searched -- but the report
     must not claim the name does not exist: no lookup ever established
     that. The hedged wording is accurate whether or not the creator holds
-    it, which is also what keeps the two outcomes indistinguishable.
+    it, which is also what keeps the two outcomes indistinguishable. Holds
+    on both call styles.
     """
-    _install_team(monkeypatch, {TEAM: []})
-
-    async def _broken_list_collections(
-        user_id=None, is_admin=None, force_realtime=False
-    ):
-        if user_id == CREATOR:
-            raise RuntimeError("storage unavailable")
-        if user_id == MEMBER:
-            return _collections(_kb("unrelated-own-doc"))
-        return _collections()
-
-    monkeypatch.setattr(document_search, "list_collections", _broken_list_collections)
-    _install_search(monkeypatch)
-
-    result = await _search(monkeypatch, runner_id=MEMBER, declared=["handbook"])
-
-    assert result.results == []
-    assert "Error:" in result.summary
-    assert "shared with the team" not in result.summary
-    assert "handbook could not be resolved for this agent" in result.summary
-    # The certainty wording is exactly what must not appear.
-    assert "None of the allowed collections exist" not in result.summary
-    assert "do not exist" not in result.summary
-
-
-@pytest.mark.asyncio
-async def test_creator_listing_failure_hedges_on_the_explicit_call_style_too(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
     _install_team(monkeypatch, {TEAM: []})
 
     async def _broken_list_collections(
@@ -1232,23 +1187,16 @@ async def test_creator_listing_failure_hedges_on_the_explicit_call_style_too(
         monkeypatch,
         runner_id=MEMBER,
         declared=["handbook"],
-        collections=["handbook"],
+        collections=["handbook"] if explicit else None,
     )
 
     assert result.results == []
+    assert "Error:" in result.summary
+    assert "shared with the team" not in result.summary
     assert "handbook could not be resolved for this agent" in result.summary
+    # The certainty wording is exactly what must not appear.
+    assert "None of the allowed collections exist" not in result.summary
     assert "do not exist" not in result.summary
-
-
-# ---------------------------------------------------------------------------
-# user_id is None returns before any team resolution.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# The save-time validation consumer (find_missing_knowledge_bases) stays
-# runner-keyed.
-# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
@@ -1299,7 +1247,99 @@ async def test_team_governed_run_without_agent_config_uses_governing_team_layer(
     assert ("own-material", MEMBER, False) in search_spy.searched
 
 
-# ---------------------------------------------------------------------------
-# The list tool is built only when the agent declares nothing, and
-# there are exactly two ListKnowledgeBasesTool( construction sites.
-# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_team_owned_undeclared_name_in_explicit_request_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The governing team owns "team-secret", and the runner is a member of
+    that team, so it is visible to this run -- but the agent never declared
+    it. Being team-owned is not authorisation: the gate is keyed on the
+    agent's declaration, and a change that whitelists team-owned names
+    would hand the model a knowledge base the agent was never configured
+    with.
+    """
+    team_kbs = [
+        kb_scope.KnowledgeBaseAccess(
+            name=name,
+            storage_user_id=CREATOR,
+            team_owned=True,
+            can_edit=False,
+            can_delete=False,
+        )
+        for name in ("handbook", "team-secret")
+    ]
+    _install_team(monkeypatch, {TEAM: team_kbs})
+    _install_collections(
+        monkeypatch,
+        {MEMBER: [], CREATOR: [_kb("handbook"), _kb("team-secret")]},
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook"],
+        collections=["team-secret"],
+    )
+
+    assert search_spy.searched == []
+    assert result.results == []
+    assert "not allowed" in result.summary
+    clause = result.summary.split("Allowed collections:", 1)[1].strip()
+    assert clause == "handbook"
+
+
+@pytest.mark.asyncio
+async def test_admin_governed_run_resolves_on_the_governing_team(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An admin's collection listing is platform-wide, so it carries every
+    tenant's collections -- including the creator's unshared one and other
+    users' entirely unrelated ones. The declared-name rule still applies:
+    the team's copy is searched against the team's tenant with is_admin
+    dropped, the creator's unshared collection is still refused, and the
+    summary still names nothing the agent did not declare.
+    """
+    ADMIN = 400
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="gov-kb",
+        storage_user_id=999,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+
+    async def _platform_wide_list_collections(
+        user_id=None, is_admin=None, force_realtime=False
+    ):
+        if is_admin:
+            return _collections(
+                _kb("gov-kb"), _kb("private-notes"), _kb("someone-elses-doc")
+            )
+        if user_id == 999:
+            return _collections(_kb("gov-kb"))
+        if user_id == CREATOR:
+            return _collections(_kb("private-notes"))
+        return _collections()
+
+    monkeypatch.setattr(
+        document_search, "list_collections", _platform_wide_list_collections
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=ADMIN,
+        is_admin=True,
+        declared=["gov-kb", "private-notes"],
+    )
+
+    # The team's copy is searched against the team's tenant, and the run's
+    # own admin flag does not travel into a team collection's search.
+    assert search_spy.searched == [("gov-kb", 999, False)]
+    # Visible platform-wide, still refused: the rule is not a visibility
+    # filter.
+    assert "private-notes" in result.summary
+    assert "has not" in result.summary and "shared with the team" in result.summary
+    assert "someone-elses-doc" not in result.summary

--- a/tests/core/tools/core/test_document_search_team_declared_names.py
+++ b/tests/core/tools/core/test_document_search_team_declared_names.py
@@ -127,6 +127,40 @@ def _install_search(monkeypatch: pytest.MonkeyPatch) -> _SearchSpy:
     return spy
 
 
+_THIRD_TENANT = 700
+
+
+def _install_team_kb_off_creator_tenant_with_broken_creator_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> _SearchSpy:
+    """The governing team owns "good", hosted on a tenant that is neither the
+    runner's nor the creator's, and the creator's own listing raises. Resolving
+    a team-owned name never touches the creator probe, so "good" is admitted
+    while every name the probe would have classified is left unresolved."""
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="good",
+        storage_user_id=_THIRD_TENANT,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+
+    async def _list_collections_with_creator_failure(
+        user_id=None, is_admin=None, force_realtime=False
+    ):
+        if user_id == CREATOR:
+            raise RuntimeError("storage unavailable")
+        if user_id == _THIRD_TENANT:
+            return _collections(_kb("good"))
+        return _collections()
+
+    monkeypatch.setattr(
+        document_search, "list_collections", _list_collections_with_creator_failure
+    )
+    return _install_search(monkeypatch)
+
+
 async def _search(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -1347,29 +1381,9 @@ async def test_unresolvable_terminal_still_reports_what_was_admitted(
     down too -- and the unresolvable branch must say so, the same way the
     mixed branch already does.
     """
-    third_tenant = 700
-    team_kb = kb_scope.KnowledgeBaseAccess(
-        name="good",
-        storage_user_id=third_tenant,
-        team_owned=True,
-        can_edit=False,
-        can_delete=False,
+    search_spy = _install_team_kb_off_creator_tenant_with_broken_creator_lookup(
+        monkeypatch
     )
-    _install_team(monkeypatch, {TEAM: [team_kb]})
-
-    async def _list_collections_with_creator_failure(
-        user_id=None, is_admin=None, force_realtime=False
-    ):
-        if user_id == CREATOR:
-            raise RuntimeError("storage unavailable")
-        if user_id == third_tenant:
-            return _collections(_kb("good"))
-        return _collections()
-
-    monkeypatch.setattr(
-        document_search, "list_collections", _list_collections_with_creator_failure
-    )
-    search_spy = _install_search(monkeypatch)
 
     result = await _search(
         monkeypatch,
@@ -1396,29 +1410,9 @@ async def test_partial_failure_hedges_when_the_creator_lookup_fails(
     must carry the hedged wording rather than assert that "handbook" is
     absent -- no lookup established that.
     """
-    third_tenant = 700
-    team_kb = kb_scope.KnowledgeBaseAccess(
-        name="good",
-        storage_user_id=third_tenant,
-        team_owned=True,
-        can_edit=False,
-        can_delete=False,
+    search_spy = _install_team_kb_off_creator_tenant_with_broken_creator_lookup(
+        monkeypatch
     )
-    _install_team(monkeypatch, {TEAM: [team_kb]})
-
-    async def _list_collections_with_creator_failure(
-        user_id=None, is_admin=None, force_realtime=False
-    ):
-        if user_id == CREATOR:
-            raise RuntimeError("storage unavailable")
-        if user_id == third_tenant:
-            return _collections(_kb("good"))
-        return _collections()
-
-    monkeypatch.setattr(
-        document_search, "list_collections", _list_collections_with_creator_failure
-    )
-    search_spy = _install_search(monkeypatch)
 
     result = await _search(
         monkeypatch,
@@ -1426,7 +1420,7 @@ async def test_partial_failure_hedges_when_the_creator_lookup_fails(
         declared=["good", "handbook"],
     )
 
-    assert search_spy.searched == [("good", third_tenant, False)]
+    assert search_spy.searched == [("good", _THIRD_TENANT, False)]
     assert result.results
     assert not result.summary.startswith("Error:")
     assert (

--- a/tests/core/tools/core/test_document_search_team_declared_names.py
+++ b/tests/core/tools/core/test_document_search_team_declared_names.py
@@ -781,12 +781,53 @@ async def test_total_kb_failure_with_same_named_personal_copies_reports_generic_
     # pre-verdict visible union and neither is searchable. Reporting either
     # as available would tell the model the exact opposite of what the rule
     # just decided.
-    available_clause = result.summary.split("Available:", 1)[1]
-    assert "handbook" not in available_clause
-    assert "policies" not in available_clause
+    #
+    # Nothing was admitted, so the clause is dropped rather than rendered
+    # with an empty list -- which is the stronger form of the same pin:
+    # neither personal copy may be reported as available.
+    assert "Available" not in result.summary
     # The declared names still appear -- in the "Allowed:" clause, which is
     # what the agent configured, not what resolved.
     assert "Allowed: handbook, policies" in result.summary
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [False, True])
+async def test_terminal_summary_omits_the_availability_clause_when_nothing_was_admitted(
+    monkeypatch: pytest.MonkeyPatch, explicit: bool
+) -> None:
+    """The runner holds a same-named personal copy of the one declared
+    name, and neither the governing team nor the creator holds it -- so the
+    visible union is non-empty (the runner's own copy is in it) but nothing
+    was admitted (the rule refuses to search the runner's own same-named
+    copy). Before this pin the two uniform terminal sentences always
+    rendered an "Available:" / "Available collections:" label followed by
+    nothing; the label itself must now be omitted, byte for byte, and the
+    "Allowed:" half of the default-style sentence must still render.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    _install_collections(
+        monkeypatch,
+        {MEMBER: [_kb("handbook")], CREATOR: []},
+    )
+    _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["handbook"],
+        collections=["handbook"] if explicit else None,
+    )
+
+    if explicit:
+        assert result.summary == (
+            "Error: The following collections do not exist: handbook."
+        )
+    else:
+        assert result.summary == (
+            "Error: None of the allowed collections exist. Allowed: handbook."
+        )
+    assert "Available" not in result.summary
 
 
 @pytest.mark.asyncio
@@ -1169,6 +1210,35 @@ async def test_declared_name_rule_inert_until_hook_installed(
     assert "could not be resolved" not in result.summary
 
 
+@pytest.mark.asyncio
+async def test_rule_stays_off_without_an_authenticated_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A governing team, an installed hook and a non-empty declaration are
+    not enough on their own: an unauthenticated call (no runner id) never
+    had a team layer resolved for it -- ``_list_visible_collections``
+    returns before any team resolution when the runner id is absent -- so
+    the declared-name rule must stay off rather than run a creator probe on
+    nobody's behalf.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+    spy = _install_collections(monkeypatch, {None: [], CREATOR: [_kb("handbook")]})
+    _install_search(monkeypatch)
+
+    result = await _search(monkeypatch, runner_id=None, declared=["handbook"])
+
+    # No probe on nobody's behalf: the creator-existence lookup is never
+    # requested, even though the creator genuinely holds "handbook".
+    assert spy.calls_for(CREATOR) == 0
+    assert "shared with the team" not in result.summary
+    # Byte-for-byte the pre-rule behaviour for an unauthenticated call: the
+    # inherited empty-visible-set guard, not a declared-name rule outcome.
+    assert result.summary == (
+        "No knowledge bases available. Please create a knowledge base and "
+        "upload documents first."
+    )
+
+
 # ---------------------------------------------------------------------------
 # The creator-collection lookup failing degrades to the generic
 # outcome and never raises.
@@ -1215,6 +1285,191 @@ async def test_creator_listing_failure_reports_unresolved_not_absent(
     # The certainty wording is exactly what must not appear.
     assert "None of the allowed collections exist" not in result.summary
     assert "do not exist" not in result.summary
+
+
+@pytest.mark.asyncio
+async def test_creator_listing_error_status_reports_unresolved_not_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The creator-collection lookup does not raise this time -- it returns
+    a result whose status reports an infrastructure failure, with an empty
+    collection list, the way a real failure degrades in
+    ``_list_collections_impl``. Read as a plain answer, that empty list
+    says "the creator holds nothing", so the probe must treat it the same
+    way it treats a raised failure: hedge, not assert an absence no lookup
+    ever established.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+
+    async def _erroring_list_collections(
+        user_id=None, is_admin=None, force_realtime=False
+    ):
+        if user_id == CREATOR:
+            return ListCollectionsResult(
+                status="error",
+                collections=[],
+                total_count=0,
+                message="storage unavailable",
+            )
+        if user_id == MEMBER:
+            return _collections(_kb("unrelated-own-doc"))
+        return _collections()
+
+    monkeypatch.setattr(document_search, "list_collections", _erroring_list_collections)
+    _install_search(monkeypatch)
+
+    result = await _search(monkeypatch, runner_id=MEMBER, declared=["handbook"])
+
+    assert result.results == []
+    assert "handbook could not be resolved for this agent" in result.summary
+    # The certainty wording is exactly what must not appear.
+    assert "do not exist" not in result.summary
+    assert "None of the allowed collections exist" not in result.summary
+
+
+# ---------------------------------------------------------------------------
+# The unresolvable terminal branch reports the same two things its sibling
+# branches report: the names actually asked about, and what the run could
+# still have asked for.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_terminal_still_reports_what_was_admitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The agent declares two names: "good", which the governing team owns
+    and hosts on a tenant other than the creator's, and "handbook", which
+    needs the creator probe to classify. The model's explicit request names
+    only "handbook", and the creator lookup raises. The verdict loop still
+    admitted "good" before the narrowing -- resolving a team-owned name
+    never touches the creator probe, so the probe's failure cannot take it
+    down too -- and the unresolvable branch must say so, the same way the
+    mixed branch already does.
+    """
+    third_tenant = 700
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="good",
+        storage_user_id=third_tenant,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+
+    async def _list_collections_with_creator_failure(
+        user_id=None, is_admin=None, force_realtime=False
+    ):
+        if user_id == CREATOR:
+            raise RuntimeError("storage unavailable")
+        if user_id == third_tenant:
+            return _collections(_kb("good"))
+        return _collections()
+
+    monkeypatch.setattr(
+        document_search, "list_collections", _list_collections_with_creator_failure
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["good", "handbook"],
+        collections=["handbook"],
+    )
+
+    assert search_spy.searched == []
+    assert result.results == []
+    assert result.summary == (
+        "Error: handbook could not be resolved for this agent. "
+        "Available collections: good."
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_hedges_when_the_creator_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same fixture as above, no explicit request: "good" is admitted and
+    searched, "handbook" is left unclassified by the failed creator lookup.
+    This is the partial-failure path, not the terminal one, and its note
+    must carry the hedged wording rather than assert that "handbook" is
+    absent -- no lookup established that.
+    """
+    third_tenant = 700
+    team_kb = kb_scope.KnowledgeBaseAccess(
+        name="good",
+        storage_user_id=third_tenant,
+        team_owned=True,
+        can_edit=False,
+        can_delete=False,
+    )
+    _install_team(monkeypatch, {TEAM: [team_kb]})
+
+    async def _list_collections_with_creator_failure(
+        user_id=None, is_admin=None, force_realtime=False
+    ):
+        if user_id == CREATOR:
+            raise RuntimeError("storage unavailable")
+        if user_id == third_tenant:
+            return _collections(_kb("good"))
+        return _collections()
+
+    monkeypatch.setattr(
+        document_search, "list_collections", _list_collections_with_creator_failure
+    )
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["good", "handbook"],
+    )
+
+    assert search_spy.searched == [("good", third_tenant, False)]
+    assert result.results
+    assert not result.summary.startswith("Error:")
+    assert (
+        "Note: handbook could not be resolved for this agent. The agent's "
+        "other knowledge bases were searched normally." in result.summary
+    )
+    assert "do not exist" not in result.summary
+    assert "None of the allowed collections exist" not in result.summary
+    assert "shared with the team" not in result.summary
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_terminal_reports_only_the_requested_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three declared names all fail to classify because the creator lookup
+    raises, and the model's explicit request narrows to just one of them.
+    The unresolvable branch must report only the requested name -- the
+    other two, which this call never asked about, must not appear.
+    """
+    _install_team(monkeypatch, {TEAM: []})
+
+    async def _broken_list_collections(
+        user_id=None, is_admin=None, force_realtime=False
+    ):
+        if user_id == CREATOR:
+            raise RuntimeError("storage unavailable")
+        return _collections()
+
+    monkeypatch.setattr(document_search, "list_collections", _broken_list_collections)
+    search_spy = _install_search(monkeypatch)
+
+    result = await _search(
+        monkeypatch,
+        runner_id=MEMBER,
+        declared=["alpha-notes", "beta-notes", "gamma-notes"],
+        collections=["gamma-notes"],
+    )
+
+    assert search_spy.searched == []
+    assert result.summary == "Error: gamma-notes could not be resolved for this agent."
+    assert "alpha-notes" not in result.summary
+    assert "beta-notes" not in result.summary
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/api/test_chat_knowledge_base_scope_http_exit.py
+++ b/tests/web/api/test_chat_knowledge_base_scope_http_exit.py
@@ -1,0 +1,97 @@
+"""The ``create_task`` endpoint maps ``KnowledgeBaseScopeError`` to the
+status and message the error itself carries, instead of letting its blanket
+handler reclassify it as an internal error.
+
+This is the one place anything reads ``status_code``/``safe_message`` off
+the knowledge-base scope seam's typed error; every other handler (the two
+on the run path, the two on the tool-build path) re-raises it unchanged so
+those attributes survive to here. The arm sits directly beside the
+``ConnectorRuntimeError`` arm that already does the same thing, and pins
+the same three properties for it:
+
+* the response status is the error's own ``status_code`` (503, "resolution
+  failed, retryable"), not the funnel's generic 500;
+* the response detail is ``safe_message``;
+* ``code`` and ``details`` are diagnostic and stay out of the response.
+
+The raise is injected at the endpoint's first statement rather than reached
+organically: no step inside this endpoint resolves the team knowledge-base
+layer today (resolution happens per search call, on the run path), so what
+is under test is the funnel's classification, not any particular producer.
+``validate_task_extension_requests`` is a convenient injection point
+precisely because it runs before any database work -- and because its own
+inner handler catches only ``TypeError``/``ValueError``, so a
+``KnowledgeBaseScopeError`` (a ``RuntimeError``) reaches the outer funnel
+unmodified.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from xagent.core.tools.core.knowledge_base_scope import KnowledgeBaseScopeError
+from xagent.web.schemas.chat import TaskCreateRequest
+
+_SAFE_MESSAGE = "Knowledge base team scope is unavailable."
+_PRIVATE_DETAIL = "team_scope_resolution_failed"
+_ERROR_CODE = "knowledge_base_scope_unavailable"
+
+
+def _scope_error() -> KnowledgeBaseScopeError:
+    return KnowledgeBaseScopeError(
+        _ERROR_CODE,
+        _SAFE_MESSAGE,
+        details={"reason": _PRIVATE_DETAIL},
+        status_code=503,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_task_answers_knowledge_base_scope_error_with_its_own_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.api import chat as chat_module
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise _scope_error()
+
+    monkeypatch.setattr(chat_module, "validate_task_extension_requests", _raise)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await chat_module.create_task(
+            TaskCreateRequest(title="kb-scope-http-exit"),
+            http_request=None,
+            db=MagicMock(),
+            user=MagicMock(id=1, is_admin=False),
+        )
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == _SAFE_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_create_task_keeps_knowledge_base_scope_details_out_of_the_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The diagnostic half of the error is logged, never returned."""
+    from xagent.web.api import chat as chat_module
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise _scope_error()
+
+    monkeypatch.setattr(chat_module, "validate_task_extension_requests", _raise)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await chat_module.create_task(
+            TaskCreateRequest(title="kb-scope-http-exit"),
+            http_request=None,
+            db=MagicMock(),
+            user=MagicMock(id=1, is_admin=False),
+        )
+
+    detail = str(excinfo.value.detail)
+    assert _PRIVATE_DETAIL not in detail
+    assert _ERROR_CODE not in detail

--- a/tests/web/api/test_chat_knowledge_base_scope_http_exit.py
+++ b/tests/web/api/test_chat_knowledge_base_scope_http_exit.py
@@ -3,9 +3,9 @@ status and message the error itself carries, instead of letting its blanket
 handler reclassify it as an internal error.
 
 This is the one place anything reads ``status_code``/``safe_message`` off
-the knowledge-base scope seam's typed error; every other handler (the two
-on the run path, the two on the tool-build path) re-raises it unchanged so
-those attributes survive to here. The arm sits directly beside the
+the knowledge-base scope seam's typed error. The handlers on the run path
+and on the tool-build path re-raise it unchanged, each to its own caller,
+rather than unpacking it here. The arm sits directly beside the
 ``ConnectorRuntimeError`` arm that already does the same thing, and pins
 the same three properties for it:
 
@@ -53,6 +53,8 @@ def _scope_error() -> KnowledgeBaseScopeError:
 async def test_create_task_answers_knowledge_base_scope_error_with_its_own_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """One raise, three properties: the status and the detail come off the
+    error, and its diagnostic half is logged rather than returned."""
     from xagent.web.api import chat as chat_module
 
     def _raise(*args: object, **kwargs: object) -> None:
@@ -70,28 +72,6 @@ async def test_create_task_answers_knowledge_base_scope_error_with_its_own_statu
 
     assert excinfo.value.status_code == 503
     assert excinfo.value.detail == _SAFE_MESSAGE
-
-
-@pytest.mark.asyncio
-async def test_create_task_keeps_knowledge_base_scope_details_out_of_the_response(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The diagnostic half of the error is logged, never returned."""
-    from xagent.web.api import chat as chat_module
-
-    def _raise(*args: object, **kwargs: object) -> None:
-        raise _scope_error()
-
-    monkeypatch.setattr(chat_module, "validate_task_extension_requests", _raise)
-
-    with pytest.raises(HTTPException) as excinfo:
-        await chat_module.create_task(
-            TaskCreateRequest(title="kb-scope-http-exit"),
-            http_request=None,
-            db=MagicMock(),
-            user=MagicMock(id=1, is_admin=False),
-        )
-
     detail = str(excinfo.value.detail)
     assert _PRIVATE_DETAIL not in detail
     assert _ERROR_CODE not in detail

--- a/tests/web/api/test_chat_team_scope_wiring_behavioral.py
+++ b/tests/web/api/test_chat_team_scope_wiring_behavioral.py
@@ -1,16 +1,19 @@
-"""Behavioral pins for the two ``create_default_tools`` call sites the
-source-level guard (``test_chat_team_scope_wiring_static.py``) cannot
-reach: that guard only proves neither call site passes a literal
-``None``, so it cannot catch a call site that derives the *wrong*
-non-``None`` value (e.g. the running user's id instead of the agent
-creator's), or one that hardcodes an empty list where the agent's own
-declaration belongs.
+"""Behavioral pins for the team-scope values ``chat.py`` forwards into
+``create_default_tools``, covering what the source-level guard
+(``test_chat_team_scope_wiring_static.py``) cannot reach: that guard only
+proves no derivation point passes a literal ``None``, so it cannot catch
+one that derives the *wrong* non-``None`` value (e.g. the running user's
+id instead of the agent creator's), or one that hardcodes an empty list
+where the agent's own declaration belongs.
 
 These tests drive the real methods (``AgentServiceManager._build_tools_for_task``
-and ``AgentServiceManager.get_agent_for_task``) with a fake ``TaskSetupSnapshot``
-and assert the values forwarded to ``create_default_tools`` equal the
-snapshot's own agent fields -- not merely "not None" -- so a swap to the
-runner's id, or a hardcoded ``[]``, fails the assertion.
+and ``AgentServiceManager.get_agent_for_task``) and assert the values
+forwarded to ``create_default_tools`` equal the agent's own fields -- not
+merely "not None" -- so a swap to the runner's id, or a hardcoded ``[]``,
+fails the assertion. All three derivation points are covered: the two
+snapshot branches, driven with a fake ``TaskSetupSnapshot``, and
+``_build_tools_for_task``'s snapshot-less branch, driven with a fake
+session that returns a live ``Agent`` row.
 """
 
 from __future__ import annotations
@@ -20,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from xagent.web.api.chat import AgentServiceManager
-from xagent.web.models.agent import AgentStatus
+from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.llm_utils import AgentRuntimeFields
@@ -177,3 +180,73 @@ async def test_get_agent_for_task_forwards_snapshot_declaration_not_empty() -> N
     assert kwargs.get("agent_creator_user_id") == _CREATOR_USER_ID
     assert kwargs.get("declared_knowledge_bases") == _DECLARED_KBS
     assert kwargs.get("declared_knowledge_bases") != []
+
+
+@pytest.mark.asyncio
+async def test_build_tools_for_task_live_orm_branch_reads_the_agent_row() -> None:
+    """Pins the third derivation point: the snapshot-less branch of
+    ``_build_tools_for_task``, which reads the creator off a live ``Agent``
+    row instead of a frozen snapshot.
+
+    The static guard only proves this branch does not hardcode ``None``,
+    which leaves the same swap the other two branches are pinned against
+    wide open: reading the *task's* ``user_id`` (whoever is running the
+    task) where the *agent row's* ``user_id`` (whoever created the agent)
+    belongs. The two ids differ in this fixture, so that swap is visible.
+
+    The branch is not reachable from production today -- the only caller
+    always supplies a snapshot -- but the team-scope rule now consumes
+    ``agent_creator_user_id`` to decide which declared knowledge-base names
+    a runner may resolve, so a snapshot-less path added later would widen
+    or narrow that resolution silently if it derived the value wrongly.
+    """
+    manager = AgentServiceManager()
+    snapshot = _make_snapshot()
+
+    # Deliberately owned by the runner, while the agent row below is owned
+    # by the creator: the forwarded value must follow the agent, not the task.
+    task_row = Task(
+        id=42,
+        user_id=_RUNNER_USER_ID,
+        title="live-orm-branch",
+        description="live-orm-branch",
+        status=TaskStatus.PENDING,
+        agent_id=7,
+        agent_type="standard",
+    )
+    agent_row = Agent(
+        id=7,
+        user_id=_CREATOR_USER_ID,
+        team_id=_TEAM_ID,
+        name="gov-agent",
+        status=AgentStatus.PUBLISHED,
+    )
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = agent_row
+
+    with (
+        patch(
+            "xagent.web.api.chat.create_default_tools",
+            new=AsyncMock(return_value=([], MagicMock())),
+        ) as create_tools_mock,
+        patch("xagent.web.api.chat.resolve_workforce_task_runtime", return_value=None),
+        patch.object(
+            manager, "_get_or_create_task_sandbox", AsyncMock(return_value=None)
+        ),
+    ):
+        await manager._build_tools_for_task(
+            task_id=42,
+            task=task_row,
+            db=db,
+            user=snapshot.runtime_user,
+            agent_config=snapshot.agent_config,
+            task_llm=None,
+            task_vision_llm=None,
+            task_setup_snapshot=None,
+        )
+
+    kwargs = create_tools_mock.call_args.kwargs
+    assert kwargs.get("agent_creator_user_id") == _CREATOR_USER_ID
+    assert kwargs.get("agent_creator_user_id") != _RUNNER_USER_ID
+    assert kwargs.get("connector_team_id") == _TEAM_ID
+    assert kwargs.get("declared_knowledge_bases") == _DECLARED_KBS

--- a/tests/web/tools/test_create_default_tools_team_scope_forwarding.py
+++ b/tests/web/tools/test_create_default_tools_team_scope_forwarding.py
@@ -14,6 +14,13 @@ out of reach of a fast unit test. ``test_chat_team_scope_wiring_static.py``
 (source-level guards) and ``test_chat_team_scope_wiring_behavioral.py``
 (driving both call sites with a fake ``TaskSetupSnapshot`` and a spy on
 ``create_default_tools``) close that gap instead.
+
+The arguments below are chosen to isolate forwarding, not to describe a
+production call: both real call sites derive ``allowed_collections`` and
+``declared_knowledge_bases`` from the same stored agent field, so the two
+are equal by construction there. Passing a declaration while leaving
+``allowed_collections`` unset keeps a dropped keyword from being masked by
+a value that happens to arrive through the other one.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
**Builds on #1349.** That PR resolves the knowledge-base team layer on the
governing agent's team, adds the typed scope error, and carries the governing
agent's creator and stored declaration to the search entry point without reading
them. This PR is the rule that reads them. With #1349 merged, this diff is the rule
plus three small pieces that only make sense once the rule exists: the typed
scope error's HTTP exit in the task-creation endpoint (defence in depth, mirroring
the connector error's exit beside it — no request path resolves the team layer
today), a behavioural pin on the live-ORM derivation branch, and docstring wording
aligned with what the production call sites actually bind.

### What this changes

With the seam in place, every value the rule needs is already at
`_search_knowledge_base_impl` and unused. This PR is the rule.

A team-governed run now gives **every name in the agent's stored `knowledge_bases`
declaration its own verdict**:

| Situation | Verdict |
|---|---|
| The governing team owns the name | The team's copy, resolved on the team's storage tenant |
| The team does not own it, and the runner **is** the agent's creator | The creator's own collection, exactly as with no governing team |
| The team does not own it, the runner is not the creator, and the creator does hold it | Nothing searchable, plus a sentence saying the knowledge base was never shared with the team |
| The team does not own it and nobody holds it | Nothing searchable, plus the existing "does not exist" wording |
| The creator lookup raised | Nothing searchable, plus wording that asserts no absence, because nothing established one |

Without this, a name the team never received quietly resolved onto whatever
same-named personal collection the runner happened to own. The visible union seeds
the runner's own collections, so a rule keyed on that union would never see the very
name it exists to reject — which is why the search set and both report sets are all
built from the verdicts, never from an intersection with what is visible.

### The gate

The rule applies only when three things hold together: a governing team, an
installed team-keyed hook, and a non-empty declaration.

- **No installed hook** means the deployment's team layer still resolves the old,
  runner-keyed way. Turning the rule on there would produce a half-migrated state
  nothing asked for, so the rule stays off and behaviour is unchanged byte for byte.
- **An empty declaration** has nothing to authorise against, so the run falls
  through to the existing "search everything visible" branch. The governing team's
  knowledge bases are still in that visible set — the team layer resolves
  independently of what was declared — so such a run searches the runner's own
  material *and* the governing team's, as it always has.

This gate is intentionally not the same predicate as the team layer's own gate: the
team layer's job is "resolve onto the governing team", which an empty declaration
does not change.

### Reporting

The terminal summary is derived from the verdicts, one report set per verdict
class, so no name is described twice and none is described as both absent and
held. When nothing in scope is the creator's own, both inherited terminal
sentences render byte for byte on their own call style; when at least one
failed name is the creator's unshared collection, the summary lists only the
names actually classified missing, then the sharing-gap sentences, then the
admitted set. The creator-existence probe excludes names on the creator's
tenant that a team the creator belongs to owns, so another team's collection
hosted there is not reported as the creator's.


The "Available"/"Allowed" clauses are derived from the names the verdict loop
admitted, captured **before** the model's explicit request narrows the search. Two
things follow:

- A fully narrowed-away request still tells the model what it could have asked for.
- The clause can never name the governing team's collections the agent did not
  declare, nor the runner's own same-named personal copies — precisely the
  collections the rule refuses to search.

The re-based "not allowed" gate takes the agent's stored declaration as its
authority rather than `tool_args.allowed_collections`, since that field is
model-authored and a model-supplied value can win over the agent's configured one.

### The creator probe

Classifying a name as the creator's own unshared collection needs one lookup of the
creator's collection names, memoised at most once per search call. A lookup that
fails degrades to "not held" for the search decision and switches the report to
wording that asserts no absence.

The probe is bound to the **stored declaration**, not to anything on `tool_args`, so
a model-supplied name can never reach it and turn its two distinguishable outcomes
into an enumeration oracle over the creator's private collection names. A remaining,
costlier existence-only side channel is documented in the probe's docstring: the
stored declaration is editable by any same-team member, so a member can add a name
and read the outcome off the summary, at the cost of an agent edit per name and
revealing only existence, never contents.



