### PR TITLE
feat(v1): project step and message content onto the task event stream

### DIFF
--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -17,7 +17,8 @@ Each connection gets its own projector, and that projector is fed only
 the frames broadcast after the connection registered. A step that was
 already running at that moment therefore has no matching start in it,
 so the step's eventual end event folds in as an orphan and is dropped:
-on this stream that step stays at whatever state it was last seen in.
+that step never appears on this stream at all, since its start was
+broadcast before this connection existed.
 Clients attaching mid-task reconcile against
 ``GET /v1/chat/tasks/{task_id}/steps``, which reads the database and
 so is unaffected by when the stream was opened.
@@ -111,9 +112,10 @@ PER_PRINCIPAL_STREAM_CAP = 32
 # ``core/task_runtime.py``'s ``MAX_TASK_RUNTIME_JSON_BYTES``), not a new
 # one invented for this module.
 MAX_FRAME_CONTENT_BYTES = 64 * 1024
-# Check on a raw broadcast frame's own text length, run after
-# ``json.loads`` parses it, gating only the call into the projection
-# pass -- ``MAX_FRAME_CONTENT_BYTES`` only bounds the *projected*
+# Check on a raw broadcast frame's text length -- measured excluding
+# the internal task-description stamp broadcast frames carry (see
+# ``_measured_content_frame``) -- run after ``json.loads`` parses it,
+# gating only the call into the projection pass -- ``MAX_FRAME_CONTENT_BYTES`` only bounds the *projected*
 # content that ends up on the wire, so without this a multi-megabyte raw
 # frame still pays for a full ``serialize_trace_data`` walk + projection
 # just to have its content truncated at the very end. 4x

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -77,6 +77,10 @@ values it deliberately leaves unbounded, in one place:
     then the cost of engaging is one forced ``resync_required`` close,
     identical in kind and price to the element cap's own overflow; a
     consumer that is keeping up never accumulates a backlog at all.
+    Tighter would hurt: 1 MiB puts the engagement average at 4 KiB,
+    inside ordinary backlog territory, so 4 MiB is the tightest value
+    that leaves ordinary traffic alone -- against the ~16 MiB a full
+    element-capped queue of maximum frames would otherwise hold.
   - Concurrent streams: ``PER_TASK_STREAM_CAP`` (2) and
     ``PER_PRINCIPAL_STREAM_CAP`` (32), both rejected with 429 at
     attach, before any sink exists.
@@ -802,7 +806,7 @@ class V1EventStreamSink:
         self.principal_key_prefix = principal_key_prefix
         self.dropped_frame_count = 0
         # Wire bytes currently sitting in ``_queue``. Maintained at the
-        # two places that touch the queue and nowhere else: ``_put_counted``
+        # three places that touch the queue and nowhere else: ``_put_counted``
         # adds a frame's length as it goes in, ``next_frame`` subtracts it
         # as it comes out, and ``enqueue_close`` zeroes it after draining.
         # No caller outside this class adjusts it.

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -634,6 +634,62 @@ def project_content_frames(
     return _feed_final_answer(frame_type, message)
 
 
+def _measured_content_frame(
+    text: str, message: dict[str, Any]
+) -> tuple[int, dict[str, Any]]:
+    """Return ``(chars, frame)`` -- the length the drop check below
+    compares against the cap, and the frame projection should consume.
+
+    ``ws_trace_handlers.py``'s ``_convert_trace_event_to_stream_event``
+    copies the task's ``description`` column onto
+    ``data["task_description"]`` for *every* trace event it converts,
+    with no event-type gate. That column has no length bound
+    (``Column(Text)``, filled from the task's first user message, which
+    has no ``max_length`` of its own), and it is re-stamped on each
+    frame -- so counting it would let one long description push every
+    subsequent ``step.*`` frame of that task past
+    ``MAX_RAW_FRAME_TEXT_CHARS`` and drop the task's whole content
+    stream for the life of the connection.
+
+    Excluding it costs the client nothing, because no content this
+    module puts on the wire can contain it: each of the four producers
+    builds its ``data`` from explicitly named keys (``_step_mapping``'s
+    ``_build_thinking_start`` / ``_build_tool_start`` /
+    ``_build_message_step`` and the ``extra_data_fn`` patches, then
+    ``message_delta_frame`` / ``message_completed_frame``), so the
+    description was consuming a budget it could never spend.
+
+    An under-cap frame is returned unchanged, description and all --
+    the walk that projection pays over it is already bounded by the
+    cap. An over-cap frame carrying a description is pruned *before*
+    both measuring and projecting, not just before measuring: the raw
+    frame check was this field's only per-frame CPU bound (a
+    synchronous, unbounded ``clean_string`` walk during projection), so
+    a frame that survives the check must not still be paying for the
+    field the check just excused it from. Measured by re-serializing
+    the parsed frame without that one field rather than by subtracting
+    an estimate of the field's serialized length: an estimate would
+    have to reproduce the producer's separators and escaping, while a
+    re-dump is exact in the same character domain ``len(text)`` is
+    measured in (``broadcast_to_task`` serializes with a default
+    ``json.dumps``, and so does this). It runs only for a frame that is
+    both over the cap and carrying a description -- the frame that
+    would otherwise be dropped outright -- so an ordinary frame still
+    costs one ``len()``, and the re-dump's own cost scales with the
+    frame *without* the description, not with the description.
+    ``json.dumps`` cannot fail here: ``message`` came out of
+    ``json.loads`` in the caller.
+    """
+    if len(text) <= MAX_RAW_FRAME_TEXT_CHARS:
+        return len(text), message
+    data = message.get("data")
+    if not isinstance(data, dict) or "task_description" not in data:
+        return len(text), message
+    pruned = {key: value for key, value in data.items() if key != "task_description"}
+    frame = {**message, "data": pruned}
+    return len(json.dumps(frame)), frame
+
+
 # -- Sink -----------------------------------------------------------------
 
 
@@ -802,35 +858,60 @@ class V1EventStreamSink:
         The raw-size check itself runs after ``json.loads`` and the
         lifecycle handling above, guarding only the call into
         ``_project_and_queue`` -- the last thing between a parsed frame
-        and the projector. It compares ``len(text)`` -- the raw
-        broadcast frame's own character count -- against
-        ``MAX_RAW_FRAME_TEXT_CHARS`` (256 KiB): strictly greater than is
-        a drop, exactly equal is kept. On a drop, ``dropped_frame_count``
-        is incremented, one ``logger.warning`` fires, and the method
-        returns -- no queued frame, no close, no ``stream.error``: a
-        dropped frame is invisible to the client.
-        The size check applies only to frames whose parsed ``type`` is
-        in ``_CONTENT_FRAME_TYPES`` and whose top-level ``event_type``
-        is not ``task_info``; dispatch into the projector is unchanged
-        for the whole ``_CONTENT_FRAME_TYPES`` set regardless. Lifecycle
-        frames are exempt from the size check structurally rather than
-        by a prefix sniff: ``task_completed`` returns above before this
-        check runs, ``task.status``/``task.input_required`` are
-        enqueued above it, and ``task_info`` is named explicitly so an
-        oversized one is neither counted as a drop nor logged as one --
-        it carries an operator-controlled task description with no size
-        bound of its own (see ``MAX_RAW_FRAME_TEXT_CHARS``'s own comment
-        for why ``task_completed`` can also legitimately cross this
-        threshold). The check runs after ``json.loads`` because what it
-        has to exempt is only knowable after it: a ``task_info``
-        frame's own top-level ``type`` is ``trace_event``, the same
-        value real content frames carry, so nothing short of parsing
-        distinguishes the two. The parse is not extra cost on the
-        fan-out path: ``ConnectionManager.broadcast_to_task``
-        serializes the frame with ``json.dumps`` once per connection,
-        inside its own send loop, before this method is called at all --
-        and the expensive half here, ``serialize_trace_data`` plus the
-        projection fold, is skipped for a frame this check drops.
+        and the projector. It applies only to frames whose parsed
+        ``type`` is in ``_CONTENT_FRAME_TYPES``; dispatch into the
+        projector is unchanged for that whole set regardless. What it
+        compares against ``MAX_RAW_FRAME_TEXT_CHARS`` (256 KiB) is the
+        frame's own character count minus the ``task_description``
+        field the broadcast conversion stamps onto every trace event --
+        see ``_measured_content_frame`` for why that subtraction exists
+        and why it costs nothing on the ordinary path. Strictly greater
+        than the cap is a drop, exactly equal is kept. On a drop,
+        ``dropped_frame_count`` is incremented, one ``logger.warning``
+        fires, and the method returns -- no queued frame, no close, no
+        ``stream.error``: a dropped frame is invisible to the client.
+
+        Two separate mechanisms keep lifecycle delivery out of this
+        check's way, and they are not interchangeable:
+
+          - Placement. Running after ``json.loads`` and after the
+            lifecycle handling above is what makes an oversized frame
+            unable to cost a client its lifecycle signal:
+            ``task_completed`` returns on the acceleration branch
+            before this check is reached, and ``task.status`` /
+            ``completion_hint`` have already been enqueued or set by
+            the time it runs. A gate placed ahead of the parse would
+            drop those frames whole -- and could not tell them apart
+            anyway, since a ``task_info`` frame's own top-level
+            ``type`` is ``trace_event``, the same value real content
+            frames carry (see ``MAX_RAW_FRAME_TEXT_CHARS``'s own
+            comment for why ``task_completed`` can legitimately cross
+            this threshold too).
+          - The ``event_type != "task_info"`` exemption. By the time
+            control reaches it, a ``task_info`` frame's status is
+            already enqueued above, and ``_feed_trace_event`` returns
+            ``[]`` for ``task_info`` whether the exemption is there or
+            not. So the exemption decides exactly one thing: whether
+            an oversized ``task_info`` increments
+            ``dropped_frame_count`` and logs a drop warning. It is not
+            what protects ``task.status``/``completion_hint``
+            delivery. It is there because such a frame carries the
+            task description with no size bound of its own, so
+            counting it as a dropped content frame would be counting a
+            drop that had no content to lose.
+
+        The parse is not extra cost on the fan-out path:
+        ``ConnectionManager.broadcast_to_task`` serializes the frame
+        with ``json.dumps`` once per connection, inside its own send
+        loop, before this method is called at all. What happens to the
+        expensive half here -- ``serialize_trace_data`` plus the
+        projection fold -- depends on where the frame lands: a frame
+        under the cap pays it in full; a frame over the cap only
+        because of its task description is pruned by
+        ``_measured_content_frame`` before projection runs, not just
+        before the comparison, so it pays that cost against the frame
+        without the description instead; and a frame still over the
+        cap after pruning is dropped outright and pays none of it.
         """
         try:
             self._assert_owner_loop()
@@ -865,19 +946,21 @@ class V1EventStreamSink:
                         # read wouldn't have closed anyway.
                         self.completion_hint.set()
             if str(message.get("type") or "") in _CONTENT_FRAME_TYPES:
-                if (
-                    message.get("event_type") != "task_info"
-                    and len(text) > MAX_RAW_FRAME_TEXT_CHARS
-                ):
-                    self.dropped_frame_count += 1
-                    logger.warning(
-                        "v1 SSE sink dropped an oversized broadcast frame "
-                        "(%d chars) for task %s before projecting it",
-                        len(text),
-                        self.task_id,
-                    )
-                    return
-                self._project_and_queue(message)
+                frame = message
+                if message.get("event_type") != "task_info":
+                    measured_chars, frame = _measured_content_frame(text, message)
+                    if measured_chars > MAX_RAW_FRAME_TEXT_CHARS:
+                        self.dropped_frame_count += 1
+                        logger.warning(
+                            "v1 SSE sink dropped an oversized broadcast frame "
+                            "(%d chars, %d excluding the task description) for "
+                            "task %s before projecting it",
+                            len(text),
+                            measured_chars,
+                            self.task_id,
+                        )
+                        return
+                self._project_and_queue(frame)
         except Exception:
             self.dropped_frame_count += 1
             logger.exception(

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1,37 +1,47 @@
 """SSE transport layer for ``GET /v1/chat/tasks/{task_id}/events``.
 
-This module owns everything about *moving bytes to the client and
-deciding when to stop* -- registration into the shared connection
-``manager``, the outbound frame queue, the 30-second watchdog, the
-1-hour absolute duration cap, and per-task / per-principal concurrency
-limits. It emits four lifecycle events -- ``task.status``,
-``task.completed``, ``task.input_required``, and ``stream.error`` --
-and nothing else.
+This module owns *moving bytes to the client and deciding when to
+stop* -- registration into the shared connection ``manager``, the
+outbound frame queue, the 30-second watchdog, the 1-hour absolute
+duration cap, and per-task / per-principal concurrency limits -- and,
+layered on top of that transport, projecting the task's ``step.*`` /
+``message.*`` content onto the same stream: each live broadcast frame
+is classified and folded through a per-connection
+``PublicStepProjector`` (see ``project_content_frames``), so a running
+task's steps and streamed message text reach an already-attached
+client without polling. Four more events are lifecycle-only and
+carry no step/message content of their own -- ``task.status``,
+``task.completed``, ``task.input_required``, and ``stream.error``.
 
-Explicitly out of scope here:
-  - Projecting ``step.*`` / ``message.*`` content from trace events.
-  - Buffering live frames during attach warm-up, or reconciling frame
-    order at all. No ``task.status`` frame is ever guaranteed to be
-    fresh or in order: ``ConnectionManager.broadcast_to_task`` stamps
-    each event with whatever ``run_id`` / ``state_version`` tuple its
-    producer captured, falling back to a fresh read of the task row
-    (status included) when the producer didn't capture one, and this
-    sink never compares that stamp against anything -- it just forwards
-    each status string it sees, deduped only against the last one it
-    sent. A stale or out-of-order
-    ``task.status`` frame can therefore reach the client at any point
-    during the stream's life, not only right after attach. This is
-    accepted: the only frames this module treats as authoritative are
-    the three close frames -- ``task.completed``, ``task.input_required``,
-    and ``stream.error`` -- and all three are produced by the watchdog
-    (or the attach-time snapshot read) reading the task row directly,
-    never inferred from frame ordering.
-  - Populating ``task.input_required``'s ``prompt`` field from the
-    agent's question text. Only the watchdog closes the stream on a
-    task stuck waiting for user input (within one watchdog cycle), and
-    it always sends ``prompt: null`` -- question-text sniffing from
-    live frames belongs to the content-projection layer, not this
-    transport layer.
+Each connection gets its own projector, and that projector is fed only
+the frames broadcast after the connection registered. A step that was
+already running at that moment therefore has no matching start in it,
+so the step's eventual end event folds in as an orphan and is dropped:
+on this stream that step stays at whatever state it was last seen in.
+Clients attaching mid-task reconcile against
+``GET /v1/chat/tasks/{task_id}/steps``, which reads the database and
+so is unaffected by when the stream was opened.
+
+No ``task.status`` frame is
+ever guaranteed to be fresh or in order, at any point in the stream's
+life: ``ConnectionManager.broadcast_to_task``
+stamps each event with whatever ``run_id`` / ``state_version`` tuple
+its producer captured, falling back to a fresh read of the task row
+(status included) when the producer didn't capture one, and this sink
+never compares that stamp against anything -- it just forwards each
+status string it sees, deduped only against the last one it sent. A
+stale or out-of-order ``task.status`` frame can therefore reach the
+client at any point during the stream's life, not only right after
+attach. This is accepted: the only frames this module treats as
+authoritative are the three close frames -- ``task.completed``,
+``task.input_required``, and ``stream.error`` -- and all three are
+produced by the watchdog (or the attach-time snapshot read) reading
+the task row directly, never inferred from frame ordering.
+``task.input_required``'s ``prompt`` field is populated from
+``_TaskInfoSnapshot.pending_question`` -- the same authoritative row
+read that already backs the close decision itself, so this never
+triggers a query of its own and never sniffs live agent_message frames
+for question text.
 
 Sink instances duck-type the ``websocket.ConnectionManager`` connection
 contract (an object with an async ``send_text(str)`` method) so they
@@ -54,9 +64,17 @@ from fastapi.responses import StreamingResponse
 from ...models.agent_api_key import AgentApiKey
 from ...models.database import get_session_local
 from ...models.task import TaskStatus
+from ...schemas.v1 import PublicStep
 from ...services.db_runtime import run_db_io_cancellation_safe
 from ...services.task_execution_controller import TaskControlState
+from ..public_trace_events import (
+    DELEGATED_AGENT_TRACE_SOURCE,
+    is_audit_only_trace_data,
+    normalize_public_trace_event,
+)
 from ..websocket import _is_versioned_task_event, manager
+from ..ws_trace_handlers import serialize_trace_data
+from ._step_mapping import PublicStepProjector
 from .deps import ApiKeyPrincipal, active_runtime_key_filters
 from .errors import V1ApiError, V1ErrorCode
 
@@ -84,6 +102,35 @@ STREAM_MAX_DURATION_SECONDS = 60.0 * 60.0
 OUTBOUND_QUEUE_MAX_SIZE = 256
 PER_TASK_STREAM_CAP = 2
 PER_PRINCIPAL_STREAM_CAP = 32
+# Bounds how large a single step.*/message.* frame's content can get --
+# unlike the other tunables above, this scopes only the content-frame
+# families this module projects (a tool's args/result, an agent
+# delegation's input/output, or a message's text), not the whole SSE
+# frame. Same
+# magnitude as the repo's existing single-blob byte caps (e.g.
+# ``core/task_runtime.py``'s ``MAX_TASK_RUNTIME_JSON_BYTES``), not a new
+# one invented for this module.
+MAX_FRAME_CONTENT_BYTES = 64 * 1024
+# Check on a raw broadcast frame's own text length, run after
+# ``json.loads`` parses it, gating only the call into the projection
+# pass -- ``MAX_FRAME_CONTENT_BYTES`` only bounds the *projected*
+# content that ends up on the wire, so without this a multi-megabyte raw
+# frame still pays for a full ``serialize_trace_data`` walk + projection
+# just to have its content truncated at the very end. 4x
+# ``MAX_FRAME_CONTENT_BYTES`` gives room for a raw frame's JSON envelope
+# (field names, escaping, nested step metadata) around content that
+# would itself end up right at the cap -- a frame this large is already
+# far past anything a capped projection would keep, so dropping it
+# outright costs nothing a client would have been able to read anyway.
+# Scoped to content frames only -- a lifecycle frame is never truncated
+# or projected by this module, so its raw size can't be judged against
+# a cap built around projected content. ``task_completed`` in
+# particular carries its whole output twice (``result`` and ``output``,
+# see ``websocket.py``) and can legitimately cross this threshold well
+# before anything is actually wrong; dropping it here would silently
+# delay the completion signal to the watchdog's next cycle instead of
+# firing it immediately.
+MAX_RAW_FRAME_TEXT_CHARS = 4 * MAX_FRAME_CONTENT_BYTES
 # Floor for the final wait when the 1-hour deadline is close: keeps the
 # queue wait from being called with a near-zero timeout, which would spin
 # the loop instead of actually waiting.
@@ -125,9 +172,10 @@ def _stream_close_reason(status: TaskStatus, control_state: str | None) -> str |
 
 # A sync callable: (task_id, principal) -> ``_TaskInfoSnapshot``-shaped
 # object (duck-typed: ``.status`` / ``.control_state`` / ``.output`` /
-# ``.error``), raising ``V1ApiError(TASK_NOT_FOUND, 404)`` when the task
-# is missing or not owned. Always run through ``run_db_io_cancellation_safe``
-# by this module -- never called directly.
+# ``.error`` / ``.pending_question``), raising
+# ``V1ApiError(TASK_NOT_FOUND, 404)`` when the task is missing or not
+# owned. Always run through ``run_db_io_cancellation_safe`` by this module
+# -- never called directly.
 TaskSnapshotReader = Callable[[int, "ApiKeyPrincipal"], Any]
 
 
@@ -142,16 +190,39 @@ def status_frame(status: str) -> str:
     return _sse_frame("task.status", {"status": status})
 
 
+# ``completed_frame``'s ``output`` and ``input_required_frame``'s
+# ``prompt`` are the two content-bearing fields on this stream with no
+# size cap. Both are the payload of a conclusion frame, taken from the
+# caller's own authoritative task-row read, and neither has an
+# equivalent on ``GET .../steps``: that endpoint returns projected
+# steps, not the task row's ``output`` column and not its pending
+# question. Truncating either one would leave a client with no way to
+# recover the full value from this stream or from ``steps()``.
+# ``step.*``/``message.*`` content is capped precisely because it does
+# have that channel -- ``steps()`` always returns a step's full,
+# untruncated ``data``. The recovery channel for these two is
+# ``GET /v1/chat/tasks/{task_id}``: ``TaskInfoResponse.output`` and
+# ``TaskInfoResponse.pending_interaction.question``. Cost of the
+# exemption is bounded by construction: each is sent once per stream, as
+# its closing frame (``enqueue_close`` on the live path, the last yield
+# on each attach-time fast path), never repeatedly.
 def completed_frame(*, status: str, output: str | None, error: str | None) -> str:
     return _sse_frame(
         "task.completed", {"status": status, "output": output, "error": error}
     )
 
 
-def input_required_frame(task_id: int) -> str:
-    # ``prompt`` is always null: populating it from the agent's question
-    # text is the content-projection layer's job, not this transport.
-    return _sse_frame("task.input_required", {"task_id": task_id, "prompt": None})
+def input_required_frame(task_id: int, prompt: str | None) -> str:
+    # ``prompt`` is uncapped for the reason stated above
+    # ``completed_frame``, which covers both conclusion-frame fields.
+    # ``prompt`` comes straight from ``_TaskInfoSnapshot.pending_question``
+    # (``tasks.py``'s ``_load_task_info_snapshot``, itself backed by
+    # ``task_interaction_read.get_pending_interaction_question`` -- see the
+    # module docstring): every caller of this function already has that
+    # snapshot in hand from its own authoritative row read, so this
+    # never triggers a query of its
+    # own and never sniffs live agent_message frames for question text.
+    return _sse_frame("task.input_required", {"task_id": task_id, "prompt": prompt})
 
 
 _ERROR_MESSAGES = {
@@ -164,8 +235,412 @@ _ERROR_MESSAGES = {
 }
 
 
-def error_frame(code: str) -> str:
-    return _sse_frame("stream.error", {"code": code, "message": _ERROR_MESSAGES[code]})
+def error_frame(code: str, *, message: str | None = None) -> str:
+    """Build a ``stream.error`` frame. ``code`` is always the machine-
+    readable value from ``_ERROR_MESSAGES`` (clients branch on it) --
+    ``message`` overrides only the human-readable text for a call site
+    whose actual cause ``_ERROR_MESSAGES[code]``'s generic wording
+    doesn't describe (e.g. a DB read failing under the ``resync_required``
+    code, which the default wording describes as a queue overflow).
+    Defaults to ``_ERROR_MESSAGES[code]`` when omitted. The lookup runs
+    either way, so an unrecognized ``code`` raises ``KeyError`` whether
+    or not a ``message`` was passed -- the check is on the code, not on
+    which optional argument the caller supplied.
+    """
+    default_message = _ERROR_MESSAGES[code]
+    return _sse_frame(
+        "stream.error", {"code": code, "message": message or default_message}
+    )
+
+
+# -- Content projection: step.* / message.* --------------------------------
+#
+# Everything below turns one already-parsed broadcast dict into zero or
+# more ``step.*`` / ``message.*`` SSE frame strings, by classifying which
+# family it belongs to (a trace event with an ``event_type``, a
+# final-answer streaming frame, or neither) and routing it accordingly.
+#
+# Deliberately absent from that classification: comparing the frame's own
+# top-level ``task_id`` against this stream's bound task_id and dropping
+# on a mismatch. That check is unreachable in practice --
+# ``register_connection`` already rebinds a sink to a new task_id before
+# any frame for the new task can arrive -- and on the one path where it
+# could theoretically fire, it would turn "wrong frame delivered" into
+# the strictly worse "silently orphaned stream still holding a connection
+# slot": it would discard frames for the *new* task the sink is actually
+# bound to, not frames from a foreign one. Must not be added back in any
+# form, including "only for content frames".
+
+
+# The broadcast ``type`` values that can ever produce a content frame --
+# shared between ``project_content_frames``'s own dispatch and the sink's
+# live routing decision (``send_text``) so the two can't drift: the set
+# ``send_text`` hands to the projector must be exactly the set this
+# dispatch acts on, or a type present in one but absent from the other
+# silently drops content on one side.
+_CONTENT_FRAME_TYPES = ("trace_event", "final_answer_delta", "final_answer_end")
+
+
+def _byte_length(value: Any) -> int:
+    return len(json.dumps(value, separators=(",", ":")).encode("utf-8"))
+
+
+def _capped_text(
+    text: str, *, limit: int = MAX_FRAME_CONTENT_BYTES
+) -> tuple[str, bool]:
+    """Truncate ``text`` to ``limit`` bytes of its own escaped-JSON wire
+    representation (``_byte_length``'s domain: ``len(json.dumps(text,
+    separators=(",", ":")).encode())``, the string's own surrounding
+    quotes included), returning ``(possibly-truncated text, whether
+    truncation happened)``.
+
+    Measured in the escaped domain, not decoded UTF-8 bytes, because
+    that's the domain this text actually goes out in: ``_sse_frame``
+    serializes with ``json.dumps``'s default ``ensure_ascii=True``, so a
+    non-ASCII character can cost far more than its own UTF-8 byte width
+    on the wire -- an emoji (4 UTF-8 bytes) becomes a 12-byte
+    ``\\uD83D\\uDE00`` surrogate-pair escape, a CJK character (3 UTF-8
+    bytes) becomes a 6-byte ``\\uXXXX`` escape. Measuring decoded UTF-8
+    bytes against this same ``limit`` instead would let a
+    16384-character emoji string -- exactly ``MAX_FRAME_CONTENT_BYTES``
+    UTF-8 bytes -- through completely untruncated, while its escaped
+    wire form runs roughly 3x over the cap. This is also the same domain
+    ``_capped_step_data``'s own cap checks already use via
+    ``_byte_length``, so a value ``_capped_text`` returns to
+    ``_capped_step_data`` never gets re-measured into a different
+    budget than the one it was actually truncated against (see the
+    per-key budgeting step in that function's docstring).
+
+    ``limit`` is overridden by ``_capped_step_data``, which needs a
+    *smaller* budget than the full frame cap for an individual
+    identifying value -- the value shares the cap with the truncation
+    marker's own JSON overhead around it, not the whole cap to itself.
+
+    Character-sliced first, then a binary search over the remaining
+    prefix's character count for the longest one whose escaped bytes
+    still fit ``limit``. The character pre-slice is a performance
+    guard, not a correctness one -- it bounds the character count, not
+    the escaped byte length the cap is measured in: every escaped character
+    costs at least 1 byte, so a text longer than ``limit`` *characters*
+    is guaranteed to still need the search below even after slicing to
+    that many -- the pre-slice only avoids running the search over an
+    entire multi-megabyte string when almost all of it will be thrown
+    away regardless. The search is what makes the cut safe; a raw
+    UTF-8-byte slice plus a lenient decode is not usable in the
+    escaped domain, because a raw byte slice of an *escaped* string can
+    land inside a multi-byte escape sequence (e.g. half of
+    ``\\uD83D\\uDE00``), and decoding that slice as UTF-8 says nothing
+    about whether the *unescaped* text it came from is still valid --
+    there is no lenient-decode equivalent for "half an escape
+    sequence". Slicing by character count instead never has this
+    problem: every prefix is a valid string by construction. The binary
+    search is safe because ``_byte_length`` is monotonically
+    non-decreasing in the string's character count -- ``ensure_ascii``
+    emits each character's own escape sequence independently, in order,
+    so a longer prefix's encoded bytes are always a shorter prefix's
+    encoded bytes plus more appended, never fewer.
+    """
+    pre_sliced = len(text) > limit
+    if pre_sliced:
+        text = text[:limit]
+    if _byte_length(text) <= limit:
+        # ``False``, not ``pre_sliced``: this branch is only reachable
+        # when no slice happened. The escaped form carries the string's
+        # own two surrounding quotes and every escaped character costs
+        # at least one byte, so a text sliced to ``limit`` characters
+        # measures at least ``limit + 2`` and can never satisfy the
+        # check above.
+        return text, False
+    lo, hi = 0, len(text)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if _byte_length(text[:mid]) <= limit:
+            lo = mid
+        else:
+            hi = mid - 1
+    return text[:lo], True
+
+
+# The small, bounded fields that identify *what* a step is, as opposed
+# to its content -- one per public step type, per ``_step_mapping.py``'s
+# ``map_trace_events_to_public_steps`` docstring: ``thinking.phase``,
+# ``tool_call.name``, ``agent_delegation.sub_agent_name``,
+# ``message.role``. Kept through ``_capped_step_data``'s truncation
+# below (unlike ``args``/``result``/``error``/``input``/``output``/
+# ``content``, which are exactly the fields that can be arbitrarily
+# large) so a client reading a truncated frame still knows which tool
+# ran, which sub-agent was delegated to, or whose message it was --
+# not just that *something* on this step was too big to send.
+_STEP_DATA_IDENTIFYING_KEYS = ("phase", "name", "sub_agent_name", "role")
+
+
+def _capped_step_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Bound one step's ``data`` sub-object to ``MAX_FRAME_CONTENT_BYTES``.
+
+    Step ``data`` shapes vary by public step type -- a tool's ``args``/
+    ``result`` or an agent delegation's ``input``/``output`` can be
+    arbitrary nested JSON, not a single string field like a message's
+    ``content``. Walking arbitrary nested structure to trim it back
+    under the cap isn't worth the complexity here: once the whole
+    sub-object is oversized, its content fields are replaced wholesale
+    with a small truncation marker instead.
+
+    Each pass over the surviving identifying keys does two things,
+    re-measured with ``_byte_length`` against the cap in the same
+    escaped-JSON byte domain ``_capped_text`` truncates in (see that
+    function's docstring), so the cap is an actual bound on what this
+    returns rather than on the pre-replacement content:
+
+      1. The marker plus this step's identifying fields
+         (``_STEP_DATA_IDENTIFYING_KEYS``) as they are, if that fits --
+         so a client reading a truncated frame still knows which tool
+         ran, which sub-agent was delegated to, or whose message it was,
+         not just that *something* on this step was too big to send.
+      2. Otherwise every surviving *string* value truncated
+         (``_capped_text``), budgeted to leave room for the marker's own
+         JSON overhead plus the other keys' shares -- truncating each to
+         the full cap and only then wrapping it would overflow on the
+         wrapper alone.
+
+    A value that is not a string (a dict- or list-valued ``name``, say)
+    cannot be truncated in place, so when a pass still does not fit, the
+    largest surviving value that cannot be truncated in place is dropped
+    (falling back to the largest overall if every survivor is a string,
+    which the budgeting math makes unreachable), and the next pass
+    rebuilds from the original ``data``. Rebuilding rather than
+    continuing matters: an un-shrinkable oversized value counts toward
+    step 2's overhead, which drives every other key's budget to zero, so
+    a pass that kept the already-truncated values would return the
+    identifying keys as empty strings -- which tells a client nothing.
+    Dropping only the key that cannot fit keeps the rest with real
+    content, and a step whose only identifying value is that one
+    degrades to the bare marker, exactly as before.
+
+    The rest of the step (id/type/status/timestamps) is always small and
+    untouched either way.
+    """
+    size = _byte_length(data)
+    if size <= MAX_FRAME_CONTENT_BYTES:
+        return data
+    bare_marker: dict[str, Any] = {"truncated": True, "original_bytes": size}
+    surviving = [key for key in _STEP_DATA_IDENTIFYING_KEYS if key in data]
+    # At most one pass per identifying key plus the final bare-marker
+    # pass: each iteration that fails drops exactly one key, and the
+    # bare marker on its own is always far under the cap.
+    for _ in range(len(_STEP_DATA_IDENTIFYING_KEYS) + 1):
+        capped = dict(bare_marker)
+        for key in surviving:
+            capped[key] = data[key]
+        if _byte_length(capped) <= MAX_FRAME_CONTENT_BYTES:
+            return capped
+        string_keys = [key for key in surviving if isinstance(capped[key], str)]
+        overhead = _byte_length({**capped, **{key: "" for key in string_keys}})
+        per_key_budget = max(
+            0, (MAX_FRAME_CONTENT_BYTES - overhead) // max(len(string_keys), 1)
+        )
+        for key in string_keys:
+            capped[key], _ = _capped_text(capped[key], limit=per_key_budget)
+        if _byte_length(capped) <= MAX_FRAME_CONTENT_BYTES:
+            return capped
+        candidates = [
+            key for key in surviving if not isinstance(data[key], str)
+        ] or surviving
+        surviving.remove(max(candidates, key=lambda key: _byte_length(data[key])))
+    return bare_marker
+
+
+def step_started_frame(public_step: dict[str, Any]) -> str:
+    return _sse_frame("step.started", {"step": public_step})
+
+
+def step_completed_frame(public_step: dict[str, Any]) -> str:
+    return _sse_frame("step.completed", {"step": public_step})
+
+
+def message_delta_frame(message_id: str, text: str) -> str:
+    capped_text, truncated = _capped_text(text)
+    data: dict[str, Any] = {"message_id": message_id, "text": capped_text}
+    if truncated:
+        data["truncated"] = True
+    return _sse_frame("message.delta", data)
+
+
+def message_completed_frame(message_id: str, content: str) -> str:
+    capped_content, truncated = _capped_text(content)
+    data: dict[str, Any] = {"message_id": message_id, "content": capped_content}
+    if truncated:
+        data["truncated"] = True
+    return _sse_frame("message.completed", data)
+
+
+def _step_wire_frame(public_step_json: dict[str, Any]) -> str:
+    """Pick ``step.started`` vs ``step.completed`` for an already-JSON-safe
+    step dict, after applying the single-frame content cap to its
+    ``data`` sub-object. One status -> event-name rule, and one size cap,
+    in one place: the only producer of step content on this stream is
+    live folding (``_step_content_frame``, below), and keeping the rule
+    here rather than inline there is what lets a second producer be added
+    later without a second copy of it that could disagree.
+    """
+    capped = {**public_step_json, "data": _capped_step_data(public_step_json["data"])}
+    if capped["status"] == "running":
+        return step_started_frame(capped)
+    return step_completed_frame(capped)
+
+
+def _step_content_frame(step: dict[str, Any]) -> str:
+    """Serialize one projector-produced step dict to its SSE frame.
+
+    Called synchronously, immediately after the ``PublicStepProjector``
+    call that produced ``step`` returns -- never stored or handed off
+    first. ``feed()``/``materialized_steps()`` return the projector's own
+    *live* dict objects, which get mutated in place when a pending step's
+    end event later arrives (see ``_step_mapping.py``'s class docstring);
+    holding one past this point instead of serializing it right away
+    would risk a ``step.started`` frame's queued text reflecting a status
+    the step had moved past by the time it was actually read out of the
+    queue. Routing every field through ``PublicStep`` here is also what
+    keeps this wire shape identical to ``steps()``'s -- same validation,
+    same JSON coercion (``started_at``/``completed_at`` in particular),
+    same public step-type list, zero second copy of any of it.
+    """
+    return _step_wire_frame(PublicStep(**step).model_dump(mode="json"))
+
+
+def _feed_trace_event(
+    projector: "PublicStepProjector", event_type: str, message: dict[str, Any]
+) -> list[str]:
+    """Fold one ``type == "trace_event"`` broadcast frame into ``projector``
+    and serialize whatever step(s) it changed.
+
+    Three filters run before anything reaches the projector, all on the
+    frame's *original* ``event_type``/``data``:
+
+      1. ``data["source"] == DELEGATED_AGENT_TRACE_SOURCE``: drop trace
+         events from a delegated child agent's own run. ``steps()``
+         reaches the same outcome through a different check: a
+         ``TraceEvent.build_id IS NULL`` column filter in its own query
+         (``tasks.py``'s ``_load_task_steps_snapshot`` /
+         ``_load_task_steps_version_snapshot``), not
+         ``public_trace_events.public_task_trace_filter`` (that
+         predicate ORs delegated-child-agent traces back *in*, for a
+         different consumer -- the opposite of what this drop does).
+         Reimplemented here as a data-field check, rather than reused
+         directly, because the live broadcast fan-out has no SQL WHERE
+         clause to piggyback on.
+         The two agree because one producer stamps both the
+         ``data["source"]`` field and the ``build_id`` column on a
+         delegated child's events; nothing enforces that they keep
+         agreeing, which is why the both-paths test persists a
+         ``build_id`` row rather than only sending an in-memory frame.
+      2. ``event_type == "task_info"``: ``task_info`` is never a public
+         step; it only ever drives ``task.status``/``task.input_required``
+         (handled elsewhere in ``send_text``, unconditionally, before this
+         function is called), so it short-circuits here before it would
+         otherwise fall through to the catch-all "not a known step
+         family" drop below.
+      3. ``is_audit_only_trace_data``: server-only RCA payloads that must
+         never reach a client.
+         ``steps()`` applies no equivalent filter on its own read. No
+         audit-only row reaches a public step there today because the
+         event types that carry audit-only data are not in the
+         projector's exposed set, but that equivalence is a coincidence
+         of the current producer rather than something either surface
+         enforces (#1405).
+
+    An ``ai_message`` event carrying ``data["stream_message_id"]`` --
+    the trace-event mirror of a final answer already delivered
+    token-by-token via ``message.delta``/``message.completed`` -- is
+    deliberately NOT filtered here: it folds into a ``message`` step
+    the same way any other ``ai_message`` does, exactly matching what
+    ``steps()`` already shows for the same persisted row. A client that
+    already rendered the delta/completed sequence sees this step as a
+    duplicate of content it has, not as new information -- duplication,
+    not loss, is the accepted trade-off. The alternative -- dropping it
+    here -- has no persisted counterpart: ``steps()`` surfaces this same
+    row as a ``message`` step regardless, so filtering it only on the
+    live path would make the stream disagree with ``steps()`` about
+    whether the step exists.
+    """
+    data = message.get("data")
+    if not isinstance(data, dict):
+        return []
+    if data.get("source") == DELEGATED_AGENT_TRACE_SOURCE:
+        return []
+    if event_type == "task_info":
+        return []
+    if is_audit_only_trace_data(data):
+        return []
+    serialized_data = serialize_trace_data(data)
+    normalized_type, normalized_data = normalize_public_trace_event(
+        event_type, serialized_data
+    )
+    # Same six fields as ``tasks.py``'s ``_TraceEventSnapshot`` -- the
+    # projector's ``_safe_get``/``_data_get`` accessors read both ORM rows
+    # and plain dicts shaped like this one, so no adapter class is needed
+    # for the live path.
+    live_event = {
+        "task_id": message.get("task_id"),
+        "event_id": message.get("event_id"),
+        "event_type": normalized_type,
+        "timestamp": message.get("timestamp"),
+        "step_id": message.get("step_id"),
+        "data": normalized_data,
+    }
+    changed = projector.feed(live_event)
+    return [_step_content_frame(step) for step in changed]
+
+
+def _feed_final_answer(frame_type: str, message: dict[str, Any]) -> list[str]:
+    """Project one ``final_answer_delta``/``final_answer_end`` broadcast
+    frame directly to its ``message.*`` SSE frame -- no projector involved.
+
+    These frames carry no ``event_type`` key and are never persisted
+    individually, so there's nothing to pair or replay here; they map
+    straight through. ``final_answer_start`` and ``final_answer_error``
+    are both deliberately not projected: a
+    ``message.delta`` sequence may therefore end with no
+    ``message.completed`` -- the next lifecycle event (``task.status`` /
+    ``task.completed`` / a fresh ``message.delta`` for a different
+    ``message_id``) is the client's signal that it was abandoned, not a
+    dedicated close event.
+    """
+    message_id = message.get("message_id")
+    if not isinstance(message_id, str):
+        return []
+    if frame_type == "final_answer_delta":
+        text = message.get("delta")
+        if not isinstance(text, str):
+            return []
+        return [message_delta_frame(message_id, text)]
+    content = message.get("content")
+    if not isinstance(content, str):
+        return []
+    return [message_completed_frame(message_id, content)]
+
+
+def project_content_frames(
+    message: dict[str, Any], projector: "PublicStepProjector"
+) -> list[str]:
+    """Classify one already-parsed broadcast dict and return its
+    ``step.*`` / ``message.*`` SSE frames, if any (see this section's
+    header comment for the classification rules and the one deliberate
+    omission from them).
+
+    Every other frame family this module already understands --
+    ``task_info``, the other versioned lifecycle types, the bare
+    ``task_completed`` acceleration dict -- produces no content frames
+    here; ``send_text`` handles those itself and calls this
+    unconditionally alongside that handling, not instead of it.
+    """
+    frame_type = str(message.get("type") or "")
+    if frame_type not in _CONTENT_FRAME_TYPES:
+        return []
+    if frame_type == "trace_event":
+        return _feed_trace_event(
+            projector, str(message.get("event_type") or ""), message
+        )
+    return _feed_final_answer(frame_type, message)
 
 
 # -- Sink -----------------------------------------------------------------
@@ -210,6 +685,23 @@ class V1EventStreamSink:
         )
         self._closing = False
         self._last_status = initial_status
+        # One incremental folding state machine per connection (never
+        # shared across sinks -- see ``PublicStepProjector``'s own
+        # preconditions). Starts empty, and every content-bearing frame
+        # broadcast from then on is fed straight into it by ``send_text``.
+        # Because it starts empty, a step already running at attach time
+        # has no matching start here, so that step's end event folds in
+        # as an orphan and is dropped -- see the module docstring.
+        # ``retain_finished=False``: this sink acts on each ``feed()``
+        # result immediately (``_step_content_frame`` serializes it on
+        # the spot) and never calls ``materialized_steps()``, so
+        # retaining every finalized step would hold each one's
+        # untruncated ``data`` -- tool args and results, delegation
+        # input/output, message content -- for as long as the connection
+        # lives (up to ``STREAM_MAX_DURATION_SECONDS``) in a list nothing
+        # on this path reads. The pending table the pairing rules need is
+        # kept either way.
+        self._projector = PublicStepProjector(retain_finished=False)
         # Recorded at construction time (always inside the endpoint's own
         # request coroutine) so later state-mutating calls -- however they
         # got here -- can be asserted to run on the same loop.
@@ -268,6 +760,20 @@ class V1EventStreamSink:
         except asyncio.QueueFull:
             self.enqueue_close(error_frame("resync_required"))
 
+    def _project_and_queue(self, message: dict[str, Any]) -> None:
+        """Project one content frame and enqueue its output. Never raises --
+        a frame that fails to project is dropped and counted, exactly like a
+        frame that fails on the live path; see ``send_text``'s discipline note.
+        """
+        try:
+            for frame_text in project_content_frames(message, self._projector):
+                self._put_or_overflow(frame_text)
+        except Exception:
+            self.dropped_frame_count += 1
+            logger.exception(
+                "v1 SSE sink dropped a content frame for task %s", self.task_id
+            )
+
     async def send_text(self, text: str) -> None:
         """Receive one broadcast frame. Duck-types ``WebSocket.send_text``.
 
@@ -276,11 +782,64 @@ class V1EventStreamSink:
         the connection, but re-raises anything else -- that re-raise
         happens on the *task's own* outbound event path, so an uncaught
         exception here would abort the broadcast for every other
-        listener on the task, not just this stream. This is the
-        one deliberate blanket ``except Exception`` in this module; every
-        drop is logged via ``logger.exception`` below, and also counted
-        on ``dropped_frame_count`` for tests to assert against (no
-        production code reads that counter today).
+        listener on the task, not just this stream. Every drop this
+        outer ``except`` catches is logged via ``logger.exception``
+        below, and also counted on ``dropped_frame_count`` for tests to
+        assert against (no production code reads that counter today).
+        A content frame that fails to *project* is caught and counted
+        one layer in, by ``_project_and_queue`` itself -- see that
+        method's docstring -- so this outer ``except`` is left to catch
+        everything else that can go wrong while parsing or dispatching a
+        broadcast frame (bad JSON, a non-dict payload, a bug in the
+        lifecycle handling above). The two never double-count the same
+        failure: a projection failure never propagates up to this
+        ``except`` in the first place.
+
+        Content frames (``step.*`` / ``message.*``) are classified and
+        projected alongside the lifecycle handling below, not instead of
+        it -- ``project_content_frames`` returns an empty list for every
+        frame shape this method already handles on its own
+        (``task_completed``, the versioned lifecycle types, ``task_info``),
+        so the two never fight over the same frame. A content frame is
+        projected and queued via ``_project_and_queue``, which always
+        routes successfully-projected output through ``_put_or_overflow``
+        like any other queued frame -- never a direct
+        ``queue.put_nowait`` -- so it gets the same closed guard and
+        overflow-to-``resync_required`` handling status frames already
+        get.
+
+        The raw-size check itself runs after ``json.loads`` and the
+        lifecycle handling above, guarding only the call into
+        ``_project_and_queue`` -- the last thing between a parsed frame
+        and the projector. It compares ``len(text)`` -- the raw
+        broadcast frame's own character count -- against
+        ``MAX_RAW_FRAME_TEXT_CHARS`` (256 KiB): strictly greater than is
+        a drop, exactly equal is kept. On a drop, ``dropped_frame_count``
+        is incremented, one ``logger.warning`` fires, and the method
+        returns -- no queued frame, no close, no ``stream.error``: a
+        dropped frame is invisible to the client.
+        The size check applies only to frames whose parsed ``type`` is
+        in ``_CONTENT_FRAME_TYPES`` and whose top-level ``event_type``
+        is not ``task_info``; dispatch into the projector is unchanged
+        for the whole ``_CONTENT_FRAME_TYPES`` set regardless. Lifecycle
+        frames are exempt from the size check structurally rather than
+        by a prefix sniff: ``task_completed`` returns above before this
+        check runs, ``task.status``/``task.input_required`` are
+        enqueued above it, and ``task_info`` is named explicitly so an
+        oversized one is neither counted as a drop nor logged as one --
+        it carries an operator-controlled task description with no size
+        bound of its own (see ``MAX_RAW_FRAME_TEXT_CHARS``'s own comment
+        for why ``task_completed`` can also legitimately cross this
+        threshold). The check runs after ``json.loads`` because what it
+        has to exempt is only knowable after it: a ``task_info``
+        frame's own top-level ``type`` is ``trace_event``, the same
+        value real content frames carry, so nothing short of parsing
+        distinguishes the two. The parse is not extra cost on the
+        fan-out path: ``ConnectionManager.broadcast_to_task``
+        serializes the frame with ``json.dumps`` once per connection,
+        inside its own send loop, before this method is called at all --
+        and the expensive half here, ``serialize_trace_data`` plus the
+        projection fold, is skipped for a frame this check drops.
         """
         try:
             self._assert_owner_loop()
@@ -314,6 +873,20 @@ class V1EventStreamSink:
                         # an early wake never closes a stream that a fresh
                         # read wouldn't have closed anyway.
                         self.completion_hint.set()
+            if str(message.get("type") or "") in _CONTENT_FRAME_TYPES:
+                if (
+                    message.get("event_type") != "task_info"
+                    and len(text) > MAX_RAW_FRAME_TEXT_CHARS
+                ):
+                    self.dropped_frame_count += 1
+                    logger.warning(
+                        "v1 SSE sink dropped an oversized broadcast frame "
+                        "(%d chars) for task %s before projecting it",
+                        len(text),
+                        self.task_id,
+                    )
+                    return
+                self._project_and_queue(message)
         except Exception:
             self.dropped_frame_count += 1
             logger.exception(
@@ -434,7 +1007,9 @@ async def watchdog_check_once(
             )
         )
     if close_reason == "input_required":
-        return sink.enqueue_close(input_required_frame(task_id))
+        return sink.enqueue_close(
+            input_required_frame(task_id, snapshot.pending_question)
+        )
     if status is TaskStatus.PAUSED:
         # SDK wait() semantics: PAUSED keeps waiting, doesn't close.
         # A "was this paused by an orphaned process?" check was considered
@@ -526,7 +1101,7 @@ async def _input_required_snapshot_stream(
     the same conclusion is only reached via the watchdog's first cycle,
     up to ``watchdog_interval_seconds`` (30s in production) after attach."""
     yield status_frame(snapshot.status.value)
-    yield input_required_frame(snapshot.task_id)
+    yield input_required_frame(snapshot.task_id, snapshot.pending_question)
 
 
 async def _generate(

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -48,6 +48,61 @@ Sink instances duck-type the ``websocket.ConnectionManager`` connection
 contract (an object with an async ``send_text(str)`` method) so they
 register into the *same* shared ``manager`` real WebSocket connections
 use, and ride the same ``broadcast_to_task`` fan-out.
+
+Size and admission bounds -- every limit this stream applies, and the
+values it deliberately leaves unbounded, in one place:
+
+  - One step's ``data`` sub-object, and one message frame's text:
+    ``MAX_FRAME_CONTENT_BYTES`` (64 KiB), measured in the escaped-JSON
+    domain the frame is actually serialized in, not decoded UTF-8 bytes
+    (see ``_capped_text``). The two families handle an overrun
+    differently on purpose: a message's text is truncated in place and
+    the frame is marked ``truncated``, while an oversized step ``data``
+    is *replaced* by a marker keeping the step's identifying keys --
+    step ``data`` is arbitrary nested JSON, so there is no single
+    string to cut (see ``_capped_step_data``).
+  - One inbound broadcast frame, before it is projected at all:
+    ``MAX_RAW_FRAME_TEXT_CHARS`` (256 KiB), measured excluding the
+    ``task_description`` stamp every converted trace event carries (see
+    ``_measured_content_frame``). Over the cap is a silent drop --
+    counted and logged, never a close, and never applied to a
+    lifecycle frame.
+  - One sink's outbound queue: ``OUTBOUND_QUEUE_MAX_SIZE`` (256
+    frames) *and* ``MAX_QUEUED_WIRE_BYTES`` (4 MiB of queued frame
+    text). Whichever binds first drains the backlog and closes with
+    ``resync_required``; the element cap binds on a long backlog of
+    ordinary frames, the byte budget on a short backlog of large ones.
+    The byte budget only engages once the queued average exceeds 16
+    KiB -- one quarter of the per-frame content cap above -- and even
+    then the cost of engaging is one forced ``resync_required`` close,
+    identical in kind and price to the element cap's own overflow; a
+    consumer that is keeping up never accumulates a backlog at all.
+  - Concurrent streams: ``PER_TASK_STREAM_CAP`` (2) and
+    ``PER_PRINCIPAL_STREAM_CAP`` (32), both rejected with 429 at
+    attach, before any sink exists.
+  - Deliberately uncapped: ``task.completed``'s ``output`` and
+    ``task.input_required``'s ``prompt`` (full argument in the comment
+    above ``completed_frame``). Both are the payload of a conclusion
+    frame, both are sent once per stream as that frame, and neither has
+    an equivalent on ``GET .../steps`` -- their recovery channel is
+    ``GET /v1/chat/tasks/{task_id}``. Neither ever meets the queue's
+    byte budget: on the live path (the watchdog closing an already-open
+    stream) they reach the client only as a budget-exempt close frame
+    via ``enqueue_close``; on the two attach-time fast paths (terminal,
+    waiting-for-user) they are ``yield``ed straight from the generator
+    before any sink or queue exists for this connection at all.
+  - Uncapped and bounded only by the frame they arrive in: a step's
+    ``id`` and a ``message.*`` frame's ``message_id``. Neither has a
+    cap of its own -- ``PublicStep.id`` is a plain ``str`` -- and an id
+    sits outside the ``data`` sub-object the 64 KiB cap covers. A step
+    id derives from the event's own ``tool_call_id``/``step_id``, so
+    what bounds it is the 256 KiB check on the inbound frame carrying
+    it, and the queue's byte budget bounds ids in aggregate. Today's
+    only ``message_id`` producer emits a fixed 45 characters
+    (``f"final_answer_{uuid4().hex}"``,
+    ``core/agent/runtime.py``'s ``start_final_answer_stream``), but
+    this path does not itself enforce that length -- the effective
+    bound here is the same 256 KiB inbound raw-frame check.
 """
 
 from __future__ import annotations
@@ -585,6 +640,12 @@ def _feed_trace_event(
         return []
     if is_audit_only_trace_data(data):
         return []
+    # Measured cost of this pass per sink (serialize, normalize, fold,
+    # validate, serialize to wire): by direct call on a development
+    # machine, median of 7, no I/O -- 6.2 ms (min 6.0 / max 6.3) for a raw
+    # frame just under ``MAX_RAW_FRAME_TEXT_CHARS``, 1.6 ms at a 64 KiB
+    # payload. ``PER_TASK_STREAM_CAP`` is 2, so one broadcast's sequential
+    # fan-out adds at most ~12.4 ms.
     serialized_data = serialize_trace_data(data)
     normalized_type, normalized_data = normalize_public_trace_event(
         event_type, serialized_data

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -235,22 +235,13 @@ _ERROR_MESSAGES = {
 }
 
 
-def error_frame(code: str, *, message: str | None = None) -> str:
+def error_frame(code: str) -> str:
     """Build a ``stream.error`` frame. ``code`` is always the machine-
-    readable value from ``_ERROR_MESSAGES`` (clients branch on it) --
-    ``message`` overrides only the human-readable text for a call site
-    whose actual cause ``_ERROR_MESSAGES[code]``'s generic wording
-    doesn't describe (e.g. a DB read failing under the ``resync_required``
-    code, which the default wording describes as a queue overflow).
-    Defaults to ``_ERROR_MESSAGES[code]`` when omitted. The lookup runs
-    either way, so an unrecognized ``code`` raises ``KeyError`` whether
-    or not a ``message`` was passed -- the check is on the code, not on
-    which optional argument the caller supplied.
-    """
-    default_message = _ERROR_MESSAGES[code]
-    return _sse_frame(
-        "stream.error", {"code": code, "message": message or default_message}
-    )
+    readable value from ``_ERROR_MESSAGES`` (clients branch on it), and
+    the lookup runs unconditionally, so an unrecognized ``code`` raises
+    ``KeyError`` rather than reaching the wire as a frame with no
+    message."""
+    return _sse_frame("stream.error", {"code": code, "message": _ERROR_MESSAGES[code]})
 
 
 # -- Content projection: step.* / message.* --------------------------------

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -112,6 +112,27 @@ PER_PRINCIPAL_STREAM_CAP = 32
 # ``core/task_runtime.py``'s ``MAX_TASK_RUNTIME_JSON_BYTES``), not a new
 # one invented for this module.
 MAX_FRAME_CONTENT_BYTES = 64 * 1024
+# The queue's second bound, on the total wire bytes it is holding rather
+# than on its element count. The element cap alone lets a slow consumer
+# retain 256 x the largest frame this module can build: a
+# ``message.completed`` whose text is capped at
+# ``MAX_FRAME_CONTENT_BYTES`` measures 65,659 bytes, so 16.0 MiB per
+# sink, and a frame whose *id* rather than its content is what made it
+# large is bounded only by ``MAX_RAW_FRAME_TEXT_CHARS`` on the frame it
+# arrived in, so it can be several times that again. Both are
+# constructive upper bounds from the frame builders, not observed
+# backlogs.
+# Sized as 64 largest-possible content frames -- expressed against
+# ``MAX_FRAME_CONTENT_BYTES`` so it tracks that cap instead of drifting
+# from it. Strictly over the budget closes, exactly on it does not --
+# the same boundary rule ``MAX_RAW_FRAME_TEXT_CHARS`` uses. Why this
+# value and not tighter or looser is argued once, in the module
+# docstring's size-bounds section, not repeated here. Frames are pure
+# ASCII (``json.dumps`` runs with the default ``ensure_ascii=True``), so
+# ``len(frame_text)`` is the wire byte count and no encode is needed.
+# CPython's own ~41-byte-per-string header is not counted: 256 of them
+# is ~10 KiB against a 4 MiB budget.
+MAX_QUEUED_WIRE_BYTES = 64 * MAX_FRAME_CONTENT_BYTES
 # Check on a raw broadcast frame's text length -- measured excluding
 # the internal task-description stamp broadcast frames carry (see
 # ``_measured_content_frame``) -- run after ``json.loads`` parses it,
@@ -719,6 +740,12 @@ class V1EventStreamSink:
         self.task_id = task_id
         self.principal_key_prefix = principal_key_prefix
         self.dropped_frame_count = 0
+        # Wire bytes currently sitting in ``_queue``. Maintained at the
+        # two places that touch the queue and nowhere else: ``_put_counted``
+        # adds a frame's length as it goes in, ``next_frame`` subtracts it
+        # as it comes out, and ``enqueue_close`` zeroes it after draining.
+        # No caller outside this class adjusts it.
+        self._queued_bytes = 0
         self.completion_hint = asyncio.Event()
         # Each element is ``(frame_text, is_close)``. ``is_close`` travels
         # with the frame itself rather than being inferred from
@@ -762,7 +789,20 @@ class V1EventStreamSink:
 
     @property
     def queue(self) -> "asyncio.Queue[tuple[str, bool]]":
+        """The raw outbound queue, for inspecting depth and emptiness.
+
+        Take frames off it through ``next_frame`` instead of reading this
+        directly: that method is where a dequeued frame's bytes are
+        discounted from ``queued_wire_bytes``, so a bare ``get`` /
+        ``get_nowait`` here drains the queue while leaving the byte
+        accounting reading high.
+        """
         return self._queue
+
+    @property
+    def queued_wire_bytes(self) -> int:
+        """Total wire bytes of the frames currently queued."""
+        return self._queued_bytes
 
     def _assert_owner_loop(self) -> None:
         if asyncio.get_running_loop() is not self._owner_loop:
@@ -795,8 +835,46 @@ class V1EventStreamSink:
                 self._queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
-        self._queue.put_nowait((frame_text, True))
+        # Exact rather than approximate: the loop above only exits with the
+        # queue empty (one event loop, no concurrent producer), so there
+        # are no bytes left to account for.
+        self._queued_bytes = 0
+        # Deliberately not routed through the byte budget: this is the one
+        # frame that must always fit. ``task.completed``'s ``output`` and
+        # ``task.input_required``'s ``prompt`` are uncapped by design (see
+        # the comment above ``completed_frame``); on the live path they
+        # only ever reach the client as a budget-exempt close frame via
+        # this method, and on the attach-time fast paths there is no sink
+        # and no queue at all -- refusing one here on a budget while the
+        # stream is closing anyway would drop a payload the client cannot
+        # recover from this stream, with no backlog left to protect.
+        self._put_counted(frame_text, is_close=True)
         return True
+
+    def _put_counted(self, frame_text: str, *, is_close: bool) -> None:
+        """The only place a frame enters the outbound queue.
+
+        Single write point so ``_queued_bytes`` cannot fall out of step
+        with the queue's actual contents: a frame that is queued is
+        counted in the same statement, and if ``put_nowait`` raises
+        ``QueueFull`` the count is not touched either.
+        """
+        self._queue.put_nowait((frame_text, is_close))
+        self._queued_bytes += len(frame_text)
+
+    async def next_frame(self) -> tuple[str, bool]:
+        """Take the next queued frame and discount its bytes.
+
+        The accounted counterpart of ``_put_counted``, and the way the
+        generator consumes this queue. There is no ``await`` between the
+        queue read and the subtraction, so a cancelled wait (the
+        generator's per-frame ``wait_for`` timeout) can never leave a
+        frame dequeued but still counted.
+        """
+        self._assert_owner_loop()
+        frame_text, is_close = await self._queue.get()
+        self._queued_bytes -= len(frame_text)
+        return frame_text, is_close
 
     def _put_or_overflow(self, frame_text: str) -> None:
         # Defense in depth: every current caller already checks ``closing``
@@ -804,8 +882,15 @@ class V1EventStreamSink:
         # matter how it's reached, so the guard lives here too.
         if self._closing:
             return
+        # Two bounds, one close path. Checked before the put rather than
+        # after it so ``_queued_bytes`` never exceeds the budget even
+        # transiently. Strictly over closes, exactly at the budget does
+        # not -- the same boundary rule ``MAX_RAW_FRAME_TEXT_CHARS`` uses.
+        if self._queued_bytes + len(frame_text) > MAX_QUEUED_WIRE_BYTES:
+            self.enqueue_close(error_frame("resync_required"))
+            return
         try:
-            self._queue.put_nowait((frame_text, False))
+            self._put_counted(frame_text, is_close=False)
         except asyncio.QueueFull:
             self.enqueue_close(error_frame("resync_required"))
 
@@ -853,9 +938,10 @@ class V1EventStreamSink:
         projected and queued via ``_project_and_queue``, which always
         routes successfully-projected output through ``_put_or_overflow``
         like any other queued frame -- never a direct
-        ``queue.put_nowait`` -- so it gets the same closed guard and
-        overflow-to-``resync_required`` handling status frames already
-        get.
+        ``queue.put_nowait`` -- so it gets the same closed guard and the
+        same overflow-to-``resync_required`` handling status frames
+        already get, on both of the queue's bounds: its element count
+        and its total queued wire bytes.
 
         The raw-size check itself runs after ``json.loads`` and the
         lifecycle handling above, guarding only the call into
@@ -1279,7 +1365,7 @@ async def _generate(
             )
             try:
                 frame_text, is_close = await asyncio.wait_for(
-                    sink.queue.get(), timeout=wait_budget
+                    sink.next_frame(), timeout=wait_budget
                 )
             except asyncio.TimeoutError:
                 yield ": ping\n\n"

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -249,26 +249,16 @@ class PublicStepProjector:
         self._open_dag_execution_key: Optional[str] = None
 
     @classmethod
-    def from_history(
-        cls, events: List[Any], *, retain_finished: bool = True
-    ) -> "PublicStepProjector":
+    def from_history(cls, events: List[Any]) -> "PublicStepProjector":
         """Build a projector pre-warmed by replaying a full event history.
 
         Feeds every event into a fresh instance, in order. The resulting
-        pairing state (open plan key/counter, any still-``pending``
+        state (the accumulated timeline plus any still-unpaired
         starts) is identical to what a live consumer would have
         accumulated by that point -- there is no separate "batch" code
         path for the folding logic itself, only this replay.
-
-        Defaults to retaining: the batch driver
-        (``map_trace_events_to_public_steps``) reads its result only
-        through :meth:`materialized_steps`, which needs the retained
-        history. A caller that keeps the projector alive after this
-        initial read and only acts on subsequent ``feed`` results can
-        pass ``retain_finished=False`` -- but only if it never calls
-        :meth:`materialized_steps` afterwards.
         """
-        projector = cls(retain_finished=retain_finished)
+        projector = cls()
         for event in events:
             projector.feed(event)
         return projector

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -182,6 +182,29 @@ class PublicStepProjector:
         late-attaching consumer pre-warms pairing state instead of seeing
         orphan ends for steps that started before it attached.
 
+    Two retention modes, chosen at construction:
+
+      - ``retain_finished=True`` (the default): every finalized step is
+        kept so :meth:`materialized_steps` can return the task's whole
+        projected timeline at the end. A one-shot request needs this,
+        and ``map_trace_events_to_public_steps`` -- and therefore
+        ``GET /v1/chat/tasks/{task_id}/steps`` -- reads its result
+        *only* through :meth:`materialized_steps`, so that driver must
+        never be built with the other mode.
+      - ``retain_finished=False``: a finalized step is returned by
+        :meth:`feed` and then forgotten. For a consumer that acts on
+        each ``feed`` result immediately and never calls
+        :meth:`materialized_steps` -- the v1 SSE sink serializes each
+        changed step to a frame as it comes and holds one projector for
+        as long as its connection lives, so retaining would accumulate
+        every step's untruncated ``data`` for that whole time in a list
+        nothing reads. :meth:`materialized_steps` raises in this mode
+        rather than returning a silently partial timeline.
+
+    ``feed``'s return value is identical in both modes; the mode only
+    decides whether the projector also keeps the step afterwards. The
+    pending table is kept either way -- the pairing rules need it.
+
     :meth:`materialized_steps` never sorts by ``started_at``. That global
     resort is a batch-only concern (see ``map_trace_events_to_public_steps``):
     a live consumer wants steps in the order they actually resolved, not
@@ -195,7 +218,7 @@ class PublicStepProjector:
     throwaway instance per call.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, retain_finished: bool = True) -> None:
         # In-progress (start seen, end not yet seen) steps keyed by
         # (public_type, pairing_key). Order of insertion is preserved by
         # Python 3.7+ dict semantics, which is what we use to emit final
@@ -203,8 +226,10 @@ class PublicStepProjector:
         self._pending: Dict[Tuple[str, str], Dict[str, Any]] = {}
         # Completed-or-emitted-immediately steps. Filled in either by an
         # end event matching a pending start, or by a one-shot event like
-        # ``user_message`` / ``ai_message`` which has no separate end.
-        self._finished: List[Dict[str, Any]] = []
+        # ``user_message`` / ``ai_message``. ``None`` when the caller
+        # opted out of retention (see the class docstring): those steps
+        # are still returned by ``feed``, they are just not kept after.
+        self._finished: Optional[List[Dict[str, Any]]] = [] if retain_finished else None
         # ``dag_plan_*`` has no per-plan identifier in the event data, so
         # we synthesize one by counting starts and remembering the
         # currently-open key. Replan in a single task (rare but legal)
@@ -224,7 +249,9 @@ class PublicStepProjector:
         self._open_dag_execution_key: Optional[str] = None
 
     @classmethod
-    def from_history(cls, events: List[Any]) -> "PublicStepProjector":
+    def from_history(
+        cls, events: List[Any], *, retain_finished: bool = True
+    ) -> "PublicStepProjector":
         """Build a projector pre-warmed by replaying a full event history.
 
         Feeds every event into a fresh instance, in order. The resulting
@@ -232,8 +259,16 @@ class PublicStepProjector:
         starts) is identical to what a live consumer would have
         accumulated by that point -- there is no separate "batch" code
         path for the folding logic itself, only this replay.
+
+        Defaults to retaining: the batch driver
+        (``map_trace_events_to_public_steps``) reads its result only
+        through :meth:`materialized_steps`, which needs the retained
+        history. A caller that keeps the projector alive after this
+        initial read and only acts on subsequent ``feed`` results can
+        pass ``retain_finished=False`` -- but only if it never calls
+        :meth:`materialized_steps` afterwards.
         """
-        projector = cls()
+        projector = cls(retain_finished=retain_finished)
         for event in events:
             projector.feed(event)
         return projector
@@ -252,7 +287,16 @@ class PublicStepProjector:
         is mutated in place when its end event arrives (see
         :meth:`feed`). Treat them as read-only views -- a caller that
         needs a stable picture must copy before storing.
+
+        Raises ``RuntimeError`` on a projector built with
+        ``retain_finished=False``: the finished steps it would need were
+        never kept, so there is no partial answer worth returning.
         """
+        if self._finished is None:
+            raise RuntimeError(
+                "materialized_steps() needs the finished-step history; this "
+                "projector was built with retain_finished=False"
+            )
         steps = list(self._finished)
         steps.extend(self._pending.values())
         return steps
@@ -271,7 +315,8 @@ class PublicStepProjector:
         :meth:`materialized_steps`'s backing storage (mutated in place
         when a pending start is later finalized), so a caller folding
         successive ``feed`` results by step id always ends up with the
-        current state of each step.
+        current state of each step (when this projector retains them;
+        see the class docstring).
         """
         event_type = _safe_get(event, "event_type")
         if not event_type:
@@ -280,11 +325,13 @@ class PublicStepProjector:
         # ===== messages: one event per message, no pairing =====
         if event_type == "user_message":
             step = _build_message_step(event, role="user")
-            self._finished.append(step)
+            if self._finished is not None:
+                self._finished.append(step)
             return [step]
         if event_type == "ai_message":
             step = _build_message_step(event, role="assistant")
-            self._finished.append(step)
+            if self._finished is not None:
+                self._finished.append(step)
             return [step]
 
         # ===== thinking: paired start/end =====
@@ -766,20 +813,24 @@ def _terminal_status_from_event(event: Any) -> str:
 
 def _finalize_pending(
     pending: Dict[Tuple[str, str], Dict[str, Any]],
-    finished: List[Dict[str, Any]],
+    finished: Optional[List[Dict[str, Any]]],
     key: Tuple[str, str],
     *,
     end_event: Any,
     status: str,
     extra_data_fn: Optional[Any] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Move ``pending[key]`` to ``finished`` and patch with end metadata.
+    """Move ``pending[key]`` out of the pending table and patch it with
+    end metadata, appending it to ``finished`` when the caller keeps one
+    (``None`` for a projector built with ``retain_finished=False`` -- see
+    :class:`PublicStepProjector`).
 
     Orphan end (no matching start in ``pending``) is dropped on
     purpose -- see module docstring. Returns the finalized step dict
-    (the same object moved into ``finished``), or ``None`` for a
-    dropped orphan end, so callers that need to report "what changed"
-    (:meth:`PublicStepProjector.feed`) don't have to re-derive it.
+    (the same object appended to ``finished`` when one is kept), or
+    ``None`` for a dropped orphan end, so callers that need to report
+    "what changed" (:meth:`PublicStepProjector.feed`) don't have to
+    re-derive it.
     """
     step = pending.pop(key, None)
     if step is None:
@@ -793,7 +844,8 @@ def _finalize_pending(
             step["data"].update(redact_runtime_sensitive_payload(extra))
         except Exception as exc:  # defensive; data shape is external
             logger.debug("step extra_data_fn failed: %s", exc)
-    finished.append(step)
+    if finished is not None:
+        finished.append(step)
     return step
 
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1313,8 +1313,10 @@ async def stream_chat_task_events(
       too large" rather than "a step was too large". A truncated
       ``message.delta``/``message.completed`` carries the shortened text
       itself plus ``truncated: true`` and no ``original_bytes``. A raw
-      broadcast frame whose own text runs past 256 KiB is dropped whole
-      instead of truncated (see Behavior below): no marker, no content.
+      broadcast frame that runs past 256 KiB -- measured without the
+      internal task-description stamp such frames carry -- is dropped
+      whole instead of truncated (see Behavior below): no marker, no
+      content.
       This cap is specific to this stream -- ``GET .../steps`` applies
       no such cap and always returns a step's full, untruncated
       ``data``, so the two surfaces can disagree on content for the

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1226,6 +1226,10 @@ async def stream_chat_task_events(
         agent's pending question when one is on record (the same value
         ``GET /v1/chat/tasks/{task_id}`` returns as
         ``pending_interaction.question``), or ``null`` if none is.
+        Earlier versions of this endpoint sent ``null`` here in every
+        case, so a client that assumed the field was never populated
+        must accept a string: the field's name and type (nullable
+        string) are unchanged, only the value can now be present.
         Answer it with ``POST /v1/chat/tasks/{task_id}/reply`` -- calling
         ``POST .../messages`` (append) on a task in this state 409s.
       - ``stream.error``: ``{code, message}``, a flat shape distinct
@@ -1329,22 +1333,22 @@ async def stream_chat_task_events(
       - This stream carries only what happens after the connection
         opens; it never sends the steps that already happened, on any
         path. That has two consequences a client must handle. First, a
-        step that was already running at attach time never reaches
-        ``step.completed`` on this stream: its end event has no matching
-        start on this connection, so it is dropped rather than sent, and
-        that step stays ``"running"`` here for the rest of the stream's
-        life even though the task actually resolved it. Second, an
-        attach that arrives once the task has already finished (or is
-        already waiting on user input) has no live content left to
-        carry, so it closes with the lifecycle frames alone. Either way,
-        ``GET .../steps`` reads the database and is unaffected by when
-        the stream was opened, so that is where a client reconciles what
-        this stream did not carry.
+        step that was already running at attach time does not appear on
+        this stream at all: its ``step.started`` was broadcast before
+        this connection existed, and its end event arrives here with no
+        matching start, so that end is dropped rather than sent. The
+        client sees neither half of the step -- it is absent, not left
+        at ``"running"``. Second, an attach that arrives once the task
+        has already finished (or is already waiting on user input) has
+        no live content left to carry, so it closes with the lifecycle
+        frames alone. Either way, ``GET .../steps`` reads the database
+        and is unaffected by when the stream was opened, so that is
+        where a client reconciles what this stream did not carry.
       - Frame sequence into ``task.completed``: a task that fails emits
         ``task.status`` (``"failed"``) from the failure broadcast first,
         then the watchdog's authoritative ``task.completed`` close
         frame. Delivery of every ``step.*``/``message.*`` content frame
-        on this stream is best-effort, not guaranteed, for three
+        on this stream is best-effort, not guaranteed, for four
         separate reasons: (1) closing a stream for any reason drains its
         queued backlog before inserting the close frame, so any
         already-queued frame -- a ``task.status``, a ``step.*``, a
@@ -1358,9 +1362,23 @@ async def stream_chat_task_events(
         raw broadcast frame is dropped whole rather than projected,
         so its content never reaches the per-field truncation cap
         described above and leaves no ``"truncated": true`` marker --
-        this is a full drop, not a truncation. (2) and (3) are silent:
-        neither one ever produces a ``stream.error`` frame or any other
-        signal on the wire. (1) is not silent in the same way -- the
+        this is a full drop, not a truncation. The size measured
+        excludes the task description that the broadcast conversion
+        stamps onto every trace event, so a task's description alone
+        can no longer blank out its step stream this way -- a frame is
+        only dropped here when its content, apart from that field, is
+        still over the cap. (4) a planning step can be left unresolved:
+        when a planning round ends without emitting its own terminal
+        event (a plan-generation error escaping before it), the next
+        round clears the pairing key that step was waiting on, so the
+        step's ``step.completed`` is never produced and the client
+        keeps a ``thinking`` step at ``"running"`` for the rest of the
+        stream's life (``_step_mapping.py``'s ``dag_execute_start``
+        branch). This one is not a stream-only artifact: ``GET
+        .../steps`` folds the same events and shows that step the same
+        way. (2), (3) and (4) are silent: none of them ever produces a
+        ``stream.error`` frame or any other signal on the wire. (1) is
+        not silent in the same way -- the
         close frame that follows a queue-drain is often itself a
         ``stream.error`` (``resync_required``/``unauthorized``/
         ``task_deleted``/``stream_expired``) -- but that close frame

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1211,73 +1211,199 @@ async def stream_chat_task_events(
     task_id: int,
     principal: ApiKeyPrincipal = Depends(get_principal_from_api_key),
 ) -> StreamingResponse:
-    """Stream a task's lifecycle as Server-Sent Events.
-
-    Transport layer only: emits ``task.status``, ``task.completed``,
-    ``task.input_required``, and ``stream.error``. Step-by-step and
-    token-by-token content
-    (``step.*`` / ``message.*``) is not projected onto this stream yet --
-    poll ``GET /v1/chat/tasks/{task_id}/steps`` for that in the meantime.
+    """Stream a task's lifecycle and step/message content as Server-Sent
+    Events.
 
     This endpoint declares no ``responses=`` schema, so the field lists
-    below are the only OpenAPI-visible contract for its four SSE event
-    types (each a ``event: <name>`` / ``data: <json>`` frame pair):
+    below are the only OpenAPI-visible contract for its 8 SSE event
+    types (each a ``event: <name>`` / ``data: <json>`` frame pair). Four
+    are lifecycle-only:
       - ``task.status``: ``{status}``.
       - ``task.completed``: ``{status, output, error}``. A failed task
         also ends the stream with this event rather than a separate
         one -- ``status`` is ``"failed"`` and ``error`` is set.
-      - ``task.input_required``: ``{task_id, prompt: null}`` -- ``prompt``
-        is always ``null`` at this transport layer (see module docstring
-        for why).
+      - ``task.input_required``: ``{task_id, prompt}``. ``prompt`` is the
+        agent's pending question when one is on record (the same value
+        ``GET /v1/chat/tasks/{task_id}`` returns as
+        ``pending_interaction.question``), or ``null`` if none is.
+        Answer it with ``POST /v1/chat/tasks/{task_id}/reply`` -- calling
+        ``POST .../messages`` (append) on a task in this state 409s.
       - ``stream.error``: ``{code, message}``, a flat shape distinct
         from the nested error envelope ``V1ApiError`` HTTP responses use
         elsewhere in this router; the two error-code vocabularies do
         not overlap.
 
+    The other four project the task's step-by-step execution and
+    streamed message text onto the same connection, from the same
+    ``PublicStep`` shape and public step-type list ``GET
+    .../steps`` uses (``thinking``/``tool_call``/``agent_delegation``/
+    ``message``):
+      - ``step.started``: ``{step}``, a running ``PublicStep``.
+      - ``step.completed``: ``{step}``, the same step once its end event
+        (or failure) resolves it -- ``status`` is ``"completed"`` or
+        ``"failed"``.
+      - ``message.delta``: ``{message_id, text}``, one chunk of a
+        streamed final answer as the agent generates it.
+      - ``message.completed``: ``{message_id, content}``, that same
+        message's full text once the stream ends successfully. A
+        ``message.delta`` sequence is not guaranteed a matching
+        ``message.completed`` -- see Behavior below.
+        Each frame is capped on its own and the delta sequence has no
+        aggregate cap, so on a long answer a ``message.completed``
+        carrying ``"truncated": true`` can hold less text than the
+        deltas the client already accumulated. It is not authoritative
+        over them: prefer the accumulated deltas, or ``steps()`` for the
+        full persisted text.
+      A ``message`` ``PublicStep``'s ``id`` cannot be correlated between
+      this stream and ``GET .../steps``: the live frame mints a fresh id
+      per broadcast, while ``steps()`` returns the persisted trace
+      event's own id as that step's id.
+      A ``thinking`` step whose id begins with ``thinking:plan:`` or
+      ``thinking:planning:`` cannot be correlated either, and is the one
+      case where trying to actively corrupts client state. Both ids end
+      in a count of the planning cycles the projection has seen, and
+      this stream's projection starts empty at attach: it numbers the
+      first planning cycle it observes ``:1`` however many already
+      happened, while ``steps()`` counts from the start of the task's
+      persisted history. A client attaching during a task's second
+      planning cycle is therefore sent ``thinking:plan:{task_id}:1`` for
+      a step ``steps()`` calls ``thinking:plan:{task_id}:2`` -- and
+      ``thinking:plan:{task_id}:1`` already exists in ``steps()`` as the
+      first cycle, a different step. Merging the two surfaces by id
+      overwrites one with the other. These ids are stable within one
+      connection and nowhere else: a re-attach after ``stream_expired``
+      (the 1-hour cap) or ``resync_required`` (queue overflow) opens a
+      new connection whose count starts over. Reconcile planning steps
+      against ``steps()`` by ``started_at`` and content, not by id.
+      Every other public step type -- ``tool_call``,
+      ``agent_delegation``, and ``thinking`` steps whose id carries the
+      originating step id rather than a count -- keeps the same id
+      across both surfaces. That holds because those ids are derived
+      from a key the event itself carries: a tool invocation's own id,
+      or the id of the step that produced the event. Both surfaces read
+      that same key off that same event, which is what makes the two
+      ids equal rather than merely similar. An event carrying neither
+      key would instead be identified by a per-delivery id that differs
+      between the two surfaces and so would not correlate; no event
+      type this stream projects reaches that state.
+      A final answer the agent streams live reaches the client twice on
+      this stream: once as its ``message.delta``/``message.completed``
+      sequence, and again as a ``message``-type ``step.completed`` once
+      the underlying ``ai_message`` trace event folds in -- the same
+      step ``steps()`` already shows for that row. This is duplication,
+      not loss: a client that already rendered the delta/completed
+      sequence can ignore the matching step, or use it as the
+      authoritative record instead, but should not expect the two to be
+      mutually exclusive.
+      A ``step.*``/``message.*`` frame whose content-bearing field would
+      exceed a per-frame byte cap has that field truncated (or, for a
+      step's structured ``data``, replaced) and flagged with
+      ``"truncated": true`` rather than sent whole. The cap is 64 KiB of
+      the field's own JSON wire form. A replaced step ``data`` carries
+      ``truncated: true``, ``original_bytes`` (what the original
+      sub-object would have measured on the wire), and -- as long as
+      they fit -- that step type's identifying key: ``name`` for a
+      ``tool_call``, ``sub_agent_name`` for an ``agent_delegation``,
+      ``phase`` for a ``thinking`` step, ``role`` for a ``message``. So
+      a client can render "the ``search`` tool ran and its result was
+      too large" rather than "a step was too large". A truncated
+      ``message.delta``/``message.completed`` carries the shortened text
+      itself plus ``truncated: true`` and no ``original_bytes``. A raw
+      broadcast frame whose own text runs past 256 KiB is dropped whole
+      instead of truncated (see Behavior below): no marker, no content.
+      This cap is specific to this stream -- ``GET .../steps`` applies
+      no such cap and always returns a step's full, untruncated
+      ``data``, so the two surfaces can disagree on content for the
+      same step once it's large enough to trip this stream's cap.
+
     Behavior:
       - Normal attach: opens the stream, emits ``task.status`` for the
-        task's current state, then a status update each time it
-        changes (consecutive duplicates are suppressed), and
+        task's current state, then goes live -- a status update each
+        time the task's status changes (consecutive duplicates are
+        suppressed), ``step.*``/``message.*`` frames as new trace
+        events and streamed answer chunks arrive, and
         ``task.completed`` when the task finishes. A ``: ping`` comment
         line is sent whenever 15s pass without any other frame going
         out, to keep the connection alive -- not on a fixed 15s
         cadence regardless of activity.
+      - This stream carries only what happens after the connection
+        opens; it never sends the steps that already happened, on any
+        path. That has two consequences a client must handle. First, a
+        step that was already running at attach time never reaches
+        ``step.completed`` on this stream: its end event has no matching
+        start on this connection, so it is dropped rather than sent, and
+        that step stays ``"running"`` here for the rest of the stream's
+        life even though the task actually resolved it. Second, an
+        attach that arrives once the task has already finished (or is
+        already waiting on user input) has no live content left to
+        carry, so it closes with the lifecycle frames alone. Either way,
+        ``GET .../steps`` reads the database and is unaffected by when
+        the stream was opened, so that is where a client reconciles what
+        this stream did not carry.
       - Frame sequence into ``task.completed``: a task that fails emits
         ``task.status`` (``"failed"``) from the failure broadcast first,
         then the watchdog's authoritative ``task.completed`` close
-        frame. This is best-effort, not guaranteed: closing a stream
-        drains its queued backlog before inserting the close frame, so
-        an already-queued ``task.status`` (``"failed"``) can be dropped
-        rather than delivered. No failure information is lost when that
-        happens -- ``task.completed`` still carries ``status: "failed"``
-        and a populated ``error``. A task that succeeds has no such
-        intermediate broadcast, so it goes straight to ``task.completed``
-        with no preceding ``task.status``. Attaching to a task that's
-        already terminal (the fast path below) always sends both frames
-        regardless.
+        frame. Delivery of every ``step.*``/``message.*`` content frame
+        on this stream is best-effort, not guaranteed, for three
+        separate reasons: (1) closing a stream for any reason drains its
+        queued backlog before inserting the close frame, so any
+        already-queued frame -- a ``task.status``, a ``step.*``, a
+        ``message.*`` -- can be dropped rather than delivered; this is
+        not specific to a failure closing the stream, it's the
+        queue-drain behavior every close goes through. (2) one content
+        frame that fails to project (a malformed field the projector
+        can't fold) is dropped on its own -- it does not close the
+        stream or affect any other frame, so a step or message can go
+        missing from an otherwise unremarkable stream. (3) an oversized
+        raw broadcast frame is dropped whole rather than projected,
+        so its content never reaches the per-field truncation cap
+        described above and leaves no ``"truncated": true`` marker --
+        this is a full drop, not a truncation. (2) and (3) are silent:
+        neither one ever produces a ``stream.error`` frame or any other
+        signal on the wire. (1) is not silent in the same way -- the
+        close frame that follows a queue-drain is often itself a
+        ``stream.error`` (``resync_required``/``unauthorized``/
+        ``task_deleted``/``stream_expired``) -- but that close frame
+        carries no record of what it drained on its way out, so its
+        presence or absence proves nothing about whether a content frame
+        was lost this way: a ``stream.error`` does not mean content was
+        dropped, and its absence does not mean nothing was. Only
+        reconciling against ``steps()`` answers that. No failure
+        information is lost when a status frame is dropped this way --
+        ``task.completed`` still carries ``status: "failed"`` and a
+        populated ``error`` -- but a dropped content frame has no such
+        backstop: a ``message.delta`` sequence can end with no
+        ``message.completed``, and a step can be left ``"running"`` on
+        this stream even though it actually resolved. Reconcile via
+        ``steps()`` for the authoritative picture; don't treat "no
+        content frame arrived" as "nothing happened". A task that
+        succeeds has no intermediate status broadcast, so it goes
+        straight to ``task.completed`` with no preceding
+        ``task.status``.
       - Attaching to an already-finished task is not an error: the
         stream opens, emits ``task.status`` then ``task.completed``,
-        and closes immediately.
-      - The stream force-closes with ``task.input_required``
-        (``prompt`` always ``null`` at this stage) if the task is
-        found waiting on user input; with ``stream.error`` if the
-        API key is revoked/paused, the task row disappears (within one
-        watchdog cycle, 30s in production, of the delete), the
-        client can't keep up (``resync_required``), or the stream has
-        been open for the 1-hour maximum (``stream_expired``, emitted
-        before the connection closes so it's distinguishable from a
-        clean end). After any ``stream.error``, re-attaching is the
-        supported recovery path (no replay -- reconcile via
-        ``steps()`` first).
+        and closes immediately, with no ``step.*`` frames in between --
+        that task's steps are read through ``GET .../steps``.
+      - The stream force-closes with ``task.input_required`` if the task
+        is found waiting on user input (same shape: ``task.status``,
+        then ``task.input_required``, then close); with ``stream.error``
+        if the API key is revoked/paused, the task row disappears
+        (within one watchdog cycle, 30s in production, of the delete),
+        the client can't keep up (``resync_required``), or the stream
+        has been open for the 1-hour maximum (``stream_expired``,
+        emitted before the connection closes so it's distinguishable
+        from a clean end). After any ``stream.error``, re-attaching is
+        the supported recovery path (no replay of missed frames --
+        reconcile via ``steps()`` first).
       - A task that's ``paused`` does not close the stream (matching
         SDK ``wait()`` semantics: another process may resume it); the
         1-hour cap is what eventually ends an orphaned paused stream.
       - No ``task.status`` frame is guaranteed to be fresh or in order,
-        at any point in the stream's life, not only at attach -- this
-        transport-only layer never buffers or reconciles frame order.
-        Accepted because only the three close frames above are treated
-        as authoritative; each comes from a direct read of the task
-        row, never from frame ordering.
+        at any point in the stream's life, not only at attach: this
+        endpoint never buffers or reconciles ``task.status`` frame
+        order against anything. Accepted because only the three close
+        frames above are treated as authoritative; each comes from a
+        direct read of the task row, never from frame ordering.
 
     Args:
         task_id: Path parameter; the target task's primary key.
@@ -1312,10 +1438,17 @@ async def stream_chat_task_events(
             process's connection manager, so a task transition driven
             by a different worker reaches this stream only once the
             watchdog's 30s database poll picks it up, not via broadcast.
-            Some transitions -- lease-expiry recovery among them --
-            never broadcast at all, in any deployment shape, so the
-            watchdog poll is their only delivery path regardless of
-            worker count.
+            That poll only ever reads task status, though, never step
+            content: an attach routed to a different worker than the one
+            executing the task still gets the authoritative close frame
+            (the watchdog reads the task row), but receives none of the
+            live ``step.*``/``message.*`` frames produced in between --
+            there is no equivalent fallback delivery for content the way
+            there is for a status transition, so such an attach
+            degrades to the lifecycle-only shape. Some transitions --
+            lease-expiry recovery among them -- never broadcast at all,
+            in any deployment shape, so the watchdog poll is their only
+            delivery path regardless of worker count.
     """
     snapshot = await run_db_io_cancellation_safe(
         lambda: _load_task_info_snapshot(task_id, principal)

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -2132,6 +2132,46 @@ async def test_a_huge_task_description_does_not_drop_a_small_content_frame():
     assert "task_description" not in step["data"]
 
 
+async def test_projection_consumes_the_pruned_frame_not_the_original():
+    """The over-cap path hands projection the frame with
+    ``task_description`` already removed, not the original.
+
+    The wire output cannot distinguish the two -- the step builders name
+    their keys explicitly, so the description never reaches a frame
+    either way. What this pins is the processing boundary: the raw-frame
+    check was that unbounded field's only per-frame CPU bound, and
+    ``_measured_content_frame`` replaces it by pruning before projection
+    rather than after, so a surviving frame's ``serialize_trace_data``
+    walk never runs over the description. Asserted at the
+    ``_project_and_queue`` boundary because no later observation point
+    can see the difference."""
+    sink = _make_sink(task_id=104)
+    received: list[dict] = []
+    original = sink._project_and_queue
+    sink._project_and_queue = lambda frame: (
+        received.append(frame),
+        original(frame),
+    )[-1]
+    huge_description = "x" * (es.MAX_RAW_FRAME_TEXT_CHARS + 1000)
+    raw = _trace_event_frame(
+        "tool_execution_start",
+        task_id=104,
+        step_id="step-1",
+        data={
+            "tool_call_id": "call-1",
+            "tool_name": "search",
+            "tool_args": {"query": "weather"},
+            "task_description": huge_description,
+        },
+    )
+
+    await sink.send_text(raw)
+
+    assert len(received) == 1
+    assert "task_description" not in received[0]["data"]
+    assert received[0]["data"]["tool_name"] == "search"
+
+
 async def test_a_frame_still_over_the_cap_without_its_description_is_dropped():
     """The control for the test above: excluding ``task_description``
     from the measurement is not a blanket exemption for any frame that

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -559,11 +559,11 @@ async def test_queued_wire_bytes_falls_back_as_frames_are_read_out():
 
 async def test_generator_read_path_keeps_queued_wire_bytes_at_zero_between_frames():
     """Division of labor with the two tests above: those pin
-    ``next_frame``'s own body (what mutation testing calls M2 -- deleting
-    the subtraction inside it). This one pins the call *site* -- that
-    ``_generate``'s per-frame read actually goes through ``next_frame``
-    rather than a bare ``sink.queue.get()`` that would bypass the byte
-    accounting entirely (M5). Runs a real attach, then puts and reads one
+    ``next_frame``'s own body (deleting the subtraction inside it turns
+    them red). This one pins the call *site* -- that ``_generate``'s
+    per-frame read actually goes through ``next_frame`` rather than a
+    bare ``sink.queue.get()`` that would bypass the byte accounting
+    entirely. Runs a real attach, then puts and reads one
     budget-sized frame at a time -- never letting more than one frame's
     worth of backlog build up -- and checks after every read that the
     delivered frame is the one just queued (not a ``resync_required``

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -556,13 +556,13 @@ async def test_watchdog_waiting_for_user_closes_with_null_prompt_when_no_questio
     )
     assert closed is True
     assert sink.closing is True
-    assert sink.queue.get_nowait() == (es.input_required_frame(task_id, None), True)
-    assert (
-        json.loads(es.input_required_frame(task_id, None).split("data: ", 1)[1])[
-            "prompt"
-        ]
-        is None
-    )
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is True
+    assert frame_text.startswith("event: task.input_required\n")
+    assert json.loads(frame_text.split("data: ", 1)[1]) == {
+        "task_id": task_id,
+        "prompt": None,
+    }
 
 
 async def test_watchdog_waiting_for_user_closes_with_the_pending_question_as_prompt():
@@ -1675,55 +1675,50 @@ async def test_trace_event_tool_call_start_then_end_projects_paired_step_frames(
     assert completed["data"]["result"] == "sunny"
 
 
-async def test_trace_event_ai_message_projects_a_completed_message_step():
-    """A one-shot ``ai_message`` (no ``stream_message_id``, i.e. a run
-    with no live token stream) still projects a step -- it's a public
-    ``message`` step, always already ``completed`` (see
-    ``_build_message_step``)."""
-    sink = _make_sink(task_id=7)
-    await sink.send_text(
-        _trace_event_frame(
-            "ai_message",
-            task_id=7,
-            event_id="persisted-event-id",
-            data={"content": "the answer"},
-        )
-    )
-    frame_text, is_close = sink.queue.get_nowait()
-    assert is_close is False
-    assert frame_text.startswith("event: step.completed\n")
-    step = json.loads(frame_text.split("data: ", 1)[1])["step"]
-    assert step["id"] == "message:persisted-event-id"
-    assert step["data"] == {"role": "assistant", "content": "the answer"}
+@pytest.mark.parametrize(
+    ("event_id", "extra_data"),
+    [
+        pytest.param("persisted-event-id", {}, id="no-stream-message-id"),
+        pytest.param(
+            "live-final-answer",
+            {"stream_message_id": "final_answer_abc"},
+            id="with-stream-message-id",
+        ),
+    ],
+)
+async def test_trace_event_ai_message_projects_a_completed_message_step(
+    event_id, extra_data
+):
+    """An ``ai_message`` folds into a public ``message`` step, always
+    already ``completed`` (see ``_build_message_step``), whether or not it
+    carries ``stream_message_id``.
 
-
-async def test_trace_event_ai_message_with_stream_message_id_also_projects_a_step():
-    """New contract: an ``ai_message`` carrying ``stream_message_id`` --
-    the persisted mirror of a final answer already delivered live via
-    ``message.delta``/``message.completed`` -- still folds into a
-    ``message`` step here, the same as any other ``ai_message``. This
-    duplicates that content as a second delivery (a ``step.completed``
-    alongside the earlier delta/completed frames), not a loss: dropping
-    it here (the old behavior) had no persisted counterpart, so
-    ``steps()`` already shows this exact row as a ``message`` step
-    regardless -- filtering only the live path made an already-attached
-    stream disagree with ``steps()`` about whether the step exists. See
+    The second cell is the new contract. An ``ai_message`` carrying
+    ``stream_message_id`` is the persisted mirror of a final answer this
+    stream already delivered live as ``message.delta`` /
+    ``message.completed``, so folding it too duplicates that content as a
+    second delivery rather than losing it. Dropping it here -- the old
+    behavior -- had no persisted counterpart: ``steps()`` shows this exact
+    row as a ``message`` step regardless, so filtering only the live path
+    made an already-attached stream disagree with ``steps()`` about whether
+    the step exists. See
     ``test_live_projection_matches_steps_for_a_streamed_final_answer``
-    below for the two-path parity this restores."""
+    below for the two-path parity this restores.
+    """
     sink = _make_sink(task_id=7)
     await sink.send_text(
         _trace_event_frame(
             "ai_message",
             task_id=7,
-            event_id="live-final-answer",
-            data={"content": "the answer", "stream_message_id": "final_answer_abc"},
+            event_id=event_id,
+            data={"content": "the answer", **extra_data},
         )
     )
     frame_text, is_close = sink.queue.get_nowait()
     assert is_close is False
     assert frame_text.startswith("event: step.completed\n")
     step = json.loads(frame_text.split("data: ", 1)[1])["step"]
-    assert step["id"] == "message:live-final-answer"
+    assert step["id"] == f"message:{event_id}"
     assert step["data"] == {"role": "assistant", "content": "the answer"}
     assert sink.queue.empty()
 
@@ -1887,48 +1882,6 @@ async def test_trace_event_tool_call_redacts_credential_shaped_fields_on_the_wir
     assert (
         completed_data["result"]["headers"]["Authorization"] == REDACTED_RUNTIME_SECRET
     )
-
-
-async def test_final_answer_delta_projects_message_delta_frame():
-    sink = _make_sink(task_id=21)
-    await sink.send_text(
-        json.dumps(
-            {
-                "type": "final_answer_delta",
-                "message_id": "final_answer_abc",
-                "task_id": 21,
-                "delta": "Hey",
-            }
-        )
-    )
-    frame_text, is_close = sink.queue.get_nowait()
-    assert is_close is False
-    assert frame_text == es.message_delta_frame("final_answer_abc", "Hey")
-    assert json.loads(frame_text.split("data: ", 1)[1]) == {
-        "message_id": "final_answer_abc",
-        "text": "Hey",
-    }
-
-
-async def test_final_answer_end_projects_message_completed_frame():
-    sink = _make_sink(task_id=21)
-    await sink.send_text(
-        json.dumps(
-            {
-                "type": "final_answer_end",
-                "message_id": "final_answer_abc",
-                "task_id": 21,
-                "content": "Hello there",
-            }
-        )
-    )
-    frame_text, is_close = sink.queue.get_nowait()
-    assert is_close is False
-    assert frame_text == es.message_completed_frame("final_answer_abc", "Hello there")
-    assert json.loads(frame_text.split("data: ", 1)[1]) == {
-        "message_id": "final_answer_abc",
-        "content": "Hello there",
-    }
 
 
 @pytest.mark.parametrize("frame_type", ["final_answer_start", "final_answer_error"])
@@ -2206,65 +2159,91 @@ async def test_poisoned_live_frame_increments_dropped_frame_count_only_once(
 # ===== single-frame content byte cap =====
 
 
-async def test_message_delta_over_the_byte_cap_is_truncated_and_flagged():
+@pytest.mark.parametrize(
+    ("frame_type", "content_key", "wire_event", "wire_key", "oversized"),
+    [
+        pytest.param(
+            "final_answer_delta",
+            "delta",
+            "message.delta",
+            "text",
+            False,
+            id="delta-under-the-cap",
+        ),
+        pytest.param(
+            "final_answer_delta",
+            "delta",
+            "message.delta",
+            "text",
+            True,
+            id="delta-over-the-cap",
+        ),
+        pytest.param(
+            "final_answer_end",
+            "content",
+            "message.completed",
+            "content",
+            False,
+            id="completed-under-the-cap",
+        ),
+        pytest.param(
+            "final_answer_end",
+            "content",
+            "message.completed",
+            "content",
+            True,
+            id="completed-over-the-cap",
+        ),
+    ],
+)
+async def test_final_answer_frames_project_message_frames_under_the_byte_cap(
+    frame_type, content_key, wire_event, wire_key, oversized
+):
+    """Each ``final_answer_*`` broadcast frame maps to its own
+    ``message.*`` SSE event, and each carries the same per-frame byte cap
+    on its own content field.
+
+    Four cells, each catching a different error:
+      - ``delta-under-the-cap`` / ``completed-under-the-cap``: the frame
+        family mapping itself (``final_answer_delta`` -> ``message.delta``
+        carrying ``text``, ``final_answer_end`` -> ``message.completed``
+        carrying ``content``), plus the absence of a ``truncated`` key on
+        content that fits. A wrong mapping, a renamed field, or a
+        ``truncated`` marker on unremarkable content fails here.
+      - ``delta-over-the-cap`` / ``completed-over-the-cap``: the cap is
+        applied on *both* paths, not just the streamed-delta one. A
+        ``_capped_text`` call missing from the final-answer *end* path
+        would leave the completed cell's content whole and unmarked while
+        the delta cells still passed.
+    """
     sink = _make_sink(task_id=51)
-    oversized = "x" * (es.MAX_FRAME_CONTENT_BYTES + 1000)
+    payload = (
+        "x" * (es.MAX_FRAME_CONTENT_BYTES + 1000)
+        if oversized
+        else "just a normal chunk"
+    )
     await sink.send_text(
         json.dumps(
             {
-                "type": "final_answer_delta",
+                "type": frame_type,
                 "message_id": "final_answer_abc",
                 "task_id": 51,
-                "delta": oversized,
+                content_key: payload,
             }
         )
     )
-    frame_text, _ = sink.queue.get_nowait()
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is False
+    assert frame_text.startswith(f"event: {wire_event}\n")
     data = json.loads(frame_text.split("data: ", 1)[1])
-    assert data["truncated"] is True
-    assert len(data["text"].encode("utf-8")) <= es.MAX_FRAME_CONTENT_BYTES
-    assert data["text"] != oversized
-
-
-async def test_message_delta_under_the_byte_cap_is_unmarked():
-    sink = _make_sink(task_id=53)
-    await sink.send_text(
-        json.dumps(
-            {
-                "type": "final_answer_delta",
-                "message_id": "final_answer_abc",
-                "task_id": 53,
-                "delta": "just a normal chunk",
-            }
-        )
-    )
-    frame_text, _ = sink.queue.get_nowait()
-    data = json.loads(frame_text.split("data: ", 1)[1])
-    assert "truncated" not in data
-    assert data["text"] == "just a normal chunk"
-
-
-async def test_message_completed_over_the_byte_cap_is_truncated_and_flagged():
-    """Same cap, same flagging, on ``message.completed`` -- pins that
-    the final-answer *end* path (not just the streamed delta path
-    above) also goes through ``_capped_text``."""
-    sink = _make_sink(task_id=52)
-    oversized = "x" * (es.MAX_FRAME_CONTENT_BYTES + 1000)
-    await sink.send_text(
-        json.dumps(
-            {
-                "type": "final_answer_end",
-                "message_id": "final_answer_abc",
-                "task_id": 52,
-                "content": oversized,
-            }
-        )
-    )
-    frame_text, _ = sink.queue.get_nowait()
-    data = json.loads(frame_text.split("data: ", 1)[1])
-    assert data["truncated"] is True
-    assert len(data["content"].encode("utf-8")) <= es.MAX_FRAME_CONTENT_BYTES
-    assert data["content"] != oversized
+    assert data["message_id"] == "final_answer_abc"
+    if oversized:
+        assert data["truncated"] is True
+        assert es._byte_length(data[wire_key]) <= es.MAX_FRAME_CONTENT_BYTES
+        assert data[wire_key] != payload
+    else:
+        assert "truncated" not in data
+        assert data == {"message_id": "final_answer_abc", wire_key: payload}
 
 
 def test_capped_text_handles_a_multibyte_character_straddling_the_byte_boundary():
@@ -2371,20 +2350,38 @@ async def test_capped_step_data_preserves_identifying_keys_per_step_type():
     )
 
 
-async def test_capped_step_data_truncates_an_oversized_identifying_value():
+@pytest.mark.parametrize(
+    "huge_name",
+    ["n" * 70_000, "名" * 12_000],
+    ids=["ascii-name", "cjk-name"],
+)
+def test_capped_step_data_truncates_an_oversized_identifying_value(huge_name):
     """An identifying value can itself be large enough to blow the cap
     once folded into the truncation marker (the first pass in
-    ``_capped_step_data``'s docstring) -- e.g. an unusually long tool
-    name. The second pass must truncate that value (not drop it) and
-    the result must still fit under ``MAX_FRAME_CONTENT_BYTES``:
-    truncating the value to the *full* cap and only then wrapping it in
-    the marker dict would overflow on the marker's own JSON overhead
-    alone, which is exactly the bug this guards against."""
-    huge_name = "n" * 70_000
+    ``_capped_step_data``'s docstring). The second pass must truncate it
+    rather than drop it, and the result must still fit under
+    ``MAX_FRAME_CONTENT_BYTES``.
+
+    Two cells, two different bugs:
+      - ``ascii-name``: truncating the value to the *full* cap and only
+        then wrapping it in the marker dict overflows on the marker's own
+        JSON overhead alone. This cell is what a per-key budget that
+        forgets that overhead fails on.
+      - ``cjk-name``: ``per_key_budget`` is computed in escaped-JSON
+        bytes, the domain ``_byte_length``'s cap checks use. Before
+        ``_capped_text`` measured in that same domain, handing it that
+        budget for a CJK name let it keep far more *characters* than the
+        escaped budget allowed (UTF-8 costs 3 bytes per "名", the escaped
+        ``\\uXXXX`` wire form costs 6), so the reassembled dict was still
+        over the cap on its own re-check and the identifying ``name``
+        field a client needs to know which tool ran was dropped entirely
+        -- not because it was genuinely too large to fit, but because the
+        two functions measured in different domains.
+    """
     result = es._capped_step_data({"name": huge_name, "junk": "x" * 1000})
     assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
     assert result["truncated"] is True
-    assert "name" in result
+    assert "name" in result  # the truncation pass preserved it -- not dropped
     assert len(result["name"]) < len(huge_name)
     assert result["original_bytes"] > es.MAX_FRAME_CONTENT_BYTES
 
@@ -2432,28 +2429,45 @@ def test_capped_step_data_drops_only_the_value_it_cannot_shrink():
     assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
 
 
-def test_capped_step_data_prefers_dropping_a_non_string_over_a_truncatable_one():
+@pytest.mark.parametrize(
+    ("data", "dropped_key", "kept_key", "kept_original"),
+    [
+        pytest.param(
+            {"sub_agent_name": {"k": "x" * 70_000}, "role": "assistant" * 9_000},
+            "sub_agent_name",
+            "role",
+            "assistant" * 9_000,
+            id="oversized-dict-beats-oversized-string",
+        ),
+        pytest.param(
+            {"name": {"k": "x" * 66_000}, "phase": "p" * 70_000},
+            "name",
+            "phase",
+            "p" * 70_000,
+            id="smaller-dict-still-dropped-first",
+        ),
+    ],
+)
+def test_capped_step_data_prefers_dropping_a_non_string_over_a_truncatable_one(
+    data, dropped_key, kept_key, kept_original
+):
     """When both a truncatable string and an un-shrinkable non-string
     survive a failed pass, the non-string is dropped first -- preferring
     to drop the salvageable string would degrade a step that could have
     kept real content down to the bare marker for no reason. Per the
     docstring, a pass over strings only always fits within the cap, so
     reaching the drop step guarantees at least one non-string survivor
-    remains; falling back to the largest overall is unreachable here."""
-    result = es._capped_step_data(
-        {"sub_agent_name": {"k": "x" * 70_000}, "role": "assistant" * 9_000}
-    )
-    assert result["truncated"] is True
-    assert "sub_agent_name" not in result
-    assert "role" in result
-    assert 0 < len(result["role"]) < len("assistant" * 9_000)
-    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
+    remains; falling back to the largest overall is unreachable here.
 
-    result = es._capped_step_data({"name": {"k": "x" * 66_000}, "phase": "p" * 70_000})
+    The second cell is the one that pins "non-string first" rather than
+    "largest first": there the dict is the *smaller* of the two values, so
+    a size-only rule would drop the string instead.
+    """
+    result = es._capped_step_data(data)
     assert result["truncated"] is True
-    assert "name" not in result
-    assert "phase" in result
-    assert 0 < len(result["phase"]) < 70_000
+    assert dropped_key not in result
+    assert kept_key in result
+    assert 0 < len(result[kept_key]) < len(kept_original)
     assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
 
 
@@ -2501,28 +2515,6 @@ async def test_message_delta_with_cjk_content_is_capped_on_the_wire_not_decoded_
     assert data["truncated"] is True
     assert es._byte_length(data["text"]) <= es.MAX_FRAME_CONTENT_BYTES
     assert data["text"] != oversized
-
-
-async def test_capped_step_data_preserves_cjk_identifying_value_via_the_wire_byte_domain():
-    """The truncation pass's per-key budget (``per_key_budget`` in
-    ``_capped_step_data``) is computed in escaped-JSON bytes -- the same
-    domain ``_byte_length``'s cap checks use. Before ``_capped_text``
-    measured in that same domain, handing it that budget for a CJK name
-    let it keep far more *characters* than the escaped budget actually
-    allowed (UTF-8 costs 3 bytes per "名", the escaped wire form costs
-    6), so the reassembled dict was still over the cap on its own
-    re-check and the identifying ``name`` field a client needs to know
-    which tool ran got dropped entirely -- not because the name was
-    genuinely too large to fit, but because the two functions were
-    measuring in different domains. This pins that a CJK name now
-    survives, truncated, instead."""
-    huge_name_cjk = "名" * 12_000
-    result = es._capped_step_data({"name": huge_name_cjk, "junk": "x" * 1000})
-    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
-    assert result["truncated"] is True
-    assert "name" in result  # the truncation pass preserved it -- not dropped
-    assert len(result["name"]) < len(huge_name_cjk)
-    assert result["original_bytes"] > es.MAX_FRAME_CONTENT_BYTES
 
 
 async def test_nonfinite_step_data_values_are_normalized_to_null_on_the_wire():

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -1951,34 +1951,6 @@ async def test_final_answer_start_and_error_produce_no_content_frame(frame_type)
     assert sink.queue.empty()
 
 
-async def test_content_frames_are_dropped_by_the_same_close_drain_as_status_frames():
-    """``enqueue_close`` drains the *entire* queue before inserting
-    the close frame (existing, unconditional behavior of this sink) --
-    content frames queued ahead of a close are silently dropped exactly like a
-    queued ``task.status`` would be. The contract is "any close may
-    truncate the content sequence; reconcile via ``steps()``", not
-    "only ``final_answer_error`` truncates it"."""
-    sink = _make_sink(task_id=23, status="running")
-    await sink.send_text(
-        _trace_event_frame(
-            "tool_execution_start",
-            task_id=23,
-            data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
-        )
-    )
-    assert sink.queue.qsize() == 1  # the step.started frame queued above
-
-    sink.enqueue_close(es.completed_frame(status="failed", output=None, error="boom"))
-
-    assert sink.queue.qsize() == 1
-    frame_text, is_close = sink.queue.get_nowait()
-    assert is_close is True
-    assert frame_text.startswith("event: task.completed\n")
-    # The step.started frame queued before the close is gone, not
-    # delivered ahead of it -- drained by enqueue_close, same as any
-    # other backlog.
-
-
 async def test_step_started_frame_text_is_unaffected_by_the_step_s_later_completion():
     """Serialization-aliasing guard: ``feed()``
     returns the projector's own live dict, which gets mutated in place
@@ -2035,32 +2007,6 @@ def _sized_content_frame(task_id: int, total_chars: int) -> str:
     raw = json.dumps(envelope)
     assert len(raw) == total_chars
     return raw
-
-
-async def test_oversized_content_frame_is_dropped_before_projection():
-    """A content frame (parsed ``type`` in ``_CONTENT_FRAME_TYPES``)
-    whose raw text is bigger than ``MAX_RAW_FRAME_TEXT_CHARS`` is
-    dropped by ``send_text``'s size check, after classification but
-    before the call into ``_project_and_queue`` -- same drop-and-count
-    discipline as every other frame this sink drops. Warm, so a bug
-    that let this fall through would show up as a queued (truncated)
-    ``message.delta`` frame instead of nothing."""
-    sink = _make_sink(task_id=91)
-    oversized_delta = "x" * (es.MAX_RAW_FRAME_TEXT_CHARS + 1)
-    raw = json.dumps(
-        {
-            "type": "final_answer_delta",
-            "message_id": "final_answer_abc",
-            "task_id": 91,
-            "delta": oversized_delta,
-        }
-    )
-    assert len(raw) > es.MAX_RAW_FRAME_TEXT_CHARS
-
-    await sink.send_text(raw)
-
-    assert sink.dropped_frame_count == 1
-    assert sink.queue.empty()
 
 
 async def test_content_frame_exactly_at_the_size_cap_is_projected():

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -14,6 +14,7 @@ matters).
 
 import asyncio
 import json
+import uuid
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +26,7 @@ from fastapi.testclient import TestClient
 from xagent.core.agent.trace import (
     ACTION_END_TOOL,
     ACTION_START_TOOL,
+    AI_MESSAGE,
     TraceAction,
     TraceCategory,
 )
@@ -2844,13 +2846,15 @@ async def test_nonfinite_step_data_values_are_normalized_to_null_on_the_wire():
     field's nesting depth -- so every ``step.*`` frame this module emits
     is already immune to this failure mode with no additional guard in
     ``_step_wire_frame`` itself. This test pins that implicit
-    invariant by exercising a real ``_step_wire_frame`` call (the
-    shared choke point) with three-deep nested non-finite values and
-    asserting the resulting wire text is strict-JSON-clean. It changes
-    no production code -- if this ever regresses (e.g. a future
-    producer bypasses ``model_dump(mode="json")`` and hands
-    ``_step_wire_frame`` a dict straight from application code), this
-    test is the tripwire.
+    invariant by handing three-deep nested non-finite values to
+    ``_step_content_frame`` -- production's only caller of
+    ``_step_wire_frame``, and where the normalization actually happens
+    -- and asserting the resulting wire text is strict-JSON-clean. The
+    raw dict goes in exactly as a projector produces it; normalizing it
+    in test setup first would have left the assertions green even if
+    ``_step_content_frame`` regressed to passing the raw dict straight
+    through. It changes no production code -- if that regression ever
+    happens, this test is the tripwire.
     """
     nested_nonfinite_data = {
         "name": "search",
@@ -2864,15 +2868,16 @@ async def test_nonfinite_step_data_values_are_normalized_to_null_on_the_wire():
         },
         "result": float("inf"),
     }
-    step = es.PublicStep(
-        id="tool_call:call-nonfinite",
-        type="tool_call",
-        status="completed",
-        started_at=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
-        completed_at=datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC),
-        data=nested_nonfinite_data,
+    frame_text = es._step_content_frame(
+        {
+            "id": "tool_call:call-nonfinite",
+            "type": "tool_call",
+            "status": "completed",
+            "started_at": datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
+            "completed_at": datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC),
+            "data": nested_nonfinite_data,
+        }
     )
-    frame_text = es._step_wire_frame(step.model_dump(mode="json"))
 
     assert "NaN" not in frame_text
     assert "Infinity" not in frame_text
@@ -3091,36 +3096,45 @@ async def test_known_divergence_message_step_id_differs_between_the_two_paths():
     to correlate a message step across ``steps()`` and the live stream by
     id. Content itself still matches -- ``data`` is the only field
     compared below; ``started_at``/``completed_at`` aren't, since this
-    fixture doesn't mirror a timestamp into the live frame either."""
+    fixture doesn't mirror a timestamp into the live frame either.
+
+    Both legs fork from one ``CoreTraceEvent`` through the real
+    producers -- ``_persist_core_event`` for the persisted row,
+    ``_broadcast_frame_for`` for the live frame -- so neither id is
+    written down here. If production ever forwarded the canonical event
+    id to the live frame, the inequality below fails; if uuid minting
+    changed shape, the uuid assertion fails. This test takes no position
+    on what the public id contract *should* be -- that is tracked
+    elsewhere."""
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-    _insert_trace_event(
-        task_id=task_id,
-        event_type="ai_message",
-        event_id="persisted-id-123",
-        timestamp=base,
+    event = CoreTraceEvent(
+        AI_MESSAGE,
+        task_id=str(task_id),
+        timestamp=base.timestamp(),
         data={"content": "the answer"},
     )
+    _persist_core_event(event, task_id=task_id)
 
     steps_resp = client.get(
         f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
     )
     polled = steps_resp.json()["steps"][0]
-    assert polled["id"] == "message:persisted-id-123"
+    # The persisted leg's id is the event's own id, written by the
+    # persistence path as ``event_id=str(event.id)``.
+    assert polled["id"] == f"message:{event.id}"
 
     sink = _make_sink(task_id=task_id)
-    await sink.send_text(
-        _trace_event_frame(
-            "ai_message",
-            task_id=task_id,
-            event_id="live-frame-uuid-456",
-            data={"content": "the answer"},
-        )
-    )
+    await sink.send_text(_broadcast_frame_for(event, task_id=task_id))
     frame_text, _ = sink.queue.get_nowait()
     step_via_live = json.loads(frame_text.split("data: ", 1)[1])["step"]
-    assert step_via_live["id"] == "message:live-frame-uuid-456"
+    # The live leg's id is minted per broadcast by ``create_stream_event``,
+    # so it is a fresh uuid that is neither the event's id nor stable
+    # across two conversions of the same event.
+    live_id = step_via_live["id"].removeprefix("message:")
+    assert uuid.UUID(live_id).version == 4
+    assert live_id != str(event.id)
     assert step_via_live["id"] != polled["id"]
     assert step_via_live["data"] == polled["data"]
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -1542,6 +1542,89 @@ async def test_broadcast_frame_reaches_generator_output_as_task_status():
     await resp.body_iterator.aclose()
 
 
+# ===== the same full path, for content frames rather than lifecycle ones =====
+
+
+async def test_broadcast_content_frames_reach_generator_output_as_step_and_message():
+    """Composition smoke test for the content path end to end: real sink
+    registration -> ``ConnectionManager.broadcast_to_task`` ->
+    ``V1EventStreamSink.send_text`` -> projection -> the outbound queue ->
+    ``_generate``'s yield -> the ``StreamingResponse`` body.
+
+    Deliberately a composition test, not per-layer coverage: what each
+    intermediate layer does with each frame family is already pinned by
+    the direct ``send_text`` tests above. What only this test can catch is
+    a break in the joins between them -- registration, the manager's
+    fan-out, or body iteration -- which would leave the endpoint
+    lifecycle-only while every direct test stayed green.
+
+    Both content families go through, because they take different routes
+    inside ``send_text``: a trace event folds through the projector, a
+    final-answer frame maps straight to a ``message.*`` frame. The trace
+    frame is built by routing a real ``CoreTraceEvent`` through the
+    production conversion (``_broadcast_frame_for``) rather than
+    hand-shaping a dict.
+
+    The first frame is pulled before broadcasting for the reason the
+    lifecycle test above states: the generator's body -- and therefore
+    ``manager.register_connection`` -- does not run until it is first
+    iterated, so a broadcast issued earlier would reach no sink.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        **_long_intervals(),
+    )
+    first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert "event: task.status" in first
+    assert es.count_task_sinks(task_id) == 1  # the sink really did register
+
+    start_event = CoreTraceEvent(
+        ACTION_START_TOOL,
+        step_id="step-1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp(),
+        data={
+            "tool_call_id": "call-1",
+            "tool_name": "search",
+            "tool_args": {"q": "weather"},
+        },
+    )
+    await es.manager.broadcast_to_task(
+        json.loads(_broadcast_frame_for(start_event, task_id=task_id)), task_id
+    )
+    step_frame = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert step_frame.startswith("event: step.started\n")
+    step = json.loads(step_frame.split("data: ", 1)[1])["step"]
+    assert step["id"] == "tool_call:call-1"
+    assert step["data"]["name"] == "search"
+
+    await es.manager.broadcast_to_task(
+        {
+            "type": "final_answer_delta",
+            "message_id": "final_answer_e2e",
+            "task_id": task_id,
+            "delta": "sun",
+        },
+        task_id,
+    )
+    message_frame = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert message_frame.startswith("event: message.delta\n")
+    assert json.loads(message_frame.split("data: ", 1)[1]) == {
+        "message_id": "final_answer_e2e",
+        "text": "sun",
+    }
+
+    await resp.body_iterator.aclose()
+    assert es.count_task_sinks(task_id) == 0  # teardown unregistered the sink
+
+
 # ===== consecutive identical statuses only produce one frame =====
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -263,20 +263,19 @@ def _long_intervals(**overrides: float) -> dict[str, float]:
 # ===== error_frame code validation =====
 
 
-def test_error_frame_rejects_an_unknown_code_with_or_without_a_message():
+def test_error_frame_rejects_an_unknown_code_without_reaching_the_wire():
     """``_ERROR_MESSAGES[code]`` is looked up unconditionally, so an
-    unrecognized code raises ``KeyError`` whether or not a ``message``
-    override was also passed -- the check is on the code, not on which
-    optional argument the caller supplied."""
+    unrecognized code raises ``KeyError`` instead of producing a
+    ``stream.error`` frame whose ``message`` a client cannot render."""
     with pytest.raises(KeyError):
         es.error_frame("nope")
-    with pytest.raises(KeyError):
-        es.error_frame("nope", message="anything")
 
-    # A known code still honors the message override.
-    frame = es.error_frame("task_deleted", message="custom text")
+    frame = es.error_frame("task_deleted")
     data = json.loads(frame.split("data: ", 1)[1])
-    assert data == {"code": "task_deleted", "message": "custom text"}
+    assert data == {
+        "code": "task_deleted",
+        "message": es._ERROR_MESSAGES["task_deleted"],
+    }
 
 
 # ===== sink.send_text never raises =====

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -1,9 +1,10 @@
 """Tests for the v1 SSE transport layer (``GET /v1/chat/tasks/{id}/events``).
 
-Covers the transport layer only: registration, the sink's frame filter
-and exception discipline, the watchdog, the 1-hour cap, and concurrency
-caps. Step/message content projection isn't part of this layer, so it
-isn't tested here. Tests either drive ``_events_stream`` directly (fast,
+Covers registration, the sink's frame filter and exception discipline,
+the watchdog, the 1-hour cap, concurrency caps, and the ``step.*`` /
+``message.*`` content projection layered on top of that transport
+(classification, filtering, and the per-frame content caps). Tests
+either drive ``_events_stream`` directly (fast,
 deterministic -- used whenever a test needs injected short intervals or
 precise control over the race between the watchdog and the deadline) or
 go through the real HTTP endpoint (used for the 401/404/429/terminal-
@@ -21,13 +22,36 @@ from fastapi import FastAPI
 from fastapi.security import HTTPAuthorizationCredentials
 from fastapi.testclient import TestClient
 
+from xagent.core.agent.trace import (
+    ACTION_END_TOOL,
+    ACTION_START_TOOL,
+    TraceAction,
+    TraceCategory,
+)
+from xagent.core.agent.trace import TraceEvent as CoreTraceEvent
+from xagent.core.agent.trace import (
+    TraceEventType,
+    TraceScope,
+)
+from xagent.core.tools.adapters.vibe.connector_runtime import (
+    REDACTED_RUNTIME_SECRET,
+    redact_runtime_sensitive_payload,
+)
 from xagent.web.api.chat import chat_router
+from xagent.web.api.trace_handlers import (
+    DatabaseTraceHandler,
+    _convert_float_to_datetime,
+)
 from xagent.web.api.v1 import _events_stream as es
 from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.api.v1.deps import ApiKeyPrincipal, _resolve_principal_from_credentials
 from xagent.web.api.v1.errors import V1ApiError, V1ErrorCode
+from xagent.web.api.ws_trace_handlers import (
+    WebSocketTraceHandler,
+    get_event_type_mapping,
+)
 from xagent.web.models.agent_api_key import AgentApiKey
-from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
 
 from ..conftest import (
     _admin_headers,
@@ -157,6 +181,72 @@ def _make_sink(task_id: int = 1, status: str = "running") -> es.V1EventStreamSin
     )
 
 
+def _insert_trace_event(
+    *,
+    task_id: int,
+    event_type: str,
+    event_id: str,
+    timestamp: datetime,
+    data: dict,
+    step_id: str | None = None,
+    build_id: str | None = None,
+) -> None:
+    """Insert one ``TraceEvent`` row directly via the test DB.
+
+    Mirrors ``test_tasks.py``'s helper of the same name -- bypasses the
+    production trace handler (which runs through asyncio + a thread
+    pool) so a test can set up "this step already happened before
+    attach" history without spinning up the agent runtime.
+    """
+    db = _direct_db_session()
+    try:
+        db.add(
+            TraceEvent(
+                task_id=task_id,
+                event_id=event_id,
+                event_type=event_type,
+                timestamp=timestamp,
+                step_id=step_id,
+                build_id=build_id,
+                data=data,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _insert_question_message(task_id: int, *, content: str) -> None:
+    """Write one assistant question row directly, bypassing the WS writer.
+
+    Mirrors ``test_tasks.py``'s helper of the same name and the row
+    shape ``_persist_agent_outbound_event`` (``api/websocket.py``) writes
+    for ``expect_response`` outbound events: ``role='assistant'``,
+    ``message_type='question'``. This is what makes
+    ``task_interaction_read.get_pending_interaction_question`` -- and
+    therefore ``_TaskInfoSnapshot.pending_question`` -- return
+    non-``None``.
+    """
+    from xagent.web.models.chat_message import TaskChatMessage
+
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        db.add(
+            TaskChatMessage(
+                task_id=task_id,
+                user_id=int(task.user_id),
+                role="assistant",
+                content=content,
+                message_type="question",
+                turn_id=f"question-{task_id}",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
 def _long_intervals(**overrides: float) -> dict[str, float]:
     """Defaults for ``build_event_stream_response``/``_generate``'s three
     tunable intervals (watchdog / absolute deadline / heartbeat): 1000s
@@ -168,6 +258,25 @@ def _long_intervals(**overrides: float) -> dict[str, float]:
         "heartbeat_interval_seconds": 1000,
         **overrides,
     }
+
+
+# ===== error_frame code validation =====
+
+
+def test_error_frame_rejects_an_unknown_code_with_or_without_a_message():
+    """``_ERROR_MESSAGES[code]`` is looked up unconditionally, so an
+    unrecognized code raises ``KeyError`` whether or not a ``message``
+    override was also passed -- the check is on the code, not on which
+    optional argument the caller supplied."""
+    with pytest.raises(KeyError):
+        es.error_frame("nope")
+    with pytest.raises(KeyError):
+        es.error_frame("nope", message="anything")
+
+    # A known code still honors the message override.
+    frame = es.error_frame("task_deleted", message="custom text")
+    data = json.loads(frame.split("data: ", 1)[1])
+    assert data == {"code": "task_deleted", "message": "custom text"}
 
 
 # ===== sink.send_text never raises =====
@@ -267,12 +376,21 @@ def test_events_terminal_task_immediate_close():
 # ===== attach on a task already waiting for user input =====
 
 
+@pytest.mark.timeout(10)
 def test_events_waiting_for_user_attach_takes_the_fast_path():
     """The attach-time fast path for a task that's already
     ``waiting_for_user`` (and not mid-resume): emits ``task.status`` +
     ``task.input_required`` and closes immediately, instead of waiting
     out the watchdog's first cycle (up to 30s in production) to reach
-    the same conclusion."""
+    the same conclusion.
+
+    ``client.get()`` here is a blocking call with no timeout of its own;
+    the fast path not registering a sink or closing the stream is the
+    only thing keeping it from hanging. A regression that fell through
+    to the normal streaming path instead would make this test hang the
+    whole suite rather than fail it, so it's pinned with an explicit
+    timeout (``pytest-timeout``, already a dev dependency) rather than
+    relying on there being no bug."""
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)
     _set_task_status(task_id, TaskStatus.WAITING_FOR_USER, control_state="idle")
@@ -418,11 +536,13 @@ async def test_watchdog_paused_does_not_close():
     assert sink.queue.get_nowait() == (es.status_frame("paused"), False)
 
 
-async def test_watchdog_waiting_for_user_closes_with_null_prompt_input_required():
+async def test_watchdog_waiting_for_user_closes_with_null_prompt_when_no_question():
     """The watchdog is the only trigger this transport layer implements
-    for input_required, and it always sends a null prompt -- populating
-    it from the agent's question text belongs to the content-projection
-    layer."""
+    for input_required. Its ``prompt`` comes from
+    ``_TaskInfoSnapshot.pending_question`` -- when the task has no
+    persisted assistant question (this test's setup), that snapshot
+    field is itself ``None``, so the frame's prompt is null too. The
+    companion test below pins the opposite case."""
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)
     principal = _principal_for(full_key)
@@ -437,11 +557,57 @@ async def test_watchdog_waiting_for_user_closes_with_null_prompt_input_required(
     )
     assert closed is True
     assert sink.closing is True
-    assert sink.queue.get_nowait() == (es.input_required_frame(task_id), True)
+    assert sink.queue.get_nowait() == (es.input_required_frame(task_id, None), True)
     assert (
-        json.loads(es.input_required_frame(task_id).split("data: ", 1)[1])["prompt"]
+        json.loads(es.input_required_frame(task_id, None).split("data: ", 1)[1])[
+            "prompt"
+        ]
         is None
     )
+
+
+async def test_watchdog_waiting_for_user_closes_with_the_pending_question_as_prompt():
+    """When the task *does* have a persisted assistant question, the
+    watchdog's close frame carries it as ``prompt`` -- sourced from
+    ``_TaskInfoSnapshot.pending_question`` (``get_latest_waiting_question``),
+    the same authoritative row read the close decision itself already
+    uses. No agent_message frame sniffing is involved."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    key_prefix = _key_prefix_for_agent(agent_id)
+    _set_task_status(task_id, TaskStatus.WAITING_FOR_USER, control_state="idle")
+    _insert_question_message(task_id, content="Where are you flying to?")
+
+    sink = es.V1EventStreamSink(
+        task_id=task_id, principal_key_prefix=key_prefix, initial_status="running"
+    )
+    closed = await es.watchdog_check_once(
+        sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
+    )
+    assert closed is True
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is True
+    assert json.loads(frame_text.split("data: ", 1)[1]) == {
+        "task_id": task_id,
+        "prompt": "Where are you flying to?",
+    }
+
+
+def test_fast_path_attach_carries_the_pending_question_as_prompt():
+    """Same ``prompt`` sourcing as the watchdog test above, but through
+    the attach-time fast path (``_input_required_snapshot_stream``) --
+    the other of the two callers ``input_required_frame`` has."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    _set_task_status(task_id, TaskStatus.WAITING_FOR_USER, control_state="idle")
+    _insert_question_message(task_id, content="Which city?")
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
+    assert resp.status_code == 200
+    blocks = [b for b in resp.text.split("\n\n") if b.strip()]
+    input_required_data = json.loads(blocks[1].split("data: ", 1)[1])
+    assert input_required_data == {"task_id": task_id, "prompt": "Which city?"}
 
 
 async def test_watchdog_waiting_for_user_with_resume_requested_does_not_close():
@@ -1145,6 +1311,32 @@ async def test_sink_send_text_never_queries_db(monkeypatch):
     await sink.send_text(
         json.dumps({"type": "task_completed", "task": {"id": sink.task_id}})
     )
+    # Content frames must stay just as DB-free as the lifecycle path
+    # above -- the step/message projection path reads only the broadcast
+    # dict, never the database.
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "trace_event",
+                "event_id": "ev-1",
+                "event_type": "tool_execution_start",
+                "task_id": sink.task_id,
+                "timestamp": 0,
+                "step_id": "step-1",
+                "data": {"tool_call_id": "call-1", "tool_name": "search", "args": {}},
+            }
+        )
+    )
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "final_answer_delta",
+                "message_id": "msg-1",
+                "task_id": sink.task_id,
+                "delta": "hi",
+            }
+        )
+    )
     assert calls == []
 
 
@@ -1359,3 +1551,1673 @@ async def test_completion_hint_wakes_watchdog_before_its_next_periodic_tick():
 
     await asyncio.wait_for(_drain(), timeout=2)
     assert any("event: task.completed" in f for f in frames)
+
+
+# ===== content projection: step.* / message.* from live broadcast frames
+# (see ``project_content_frames`` and its docstring for the frame-family
+# classification this section pins) =====
+
+
+def _trace_event_frame(
+    event_type: str,
+    *,
+    task_id: int,
+    data: dict,
+    event_id: str = "ev-1",
+    step_id: str | None = None,
+    timestamp: float = 0.0,
+) -> str:
+    payload: dict = {
+        "type": "trace_event",
+        "event_id": event_id,
+        "event_type": event_type,
+        "task_id": task_id,
+        "timestamp": timestamp,
+        "data": data,
+    }
+    if step_id is not None:
+        payload["step_id"] = step_id
+    return json.dumps(payload)
+
+
+def _broadcast_frame_for(event: "CoreTraceEvent", *, task_id: int) -> str:
+    """The exact text a real broadcast of ``event`` would carry.
+
+    Routes the core trace event through the production conversion --
+    ``WebSocketTraceHandler._convert_trace_event_to_stream_event``, which
+    applies ``serialize_trace_data``, ``normalize_public_trace_event``
+    and ``create_stream_event`` -- and serializes it the way
+    ``ConnectionManager.broadcast_to_task`` does. Constructing the
+    handler touches no database (its ``__init__`` sets three attributes;
+    ``_load_task_description`` is the async path and is deliberately not
+    called, so no ``task_description`` is injected).
+    """
+    handler = WebSocketTraceHandler(task_id)
+    converted = handler._convert_trace_event_to_stream_event(event)
+    assert converted is not None, "fixture event must be projectable"
+    return json.dumps(converted)
+
+
+def _persist_core_event(event: "CoreTraceEvent", *, task_id: int) -> None:
+    """Write the row the persistence path would write for ``event``.
+
+    Reproduces what ``DatabaseTraceHandler._save_trace_event`` derives --
+    ``get_event_type_mapping`` for the event type,
+    ``_serialize_data_for_json`` for the data,
+    ``redact_runtime_sensitive_payload`` for the ``tool_execution_*``
+    family, ``event_id=str(event.id)`` and ``step_id=event.step_id`` --
+    then inserts through the test's own ``_insert_trace_event`` with
+    ``timestamp=_convert_float_to_datetime(event.timestamp)``.
+
+    Deliberately does NOT reproduce ``stage_trace_event_row``'s
+    ``stored_data`` rewrite or its ``build_id``/``parent_event_id``
+    stamping -- the real path runs ``data = staged.stored_data`` at
+    ``trace_handlers.py:709``; no fixture in this module needs either.
+    """
+    event_type_str = get_event_type_mapping(event)
+    handler = DatabaseTraceHandler(task_id=task_id)
+    data = handler._serialize_data_for_json(event.data or {})
+    if event_type_str in {
+        "tool_execution_start",
+        "tool_execution_end",
+        "tool_execution_failed",
+    }:
+        data = redact_runtime_sensitive_payload(data)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type=event_type_str,
+        event_id=str(event.id),
+        timestamp=_convert_float_to_datetime(event.timestamp),
+        data=data,
+        step_id=event.step_id,
+    )
+
+
+async def test_trace_event_tool_call_start_then_end_projects_paired_step_frames():
+    """A live start/end pair for the same ``tool_call_id`` folds through
+    the same ``PublicStepProjector`` pairing rule ``steps()`` uses:
+    ``step.started`` (running) first, then ``step.completed`` carrying
+    the tool's result, both keyed by the same public step id."""
+    sink = _make_sink(task_id=42)
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=42,
+            step_id="step-1",
+            data={
+                "tool_call_id": "call-1",
+                "tool_name": "search",
+                "tool_args": {"query": "weather"},
+            },
+        )
+    )
+    started_text, started_close = sink.queue.get_nowait()
+    assert started_close is False
+    assert started_text.startswith("event: step.started\n")
+    started = json.loads(started_text.split("data: ", 1)[1])["step"]
+    assert started["id"] == "tool_call:call-1"
+    assert started["status"] == "running"
+    assert started["data"]["name"] == "search"
+
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_end",
+            task_id=42,
+            step_id="step-1",
+            data={"tool_call_id": "call-1", "success": True, "result": "sunny"},
+        )
+    )
+    completed_text, completed_close = sink.queue.get_nowait()
+    assert completed_close is False
+    assert completed_text.startswith("event: step.completed\n")
+    completed = json.loads(completed_text.split("data: ", 1)[1])["step"]
+    assert completed["id"] == "tool_call:call-1"
+    assert completed["status"] == "completed"
+    assert completed["data"]["result"] == "sunny"
+
+
+async def test_trace_event_ai_message_projects_a_completed_message_step():
+    """A one-shot ``ai_message`` (no ``stream_message_id``, i.e. a run
+    with no live token stream) still projects a step -- it's a public
+    ``message`` step, always already ``completed`` (see
+    ``_build_message_step``)."""
+    sink = _make_sink(task_id=7)
+    await sink.send_text(
+        _trace_event_frame(
+            "ai_message",
+            task_id=7,
+            event_id="persisted-event-id",
+            data={"content": "the answer"},
+        )
+    )
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is False
+    assert frame_text.startswith("event: step.completed\n")
+    step = json.loads(frame_text.split("data: ", 1)[1])["step"]
+    assert step["id"] == "message:persisted-event-id"
+    assert step["data"] == {"role": "assistant", "content": "the answer"}
+
+
+async def test_trace_event_ai_message_with_stream_message_id_also_projects_a_step():
+    """New contract: an ``ai_message`` carrying ``stream_message_id`` --
+    the persisted mirror of a final answer already delivered live via
+    ``message.delta``/``message.completed`` -- still folds into a
+    ``message`` step here, the same as any other ``ai_message``. This
+    duplicates that content as a second delivery (a ``step.completed``
+    alongside the earlier delta/completed frames), not a loss: dropping
+    it here (the old behavior) had no persisted counterpart, so
+    ``steps()`` already shows this exact row as a ``message`` step
+    regardless -- filtering only the live path made an already-attached
+    stream disagree with ``steps()`` about whether the step exists. See
+    ``test_live_projection_matches_steps_for_a_streamed_final_answer``
+    below for the two-path parity this restores."""
+    sink = _make_sink(task_id=7)
+    await sink.send_text(
+        _trace_event_frame(
+            "ai_message",
+            task_id=7,
+            event_id="live-final-answer",
+            data={"content": "the answer", "stream_message_id": "final_answer_abc"},
+        )
+    )
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is False
+    assert frame_text.startswith("event: step.completed\n")
+    step = json.loads(frame_text.split("data: ", 1)[1])["step"]
+    assert step["id"] == "message:live-final-answer"
+    assert step["data"] == {"role": "assistant", "content": "the answer"}
+    assert sink.queue.empty()
+
+
+async def test_trace_event_delegated_child_source_is_filtered():
+    """A trace_event whose ``data["source"]`` marks it as a
+    delegated child agent's own trace is dropped, the same
+    ``build_id IS NOT NULL``-equivalent exclusion ``steps()`` gets for
+    free from its SQL WHERE clause."""
+    sink = _make_sink(task_id=9)
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=9,
+            data={
+                "tool_call_id": "call-1",
+                "tool_name": "search",
+                "tool_args": {},
+                "source": "xagent-agent-tool-child",
+            },
+        )
+    )
+    assert sink.queue.empty()
+
+
+async def test_trace_event_task_info_produces_no_step_frame():
+    """``task_info`` short-circuits to the
+    ``task.status``/``task.input_required`` lifecycle handling in
+    ``send_text`` (unchanged, tested elsewhere in this file) and never
+    reaches the step projector -- it isn't, and never becomes, a public
+    step.
+
+    An empty outbound queue alone doesn't pin this: ``task_info`` isn't
+    one of ``_step_mapping.py``'s recognized event types either, so
+    feeding it to the projector directly would *also* produce no step
+    frame -- the short-circuit's queue-visible effect would be
+    unchanged if it were deleted. What the short-circuit actually
+    controls is whether the projector is invoked at all, which is why
+    the projector's ``feed`` is spied on below and asserted never
+    called -- that assertion alone would fail if the short-circuit were
+    removed, even though the queue-emptiness assertion would not."""
+    sink = _make_sink(task_id=11, status="running")
+    feed_spy = MagicMock(wraps=sink._projector.feed)
+    sink._projector.feed = feed_spy
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "trace_event",
+                "event_id": "ev-1",
+                "event_type": "task_info",
+                "task_id": 11,
+                "timestamp": 0,
+                # Real broadcasts carry status/control_state both at the
+                # top level (what ``_is_versioned_task_event`` reads) and
+                # merged into ``data`` (``_with_task_control_state_snapshot``,
+                # ``websocket.py``) -- both are set here to match.
+                "status": "waiting_for_user",
+                "control_state": "idle",
+                "data": {
+                    "status": "waiting_for_user",
+                    "control_state": "idle",
+                    "message": "What city?",
+                },
+            }
+        )
+    )
+    # The lifecycle side still reacts (a status frame is queued and the
+    # completion hint fires) -- only the *step* projection is asserted
+    # absent here.
+    assert sink.completion_hint.is_set()
+    frame_text, _ = sink.queue.get_nowait()
+    assert frame_text.startswith("event: task.status\n")
+    assert sink.queue.empty()
+    feed_spy.assert_not_called()
+
+
+async def test_trace_event_audit_only_data_is_filtered():
+    """The same ``__audit_only__`` server-side-RCA marker the WebSocket
+    broadcaster already drops before fanning out (see
+    ``is_audit_only_trace_data``) is honored on the live SSE path too."""
+    sink = _make_sink(task_id=13)
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=13,
+            data={
+                "tool_call_id": "call-1",
+                "tool_name": "search",
+                "tool_args": {},
+                "__audit_only__": True,
+            },
+        )
+    )
+    assert sink.queue.empty()
+
+
+async def test_trace_event_tool_call_redacts_credential_shaped_fields_on_the_wire():
+    """The same runtime-secret redaction ``normalize_public_trace_event``
+    already applies before a trace event reaches this stream's projector
+    (see ``test_normalize_public_trace_event_redacts_tool_runtime_secrets``
+    in ``tests/web/api/test_public_trace_events.py``, the ``steps()``-side
+    fixture this mirrors) must also hold for a *live* SSE frame, not just
+    for the function in isolation: this pins that the emitted
+    ``step.started``/``step.completed`` wire text itself never carries the
+    raw secret, only the shared redaction marker."""
+    sink = _make_sink(task_id=17)
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=17,
+            data={
+                "tool_call_id": "call-1",
+                "tool_name": "shiftcare",
+                "tool_args": {
+                    "headers": {
+                        "Authorization": "Bearer live-stream-secret-token",
+                        "X-Account": "6185",
+                    },
+                    "connector_runtime": {
+                        "secrets": {"authorization": "Bearer nested-live-token"},
+                        "auth_selector": {"resource_owner_key": "xagent:user:owner"},
+                    },
+                },
+            },
+        )
+    )
+    started_text, started_close = sink.queue.get_nowait()
+    assert started_close is False
+    assert started_text.startswith("event: step.started\n")
+    assert "live-stream-secret-token" not in started_text
+    assert "nested-live-token" not in started_text
+    assert "xagent:user:owner" not in started_text
+    # The public step's ``data.args`` is the (already-redacted) source
+    # ``tool_args``: see ``_build_tool_start`` in ``_step_mapping.py``.
+    started_data = json.loads(started_text.split("data: ", 1)[1])["step"]["data"]
+    assert started_data["args"]["headers"]["Authorization"] == REDACTED_RUNTIME_SECRET
+    assert started_data["args"]["headers"]["X-Account"] == "6185"
+    assert (
+        started_data["args"]["connector_runtime"]["auth_selector"]["resource_owner_key"]
+        == REDACTED_RUNTIME_SECRET
+    )
+
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_end",
+            task_id=17,
+            data={
+                "tool_call_id": "call-1",
+                "success": True,
+                "result": {
+                    "headers": {"Authorization": "Bearer live-stream-secret-token"}
+                },
+            },
+        )
+    )
+    completed_text, completed_close = sink.queue.get_nowait()
+    assert completed_close is False
+    assert completed_text.startswith("event: step.completed\n")
+    assert "live-stream-secret-token" not in completed_text
+    completed_data = json.loads(completed_text.split("data: ", 1)[1])["step"]["data"]
+    assert (
+        completed_data["result"]["headers"]["Authorization"] == REDACTED_RUNTIME_SECRET
+    )
+
+
+async def test_final_answer_delta_projects_message_delta_frame():
+    sink = _make_sink(task_id=21)
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "final_answer_delta",
+                "message_id": "final_answer_abc",
+                "task_id": 21,
+                "delta": "Hey",
+            }
+        )
+    )
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is False
+    assert frame_text == es.message_delta_frame("final_answer_abc", "Hey")
+    assert json.loads(frame_text.split("data: ", 1)[1]) == {
+        "message_id": "final_answer_abc",
+        "text": "Hey",
+    }
+
+
+async def test_final_answer_end_projects_message_completed_frame():
+    sink = _make_sink(task_id=21)
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "final_answer_end",
+                "message_id": "final_answer_abc",
+                "task_id": 21,
+                "content": "Hello there",
+            }
+        )
+    )
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is False
+    assert frame_text == es.message_completed_frame("final_answer_abc", "Hello there")
+    assert json.loads(frame_text.split("data: ", 1)[1]) == {
+        "message_id": "final_answer_abc",
+        "content": "Hello there",
+    }
+
+
+@pytest.mark.parametrize("frame_type", ["final_answer_start", "final_answer_error"])
+async def test_final_answer_start_and_error_produce_no_content_frame(frame_type):
+    """Neither is on the public event list. A ``message.delta``
+    sequence may therefore end with no ``message.completed`` -- the next
+    lifecycle event is the client's abandonment signal, not a dedicated
+    close event from this pair."""
+    sink = _make_sink(task_id=21)
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": frame_type,
+                "message_id": "final_answer_abc",
+                "task_id": 21,
+                "error": "boom",
+            }
+        )
+    )
+    assert sink.queue.empty()
+
+
+async def test_content_frames_are_dropped_by_the_same_close_drain_as_status_frames():
+    """``enqueue_close`` drains the *entire* queue before inserting
+    the close frame (existing, unconditional behavior of this sink) --
+    content frames queued ahead of a close are silently dropped exactly like a
+    queued ``task.status`` would be. The contract is "any close may
+    truncate the content sequence; reconcile via ``steps()``", not
+    "only ``final_answer_error`` truncates it"."""
+    sink = _make_sink(task_id=23, status="running")
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=23,
+            data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+        )
+    )
+    assert sink.queue.qsize() == 1  # the step.started frame queued above
+
+    sink.enqueue_close(es.completed_frame(status="failed", output=None, error="boom"))
+
+    assert sink.queue.qsize() == 1
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is True
+    assert frame_text.startswith("event: task.completed\n")
+    # The step.started frame queued before the close is gone, not
+    # delivered ahead of it -- drained by enqueue_close, same as any
+    # other backlog.
+
+
+async def test_step_started_frame_text_is_unaffected_by_the_step_s_later_completion():
+    """Serialization-aliasing guard: ``feed()``
+    returns the projector's own live dict, which gets mutated in place
+    when the step's end event later arrives. The ``step.started`` frame
+    text must have been fully serialized to a JSON string at enqueue
+    time -- if it instead held a reference to the projector's dict and
+    serialized lazily, this test's already-queued frame would show
+    ``status: "completed"`` after the second ``send_text`` call below,
+    not the ``"running"`` it captured when the start event arrived."""
+    sink = _make_sink(task_id=29)
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=29,
+            data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+        )
+    )
+    started_text, _ = sink.queue.get_nowait()
+
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_end",
+            task_id=29,
+            data={"tool_call_id": "call-1", "success": True, "result": "sunny"},
+        )
+    )
+    # Draining the second frame too is incidental to this test's point;
+    # what matters is that re-reading the *first* frame's text (captured
+    # before the mutation) still says "running".
+    sink.queue.get_nowait()
+
+    assert json.loads(started_text.split("data: ", 1)[1])["step"]["status"] == "running"
+
+
+# ===== raw-frame size pre-check: an oversized content frame is dropped
+# before it's projected =====
+
+
+def _sized_content_frame(task_id: int, total_chars: int) -> str:
+    """A ``final_answer_delta`` frame whose serialized text is exactly
+    ``total_chars`` long: build the envelope with an empty ``delta``,
+    measure it, then pad with that many ASCII characters (each costs
+    exactly one character in the serialized form)."""
+    envelope: dict = {
+        "type": "final_answer_delta",
+        "message_id": "final_answer_abc",
+        "task_id": task_id,
+        "delta": "",
+    }
+    base_len = len(json.dumps(envelope))
+    pad = total_chars - base_len
+    assert pad >= 0
+    envelope["delta"] = "a" * pad
+    raw = json.dumps(envelope)
+    assert len(raw) == total_chars
+    return raw
+
+
+async def test_oversized_content_frame_is_dropped_before_projection():
+    """A content frame (parsed ``type`` in ``_CONTENT_FRAME_TYPES``)
+    whose raw text is bigger than ``MAX_RAW_FRAME_TEXT_CHARS`` is
+    dropped by ``send_text``'s size check, after classification but
+    before the call into ``_project_and_queue`` -- same drop-and-count
+    discipline as every other frame this sink drops. Warm, so a bug
+    that let this fall through would show up as a queued (truncated)
+    ``message.delta`` frame instead of nothing."""
+    sink = _make_sink(task_id=91)
+    oversized_delta = "x" * (es.MAX_RAW_FRAME_TEXT_CHARS + 1)
+    raw = json.dumps(
+        {
+            "type": "final_answer_delta",
+            "message_id": "final_answer_abc",
+            "task_id": 91,
+            "delta": oversized_delta,
+        }
+    )
+    assert len(raw) > es.MAX_RAW_FRAME_TEXT_CHARS
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 1
+    assert sink.queue.empty()
+
+
+async def test_content_frame_exactly_at_the_size_cap_is_projected():
+    """Boundary case, built to land exactly on the threshold: a content
+    frame whose raw text is exactly ``MAX_RAW_FRAME_TEXT_CHARS`` long is
+    still parsed and projected -- the size check only rejects frames
+    strictly larger. 256 KiB of delta text is itself over the 64 KiB
+    per-frame content cap, so the projected frame carries
+    ``truncated: true`` -- this test states that whole outcome, not
+    just that the frame arrived."""
+    sink = _make_sink(task_id=93)
+    raw = _sized_content_frame(93, es.MAX_RAW_FRAME_TEXT_CHARS)
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 0
+    frame_text, _ = sink.queue.get_nowait()
+    assert frame_text.startswith("event: message.delta\n")
+    data = json.loads(frame_text.split("data: ", 1)[1])
+    assert data["truncated"] is True
+
+
+async def test_content_frame_one_char_over_the_size_cap_is_dropped():
+    """One character over the same boundary is dropped and counted, so
+    an off-by-one in the comparison would fail this test but not the
+    one above."""
+    sink = _make_sink(task_id=94)
+    raw = _sized_content_frame(94, es.MAX_RAW_FRAME_TEXT_CHARS + 1)
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 1
+    assert sink.queue.empty()
+
+
+def test_capped_text_keeps_a_string_exactly_at_the_cap():
+    """``_capped_text`` measures a string's escaped-JSON wire form,
+    quotes included: ``MAX_FRAME_CONTENT_BYTES - 2`` plain ASCII
+    characters plus the two wrapping quotes lands exactly on the cap
+    (65536 bytes), so that length must survive untouched. One character
+    more must truncate, to a 65534-character result."""
+    at_cap = "a" * (es.MAX_FRAME_CONTENT_BYTES - 2)
+    assert es._byte_length(at_cap) == es.MAX_FRAME_CONTENT_BYTES
+    text, truncated = es._capped_text(at_cap)
+    assert truncated is False
+    assert text == at_cap
+
+    over_cap = "a" * (es.MAX_FRAME_CONTENT_BYTES - 1)
+    text, truncated = es._capped_text(over_cap)
+    assert truncated is True
+    assert len(text) == 65534
+
+
+async def test_oversized_task_completed_frame_is_not_dropped_by_the_raw_precheck():
+    """The size check applies only to frames whose parsed ``type`` is in
+    ``_CONTENT_FRAME_TYPES`` -- a ``task_completed`` broadcast returns on
+    ``send_text``'s acceleration branch before the content check is ever
+    reached, regardless of size. It carries its whole output twice
+    (``result`` and ``output``, see ``websocket.py``), so it can cross
+    ``MAX_RAW_FRAME_TEXT_CHARS`` on an ordinary large response, well
+    before anything is actually wrong. A size check placed ahead of the
+    parse cannot make this distinction -- it would drop a large
+    ``task_completed`` whole, leaving ``completion_hint`` unset and
+    delaying the watchdog's terminal close to its next scheduled cycle
+    (30s in production) instead of firing immediately."""
+    sink = _make_sink(task_id=97)
+    duplicated_output = "x" * ((es.MAX_RAW_FRAME_TEXT_CHARS // 2) + 100)
+    raw = json.dumps(
+        {
+            "type": "task_completed",
+            "task": {"id": 97, "title": "t", "status": "completed", "description": ""},
+            "result": duplicated_output,
+            "output": duplicated_output,
+            "success": True,
+        }
+    )
+    assert len(raw) > es.MAX_RAW_FRAME_TEXT_CHARS
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 0
+    assert sink.completion_hint.is_set()
+
+
+async def test_oversized_task_info_frame_is_not_dropped_by_the_raw_precheck():
+    """``task_info`` is a lifecycle envelope (``_feed_trace_event``'s own
+    ``event_type == "task_info"`` short-circuit), not step/message
+    content, but its raw frame's own top-level ``"type"`` is
+    ``"trace_event"`` -- the same type actual content frames
+    (tool_call/thinking/agent_delegation/message) carry. The size check
+    exempts it by its parsed ``event_type`` explicitly
+    (``!= "task_info"``), after ``json.loads`` -- not by a prefix sniff.
+    A check placed ahead of the parse would judge every ``trace_event``
+    frame the same way regardless of its nested ``event_type``, and
+    would drop a legitimately large ``task_info`` whole (its task
+    description has no size bound of its own) -- losing
+    ``task.status`` and ``completion_hint`` the same way it would cost
+    an oversized ``task_completed`` its ``task.completed`` (see the
+    companion test above)."""
+    sink = _make_sink(task_id=101, status="running")
+    huge_description = "x" * (es.MAX_RAW_FRAME_TEXT_CHARS + 1000)
+    raw = json.dumps(
+        {
+            "type": "trace_event",
+            "event_id": "ev-101",
+            "event_type": "task_info",
+            "task_id": 101,
+            "timestamp": 0,
+            "status": "waiting_for_user",
+            "control_state": "idle",
+            "data": {
+                "status": "waiting_for_user",
+                "control_state": "idle",
+                "message": huge_description,
+            },
+        }
+    )
+    assert len(raw) > es.MAX_RAW_FRAME_TEXT_CHARS
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 0
+    assert sink.completion_hint.is_set()
+    frame_text, _ = sink.queue.get_nowait()
+    assert frame_text.startswith("event: task.status\n")
+    assert json.loads(frame_text.split("data: ", 1)[1]) == {
+        "status": "waiting_for_user"
+    }
+
+
+async def test_unparseable_frame_is_dropped_and_counted():
+    """A frame that isn't valid JSON can't be classified at all -- there
+    is no parsed ``type`` to check -- so ``json.loads`` itself raises
+    and the outer ``except`` in ``send_text`` drops and counts it, the
+    same discipline every other drop in this method gets. Length is
+    irrelevant on this path: the failure happens at the very first
+    character, well before any size check would run, so a short input
+    is enough to exercise it."""
+    sink = _make_sink(task_id=99)
+    raw = "x" * 64
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 1
+    assert sink.queue.empty()
+
+
+async def test_oversized_non_dict_json_frame_is_ignored_without_counting():
+    """A frame that IS valid JSON but not a dict (a bare array here) is
+    ignored by ``send_text``'s own ``isinstance(message, dict)`` guard,
+    before classification or the size check ever run -- even though it's
+    larger than ``MAX_RAW_FRAME_TEXT_CHARS``. Deliberate semantic change
+    from the pre-parse-sniffing era: only a frame classifiable as
+    content (``_CONTENT_FRAME_TYPES``) counts as a drop now: this one is
+    silently ignored, not counted."""
+    sink = _make_sink(task_id=103)
+    raw = json.dumps(["x"] * (es.MAX_RAW_FRAME_TEXT_CHARS // 2))
+    assert len(raw) > es.MAX_RAW_FRAME_TEXT_CHARS
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 0
+    assert sink.queue.empty()
+
+
+# ===== a frame that fails to project is dropped, not fatal, and never
+# double-counted between the sink's two except layers
+# (see _project_and_queue) =====
+
+
+async def test_poisoned_live_frame_increments_dropped_frame_count_only_once(
+    monkeypatch,
+):
+    """A projection failure on the live path is
+    caught inside ``_project_and_queue`` and never re-raises -- if it
+    did, ``send_text``'s own outer ``except`` would catch it too and
+    count the same dropped frame twice."""
+    sink = _make_sink(task_id=73)
+
+    def _boom(message, projector):
+        raise RuntimeError("boom live")
+
+    monkeypatch.setattr(es, "project_content_frames", _boom)
+
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=73,
+            data={"tool_call_id": "call-1", "tool_name": "x", "tool_args": {}},
+        )
+    )  # must not raise
+
+    assert sink.dropped_frame_count == 1
+    assert sink.queue.empty()
+
+
+# ===== single-frame content byte cap =====
+
+
+async def test_message_delta_over_the_byte_cap_is_truncated_and_flagged():
+    sink = _make_sink(task_id=51)
+    oversized = "x" * (es.MAX_FRAME_CONTENT_BYTES + 1000)
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "final_answer_delta",
+                "message_id": "final_answer_abc",
+                "task_id": 51,
+                "delta": oversized,
+            }
+        )
+    )
+    frame_text, _ = sink.queue.get_nowait()
+    data = json.loads(frame_text.split("data: ", 1)[1])
+    assert data["truncated"] is True
+    assert len(data["text"].encode("utf-8")) <= es.MAX_FRAME_CONTENT_BYTES
+    assert data["text"] != oversized
+
+
+async def test_message_delta_under_the_byte_cap_is_unmarked():
+    sink = _make_sink(task_id=53)
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "final_answer_delta",
+                "message_id": "final_answer_abc",
+                "task_id": 53,
+                "delta": "just a normal chunk",
+            }
+        )
+    )
+    frame_text, _ = sink.queue.get_nowait()
+    data = json.loads(frame_text.split("data: ", 1)[1])
+    assert "truncated" not in data
+    assert data["text"] == "just a normal chunk"
+
+
+async def test_message_completed_over_the_byte_cap_is_truncated_and_flagged():
+    """Same cap, same flagging, on ``message.completed`` -- pins that
+    the final-answer *end* path (not just the streamed delta path
+    above) also goes through ``_capped_text``."""
+    sink = _make_sink(task_id=52)
+    oversized = "x" * (es.MAX_FRAME_CONTENT_BYTES + 1000)
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "final_answer_end",
+                "message_id": "final_answer_abc",
+                "task_id": 52,
+                "content": oversized,
+            }
+        )
+    )
+    frame_text, _ = sink.queue.get_nowait()
+    data = json.loads(frame_text.split("data: ", 1)[1])
+    assert data["truncated"] is True
+    assert len(data["content"].encode("utf-8")) <= es.MAX_FRAME_CONTENT_BYTES
+    assert data["content"] != oversized
+
+
+def test_capped_text_handles_a_multibyte_character_straddling_the_byte_boundary():
+    """``_capped_text``'s character-slice pre-check bounds character
+    *count*, not the escaped-JSON byte count the function actually caps
+    against -- for an all-ASCII text (the shape every other byte-cap
+    test in this module uses) that pre-slice usually still lands close
+    enough to the cap to take the function's early-return branch. A
+    multi-byte character (every "中" is 3 UTF-8 bytes but a 6-byte
+    ``\\uXXXX`` escape on the wire) blows well past the cap even after
+    that pre-slice, which is what exercises the function's other
+    branch: a binary search over the character-sliced prefix for the
+    longest one whose escaped bytes still fit (see the function's own
+    docstring for why this replaces a raw UTF-8 byte-slice, which is
+    unsafe once the measured domain is escaped bytes instead of decoded
+    ones).
+    """
+    oversized = "中" * (es.MAX_FRAME_CONTENT_BYTES + 1000)
+    capped, truncated = es._capped_text(oversized)
+    assert truncated is True
+    assert len(capped.encode("utf-8")) <= es.MAX_FRAME_CONTENT_BYTES
+    # The cap is on the escaped wire form, so this is the assertion that
+    # discriminates. A decoded-UTF-8-byte implementation returns 21845
+    # characters for this input -- 65535 decoded bytes, satisfying the
+    # assertion above -- while its escaped form measures 131072 bytes,
+    # twice the cap.
+    assert es._byte_length(capped) <= es.MAX_FRAME_CONTENT_BYTES
+    # Escaped-byte-sliced inside the character-sliced prefix: strictly
+    # fewer whole characters survive than a pure character-count slice
+    # would keep (that would be MAX_FRAME_CONTENT_BYTES characters,
+    # escaping to 6x as many wire bytes).
+    assert len(capped) < es.MAX_FRAME_CONTENT_BYTES
+
+
+async def test_step_data_over_the_byte_cap_collapses_to_a_truncation_marker():
+    sink = _make_sink(task_id=55)
+    oversized_result = "y" * (es.MAX_FRAME_CONTENT_BYTES + 1000)
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=55,
+            data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+        )
+    )
+    sink.queue.get_nowait()  # drain the (small) step.started frame
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_end",
+            task_id=55,
+            data={
+                "tool_call_id": "call-1",
+                "success": True,
+                "result": oversized_result,
+            },
+        )
+    )
+    frame_text, _ = sink.queue.get_nowait()
+    step = json.loads(frame_text.split("data: ", 1)[1])["step"]
+    # "name" (the tool's identifying field, carried since the start
+    # event) survives the truncation marker -- see
+    # ``_STEP_DATA_IDENTIFYING_KEYS`` -- only the oversized "result"
+    # content is dropped.
+    assert step["data"] == {
+        "truncated": True,
+        "original_bytes": step["data"]["original_bytes"],
+        "name": "search",
+    }
+    assert step["data"]["original_bytes"] > es.MAX_FRAME_CONTENT_BYTES
+    # The step's own identity/status fields are untouched by the cap --
+    # only its content-bearing ``data`` sub-object is affected.
+    assert step["id"] == "tool_call:call-1"
+    assert step["status"] == "completed"
+
+
+async def test_capped_step_data_preserves_identifying_keys_per_step_type():
+    """``_capped_step_data`` keeps each public step type's own
+    identifying field (``phase``/``name``/``sub_agent_name``/``role``)
+    through the truncation marker -- a client reading a truncated frame
+    still knows *what* the step was, not just that it was too big."""
+    oversized = "z" * (es.MAX_FRAME_CONTENT_BYTES + 1000)
+    assert es._capped_step_data({"phase": "planning", "junk": oversized}) == {
+        "truncated": True,
+        "original_bytes": es._byte_length({"phase": "planning", "junk": oversized}),
+        "phase": "planning",
+    }
+    assert es._capped_step_data(
+        {"sub_agent_name": "researcher", "input": oversized}
+    ) == {
+        "truncated": True,
+        "original_bytes": es._byte_length(
+            {"sub_agent_name": "researcher", "input": oversized}
+        ),
+        "sub_agent_name": "researcher",
+    }
+    assert es._capped_step_data({"role": "assistant", "content": oversized}) == {
+        "truncated": True,
+        "original_bytes": es._byte_length({"role": "assistant", "content": oversized}),
+        "role": "assistant",
+    }
+    # A key genuinely absent from this step's data is never synthesized.
+    small_but_over_cap = {"role": "assistant"}
+    assert "phase" not in es._capped_step_data(
+        {**small_but_over_cap, "content": oversized}
+    )
+
+
+async def test_capped_step_data_truncates_an_oversized_identifying_value():
+    """An identifying value can itself be large enough to blow the cap
+    once folded into the truncation marker (the first pass in
+    ``_capped_step_data``'s docstring) -- e.g. an unusually long tool
+    name. The second pass must truncate that value (not drop it) and
+    the result must still fit under ``MAX_FRAME_CONTENT_BYTES``:
+    truncating the value to the *full* cap and only then wrapping it in
+    the marker dict would overflow on the marker's own JSON overhead
+    alone, which is exactly the bug this guards against."""
+    huge_name = "n" * 70_000
+    result = es._capped_step_data({"name": huge_name, "junk": "x" * 1000})
+    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
+    assert result["truncated"] is True
+    assert "name" in result
+    assert len(result["name"]) < len(huge_name)
+    assert result["original_bytes"] > es.MAX_FRAME_CONTENT_BYTES
+
+
+def test_capped_step_data_drops_only_the_value_it_cannot_shrink():
+    """A non-string identifying value (a dict- or list-valued ``name``/
+    ``role``, say) can't be truncated in place -- ``_capped_text`` only
+    accepts a string. The naive fix (drop it at the final bare-marker
+    step and stop) still fails: the un-shrinkable value counts toward
+    the first pass's own overhead, driving every *other* key's budget
+    to zero, so a survivor that should have kept real content comes
+    back as ``""``. The actual fix is a bounded retry: drop only the
+    largest surviving value that cannot be truncated in place and
+    rebuild the marker from the original data, so the keys that survive
+    get a real, non-zero budget."""
+    oversized_dict = {"nested": "x" * 70_000}
+    result = es._capped_step_data({"name": oversized_dict, "phase": "planning"})
+    assert result["truncated"] is True
+    assert "name" not in result
+    assert result["phase"] == "planning"
+    assert result["original_bytes"] > es.MAX_FRAME_CONTENT_BYTES
+    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
+
+    result = es._capped_step_data({"role": ["a" * 70_000], "name": "search"})
+    assert result["truncated"] is True
+    assert "role" not in result
+    assert result["name"] == "search"
+    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
+
+    # Nothing else to keep once the one identifying value is dropped:
+    # the honest limit of this fix, same as before it.
+    result = es._capped_step_data({"name": oversized_dict})
+    assert result == {
+        "truncated": True,
+        "original_bytes": result["original_bytes"],
+    }
+
+    # Regression guard: the string-only ladder is unchanged -- both
+    # values survive, each truncated, when both can be shrunk.
+    result = es._capped_step_data({"name": "n" * 70_000, "role": "r" * 70_000})
+    assert result["truncated"] is True
+    assert "name" in result and "role" in result
+    assert 0 < len(result["name"]) < 70_000
+    assert 0 < len(result["role"]) < 70_000
+    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
+
+
+def test_capped_step_data_prefers_dropping_a_non_string_over_a_truncatable_one():
+    """When both a truncatable string and an un-shrinkable non-string
+    survive a failed pass, the non-string is dropped first -- preferring
+    to drop the salvageable string would degrade a step that could have
+    kept real content down to the bare marker for no reason. Per the
+    docstring, a pass over strings only always fits within the cap, so
+    reaching the drop step guarantees at least one non-string survivor
+    remains; falling back to the largest overall is unreachable here."""
+    result = es._capped_step_data(
+        {"sub_agent_name": {"k": "x" * 70_000}, "role": "assistant" * 9_000}
+    )
+    assert result["truncated"] is True
+    assert "sub_agent_name" not in result
+    assert "role" in result
+    assert 0 < len(result["role"]) < len("assistant" * 9_000)
+    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
+
+    result = es._capped_step_data({"name": {"k": "x" * 66_000}, "phase": "p" * 70_000})
+    assert result["truncated"] is True
+    assert "name" not in result
+    assert "phase" in result
+    assert 0 < len(result["phase"]) < 70_000
+    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
+
+
+def test_capped_text_bounds_emoji_content_in_the_escaped_wire_byte_domain():
+    """``_sse_frame`` serializes with ``json.dumps``'s default
+    ``ensure_ascii=True``, so a non-BMP character like an emoji escapes
+    to a 12-byte ``\\uD83D\\uDE00`` surrogate pair on the wire -- 3x its
+    own 4-byte UTF-8 width. 16384 emoji is exactly
+    ``MAX_FRAME_CONTENT_BYTES`` in UTF-8 bytes, the domain a decoded-byte
+    cap check would measure -- a check in that domain would let this
+    input sail through completely untruncated, while its escaped wire
+    form runs to roughly 3x the cap. ``_capped_text`` measures the
+    escaped form itself, so it catches this case.
+    """
+    oversized = "\U0001f600" * 16384
+    capped, truncated = es._capped_text(oversized)
+    assert truncated is True
+    assert es._byte_length(capped) <= es.MAX_FRAME_CONTENT_BYTES
+    assert capped != oversized
+
+
+async def test_message_delta_with_cjk_content_is_capped_on_the_wire_not_decoded_bytes():
+    """A CJK string long enough to fit under a decoded-UTF-8-byte cap (3
+    bytes/character) but not under its escaped wire form (6 bytes/
+    character via ``\\uXXXX``, ``ensure_ascii=True``) would reach the
+    client whole under that measurement -- 12000 "中" characters is
+    36000 UTF-8 bytes (well under ``MAX_FRAME_CONTENT_BYTES``) but
+    roughly 72000 escaped wire bytes (over it). Pins that
+    ``message.delta``'s ``text`` field is capped in the same domain the
+    frame is actually serialized in."""
+    sink = _make_sink(task_id=57)
+    oversized = "中" * 12_000
+    await sink.send_text(
+        json.dumps(
+            {
+                "type": "final_answer_delta",
+                "message_id": "final_answer_cjk",
+                "task_id": 57,
+                "delta": oversized,
+            }
+        )
+    )
+    frame_text, _ = sink.queue.get_nowait()
+    data = json.loads(frame_text.split("data: ", 1)[1])
+    assert data["truncated"] is True
+    assert es._byte_length(data["text"]) <= es.MAX_FRAME_CONTENT_BYTES
+    assert data["text"] != oversized
+
+
+async def test_capped_step_data_preserves_cjk_identifying_value_via_the_wire_byte_domain():
+    """The truncation pass's per-key budget (``per_key_budget`` in
+    ``_capped_step_data``) is computed in escaped-JSON bytes -- the same
+    domain ``_byte_length``'s cap checks use. Before ``_capped_text``
+    measured in that same domain, handing it that budget for a CJK name
+    let it keep far more *characters* than the escaped budget actually
+    allowed (UTF-8 costs 3 bytes per "名", the escaped wire form costs
+    6), so the reassembled dict was still over the cap on its own
+    re-check and the identifying ``name`` field a client needs to know
+    which tool ran got dropped entirely -- not because the name was
+    genuinely too large to fit, but because the two functions were
+    measuring in different domains. This pins that a CJK name now
+    survives, truncated, instead."""
+    huge_name_cjk = "名" * 12_000
+    result = es._capped_step_data({"name": huge_name_cjk, "junk": "x" * 1000})
+    assert es._byte_length(result) <= es.MAX_FRAME_CONTENT_BYTES
+    assert result["truncated"] is True
+    assert "name" in result  # the truncation pass preserved it -- not dropped
+    assert len(result["name"]) < len(huge_name_cjk)
+    assert result["original_bytes"] > es.MAX_FRAME_CONTENT_BYTES
+
+
+async def test_nonfinite_step_data_values_are_normalized_to_null_on_the_wire():
+    """``PublicStep.data`` is typed ``Dict[str, Any]`` (see
+    ``xagent.web.schemas.v1``), so nothing stops a tool result or
+    delegation payload from carrying a raw ``float('nan')``/``inf``/
+    ``-inf`` -- Python's ``json.dumps`` (used by ``_sse_frame``, the
+    function every frame builder in this module funnels through)
+    accepts those by default and emits the bare, non-standard tokens
+    ``NaN``/``Infinity``/``-Infinity``, which a strict ``JSON.parse``
+    client rejects outright.
+
+    A ``step.*`` frame's only producer, live projection
+    (``_step_content_frame``), funnels
+    through ``_step_wire_frame``, which receives its dict only after a
+    ``PublicStep(**step).model_dump(mode="json")`` call. Pydantic v2's
+    JSON serialization mode normalizes non-finite floats to ``null`` for
+    any field typed ``Any`` (verified directly below), independent of a
+    field's nesting depth -- so every ``step.*`` frame this module emits
+    is already immune to this failure mode with no additional guard in
+    ``_step_wire_frame`` itself. This test pins that implicit
+    invariant by exercising a real ``_step_wire_frame`` call (the
+    shared choke point) with three-deep nested non-finite values and
+    asserting the resulting wire text is strict-JSON-clean. It changes
+    no production code -- if this ever regresses (e.g. a future
+    producer bypasses ``model_dump(mode="json")`` and hands
+    ``_step_wire_frame`` a dict straight from application code), this
+    test is the tripwire.
+    """
+    nested_nonfinite_data = {
+        "name": "search",
+        "args": {
+            "level_one": {
+                "level_two": {
+                    "level_three": [float("nan"), float("inf"), float("-inf")]
+                },
+                "solo_nan": float("nan"),
+            }
+        },
+        "result": float("inf"),
+    }
+    step = es.PublicStep(
+        id="tool_call:call-nonfinite",
+        type="tool_call",
+        status="completed",
+        started_at=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC),
+        data=nested_nonfinite_data,
+    )
+    frame_text = es._step_wire_frame(step.model_dump(mode="json"))
+
+    assert "NaN" not in frame_text
+    assert "Infinity" not in frame_text
+
+    payload = frame_text.split("data: ", 1)[1].strip()
+
+    def _reject_nonfinite(constant_text: str) -> None:
+        pytest.fail(
+            f"strict JSON parse hit a non-finite constant token: {constant_text!r}"
+        )
+
+    parsed = json.loads(payload, parse_constant=_reject_nonfinite)
+    wire_args = parsed["step"]["data"]["args"]
+    assert wire_args["level_one"]["level_two"]["level_three"] == [None, None, None]
+    assert wire_args["level_one"]["solo_nan"] is None
+    assert parsed["step"]["data"]["result"] is None
+
+
+async def test_stream_projector_keeps_no_finished_steps_for_the_connection():
+    """The sink's projector is built with ``retain_finished=False`` (see
+    ``V1EventStreamSink.__init__``): it acts on each ``feed()`` result
+    immediately by serializing it to a frame, and never calls
+    ``materialized_steps()``, so retaining every finalized step would
+    hold each one's untruncated ``data`` for as long as the connection
+    lives. Feeds 50 tool-call pairs plus one message -- enough that the
+    fold definitely ran repeatedly, not just once -- and checks what's
+    left behind rather than trusting it was never accumulated.
+    """
+    sink = _make_sink(task_id=99)
+    for i in range(50):
+        await sink.send_text(
+            _trace_event_frame(
+                "tool_execution_start",
+                task_id=99,
+                step_id=f"step-{i}",
+                data={
+                    "tool_call_id": f"call-{i}",
+                    "tool_name": "search",
+                    "tool_args": {"query": f"q{i}"},
+                },
+            )
+        )
+        await sink.send_text(
+            _trace_event_frame(
+                "tool_execution_end",
+                task_id=99,
+                step_id=f"step-{i}",
+                data={"tool_call_id": f"call-{i}", "success": True, "result": "ok"},
+            )
+        )
+    await sink.send_text(
+        _trace_event_frame(
+            "ai_message",
+            task_id=99,
+            data={"content": "done"},
+        )
+    )
+    queued = []
+    while not sink.queue.empty():
+        queued.append(sink.queue.get_nowait())
+    assert len(queued) == 101
+    assert sink._projector._finished is None
+    assert sink._projector._pending == {}
+
+
+# ===== two-path consistency: the same trace event sequence collapses to
+# the same PublicStep whether read via steps() or via the live stream =====
+
+
+async def test_live_projection_matches_steps_endpoint_for_the_same_events():
+    """Same trace event sequence, same collapsed ``PublicStep`` --
+    ``id``/``type``/``status``/``data``/``started_at``/``completed_at``
+    -- whether read through ``steps()`` (the persisted-history path) or
+    through this stream's live projection (the same
+    ``PublicStepProjector``, fed the broadcast-shaped frame instead of
+    the ORM row). Both surfaces derive from the same two
+    ``xagent.core.agent.trace.TraceEvent`` objects through the real
+    conversion pipeline -- ``_persist_core_event`` for the ``steps()``
+    leg, ``_broadcast_frame_for`` for the live leg -- so a change on
+    either side of that pipeline shows up here rather than being masked
+    by two independently hand-built literals. Fixture data carries no
+    credential-shaped keys, so both redaction call sites are a no-op and
+    cannot mask a divergence. Message steps are excluded here -- see the
+    divergence test below for that one, explicitly accepted difference.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    start_event = CoreTraceEvent(
+        ACTION_START_TOOL,
+        step_id="step-1",
+        timestamp=base.timestamp(),
+        data={
+            "tool_call_id": "call-1",
+            "tool_name": "search",
+            "tool_args": {"q": "weather"},
+        },
+    )
+    end_event = CoreTraceEvent(
+        ACTION_END_TOOL,
+        step_id="step-1",
+        timestamp=base.timestamp(),
+        data={"tool_call_id": "call-1", "success": True, "result": "sunny"},
+    )
+    _persist_core_event(start_event, task_id=task_id)
+    _persist_core_event(end_event, task_id=task_id)
+
+    steps_resp = client.get(
+        f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+    )
+    assert steps_resp.status_code == 200
+    steps_via_polling = steps_resp.json()["steps"]
+    assert len(steps_via_polling) == 1
+
+    sink = _make_sink(task_id=task_id)
+    await sink.send_text(_broadcast_frame_for(start_event, task_id=task_id))
+    sink.queue.get_nowait()  # the step.started frame -- not under test here
+    await sink.send_text(_broadcast_frame_for(end_event, task_id=task_id))
+    frame_text, _ = sink.queue.get_nowait()
+    step_via_live = json.loads(frame_text.split("data: ", 1)[1])["step"]
+
+    polled = steps_via_polling[0]
+    assert step_via_live["id"] == polled["id"]
+    assert step_via_live["type"] == polled["type"]
+    assert step_via_live["status"] == polled["status"]
+    assert step_via_live["data"] == polled["data"]
+    assert step_via_live["started_at"] == polled["started_at"]
+    assert step_via_live["completed_at"] == polled["completed_at"]
+
+
+async def test_planning_step_ids_count_per_connection_and_collide_with_steps():
+    """Known divergence, not a bug, for a ``thinking:plan:``/``thinking:
+    planning:`` step id -- pins the endpoint docstring's carve-out.
+
+    Two planning cycles happen on the task: cycle 1 opens and closes
+    (``dag_execution`` phase ``planning`` then ``executing``), cycle 2
+    opens and is still running. ``steps()`` replays the whole persisted
+    history, so it numbers them ``:1`` and ``:2`` in order. A fresh sink
+    -- a client attaching mid-task -- only ever sees cycle 2's start
+    broadcast (cycle 1 already happened before it attached), so its own
+    projector, starting empty, numbers that as its *first* observed
+    planning cycle: ``:1``. That id is not a mismatch, it's an outright
+    collision -- it equals ``steps()``'s id for cycle 1's *different*
+    step, not merely differing from cycle 2's own id. ``data`` and
+    ``started_at`` still agree with cycle 2's row, which is what makes
+    the id divergence the only thing wrong with treating the two as the
+    same step.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    dag_execution_type = TraceEventType(
+        TraceScope.TASK, TraceAction.UPDATE, TraceCategory.DAG
+    )
+    t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    t1 = datetime(2026, 1, 1, 12, 0, 5, tzinfo=UTC)
+    t2 = datetime(2026, 1, 1, 12, 0, 10, tzinfo=UTC)
+    cycle1_start = CoreTraceEvent(
+        dag_execution_type,
+        task_id=str(task_id),
+        timestamp=t0.timestamp(),
+        data={"phase": "planning"},
+    )
+    cycle1_end = CoreTraceEvent(
+        dag_execution_type,
+        task_id=str(task_id),
+        timestamp=t1.timestamp(),
+        data={"phase": "executing"},
+    )
+    cycle2_start = CoreTraceEvent(
+        dag_execution_type,
+        task_id=str(task_id),
+        timestamp=t2.timestamp(),
+        data={"phase": "planning"},
+    )
+    _persist_core_event(cycle1_start, task_id=task_id)
+    _persist_core_event(cycle1_end, task_id=task_id)
+    _persist_core_event(cycle2_start, task_id=task_id)
+
+    steps_resp = client.get(
+        f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+    )
+    assert steps_resp.status_code == 200
+    thinking_steps = [s for s in steps_resp.json()["steps"] if s["type"] == "thinking"]
+    assert len(thinking_steps) == 2
+    step_one = next(
+        s for s in thinking_steps if s["id"] == f"thinking:planning:{task_id}:1"
+    )
+    step_two = next(
+        s for s in thinking_steps if s["id"] == f"thinking:planning:{task_id}:2"
+    )
+    assert step_one["started_at"] != step_two["started_at"]
+
+    sink = _make_sink(task_id=task_id)
+    await sink.send_text(_broadcast_frame_for(cycle2_start, task_id=task_id))
+    frame_text, _ = sink.queue.get_nowait()
+    live_step = json.loads(frame_text.split("data: ", 1)[1])["step"]
+
+    # The live id is the collision, not merely a mismatch: it equals the
+    # *other*, earlier step's steps() id rather than merely differing
+    # from the step it actually is.
+    assert live_step["id"] == f"thinking:planning:{task_id}:1"
+    assert live_step["id"] != step_two["id"]
+    assert live_step["id"] == step_one["id"]
+    # Divergence is confined to the id: content and timing still agree
+    # with the step this live frame actually is (cycle 2).
+    assert live_step["data"] == step_two["data"]
+    assert live_step["started_at"] == step_two["started_at"]
+
+
+async def test_known_divergence_message_step_id_differs_between_the_two_paths():
+    """Accepted divergence, not a bug: an ``ai_message``'s ``PublicStep``
+    id is the persisted trace ``event_id`` via ``steps()`` (the row's own
+    primary identifier) but a fresh uuid4 minted per broadcast frame via
+    the live stream (``create_stream_event`` mints a new one on every
+    send) -- the two paths can't share this id, so a client must not try
+    to correlate a message step across ``steps()`` and the live stream by
+    id. Content itself still matches -- ``data`` is the only field
+    compared below; ``started_at``/``completed_at`` aren't, since this
+    fixture doesn't mirror a timestamp into the live frame either."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="ai_message",
+        event_id="persisted-id-123",
+        timestamp=base,
+        data={"content": "the answer"},
+    )
+
+    steps_resp = client.get(
+        f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+    )
+    polled = steps_resp.json()["steps"][0]
+    assert polled["id"] == "message:persisted-id-123"
+
+    sink = _make_sink(task_id=task_id)
+    await sink.send_text(
+        _trace_event_frame(
+            "ai_message",
+            task_id=task_id,
+            event_id="live-frame-uuid-456",
+            data={"content": "the answer"},
+        )
+    )
+    frame_text, _ = sink.queue.get_nowait()
+    step_via_live = json.loads(frame_text.split("data: ", 1)[1])["step"]
+    assert step_via_live["id"] == "message:live-frame-uuid-456"
+    assert step_via_live["id"] != polled["id"]
+    assert step_via_live["data"] == polled["data"]
+
+
+async def test_live_projection_matches_steps_for_a_streamed_final_answer():
+    """``data``/``type``/``status`` parity for an ``ai_message`` that
+    also carries ``stream_message_id`` -- the persisted mirror of a
+    final answer that is ALSO delivered live via
+    ``message.delta``/``message.completed`` on this same stream. The
+    two-path parity tests above deliberately exclude message steps, so
+    this combination gets its coverage here: the live fold projects a
+    ``message`` step for it (see
+    ``test_trace_event_ai_message_with_stream_message_id_also_projects_a_step``),
+    and this pins that the step carries the *same* content ``steps()``
+    shows for the persisted row. The live stream additionally emits the
+    ``message.delta``/``message.completed`` frames for the same content
+    -- duplication the contract accepts in exchange for parity -- not
+    asserted again here since
+    ``test_final_answer_delta_projects_message_delta_frame`` and its
+    ``_completed`` counterpart already pin that half independently.
+    ``id`` is excluded below for the same reason the plain-``ai_message``
+    divergence test above excludes it (a fresh uuid4 per live frame);
+    ``started_at``/``completed_at`` are compared, with the live frame's
+    timestamp mirroring the persisted event's -- both derive from the
+    same event timestamp field regardless of path (see
+    ``_step_mapping.py``'s ``_ts``), so a client can rely on those two
+    fields matching even though ``id`` never will."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="ai_message",
+        event_id="persisted-final-answer",
+        timestamp=base,
+        data={"content": "the answer", "stream_message_id": "final_answer_xyz"},
+    )
+
+    steps_resp = client.get(
+        f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+    )
+    assert steps_resp.status_code == 200
+    steps_via_polling = steps_resp.json()["steps"]
+    assert len(steps_via_polling) == 1
+    polled = steps_via_polling[0]
+    assert polled["data"] == {"role": "assistant", "content": "the answer"}
+
+    sink = _make_sink(task_id=task_id)
+    await sink.send_text(
+        _trace_event_frame(
+            "ai_message",
+            task_id=task_id,
+            event_id="live-final-answer-uuid",
+            timestamp=base.timestamp(),
+            data={"content": "the answer", "stream_message_id": "final_answer_xyz"},
+        )
+    )
+    frame_text, _ = sink.queue.get_nowait()
+    step_via_live = json.loads(frame_text.split("data: ", 1)[1])["step"]
+    # Same accepted id divergence as the plain-ai_message case above --
+    # data/type/status/timestamps are compared below, id is not.
+    assert (
+        step_via_live["data"]
+        == polled["data"]
+        == {
+            "role": "assistant",
+            "content": "the answer",
+        }
+    )
+    assert step_via_live["type"] == polled["type"] == "message"
+    assert step_via_live["status"] == polled["status"] == "completed"
+    assert step_via_live["started_at"] == polled["started_at"]
+    assert step_via_live["completed_at"] == polled["completed_at"]
+    assert sink.queue.empty()
+
+
+async def test_delegated_child_events_excluded_from_both_paths_consistently():
+    """A delegated child agent's own trace events never reach a public
+    step on either path -- but the two paths exclude them via different
+    checks, not the same predicate: ``steps()`` excludes via its
+    ``TraceEvent.build_id IS NULL`` column filter, the live path
+    excludes via the ``data["source"]`` field filter (see
+    ``test_trace_event_delegated_child_source_is_filtered``). They agree
+    because one producer stamps both on a delegated child's events;
+    nothing enforces that they keep agreeing. Verifies the two
+    independent mechanisms agree in practice: the resulting step id sets
+    match, not just that each mechanism works in isolation -- and
+    exercises the REST-side filter for real by persisting a row with a
+    non-null ``build_id`` (rather than relying on none existing to
+    exclude), so ``polled_ids`` matching means the filter actually
+    excluded something. Only id-set membership is compared here -- no
+    per-field (let alone timestamp) comparison, since the point under
+    test is exclusion, not content."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_start",
+        event_id="hist-1",
+        timestamp=base,
+        step_id="step-1",
+        data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+    )
+    # A delegated child's own persisted row -- excluded from steps() by
+    # its non-null build_id, not by an absence of matching rows.
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_start",
+        event_id="hist-child-1",
+        timestamp=base,
+        step_id="step-2",
+        build_id="child-build-1",
+        data={
+            "tool_call_id": "call-child-1",
+            "tool_name": "child_tool",
+            "tool_args": {},
+        },
+    )
+
+    steps_resp = client.get(
+        f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+    )
+    polled_ids = {step["id"] for step in steps_resp.json()["steps"]}
+    assert polled_ids == {"tool_call:call-1"}
+
+    sink = _make_sink(task_id=task_id)
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=task_id,
+            step_id="step-1",
+            data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+        )
+    )
+    started_frame_text, _ = sink.queue.get_nowait()
+    live_ids = {json.loads(started_frame_text.split("data: ", 1)[1])["step"]["id"]}
+
+    # The delegated child agent's own trace event -- same shape a real
+    # broadcast for it would have, filtered by data.source before it
+    # ever reaches the projector (see _feed_trace_event).
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=task_id,
+            step_id="step-2",
+            data={
+                "tool_call_id": "call-child-1",
+                "tool_name": "child_tool",
+                "tool_args": {},
+                "source": "xagent-agent-tool-child",
+            },
+        )
+    )
+    assert sink.queue.empty()  # nothing else was projected for the child event
+
+    assert live_ids == polled_ids
+
+
+async def test_an_unclosed_dag_planning_phase_projects_a_running_thinking_step():
+    """Two-path consistency for a task whose *planning* phase never
+    resolves because no ``dag_execute_end`` ever arrives to close it.
+
+    This fixture only ever sends the ``dag_execution{phase: "planning"}``
+    start, with no matching ``phase: "executing"`` end and no
+    ``dag_execute_end`` at all -- so on *both* paths the ``thinking``
+    step is left at ``status: "running"`` forever; there is no event
+    either path treats as a close for it. That's what this test pins:
+    the two paths still agree with each other on the open-ended case.
+    ``_step_mapping.py`` does consume ``dag_execute_end``: see
+    ``test_dag_execute_end_closes_the_planning_step_as_failed``,
+    directly below, for the case where that event does arrive and
+    closes the step as ``failed``. This fixture is deliberately kept
+    separate rather than repurposed for that outcome, since the point
+    made here is specifically about the still-open, never-closed case.
+
+    Scope of what this pins: each surface's own outcome for this event
+    shape, from a literal built per surface. It is not producer-faithful
+    parity coverage -- that lives in
+    ``test_live_projection_matches_steps_endpoint_for_the_same_events``
+    and ``test_planning_step_ids_count_per_connection_and_collide_with_steps``,
+    which fork both legs from one shared ``CoreTraceEvent`` through the
+    real production pipelines, so a change on either pipeline shows up
+    there. ``type``/``status``/``data``/``started_at``/``completed_at``
+    are compared across the two legs below; ``id`` is deliberately not
+    (see the comment at the assertions).
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="dag_execution",
+        event_id="hist-1",
+        timestamp=base,
+        data={"pattern": "DAGPattern", "phase": "planning"},
+    )
+    _set_task_status(task_id, TaskStatus.FAILED, error_message="plan validation failed")
+
+    steps_resp = client.get(
+        f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+    )
+    assert steps_resp.status_code == 200
+    steps_via_polling = steps_resp.json()["steps"]
+    assert len(steps_via_polling) == 1
+    assert steps_via_polling[0]["status"] == "running"
+    assert steps_via_polling[0]["data"] == {"phase": "planning"}
+
+    sink = _make_sink(task_id=task_id)
+    await sink.send_text(
+        _trace_event_frame(
+            "dag_execution",
+            task_id=task_id,
+            event_id="hist-1",
+            timestamp=base.timestamp(),
+            data={"pattern": "DAGPattern", "phase": "planning"},
+        )
+    )
+    frame_text, _ = sink.queue.get_nowait()
+    assert frame_text.startswith("event: step.started\n")
+    step_via_live = json.loads(frame_text.split("data: ", 1)[1])["step"]
+
+    polled = steps_via_polling[0]
+    # ``id`` is not compared across the two legs on purpose: a
+    # ``thinking:planning:`` id ends in the projecting side's own count
+    # of planning cycles, which the endpoint docstring documents as not
+    # comparable across surfaces (``test_planning_step_ids_count_per_
+    # connection_and_collide_with_steps`` pins the collision). Both legs
+    # here are that count's first value, so asserting them equal would
+    # pin a fixture coincidence rather than the contract. ``started_at``
+    # and content are what the docstring tells clients to reconcile on,
+    # and they are asserted below.
+    assert step_via_live["type"] == polled["type"]
+    assert step_via_live["status"] == polled["status"] == "running"
+    assert step_via_live["data"] == polled["data"]
+    assert step_via_live["started_at"] == polled["started_at"]
+    assert step_via_live["completed_at"] == polled["completed_at"]
+    assert sink.queue.empty()  # no further frame -- nothing ever closes it
+
+
+async def test_dag_execute_end_closes_the_planning_step_as_failed():
+    """Two-path consistency for a closed planning failure: a full
+    ``dag_execute_start`` -> ``dag_execution{phase: "planning"}`` ->
+    ``dag_execute_end{status: "failed"}`` sequence, where the trailing
+    event reaches into the still-open planning step and closes it
+    as ``failed`` (see ``_step_mapping.py``'s ``dag_execute_end``
+    branch). Companion to
+    ``test_an_unclosed_dag_planning_phase_projects_a_running_thinking_step``
+    above, which pins the still-open case this one's ``dag_execute_end``
+    resolves -- that test's fixture is intentionally left alone rather
+    than being turned into this one.
+
+    ``dag_execute_start`` carries no step of its own (it only clears a
+    stale open key from a prior round -- see the module docstring's
+    ``dag_execute_start`` paragraph), so it is expected to project no
+    frame at all on the live path; that's asserted explicitly below
+    rather than just being skipped over.
+
+    Same scope note as the companion test above: this pins each
+    surface's own outcome for this event shape, from a literal built per
+    surface, and ``id`` is deliberately not compared across the two
+    legs. Producer-faithful parity coverage lives in the two
+    shared-``CoreTraceEvent`` tests.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    plan_start = datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC)
+    plan_end = datetime(2026, 1, 1, 12, 0, 2, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="dag_execute_start",
+        event_id="hist-0",
+        timestamp=base,
+        data={"pattern": "DAGPattern"},
+    )
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="dag_execution",
+        event_id="hist-1",
+        timestamp=plan_start,
+        data={"pattern": "DAGPattern", "phase": "planning"},
+    )
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="dag_execute_end",
+        event_id="hist-2",
+        timestamp=plan_end,
+        data={"status": "failed", "result": {"success": False}},
+    )
+    _set_task_status(task_id, TaskStatus.FAILED, error_message="plan validation failed")
+
+    steps_resp = client.get(
+        f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+    )
+    assert steps_resp.status_code == 200
+    steps_via_polling = steps_resp.json()["steps"]
+    assert len(steps_via_polling) == 1
+    assert steps_via_polling[0]["status"] == "failed"
+    assert steps_via_polling[0]["data"] == {"phase": "planning"}
+
+    sink = _make_sink(task_id=task_id)
+    await sink.send_text(
+        _trace_event_frame(
+            "dag_execute_start",
+            task_id=task_id,
+            timestamp=base.timestamp(),
+            data={"pattern": "DAGPattern"},
+        )
+    )
+    assert sink.queue.empty()  # dag_execute_start projects no step of its own
+
+    await sink.send_text(
+        _trace_event_frame(
+            "dag_execution",
+            task_id=task_id,
+            timestamp=plan_start.timestamp(),
+            data={"pattern": "DAGPattern", "phase": "planning"},
+        )
+    )
+    started_frame_text, _ = sink.queue.get_nowait()
+    assert started_frame_text.startswith("event: step.started\n")
+
+    await sink.send_text(
+        _trace_event_frame(
+            "dag_execute_end",
+            task_id=task_id,
+            timestamp=plan_end.timestamp(),
+            data={"status": "failed", "result": {"success": False}},
+        )
+    )
+    completed_frame_text, _ = sink.queue.get_nowait()
+    assert completed_frame_text.startswith("event: step.completed\n")
+    step_via_live = json.loads(completed_frame_text.split("data: ", 1)[1])["step"]
+
+    polled = steps_via_polling[0]
+    # ``id`` deliberately not compared across the legs -- see the
+    # companion test above for why a planning id's trailing count is a
+    # per-surface value.
+    assert step_via_live["type"] == polled["type"]
+    assert step_via_live["status"] == polled["status"] == "failed"
+    assert step_via_live["data"] == polled["data"] == {"phase": "planning"}
+    assert step_via_live["started_at"] == polled["started_at"]
+    assert step_via_live["completed_at"] == polled["completed_at"]
+    assert sink.queue.empty()  # no further frame after the close

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -2090,6 +2090,77 @@ async def test_oversized_task_info_frame_is_not_dropped_by_the_raw_precheck():
     }
 
 
+async def test_a_huge_task_description_does_not_drop_a_small_content_frame():
+    """The size check measures the frame without its
+    ``task_description``, so a long description cannot drop content.
+
+    ``ws_trace_handlers.py``'s ``_convert_trace_event_to_stream_event``
+    stamps the task's ``description`` column onto *every* trace event
+    it converts, not just ``task_info``, and that column has no length
+    bound. Counting it would put every ``step.*`` frame of such a task
+    past ``MAX_RAW_FRAME_TEXT_CHARS`` for the life of the connection --
+    a task whose first user message is long enough would receive no
+    step content at all. The frame built here is over the raw cap on
+    the description alone while its actual step content is a few dozen
+    characters, and it must still project. The projected ``data`` is
+    asserted too: the description is not merely uncounted, it never
+    reaches the wire, because the step builders name their keys
+    explicitly."""
+    sink = _make_sink(task_id=102)
+    huge_description = "x" * (es.MAX_RAW_FRAME_TEXT_CHARS + 1000)
+    raw = _trace_event_frame(
+        "tool_execution_start",
+        task_id=102,
+        step_id="step-1",
+        data={
+            "tool_call_id": "call-1",
+            "tool_name": "search",
+            "tool_args": {"query": "weather"},
+            "task_description": huge_description,
+        },
+    )
+    assert len(raw) > es.MAX_RAW_FRAME_TEXT_CHARS
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 0
+    frame_text, _ = sink.queue.get_nowait()
+    assert frame_text.startswith("event: step.started\n")
+    step = json.loads(frame_text.split("data: ", 1)[1])["step"]
+    assert step["id"] == "tool_call:call-1"
+    assert step["data"]["name"] == "search"
+    assert "task_description" not in step["data"]
+
+
+async def test_a_frame_still_over_the_cap_without_its_description_is_dropped():
+    """The control for the test above: excluding ``task_description``
+    from the measurement is not a blanket exemption for any frame that
+    carries one. This frame's own tool arguments are over the raw cap
+    by themselves, so it is still dropped and counted -- and nothing is
+    queued, which a projection of the same frame would not have left
+    (an oversized ``tool_execution_start`` still projects a
+    ``step.started`` with truncated ``data``)."""
+    sink = _make_sink(task_id=103)
+    huge_description = "x" * (es.MAX_RAW_FRAME_TEXT_CHARS + 1000)
+    huge_args = "y" * (es.MAX_RAW_FRAME_TEXT_CHARS + 1000)
+    raw = _trace_event_frame(
+        "tool_execution_start",
+        task_id=103,
+        step_id="step-2",
+        data={
+            "tool_call_id": "call-2",
+            "tool_name": "search",
+            "tool_args": {"query": huge_args},
+            "task_description": huge_description,
+        },
+    )
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 1
+    assert sink.queue.empty()
+
+
 async def test_unparseable_frame_is_dropped_and_counted():
     """A frame that isn't valid JSON can't be classified at all -- there
     is no parsed ``type`` to check -- so ``json.loads`` itself raises

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -488,6 +488,120 @@ async def test_slow_consumer_queue_overflow_closes_with_resync_required():
     assert sink.queue.get_nowait() == (es.error_frame("resync_required"), True)
 
 
+def _budget_sized_frame() -> tuple[str, int]:
+    """One 64 KiB frame plus how many of them fit exactly in the budget.
+
+    Sized so the byte budget is what the tests below exercise: at 64 KiB
+    a frame, the budget holds 64 of them, well under
+    ``OUTBOUND_QUEUE_MAX_SIZE`` -- asserted rather than assumed, so this
+    can never silently decay into another item-count test if either
+    constant moves.
+    """
+    frame = "x" * (64 * 1024)
+    fits = es.MAX_QUEUED_WIRE_BYTES // len(frame)
+    assert fits * len(frame) == es.MAX_QUEUED_WIRE_BYTES, (
+        "premise: the budget is a whole multiple of this frame size"
+    )
+    assert fits < es.OUTBOUND_QUEUE_MAX_SIZE, (
+        "premise: the byte budget must bind before the item-count cap"
+    )
+    return frame, fits
+
+
+async def test_backlog_exactly_at_the_byte_budget_does_not_close():
+    """The budget is an upper bound, not an exclusive one: a backlog whose
+    queued wire bytes land exactly on ``MAX_QUEUED_WIRE_BYTES`` keeps
+    streaming, and only the frame that would push it over closes. Same
+    boundary rule ``MAX_RAW_FRAME_TEXT_CHARS`` uses -- strictly over is
+    the event, exactly equal is not."""
+    sink = _make_sink()
+    frame, fits = _budget_sized_frame()
+    for _ in range(fits):
+        sink._put_or_overflow(frame)
+    assert sink.closing is False
+    assert sink.queued_wire_bytes == es.MAX_QUEUED_WIRE_BYTES
+    assert sink.queue.qsize() == fits
+
+
+async def test_byte_budget_overflow_closes_with_resync_required_and_drains():
+    """One frame past the budget closes the stream through the existing
+    overflow path: the backlog is dropped, the ``resync_required`` close
+    frame is the only thing left queued, and the byte accounting returns
+    to zero. The item-count cap is not reached here (see
+    ``_budget_sized_frame``'s premise assertions), so this closure can
+    only have come from the byte budget."""
+    sink = _make_sink()
+    frame, fits = _budget_sized_frame()
+    for _ in range(fits + 1):
+        sink._put_or_overflow(frame)
+    assert sink.closing is True
+    assert sink.queue.qsize() == 1
+    assert await sink.next_frame() == (es.error_frame("resync_required"), True)
+    assert sink.queued_wire_bytes == 0
+
+
+async def test_queued_wire_bytes_falls_back_as_frames_are_read_out():
+    """The budget bounds what is *currently* queued, not what has ever
+    been queued: a consumer that keeps up never accumulates toward it.
+    Pins that ``next_frame`` -- the sink's own accounted read method --
+    is what discounts a delivered frame's bytes."""
+    sink = _make_sink()
+    sink._put_or_overflow("a" * 100)
+    sink._put_or_overflow("b" * 50)
+    assert sink.queued_wire_bytes == 150
+    assert await sink.next_frame() == ("a" * 100, False)
+    assert sink.queued_wire_bytes == 50
+    assert await sink.next_frame() == ("b" * 50, False)
+    assert sink.queued_wire_bytes == 0
+
+
+async def test_generator_read_path_keeps_queued_wire_bytes_at_zero_between_frames():
+    """Division of labor with the two tests above: those pin
+    ``next_frame``'s own body (what mutation testing calls M2 -- deleting
+    the subtraction inside it). This one pins the call *site* -- that
+    ``_generate``'s per-frame read actually goes through ``next_frame``
+    rather than a bare ``sink.queue.get()`` that would bypass the byte
+    accounting entirely (M5). Runs a real attach, then puts and reads one
+    budget-sized frame at a time -- never letting more than one frame's
+    worth of backlog build up -- and checks after every read that the
+    delivered frame is the one just queued (not a ``resync_required``
+    close) and that ``queued_wire_bytes`` is back at zero. Precondition:
+    ``fits < OUTBOUND_QUEUE_MAX_SIZE`` (asserted in
+    ``_budget_sized_frame``), so the element cap never intervenes and
+    every read in this loop can only be explained by the byte budget's
+    own accounting.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        **_long_intervals(),
+    )
+    first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+    assert "event: task.status" in first
+
+    sink = next(
+        connection
+        for connection in es.manager.connections_for_task(task_id)
+        if isinstance(connection, es.V1EventStreamSink)
+    )
+    frame, fits = _budget_sized_frame()
+    for _ in range(fits + 4):
+        sink._put_or_overflow(frame)
+        delivered = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert delivered == frame
+        assert sink.queued_wire_bytes == 0
+    assert sink.closing is False
+
+    await resp.body_iterator.aclose()
+
+
 # ===== key revoked/paused closes within one watchdog cycle =====
 
 

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -1196,6 +1196,11 @@ def test_projector_equivalent_to_batch(events):
     direct-call tests above, which now exercise the projector itself.
     What this test guards instead is that the batch driver never grows
     a second, independent folding implementation.
+
+    It is also the pin on the retention default: this path goes through
+    ``from_history(events).materialized_steps()`` with no override, so a
+    projector that stopped retaining finished steps by default would
+    raise rather than return the task's whole timeline here.
     """
     expected = map_trace_events_to_public_steps(events)
     projected = PublicStepProjector.from_history(events).materialized_steps()
@@ -1257,21 +1262,6 @@ def test_projector_without_retention_returns_the_same_steps_and_keeps_none(event
     assert non_retaining._finished is None
     with pytest.raises(RuntimeError):
         non_retaining.materialized_steps()
-
-
-def test_batch_projector_still_retains_finished_steps():
-    """Re-pins the default explicitly: ``map_trace_events_to_public_steps``
-    -- and therefore ``GET /v1/chat/tasks/{task_id}/steps`` -- goes
-    through ``from_history(events).materialized_steps()`` with no
-    ``retain_finished`` override, so it must still return the task's
-    whole projected timeline, not an empty one.
-    """
-    events = _PROJECTOR_EQUIVALENCE_CASES["tool_call_success"]
-    expected = map_trace_events_to_public_steps(events)
-    assert expected
-    projected = PublicStepProjector.from_history(events).materialized_steps()
-    projected.sort(key=lambda s: s["started_at"])
-    assert projected == expected
 
 
 def test_feed_return_value_reflects_step_state_at_call_time():

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -1226,6 +1226,54 @@ def test_projector_incremental_feed_matches_materialized_steps(events):
     assert reconstructed == materialized
 
 
+@pytest.mark.parametrize(
+    "events",
+    _PROJECTOR_EQUIVALENCE_CASES.values(),
+    ids=list(_PROJECTOR_EQUIVALENCE_CASES.keys()),
+)
+def test_projector_without_retention_returns_the_same_steps_and_keeps_none(events):
+    """``retain_finished=False`` changes only what the projector keeps
+    after ``feed()`` returns, never what ``feed()`` itself returns.
+
+    Feeds the same event sequence into a retaining and a non-retaining
+    projector in lockstep, deep-copying each ``feed()`` result
+    immediately (the same reason ``test_feed_return_value_reflects_step_
+    state_at_call_time`` does -- a returned dict is mutated in place
+    when its end event later arrives, and a non-retaining projector
+    still hands back that same live object, it just doesn't also keep
+    it in ``_finished``). The two sequences must be equal event-for-
+    event. Afterwards, the non-retaining projector's ``_finished`` is
+    ``None`` and ``materialized_steps()`` raises rather than returning a
+    silently partial timeline.
+    """
+    retaining = PublicStepProjector()
+    non_retaining = PublicStepProjector(retain_finished=False)
+    retaining_results = []
+    non_retaining_results = []
+    for event in events:
+        retaining_results.append(copy.deepcopy(retaining.feed(event)))
+        non_retaining_results.append(copy.deepcopy(non_retaining.feed(event)))
+    assert retaining_results == non_retaining_results
+    assert non_retaining._finished is None
+    with pytest.raises(RuntimeError):
+        non_retaining.materialized_steps()
+
+
+def test_batch_projector_still_retains_finished_steps():
+    """Re-pins the default explicitly: ``map_trace_events_to_public_steps``
+    -- and therefore ``GET /v1/chat/tasks/{task_id}/steps`` -- goes
+    through ``from_history(events).materialized_steps()`` with no
+    ``retain_finished`` override, so it must still return the task's
+    whole projected timeline, not an empty one.
+    """
+    events = _PROJECTOR_EQUIVALENCE_CASES["tool_call_success"]
+    expected = map_trace_events_to_public_steps(events)
+    assert expected
+    projected = PublicStepProjector.from_history(events).materialized_steps()
+    projected.sort(key=lambda s: s["started_at"])
+    assert projected == expected
+
+
 def test_feed_return_value_reflects_step_state_at_call_time():
     """``feed()``'s return is the same dict object later mutated in place
     when the matching end event finalizes the step -- so a caller that


### PR DESCRIPTION
## What

`GET /v1/chat/tasks/{task_id}/events` streamed only lifecycle events:
`task.status`, `task.completed`, `task.input_required`, `stream.error`. A
client that wanted to see what the task was actually doing had to poll
`GET /v1/chat/tasks/{task_id}/steps` alongside the stream.

This projects the task's step-by-step execution and streamed message text
onto the same connection, adding four events built from the same
`PublicStep` shape and public step-type list `steps()` already uses:

| event | payload |
| --- | --- |
| `step.started` | `{step}` — a running `PublicStep` |
| `step.completed` | `{step}` — the same step once its end event resolves it |
| `message.delta` | `{message_id, text}` — one chunk of a streamed final answer |
| `message.completed` | `{message_id, content}` — that message's full text |

Each connection gets its own `PublicStepProjector`, fed only the frames
broadcast after it registered. `task.input_required` now also carries the
agent's pending question as `prompt`, read from the same authoritative
task-row read that already backs the close decision.

## The contract in one line

Steps and message content the task produces **after** the client attaches
are pushed live; content from before the attach is reconciled through
`steps()`; a single frame's content-bearing field is truncated at 64 KiB
of its own JSON wire form, and a raw broadcast frame past 256 KiB is
dropped whole rather than projected (lifecycle `task_info` trace frames
are exempt from that cap -- they are never projected or truncated here).

The "after the attach" half has a consequence a client must handle: a
step already running when the stream opened has no matching start in this
connection's projector, so its end event folds in as an orphan and is
dropped. That step stays `"running"` here for the rest of the stream's
life even though the task resolved it. `steps()` reads the database and is
unaffected by when the stream opened, so that is where a mid-task attach
reconciles.

Attaching to a task that is already finished, or already waiting on user
input, still closes immediately with `task.status` followed by the
conclusion frame and no step content — those attaches read their steps
through `steps()`.

## Scope

This PR is the live projection only. Sending a one-shot step snapshot on
those two attach-time close paths is a separate change and follows as its
own PR, stacked on this one: it needs a cache-backed steps read, a bound
on how much one response may hold, and a re-read of the task row to
confirm the snapshot's run/state generation before any step content goes
out — none of which the live path has or needs.

## Delivery guarantees

Content-frame delivery is best-effort, for three separate reasons:

1. Closing a stream for any reason drains its queued backlog before
   inserting the close frame, so an already-queued frame can be dropped.
2. One frame that fails to project is dropped on its own, silently.
3. An oversized raw broadcast frame is dropped whole, silently — no
   truncation marker. Lifecycle `task_info` trace frames are exempt from
   that cap.

Neither (2) nor (3) produces any signal on the wire, and the close frame
in (1) carries no record of what it drained. So a `stream.error` does not
mean content was dropped, and its absence does not mean nothing was.
Reconciling against `steps()` is the only answer. This is stated in the
endpoint docstring, which is the only OpenAPI-visible contract for these
events.

## Correlation with `steps()`

- A `message` step's `id` does not correlate: the live frame mints a fresh
  id per broadcast, `steps()` returns the persisted trace event's id.
- A `thinking` step whose id begins `thinking:plan:` / `thinking:planning:`
  does not correlate either, and merging by id actively corrupts client
  state: both ids end in a count of planning cycles, and this stream's
  projection starts empty at attach. Reconcile planning steps by
  `started_at` and content.
- Every other public step type keeps the same id across both surfaces,
  because both derive it from a key the event itself carries.
- A live-streamed final answer reaches the client twice — as its
  `message.delta`/`message.completed` sequence, and again as a
  `message`-type `step.completed` once the `ai_message` trace event folds
  in. Duplication, not loss.

## Tests

`tests/web/api/v1/test_events_stream.py`, `tests/web/api/v1/test_steps_mapping.py`.
Covers frame-family classification and each filter, the byte caps in the
escaped-JSON wire domain the frames are actually serialized in (ASCII,
CJK, emoji, and the non-string identifying value the marker cannot
shrink), the projector's non-retaining mode, and two-path parity: the same
trace event sequence collapsing to the same `PublicStep` whether read
through `steps()` or through the live stream, including the known
divergences above.
