### PR TITLE
fix: preserve traceback on MCP sandbox tool-listing failures

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1480,15 +1480,21 @@ async def load_mcp_tools_as_agent_tools(
                     )
                 except Exception as e:
                     error_type = type(e).__name__
-                    # exc_info so the actual message and traceback survive in
-                    # logs -- without it, only the exception's class name
-                    # (e.g. "AttributeError") is recorded, which identifies
-                    # that something broke but not where, forcing a second
-                    # reproduction just to see the message.
                     logger.error(
                         "Failed to list sandboxed MCP tools from server %s (%s)",
                         server_name,
                         error_type,
+                    )
+                    # DEBUG, not ERROR: the sandboxed process's raw error
+                    # (e.g. its stderr) can carry secrets that flowed into
+                    # the MCP connection, so the always-on ERROR log above
+                    # deliberately keeps only the exception's class name
+                    # (see test_sandbox_list_failure_is_preserved_without_secret).
+                    # This traceback is opt-in -- raise this logger to DEBUG
+                    # to capture it when reproducing a failure.
+                    logger.debug(
+                        "Sandboxed MCP tool listing failure detail for server %s",
+                        server_name,
                         exc_info=True,
                     )
                     failures.append(
@@ -1556,13 +1562,18 @@ async def load_mcp_tools_as_agent_tools(
                 if isinstance(e, TimeoutError)
                 else MCPFailurePhase.SESSION_START
             )
-            # exc_info: see the sandboxed-load handler above for why the
-            # message/traceback, not just the exception class name, needs
-            # to survive in logs.
             logger.error(
                 "Unexpected failure loading tools from MCP server %s (%s)",
                 server_name,
                 error_type,
+            )
+            # DEBUG, not ERROR: same secret-leak concern as the sandboxed-load
+            # handler above -- a session-start/initialize failure can carry
+            # secrets from the connection (e.g. an oauth-authenticated
+            # request's URL or headers surfacing in the exception message).
+            logger.debug(
+                "MCP server load failure detail for server %s",
+                server_name,
                 exc_info=True,
             )
             failures.append(

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1192,6 +1192,20 @@ async def _load_direct_mcp_tools(
                     error_type,
                 )
                 await asyncio.sleep(1)
+            else:
+                # DEBUG, not WARNING: same secret-leak concern as the
+                # sandboxed-load handler below -- a session-start/initialize
+                # /list-tools failure can carry secrets from the connection
+                # (e.g. an oauth-authenticated request's URL or headers
+                # surfacing in the exception message). Opt-in: set
+                # XAGENT_LOG_LEVEL=DEBUG (or run with --debug) to capture it
+                # when reproducing a failure.
+                logger.debug(
+                    "Exhausted retries loading tools from MCP server %s during %s",
+                    server_name,
+                    current_phase.value,
+                    exc_info=True,
+                )
     else:
         return MCPLoadResult(
             tools=(),
@@ -1490,8 +1504,9 @@ async def load_mcp_tools_as_agent_tools(
                     # the MCP connection, so the always-on ERROR log above
                     # deliberately keeps only the exception's class name
                     # (see test_sandbox_list_failure_is_preserved_without_secret).
-                    # This traceback is opt-in -- raise this logger to DEBUG
-                    # to capture it when reproducing a failure.
+                    # This traceback is opt-in -- set XAGENT_LOG_LEVEL=DEBUG
+                    # (or run with --debug) to capture it when reproducing a
+                    # failure.
                     logger.debug(
                         "Sandboxed MCP tool listing failure detail for server %s",
                         server_name,
@@ -1567,10 +1582,14 @@ async def load_mcp_tools_as_agent_tools(
                 server_name,
                 error_type,
             )
-            # DEBUG, not ERROR: same secret-leak concern as the sandboxed-load
-            # handler above -- a session-start/initialize failure can carry
-            # secrets from the connection (e.g. an oauth-authenticated
-            # request's URL or headers surfacing in the exception message).
+            # DEBUG, not ERROR, for the same secret-leak reason as the
+            # handlers above. This outer handler mostly catches
+            # _load_server_tools_bounded's wall-clock TimeoutError (a
+            # fixed-format message with no secret) or a genuine bug escaping
+            # the loop -- per-server session/initialize/list-tools failures
+            # for direct transports are handled, and logged, inside
+            # _load_direct_mcp_tools's retry loop instead. Opt-in: set
+            # XAGENT_LOG_LEVEL=DEBUG (or run with --debug) to capture it.
             logger.debug(
                 "MCP server load failure detail for server %s",
                 server_name,

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1480,10 +1480,16 @@ async def load_mcp_tools_as_agent_tools(
                     )
                 except Exception as e:
                     error_type = type(e).__name__
+                    # exc_info so the actual message and traceback survive in
+                    # logs -- without it, only the exception's class name
+                    # (e.g. "AttributeError") is recorded, which identifies
+                    # that something broke but not where, forcing a second
+                    # reproduction just to see the message.
                     logger.error(
                         "Failed to list sandboxed MCP tools from server %s (%s)",
                         server_name,
                         error_type,
+                        exc_info=True,
                     )
                     failures.append(
                         MCPServerLoadFailure(
@@ -1550,10 +1556,14 @@ async def load_mcp_tools_as_agent_tools(
                 if isinstance(e, TimeoutError)
                 else MCPFailurePhase.SESSION_START
             )
+            # exc_info: see the sandboxed-load handler above for why the
+            # message/traceback, not just the exception class name, needs
+            # to survive in logs.
             logger.error(
                 "Unexpected failure loading tools from MCP server %s (%s)",
                 server_name,
                 error_type,
+                exc_info=True,
             )
             failures.append(
                 MCPServerLoadFailure(

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -171,6 +171,34 @@ async def test_mcp_loader_classifies_direct_failure_phase(
 
 
 @pytest.mark.asyncio
+async def test_mcp_loader_direct_retry_exhaustion_logs_debug_traceback(
+    monkeypatch, caplog
+):
+    # Companion to test_mcp_loader_classifies_direct_failure_phase above:
+    # that test pins WARNING and checks no secret leaks into the always-on
+    # log; this one pins DEBUG and checks the opt-in traceback is actually
+    # there once retries are exhausted -- the retry loop's final attempt
+    # falls through to a silent `else` branch otherwise, so this is the only
+    # place that failure detail is ever logged for a direct-transport server.
+    @asynccontextmanager
+    async def fake_create_session(_connection):
+        raise ValueError("boom")
+        yield  # pragma: no cover - unreachable, satisfies asynccontextmanager
+
+    monkeypatch.setattr(mcp_adapter_module, "create_session", fake_create_session)
+    monkeypatch.setattr(mcp_adapter_module.asyncio, "sleep", AsyncMock())
+    caplog.set_level("DEBUG")
+
+    result = await load_mcp_tools_as_agent_tools(
+        {"broken": {"transport": "stdio", "command": "python", "args": []}}
+    )
+
+    assert len(result.failures) == 1
+    assert result.failures[0].attempts == 3
+    assert "ValueError: boom" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_mcp_loader_reports_no_tools(monkeypatch):
     class FakeSession:
         async def initialize(self):

--- a/tests/core/tools/test_mcp_sandbox_integration.py
+++ b/tests/core/tools/test_mcp_sandbox_integration.py
@@ -142,6 +142,13 @@ class TestLoadMcpToolsAsAgentTools:
 
     @pytest.mark.asyncio
     async def test_sandbox_list_failure_is_preserved_without_secret(self, caplog):
+        # Pinned below default: the sandboxed-load path also emits a DEBUG
+        # traceback (test_sandbox_list_failure_debug_traceback_is_opt_in
+        # below), which would otherwise make this secret-safety assertion
+        # fail under an ambient DEBUG log level (e.g. `pytest -o
+        # log_level=DEBUG`) for a reason unrelated to what it actually
+        # guards: the always-on ERROR log staying class-name-only.
+        caplog.set_level("WARNING")
         connection: Connection = {
             "transport": "stdio",
             "command": "npx",
@@ -165,6 +172,30 @@ class TestLoadMcpToolsAsAgentTools:
         assert result.failures[0].error_type == "RuntimeError"
         assert "planted-sandbox-list-secret" not in repr(result)
         assert "planted-sandbox-list-secret" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_sandbox_list_failure_debug_traceback_is_opt_in(self, caplog):
+        # Companion to the test above: pins the other half of the two-layer
+        # contract -- opting into DEBUG surfaces the full traceback, so
+        # reproducing a failure with XAGENT_LOG_LEVEL=DEBUG (or --debug)
+        # actually captures it rather than silently getting nothing more
+        # than the always-on ERROR log already gives.
+        caplog.set_level("DEBUG")
+        connection: Connection = {
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["demo"],
+        }
+
+        with patch(
+            "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper.list_tools_in_sandbox",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            await load_mcp_tools_as_agent_tools(
+                {"demo": connection}, sandbox=MagicMock()
+            )
+
+        assert "RuntimeError: boom" in caplog.text
 
     @pytest.mark.asyncio
     async def test_sandbox_wrap_failure_preserves_other_wrapped_tools(self):


### PR DESCRIPTION
## Summary
- Sandboxed/direct MCP tool-listing failures were logged with only the exception's class name, discarding the message and traceback.
- This blocks root-causing intermittent/environment-specific failures (e.g. the chrome-devtools connector's `sandbox_list_tools` failure phase) without reproducing them again under closer instrumentation.
- Two-layer logging: the always-on `logger.error` calls stay class-name-only (some of these errors can carry secrets from the connection, e.g. sandbox stderr or an oauth request's URL/headers — see `test_sandbox_list_failure_is_preserved_without_secret`). A new opt-in `logger.debug(..., exc_info=True)` alongside each one exposes the full traceback when `XAGENT_LOG_LEVEL=DEBUG` (or `--debug`) is set.
- Covers three failure sites: the sandboxed list-tools path, the direct-path retry loop's final-attempt exhaustion (previously silent), and the outer escape handler (mainly `_load_server_tools_bounded`'s wall-clock timeout).

## Test plan
- [x] `ruff check` / `ruff format` / `isort` / `mypy` (via pre-commit hooks on each commit)
- [x] New tests pin the opt-in DEBUG contract: `test_sandbox_list_failure_debug_traceback_is_opt_in`, `test_mcp_loader_direct_retry_exhaustion_logs_debug_traceback` — both verified to fail against the pre-PR baseline and pass with the fix
- [x] Existing secret-safety tests still pass, including under an ambient `-o log_level=DEBUG` (verified `test_sandbox_list_failure_is_preserved_without_secret`'s pinned `caplog.set_level("WARNING")` prevents a false failure there)