### PR TITLE
feat(interactions): classify why the answer fence missed

### DIFF
--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -2327,20 +2327,38 @@ def respond(
                     )
                     .first()
                 )
-                if fresh_command is not None and _matches_existing(
-                    fresh_command,
-                    actor_user_id=actor_user_id,
-                    kind=TaskCommandKind.RESUME,
-                    payload=command_payload,
-                ):
-                    return RespondReplayed(
-                        receipt=_respond_receipt(
-                            interaction=reread,
-                            task=task,
-                            command_db_id=int(fresh_command.id),
-                            idempotency_key=normalized_key,
+                if fresh_command is not None:
+                    # A command row under this exact idempotency key exists
+                    # now, even though step 5's pre-read (run before the
+                    # fence attempt) found none: the row that answered this
+                    # interaction was staged concurrently, in the same
+                    # window this call's own fence attempt lost. Whether
+                    # that command is this call's own request replaying, or
+                    # a different payload racing under the same reused key,
+                    # is exactly the question step 5's own two-way split
+                    # answers, so this reread applies the same test: a
+                    # payload match is a replay, a mismatch is
+                    # ``idempotency_key_reused`` (see step 5 above).
+                    if _matches_existing(
+                        fresh_command,
+                        actor_user_id=actor_user_id,
+                        kind=TaskCommandKind.RESUME,
+                        payload=command_payload,
+                    ):
+                        return RespondReplayed(
+                            receipt=_respond_receipt(
+                                interaction=reread,
+                                task=task,
+                                command_db_id=int(fresh_command.id),
+                                idempotency_key=normalized_key,
+                            )
                         )
-                    )
+                    increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
+                    return RespondConflict(reason="idempotency_key_reused")
+                # No command row exists under this key at all: some other,
+                # unrelated write answered this row (not one racing this
+                # call's own idempotency key), so there is nothing to
+                # replay or compare payloads against.
                 increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
                 return RespondConflict(reason="already_answered")
             if reread.status == "terminated":

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -2015,11 +2015,12 @@ def respond(
        requires the owner in person, so an admin acting on another user's
        task and a guest whose ``principal.user_id`` is not the owner's
        both reach it on PostgreSQL too, alongside SQLite's own concurrent
-       ownership change (see that predicate's own docstring). The reread
-       row's state is logged before the classification runs, because no
-       outcome variant carries those columns. ``rowcount > 1`` is a schema
-       invariant violation (``uq_task_interaction_active_slot``) and
-       raises.
+       ownership change and, for a guest, SQLite's own concurrent write to
+       ``agent_config["guest_id"]`` between step 2's read and the fence
+       (see that predicate's own docstring). The reread row's state is
+       logged before the classification runs, because no outcome variant
+       carries those columns. ``rowcount > 1`` is a schema invariant
+       violation (``uq_task_interaction_active_slot``) and raises.
     7. The Task CAS via ``apply_task_control_transition``, called with no
        ``expected_run_id`` / ``expected_state_version`` -- this function
        takes no caller-supplied optimistic-concurrency token, so neither of
@@ -2279,7 +2280,14 @@ def respond(
             # changed since step 4's read); without expiring first, the
             # ORM would hand this query's result back through the same
             # already-loaded, now-stale Python object instead of the fresh
-            # row this reread exists to see.
+            # row this reread exists to see. This has to expire the whole
+            # session, not just ``ir`` -- the classification below also
+            # reads ``task.status`` and ``task.run_id`` (the "active"
+            # branch further down), and those need refreshing too: without
+            # it, ``task.status`` would still read back step 2's own
+            # WAITING_FOR_USER value even after some other writer moved the
+            # task on, and a genuine ``run_ended`` miss would misclassify
+            # as an ownership miss (``not_task_principal``) instead.
             db.expire_all()
             reread = get(db, task_id=task_id, interaction_id=interaction_id)
             if reread is None:
@@ -2291,7 +2299,14 @@ def respond(
             # what it found costs no extra statement. The classification
             # below tells the *caller* which miss this was; this line tells
             # an *operator* what the row actually looked like, and the two
-            # are not the same information. No ``RespondOutcome`` variant
+            # are not the same information. The reason it hands back
+            # describes the row and task as this reread found them, not
+            # necessarily the exact condition that made the fence UPDATE's
+            # own WHERE clause fail to match: neither backend holds a lock
+            # across the gap between that UPDATE and this SELECT, so in
+            # principle the row could change again in between and the
+            # label would name whatever this reread actually saw, not the
+            # original miss. No ``RespondOutcome`` variant
             # carries ``active_slot``, ``terminal_reason``, ``run_id`` or
             # ``responder_identity``: ``Stale(run_superseded)`` names the
             # reason without naming the run, and ``Conflict
@@ -2362,13 +2377,22 @@ def respond(
                 increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
                 return RespondConflict(reason="already_answered")
             if reread.status == "terminated":
-                terminal_reason_map: dict[str, RespondStaleReason] = {
+                # No ``or ""`` fallback needed on the lookup key --
+                # ``ck_task_interaction_requests_terminal_pairs_status`` is
+                # a biconditional (``status = 'terminated'`` iff
+                # ``terminal_reason IS NOT NULL``), so a row that reaches
+                # this branch is guaranteed by the database itself to carry
+                # a non-``None`` ``terminal_reason``. The ``cast`` below is
+                # only for mypy's benefit (the mapped column's static type
+                # is ``str | None``); it asserts that guarantee, it does
+                # not substitute a runtime value the way ``or ""`` did.
+                terminal_stale_reasons: dict[str, RespondStaleReason] = {
                     "deadline_elapsed": "expired",
                     "run_superseded": "run_superseded",
                     "answered_via_legacy_resume": "answered_via_chat",
                 }
-                mapped_reason = terminal_reason_map.get(
-                    str(reread.terminal_reason or "")
+                mapped_reason = terminal_stale_reasons.get(
+                    cast(str, reread.terminal_reason)
                 )
                 if mapped_reason is None:
                     raise RuntimeError(
@@ -2385,16 +2409,23 @@ def respond(
                 # left that can have failed is
                 # ``_answer_fence_task_predicate``'s ownership conjunction
                 # -- which requires ``principal.user_id`` to be the task's
-                # owner on both backends. Three callers land here: an admin
+                # owner on both backends. Four callers land here: an admin
                 # answering someone else's task, a guest whose bindings
                 # match but whose ``principal.user_id`` is not the owner's
                 # (both of which pass step 3's Python authorization and
                 # fail only at the write point), and, on SQLite alone,
-                # ownership changing between step 2's read and this
-                # statement. See ``_answer_fence_task_predicate``'s own
-                # docstring for which of its six terms are re-asserted in
-                # SQL and which are checked once in Python.
+                # ``Task.user_id`` changing between step 2's read and this
+                # statement, or, also SQLite-only, a guest's
+                # ``agent_config["guest_id"]`` changing in that same window.
+                # See ``_answer_fence_task_predicate``'s own docstring for
+                # which of its six terms are re-asserted in SQL and which
+                # are checked once in Python.
                 if task.status != TaskStatus.WAITING_FOR_USER:
+                    # Covers every other ``TaskStatus`` member: PENDING,
+                    # RUNNING, PAUSED, COMPLETED, FAILED -- five non-waiting
+                    # states this one comparison treats alike, without
+                    # distinguishing which of them the task actually moved
+                    # to.
                     return RespondStale(reason="run_ended")
                 if task.run_id != reread.run_id:
                     return RespondStale(reason="foreign_run")

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -51,13 +51,14 @@ discriminated unions; the ``create()`` typed seam (validates and returns,
 does not stage a row); ``get()``/``list_active()``; the three-tier
 compatibility materialization view; the answer fence and its active-row
 predicate; ``respond()``'s own call body (validation, authorization, the
-idempotency pre-read, anchor resolution, the answer fence, the task
-control-state transition, staging the resume command, and committing or
-reconciling an ambiguous acknowledgment -- this delivery classifies a
-staging conflict and reconciles an ambiguous commit against the durable
-graph, and still reports an unresolved fence miss as
-``RespondOutcomeUnknown`` rather than classifying it, which is a separate
-follow-up build); and the response-conflict counter
+idempotency pre-read, anchor resolution, the answer fence and its
+zero-rowcount classification, the task control-state transition, staging
+the resume command, and committing or reconciling an ambiguous
+acknowledgment -- this delivery classifies why the fence missed,
+classifies a staging conflict, and reconciles an ambiguous commit against
+the durable graph, so ``RespondOutcomeUnknown`` is left reporting only a
+commit whose acknowledgment was lost and whose reconciliation could not
+confirm what landed); and the response-conflict counter
 (``COUNTER_LIFECYCLE_RESPONSE_CONFLICT``).
 
 Not delivered here, and named so a reader does not go looking for them in
@@ -554,8 +555,15 @@ RespondUnauthorizedReason = Literal["not_task_principal"]
 RespondUnavailableReason = Literal[
     "task_missing", "interaction_missing", "checkpoint_unavailable"
 ]
-RespondConflictReason = Literal["idempotency_key_reused"]
-RespondStaleReason = Literal["anchor_dangling"]
+RespondConflictReason = Literal["already_answered", "idempotency_key_reused"]
+RespondStaleReason = Literal[
+    "expired",
+    "run_superseded",
+    "answered_via_chat",
+    "run_ended",
+    "foreign_run",
+    "anchor_dangling",
+]
 
 
 @dataclass(frozen=True)
@@ -596,27 +604,31 @@ class RespondStale:
 @dataclass(frozen=True)
 class RespondOutcomeUnknown:
     """A call this function could not resolve to one of the specific
-    outcomes above, for either of two reasons this build does not further
-    distinguish: the answer fence's UPDATE matched zero rows and this
-    build does not classify why (step 6 -- a future delivery may reread
-    and classify that miss the way the fence classification build does),
-    or committing raised and the durable-graph reconciliation this build
-    runs afterward could not confirm the write landed on every one of its
-    three attempts (step 9). Step 8's staging race is no longer one of
-    them: both of its doors are classified into ``Replayed`` or
-    ``Conflict`` now. Not an exception this service lets escape -- a
-    stable, typed result a caller can act on (e.g. surface "we could not
-    confirm this went through" rather than crash).
+    outcomes above, for the one reason that still reaches it: committing
+    raised, and the durable-graph reconciliation this build runs
+    afterward could not confirm the write landed on every one of its
+    three attempts (step 9) -- the acknowledgment could have been lost
+    after the server applied the write, and reading the graph back did
+    not settle it either way, so this build reports the ambiguity rather
+    than guessing. Neither of the other two races arrives here any more.
+    The answer fence's UPDATE matching zero rows (step 6) is *not* one of
+    them: this build rereads the row and classifies every such miss into
+    a specific outcome. Step 8's staging race is not one either: both of
+    its doors are classified into ``Replayed`` or ``Conflict`` now. Not an
+    exception this service lets escape -- a stable, typed result a caller
+    can act on (e.g. surface "we could not confirm this went through"
+    rather than crash).
 
-    Retrying under the same idempotency key resolves the second reason and
-    not the first, and a caller should not be told otherwise. A retry
+    Retrying under the same idempotency key resolves every reason that
+    still reaches this outcome, and that is now the whole set. A retry
     after an ambiguous commit finds the command this call staged and
-    returns ``Replayed``. A retry after a fence miss re-evaluates the same
-    predicate against the same row and misses again: a terminated,
-    superseded, foreign-run, or foreign-owned row stays that way, so the
-    second ``OutcomeUnknown`` is as final as the first. Step 6 logs the
-    reread row's state for that reason -- until the fence classification
-    build lands, that log line is the only place the distinction exists.
+    returns ``Replayed``. What a retry could never have clarified on its
+    own is a fence miss -- a terminated, superseded, foreign-run, or
+    foreign-owned row stays that way and misses again -- but that case no
+    longer lands on this outcome: step 6 hands the caller the specific
+    reason directly, and its own warning log records the reread row state
+    (``active_slot``, ``terminal_reason``, ``run_id``,
+    ``responder_identity``) that no outcome variant carries.
     """
 
 
@@ -1609,15 +1621,21 @@ def _respond_receipt(
     ``principal.identity_string()`` value, so the column and the local are
     equal by the fence write's own semantics, not by coincidence.
 
-    Two callers, each with its own precondition for why the row it hands in
-    is already answered. ``respond()``'s idempotent-replay pre-read branch
-    (step 5) calls this on a row it found by this call's own idempotency
-    key -- a staged RESUME command this service itself committed in some
-    earlier transaction alongside the answer fence UPDATE, which implies an
-    answered row. ``_verify_respond_durable_graph`` calls this only after
-    its own three checks already confirmed the row it is holding matches:
-    ``status == "answered"``, the answering identity, and the canonical
-    submitted payload. Either way, the paired CHECK constraints
+    Three callers, each with its own precondition for why the row it hands
+    in is already answered. ``respond()``'s idempotent-replay pre-read
+    branch (step 5) calls this on a row it found by this call's own
+    idempotency key -- a staged RESUME command this service itself
+    committed in some earlier transaction alongside the answer fence
+    UPDATE, which implies an answered row. ``respond()``'s fence-miss
+    classification (step 6) calls it on the row its own reread just read
+    back as ``status == "answered"``, paired with a command row found
+    under this call's own idempotency key whose payload matches -- the
+    same two facts the pre-read branch stands on, established one
+    statement earlier instead of before the fence attempt.
+    ``_verify_respond_durable_graph`` calls this only after its own three
+    checks already confirmed the row it is holding matches: ``status ==
+    "answered"``, the answering identity, and the canonical submitted
+    payload. In all three cases, the paired CHECK constraints
     (``ck_task_interaction_requests_responded_at_pairs_status`` and
     ``ck_task_interaction_requests_responder_pairs_responded_at``) make an
     answered row with a NULL ``responded_at`` or ``responder_identity``
@@ -1988,16 +2006,20 @@ def respond(
        to a legacy scan on failure (see that resolver's own docstring for
        why).
     6. The answer fence UPDATE. ``rowcount == 1`` continues; ``rowcount == 0``
-       rereads the interaction row only to confirm it did not disappear out
-       from under this transaction's own row lock, then reports
-       ``OutcomeUnknown`` without further classifying why the fence missed
-       (a fine-grained classification -- already-answered replay/conflict,
-       three terminated reasons, wrong task state, foreign run, or an
-       ownership miss, reachable on both backends (see
-       ``_answer_fence_task_predicate``) -- is not delivered in this build);
-       ``rowcount > 1``
-       is a schema invariant violation (``uq_task_interaction_active_slot``)
-       and raises.
+       rereads the interaction row -- which also confirms it did not
+       disappear out from under this transaction's own row lock -- and
+       classifies the miss: already-answered replay/conflict, three
+       terminated reasons, wrong task state, foreign run, or an ownership
+       miss. That last one is reachable on both backends, not only on
+       SQLite: ``_answer_fence_task_predicate``'s ``Task.user_id`` term
+       requires the owner in person, so an admin acting on another user's
+       task and a guest whose ``principal.user_id`` is not the owner's
+       both reach it on PostgreSQL too, alongside SQLite's own concurrent
+       ownership change (see that predicate's own docstring). The reread
+       row's state is logged before the classification runs, because no
+       outcome variant carries those columns. ``rowcount > 1`` is a schema
+       invariant violation (``uq_task_interaction_active_slot``) and
+       raises.
     7. The Task CAS via ``apply_task_control_transition``, called with no
        ``expected_run_id`` / ``expected_state_version`` -- this function
        takes no caller-supplied optimistic-concurrency token, so neither of
@@ -2080,9 +2102,18 @@ def respond(
       ``stage_task_command``. Neither is an ``IntegrityError`` subclass, so
       step 8's catch does not see them, and both mean a precondition this
       function already checked has changed underneath it.
-    - ``RuntimeError`` from the two structural invariants asserted above:
-      a fence rowcount above one, and an interaction row that disappeared
-      while this transaction held the tasks row lock.
+    - ``RuntimeError`` from the five structural invariants asserted above:
+      a fence rowcount above one, an interaction row that disappeared
+      while this transaction held the tasks row lock, a
+      ``RACED_DUPLICATE`` classification arriving from step 8 with no
+      raced projection attached, and -- both added by step 6's
+      classification -- a reread row that is ``terminated`` under a
+      ``terminal_reason`` outside the three this service maps, or one
+      whose ``status`` is a value this module does not know. The last two
+      are deliberately loud rather than folded into ``OutcomeUnknown``:
+      each means the interaction table grew a state this classification
+      has not been taught, and answering "we could not confirm this went
+      through" would hide a schema change behind a normal-looking result.
 
     On every one of those paths the ``finally`` below retires the session,
     which rolls back an uncommitted transaction, so an escaping exception
@@ -2248,12 +2279,7 @@ def respond(
             # changed since step 4's read); without expiring first, the
             # ORM would hand this query's result back through the same
             # already-loaded, now-stale Python object instead of the fresh
-            # row this reread exists to see. This build does not classify
-            # why the fence missed -- a fine-grained classification against
-            # the reread row's status is not delivered here -- it only
-            # confirms the row did not disappear out from under this
-            # transaction's own row lock, then reports the miss as
-            # ``OutcomeUnknown`` (see that outcome's own docstring).
+            # row this reread exists to see.
             db.expire_all()
             reread = get(db, task_id=task_id, interaction_id=interaction_id)
             if reread is None:
@@ -2262,16 +2288,24 @@ def respond(
                     "while this transaction held the tasks row lock"
                 )
             # The reread above already has the row in hand, so recording
-            # what it found costs no extra statement. Without this line a
-            # fence miss is the one exit a retry cannot clarify on its
-            # own: the caller is told ``OutcomeUnknown``, and a retry
-            # against a terminated, superseded, or foreign-owned row
-            # produces the same miss and the same ``OutcomeUnknown`` every
-            # time, so no amount of retrying ever reveals which of them it
-            # was -- unlike the commit-exception door below, where a retry
-            # under the same idempotency key resolves the ambiguity by
-            # itself. The classification this build does not compute is
-            # exactly the set of fields logged here.
+            # what it found costs no extra statement. The classification
+            # below tells the *caller* which miss this was; this line tells
+            # an *operator* what the row actually looked like, and the two
+            # are not the same information. No ``RespondOutcome`` variant
+            # carries ``active_slot``, ``terminal_reason``, ``run_id`` or
+            # ``responder_identity``: ``Stale(run_superseded)`` names the
+            # reason without naming the run, and ``Conflict
+            # (already_answered)`` names neither who answered nor when. A
+            # fence miss is also still the one exit a retry cannot clarify
+            # on its own -- a terminated, superseded, or foreign-owned row
+            # produces the same miss every time, unlike the commit-exception
+            # door below, where a retry under the same idempotency key
+            # resolves the ambiguity by itself -- so the row state at the
+            # moment of the miss is worth a line whether or not the caller
+            # got a specific reason back. Logged before the classification
+            # runs so that the two ``RuntimeError`` exits below (an
+            # unrecognized ``terminal_reason``, an unrecognized ``status``)
+            # are covered by it too.
             logger.warning(
                 "answer fence matched zero rows for interaction %s on task "
                 "%s; reread status=%s active_slot=%s terminal_reason=%s "
@@ -2284,7 +2318,74 @@ def respond(
                 reread.run_id,
                 reread.responder_identity,
             )
-            return RespondOutcomeUnknown()
+            if reread.status == "answered":
+                fresh_command = (
+                    db.query(TaskExecutionCommand)
+                    .filter(
+                        TaskExecutionCommand.task_id == task_id,
+                        TaskExecutionCommand.command_id == normalized_key,
+                    )
+                    .first()
+                )
+                if fresh_command is not None and _matches_existing(
+                    fresh_command,
+                    actor_user_id=actor_user_id,
+                    kind=TaskCommandKind.RESUME,
+                    payload=command_payload,
+                ):
+                    return RespondReplayed(
+                        receipt=_respond_receipt(
+                            interaction=reread,
+                            task=task,
+                            command_db_id=int(fresh_command.id),
+                            idempotency_key=normalized_key,
+                        )
+                    )
+                increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
+                return RespondConflict(reason="already_answered")
+            if reread.status == "terminated":
+                terminal_reason_map: dict[str, RespondStaleReason] = {
+                    "deadline_elapsed": "expired",
+                    "run_superseded": "run_superseded",
+                    "answered_via_legacy_resume": "answered_via_chat",
+                }
+                mapped_reason = terminal_reason_map.get(
+                    str(reread.terminal_reason or "")
+                )
+                if mapped_reason is None:
+                    raise RuntimeError(
+                        f"interaction {interaction_id} on task {task_id} is "
+                        f"terminated with an unrecognized terminal_reason "
+                        f"{reread.terminal_reason!r}"
+                    )
+                return RespondStale(reason=mapped_reason)
+            if reread.status == "active":
+                # Same order as the fence's own WHERE clause narrows: the
+                # task-level terms first, the ownership term last. Reaching
+                # the final return means the row is still live and the task
+                # is still waiting on this very run, so the only fence term
+                # left that can have failed is
+                # ``_answer_fence_task_predicate``'s ownership conjunction
+                # -- which requires ``principal.user_id`` to be the task's
+                # owner on both backends. Three callers land here: an admin
+                # answering someone else's task, a guest whose bindings
+                # match but whose ``principal.user_id`` is not the owner's
+                # (both of which pass step 3's Python authorization and
+                # fail only at the write point), and, on SQLite alone,
+                # ownership changing between step 2's read and this
+                # statement. See ``_answer_fence_task_predicate``'s own
+                # docstring for which of its six terms are re-asserted in
+                # SQL and which are checked once in Python.
+                if task.status != TaskStatus.WAITING_FOR_USER:
+                    return RespondStale(reason="run_ended")
+                if task.run_id != reread.run_id:
+                    return RespondStale(reason="foreign_run")
+                return RespondUnauthorized(reason="not_task_principal")
+            raise RuntimeError(
+                f"interaction {interaction_id} on task {task_id} has an "
+                f"unrecognized status {reread.status!r} after a zero-rowcount "
+                "answer fence"
+            )
 
         # No expected_run_id/expected_state_version to pass: this function
         # takes no caller-supplied optimistic-concurrency token, so

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -9,41 +9,41 @@ extracted from and tested alongside ``public_chat_access.py``) and the
 ``test_task_interaction_service_create_gate.py``).
 
 RespondOutcome's failure matrix, and what this delivery does and does not
-do with it: this build's ``RespondConflictReason``/``RespondStaleReason``
-``Literal``s stay narrower than a build that also classifies why the
-answer fence's UPDATE matched zero rows would need (see
-``RespondOutcomeUnknown``'s own docstring in
-``task_interaction_service.py``) -- six such triggering scenarios still
-collapse onto this build's single ``(OutcomeUnknown, None)`` pair, same as
-its conservative sibling. What this build restores over that sibling is
-steps 8 and 9. Step 8's staging race is classified through both of its
-doors: an ``IntegrityError`` through ``classify_task_command_conflict``,
-a ``created=False`` result through the ``payload_matches`` verdict
+do with it: this build classifies every zero-rowcount answer fence miss
+specifically (step 6 -- see ``respond()``'s own docstring), so the six
+triggering scenarios its conservative sibling collapsed onto
+``(OutcomeUnknown, None)`` now split back out into five distinct ``Stale``
+reasons plus ``Conflict(already_answered)``, and the guest whose
+fence-level mismatch that sibling could not label now reports
+``Unauthorized(not_task_principal)``. Steps 8 and 9 are classified as
+well. Step 8's staging race is classified through both of its doors: an
+``IntegrityError`` through ``classify_task_command_conflict``, a
+``created=False`` result through the ``payload_matches`` verdict
 ``stage_task_command`` already computed, and a winner's row carrying this
 call's own payload is a ``Replayed`` while a mismatched one is a
 ``Conflict``. Step 9's commit exception is reconciled against the durable
-graph in a fresh session before falling back to ``OutcomeUnknown``. So
-this build's four ``OutcomeUnknown``-producing cells are a
-still-unclassified fence miss, a guest whose fence-level mismatch this
-build still cannot label, and two durable-graph reconciliation failures
-(an ambiguous commit with nothing in the graph to find, and one that
-lands under a different identity) -- not the staging and commit
-shortcuts its conservative sibling used. The matrix
-below enumerates this build's own 29 triggering cells, producing 14
-distinct (outcome type, reason) pairs -- fewer than 29 because several
-cells share a pair (six "principal does not own this task" cells all
+graph in a fresh session before falling back to ``OutcomeUnknown``. So the
+only ``OutcomeUnknown``-producing cells left are the two durable-graph
+reconciliation failures: an ambiguous commit with nothing in the graph to
+find, and one that lands under a different identity. The matrix
+below enumerates this build's own 36 triggering cells, producing 20
+distinct (outcome type, reason) pairs -- fewer than 36 because several
+cells share a pair (eight "principal does not own this task" cells all
 produce ``(RespondUnauthorized, not_task_principal)``; three "same
 idempotency key, different actor" cells all produce ``(RespondConflict,
-idempotency_key_reused)``; four distinct triggers collapse onto
-``(OutcomeUnknown, None)``; one cell, kind/version validation, is
-parametrized over two reasons on its own). The full cell-to-pair mapping:
+idempotency_key_reused)``; two "the task is no longer waiting" cells both
+produce ``(RespondStale, run_ended)``; two distinct triggers collapse
+onto ``(OutcomeUnknown, None)``; one cell, kind/version validation, is
+parametrized over two reasons on its own). ``respond()`` takes no
+caller-supplied optimistic-concurrency token, so there is no cell for a
+stale one -- the ``Stale`` row has six pairs, not seven, for that reason.
+The full cell-to-pair mapping:
 
-    (Cell ids are this build's subset of the full matrix an end-to-end
-    delivery would enumerate; the gaps -- there is no C1 or S1-S5
-    here -- are cells only a build that classifies fence misses can
-    reach. Step 8's own ``UNRELATED`` classification is not a cell at
-    all: it re-raises rather than returning a ``RespondOutcome``, and its
-    test lives with the escape-surface tests instead.)
+    (The C1 and S1-S5 cells its conservative sibling left empty -- the
+    ones only a build that classifies fence misses can reach -- are
+    filled in here. Step 8's own ``UNRELATED`` classification is not a
+    cell at all: it re-raises rather than returning a ``RespondOutcome``,
+    and its test lives with the escape-surface tests instead.)
 
     OK1..OK4  -> (Accepted, None)      1 (4 cells share it -- the plain
                  accepted path, a commit that succeeds but whose
@@ -58,13 +58,15 @@ parametrized over two reasons on its own). The full cell-to-pair mapping:
                  it -- a non-dict ``values`` payload, and a dict
                  ``values`` payload that cannot be rendered as JSON)
     V5        -> (ValidationRejected, kind_version_mismatch)         1
-    A1..A6    -> (Unauthorized, not_task_principal)      1 (6 cells share
+    A1..A8    -> (Unauthorized, not_task_principal)      1 (8 cells share
                  it -- a user principal that does not own the task, the
                  authorization-before-idempotency ordering guard, a guest
                  principal on a non-matching task, a guest principal with
                  two populated entity-binding directions, an unknown
-                 principal kind, and a guest principal with zero
-                 populated entity-binding directions)
+                 principal kind, a guest principal with zero populated
+                 entity-binding directions, a guest whose bindings match
+                 but whose principal.user_id is not the owner's, and an
+                 ownership change racing the fence)
     U1        -> (Unavailable, task_missing)                         1
     U2        -> (Unavailable, interaction_missing)                  1
     U3        -> (Unavailable, checkpoint_unavailable)                1
@@ -72,19 +74,26 @@ parametrized over two reasons on its own). The full cell-to-pair mapping:
                  replay, a replay of an already-answered row whose resume
                  anchor was pruned before the retry, and a staging race
                  whose winner's row carries this call's own payload)
+    C1        -> (Conflict, already_answered)                        1
     C2..C4    -> (Conflict, idempotency_key_reused)      1 (3 cells share
                  it -- two "same key, different submitter" cells, and a
                  staging race whose winner's row carries a different
                  payload)
-    S6        -> (Stale, anchor_dangling)                             1
-    X1..X4    -> (OutcomeUnknown, None)      1 (4 cells share it -- a
-                 fence miss with no further classification, a guest whose
-                 fence-level mismatch this build cannot label, a commit
-                 whose durable-graph reconciliation never finds a landed
-                 write, and one whose reconciliation finds a landed row
-                 under a different identity)
+    S1        -> (Stale, expired)                                    1
+    S2        -> (Stale, run_superseded)                             1
+    S3        -> (Stale, answered_via_chat)                          1
+    S4,S4'    -> (Stale, run_ended)      1 (2 cells share it -- the task
+                 no longer waiting, and the overlap where it is also on a
+                 different run, which pins that the status guard runs
+                 before the run guard)
+    S5        -> (Stale, foreign_run)                                1
+    S6        -> (Stale, anchor_dangling)                            1
+    X1,X2     -> (OutcomeUnknown, None)      1 (2 cells share it -- a
+                 commit whose durable-graph reconciliation never finds a
+                 landed write, and one whose reconciliation finds a
+                 landed row under a different identity)
     -----------------------------------------------------------------
-    29 cells; 14 distinct pairs (12 single-reason cells + V1's own 2)
+    36 cells; 20 distinct pairs (18 single-reason cells + V1's own 2)
 
 The cell-by-cell tests this matrix implies, and the mapping meta-test that
 checks their coverage against the vocabulary, are both in this file now,
@@ -98,8 +107,8 @@ layers:
 | Assertion | Checks | Catches | Misses |
 |---|---|---|---|
 | Union-membership guard (this file, written) | ``RespondOutcome`` has exactly its eight known member classes | A variant added or removed without updating this list | Reason-level coverage |
-| Cell-by-cell tests (this file, written) | One test per of the 29 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
-| Mapping meta-test (this file, written) | Each of the 14 pairs is produced by >= 1 cell's test (12 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a seventh not_task_principal scenario) -- caught by review, not this meta-test |
+| Cell-by-cell tests (this file, written) | One test per of the 36 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
+| Mapping meta-test (this file, written) | Each of the 20 pairs is produced by >= 1 cell's test (18 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a ninth not_task_principal scenario) -- caught by review, not this meta-test |
 """
 
 from __future__ import annotations
@@ -1458,11 +1467,11 @@ def _answered_row_with_valid_anchor(
 ) -> int:
     """A row this service already answered in some earlier, successful call
     -- its resume anchor is still valid (nothing has pruned the checkpoint
-    it points at). A live anchor is still what makes the fence-miss tests
-    below reachable past step 5.5; the already-answered replay tests no
-    longer need it, since step 5's pre-read now recognizes the replay
-    before anchor resolution runs (the pruned-anchor replay test below is
-    what pins that down)."""
+    it points at). A live anchor is still what makes the fence-miss
+    classification tests below reachable past step 5.5; the
+    already-answered replay tests no longer need it, since step 5's
+    pre-read now recognizes the replay before anchor resolution runs (the
+    pruned-anchor replay test below is what pins that down)."""
 
     db = session_factory()
     try:
@@ -1481,6 +1490,40 @@ def _answered_row_with_valid_anchor(
         row.responded_at = now
         row.responder_identity = responder_identity
         row.request_idempotency_key = "prior-answer-key"
+        db.commit()
+        return int(row.id)
+    finally:
+        db.close()
+
+
+def _terminated_row_with_valid_anchor(
+    session_factory,
+    *,
+    task_id: int,
+    run_id: str,
+    terminal_reason: str,
+) -> int:
+    """The terminated counterpart to ``_answered_row_with_valid_anchor``:
+    a row some earlier writer closed out, its resume anchor still live so
+    the call under test reaches the fence (step 6) and misses there
+    rather than being turned away at step 5.5's anchor resolution."""
+
+    db = session_factory()
+    try:
+        trace_event_id = _make_trace_event(db, task_id=task_id, run_partition=run_id)
+        row = _make_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id=run_id,
+            resume_trace_event_id=trace_event_id,
+            resume_run_partition=run_id,
+        )
+        now = _now()
+        row.status = "terminated"
+        row.active_slot = None
+        row.terminal_reason = terminal_reason
+        row.terminated_at = now
+        row.request_idempotency_key = "terminated-row-key"
         db.commit()
         return int(row.id)
     finally:
@@ -1793,13 +1836,15 @@ def test_respond_rejects_a_guest_whose_bindings_match_but_principal_user_id_does
     principal.user_id`` term (present for both principal kinds, not only
     the guest-specific JSON check) is what refuses it, on both backends,
     since this is a plain mismatch present from the start, not a
-    concurrent change to catch only via SQLite's missing lock. The refusal
-    lands as a zero-rowcount fence miss, which this build reports as
-    ``OutcomeUnknown`` rather than the fine-grained ``Unauthorized`` a more
-    detailed classification would give it (see respond()'s own docstring,
-    step 6) -- the security property this test exists to pin (the guest
-    never gets an answer accepted) holds either way; only the label does
-    not."""
+    concurrent change to catch only via SQLite's missing lock.
+
+    The label comes from step 6's reread: the row is still ``active`` and
+    the task is still waiting on this same run, so the only fence term
+    left that can have failed is the ownership conjunction, and this build
+    reports that as ``Unauthorized(not_task_principal)`` rather than the
+    unlabelled ``OutcomeUnknown`` its conservative sibling gave it. The
+    security property this test exists to pin -- the guest never gets an
+    answer accepted -- held either way; only the label changed."""
 
     owner_id, task_id = _waiting_task(
         _respond_db,
@@ -1834,7 +1879,7 @@ def test_respond_rejects_a_guest_whose_bindings_match_but_principal_user_id_does
             envelope=_respond_envelope(),
         )
 
-        assert isinstance(outcome, svc.RespondOutcomeUnknown)
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
 
 
 def test_respond_rejects_a_guest_principal_on_a_non_matching_task(
@@ -2175,22 +2220,19 @@ def test_respond_receipt_refuses_a_row_that_carries_no_answer() -> None:
         )
 
 
-def test_respond_reports_outcome_unknown_when_the_fence_misses_and_leaves_no_residue(
+def test_respond_reports_conflict_for_an_already_answered_row_under_a_fresh_key(
     _respond_db,
 ) -> None:
-    """This build does not classify why the answer fence's UPDATE matched
-    zero rows (see ``RespondOutcomeUnknown``'s own docstring) -- every
-    fine-grained fence-miss scenario (already answered, terminated, wrong
-    task state, foreign run, a concurrent ownership change) collapses onto
-    this single conservative outcome instead of the outcome/reason such a
-    build's more detailed sibling would report. Picks one concrete trigger
-    -- the row already answered by someone else, under a fresh idempotency
-    key this call has never seen -- and proves both the collapse and the
-    safety property that makes it acceptable: this call changes nothing.
-    The pre-existing answer, its already-staged command, and the conflict
-    counter are all untouched -- a conservative miss must never be
-    misreported as a conflict, since this build never confirmed it was
-    one."""
+    """The fence misses because the row is already answered, and this
+    build classifies that miss instead of collapsing it onto
+    ``OutcomeUnknown``: a fresh idempotency key this call has never seen
+    means step 5's pre-read finds nothing, so the reread at step 6 is the
+    first place the pre-existing answer becomes visible. The classified
+    ``Conflict`` is what increments the response-conflict counter -- the
+    conservative sibling left the counter untouched here, because it had
+    never confirmed the miss was a conflict. Everything else is
+    unchanged: the pre-existing answer and its already-staged command are
+    left exactly as they were."""
 
     user_id, task_id = _waiting_task(_respond_db)
     principal = _owning_principal(user_id)
@@ -2212,13 +2254,23 @@ def test_respond_reports_outcome_unknown_when_the_fence_misses_and_leaves_no_res
             envelope=_respond_envelope(idempotency_key="never-seen-before"),
         )
 
-        assert isinstance(outcome, svc.RespondOutcomeUnknown)
-    assert _conflict_counter() == before_counter
+        assert outcome == svc.RespondConflict(reason="already_answered")
+    assert _conflict_counter() == before_counter + 1
 
 
 def test_respond_logs_the_reread_row_state_when_the_fence_misses(
     _respond_db, caplog: pytest.LogCaptureFixture
 ) -> None:
+    """The reread-state log survives this build's classification rather
+    than being replaced by it. The two carry different information: the
+    caller gets ``Conflict(already_answered)``, which names neither who
+    answered the row nor which run it belonged to, while the operator's
+    log line carries ``status``, ``active_slot``, ``terminal_reason``,
+    ``run_id`` and ``responder_identity`` -- columns no ``RespondOutcome``
+    variant has a field for. Asserting the log here, on a cell whose
+    outcome is now specific, is what keeps the classification from being
+    read as a licence to drop it."""
+
     user_id, task_id = _waiting_task(_respond_db)
     principal = _owning_principal(user_id)
     interaction_id = _answered_row_with_valid_anchor(
@@ -2236,7 +2288,7 @@ def test_respond_logs_the_reread_row_state_when_the_fence_misses(
             envelope=_respond_envelope(idempotency_key="never-seen-before-logged"),
         )
 
-    assert isinstance(outcome, svc.RespondOutcomeUnknown)
+    assert outcome == svc.RespondConflict(reason="already_answered")
     matching = [
         record
         for record in caplog.records
@@ -2326,6 +2378,216 @@ def test_respond_reports_conflict_when_a_guest_and_the_owner_share_one_key(
 
         assert outcome == svc.RespondConflict(reason="idempotency_key_reused")
     assert _conflict_counter() == before_counter + 1
+
+
+@pytest.mark.parametrize(
+    "terminal_reason,expected_reason",
+    [
+        pytest.param("deadline_elapsed", "expired", id="expired"),
+        pytest.param("run_superseded", "run_superseded", id="run_superseded"),
+        pytest.param(
+            "answered_via_legacy_resume", "answered_via_chat", id="answered_via_chat"
+        ),
+    ],
+)
+def test_respond_reports_stale_for_a_terminated_row(
+    _respond_db, terminal_reason: str, expected_reason: str
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _terminated_row_with_valid_anchor(
+        _respond_db, task_id=task_id, run_id="run-a", terminal_reason=terminal_reason
+    )
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_principal(user_id),
+            envelope=_respond_envelope(idempotency_key="never-seen-before-terminal"),
+        )
+
+        # Written out as three literal constructions rather than the one
+        # line ``svc.RespondStale(reason=expected_reason)`` this branch
+        # collapses to: the mapping meta-test at the bottom of this file
+        # finds a covered pair by AST-scanning for
+        # ``svc.Respond*(reason=<constant>)``, and a variable in that slot
+        # is invisible to it -- collapsing this would silently drop three
+        # Stale pairs from the coverage set while every test still passed.
+        if expected_reason == "expired":
+            assert outcome == svc.RespondStale(reason="expired")
+        elif expected_reason == "run_superseded":
+            assert outcome == svc.RespondStale(reason="run_superseded")
+        else:
+            assert outcome == svc.RespondStale(reason="answered_via_chat")
+    # Reverse assertion: a Stale outcome must never increment the
+    # response-conflict counter -- only the three Conflict cells do.
+    assert _conflict_counter() == before_counter
+
+
+def test_respond_reports_stale_when_the_task_has_moved_on_from_waiting(
+    _respond_db,
+) -> None:
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    db = _respond_db()
+    try:
+        db.query(Task).filter(Task.id == task_id).update({"status": TaskStatus.RUNNING})
+        db.commit()
+    finally:
+        db.close()
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_principal(user_id),
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondStale(reason="run_ended")
+    assert _conflict_counter() == before_counter
+
+
+def test_respond_prefers_run_ended_over_foreign_run_when_both_hold(
+    _respond_db,
+) -> None:
+    """The overlap: the task is no longer ``WAITING_FOR_USER`` *and* it has
+    moved to a different ``run_id`` than the interaction row's. This is the
+    ordinary production shape, not a corner -- one run ends and the next
+    one starts, so ``status`` and ``run_id`` change together -- and it is
+    the only cell in which the order of the two guards is observable at
+    all. Either guard alone is already pinned by the two tests around this
+    one; neither of them can tell which runs first.
+
+    The contract this pins is that order: with both conditions true the
+    caller gets ``run_ended``, because "this task is not waiting for an
+    answer any more" is the more accurate and the less leaky of the two
+    answers. It is more accurate because it describes the task's own
+    current state rather than a relationship between two rows, and a
+    caller told ``foreign_run`` would reasonably conclude that answering
+    the *current* run's question would still work, which is false here.
+    It is less leaky because ``foreign_run`` implicitly reports that some
+    other run exists and that this row belongs to an older one -- a fact
+    about the task's history that a caller who is simply too late does not
+    need. Swapping the two ``if`` statements in ``respond()``'s step 6
+    classification must turn this test red; nothing else in the suite
+    notices the swap."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    db = _respond_db()
+    try:
+        db.query(Task).filter(Task.id == task_id).update(
+            {"status": TaskStatus.RUNNING, "run_id": "run-next"}
+        )
+        db.commit()
+    finally:
+        db.close()
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_principal(user_id),
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondStale(reason="run_ended")
+    assert _conflict_counter() == before_counter
+
+
+def test_respond_reports_stale_when_the_task_is_waiting_on_a_different_run(
+    _respond_db,
+) -> None:
+    """The interaction row belongs to the run it was created under; the
+    task has since moved on to a new one. Both helpers build their rows on
+    ``run-a``, so the divergence is introduced afterwards by advancing the
+    task alone -- the same shape as the ``run_ended`` test above, and the
+    reason neither helper carries a ``run_id`` parameter."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    db = _respond_db()
+    try:
+        db.query(Task).filter(Task.id == task_id).update({"run_id": "run-current"})
+        db.commit()
+    finally:
+        db.close()
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_owning_principal(user_id),
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondStale(reason="foreign_run")
+    assert _conflict_counter() == before_counter
+
+
+def _racing_fence_stmt_that_changes_ownership(
+    session_factory, *, task_id: int, intruder_owner_id: int
+) -> Any:
+    """Build a monkeypatch replacement for ``svc._answer_fence_stmt`` that
+    races a concurrent ownership change onto the task row between step 2's
+    read and the fence statement's own execution -- the SQLite-only TOCTOU
+    window (SQLite's dialect drops ``FOR UPDATE`` entirely; PostgreSQL's row
+    lock closes it, see ``_answer_fence_task_predicate``'s own docstring) the
+    test below needs to reproduce it."""
+
+    real_fence_stmt = svc._answer_fence_stmt
+
+    def _racing_fence_stmt(*args: Any, **kwargs: Any) -> Any:
+        race_db = session_factory()
+        try:
+            race_db.query(Task).filter(Task.id == task_id).update(
+                {"user_id": intruder_owner_id}
+            )
+            race_db.commit()
+        finally:
+            race_db.close()
+        return real_fence_stmt(*args, **kwargs)
+
+    return _racing_fence_stmt
+
+
+def test_respond_reports_unauthorized_when_ownership_changes_between_the_check_and_the_write(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The SQLite-only TOCTOU window between step 3's authorization read and
+    step 6's write-point fence (see ``_answer_fence_task_predicate``'s own
+    docstring for why PostgreSQL's row lock closes this window and SQLite's
+    dialect does not)."""
+
+    owner_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    intruder_owner_id = make_user(_respond_db())
+
+    monkeypatch.setattr(
+        svc,
+        "_answer_fence_stmt",
+        _racing_fence_stmt_that_changes_ownership(
+            _respond_db, task_id=task_id, intruder_owner_id=intruder_owner_id
+        ),
+    )
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=_owning_principal(owner_id),
+        envelope=_respond_envelope(),
+    )
+
+    assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
 
 
 def test_respond_checks_authorization_before_the_idempotency_prequery(
@@ -3108,15 +3370,17 @@ def test_respond_reports_outcome_unknown_when_the_replay_branch_commit_fails_and
 
 
 # ---------------------------------------------------------------------------
-# The mapping meta-test. For every one of the 14 (outcome, reason) pairs in
+# The mapping meta-test. For every one of the 20 (outcome, reason) pairs in
 # the vocabulary, at least one test above must produce it. This is
 # deliberately not an arithmetic comparison against the total cell count
 # (see the module docstring's three-way division of labor table) -- several
-# triggering conditions collapse onto the same pair (six distinct
+# triggering conditions collapse onto the same pair (eight distinct
 # "principal does not own this task" scenarios all produce
 # ``not_task_principal``; three distinct "same idempotency key, different
-# submitter" scenarios all produce ``idempotency_key_reused``), and one
-# validation scenario is parametrized over two reasons on its own.
+# submitter" scenarios all produce ``idempotency_key_reused``; two
+# distinct "the task is no longer waiting" scenarios both produce
+# ``run_ended``), and one validation scenario is parametrized over two
+# reasons on its own.
 # ---------------------------------------------------------------------------
 
 
@@ -3151,13 +3415,14 @@ def test_every_vocabulary_pair_is_produced_by_at_least_one_cell_test() -> None:
     every ``isinstance(outcome, svc.Respond<Type>)`` check the cell tests
     above use, and cross-checks the resulting (type, reason) set against
     the vocabulary. Deliberately not ``len(produced) == len(vocabulary)`` or
-    any other arithmetic against the 29-cell count -- six
-    not_task_principal cells and three idempotency_key_reused cells
-    legitimately collapse onto one pair each; this only asserts that no
-    vocabulary pair is left with zero producing cells. Its blind spot: a
-    new cell that produces no *new* pair -- for example a seventh
-    not_task_principal scenario -- adds nothing this scan would notice
-    missing, so that gap is caught by review, not by this test."""
+    any other arithmetic against the 36-cell count -- eight
+    not_task_principal cells, three idempotency_key_reused cells and two
+    run_ended cells legitimately collapse onto one pair each; this only
+    asserts that no vocabulary pair is left with zero producing cells. Its
+    blind spot: a new cell that produces no *new* pair -- for example a
+    ninth not_task_principal scenario, or the guard-order overlap cell
+    this build adds to ``run_ended`` -- adds nothing this scan would
+    notice missing, so that gap is caught by review, not by this test."""
 
     import ast
     import inspect

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -26,10 +26,10 @@ graph in a fresh session before falling back to ``OutcomeUnknown``. So the
 only ``OutcomeUnknown``-producing cells left are the two durable-graph
 reconciliation failures: an ambiguous commit with nothing in the graph to
 find, and one that lands under a different identity. The matrix
-below enumerates this build's own 36 triggering cells, producing 20
-distinct (outcome type, reason) pairs -- fewer than 36 because several
+below enumerates this build's own 38 triggering cells, producing 20
+distinct (outcome type, reason) pairs -- fewer than 38 because several
 cells share a pair (eight "principal does not own this task" cells all
-produce ``(RespondUnauthorized, not_task_principal)``; three "same
+produce ``(RespondUnauthorized, not_task_principal)``; four "same
 idempotency key, different actor" cells all produce ``(RespondConflict,
 idempotency_key_reused)``; two "the task is no longer waiting" cells both
 produce ``(RespondStale, run_ended)``; two distinct triggers collapse
@@ -70,15 +70,20 @@ The full cell-to-pair mapping:
     U1        -> (Unavailable, task_missing)                         1
     U2        -> (Unavailable, interaction_missing)                  1
     U3        -> (Unavailable, checkpoint_unavailable)                1
-    R1..R3    -> (Replayed, None)      1 (3 cells share it -- the plain
+    R1..R4    -> (Replayed, None)      1 (4 cells share it -- the plain
                  replay, a replay of an already-answered row whose resume
-                 anchor was pruned before the retry, and a staging race
-                 whose winner's row carries this call's own payload)
+                 anchor was pruned before the retry, a staging race whose
+                 winner's row carries this call's own payload, and a
+                 replay recognized only at the fence-miss reread because
+                 the racing command lands under this call's own key after
+                 step 5's own pre-read already ran and found nothing)
     C1        -> (Conflict, already_answered)                        1
-    C2..C4    -> (Conflict, idempotency_key_reused)      1 (3 cells share
-                 it -- two "same key, different submitter" cells, and a
-                 staging race whose winner's row carries a different
-                 payload)
+    C2..C5    -> (Conflict, idempotency_key_reused)      1 (4 cells share
+                 it -- the two step-5 pre-read cells, a staging race whose
+                 winner's row carries a different payload, and a
+                 fence-miss reread finding a same-key command staged after
+                 step 5's pre-read whose payload does not match this
+                 call's own)
     S1        -> (Stale, expired)                                    1
     S2        -> (Stale, run_superseded)                             1
     S3        -> (Stale, answered_via_chat)                          1
@@ -93,7 +98,7 @@ The full cell-to-pair mapping:
                  landed write, and one whose reconciliation finds a
                  landed row under a different identity)
     -----------------------------------------------------------------
-    36 cells; 20 distinct pairs (18 single-reason cells + V1's own 2)
+    38 cells; 20 distinct pairs (18 single-reason cells + V1's own 2)
 
 The cell-by-cell tests this matrix implies, and the mapping meta-test that
 checks their coverage against the vocabulary, are both in this file now,
@@ -107,7 +112,7 @@ layers:
 | Assertion | Checks | Catches | Misses |
 |---|---|---|---|
 | Union-membership guard (this file, written) | ``RespondOutcome`` has exactly its eight known member classes | A variant added or removed without updating this list | Reason-level coverage |
-| Cell-by-cell tests (this file, written) | One test per of the 36 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
+| Cell-by-cell tests (this file, written) | One test per of the 38 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
 | Mapping meta-test (this file, written) | Each of the 20 pairs is produced by >= 1 cell's test (18 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a ninth not_task_principal scenario) -- caught by review, not this meta-test |
 """
 
@@ -2298,6 +2303,171 @@ def test_respond_logs_the_reread_row_state_when_the_fence_misses(
     assert "status=answered" in matching[0].getMessage()
 
 
+def _racing_fence_stmt_that_answers_with_command(
+    session_factory,
+    *,
+    interaction_id: int,
+    task_id: int,
+    responder_identity: str,
+    response_payload: dict[str, Any],
+    command_id: str,
+    actor_user_id: int | None,
+    command_payload: dict[str, Any],
+    race_result: dict[str, Any],
+) -> Any:
+    """Build a monkeypatch replacement for ``svc._answer_fence_stmt`` that
+    races a concurrent answer plus a same-idempotency-key RESUME command
+    onto the row in the one window that can produce it: after step 5's
+    idempotency pre-read has already run and found nothing under this key,
+    but before step 6's own fence UPDATE (and its zero-rowcount reread)
+    sees the row. Staging the same race as ordinary test setup *before*
+    calling ``respond()`` -- the way the C2/C3 pre-read tests below do --
+    would make step 5's own pre-read find it first and answer from there,
+    never reaching the reread branch this pair of tests exists to cover.
+
+    Records the post-race graph snapshot and the racer's own staged
+    ``command_db_id`` into ``race_result`` so the two tests using this can
+    assert, respectively, that the receipt names the racer's row and that
+    this call's own losing attempt adds nothing on top of the race."""
+
+    real_fence_stmt = svc._answer_fence_stmt
+
+    def _racing_fence_stmt(*args: Any, **kwargs: Any) -> Any:
+        race_db = session_factory()
+        try:
+            race_db.query(TaskInteractionRequest).filter(
+                TaskInteractionRequest.id == interaction_id
+            ).update(
+                {
+                    "status": "answered",
+                    "active_slot": None,
+                    "response_payload": response_payload,
+                    "responded_at": _now(),
+                    "responder_identity": responder_identity,
+                }
+            )
+            command = TaskExecutionCommand(
+                task_id=task_id,
+                actor_user_id=actor_user_id,
+                command_id=command_id,
+                kind=svc.TaskCommandKind.RESUME.value,
+                payload=command_payload,
+                status="completed",
+            )
+            race_db.add(command)
+            race_db.commit()
+            race_db.refresh(command)
+            race_result["command_db_id"] = int(command.id)
+        finally:
+            race_db.close()
+        race_result["snapshot"] = _graph_snapshot(
+            session_factory, task_id=task_id, interaction_id=interaction_id
+        )
+        return real_fence_stmt(*args, **kwargs)
+
+    return _racing_fence_stmt
+
+
+def test_respond_reports_replay_when_a_racing_command_lands_between_the_preread_and_the_fence(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fence-miss reread branch (step 6), not step 5's own pre-read,
+    is what recognizes this replay: the racing command is staged in the
+    window between the two, so step 5 finds nothing and this call only
+    discovers its own answer already landed once it rereads the row after
+    losing the fence. The receipt it returns must name the racing
+    command's own row, not synthesize one of this call's own."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    principal = _owning_principal(user_id)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    envelope = _respond_envelope(idempotency_key="racing-replay-key")
+    command_payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values=envelope.values
+    )
+    race_result: dict[str, Any] = {}
+    monkeypatch.setattr(
+        svc,
+        "_answer_fence_stmt",
+        _racing_fence_stmt_that_answers_with_command(
+            _respond_db,
+            interaction_id=interaction_id,
+            task_id=task_id,
+            responder_identity=principal.identity_string(),
+            response_payload=envelope.values,
+            command_id=envelope.idempotency_key,
+            actor_user_id=principal.user_id,
+            command_payload=command_payload,
+            race_result=race_result,
+        ),
+    )
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=envelope,
+    )
+
+    assert isinstance(outcome, svc.RespondReplayed)
+    assert outcome.receipt.command_db_id == race_result["command_db_id"]
+
+
+def test_respond_reports_conflict_when_a_racing_command_with_a_different_payload_lands_between_the_preread_and_the_fence(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same race as the replay test above, except the command that lands
+    under this call's idempotency key carries different answer values --
+    a second submitter reusing the key, not this call's own retry. The
+    fence-miss reread branch must draw the same already-answered/idempotency
+    distinction step 5's own pre-read draws: a same-key command that does
+    not match this call's payload is ``idempotency_key_reused``, not
+    ``already_answered`` (which is reserved for a miss where no command
+    exists under this key at all). This call's own losing attempt must add
+    nothing beyond what the race itself committed -- checked directly
+    against the race's own post-commit snapshot, since the standard
+    ``_asserts_no_side_effects`` helper's pre-call snapshot would predate
+    the race and always show a diff that is the race's doing, not this
+    call's."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    principal = _owning_principal(user_id)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    envelope = _respond_envelope(idempotency_key="racing-conflict-key")
+    mismatched_payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values={"env": "staging"}
+    )
+    race_result: dict[str, Any] = {}
+    monkeypatch.setattr(
+        svc,
+        "_answer_fence_stmt",
+        _racing_fence_stmt_that_answers_with_command(
+            _respond_db,
+            interaction_id=interaction_id,
+            task_id=task_id,
+            responder_identity=principal.identity_string(),
+            response_payload={"env": "staging"},
+            command_id=envelope.idempotency_key,
+            actor_user_id=principal.user_id,
+            command_payload=mismatched_payload,
+            race_result=race_result,
+        ),
+    )
+    before_counter = _conflict_counter()
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=envelope,
+    )
+
+    assert outcome == svc.RespondConflict(reason="idempotency_key_reused")
+    assert _conflict_counter() == before_counter + 1
+    after = _graph_snapshot(_respond_db, task_id=task_id, interaction_id=interaction_id)
+    assert after == race_result["snapshot"]
+
+
 def test_respond_reports_conflict_for_the_same_key_with_a_different_payload(
     _respond_db,
 ) -> None:
@@ -3376,7 +3546,7 @@ def test_respond_reports_outcome_unknown_when_the_replay_branch_commit_fails_and
 # (see the module docstring's three-way division of labor table) -- several
 # triggering conditions collapse onto the same pair (eight distinct
 # "principal does not own this task" scenarios all produce
-# ``not_task_principal``; three distinct "same idempotency key, different
+# ``not_task_principal``; four distinct "same idempotency key, different
 # submitter" scenarios all produce ``idempotency_key_reused``; two
 # distinct "the task is no longer waiting" scenarios both produce
 # ``run_ended``), and one validation scenario is parametrized over two
@@ -3415,8 +3585,8 @@ def test_every_vocabulary_pair_is_produced_by_at_least_one_cell_test() -> None:
     every ``isinstance(outcome, svc.Respond<Type>)`` check the cell tests
     above use, and cross-checks the resulting (type, reason) set against
     the vocabulary. Deliberately not ``len(produced) == len(vocabulary)`` or
-    any other arithmetic against the 36-cell count -- eight
-    not_task_principal cells, three idempotency_key_reused cells and two
+    any other arithmetic against the 38-cell count -- eight
+    not_task_principal cells, four idempotency_key_reused cells and two
     run_ended cells legitimately collapse onto one pair each; this only
     asserts that no vocabulary pair is left with zero producing cells. Its
     blind spot: a new cell that produces no *new* pair -- for example a

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -185,7 +185,7 @@ def _clean_degradation_registry():
 # The two assertions below read that type back rather than duplicating it:
 # the first confirms the Union has exactly the eight known member classes,
 # the second (further down, next to the mapping meta-test) confirms the
-# 14 (outcome, reason) pairs it derives from those classes' own Literal
+# 20 (outcome, reason) pairs it derives from those classes' own Literal
 # annotations still match what every test in this file actually produces.
 
 
@@ -2580,11 +2580,14 @@ def test_respond_reports_stale_for_a_terminated_row(
 
         # Written out as three literal constructions rather than the one
         # line ``svc.RespondStale(reason=expected_reason)`` this branch
-        # collapses to: the mapping meta-test at the bottom of this file
-        # finds a covered pair by AST-scanning for
+        # collapses to, kept apart deliberately: the mapping meta-test at
+        # the bottom of this file finds a covered pair by AST-scanning for
         # ``svc.Respond*(reason=<constant>)``, and a variable in that slot
-        # is invisible to it -- collapsing this would silently drop three
-        # Stale pairs from the coverage set while every test still passed.
+        # is invisible to that scan. Written as a literal here is what
+        # makes each of the three reasons visible to it; collapsing to the
+        # variable form would not fail silently -- the meta-test would
+        # turn red, reporting these same three ``Stale`` pairs as having
+        # zero covering cells.
         if expected_reason == "expired":
             assert outcome == svc.RespondStale(reason="expired")
         elif expected_reason == "run_superseded":

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -11,19 +11,16 @@ in this delivery that a SQLite-backed test cannot actually exercise:
   backends agree. (The TaskStatus-bind-parameter structural guard this
   bullet used to also cover needs no database at all and lives in the
   sibling SQLite-backed file instead.)
-- The three answered-row CHECK constraints. (This build does not classify
-  a rowcount=0 fence miss -- see ``RespondOutcomeUnknown``'s own
-  docstring -- so the six non-active-row classification cells a more
-  detailed build would need proven against a real PostgreSQL server are
-  not delivered here either.)
+- ``respond()``'s six non-active-row rowcount=0 classifications and the
+  three answered-row CHECK constraints, run against a real PostgreSQL
+  server rather than as a second copy of the SQLite-backed cell tests --
+  the point here is the backend, not new behavior coverage.
 - Four genuinely concurrent tests, each opening a second real connection:
   the ownership-change TOCTOU window that PostgreSQL's row lock closes
   (which SQLite's single-writer model cannot reproduce), two
   ``respond()`` calls serializing on the same ``tasks`` row, and two
   lock-order deadlock regressions (``respond()`` racing a staging
-  reclaim, and ``respond()`` racing a concurrent purge) -- both
-  deadlock regressions assert this build's own conservative outcome
-  where their more detailed sibling would assert a specific reason.
+  reclaim, and ``respond()`` racing a concurrent purge).
 - One sequential (not concurrent) test running both
   ``respond()``-vs-``purge_task_rows`` orderings one after another --
   each ordering runs to completion and commits before the next
@@ -362,10 +359,9 @@ def test_answer_fence_guest_entity_binding_matches_on_postgresql(db_session) -> 
 
 
 # ---------------------------------------------------------------------------
-# Fixtures shared by every real svc.respond() call in this file, plus the
-# CHECK-guarded answered-row shape. (The six rowcount=0 classification
-# cells this build does not classify are not exercised here -- see this
-# file's own module docstring.)
+# The six rowcount=0 classification cells, exercised through a real
+# svc.respond() call against PostgreSQL, plus the CHECK-guarded answered-row
+# shape.
 # ---------------------------------------------------------------------------
 
 
@@ -432,6 +428,111 @@ def _pg_envelope(idempotency_key: str) -> svc.RespondEnvelope:
         values={"env": "prod"},
         idempotency_key=idempotency_key,
     )
+
+
+def test_answer_fence_rowcount_across_six_non_active_states(_respond_pg) -> None:
+    """Each of the six ways the fence UPDATE can land on rowcount=0,
+    exercised sequentially (one ``svc.respond()`` call after another, no
+    concurrent writer) against a real PostgreSQL server rather than SQLite --
+    the point of running this here instead of in the SQLite-backed sibling
+    file is the backend, not concurrency. Each case runs through
+    ``svc.respond()`` end to end rather than the fence statement in
+    isolation. Actual concurrent-writer coverage lives in the dedicated
+    tests below this one (``test_concurrent_ownership_change_is_blocked...``,
+    ``test_two_concurrent_respond_calls_serialize...``, and the
+    deadlock/residue tests), which do open a second connection."""
+
+    # 1. Already answered, fresh key -> Conflict(already_answered).
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    db = _respond_pg()
+    try:
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == interaction_id)
+            .first()
+        )
+        row.status = "answered"
+        row.active_slot = None
+        row.response_payload = {"env": "prod"}
+        row.responded_at = _now()
+        row.responder_identity = _pg_owning_principal(user_id).identity_string()
+        db.commit()
+    finally:
+        db.close()
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=_pg_owning_principal(user_id),
+        envelope=_pg_envelope("pg-already-answered"),
+    )
+    assert outcome == svc.RespondConflict(reason="already_answered")
+
+    # 2/3/4. Terminated, three reasons.
+    for terminal_reason, expected in (
+        ("deadline_elapsed", "expired"),
+        ("run_superseded", "run_superseded"),
+        ("answered_via_legacy_resume", "answered_via_chat"),
+    ):
+        user_id, task_id = _pg_waiting_task(_respond_pg)
+        interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+        db = _respond_pg()
+        try:
+            row = (
+                db.query(TaskInteractionRequest)
+                .filter(TaskInteractionRequest.id == interaction_id)
+                .first()
+            )
+            row.status = "terminated"
+            row.active_slot = None
+            row.terminal_reason = terminal_reason
+            row.terminated_at = _now()
+            db.commit()
+        finally:
+            db.close()
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=_pg_owning_principal(user_id),
+            envelope=_pg_envelope(f"pg-terminated-{terminal_reason}"),
+        )
+        assert outcome == svc.RespondStale(reason=expected)
+
+    # 5. Still active, task not WAITING.
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    db = _respond_pg()
+    try:
+        db.query(Task).filter(Task.id == task_id).update({"status": TaskStatus.RUNNING})
+        db.commit()
+    finally:
+        db.close()
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=_pg_owning_principal(user_id),
+        envelope=_pg_envelope("pg-not-waiting"),
+    )
+    assert outcome == svc.RespondStale(reason="run_ended")
+
+    # 6. Still active, waiting, but a foreign run. Both helpers build on
+    # "run-a", so the task alone is advanced afterwards -- neither carries
+    # a run_id parameter.
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    db = _respond_pg()
+    try:
+        db.query(Task).filter(Task.id == task_id).update({"run_id": "run-current"})
+        db.commit()
+    finally:
+        db.close()
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=_pg_owning_principal(user_id),
+        envelope=_pg_envelope("pg-foreign-run"),
+    )
+    assert outcome == svc.RespondStale(reason="foreign_run")
 
 
 # ---------------------------------------------------------------------------
@@ -567,12 +668,14 @@ def test_two_concurrent_respond_calls_serialize_on_the_tasks_row(_respond_pg) ->
     """Two real connections answering the same row with different
     idempotency keys must never both win: step 2's row lock serializes
     them, and the loser's fence UPDATE matches zero rows once the winner
-    commits. This build does not classify why the loser's fence missed
-    (see ``RespondOutcomeUnknown``'s own docstring) -- a more detailed
-    build's loser would land on ``Stale`` or ``Conflict``, this build's
-    lands on ``OutcomeUnknown`` -- so the loser is accepted here as any
-    non-``Accepted`` outcome; the invariant this test exists to pin is
-    "never both win", not which label the loser gets."""
+    commits. This build classifies that miss, so the loser now gets a
+    specific outcome rather than the conservative sibling's
+    ``OutcomeUnknown`` -- but the assertion below deliberately stays wide,
+    accepting any ``Stale`` or ``Conflict``. Which of them the loser lands
+    on depends on how far the winner's transaction had progressed when the
+    loser reread the row, and pinning that would be pinning an
+    interleaving, not a contract. The invariant this test exists to pin is
+    "never both win"."""
 
     user_id, task_id = _pg_waiting_task(_respond_pg)
     interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
@@ -598,11 +701,7 @@ def test_two_concurrent_respond_calls_serialize_on_the_tasks_row(_respond_pg) ->
 
     accepted = [o for o in outcomes if isinstance(o, svc.RespondAccepted)]
     stale_or_conflict = [
-        o
-        for o in outcomes
-        if isinstance(
-            o, (svc.RespondStale, svc.RespondConflict, svc.RespondOutcomeUnknown)
-        )
+        o for o in outcomes if isinstance(o, (svc.RespondStale, svc.RespondConflict))
     ]
     assert len(accepted) == 1, outcomes
     assert len(stale_or_conflict) == 1, outcomes
@@ -768,16 +867,12 @@ def test_respond_vs_staging_reclaim_does_not_deadlock(_respond_pg, engine) -> No
     # The reclaim's UPDATE lands, uncommitted, before respond()'s own fence
     # UPDATE reaches the same row; respond() blocks on it (a plain row lock,
     # not the tasks lock this test is about), resumes once the reclaim
-    # commits, and correctly reports the miss rather than timing out or
-    # raising -- the interesting fact this test pins is that neither thread
-    # deadlocks getting there, not which of them "wins". This build does
-    # not classify why the fence missed (a more detailed build's sibling
-    # asserts the specific ``Stale(run_superseded)`` this scenario produces
-    # -- see ``RespondOutcomeUnknown``'s own docstring for why this build
-    # reports the ambiguity instead).
-    assert isinstance(results.get("respond_outcome"), svc.RespondOutcomeUnknown), (
-        results
-    )
+    # commits, and correctly reports the row as superseded rather than
+    # timing out or raising -- the interesting fact this test pins is that
+    # neither thread deadlocks getting there, not which of them "wins".
+    assert results.get("respond_outcome") == svc.RespondStale(
+        reason="run_superseded"
+    ), results
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -11,10 +11,13 @@ in this delivery that a SQLite-backed test cannot actually exercise:
   backends agree. (The TaskStatus-bind-parameter structural guard this
   bullet used to also cover needs no database at all and lives in the
   sibling SQLite-backed file instead.)
-- ``respond()``'s six non-active-row rowcount=0 classifications and the
-  three answered-row CHECK constraints, run against a real PostgreSQL
-  server rather than as a second copy of the SQLite-backed cell tests --
-  the point here is the backend, not new behavior coverage.
+- ``respond()``'s six fence-miss (rowcount=0) classifications -- four of
+  them from a non-active interaction row (already answered, or terminated
+  for one of three reasons), the other two from a row that is still
+  ``active`` but whose *task* has moved on -- and the three answered-row
+  CHECK constraints, run against a real PostgreSQL server rather than as a
+  second copy of the SQLite-backed cell tests -- the point here is the
+  backend, not new behavior coverage.
 - Four genuinely concurrent tests, each opening a second real connection:
   the ownership-change TOCTOU window that PostgreSQL's row lock closes
   (which SQLite's single-writer model cannot reproduce), two
@@ -430,15 +433,20 @@ def _pg_envelope(idempotency_key: str) -> svc.RespondEnvelope:
     )
 
 
-def test_answer_fence_rowcount_across_six_non_active_states(_respond_pg) -> None:
+def test_answer_fence_rowcount_across_six_fence_miss_states(_respond_pg) -> None:
     """Each of the six ways the fence UPDATE can land on rowcount=0,
     exercised sequentially (one ``svc.respond()`` call after another, no
     concurrent writer) against a real PostgreSQL server rather than SQLite --
     the point of running this here instead of in the SQLite-backed sibling
-    file is the backend, not concurrency. Each case runs through
-    ``svc.respond()`` end to end rather than the fence statement in
-    isolation. Actual concurrent-writer coverage lives in the dedicated
-    tests below this one (``test_concurrent_ownership_change_is_blocked...``,
+    file is the backend, not concurrency. Only cases 1-4 below put the
+    interaction row itself in a non-active state (answered, or terminated
+    for one of three reasons); cases 5 and 6 leave the row ``active`` and
+    move the *task* on instead (off ``WAITING_FOR_USER``, and onto a
+    different run), which is what still lands the fence on rowcount=0 for
+    those two. Each case runs through ``svc.respond()`` end to end rather
+    than the fence statement in isolation. Actual concurrent-writer
+    coverage lives in the dedicated tests below this one
+    (``test_concurrent_ownership_change_is_blocked...``,
     ``test_two_concurrent_respond_calls_serialize...``, and the
     deadlock/residue tests), which do open a second connection."""
 
@@ -666,16 +674,25 @@ def test_concurrent_ownership_change_is_blocked_until_respond_commits(
 
 def test_two_concurrent_respond_calls_serialize_on_the_tasks_row(_respond_pg) -> None:
     """Two real connections answering the same row with different
-    idempotency keys must never both win: step 2's row lock serializes
-    them, and the loser's fence UPDATE matches zero rows once the winner
-    commits. This build classifies that miss, so the loser now gets a
-    specific outcome rather than the conservative sibling's
-    ``OutcomeUnknown`` -- but the assertion below deliberately stays wide,
-    accepting any ``Stale`` or ``Conflict``. Which of them the loser lands
-    on depends on how far the winner's transaction had progressed when the
-    loser reread the row, and pinning that would be pinning an
-    interleaving, not a contract. The invariant this test exists to pin is
-    "never both win"."""
+    idempotency keys must never both win: step 2's ``FOR NO KEY UPDATE``
+    row lock blocks the loser at its own step 2 until the winner's entire
+    transaction -- fence UPDATE, Task CAS, staged command, and commit --
+    has gone through, so the loser's own fence UPDATE only ever runs
+    against an already-answered row. That ordering makes the loser's path
+    deterministic, not merely "some Stale or Conflict": the winner's CAS
+    (``apply_task_control_transition``, step 7) never touches
+    ``Task.status``, only ``state_version``/``control_state``, so the
+    loser's own fence still finds ``Task.status`` at ``WAITING_FOR_USER``
+    and only the interaction row's own active-row criteria fail; nothing
+    in this test reclaims the interaction's resume anchor between the two
+    calls, so the loser's step 5.5 still resolves it; and the winner's
+    idempotency key is not the loser's own, so the loser's reread finds no
+    command staged under its key. Every one of those is what the loser's
+    fence-miss classification (step 6) needs to land on
+    ``Conflict(already_answered)`` specifically. The assertion below still
+    only checks that exactly one call lands outside ``Accepted``, without
+    pinning that specific reason -- the invariant this test exists to pin
+    is "never both win", not the loser's exact outcome."""
 
     user_id, task_id = _pg_waiting_task(_respond_pg)
     interaction_id = _pg_active_row(_respond_pg, task_id=task_id)


### PR DESCRIPTION
## Summary

Classifies why the answer fence missed. The merged answer-side entry point (#1354) collapses every zero-row fence UPDATE onto `RespondOutcomeUnknown` by design, with the reread row state visible only in a log line; this change delivers the classification that build deferred: the reread now resolves to a typed outcome — `Conflict(already_answered)`, `Unauthorized(not_task_principal)` for an ownership miss, and the stale family (`run_ended`, `run_superseded`, `expired`, `answered_via_chat`, `foreign_run`) — instead of the catch-all. A same-key command whose payload does not match resolves to `Conflict(idempotency_key_reused)`, the same verdict the idempotency pre-read gives that situation, so the pre-read and the fence-miss classification agree.

## What's here

- The reread-and-classify block in the fence-miss branch, ordered so the most specific verdicts resolve first, with two structural invariants that raise rather than classify (an unrecognized terminal reason or row status is a schema fact, not an outcome).
- One deliberate ordering pin: when a run has ended **and** the row hangs on the old run — the most common overlap in practice, since status and run id move together — the verdict is `run_ended`, because it describes the task's own present state and does not disclose run history to a caller that was merely late. A test pins the guard order; swapping the two checks turns exactly that test red.
- The fence-miss log line stays: the classification hands the caller a verdict, while the log carries row fields (`active_slot`, `terminal_reason`, `run_id`, `responder_identity`) that no outcome variant reports — operator information, not a duplicate of the outcome.
- The conflict counter now increments on a confirmed `already_answered` — the previous build deliberately did not count an unclassified miss as a conflict, and the test that pinned "counter untouched" is translated to pin the confirmed-conflict semantics instead.
- Matrix and vocabulary arithmetic rebuilt over the merged build's cells; the outcome vocabulary meta-test derives the new pairs from the `Literal` types as before.

## Verification

Full SQLite suite for the touched surfaces (122 in the service file after this round's two race tests), PostgreSQL-only suite against a disposable database, and red/green mutation for every restored branch: reverting the ownership classification to the catch-all turns the ownership tests red, deleting the fence-miss log turns its pin red, swapping the ordered guards turns the ordering pin red while everything else stays green, deleting the reread's replay recognition turns the matching-payload race test red, and reverting the mismatched-payload verdict to `already_answered` turns the mismatched race test red.

