### PR TITLE
fix(mcp): forward structuredContent and read result fields by wire name

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -6,6 +6,7 @@ enabling MCP tools to be used in DAG plan-execute patterns and other agent workf
 
 import asyncio
 import inspect
+import json
 import logging
 import os
 import re
@@ -305,20 +306,37 @@ def _mcp_access_denied_result(user_id: Optional[str], tool_name: str) -> dict[st
 
 
 def _mcp_return_value_as_string(value: Any) -> str:
+    """Renders an MCP result dict for the ``AbstractBaseTool.return_value_as_string``
+    interface, used only by the tool wrappers (e.g. output-filter/sandboxed
+    wrappers). This is NOT the path the LLM's observation text is built from
+    for MCP tool calls in ReAct -- that is
+    ``ExecutionContext._format_tool_result`` (execution.py), which
+    stringifies the whole result dict returned by ``_execute_mcp_call``
+    directly. Keep this renderer lossless anyway, since any future caller
+    of ``return_value_as_string`` should see the same fields.
+    """
     try:
         if isinstance(value, dict):
+            texts = []
             content = value.get("content", [])
             if isinstance(content, list) and content:
-                texts = []
                 for item in content:
                     if isinstance(item, dict) and "text" in item:
                         texts.append(item["text"])
                     else:
                         texts.append(str(item))
-                return "\n".join(texts)
-            if content:
-                return str(content)
-            return "No content returned"
+            elif content:
+                texts.append(str(content))
+            else:
+                texts.append("No content returned")
+
+            structured_content = value.get("structured_content")
+            if structured_content is not None:
+                texts.append(
+                    "Structured result: " + json.dumps(structured_content, default=str)
+                )
+
+            return "\n".join(texts)
         return str(value)
     except Exception as e:
         logger.warning(f"Failed to convert return value to string: {e}")
@@ -535,6 +553,13 @@ class MCPToolAdapter(AbstractBaseTool):
         class MCPToolResult(BaseModel):
             content: List[Dict[str, Any]] = Field(
                 default_factory=list, description="Tool execution result content"
+            )
+            structured_content: Any = Field(
+                default=None,
+                description=(
+                    "Structured JSON result of the tool call, if the server "
+                    "returned one."
+                ),
             )
             is_error: bool = Field(
                 default=False,
@@ -785,9 +810,20 @@ class MCPToolAdapter(AbstractBaseTool):
                     else:
                         content.append({"text": str(content_item)})
 
+            # Read by wire name (by_alias=True), not by Python attribute name:
+            # the mcp SDK's CallToolResult field naming has changed across
+            # major versions (1.x uses plain camelCase attributes, 2.x uses
+            # snake_case attributes with a camelCase alias), but the MCP
+            # wire/JSON field names ("structuredContent", "isError") are
+            # spec-fixed and stable across both. `content` is excluded and
+            # handled by the loop above instead, since by_alias=True would
+            # also rename each content item's `meta` field to `_meta`.
+            other_fields = result.model_dump(by_alias=True, exclude={"content"})
+
             return {
                 "content": content,
-                "is_error": result.isError if hasattr(result, "isError") else False,
+                "structured_content": other_fields.get("structuredContent"),
+                "is_error": bool(other_fields.get("isError")),
             }
 
     async def _retry_after_authorization_failure(

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -327,14 +327,15 @@ def _mcp_return_value_as_string(value: Any) -> str:
                         texts.append(str(item))
             elif content:
                 texts.append(str(content))
-            else:
-                texts.append("No content returned")
 
             structured_content = value.get("structured_content")
             if structured_content is not None:
                 texts.append(
                     "Structured result: " + json.dumps(structured_content, default=str)
                 )
+
+            if not texts:
+                texts.append("No content returned")
 
             return "\n".join(texts)
         return str(value)

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -120,6 +120,27 @@ def test_add_tool_result_sanitizes_path_metadata_without_artifacts() -> None:
     assert raw_result["file_ref"]["relative_path"] == "output/deck.pptx"
 
 
+def test_format_tool_result_preserves_unknown_result_keys() -> None:
+    """MCP tool results carry a structured_content key that
+    _format_tool_result has no dedicated handling for -- it must still
+    surface it via the generic dict fallback, since this is the actual
+    mechanism (not the MCP adapter's own string-rendering helper) that
+    gets structured MCP results in front of the model."""
+    ctx = ExecutionContext()
+
+    content = ctx._format_tool_result(
+        "mcp_tool",
+        {
+            "content": [],
+            "structured_content": {"status": "completed", "run_id": "abc"},
+            "is_error": False,
+        },
+    )
+
+    assert "completed" in content
+    assert "abc" in content
+
+
 def test_format_tool_result_uses_shared_image_artifact_observation() -> None:
     ctx = ExecutionContext()
 

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -536,6 +536,19 @@ def test_mcp_return_value_as_string_omits_structured_content_when_absent():
     assert _mcp_return_value_as_string(value) == "ok"
 
 
+def test_mcp_return_value_as_string_omits_no_content_placeholder_when_structured_content_present():
+    value = {
+        "content": [],
+        "structured_content": {"status": "completed"},
+        "is_error": False,
+    }
+
+    rendered = _mcp_return_value_as_string(value)
+
+    assert "No content returned" not in rendered
+    assert "completed" in rendered
+
+
 @pytest.mark.asyncio
 async def test_execute_mcp_call_forwards_structured_content(monkeypatch):
     mcp_tool = _mcp_tool("status")

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -3,10 +3,14 @@ import re
 from contextlib import asynccontextmanager
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 from xagent.core.tools.adapters.vibe import mcp_adapter as mcp_adapter_module
 from xagent.core.tools.adapters.vibe.agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
@@ -40,6 +44,21 @@ def _mcp_tool(name: str = "echo") -> SimpleNamespace:
         description=f"{name} tool",
         inputSchema={"type": "object", "properties": {}},
     )
+
+
+class _SdkV2CallToolResult(BaseModel):
+    """Mirrors mcp SDK 2.0.0's ``CallToolResult`` field naming (snake_case
+    Python attributes with camelCase wire aliases), unlike the currently
+    locked mcp 1.19.0's plain camelCase attributes. Guards against the
+    adapter silently regressing to dropping structured_content/is_error
+    if the SDK constraint ever allows resolving mcp>=2.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    content: list[Any] = []
+    structured_content: Any = None
+    is_error: bool = False
 
 
 def test_mcp_server_load_failure_is_immutable():
@@ -497,6 +516,209 @@ def test_mcp_return_value_as_string_keeps_malformed_scalar_content_together():
     assert _mcp_return_value_as_string({"content": "error"}) == "error"
 
 
+def test_mcp_return_value_as_string_surfaces_structured_content():
+    value = {
+        "content": [{"text": "I'll wait for the background agents to complete."}],
+        "structured_content": {"status": "completed", "run_id": "abc"},
+        "is_error": False,
+    }
+
+    rendered = _mcp_return_value_as_string(value)
+
+    assert "I'll wait for the background agents to complete." in rendered
+    assert "completed" in rendered
+    assert "abc" in rendered
+
+
+def test_mcp_return_value_as_string_omits_structured_content_when_absent():
+    value = {"content": [{"text": "ok"}], "is_error": False}
+
+    assert _mcp_return_value_as_string(value) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_call_forwards_structured_content(monkeypatch):
+    mcp_tool = _mcp_tool("status")
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, arguments, **kwargs):
+            return CallToolResult(
+                content=[],
+                isError=False,
+                structuredContent={"status": "completed", "run_id": "abc"},
+            )
+
+    @asynccontextmanager
+    async def _fake_create_session(_connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(mcp_adapter_module, "create_session", _fake_create_session)
+
+    result = await adapter._execute_mcp_call(adapter.connection, {}, {})
+
+    assert result["structured_content"] == {"status": "completed", "run_id": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_call_structured_content_defaults_to_none(monkeypatch):
+    mcp_tool = _mcp_tool("echo")
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, arguments, **kwargs):
+            return CallToolResult(content=[], isError=False)
+
+    @asynccontextmanager
+    async def _fake_create_session(_connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(mcp_adapter_module, "create_session", _fake_create_session)
+
+    result = await adapter._execute_mcp_call(adapter.connection, {}, {})
+
+    assert result["structured_content"] is None
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_call_reads_snake_case_sdk_structured_content(monkeypatch):
+    """Guards against the adapter silently regressing on an mcp SDK version
+    (e.g. 2.0.0) whose CallToolResult exposes structured_content instead of
+    structuredContent as the Python attribute name."""
+    mcp_tool = _mcp_tool("status")
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, arguments, **kwargs):
+            return _SdkV2CallToolResult(
+                content=[],
+                structured_content={"status": "completed", "run_id": "abc"},
+                is_error=False,
+            )
+
+    @asynccontextmanager
+    async def _fake_create_session(_connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(mcp_adapter_module, "create_session", _fake_create_session)
+
+    result = await adapter._execute_mcp_call(adapter.connection, {}, {})
+
+    assert result["structured_content"] == {"status": "completed", "run_id": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_call_reads_snake_case_sdk_error_flag(monkeypatch):
+    """Same regression guard as above, for the error flag: a hasattr-based
+    read on ``isError`` would silently report success on an SDK version
+    whose attribute is ``is_error`` instead."""
+    mcp_tool = _mcp_tool("status")
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, arguments, **kwargs):
+            return _SdkV2CallToolResult(content=[], is_error=True)
+
+    @asynccontextmanager
+    async def _fake_create_session(_connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(mcp_adapter_module, "create_session", _fake_create_session)
+
+    result = await adapter._execute_mcp_call(adapter.connection, {}, {})
+
+    assert result["is_error"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_call_structured_content_reaches_the_model_observation(
+    monkeypatch,
+):
+    """The seam test: proves structured_content actually reaches the string
+    the LLM reads, by running it through the real _execute_mcp_call and then
+    the real ExecutionContext.add_tool_result -- not just that a hand-built
+    dict happens to render correctly."""
+    from xagent.core.agent.context import ExecutionContext
+
+    mcp_tool = _mcp_tool("coding_agent_status")
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    class _FakeSession:
+        async def initialize(self):
+            return None
+
+        async def call_tool(self, name, arguments, **kwargs):
+            return CallToolResult(
+                content=[],
+                structuredContent={"status": "completed", "run_id": "abc"},
+                isError=False,
+            )
+
+    @asynccontextmanager
+    async def _fake_create_session(_connection):
+        yield _FakeSession()
+
+    monkeypatch.setattr(mcp_adapter_module, "create_session", _fake_create_session)
+
+    result = await adapter._execute_mcp_call(adapter.connection, {}, {})
+
+    context = ExecutionContext()
+    message = context.add_tool_result(
+        "coding_agent_status", result, tool_call_id="tool-1"
+    )
+
+    assert message.content.startswith("Tool coding_agent_status returned: ")
+    assert "completed" in message.content
+    assert "abc" in message.content
+
+
+def test_return_type_declares_structured_content_field():
+    mcp_tool = SimpleNamespace(
+        name="status",
+        description="status tool",
+        inputSchema={"type": "object", "properties": {}},
+        outputSchema={
+            "type": "object",
+            "properties": {"status": {"type": "string"}},
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "streamable_http", "url": "https://mcp.example.test"},
+    )
+
+    return_model = adapter.return_type()
+
+    assert "structured_content" in return_model.model_fields
+
+
 def test_build_mcp_tool_adapter_honors_concurrent_tool_allowlist():
     safe_tool = SimpleNamespace(
         name="list_messages",
@@ -711,7 +933,7 @@ async def test_runtime_bindings_hide_and_inject_mcp_meta_and_tool_arguments(
             captured["name"] = name
             captured["arguments"] = arguments
             captured["kwargs"] = kwargs
-            return SimpleNamespace(content=[], isError=False)
+            return CallToolResult(content=[], isError=False)
 
     @asynccontextmanager
     async def _fake_create_session(_connection):
@@ -1034,6 +1256,7 @@ async def test_real_mcp_session_retries_nested_resolver_401_once(monkeypatch, ca
                 "meta": None,
             }
         ],
+        "structured_content": None,
         "is_error": False,
     }
     assert initial_client_builds == 1
@@ -1527,8 +1750,8 @@ async def test_delegated_authorization_401_refreshes_connection_once(monkeypatch
                 raise RuntimeError("HTTP 401 Unauthorized")
 
         async def call_tool(self, name, arguments, **kwargs):
-            return SimpleNamespace(
-                content=[SimpleNamespace(model_dump=lambda: {"text": "ok"})],
+            return CallToolResult(
+                content=[TextContent(type="text", text="ok")],
                 isError=False,
             )
 
@@ -1544,7 +1767,18 @@ async def test_delegated_authorization_401_refreshes_connection_once(monkeypatch
 
     result = await adapter.run_json_async({})
 
-    assert result == {"content": [{"text": "ok"}], "is_error": False}
+    assert result == {
+        "content": [
+            {
+                "type": "text",
+                "text": "ok",
+                "annotations": None,
+                "meta": None,
+            }
+        ],
+        "structured_content": None,
+        "is_error": False,
+    }
     assert refresh_calls == 1
     assert [item["headers"]["Authorization"] for item in connections] == [
         "Bearer expired-token",


### PR DESCRIPTION
## Summary

`MCPToolAdapter._execute_mcp_call` discarded `CallToolResult.structuredContent` entirely, so the LLM never saw an MCP tool's machine-readable result — only the human-readable `content` text. This silently breaks any MCP server that puts meaningful state only in `structuredContent` (both are official MCP spec fields, not custom extensions).

Reproduced with a real MCP server (a long-poll status tool): its `structuredContent` carried the actual terminal state (`{"status": "completed", ...}`), while `content` held a vague conversational status update. Because `structuredContent` never reached the model, the agent polled the same already-finished run 50+ times.

## Fix

- `_execute_mcp_call` now reads `structured_content`/`is_error` via `result.model_dump(by_alias=True, exclude={"content"})` instead of a `getattr`/`hasattr` chain keyed to one SDK version's Python attribute names. The MCP wire/JSON field names (`structuredContent`, `isError`) are spec-fixed and stable across mcp SDK 1.x and 2.x, even though the SDK renamed its Python attributes between those versions (verified against both a real 1.19.0 and a real 2.0.0 install).
- The adapter's declared return model (`MCPToolResult`) now includes a `structured_content` field, matching what `run_json_async` actually returns.
- `_mcp_return_value_as_string` gained a docstring clarifying it is not the path ReAct's observation text is built from for MCP tool calls (that's `ExecutionContext._format_tool_result`), to avoid a future reader assuming otherwise.

## Out of scope (filed as follow-ups, not fixed here)

- Surfacing the MCP tool's declared `outputSchema` to the LLM would require wiring it into `react.py`'s shared tool-schema construction (used by every tool of every agent) — too broad a blast radius for this bug fix, which is about not discarding a result value that's already returned.
- Hardening `inputSchema` access elsewhere in the adapter (and in `cua_driver.py`) against the same mcp SDK 2.x attribute-naming change is a separate "support mcp 2.x" migration, not part of this fix.
- Servers using the official Python SDK's convenience path (which mirrors dict-shaped structured results into `content` as serialized JSON for backward compatibility) will now see that payload appear twice in the observation text; no truncation/dedup is added here.

## Test plan

- [x] New tests simulate mcp SDK 2.x's field naming (a pydantic double using `alias_generator=to_camel`) to guard against silently regressing to the original bug if the SDK dependency ever resolves to 2.x.
- [x] A seam test runs a fake MCP call through `_execute_mcp_call` and then the real `ExecutionContext.add_tool_result`, asserting the structured data actually reaches the LLM-visible string (not just that the adapter's return dict contains the key).
- [x] Existing fakes for `call_tool`'s return value migrated from loosely-typed `SimpleNamespace` to real `mcp.types.CallToolResult`/`TextContent` instances.
- [x] `tests/core/tools/adapters/vibe/test_mcp_adapter.py` and `tests/core/agent/test_context.py` pass; full `tests/core/tools`/`tests/core/agent` regression sweep passes (excluding pre-existing, unrelated `test_pptx_tool.py` failures present on `main` as well).
- [x] `pre-commit run --all-files` passes (ruff, ruff-format, mypy, isort, codespell, alembic-check; `npm lint`/`npm type-check` fail only due to missing local frontend toolchain, unrelated to this change — no frontend files touched).

Closes #1378.