### PR TITLE
feat(interactions): reconcile the durable graph after an ambiguous commit

### DIFF
--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -385,12 +385,21 @@ def classify_task_command_conflict(
     deleted concurrently with the insert (TASK_MISSING), and a conflict on
     neither -- the row references two foreign keys, so absence of a duplicate
     does not prove the task caused it: a concurrently deleted actor fails the
-    users FK while the task is still present (UNRELATED).
+    users FK while the task is still present (UNRELATED). Rolling back to a
+    savepoint opened before the failing insert is equivalent to rolling back
+    the whole transaction for this purpose, as long as that savepoint
+    predates the insert: either way, the post-rollback state this function
+    queries no longer contains the failed statement's own effects.
 
     RACED_DUPLICATE means the command survived the race, not that the
     caller's work did: the rollback that had to precede this call also undid
     whatever else the caller had written. A caller that had such writes must
-    redo them rather than report success. A caller with nothing else pending
+    redo them rather than report success. Opening the savepoint after those
+    writes is the way out of redoing them: a rollback to a savepoint that
+    postdates them leaves them pending in the still-open outer transaction,
+    so the caller decides whether to commit or discard them once it knows
+    what this function found. ``task_interaction_service.respond()`` is
+    that shape. A caller with nothing else pending
     -- enqueue_task_command is one -- has nothing to redo and reports the
     raced row as created=False.
     """

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -2400,7 +2400,45 @@ def respond(
             # that staged that row owes it (see ``stage_task_command``'s
             # caller obligation (a)), and the dispatcher's idle poll is the
             # documented fallback either way.
-            db.commit()
+            try:
+                db.commit()
+            except Exception:
+                # Same ambiguity as step 9's commit below, on the other
+                # door of this function's single race funnel: the fence
+                # UPDATE and CAS this call issued may have landed durably
+                # even though this call never saw the acknowledgment. The
+                # winner's command row is not this transaction's own write
+                # and is not rolled back by this exception, so a bare
+                # re-raise would turn an already-committed answer into a
+                # crash loop on retry -- a retry under the same
+                # idempotency key would land on the replay branch above
+                # and hit this same commit again. Reconcile against a
+                # fresh session instead, exactly as step 9 does.
+                logger.warning(
+                    "commit failed while answering interaction %s on task %s; "
+                    "the write may or may not be durable -- reconciling against "
+                    "the durable graph",
+                    interaction_id,
+                    task_id,
+                    exc_info=True,
+                )
+                session_retired = True
+                _retire_respond_session_best_effort(db)
+                receipt = _verify_respond_durable_graph(
+                    task_id=task_id,
+                    interaction_id=interaction_id,
+                    expected_run_id=run_id_for_verification,
+                    expected_state_version_after=expected_state_version_after,
+                    principal=principal,
+                    canonical_submitted_values=canonical_submitted_values,
+                    command_id=normalized_key,
+                    command_kind=TaskCommandKind.RESUME,
+                    command_payload=command_payload,
+                    actor_user_id=actor_user_id,
+                )
+                if receipt is not None:
+                    return RespondReplayed(receipt=receipt)
+                return RespondOutcomeUnknown()
             return RespondReplayed(
                 receipt=InteractionResponseReceipt(
                     interaction_id=interaction_id,

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1609,10 +1609,15 @@ def _respond_receipt(
     ``principal.identity_string()`` value, so the column and the local are
     equal by the fence write's own semantics, not by coincidence.
 
-    The only caller is ``respond()``'s idempotent-replay branch, whose
-    precondition -- a staged RESUME command this service itself committed
-    in the same transaction as the answer fence UPDATE -- implies an
-    answered row, and the paired CHECK constraints
+    Two callers, each with its own precondition for why the row it hands in
+    is already answered. ``respond()``'s idempotent-replay pre-read branch
+    (step 5) calls this on a row it found by this call's own idempotency
+    key -- a staged RESUME command this service itself committed in some
+    earlier transaction alongside the answer fence UPDATE, which implies an
+    answered row. ``_verify_respond_durable_graph`` calls this only after
+    its own three checks already confirmed the row it is holding matches:
+    ``status == "answered"``, the answering identity, and the canonical
+    submitted payload. Either way, the paired CHECK constraints
     (``ck_task_interaction_requests_responded_at_pairs_status`` and
     ``ck_task_interaction_requests_responder_pairs_responded_at``) make an
     answered row with a NULL ``responded_at`` or ``responder_identity``
@@ -2356,7 +2361,15 @@ def respond(
                 # ambiguous" about a database-level failure. Re-raised.
                 db.rollback()
                 raise
-            assert classification.raced is not None
+            if classification.raced is None:
+                raise RuntimeError(
+                    f"classify_task_command_conflict reported RACED_DUPLICATE "
+                    f"for interaction {interaction_id} on task {task_id} "
+                    "with no raced projection attached; "
+                    "TaskCommandConflictClassification's own constructor "
+                    "always pairs RACED_DUPLICATE with a raced projection, "
+                    "making this impossible"
+                )
             raced_command_db_id = classification.raced.command_db_id
             raced_payload_matches = classification.raced.payload_matches
         else:

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -10,7 +10,9 @@ both live on the ask side, and both require the caller to already hold the
 transaction they run inside. This module's ``respond()`` is the opposite
 shape on every one of those points: it owns its own session end to end
 (opens it, commits or rolls it back, retires it) and never nests inside a
-caller's transaction. ``create()``, by contrast, takes a caller-owned
+caller's transaction -- the one savepoint it opens
+(``db.begin_nested()``, around staging its own resume command) is its
+own, not a caller's. ``create()``, by contrast, takes a caller-owned
 session and only reads through it, never opening or committing one of its
 own. Putting ``respond()`` in the same file as the staging primitive would
 make that staging module's merge-reason docstring false. What this module
@@ -50,10 +52,12 @@ does not stage a row); ``get()``/``list_active()``; the three-tier
 compatibility materialization view; the answer fence and its active-row
 predicate; ``respond()``'s own call body (validation, authorization, the
 idempotency pre-read, anchor resolution, the answer fence, the task
-control-state transition, staging the resume command, and committing --
-this delivery reports an unresolved fence miss or a failed commit as
-``RespondOutcomeUnknown`` rather than further classifying or reconciling
-either); and the response-conflict counter
+control-state transition, staging the resume command, and committing or
+reconciling an ambiguous acknowledgment -- this delivery classifies a
+staging conflict and reconciles an ambiguous commit against the durable
+graph, and still reports an unresolved fence miss as
+``RespondOutcomeUnknown`` rather than classifying it, which is a separate
+follow-up build); and the response-conflict counter
 (``COUNTER_LIFECYCLE_RESPONSE_CONFLICT``).
 
 Not delivered here, and named so a reader does not go looking for them in
@@ -79,6 +83,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -107,9 +112,12 @@ from .ops_signals import (
     register_degradation,
 )
 from .task_command_transport import (
+    TaskCommandConflictKind,
     TaskCommandKind,
+    _canonical_payload,
     _matches_existing,
     _normalize_command_id,
+    classify_task_command_conflict,
     notify_task_command_dispatcher,
     stage_task_command,
 )
@@ -592,19 +600,18 @@ class RespondOutcomeUnknown:
     distinguish: the answer fence's UPDATE matched zero rows and this
     build does not classify why (step 6 -- a future delivery may reread
     and classify that miss the way the fence classification build does),
-    or committing raised and this build does not attempt to reconcile the
-    durable graph afterward (steps 8/9) -- the acknowledgment could have
-    been lost after the server applied the write, or a racing writer could
-    have taken the idempotency key first; either way this build reports
-    the ambiguity rather than guessing. Not an exception this service lets
-    escape -- a stable, typed result a caller can act on (e.g. surface "we
-    could not confirm this went through" rather than crash).
+    or committing raised and the durable-graph reconciliation this build
+    runs afterward could not confirm the write landed on every one of its
+    three attempts (step 9). Step 8's staging race is no longer one of
+    them: both of its doors are classified into ``Replayed`` or
+    ``Conflict`` now. Not an exception this service lets escape -- a
+    stable, typed result a caller can act on (e.g. surface "we could not
+    confirm this went through" rather than crash).
 
     Retrying under the same idempotency key resolves the second reason and
     not the first, and a caller should not be told otherwise. A retry
     after an ambiguous commit finds the command this call staged and
-    returns ``Replayed``, and a retry after a rolled-back staging race
-    simply runs again. A retry after a fence miss re-evaluates the same
+    returns ``Replayed``. A retry after a fence miss re-evaluates the same
     predicate against the same row and misses again: a terminated,
     superseded, foreign-run, or foreign-owned row stays that way, so the
     second ``OutcomeUnknown`` is as final as the first. Step 6 logs the
@@ -1635,6 +1642,10 @@ def _respond_receipt(
     )
 
 
+_RESPOND_DURABLE_GRAPH_ATTEMPTS = 3
+_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS = 0.01
+
+
 def _retire_respond_session_best_effort(db: "Session") -> None:
     """Release an owned Session without letting a close/invalidate failure
     replace the transaction error that is already in flight. Same shape as
@@ -1654,6 +1665,164 @@ def _retire_respond_session_best_effort(db: "Session") -> None:
         db.invalidate()
     except Exception:
         logger.warning("failed to invalidate respond() session", exc_info=True)
+
+
+def _notify_dispatcher_best_effort(*, interaction_id: int, task_id: int) -> None:
+    """Wake the task command dispatcher after an answer is already durable,
+    and never let that wakeup turn a committed answer into a raised
+    exception.
+
+    ``notify_task_command_dispatcher`` reads two module globals and calls
+    ``loop.call_soon_threadsafe`` after checking ``loop.is_closed()``; the
+    loop can close between that check and that call, raising
+    ``RuntimeError``. Letting it out would make the caller read a
+    committed answer as a failure, retry, land on the replay branch, and
+    get a receipt without a second notify anyway. Skipping the wakeup
+    costs at most ``DISPATCHER_IDLE_SECONDS`` of latency because the
+    dispatcher's idle poll still finds the staged command; that is the
+    documented fallback (see ``stage_task_command``'s caller obligation
+    (a)).
+
+    Narrow on purpose: this wraps one post-commit best-effort
+    notification and nothing else -- no statement above a commit is
+    inside it. ``respond()`` calls it from both of its two post-commit
+    exits: the ordinary one after step 9's own commit, and the one after
+    step 9's durable-graph reconciliation recovers a receipt from a
+    commit whose acknowledgment was lost. The second exit is the reason
+    this is a function rather than an inline ``try`` -- the answer is
+    just as durable there, so it must not raise there either.
+    """
+
+    try:
+        notify_task_command_dispatcher()
+    except Exception:
+        logger.warning(
+            "failed to notify the task command dispatcher after "
+            "committing the answer for interaction %s on task %s; "
+            "the dispatcher's idle poll will still pick the command up",
+            interaction_id,
+            task_id,
+            exc_info=True,
+        )
+
+
+def _verify_respond_durable_graph(
+    *,
+    task_id: int,
+    interaction_id: int,
+    expected_run_id: str,
+    expected_state_version_after: int,
+    principal: InteractionPrincipal,
+    canonical_submitted_values: str,
+    command_id: str,
+    command_kind: TaskCommandKind,
+    command_payload: dict[str, Any],
+    actor_user_id: int | None,
+) -> InteractionResponseReceipt | None:
+    """Check the complete accepted answer graph in a fresh, owned Session,
+    up to three times with a short sleep between attempts. Same retry shape
+    as ``task_orchestrator._reconcile_claimed_turn_after_commit_ack_failure``:
+    a new ``SessionLocal()`` per attempt, ``time.sleep(0.01)`` between
+    failures, the session retired in every case before the next attempt or
+    return.
+
+    Three independent facts must all hold -- the row's key, the answer's
+    hash, and the answering principal's identity: (1) the
+    ``tasks`` row has advanced past ``expected_state_version_after - 1`` on
+    the same ``run_id`` -- ``>=``, not ``==``, and ``control_state`` is not
+    compared at all, because the resume coordinator re-issues the same
+    ``RESUME_REQUESTED`` transition when it applies the command this call
+    staged (see ``respond()``'s own docstring for the verbatim reasoning);
+    (2) the interaction row is answered, by this identity, with a
+    ``response_payload`` that canonicalizes to the same string as the
+    answer ``values`` the caller submitted (``canonical_submitted_values``
+    -- the interaction row stores the answer values alone, not the wrapping
+    command payload the third check below compares); (3) exactly one
+    command row exists for this idempotency key and it matches what this
+    call staged. Returns the receipt on success, ``None`` if every attempt
+    fails to confirm all three.
+    """
+
+    from ..models.database import get_session_local
+
+    SessionLocal = get_session_local()
+    for attempt in range(_RESPOND_DURABLE_GRAPH_ATTEMPTS):
+        reconcile_db: "Session | None" = None
+        try:
+            reconcile_db = SessionLocal()
+            task = (
+                reconcile_db.query(Task)
+                .filter(
+                    Task.id == task_id,
+                    Task.run_id == expected_run_id,
+                    Task.state_version >= expected_state_version_after,
+                )
+                .first()
+            )
+            if task is not None:
+                ir = (
+                    reconcile_db.query(TaskInteractionRequest)
+                    .filter(
+                        TaskInteractionRequest.id == interaction_id,
+                        TaskInteractionRequest.task_id == task_id,
+                        TaskInteractionRequest.status == "answered",
+                        TaskInteractionRequest.responder_identity
+                        == principal.identity_string(),
+                    )
+                    .first()
+                )
+                if (
+                    ir is not None
+                    and _canonical_payload(
+                        ir.response_payload
+                        if isinstance(ir.response_payload, dict)
+                        else {}
+                    )
+                    == canonical_submitted_values
+                ):
+                    commands = (
+                        reconcile_db.query(TaskExecutionCommand)
+                        .filter(
+                            TaskExecutionCommand.task_id == task_id,
+                            TaskExecutionCommand.command_id == command_id,
+                        )
+                        .all()
+                    )
+                    if len(commands) == 1 and _matches_existing(
+                        commands[0],
+                        actor_user_id=actor_user_id,
+                        kind=command_kind,
+                        payload=command_payload,
+                    ):
+                        return _respond_receipt(
+                            interaction=ir,
+                            task=task,
+                            command_db_id=int(commands[0].id),
+                            idempotency_key=command_id,
+                        )
+        except Exception:
+            # Deliberately broad, and it does not widen ``respond()``'s
+            # escape surface: this whole function runs only after step 9
+            # already caught a commit exception, so anything raised while
+            # reading the graph back means the attempt could not answer
+            # "did it land?", not that a new failure needs reporting. Each
+            # attempt logs on its own, and exhausting all three returns
+            # ``None`` -- the same ``OutcomeUnknown`` the caller would have
+            # been given had this reconciliation never run.
+            logger.warning(
+                "respond() durable-graph reconciliation attempt %s failed for "
+                "task %s interaction %s",
+                attempt + 1,
+                task_id,
+                interaction_id,
+                exc_info=True,
+            )
+        finally:
+            if reconcile_db is not None:
+                _retire_respond_session_best_effort(reconcile_db)
+        if attempt < _RESPOND_DURABLE_GRAPH_ATTEMPTS - 1:
+            time.sleep(_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS)
+    return None
 
 
 def respond(
@@ -1837,35 +2006,49 @@ def respond(
        WHERE clause cannot fail to match. This call is therefore left
        uncaught; ``StaleTaskRunError`` surfacing here would mean that
        invariant broke, not a normal stale-answer outcome.
-    8. Stage the RESUME command, and require the result to be a row this
-       call itself created carrying this call's own payload. Two different
+    8. Stage the RESUME command inside this function's own
+       ``db.begin_nested()``, and require the result to be a row this call
+       itself created carrying this call's own payload. Two different
        signals report the same race -- a second writer took this
        idempotency key between step 5's pre-read and this statement -- and
-       both get the same conservative answer. An ``IntegrityError`` is
-       raised when that writer's row lands on the unique constraint;
+       both are classified the same way. An ``IntegrityError`` is raised
+       when that writer's row lands on the unique constraint;
        ``created=False`` is returned instead when the row was already
        committed and visible, because ``stage_task_command`` checks for an
-       existing row before inserting and returns it rather than raising. A
-       ``created=False`` result whose ``payload_matches`` is also true is
-       treated the same way rather than as a replay: step 5 is where a
-       replay is recognized, and a hit that only becomes visible after it
-       is a race. Neither case is classified further in this build (a
-       fine-grained classification via ``classify_task_command_conflict``,
-       distinguishing a genuine replay from a real conflict, is not
-       delivered here): the whole transaction rolls back, undoing this
-       call's own fence UPDATE and CAS along with it, and this call reports
-       ``OutcomeUnknown``.
+       existing row before inserting and returns it rather than raising.
+       Either way this function rolls back to its savepoint (not the whole
+       transaction -- see ``classify_task_command_conflict``'s own
+       docstring for why a savepoint rollback satisfies the
+       post-rollback-state precondition it documents) and asks one
+       question about the row that won: does it carry this call's own
+       ``actor_user_id``, kind and canonical payload? The
+       ``IntegrityError`` door answers it through
+       ``classify_task_command_conflict``, the ``created=False`` door
+       through the ``payload_matches`` ``stage_task_command`` already
+       computed; both compute it with the same ``_matches_existing``, so
+       the two doors cannot disagree. A match means the RESUME that will
+       execute carries exactly this answer, so this call commits its own
+       fence UPDATE and CAS and reports ``Replayed`` naming the winner's
+       row -- not ``Accepted``, because the command row is the other
+       writer's. A mismatch means two different answers under one key: the
+       whole transaction rolls back, undoing this call's own fence UPDATE
+       and CAS along with it, and this call reports
+       ``Conflict(idempotency_key_reused)``. A ``TASK_MISSING``
+       classification maps to ``Unavailable(task_missing)``; an
+       ``UNRELATED`` one is re-raised, because it means a foreign key
+       other than this call's own duplicate failed.
     9. Commit. A raised exception here does not mean the write failed --
        the acknowledgment could have been lost after the server applied it
-       -- but this build does not attempt to reconcile that against the
-       durable graph (that reconciliation is not delivered here): it
-       retires its session and reports ``OutcomeUnknown`` unconditionally,
-       leaving the caller to re-check.
+       -- so this function retires its session and checks the durable graph
+       in a fresh one (``_verify_respond_durable_graph``) before deciding
+       between ``Accepted`` and ``OutcomeUnknown``.
     10. After a successful commit, outside any transaction:
-        ``notify_task_command_dispatcher()``. Best-effort: a raise here
-        would turn a committed answer into a reported failure, so it is
-        caught, logged as a warning, and the dispatcher's idle poll
-        delivers the command instead.
+        ``_notify_dispatcher_best_effort()``. A raise there would turn a
+        committed answer into a reported failure, so it is caught, logged
+        as a warning, and the dispatcher's idle poll delivers the command
+        instead. Both post-commit exits go through it -- step 9's own
+        commit and step 9's reconciliation recovering a lost
+        acknowledgment -- because the answer is equally durable on both.
 
     What this function lets escape, deliberately, and what it does not.
     The eight ``RespondOutcome`` variants cover every outcome this build
@@ -1874,12 +2057,20 @@ def respond(
     a caller that cannot tell "the database is down" from "your answer was
     ambiguous" will retry the first one forever:
 
-    - Database-level failures outside the two units caught above --
-      a deadlock, a lost connection, a pool checkout timeout -- raised by
-      any statement from step 2 onward. The three catches are narrow on
-      purpose: step 8's is ``IntegrityError`` only, step 9's covers the
-      commit only, and step 10's wraps one post-commit best-effort
-      notification whose failure is logged and swallowed.
+    - Database-level failures outside the units caught above -- a
+      deadlock, a lost connection, a pool checkout timeout -- raised by
+      any statement from step 2 onward. Three of the four catches are
+      narrow on purpose: step 8's is ``IntegrityError`` only (and it
+      re-raises an ``UNRELATED`` classification rather than swallowing
+      it), step 9's covers the commit only, and step 10's wraps one
+      post-commit best-effort notification whose failure is logged and
+      swallowed. The fourth is the broad ``except Exception`` inside
+      ``_verify_respond_durable_graph``, which is deliberately broad and
+      does not widen this surface: it runs only after step 9 already
+      caught a commit exception, its own failure is logged per attempt,
+      and exhausting all three attempts returns ``None``, which this
+      function reports as ``OutcomeUnknown`` -- exactly the answer it
+      would have given had the reconciliation not existed.
     - ``TaskCommandOwnerStateError`` and ``TaskCommandTaskMissing`` from
       ``stage_task_command``. Neither is an ``IntegrityError`` subclass, so
       step 8's catch does not see them, and both mean a precondition this
@@ -1977,6 +2168,7 @@ def respond(
         command_payload = _respond_command_payload(
             interaction_id=interaction_id, principal=principal, values=envelope.values
         )
+        canonical_submitted_values = _canonical_payload(envelope.values)
         actor_user_id = principal.user_id
 
         # Runs before anchor resolution below, not after it. Answering
@@ -2098,6 +2290,9 @@ def respond(
         # docstring, step 7).
         apply_task_control_transition(task, TaskControlState.RESUME_REQUESTED)
 
+        expected_state_version_after = int(task.state_version)
+        run_id_for_verification = str(task.run_id)
+        savepoint = db.begin_nested()
         # Capture every receipt value this transaction can still commit as
         # plain Python locals now, before the commit below. SQLAlchemy's
         # default ``expire_on_commit=True`` invalidates every ORM attribute
@@ -2118,6 +2313,11 @@ def respond(
         committed_state_version = int(task.state_version)
         committed_control_state = str(task.control_state)
 
+        # Both doors of step 8's race funnel into these two locals, so the
+        # decision below is written once. ``None`` means no race: this call
+        # created the row itself.
+        raced_command_db_id: int | None = None
+        raced_payload_matches = False
         try:
             staged = stage_task_command(
                 db,
@@ -2128,36 +2328,93 @@ def respond(
                 payload=command_payload,
             )
         except IntegrityError:
-            # A second writer raced this call's own insert for the same
-            # idempotency key. This build does not classify what that
-            # means (a fine-grained classification via
-            # ``classify_task_command_conflict``, distinguishing a genuine
-            # replay from a real conflict, is not delivered here): the
-            # whole transaction rolls back, undoing this call's own fence
-            # UPDATE and CAS along with it, and this call reports the
-            # ambiguity rather than guessing which case it was.
-            db.rollback()
-            return RespondOutcomeUnknown()
+            # Door one: the other writer's row was not visible at
+            # ``stage_task_command``'s own existing-row check and landed on
+            # the unique constraint at the flush. Roll back to this
+            # function's own savepoint rather than the whole transaction,
+            # so the fence UPDATE and the CAS survive long enough for the
+            # classification below to decide whether they should commit.
+            savepoint.rollback()
+            classification = classify_task_command_conflict(
+                db,
+                task_id=task_id,
+                command_id=normalized_key,
+                actor_user_id=actor_user_id,
+                kind=TaskCommandKind.RESUME,
+                payload=command_payload,
+            )
+            if classification.kind == TaskCommandConflictKind.TASK_MISSING:
+                db.rollback()
+                return RespondUnavailable(reason="task_missing")
+            if classification.kind != TaskCommandConflictKind.RACED_DUPLICATE:
+                # ``UNRELATED``: no duplicate row exists and the task is
+                # still there, so some other constraint on the row this
+                # call tried to insert failed -- most plausibly the
+                # ``actor_user_id`` foreign key. That is not a race this
+                # function has an answer for, and folding it into a typed
+                # outcome would tell the caller "your answer was
+                # ambiguous" about a database-level failure. Re-raised.
+                db.rollback()
+                raise
+            assert classification.raced is not None
+            raced_command_db_id = classification.raced.command_db_id
+            raced_payload_matches = classification.raced.payload_matches
+        else:
+            if not (staged.created and staged.payload_matches):
+                # Door two: the same race, seen one statement earlier.
+                # ``stage_task_command`` does not raise when a row for this
+                # ``(task_id, command_id)`` already exists -- it returns
+                # that row with ``created=False`` -- so without this branch
+                # the transaction would commit the fence and the CAS while
+                # the RESUME carrying this answer was never staged at all,
+                # and return ``RespondAccepted`` naming the other writer's
+                # row. ``created=True`` is only ever returned together with
+                # ``payload_matches=True`` (see ``stage_task_command``), so
+                # reaching here means ``created=False`` and
+                # ``staged.payload_matches`` is the verdict on the winner's
+                # row -- computed by the same ``_matches_existing``
+                # ``classify_task_command_conflict`` uses on the other
+                # door, which is why the two doors cannot disagree and are
+                # decided together below. The savepoint holds nothing at
+                # this point (this call inserted nothing), and is rolled
+                # back anyway to keep both doors on one shape.
+                savepoint.rollback()
+                raced_command_db_id = staged.staged_db_id
+                raced_payload_matches = staged.payload_matches
 
-        if not (staged.created and staged.payload_matches):
-            # The same race the IntegrityError branch above catches,
-            # arriving through the other door. ``stage_task_command`` does
-            # not raise when a row for this ``(task_id, command_id)``
-            # already exists -- it returns that row with ``created=False``
-            # -- so a writer that committed one between step 5's pre-read
-            # and this call would otherwise leave this transaction
-            # committing the fence and the CAS while the RESUME carrying
-            # this answer was never staged at all, and returning
-            # ``RespondAccepted`` naming the other writer's row. Both doors
-            # get this build's one conservative answer: roll the whole
-            # transaction back, undoing this call's own fence UPDATE and
-            # CAS, and report the ambiguity. ``created=False`` with a
-            # matching payload is folded in here rather than reported as
-            # ``Replayed`` on purpose -- step 5 is where a replay is
-            # recognized, and a hit that only appears after it is a race,
-            # not a replay.
-            db.rollback()
-            return RespondOutcomeUnknown()
+        if raced_command_db_id is not None:
+            if not raced_payload_matches:
+                # Two different answers under one idempotency key. The
+                # whole transaction rolls back, undoing this call's own
+                # fence UPDATE and CAS along with it.
+                db.rollback()
+                increment_counter(COUNTER_LIFECYCLE_RESPONSE_CONFLICT)
+                return RespondConflict(reason="idempotency_key_reused")
+            # The winner's row carries this call's own actor, kind and
+            # canonical payload, so the RESUME that executes is this
+            # answer. Commit the fence UPDATE and the CAS -- they are what
+            # makes the interaction row agree with the command that will
+            # run -- and report ``Replayed`` naming the winner's row rather
+            # than ``Accepted``, because the command row is not this
+            # call's. No dispatcher notification is sent here: the writer
+            # that staged that row owes it (see ``stage_task_command``'s
+            # caller obligation (a)), and the dispatcher's idle poll is the
+            # documented fallback either way.
+            db.commit()
+            return RespondReplayed(
+                receipt=InteractionResponseReceipt(
+                    interaction_id=interaction_id,
+                    task_id=task_id,
+                    run_id=answered_run_id,
+                    status="answered",
+                    responded_at=answered_responded_at,
+                    responder_identity=answered_responder_identity,
+                    idempotency_key=normalized_key,
+                    command_db_id=raced_command_db_id,
+                    task_state_version=committed_state_version,
+                    task_control_state=committed_control_state,
+                )
+            )
 
         command_db_id = staged.staged_db_id
         try:
@@ -2165,49 +2422,43 @@ def respond(
         except Exception:
             # A raised exception here does not mean the write failed -- the
             # acknowledgment could have been lost after the server applied
-            # it -- but this build does not attempt to reconcile that
-            # against the durable graph (that reconciliation is not
-            # delivered here): it retires its session and reports the
-            # ambiguity, leaving the caller to re-check.
+            # it -- so this call retires its session and asks the durable
+            # graph, in a fresh one, what actually landed. Logged first,
+            # unconditionally: the reconciliation below can turn this into
+            # an ``Accepted``, but an operator still needs the record that
+            # a commit acknowledgment went missing at all, and the
+            # reconciliation's own per-attempt logs only fire when *it*
+            # fails.
             logger.warning(
                 "commit failed while answering interaction %s on task %s; "
-                "the write may or may not be durable -- a retry under the "
-                "same idempotency key resolves which",
+                "the write may or may not be durable -- reconciling against "
+                "the durable graph",
                 interaction_id,
                 task_id,
                 exc_info=True,
             )
             session_retired = True
             _retire_respond_session_best_effort(db)
+            receipt = _verify_respond_durable_graph(
+                task_id=task_id,
+                interaction_id=interaction_id,
+                expected_run_id=run_id_for_verification,
+                expected_state_version_after=expected_state_version_after,
+                principal=principal,
+                canonical_submitted_values=canonical_submitted_values,
+                command_id=normalized_key,
+                command_kind=TaskCommandKind.RESUME,
+                command_payload=command_payload,
+                actor_user_id=actor_user_id,
+            )
+            if receipt is not None:
+                _notify_dispatcher_best_effort(
+                    interaction_id=interaction_id, task_id=task_id
+                )
+                return RespondAccepted(receipt=receipt)
             return RespondOutcomeUnknown()
 
-        try:
-            notify_task_command_dispatcher()
-        except Exception:
-            # Post-commit, and the only statement here that runs after the
-            # answer is already durable. ``notify_task_command_dispatcher``
-            # reads two module globals and calls
-            # ``loop.call_soon_threadsafe`` after checking
-            # ``loop.is_closed()``; the loop can close between that check
-            # and that call, raising ``RuntimeError``. Letting it out would
-            # turn a committed answer into a raised exception -- the caller
-            # would read it as a failure, retry, land on the replay branch,
-            # and get a receipt without a second notify anyway. Skipping
-            # the wakeup costs at most ``DISPATCHER_IDLE_SECONDS`` of
-            # latency because the dispatcher's idle poll still finds the
-            # staged command; that is the documented fallback (see
-            # ``stage_task_command``'s caller obligation (a)). Narrow on
-            # purpose: this wraps one post-commit best-effort notification
-            # and nothing else -- no statement above the commit is inside
-            # it.
-            logger.warning(
-                "failed to notify the task command dispatcher after "
-                "committing the answer for interaction %s on task %s; "
-                "the dispatcher's idle poll will still pick the command up",
-                interaction_id,
-                task_id,
-                exc_info=True,
-            )
+        _notify_dispatcher_best_effort(interaction_id=interaction_id, task_id=task_id)
         return RespondAccepted(
             receipt=InteractionResponseReceipt(
                 interaction_id=interaction_id,

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -2144,13 +2144,18 @@ def test_respond_replays_an_answered_row_whose_anchor_was_pruned(
 
 
 def test_respond_receipt_refuses_a_row_that_carries_no_answer() -> None:
-    """``_respond_receipt`` may only ever see an answered row: its one
-    caller is the idempotent-replay branch, and the paired CHECK
-    constraints make an answered row with a NULL ``responded_at`` or
-    ``responder_identity`` impossible. That reasoning spans two modules
-    with nothing else pinning it, so the builder raises loudly on a row
-    with no answer rather than coercing ``None`` into the string
-    ``'None'`` (or a falsy ``""``) inside an audit-bearing receipt."""
+    """``_respond_receipt`` may only ever see an answered row: its two
+    callers each guarantee that on their own terms -- the idempotent-replay
+    pre-read branch finds the row by this call's own idempotency key, which
+    only matches an already-staged (and therefore already-answered) RESUME
+    command, and ``_verify_respond_durable_graph`` only reaches this call
+    after its own checks already confirmed ``status == "answered"`` on the
+    row it is holding -- and the paired CHECK constraints make an answered
+    row with a NULL ``responded_at`` or ``responder_identity`` impossible
+    either way. That reasoning spans two modules with nothing else pinning
+    it, so the builder raises loudly on a row with no answer rather than
+    coercing ``None`` into the string ``'None'`` (or a falsy ``""``) inside
+    an audit-bearing receipt."""
 
     from types import SimpleNamespace
 

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -2928,6 +2928,180 @@ def test_respond_replays_when_staging_finds_a_raced_row_with_a_matching_payload(
     assert after["task_control_state"] == TaskControlState.RESUME_REQUESTED.value
 
 
+def test_respond_reports_replayed_when_the_replay_branch_commit_ack_is_lost_but_the_graph_landed(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The replay branch's own commit (the raced-duplicate door's ``Commit
+    the fence UPDATE and the CAS`` statement) can lose its acknowledgment
+    the same way step 9's does, and until this delivery it had no
+    reconciliation at all -- a lost ack there fell straight through to a
+    raised exception.
+
+    ``stage_task_command`` is monkeypatched to report the same bare
+    ``created=False, payload_matches=True`` race
+    ``test_respond_replays_when_staging_finds_a_raced_row_with_a_matching_payload``
+    injects -- no row backs it yet, because any row inserted from inside
+    that mock would live inside the ``db.begin_nested()`` savepoint the
+    real door-two branch unconditionally rolls back right after staging
+    returns, and a genuinely concurrent second writer cannot land on
+    SQLite here either: by the time ``respond()`` reaches step 8 it has
+    already issued the fence UPDATE on this same connection, which
+    already holds SQLite's one whole-database writer lock (see the
+    module's own RACED_DUPLICATE commentary above -- the reason that
+    race's real PostgreSQL coverage lives in a separate file). Instead,
+    the winning row is inserted by the ``Session.commit`` monkeypatch
+    itself, immediately before it defers to the real commit -- by that
+    point door two's ``savepoint.rollback()`` has already run and the
+    only savepoint standing between the row and the outer transaction is
+    gone, so the row commits durably alongside this call's own fence
+    UPDATE and CAS when the real commit underneath the injected failure
+    actually runs. The underlying commit genuinely lands -- only the
+    acknowledgment back to this process is lost -- so reconciliation must
+    recover a receipt naming the winning row and report ``Replayed``, not
+    ``Accepted``: the command that runs is the winner's, not the bare
+    ``staged_db_id=4242`` this call's own staging mock returned."""
+
+    from xagent.web.services.task_command_transport import StagedTaskCommand
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_principal(user_id)
+
+    idempotency_key = "replay-commit-lands"
+    envelope = _respond_envelope(idempotency_key=idempotency_key)
+    command_payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values=envelope.values
+    )
+
+    def _racing_stage_task_command(*args: Any, **kwargs: Any) -> StagedTaskCommand:
+        return StagedTaskCommand(
+            staged_db_id=4242,
+            client_command_id=kwargs.get("command_id", idempotency_key),
+            created=False,
+            payload_matches=True,
+            status="pending",
+        )
+
+    monkeypatch.setattr(svc, "stage_task_command", _racing_stage_task_command)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+    winner: dict[str, int] = {}
+
+    def _lost_ack_but_committed(self: Any) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Stand in for the other writer whose row this call's own
+            # race doors detected: inserted here, outside any savepoint,
+            # so it commits durably with the real commit below instead of
+            # being wiped out by door two's savepoint.rollback().
+            command = TaskExecutionCommand(
+                task_id=task_id,
+                actor_user_id=principal.user_id,
+                command_id=idempotency_key,
+                kind=svc.TaskCommandKind.RESUME.value,
+                payload=command_payload,
+                status="completed",
+            )
+            self.add(command)
+            self.flush()
+            winner["command_db_id"] = int(command.id)
+            original_commit(self)
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
+
+    monkeypatch.setattr(OrmSession, "commit", _lost_ack_but_committed)
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=envelope,
+    )
+
+    assert isinstance(outcome, svc.RespondReplayed)
+    assert outcome.receipt.command_db_id == winner["command_db_id"]
+    assert outcome.receipt.command_db_id != 4242
+    assert outcome.receipt.responder_identity == principal.identity_string()
+
+    after = _graph_snapshot(_respond_db, task_id=task_id, interaction_id=interaction_id)
+    assert after["ir_status"] == "answered"
+    assert after["ir_responder_identity"] == principal.identity_string()
+    assert after["task_control_state"] == TaskControlState.RESUME_REQUESTED.value
+    # Exactly one command row for this idempotency key -- the winner's
+    # row, created by the mock itself -- not a second one this call's own
+    # staging never actually inserted (door two's mock is a bare return
+    # value).
+    assert after["commands_count"] == 1
+
+
+def test_respond_reports_outcome_unknown_when_the_replay_branch_commit_fails_and_the_graph_never_lands(
+    _respond_db, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Same injected failure as the replay branch's ``Replayed`` sibling
+    above, except this time the commit never reaches the database at all --
+    standing in for a commit that genuinely failed rather than one whose
+    acknowledgment alone was lost. With nothing landed, the durable-graph
+    reconciliation has nothing to find on any of its three attempts, so the
+    call reports ``OutcomeUnknown`` and leaves the fence UPDATE and CAS this
+    call attempted with no residue -- same shape as step 9's own
+    conservative sibling, now proven on the replay branch's door too."""
+
+    from xagent.web.services.task_command_transport import StagedTaskCommand
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_principal(user_id)
+
+    def _racing_stage_task_command(*args: Any, **kwargs: Any) -> StagedTaskCommand:
+        return StagedTaskCommand(
+            staged_db_id=4242,
+            client_command_id=kwargs.get("command_id", "replay-commit-fails"),
+            created=False,
+            payload_matches=True,
+            status="pending",
+        )
+
+    monkeypatch.setattr(svc, "stage_task_command", _racing_stage_task_command)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    call_count = {"n": 0}
+
+    def _failing_commit(self: Any) -> None:
+        call_count["n"] += 1
+        raise RuntimeError("simulated lost commit acknowledgment")
+
+    monkeypatch.setattr(OrmSession, "commit", _failing_commit)
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    before_counter = _conflict_counter()
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        with caplog.at_level(logging.WARNING):
+            outcome = svc.respond(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                principal=principal,
+                envelope=_respond_envelope(idempotency_key="replay-commit-fails"),
+            )
+
+        assert isinstance(outcome, svc.RespondOutcomeUnknown)
+        matching = [
+            record
+            for record in caplog.records
+            if "commit failed while answering" in record.getMessage()
+        ]
+        assert len(matching) == 1
+        assert matching[0].levelno == logging.WARNING
+    assert _conflict_counter() == before_counter
+    assert call_count["n"] == 1
+
+
 # ---------------------------------------------------------------------------
 # The mapping meta-test. For every one of the 14 (outcome, reason) pairs in
 # the vocabulary, at least one test above must produce it. This is

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -10,33 +10,47 @@ extracted from and tested alongside ``public_chat_access.py``) and the
 
 RespondOutcome's failure matrix, and what this delivery does and does not
 do with it: this build's ``RespondConflictReason``/``RespondStaleReason``
-``Literal``s are narrower than a build that also classifies why the
-answer fence's UPDATE matched zero rows and reconciles an ambiguous
-commit against the durable graph would need (see ``RespondOutcomeUnknown``
-'s own docstring in ``task_interaction_service.py``) -- six triggering
-scenarios that such a build would classify into five distinct ``Stale``
-reasons plus ``Conflict(already_answered)`` collapse onto this build's
-single ``(OutcomeUnknown, None)`` pair instead, alongside the four other
-triggers (an unclassified staging ``IntegrityError``, the two
-staging-race doors, and an unreconciled commit exception) this build
-already reports the same way. The matrix
-below enumerates this build's own 27 triggering cells, producing 14
-distinct (outcome type, reason) pairs -- fewer than 27 because several
+``Literal``s stay narrower than a build that also classifies why the
+answer fence's UPDATE matched zero rows would need (see
+``RespondOutcomeUnknown``'s own docstring in
+``task_interaction_service.py``) -- six such triggering scenarios still
+collapse onto this build's single ``(OutcomeUnknown, None)`` pair, same as
+its conservative sibling. What this build restores over that sibling is
+steps 8 and 9. Step 8's staging race is classified through both of its
+doors: an ``IntegrityError`` through ``classify_task_command_conflict``,
+a ``created=False`` result through the ``payload_matches`` verdict
+``stage_task_command`` already computed, and a winner's row carrying this
+call's own payload is a ``Replayed`` while a mismatched one is a
+``Conflict``. Step 9's commit exception is reconciled against the durable
+graph in a fresh session before falling back to ``OutcomeUnknown``. So
+this build's four ``OutcomeUnknown``-producing cells are a
+still-unclassified fence miss, a guest whose fence-level mismatch this
+build still cannot label, and two durable-graph reconciliation failures
+(an ambiguous commit with nothing in the graph to find, and one that
+lands under a different identity) -- not the staging and commit
+shortcuts its conservative sibling used. The matrix
+below enumerates this build's own 29 triggering cells, producing 14
+distinct (outcome type, reason) pairs -- fewer than 29 because several
 cells share a pair (six "principal does not own this task" cells all
-produce ``(RespondUnauthorized, not_task_principal)``; two "same
-idempotency key, different actor" cells both produce ``(RespondConflict,
-idempotency_key_reused)``; six distinct triggers collapse onto
+produce ``(RespondUnauthorized, not_task_principal)``; three "same
+idempotency key, different actor" cells all produce ``(RespondConflict,
+idempotency_key_reused)``; four distinct triggers collapse onto
 ``(OutcomeUnknown, None)``; one cell, kind/version validation, is
 parametrized over two reasons on its own). The full cell-to-pair mapping:
 
     (Cell ids are this build's subset of the full matrix an end-to-end
     delivery would enumerate; the gaps -- there is no C1 or S1-S5
-    here -- are cells only a build that stages rows and classifies fence
-    misses can reach.)
+    here -- are cells only a build that classifies fence misses can
+    reach. Step 8's own ``UNRELATED`` classification is not a cell at
+    all: it re-raises rather than returning a ``RespondOutcome``, and its
+    test lives with the escape-surface tests instead.)
 
-    OK,OK2    -> (Accepted, None)      1 (2 cells share it -- the plain
-                 accepted path, and a commit that succeeds but whose
-                 post-commit dispatcher notify raises)
+    OK1..OK4  -> (Accepted, None)      1 (4 cells share it -- the plain
+                 accepted path, a commit that succeeds but whose
+                 post-commit dispatcher notify raises, a commit whose
+                 acknowledgment was lost but whose write landed, and the
+                 same with the resume coordinator having already advanced
+                 state_version past what this call wrote)
     V1        -> (ValidationRejected, unknown_kind)                  }  2
                  (ValidationRejected, unknown_protocol_version)      }
     V2        -> (ValidationRejected, malformed_idempotency_key)     1
@@ -54,20 +68,23 @@ parametrized over two reasons on its own). The full cell-to-pair mapping:
     U1        -> (Unavailable, task_missing)                         1
     U2        -> (Unavailable, interaction_missing)                  1
     U3        -> (Unavailable, checkpoint_unavailable)                1
-    R1,R2     -> (Replayed, None)      1 (2 cells share it -- the plain
-                 replay, and a replay of an already-answered row whose
-                 resume anchor was pruned before the retry)
-    C2,C3     -> (Conflict, idempotency_key_reused)      1 (2 cells share it)
-    S6        -> (Stale, anchor_dangling)                             1
-    X1..X6    -> (OutcomeUnknown, None)      1 (6 cells share it -- a
-                 fence miss with no further classification, a guest whose
-                 fence-level mismatch this build cannot label, a staging
-                 IntegrityError, a commit exception, and two staging-race
-                 doors -- a raced row found already staged with a
-                 mismatched payload, and one found with a matching
+    R1..R3    -> (Replayed, None)      1 (3 cells share it -- the plain
+                 replay, a replay of an already-answered row whose resume
+                 anchor was pruned before the retry, and a staging race
+                 whose winner's row carries this call's own payload)
+    C2..C4    -> (Conflict, idempotency_key_reused)      1 (3 cells share
+                 it -- two "same key, different submitter" cells, and a
+                 staging race whose winner's row carries a different
                  payload)
+    S6        -> (Stale, anchor_dangling)                             1
+    X1..X4    -> (OutcomeUnknown, None)      1 (4 cells share it -- a
+                 fence miss with no further classification, a guest whose
+                 fence-level mismatch this build cannot label, a commit
+                 whose durable-graph reconciliation never finds a landed
+                 write, and one whose reconciliation finds a landed row
+                 under a different identity)
     -----------------------------------------------------------------
-    27 cells; 14 distinct pairs (12 single-reason cells + V1's own 2)
+    29 cells; 14 distinct pairs (12 single-reason cells + V1's own 2)
 
 The cell-by-cell tests this matrix implies, and the mapping meta-test that
 checks their coverage against the vocabulary, are both in this file now,
@@ -81,7 +98,7 @@ layers:
 | Assertion | Checks | Catches | Misses |
 |---|---|---|---|
 | Union-membership guard (this file, written) | ``RespondOutcome`` has exactly its eight known member classes | A variant added or removed without updating this list | Reason-level coverage |
-| Cell-by-cell tests (this file, written) | One test per of the 27 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
+| Cell-by-cell tests (this file, written) | One test per of the 29 cells, asserting outcome + reason + zero side effects | A regression in one specific cell's behavior | A forgotten test |
 | Mapping meta-test (this file, written) | Each of the 14 pairs is produced by >= 1 cell's test (12 singles + one cell's own 2) | A new cell that produces a new pair with no test written for it; the two-reason cell's parametrization missing a reason | A new cell that produces no *new* pair (e.g. a seventh not_task_principal scenario) -- caught by review, not this meta-test |
 """
 
@@ -2470,21 +2487,19 @@ def test_respond_receipt_fields_do_not_touch_the_session_after_commit(
         verify_db.close()
 
 
-def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residue(
+def test_respond_reports_outcome_unknown_when_commit_ack_is_lost_and_the_graph_never_lands(
     _respond_db, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A raised exception at commit does not, by itself, mean the write
-    failed -- the acknowledgment could have been lost after the server
-    applied it -- but this build does not attempt to reconcile that
-    against the durable graph (a fine-grained reconciliation via a fresh
-    session's own read, distinguishing a landed write from a lost one, is
-    not delivered here; see respond()'s own docstring, step 9): it reports
-    the ambiguity unconditionally. Simulates a commit that never actually
-    reaches the database and proves that in this build's conservative
-    handling nothing landed either -- the interaction row, the task row,
-    and the command table are all exactly as they were before the call.
-    Also asserts the ambiguity is logged: unlike the fence-miss branch,
-    this door used to leave no trace for an operator to find."""
+    """Injects a commit that raises without ever reaching the database, so
+    the durable-graph reconciliation has nothing to find and all three of
+    its attempts fail. Keeps both of the assertions the conservative
+    sibling made on this same door, because reconciling does not weaken
+    either: nothing landed (the interaction row, the task row and the
+    command table are exactly as they were), and the lost acknowledgment
+    is logged. The log fires before the reconciliation runs and regardless
+    of what it concludes -- an operator needs the record that an
+    acknowledgment went missing even on the runs where the write is later
+    confirmed."""
 
     user_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
@@ -2492,10 +2507,17 @@ def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residu
 
     from sqlalchemy.orm import Session as OrmSession
 
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+
     def _failing_commit(self: Any) -> None:
-        raise RuntimeError("simulated lost commit acknowledgment")
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
 
     monkeypatch.setattr(OrmSession, "commit", _failing_commit)
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
 
     with _asserts_no_side_effects(
         _respond_db, task_id=task_id, interaction_id=interaction_id
@@ -2505,7 +2527,7 @@ def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residu
                 interaction_id=interaction_id,
                 task_id=task_id,
                 principal=principal,
-                envelope=_respond_envelope(idempotency_key="commit-raises"),
+                envelope=_respond_envelope(idempotency_key="ambiguous-commit-no-graph"),
             )
 
         assert isinstance(outcome, svc.RespondOutcomeUnknown)
@@ -2518,23 +2540,257 @@ def test_respond_reports_outcome_unknown_when_commit_raises_and_leaves_no_residu
         assert matching[0].levelno == logging.WARNING
 
 
-# ---------------------------------------------------------------------------
-# Step 8's own IntegrityError catch, reached when stage_task_command's own
-# insert collides with a UNIQUE or FOREIGN KEY constraint (the real trigger
-# is a second writer racing this call for the same idempotency key -- only
-# reproducible against a real PostgreSQL server, see
-# test_task_interaction_service_postgresql.py; simulated directly here).
-# This build does not classify what an IntegrityError there means (a
-# fine-grained classification via classify_task_command_conflict,
-# distinguishing a genuine replay from a real conflict, is not delivered --
-# see respond()'s own docstring, step 8): the whole transaction rolls back
-# and this call reports the ambiguity.
-# ---------------------------------------------------------------------------
-
-
-def test_respond_reports_outcome_unknown_when_staging_the_command_raises_and_leaves_no_residue(
+def test_respond_reports_accepted_when_commit_ack_is_lost_but_the_graph_landed(
     _respond_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Same injected failure as the OutcomeUnknown case above, except this
+    time the underlying commit genuinely succeeded at the database layer
+    (only the acknowledgment back to this process was lost) -- proving the
+    reconciliation path returns Accepted, not a false negative, once the
+    complete graph is actually there to find."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_principal(user_id)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+
+    def _lost_ack_but_committed(self: Any) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            original_commit(self)
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
+
+    monkeypatch.setattr(OrmSession, "commit", _lost_ack_but_committed)
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="ambiguous-commit-landed"),
+    )
+
+    assert isinstance(outcome, svc.RespondAccepted)
+    assert outcome.receipt.responder_identity == principal.identity_string()
+
+
+def test_respond_durable_graph_check_is_monotone_when_the_coordinator_has_already_advanced_state(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The resume coordinator re-issues the same RESUME_REQUESTED
+    transition once it applies the command this call staged, bumping
+    state_version a second time -- the durable-graph check must still
+    report Accepted against a state_version that has moved past what this
+    call itself wrote, and must not compare control_state (see respond()'s
+    own docstring)."""
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_principal(user_id)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+
+    def _lost_ack_then_coordinator_advances(self: Any) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            original_commit(self)
+            # Simulate the coordinator re-applying its own transition on a
+            # separate connection before this call's reconciliation runs.
+            side_db = _respond_db()
+            try:
+                side_db.query(Task).filter(Task.id == task_id).update(
+                    {
+                        "state_version": Task.state_version + 1,
+                        "control_state": "running",
+                    }
+                )
+                side_db.commit()
+            finally:
+                side_db.close()
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
+
+    monkeypatch.setattr(OrmSession, "commit", _lost_ack_then_coordinator_advances)
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="monotone-check"),
+    )
+
+    assert isinstance(outcome, svc.RespondAccepted)
+
+
+def test_respond_reports_outcome_unknown_when_the_landed_row_answers_a_different_identity(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same lost-commit-acknowledgment injection as the two cases above, but
+    this time the row the durable-graph check reads back was answered under
+    a *different* ``responder_identity`` than the one this call's own
+    principal carries. A mismatched identity, not an absent one, is the
+    only way an answered row can fail to attest to this call: two CHECK
+    constraints chain to rule out a null identity on an answered row --
+    ``ck_task_interaction_requests_responded_at_pairs_status`` ties
+    ``status = 'answered'`` to ``responded_at IS NOT NULL``, and
+    ``ck_task_interaction_requests_responder_pairs_responded_at`` ties
+    ``responded_at IS NOT NULL`` to ``responder_identity IS NOT NULL`` --
+    so an answered row always carries *some* identity, just not
+    necessarily this call's own. See ``_verify_respond_durable_graph``'s
+    own docstring for why the comparison exists. The reconciliation must
+    not treat "an answer landed" as "my answer landed": with nothing tying
+    the row to this principal, every attempt has to keep failing and the
+    call must report OutcomeUnknown, never Accepted.
+    """
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_principal(user_id)
+
+    from sqlalchemy.orm import Session as OrmSession
+
+    original_commit = OrmSession.commit
+    call_count = {"n": 0}
+
+    def _lost_ack_but_landed_under_another_identity(self: Any) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            original_commit(self)
+            # The row genuinely committed (columns and all), but stamped
+            # with a different identity than this call's own principal --
+            # standing in for the row this call's ambiguous commit might
+            # have raced against, not a corruption of this call's own
+            # write.
+            side_db = _respond_db()
+            try:
+                side_db.query(TaskInteractionRequest).filter(
+                    TaskInteractionRequest.id == interaction_id
+                ).update({"responder_identity": "user:999999"})
+                side_db.commit()
+            finally:
+                side_db.close()
+            raise RuntimeError("simulated lost commit acknowledgment")
+        return original_commit(self)
+
+    monkeypatch.setattr(
+        OrmSession, "commit", _lost_ack_but_landed_under_another_identity
+    )
+    monkeypatch.setattr(svc, "_RESPOND_DURABLE_GRAPH_RETRY_SLEEP_SECONDS", 0.0)
+
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="ambiguous-commit-wrong-identity"),
+    )
+
+    assert isinstance(outcome, svc.RespondOutcomeUnknown)
+
+
+# ---------------------------------------------------------------------------
+# classify_task_command_conflict's IntegrityError branch (step 8), reached
+# when stage_task_command's own insert (inside this call's own
+# `db.begin_nested()`) collides with a UNIQUE or FOREIGN KEY constraint.
+# This repo already has real coverage for classify_task_command_conflict
+# itself (test_task_command_transport.py) and for the pre-existing-command
+# shortcut at step 5 (the idempotency_key_reused cells above), but never for
+# this specific call site -- respond() reaching an IntegrityError on its own
+# insert has no test anywhere in the repo before this delivery.
+#
+# Of TaskCommandConflictKind's three values, only RACED_DUPLICATE is
+# reachable through a real race here, and only on PostgreSQL. The other
+# two are not reachable through respond() at all, verified against the
+# real code rather than assumed:
+#
+# - UNRELATED needs the staged row's actor_user_id foreign key to fail --
+#   the referenced user deleted out from under a still-pending insert. In
+#   respond(), actor_user_id is always `principal.user_id`, and the answer
+#   fence's own task-side predicate (`_answer_fence_task_predicate`)
+#   requires `Task.user_id == principal.user_id` unconditionally for
+#   *both* principal kinds (guest included -- its "owning user" is the
+#   value in this same term) as a condition of the fence UPDATE actually
+#   matching a row. Confirmed by running an admin principal whose user_id
+#   does not equal the task's owner through respond(): the fence's own
+#   ownership term makes its UPDATE match zero rows, and this build
+#   returns at step 6's rowcount=0 branch long before step 8 --
+#   `principal.is_admin` only bypasses the earlier, separate Python check
+#   at step 3, never the fence's own SQL. So the only user_id that can ever
+#   reach step 8 is the task's actual owner, and that user cannot be
+#   deleted while this same transaction still holds the task row it owns
+#   (`tasks.user_id` has no `ondelete`, i.e. FK `RESTRICT` -- deleting it
+#   while a referencing task row exists is rejected at the database level,
+#   independent of any lock this transaction holds). No real race can
+#   produce UNRELATED, so it gets no race test -- but the branch that
+#   handles it is not left uncovered: the first test below injects an
+#   IntegrityError with no duplicate row behind it, which is exactly what
+#   classify_task_command_conflict calls UNRELATED, and pins that
+#   respond() re-raises it instead of folding a database-level failure
+#   into a typed outcome.
+# - TASK_MISSING needs the task to disappear between step 2 and step 8.
+#   respond() holds the tasks row through step 2's `with_for_update` for
+#   the whole transaction, and by step 8 has already written on this same
+#   connection at steps 6 and 7 -- on PostgreSQL that is the row lock
+#   itself blocking a concurrent DELETE; on SQLite (where `with_for_update`
+#   compiles to nothing, see
+#   `test_every_with_for_update_call_passes_key_share_true`'s own
+#   docstring) it is SQLite's whole-database writer lock, already held by
+#   this connection since step 6's fence UPDATE. Either way a concurrent
+#   delete of this task cannot land before this call's own insert attempt,
+#   so classify_task_command_conflict can never observe the task gone
+#   here. TASK_MISSING gets no test either.
+#
+# RACED_DUPLICATE needs a second writer to commit a row for the same
+# (task_id, command_id) strictly between stage_task_command's own
+# existing-row check and its own insert flush -- a real second connection
+# genuinely open at that instant, not a pre-committed row (which either of
+# respond()'s own two earlier existing-command checks, at step 5 and inside
+# stage_task_command itself, would catch first and never reach the flush
+# at all). SQLite cannot reproduce this: by the time respond() reaches
+# step 8 it has already written the fence UPDATE (step 6) and the CAS
+# (step 7) on this same connection, which already holds SQLite's one
+# whole-database writer lock (the same fact
+# `postgres_task_command_sessions`'s own docstring in
+# test_task_command_transport.py documents for the sibling raced-insert
+# test on enqueue_task_command) -- a second writer's commit cannot land
+# inside that window until this transaction ends. PostgreSQL's row lock,
+# held by step 2's `with_for_update` only on the specific `tasks` row,
+# does not extend to the `task_execution_commands` table, so a second
+# writer can complete there while this transaction is still open. Both of
+# RACED_DUPLICATE's sub-branches (payload_matches True and False -- they
+# produce different RespondOutcomes and only one increments the conflict
+# counter) live in test_task_interaction_service_postgresql.py for that
+# reason. What this file covers at this call site is the other door and
+# the escape: the created=False result, whose payload_matches verdict this
+# build decides on exactly like the IntegrityError door's, and the
+# UNRELATED re-raise.
+# ---------------------------------------------------------------------------
+
+
+def test_respond_reraises_an_unrelated_staging_integrity_error_and_leaves_no_residue(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An ``IntegrityError`` with no duplicate row behind it and the task
+    still present is what ``classify_task_command_conflict`` calls
+    ``UNRELATED``: some constraint other than this call's own idempotency
+    key failed. ``respond()`` must let it out rather than fold a
+    database-level failure into ``OutcomeUnknown`` -- a caller that cannot
+    tell "the database rejected this row" from "your answer was ambiguous"
+    retries the first one forever (see respond()'s own docstring on what
+    it lets escape). The zero-residue half is unchanged from the
+    conservative sibling, which reported this same injected error as
+    ``OutcomeUnknown``: the whole transaction still rolls back, and the
+    conflict counter is still untouched, because nothing here was ever
+    confirmed to be a conflict."""
+
     from sqlalchemy.exc import IntegrityError as _IntegrityError
 
     user_id, task_id = _waiting_task(_respond_db)
@@ -2552,39 +2808,31 @@ def test_respond_reports_outcome_unknown_when_staging_the_command_raises_and_lea
     with _asserts_no_side_effects(
         _respond_db, task_id=task_id, interaction_id=interaction_id
     ):
-        outcome = svc.respond(
-            interaction_id=interaction_id,
-            task_id=task_id,
-            principal=principal,
-            envelope=_respond_envelope(idempotency_key="staging-raises"),
-        )
+        with pytest.raises(_IntegrityError):
+            svc.respond(
+                interaction_id=interaction_id,
+                task_id=task_id,
+                principal=principal,
+                envelope=_respond_envelope(idempotency_key="staging-raises"),
+            )
 
-        assert isinstance(outcome, svc.RespondOutcomeUnknown)
-    # A conservative miss must not be misreported as a conflict either --
-    # the counter only increments for an outcome this build actually
-    # confirmed was a conflict.
     assert _conflict_counter() == before_counter
 
 
-@pytest.mark.parametrize(
-    "payload_matches",
-    [False, True],
-    ids=["payload-mismatch", "payload-matches"],
-)
-def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row(
-    _respond_db, monkeypatch: pytest.MonkeyPatch, payload_matches: bool
+def test_respond_reports_conflict_when_staging_finds_a_raced_row_with_another_payload(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A ``created=False`` staging result -- the row was already committed
-    and visible by the time this call's own staging statement ran -- is
-    reported as ``OutcomeUnknown`` and leaves no residue, regardless of
-    whether the raced row's payload happens to match this call's own
-    envelope. A matching payload is deliberately not treated as a replay:
-    replay recognition happens once, at step 5's idempotency pre-read,
-    before the staging statement runs. A raced hit that only becomes
-    visible after that pre-read is a race this build cannot distinguish
-    from a genuine conflict, not a replay it missed, so both the
-    mismatched and the matching case collapse onto the same conservative
-    outcome."""
+    and visible by the time this call's own staging statement ran -- whose
+    payload does not match this call's own envelope. Two different answers
+    landed under one idempotency key, which is the same fact step 5's
+    pre-read reports as ``idempotency_key_reused``; the only difference is
+    that the losing writer's row became visible one statement later. The
+    whole transaction rolls back, so this call's own fence UPDATE and CAS
+    leave no residue, and the conflict counter moves because this build
+    did confirm the conflict rather than guessing at it -- the
+    conservative sibling reported ``OutcomeUnknown`` here and left the
+    counter alone precisely because it could not."""
 
     from xagent.web.services.task_command_transport import StagedTaskCommand
 
@@ -2597,12 +2845,13 @@ def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row(
             staged_db_id=4242,
             client_command_id=kwargs.get("command_id", "staging-race"),
             created=False,
-            payload_matches=payload_matches,
+            payload_matches=False,
             status="pending",
         )
 
     monkeypatch.setattr(svc, "stage_task_command", _racing_stage_task_command)
 
+    before_counter = _conflict_counter()
     with _asserts_no_side_effects(
         _respond_db, task_id=task_id, interaction_id=interaction_id
     ):
@@ -2613,7 +2862,70 @@ def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row(
             envelope=_respond_envelope(idempotency_key="staging-race"),
         )
 
-        assert isinstance(outcome, svc.RespondOutcomeUnknown)
+        assert outcome == svc.RespondConflict(reason="idempotency_key_reused")
+    assert _conflict_counter() == before_counter + 1
+
+
+def test_respond_replays_when_staging_finds_a_raced_row_with_a_matching_payload(
+    _respond_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same ``created=False`` door, with the winner's row carrying this
+    call's own actor, kind and canonical payload. This build reports
+    ``Replayed`` rather than the conservative sibling's ``OutcomeUnknown``,
+    and the reversal is deliberate: that sibling's argument was that it
+    could not tell a race from a replay, and ``payload_matches`` -- the
+    same ``_matches_existing`` verdict ``classify_task_command_conflict``
+    computes on the other door -- is exactly the fact it was missing. With
+    the winner's row proven to carry this answer, the RESUME that executes
+    is this answer, so this call commits its own fence UPDATE and CAS
+    instead of rolling them back: the interaction row must end up answered
+    and the task advanced, or the command that runs would be answering a
+    row that never recorded an answer. The receipt names the winner's row,
+    not one this call staged, which is why the outcome is ``Replayed`` and
+    not ``Accepted``. The conflict counter must not move -- a confirmed
+    replay is not a conflict."""
+
+    from xagent.web.services.task_command_transport import StagedTaskCommand
+
+    user_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = _owning_principal(user_id)
+    before = _graph_snapshot(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    )
+
+    def _racing_stage_task_command(*args: Any, **kwargs: Any) -> StagedTaskCommand:
+        return StagedTaskCommand(
+            staged_db_id=4242,
+            client_command_id=kwargs.get("command_id", "staging-race"),
+            created=False,
+            payload_matches=True,
+            status="pending",
+        )
+
+    monkeypatch.setattr(svc, "stage_task_command", _racing_stage_task_command)
+
+    before_counter = _conflict_counter()
+    outcome = svc.respond(
+        interaction_id=interaction_id,
+        task_id=task_id,
+        principal=principal,
+        envelope=_respond_envelope(idempotency_key="staging-race"),
+    )
+
+    assert isinstance(outcome, svc.RespondReplayed)
+    # The winner's row id, taken straight from the staging result -- this
+    # build does not re-query for it on this door.
+    assert outcome.receipt.command_db_id == 4242
+    assert outcome.receipt.responder_identity == principal.identity_string()
+    assert _conflict_counter() == before_counter
+
+    after = _graph_snapshot(_respond_db, task_id=task_id, interaction_id=interaction_id)
+    assert before["ir_status"] == "active"
+    assert after["ir_status"] == "answered"
+    assert after["ir_responder_identity"] == principal.identity_string()
+    assert after["task_state_version"] == before["task_state_version"] + 1
+    assert after["task_control_state"] == TaskControlState.RESUME_REQUESTED.value
 
 
 # ---------------------------------------------------------------------------
@@ -2623,8 +2935,8 @@ def test_respond_reports_outcome_unknown_when_staging_finds_a_raced_row(
 # (see the module docstring's three-way division of labor table) -- several
 # triggering conditions collapse onto the same pair (six distinct
 # "principal does not own this task" scenarios all produce
-# ``not_task_principal``; two distinct "same idempotency key, different
-# submitter" scenarios both produce ``idempotency_key_reused``), and one
+# ``not_task_principal``; three distinct "same idempotency key, different
+# submitter" scenarios all produce ``idempotency_key_reused``), and one
 # validation scenario is parametrized over two reasons on its own.
 # ---------------------------------------------------------------------------
 
@@ -2660,8 +2972,8 @@ def test_every_vocabulary_pair_is_produced_by_at_least_one_cell_test() -> None:
     every ``isinstance(outcome, svc.Respond<Type>)`` check the cell tests
     above use, and cross-checks the resulting (type, reason) set against
     the vocabulary. Deliberately not ``len(produced) == len(vocabulary)`` or
-    any other arithmetic against the 27-cell count -- six
-    not_task_principal cells and two idempotency_key_reused cells
+    any other arithmetic against the 29-cell count -- six
+    not_task_principal cells and three idempotency_key_reused cells
     legitimately collapse onto one pair each; this only asserts that no
     vocabulary pair is left with zero producing cells. Its blind spot: a
     new cell that produces no *new* pair -- for example a seventh

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -1016,6 +1016,17 @@ def test_respond_races_a_committed_duplicate_command_and_replays_on_matching_pay
         assert len(commands) == 1, commands
         assert commands[0].id == winner.command_id
         assert commands[0].actor_user_id == principal.user_id
+
+        row = (
+            verify_db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == interaction_id)
+            .first()
+        )
+        assert row.status == "answered"
+        assert row.responded_at is not None
+
+        task = verify_db.query(Task).filter(Task.id == task_id).first()
+        assert task.state_version == 6
     finally:
         verify_db.close()
 

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -29,6 +29,13 @@ in this delivery that a SQLite-backed test cannot actually exercise:
   each ordering runs to completion and commits before the next
   statement starts, so nothing here actually contends on a lock -- and
   confirming neither ordering leaves residue.
+- Step 8's ``classify_task_command_conflict`` RACED_DUPLICATE branch,
+  reached only on PostgreSQL (SQLite's single-writer lock closes the
+  window before this call reaches its own insert): two tests pause
+  ``respond()`` right after its own existing-row check finds nothing and
+  let a second, independent writer commit first, one with a matching
+  payload (replayed) and one with a different one (conflict, whole
+  transaction rolled back).
 
 Fixture pattern follows ``test_interaction_staging_postgresql.py``: a
 disposable, uniquely-named schema inside whatever database
@@ -49,6 +56,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import sessionmaker
 
+import xagent.web.models.database as database_module
 from tests.web.services.task_interaction_schema_shared import (
     assert_rejected,
     make_row,
@@ -58,12 +66,18 @@ from tests.web.services.task_interaction_schema_shared import (
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import task_interaction_service as svc
+from xagent.web.services.interaction_rollout import counters_snapshot
 from xagent.web.services.ops_signals import (
     CHECKPOINT_LOAD_UNAVAILABLE,
     CHECKPOINT_PK_ANCHOR_DANGLING,
     clear_degradation,
+)
+from xagent.web.services.task_command_transport import (
+    TaskCommandKind,
+    enqueue_task_command,
 )
 from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD
 
@@ -846,3 +860,256 @@ def test_respond_vs_concurrent_purge_does_not_deadlock(_respond_pg, engine) -> N
     assert results.get("respond_outcome") == svc.RespondUnavailable(
         reason="interaction_missing"
     ), results
+
+
+# ---------------------------------------------------------------------------
+# classify_task_command_conflict's IntegrityError branch (step 8), reached
+# from svc.respond() when stage_task_command's own insert -- inside this
+# call's own ``db.begin_nested()`` -- collides with the
+# ``uq_task_command_identity`` unique constraint. See
+# test_task_interaction_service.py's own section by this name for the full
+# reachability audit of all three TaskCommandConflictKind values against
+# the real code: UNRELATED and TASK_MISSING are both provably unreachable
+# through respond() on either backend (actor_user_id is always the task's
+# own owner, which the fence's ownership predicate requires and which
+# cannot be deleted out from under a task row this transaction still
+# references; the task row itself cannot disappear before this call's own
+# insert either). RACED_DUPLICATE is the only reachable one, and only here
+# on PostgreSQL: a second writer must commit a row for the same
+# (task_id, command_id) strictly between stage_task_command's own
+# existing-row check and its own insert flush, a window SQLite's single
+# whole-database writer lock closes (respond() has already written the
+# fence UPDATE and the CAS on its own connection by the time it reaches
+# step 8, so that connection already holds SQLite's one writer lock).
+# PostgreSQL's row lock from step 2 is scoped to the specific ``tasks`` row
+# alone, so a second writer can complete an insert into the unrelated
+# ``task_execution_commands`` table while this transaction is still open.
+#
+# Both of RACED_DUPLICATE's sub-branches are pinned below -- they produce
+# different RespondOutcomes and only one touches the response-conflict
+# counter (the same counter the idempotency_key_reused cells in the
+# SQLite-backed file exercise through the earlier, pre-existing-command
+# shortcut at step 5; this is the same counter's other, previously
+# untested, wiring point at step 8):
+#
+# - payload_matches=True: the second writer's row carries the identical
+#   actor/kind/payload this call would itself have staged. respond()
+#   replays the winning row (``RespondReplayed``) rather than treating the
+#   loss as a failure, and does not touch the counter.
+# - payload_matches=False: the second writer's row carries different
+#   ``values``, so it canonicalizes to a different payload.
+#   classify_task_command_conflict still finds it (it does not compare
+#   payloads to decide whether a row raced -- only to decide what to do
+#   once one has), and respond() reports ``RespondConflict`` and does
+#   increment the counter, rolling back the whole transaction -- including
+#   the fence UPDATE and the CAS this call had already issued -- since none
+#   of that write was this call's own to keep.
+# ---------------------------------------------------------------------------
+
+
+def _pg_conflict_counter() -> int:
+    return counters_snapshot().get(svc.COUNTER_LIFECYCLE_RESPONSE_CONFLICT, 0)
+
+
+def _pause_command_add_session_factory(
+    base_session_factory, *, precheck_done, release_event
+):
+    """A session factory wrapping ``base_session_factory`` whose returned
+    session pauses the instant something calls ``.add()`` with a
+    ``TaskExecutionCommand`` -- the exact point stage_task_command reaches
+    right after its own existing-row check has already found nothing and
+    right before the insert flush this test needs a second writer to beat.
+    Only ``get_session_local`` is repointed at this wrapper, and only after
+    every setup call already used the plain ``_respond_pg`` factory
+    directly, so only respond()'s own internally-created session is
+    instrumented -- the racing writer below opens its own, unpatched
+    session straight off the base factory."""
+
+    def factory():
+        db = base_session_factory()
+        real_add = db.add
+
+        def paused_add(instance):
+            if isinstance(instance, TaskExecutionCommand):
+                precheck_done.set()
+                assert release_event.wait(timeout=10)
+            real_add(instance)
+
+        db.add = paused_add
+        return db
+
+    return factory
+
+
+def test_respond_races_a_committed_duplicate_command_and_replays_on_matching_payload(
+    _respond_pg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second, independent writer commits a TaskExecutionCommand row for
+    the same (task_id, command_id) with the identical actor/kind/payload
+    while respond() is paused right after its own stage_task_command's
+    existing-row check already found nothing. respond()'s own insert then
+    collides on the unique constraint; classify_task_command_conflict
+    reports RACED_DUPLICATE with payload_matches=True, and respond() commits
+    and replays the winning row instead of treating this as a failure."""
+
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    principal = _pg_owning_principal(user_id)
+    envelope = _pg_envelope("pg-raced-duplicate-match")
+    matching_payload = svc._respond_command_payload(
+        interaction_id=interaction_id, principal=principal, values=envelope.values
+    )
+
+    precheck_done = threading.Event()
+    release_respond = threading.Event()
+    results: dict = {}
+
+    monkeypatch.setattr(
+        database_module,
+        "get_session_local",
+        lambda: _pause_command_add_session_factory(
+            _respond_pg, precheck_done=precheck_done, release_event=release_respond
+        ),
+    )
+
+    def call_respond() -> None:
+        results["outcome"] = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=envelope,
+        )
+
+    t_respond = threading.Thread(target=call_respond)
+    t_respond.start()
+    assert precheck_done.wait(timeout=10)
+
+    db_racer = _respond_pg()
+    try:
+        winner = enqueue_task_command(
+            db_racer,
+            task_id=task_id,
+            actor_user_id=principal.user_id,
+            command_id=envelope.idempotency_key,
+            kind=TaskCommandKind.RESUME,
+            payload=matching_payload,
+        )
+    finally:
+        db_racer.close()
+
+    before_counter = _pg_conflict_counter()
+    release_respond.set()
+    t_respond.join(timeout=10)
+
+    outcome = results["outcome"]
+    assert isinstance(outcome, svc.RespondReplayed), outcome
+    assert outcome.receipt.command_db_id == winner.command_id
+    assert _pg_conflict_counter() == before_counter
+
+    verify_db = _respond_pg()
+    try:
+        commands = (
+            verify_db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.task_id == task_id)
+            .all()
+        )
+        assert len(commands) == 1, commands
+        assert commands[0].id == winner.command_id
+        assert commands[0].actor_user_id == principal.user_id
+    finally:
+        verify_db.close()
+
+
+def test_respond_races_a_committed_duplicate_command_and_conflicts_on_mismatched_payload(
+    _respond_pg, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same race as above, except the second writer's row carries different
+    answer values -- a different canonicalized payload.
+    classify_task_command_conflict still classifies this as
+    RACED_DUPLICATE (it finds the row purely by (task_id, command_id), not
+    by payload), but with payload_matches=False; respond() reports
+    RespondConflict, increments the response-conflict counter, and rolls
+    back the whole transaction -- undoing its own fence UPDATE and CAS,
+    since none of that write is this call's to keep once its own command
+    lost the race."""
+
+    user_id, task_id = _pg_waiting_task(_respond_pg)
+    interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
+    principal = _pg_owning_principal(user_id)
+    envelope = _pg_envelope("pg-raced-duplicate-mismatch")
+    mismatched_payload = svc._respond_command_payload(
+        interaction_id=interaction_id,
+        principal=principal,
+        values={"env": "a-different-answer-than-this-call-submits"},
+    )
+
+    precheck_done = threading.Event()
+    release_respond = threading.Event()
+    results: dict = {}
+
+    monkeypatch.setattr(
+        database_module,
+        "get_session_local",
+        lambda: _pause_command_add_session_factory(
+            _respond_pg, precheck_done=precheck_done, release_event=release_respond
+        ),
+    )
+
+    def call_respond() -> None:
+        results["outcome"] = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
+            envelope=envelope,
+        )
+
+    t_respond = threading.Thread(target=call_respond)
+    t_respond.start()
+    assert precheck_done.wait(timeout=10)
+
+    db_racer = _respond_pg()
+    try:
+        winner = enqueue_task_command(
+            db_racer,
+            task_id=task_id,
+            actor_user_id=principal.user_id,
+            command_id=envelope.idempotency_key,
+            kind=TaskCommandKind.RESUME,
+            payload=mismatched_payload,
+        )
+    finally:
+        db_racer.close()
+
+    before_counter = _pg_conflict_counter()
+    release_respond.set()
+    t_respond.join(timeout=10)
+
+    outcome = results["outcome"]
+    assert outcome == svc.RespondConflict(reason="idempotency_key_reused"), outcome
+    assert _pg_conflict_counter() == before_counter + 1
+
+    verify_db = _respond_pg()
+    try:
+        commands = (
+            verify_db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.task_id == task_id)
+            .all()
+        )
+        assert len(commands) == 1, commands
+        assert commands[0].id == winner.command_id
+        assert commands[0].payload == mismatched_payload
+
+        row = (
+            verify_db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == interaction_id)
+            .first()
+        )
+        assert row.status == "active"
+        assert row.active_slot == 1
+        assert row.responded_at is None
+
+        task = verify_db.query(Task).filter(Task.id == task_id).first()
+        assert task.state_version == 5
+        assert task.control_state == "waiting_for_user"
+    finally:
+        verify_db.close()


### PR DESCRIPTION
## Summary

Reconciles an ambiguous commit against the durable graph, and classifies staging conflicts precisely. The merged answer-side entry point (#1354) reports two situations as `RespondOutcomeUnknown` by design: a commit that raised after the answer may or may not have become durable, and a staged-command collision with a concurrent writer. This change delivers the precision that build deferred.

## What's here

- `_verify_respond_durable_graph`: after a failed commit acknowledgment, a fresh session reads what actually landed. If the interaction row is answered under this call's identity and the staged command carries this call's payload, the answer was durable and the caller receives `Accepted` with the real receipt; a graph that landed differently (or not at all) keeps the unresolved outcome. Each verification attempt logs on failure; three exhausted attempts fall back to exactly what the merged build returns without this layer.
- Both staging-race doors classified the same way: the unique-constraint `IntegrityError` and the returned pre-existing row are two signals for one race, and both now resolve through the same comparison — a matching payload is a replay (the winning row carries this call's own actor, kind and canonical payload, so the RESUME about to execute is this answer), a mismatched one is a `Conflict`. The replay verdict additionally asserts the fence UPDATE and the control-state transition commit — without them the executing command would answer a row that never recorded an answer.
- The post-commit dispatcher notify is best-effort on both exits (the normal accept and the reconciled accept), through one shared helper carrying the merged build's guarantee: a durable answer is never reported as a failure because a wakeup raised.
- The commit-failure warning log stays, unconditionally, before reconciliation begins: even when reconciliation upgrades the result to `Accepted`, the lost acknowledgment itself is something an operator should be able to find.
- A database-level `IntegrityError` with no duplicate row behind it re-raises rather than folding into a typed outcome, and a test pins that escape.

## Verification

Full SQLite suite for the touched surfaces (116 in the service file, 186 with the command-transport suite), PostgreSQL-only suite against a disposable database, and red/green mutation for every restored branch: collapsing the raced-row door back to the catch-all turns both race tests red, ignoring the reconciliation verdict turns the landed-graph tests red, and removing the identity condition from the graph check turns the foreign-identity test red.
