### PR TITLE
fix(steps): close planning step on dag_execute_end failure

### DIFF
--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -86,19 +86,28 @@ Pairing rule:
         entry. ``dag_execute_end`` instead reaches into whichever
         ``dag_execution`` planning key is currently open and closes it
         as ``"failed"`` -- but only when ``data['status']`` is the
-        literal string ``"failed"``. ``"interrupted"``,
-        ``"waiting_for_user"``, ``"completed"``, a missing key, and
-        ``None`` all leave the planning step running instead, the
-        opposite fallback direction from ``dag_step_*`` above (which
-        cannot be reused here for exactly that reason). A plan-
+        literal string ``"failed"``. This branch only has a key left
+        to close while plan generation itself is still open: the
+        ``dag_execution`` ``executing``-phase event already clears
+        the key the moment plan generation finishes, so an
+        ``"interrupted"`` or ``"waiting_for_user"`` round reported
+        from that point on (during step execution) can't reach back
+        here. Only a round that is interrupted (or reports
+        ``"waiting_for_user"``, ``"completed"``, a missing key, or
+        ``None``) *during plan generation* leaves the planning step
+        running, the opposite fallback direction from ``dag_step_*``
+        above (which cannot be reused here for exactly that reason). A plan-
         generation exception that escapes ``DAGPattern.run()``
         before it ever calls ``on_pattern_end`` emits no
         ``dag_execute_end`` at all, so the planning step is left
         running indefinitely too -- out of scope for this module.
         ``dag_execute_start`` clears a stale open planning key left by
-        a prior ``DAGPattern.run()`` invocation that never reached a terminal
-        event, so a later round's failure can't reach back and close
-        an unrelated stranded step.
+        a prior round that ended with any non-``"failed"`` status
+        (typically ``"interrupted"`` -- that round did reach a
+        terminal ``dag_execute_end``, it just wasn't the literal
+        ``"failed"`` this module closes on), or whose terminal event
+        was itself dropped, so a later round's failure can't reach
+        back and close an unrelated stranded step.
 
     Orphan ends (end with no matching start) are dropped -- they
     represent malformed data and the SDK contract is "every step has
@@ -148,8 +157,11 @@ class PublicStepProjector:
     """Incremental folding state machine: trace events -> public steps.
 
     Holds all the folding state a fold needs -- the pending
-    (start-seen, end-not-yet-seen) pairing table and the ``dag_plan_*``
-    counter/open-key used to disambiguate replan. The batch driver
+    (start-seen, end-not-yet-seen) pairing table, the ``dag_plan_*``
+    counter/open-key used to disambiguate replan, and the
+    ``dag_execution`` counter/open-key (``_dag_execution_counter`` /
+    ``_open_dag_execution_key``) that tracks the same planning phase
+    from its second, independent event source. The batch driver
     (``map_trace_events_to_public_steps``) keeps none of its own: it
     builds one instance and reads back the result. Holding this state
     on an instance is what lets a caller feed a live event stream one
@@ -484,8 +496,11 @@ class PublicStepProjector:
         # the module docstring's "Pairing rule" section for the full
         # rationale. =====
         if event_type == "dag_execute_start":
-            # Drop a stale open key from a prior DAGPattern.run() round that
-            # never reached a terminal event; the stale pending step
+            # Drop a stale open key left by a prior round that ended with
+            # any non-"failed" status (typically "interrupted" -- that
+            # round did reach a terminal dag_execute_end, it just wasn't
+            # the literal "failed" this module closes on), or whose
+            # terminal event was itself dropped. The stale pending step
             # itself is left as-is (still "running").
             self._open_dag_execution_key = None
             return []

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -19,10 +19,11 @@ Background:
                               meaningfully different from a flat tool)
       - ``message``          (one user or assistant message)
 
-    Everything else (llm_call_*, memory_*, dag_execute_*, react_task_*,
-    react_step_*, visualization_update, task_completion, trace_error,
+    Everything else (llm_call_*, memory_*, react_task_*, react_step_*,
+    visualization_update, task_completion, trace_error,
     action_*_compact) is **intentionally not exposed** so the SDK
-    surface can evolve without breaking clients.
+    surface can evolve without breaking clients. ``dag_execute_*`` is
+    a partial exception -- see the "Pairing rule" section below.
 
 Pure-function design:
 
@@ -80,6 +81,24 @@ Pairing rule:
         when both appear in the same event stream.
       - ``skill_select_*`` events pair on ``task_id`` (single skill
         selection phase per task).
+      - ``dag_execute_*`` events carry the whole DAGPattern's lifecycle,
+        not a single step's, so they never open their own pending
+        entry. ``dag_execute_end`` instead reaches into whichever
+        ``dag_execution`` planning key is currently open and closes it
+        as ``"failed"`` -- but only when ``data['status']`` is the
+        literal string ``"failed"``. ``"interrupted"``,
+        ``"waiting_for_user"``, ``"completed"``, a missing key, and
+        ``None`` all leave the planning step running instead, the
+        opposite fallback direction from ``dag_step_*`` above (which
+        cannot be reused here for exactly that reason). A plan-
+        generation exception that escapes ``DAGPattern.run()``
+        before it ever calls ``on_pattern_end`` emits no
+        ``dag_execute_end`` at all, so the planning step is left
+        running indefinitely too -- out of scope for this module.
+        ``dag_execute_start`` clears a stale open planning key left by
+        a prior ``DAGPattern.run()`` invocation that never reached a terminal
+        event, so a later round's failure can't reach back and close
+        an unrelated stranded step.
 
     Orphan ends (end with no matching start) are dropped -- they
     represent malformed data and the SDK contract is "every step has
@@ -460,10 +479,42 @@ class PublicStepProjector:
             # Other phases (e.g. completion_assessment): not exposed.
             return []
 
-        # Everything else (llm_call_*, memory_*, dag_execute_*,
-        # react_task_*, react_step_*, visualization_update,
-        # task_completion, trace_error, action_*_compact) -- not
-        # exposed in the SDK contract. Silently drop.
+        # ===== dag_execute_start / dag_execute_end: close an open
+        # dag_execution planning step on outright plan failure. See
+        # the module docstring's "Pairing rule" section for the full
+        # rationale. =====
+        if event_type == "dag_execute_start":
+            # Drop a stale open key from a prior DAGPattern.run() round that
+            # never reached a terminal event; the stale pending step
+            # itself is left as-is (still "running").
+            self._open_dag_execution_key = None
+            return []
+        if event_type == "dag_execute_end":
+            if self._open_dag_execution_key is None:
+                return []  # No open planning step to close.
+            # Deliberately not _terminal_status_from_event: that
+            # helper's fallback direction (anything but "failed"
+            # becomes "completed") is the opposite of what this branch
+            # needs -- only the literal "failed" may close the step.
+            if _data_get(event, "status") != "failed":
+                return []
+            finalized = _finalize_pending(
+                self._pending,
+                self._finished,
+                ("thinking", self._open_dag_execution_key),
+                end_event=event,
+                status="failed",
+                # No extra_data_fn: data['result'] is the DAG
+                # pattern's full output and must not reach the public
+                # surface. Keeps data == {"phase": "planning"}.
+            )
+            self._open_dag_execution_key = None
+            return [finalized] if finalized is not None else []
+
+        # Everything else (llm_call_*, memory_*, react_task_*,
+        # react_step_*, visualization_update, task_completion,
+        # trace_error, action_*_compact) -- not exposed in the SDK
+        # contract. Silently drop.
         return []
 
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1178,9 +1178,14 @@ async def get_chat_task_steps(
     events not on the public allow-list (LLM calls, memory ops,
     visualization ticks, most DAG bookkeeping) are silently dropped --
     intentionally, so internal trace evolution doesn't break the SDK
-    contract; the exception is dag_execution's planning/replanning/
+    contract; the exceptions are dag_execution's planning/replanning/
     executing phase transitions, which project onto a planning
-    thinking step.
+    thinking step, and a literal ``status="failed"`` on
+    dag_execute_end, which closes a still-open planning step as
+    ``failed`` instead of leaving it running forever (a plan-generation
+    exception that escapes DAGPattern.run() before it emits
+    dag_execute_end still leaves the planning step running -- see
+    ``_step_mapping.py``'s module docstring).
 
     Args:
         task_id: Path parameter; the target task's primary key.

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -687,7 +687,13 @@ class PublicStep(BaseModel):
             "state can still contain running steps: interrupted or "
             "cancelled steps never get an end event, so terminal "
             "state is judged from the task's own status, not from "
-            "the absence of running steps."
+            "the absence of running steps. A planning ('thinking' with "
+            "data.phase='planning') step follows the same terminal-"
+            "event rule: it is marked failed only when the DAG "
+            "pattern's own run reports a literal status='failed'; an "
+            "interrupted or waiting_for_user outcome, or a plan-"
+            "generation error that never reaches a terminal event at "
+            "all, leaves it running instead."
         ),
     )
     started_at: datetime = Field(

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -689,11 +689,17 @@ class PublicStep(BaseModel):
             "state is judged from the task's own status, not from "
             "the absence of running steps. A planning ('thinking' with "
             "data.phase='planning') step follows the same terminal-"
-            "event rule: it is marked failed only when the DAG "
-            "pattern's own run reports a literal status='failed'; an "
-            "interrupted or waiting_for_user outcome, or a plan-"
-            "generation error that never reaches a terminal event at "
-            "all, leaves it running instead."
+            "event rule only while plan generation is still in "
+            "flight: it is marked failed when the DAG pattern's own "
+            "run reports a literal status='failed' during that "
+            "window, and it is left running if plan generation is "
+            "itself interrupted, reports waiting_for_user, or raises "
+            "an error that never reaches a terminal event, before "
+            "that window closes. Once plan generation finishes, the "
+            "executing-phase signal closes this step as completed "
+            "immediately, so an interrupted run or a wait for user "
+            "input that happens afterward, during step execution, "
+            "can no longer affect it."
         ),
     )
     started_at: datetime = Field(

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -1098,6 +1098,19 @@ _PROJECTOR_EQUIVALENCE_CASES: Dict[str, List[SimpleNamespace]] = {
             timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
         ),
     ],
+    "dag_execution_planning_failure": [
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "dag_execute_end",
+            task_id="t1",
+            data={"status": "failed"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+    ],
     "dag_plan_and_dag_execution_coexist": [
         _ev(
             "dag_plan_start",
@@ -1511,3 +1524,113 @@ def test_dag_plan_and_dag_execution_coexist_without_id_collision():
     ids = {s["id"] for s in steps}
     assert len(ids) == 2
     assert ids == {"thinking:plan:t1:1", "thinking:planning:t1:1"}
+
+
+# ===== dag_execute_end: planning failure closes an open planning step =====
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["failed", "interrupted", "waiting_for_user", "completed", "__missing__", None],
+)
+def test_dag_execute_end_only_failed_closes_open_planning_step(status):
+    """Only the literal string "failed" closes the open planning step;
+    every other observed value -- interrupted, waiting_for_user,
+    completed, a missing key, or None -- leaves it running. This is
+    the opposite fallback direction from _terminal_status_from_event,
+    which this branch does not reuse."""
+    start = _dag_exec_ev(
+        "planning",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    data = {} if status == "__missing__" else {"status": status}
+    end = _ev(
+        "dag_execute_end",
+        task_id="t1",
+        data=data,
+        timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+    )
+    steps = map_trace_events_to_public_steps([start, end])
+    assert len(steps) == 1
+    step = steps[0]
+    assert step["type"] == "thinking"
+    assert step["data"] == {"phase": "planning"}
+    if status == "failed":
+        assert step["status"] == "failed"
+        assert step["completed_at"] is not None
+    else:
+        assert step["status"] == "running"
+        assert step["completed_at"] is None
+
+
+def test_dag_execute_end_failed_data_is_phase_only():
+    """Anti-leak gate: dag_execute_end's data['result'] carries the
+    full DAG pattern output. The closed step's data must be exactly
+    {"phase": "planning"}, not a superset."""
+    start = _dag_exec_ev(
+        "planning",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    end = _ev(
+        "dag_execute_end",
+        task_id="t1",
+        data={
+            "status": "failed",
+            "result": {
+                "success": False,
+                "error": "plan validation failed",
+                "step_results": {"s1": {"output": "secret intermediate output"}},
+                "output": "should never leak",
+            },
+        },
+        timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+    )
+    steps = map_trace_events_to_public_steps([start, end])
+    assert len(steps) == 1
+    assert set(steps[0]["data"].keys()) == {"phase"}
+
+
+def test_dag_execute_end_without_open_planning_is_noop():
+    """No open planning step to close -- same orphan-end policy as
+    elsewhere in this module."""
+    events = [
+        _ev(
+            "dag_execute_end",
+            task_id="t1",
+            data={"status": "failed"},
+        )
+    ]
+    assert map_trace_events_to_public_steps(events) == []
+
+
+def test_dag_execute_start_clears_stale_open_planning_key():
+    """A fresh dag_execute_start clears any planning key left open by
+    a prior round that never reached a terminal event, so a failure
+    in the new round can't reach back and close the old round's
+    stranded planning step (left as-is, still "running")."""
+    round_one_start = _dag_exec_ev(
+        "planning",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    dag_execute_start_round_two = _ev(
+        "dag_execute_start",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+    )
+    round_two_failure = _ev(
+        "dag_execute_end",
+        task_id="t1",
+        data={"status": "failed"},
+        timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+    )
+    steps = map_trace_events_to_public_steps(
+        [round_one_start, dag_execute_start_round_two, round_two_failure]
+    )
+    # Round 1's planning step is still open/running -- the round 2
+    # failure must not have reached back and closed it.
+    assert len(steps) == 1
+    assert steps[0]["status"] == "running"
+    assert steps[0]["completed_at"] is None


### PR DESCRIPTION
## Why

When planning fails, the DAG pattern emits `dag_execute_end` with
`data['status'] == 'failed'`, but the public step projector dropped the whole
`dag_execute_*` family — so the planning step stayed `running` forever on
`GET /v1/chat/tasks/{task_id}/steps`.

## What

The projector now consumes two events from that family. `dag_execute_end`
closes the open planning step as `failed` only when `data['status']` is the
literal `"failed"`; `interrupted`, `waiting_for_user`, `completed`, a missing
key, or `None` all leave it running — the rule stays: a step's status changes
only on an explicit terminal signal, and no signal leaves it running.
`dag_execute_start` clears a stale open-planning key from a prior
`DAGPattern.run()` round, so a later round's failure cannot reach back and
close an unrelated stranded step. The close attaches no extra data —
`dag_execute_end`'s `data['result']` carries the full DAG output and must not
reach the public surface, so the step's public `data` stays exactly
`{"phase": "planning"}`.

A plan-generation exception that escapes `DAGPattern.run()` before
`dag_execute_end` is emitted still leaves the planning step running: that path
emits no end event, matching the documented rule that a step without an end
event stays `running`.

## Verification

A parametrized test over six `data['status']` cases (only `failed` closes;
`interrupted`, `waiting_for_user`, `completed`, a missing key and `None` all
leave the step running); an orphan-end test pinning that a failure with no open
planning step is a no-op; a stale-key test proving a prior round's open step is
not closed by a later round's failure; a leak gate asserting the closed step's
public `data` keys equal exactly `{"phase"}` against an event carrying a full
`result`; and a planning-failure sequence added to the projector/batch
equivalence set, pinning the incremental and batch paths to the same output.
Full `tests/web/api/v1` suite green (364 passed).
