### PR TITLE
fix(mcp): emit connector attachability from /api/mcp/apps (#1347)

### DIFF
--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -205,6 +205,10 @@ function deferred<T>(): Deferred<T> {
   return { promise, resolve }
 }
 
+// The fixtures below carry the can_attach/can_authorize pair list_mcp_apps
+// emits for each shape (#1347). They are the picker's only inputs for both
+// decisions now, so a fixture that omits them models a connector the backend
+// never emits — and would silently render every card unattachable.
 function customApiApp(id: number, name: string) {
   return {
     id: name,
@@ -216,6 +220,9 @@ function customApiApp(id: number, name: string) {
     is_local: true,
     server_id: id,
     transport: "custom_api",
+    // A Custom API has no OAuth consent step of any kind.
+    can_attach: true,
+    can_authorize: false,
   }
 }
 
@@ -230,6 +237,8 @@ function mcpApp(id: number, name: string) {
     is_local: true,
     server_id: id,
     transport: "streamable_http",
+    can_attach: true,
+    can_authorize: false,
   }
 }
 
@@ -244,6 +253,12 @@ function mcpOauthApp() {
     is_connected: false,
     transport: "streamable_http",
     auth_type: "mcp_oauth",
+    // Unconnected catalog app: no association row exists for this user, so
+    // there is no connector to attach. can_authorize is false for every
+    // catalog entry — their Connect is dispatched on auth_type, through
+    // /apps/{id}/oauth/connect rather than the per-server route.
+    can_attach: false,
+    can_authorize: false,
   }
 }
 
@@ -263,6 +278,11 @@ function customMcpOauthApp() {
     server_id: 9,
     transport: "streamable_http",
     auth_type: "mcp_oauth",
+    // Standalone shape: nothing can supply tokens for a server whose consent
+    // was never completed, so attaching it would fail at run time — but the
+    // consent flow itself is available and is the recovery.
+    can_attach: false,
+    can_authorize: true,
   }
 }
 
@@ -277,6 +297,10 @@ function keylessApp(id = "chrome", name = "Chrome") {
     is_connected: false,
     transport: "stdio",
     auth_type: "keyless",
+    // Every unconnected catalog entry: no association row, so nothing to
+    // attach, and its Connect is dispatched on auth_type, not can_authorize.
+    can_attach: false,
+    can_authorize: false,
   }
 }
 
@@ -291,6 +315,8 @@ function builtinOauthApp() {
     transport: "oauth",
     auth_type: "builtin_oauth",
     provider: "zoom",
+    can_attach: false,
+    can_authorize: false,
   }
 }
 
@@ -307,6 +333,8 @@ function apiKeyApp() {
     transport: "stdio",
     auth_type: "api_key",
     launch_config: { required_env: ["GOOGLE_MAPS_API_KEY"] },
+    can_attach: false,
+    can_authorize: false,
   }
 }
 
@@ -1678,6 +1706,8 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
               is_connected: true,
               transport: "stdio",
               auth_type: "keyless",
+              can_attach: true,
+              can_authorize: false,
             },
           ],
         })
@@ -1714,13 +1744,26 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(onConnectSelected).toHaveBeenCalledWith([])
   })
 
-  // A custom mcp_oauth connector whose access tokens are supplied out of band
-  // through set_oauth_token_resolver_hook: is_connected stays false forever
-  // because no MCPOAuthGrant is ever written for the editor, so gating the
-  // select-mode toggle on it made the connector permanently unattachable —
-  // even though the agent endpoints accept its selector with no
-  // connected-state check and the runtime resolves credentials without a
-  // grant (#1332).
+  // The two populations the split in #1347 exists to separate. Both are
+  // custom mcp_oauth connectors the editor holds no MCPOAuthGrant for, so
+  // is_connected is false for both and the old predicate could not tell them
+  // apart -- it attached both, and offered both an Authorize button.
+  //
+  // Tokens supplied out of band through set_oauth_token_resolver_hook: no
+  // grant row is ever written, there is no interactive consent, and no
+  // identity the editor could sign in as. Attachable; nothing to authorize.
+  const hookResolvedCustomMcp = () => ({
+    ...customMcpOauthApp(),
+    name: "Records MCP",
+    can_attach: true,
+    can_authorize: false,
+  })
+
+  // Consent simply never started (create_mcp_server writes the association row
+  // long before it). Nothing can supply its tokens in a standalone
+  // deployment, so attaching it would fail at run time with "MCP server
+  // credentials are unavailable" -- refused here instead, with consent
+  // advertised as the one-click recovery.
   const unauthorizedCustomMcp = () => ({ ...customMcpOauthApp(), name: "Records MCP" })
 
   // Shared by renderSelectModeWith below and the non-select-mode card-click
@@ -1746,14 +1789,17 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     )
   }
 
-  it("selects and deselects a custom mcp_oauth connector the editor holds no grant for (#1332)", async () => {
+  it("selects and deselects a hook-resolved custom mcp_oauth connector (#1332)", async () => {
     const onConnectSelected = vi.fn()
-    renderSelectModeWith([unauthorizedCustomMcp()], onConnectSelected)
+    renderSelectModeWith([hookResolvedCustomMcp()], onConnectSelected)
     await screen.findByText("Records MCP")
 
     fireEvent.click(screen.getByText("Records MCP"))
     // The click must toggle the selection, not divert to the detail modal.
     expect(screen.getByTestId("settings-open-app").textContent).toBe("")
+    // And no Authorize trigger: there is no consent flow behind it, so the
+    // label would assert a step this connector does not have (#1347).
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
     // Becoming attachable must not change connected-state display: this
     // connector is still unconnected (is_connected: false), so it must stay
     // unchecked. Scoped through the card: connected-check is non-unique
@@ -1772,11 +1818,16 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
   })
 
   it("shows Configure and the connected checkmark, not Authorize, for a connected custom mcp_oauth entry (#1332)", async () => {
-    // isAttachable widening the select-mode gate must not disturb the
-    // isGloballyConnected branch of the footer ternary: a connected entry
-    // has to keep showing Configure plus the checkmark, never Authorize.
+    // The isGloballyConnected branch of the footer ternary is checked first
+    // and must keep winning: a connected entry shows Configure plus the
+    // checkmark, never Authorize -- including now that can_authorize is true
+    // for it (re-consent is legitimate; the picker suppresses the trigger on
+    // connected state itself, which is why the backend does not).
     const onConnectSelected = vi.fn()
-    renderSelectModeWith([{ ...unauthorizedCustomMcp(), is_connected: true }], onConnectSelected)
+    renderSelectModeWith(
+      [{ ...unauthorizedCustomMcp(), is_connected: true, can_attach: true }],
+      onConnectSelected,
+    )
     await screen.findByText("Records MCP")
 
     // getBy* throws when absent, so the bare calls are the assertions.
@@ -1788,11 +1839,10 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     within(screen.getByTestId("connector-card-records")).getByTestId("connected-check")
   })
 
-  it("keeps the per-server OAuth flow reachable from the card in select mode (#1323)", async () => {
-    // The card click no longer opens the detail modal for these entries, so
-    // the Connect button repaired in #1323 needs its own trigger — otherwise
-    // relaxing the gate would strip the interactive flow from editors who do
-    // authorize personally.
+  it("offers Authorize, and refuses selection, for a connector whose consent was never started (#1323)", async () => {
+    // The fail-early half of #1347: attaching this connector would load zero
+    // tools, so the card is not selectable -- but the flow repaired in #1323
+    // has to stay one click away, or the refusal would be a dead end.
     const onConnectSelected = vi.fn()
     renderSelectModeWith([unauthorizedCustomMcp()], onConnectSelected)
     await screen.findByText("Records MCP")
@@ -1803,18 +1853,51 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     // Opening the modal must not have counted as a selection toggle.
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
+
+    // The card click itself must not attach it either. Scoped through the
+    // card: the stub settings dialog now also renders this name.
+    fireEvent.click(
+      within(screen.getByTestId("connector-card-records")).getByText("Records MCP"),
+    )
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("attaches a team-owned mcp_oauth connector without advertising a flow that would 404", async () => {
+    // The #1338 population, and the case that motivated splitting the two
+    // fields: the member holds no personal association, so
+    // /{server_id}/oauth/connect would 404 -- but the team overlay listed the
+    // connector precisely so members could attach it. Withholding auth_type
+    // was the only way to say "not authorizable", and it said "not
+    // attachable" too, which is why this entry carries no auth_type at all.
+    const onConnectSelected = vi.fn()
+    const teamOwned: Record<string, unknown> = {
+      ...hookResolvedCustomMcp(),
+      name: "Team Records",
+      id: "team-records",
+    }
+    delete teamOwned.auth_type
+    renderSelectModeWith([teamOwned], onConnectSelected)
+    await screen.findByText("Team Records")
+
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
+    fireEvent.click(screen.getByText("Team Records"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith(["Team Records"])
   })
 
   it("still gates selection on connected state for unconnected catalog apps", async () => {
-    // Only local/custom entries are relaxed. mcpOauthApp() (Granola) is the
-    // load-bearing fixture here: it carries the exact same auth_type as the
-    // custom mcp_oauth population this predicate widens, but it is a
+    // mcpOauthApp() (Granola) is the load-bearing fixture: it carries the
+    // exact same auth_type as the custom mcp_oauth population, but it is a
     // *catalog* entry, so its is_connected: false means the user has no
-    // association row for it at all — connecting really is a prerequisite,
-    // and dropping the is_custom conjunct would wrongly attach it. keylessApp
-    // (Chrome) is included alongside it as a non-mcp_oauth catalog control.
-    // Both must keep routing the card click to the detail modal instead of
-    // attaching a connector that does not exist for them.
+    // association row for it at all — connecting really is a prerequisite.
+    // This used to be decided here by is_custom being absent from catalog
+    // entries, an emission rule the backend never stated; can_attach: false
+    // now says it outright (#1347). keylessApp (Chrome) is included as a
+    // non-mcp_oauth catalog control. Both must keep routing the card click to
+    // the detail modal instead of attaching a connector that does not exist
+    // for them.
     const onConnectSelected = vi.fn()
     renderSelectModeWith([mcpOauthApp(), keylessApp()], onConnectSelected)
     await screen.findByText("Chrome")
@@ -1826,36 +1909,38 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     fireEvent.click(screen.getByText("Chrome"))
     expect(screen.getByTestId("settings-open-app").textContent).toBe("Chrome")
 
-    // No card-level Authorize trigger for either: is_custom is required too.
+    // No card-level Authorize trigger for either: a catalog entry's Connect
+    // is dispatched on auth_type from the detail modal, so can_authorize is
+    // false for the whole catalog branch.
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
 
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })
 
-  it("still gates selection on a custom mcp_oauth entry whose association was deactivated before consent completed", async () => {
-    // list_mcp_apps' local loop does not filter is_active, and emits auth_type
-    // only while the association *is* active — so a deactivated mcp_oauth
-    // server with no completed grant is listed as is_connected: false with no
-    // auth_type. (toggle_mcp_server never revokes a completed grant, so this
-    // only holds pre-consent: deactivating *after* consent instead lists
-    // is_connected: true and is attachable through the first disjunct, with
-    // the checkmark and Configure. No test renders that exact shape — it is
-    // indistinguishable here from an ordinary connected entry, and the
-    // regression it would guard against, replacing the first disjunct with
-    // one that also demands auth_type, already fails the seeded keyless
-    // test below.)
-    // The runtime's server query drops inactive associations outright, so
-    // attaching this one would silently load zero tools — hence it must keep
-    // its card-click route to the detail modal rather than becoming
-    // selectable. That route offers no recovery today either; see the
-    // isAttachable comment.
+  it("refuses a deactivated association even when it lists as connected", async () => {
+    // toggle_mcp_server flips is_active and never revokes a completed grant,
+    // so a connector deactivated *after* consent lists as is_connected: true
+    // with auth_type — indistinguishable from an ordinary connected entry in
+    // everything the picker used to read, and attachable through the old
+    // is_connected disjunct. The runtime's server query drops inactive
+    // associations outright, so attaching it would silently load zero tools.
+    // can_attach is the only field that can carry this (#1347), and
+    // can_authorize is false alongside it because the per-server OAuth
+    // endpoints require an active association: this connector needs
+    // re-enabling, not re-authorization.
     const onConnectSelected = vi.fn()
-    const dormant: Record<string, unknown> = { ...unauthorizedCustomMcp() }
-    delete dormant.auth_type
+    const dormant = {
+      ...unauthorizedCustomMcp(),
+      is_connected: true,
+      can_attach: false,
+      can_authorize: false,
+    }
     renderSelectModeWith([dormant], onConnectSelected)
     await screen.findByText("Records MCP")
 
+    // Connected, so the footer shows Configure; the card click must still
+    // not toggle a selection.
     fireEvent.click(screen.getByText("Records MCP"))
     expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
@@ -1866,7 +1951,9 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
   it("opens the detail modal on card click outside select mode", async () => {
     // The Tools page has no selection to toggle, so the card click keeps its
-    // original destination for connected and unconnected entries alike.
+    // original destination for connected and unconnected entries alike — and
+    // the Authorize trigger, which exists to explain a diverted click, stays
+    // scoped to select mode even for an authorizable entry.
     mockAppsList([unauthorizedCustomMcp()])
     render(<ConnectMcpDialog open onOpenChange={vi.fn()} selectedMcpServers={selectedMcpServers} />)
     await screen.findByText("Records MCP")

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -207,8 +207,11 @@ function deferred<T>(): Deferred<T> {
 
 // The fixtures below carry the can_attach/can_authorize pair list_mcp_apps
 // emits for each shape (#1347). They are the picker's only inputs for both
-// decisions now, so a fixture that omits them models a connector the backend
-// never emits — and would silently render every card unattachable.
+// decisions now, so any fixture reaching a select-mode assertion must carry
+// them — omitting the pair models a connector the backend never emits, and
+// renders the card unattachable with no other symptom. Inline literals in
+// tests that never enter select mode (the connect-flow tests below) are
+// exempt, and are left as they are rather than gaining two inert keys each.
 function customApiApp(id: number, name: string) {
   return {
     id: name,
@@ -1766,6 +1769,25 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
   // advertised as the one-click recovery.
   const unauthorizedCustomMcp = () => ({ ...customMcpOauthApp(), name: "Records MCP" })
 
+  // Deactivated *after* consent: toggle_mcp_server never revokes the grant, so
+  // this still lists as connected (checkmark + Configure) while the runtime's
+  // is_active filter drops it — can_attach is the only field that can say so.
+  const deactivatedCustomMcp = () => ({
+    ...unauthorizedCustomMcp(),
+    is_connected: true,
+    can_attach: false,
+    can_authorize: false,
+  })
+
+  // Deactivated *before* any consent: all four signals false and no auth_type,
+  // so the card carries no button at all. The detail modal is reachable but
+  // offers no recovery — its Connect has no auth_type to dispatch on.
+  const dormantBeforeConsent = () => {
+    const entry: Record<string, unknown> = { ...deactivatedCustomMcp(), is_connected: false }
+    delete entry.auth_type
+    return entry
+  }
+
   // Shared by renderSelectModeWith below and the non-select-mode card-click
   // test, which otherwise duplicated this exact mockImplementation block.
   function mockAppsList(apps: object[]) {
@@ -1930,13 +1952,7 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     // endpoints require an active association: this connector needs
     // re-enabling, not re-authorization.
     const onConnectSelected = vi.fn()
-    const dormant = {
-      ...unauthorizedCustomMcp(),
-      is_connected: true,
-      can_attach: false,
-      can_authorize: false,
-    }
-    renderSelectModeWith([dormant], onConnectSelected)
+    renderSelectModeWith([deactivatedCustomMcp()], onConnectSelected)
     await screen.findByText("Records MCP")
 
     // Connected, so the footer shows Configure; the card click must still
@@ -1958,13 +1974,7 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     // own list — the un-removable state #1280 was filed for. Attaching stays
     // gated; removing does not.
     const onConnectSelected = vi.fn()
-    const dormant = {
-      ...unauthorizedCustomMcp(),
-      is_connected: true,
-      can_attach: false,
-      can_authorize: false,
-    }
-    mockAppsList([dormant])
+    mockAppsList([deactivatedCustomMcp()])
     render(
       <ConnectMcpDialog
         open
@@ -1987,6 +1997,56 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     fireEvent.click(
       within(screen.getByTestId("connector-card-records")).getByText("Records MCP"),
     )
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("routes a buttonless deactivated-before-consent entry to the modal", async () => {
+    // All four signals false and no auth_type: no checkmark, no Configure, no
+    // Authorize. The card click must still reach the detail modal — that route
+    // offers no recovery for this population (Connect has no auth_type to
+    // dispatch on), but it is the only thing the card has left, and the
+    // isAttachable comment records why.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([dormantBeforeConsent()], onConnectSelected)
+    await screen.findByText("Records MCP")
+
+    expect(
+      within(screen.getByTestId("connector-card-records")).queryByTestId("connected-check"),
+    ).toBeNull()
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
+
+    fireEvent.click(screen.getByText("Records MCP"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("deselects a buttonless entry on the first click, then opens the modal on the second", async () => {
+    // The buttonless shape carries no affordance of its own, so the removal
+    // has to read from the card itself: the ring drops and the footer count
+    // decrements. The second click, with nothing left to remove, falls through
+    // to the modal like any other unattachable card.
+    const onConnectSelected = vi.fn()
+    mockAppsList([dormantBeforeConsent()])
+    render(
+      <ConnectMcpDialog
+        open
+        onOpenChange={vi.fn()}
+        selectedMcpServers={["Records MCP"]}
+        onConnectSelected={onConnectSelected}
+      />,
+    )
+    await screen.findByText("Records MCP")
+    expect(screen.getByTestId("connector-card-records")).toHaveAttribute("data-selected", "true")
+
+    fireEvent.click(screen.getByText("Records MCP"))
+    expect(screen.getByTestId("connector-card-records")).toHaveAttribute("data-selected", "false")
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("")
+
+    fireEvent.click(screen.getByText("Records MCP"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -1772,21 +1772,29 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
   // Deactivated *after* consent: toggle_mcp_server never revokes the grant, so
   // this still lists as connected (checkmark + Configure) while the runtime's
   // is_active filter drops it — can_attach is the only field that can say so.
-  const deactivatedCustomMcp = () => ({
-    ...unauthorizedCustomMcp(),
-    is_connected: true,
-    can_attach: false,
-    can_authorize: false,
-  })
-
-  // Deactivated *before* any consent: all four signals false and no auth_type,
-  // so the card carries no button at all. The detail modal is reachable but
-  // offers no recovery — its Connect has no auth_type to dispatch on.
-  const dormantBeforeConsent = () => {
-    const entry: Record<string, unknown> = { ...deactivatedCustomMcp(), is_connected: false }
+  // The grant survives; the auth_type hint does not.
+  const deactivatedCustomMcp = () => {
+    // No auth_type: the backend emits it only alongside an *active* personal
+    // association (_local_mcp_consent_association_ok), so a deactivated entry
+    // never carries one however its consent went. Deleted rather than omitted
+    // because the base factory is the connected shape, which does carry it.
+    const entry: Record<string, unknown> = {
+      ...unauthorizedCustomMcp(),
+      is_connected: true,
+      can_attach: false,
+      can_authorize: false,
+    }
     delete entry.auth_type
     return entry
   }
+
+  // Deactivated *before* any consent: the same shape with is_connected false
+  // too, so the card carries no button at all. The detail modal is reachable
+  // but offers no recovery — its Connect has no auth_type to dispatch on.
+  const dormantBeforeConsent = () => ({
+    ...deactivatedCustomMcp(),
+    is_connected: false,
+  })
 
   // Shared by renderSelectModeWith below and the non-select-mode card-click
   // test, which otherwise duplicated this exact mockImplementation block.
@@ -1942,10 +1950,11 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
   it("refuses a deactivated association even when it lists as connected", async () => {
     // toggle_mcp_server flips is_active and never revokes a completed grant,
-    // so a connector deactivated *after* consent lists as is_connected: true
-    // with auth_type — indistinguishable from an ordinary connected entry in
-    // everything the picker used to read, and attachable through the old
-    // is_connected disjunct. The runtime's server query drops inactive
+    // so a connector deactivated *after* consent still lists as
+    // is_connected: true — indistinguishable from an ordinary connected entry
+    // in the one field the old predicate's first disjunct read, and attachable
+    // through it. (auth_type is withheld here, but the old predicate never
+    // reached its second disjunct for a connected entry.) The runtime's server query drops inactive
     // associations outright, so attaching it would silently load zero tools.
     // can_attach is the only field that can carry this (#1347), and
     // can_authorize is false alongside it because the per-server OAuth

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -1949,6 +1949,48 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })
 
+  it("deselects an entry that became unattachable while already selected", async () => {
+    // can_attach can go false under a selection that already exists: a
+    // connector disabled on the Tools page after being attached, or one
+    // attached before the gate existed. The card still renders selected
+    // (isSelected reads the selection, not the gate), so refusing the click
+    // would leave it visibly selected and removable only from the builder's
+    // own list — the un-removable state #1280 was filed for. Attaching stays
+    // gated; removing does not.
+    const onConnectSelected = vi.fn()
+    const dormant = {
+      ...unauthorizedCustomMcp(),
+      is_connected: true,
+      can_attach: false,
+      can_authorize: false,
+    }
+    mockAppsList([dormant])
+    render(
+      <ConnectMcpDialog
+        open
+        onOpenChange={vi.fn()}
+        selectedMcpServers={["Records MCP"]}
+        onConnectSelected={onConnectSelected}
+      />,
+    )
+    await screen.findByText("Records MCP")
+    expect(screen.getByTestId("connector-card-records")).toHaveAttribute("data-selected", "true")
+
+    fireEvent.click(screen.getByText("Records MCP"))
+    expect(screen.getByTestId("connector-card-records")).toHaveAttribute("data-selected", "false")
+    // Removing must not have opened the modal instead.
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+
+    // And it must not be re-attachable: the gate still refuses the second click.
+    fireEvent.click(
+      within(screen.getByTestId("connector-card-records")).getByText("Records MCP"),
+    )
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
   it("opens the detail modal on card click outside select mode", async () => {
     // The Tools page has no selection to toggle, so the card click keeps its
     // original destination for connected and unconnected entries alike — and

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -976,8 +976,21 @@ export function ConnectMcpDialog({
     mcpOauthPollTimersRef.current.add(checkPopup)
   }
 
+  // Whether this entry is in the working selection, by the same id-OR-name
+  // check the card's own isSelected uses.
+  const isLocallySelected = (app: AppIntegration) =>
+    localSelectedServers.some(name => name === app.id || name === app.name)
+
   const handleCardClick = (app: AppIntegration) => {
-    if (isSelectMode && isAttachable(app)) {
+    // Deselection is not gated on can_attach (#1347). An entry can become
+    // unattachable while it is already in the selection -- a connector
+    // disabled on the Tools page after being attached, or one attached before
+    // this gate existed -- and the card still renders selected, because
+    // isSelected is computed from the selection alone. Refusing the click
+    // there would leave a visibly-selected card that clicking only ever opens
+    // a modal for, the same un-removable state #1280 was filed for. Attaching
+    // stays gated; only removing is always allowed.
+    if (isSelectMode && (isAttachable(app) || isLocallySelected(app))) {
       // Match isSelected's own check (id OR name) below, not just name: a
       // consumer (e.g. agent-builder.tsx re-seeding after save) can store
       // this connector's id instead of its display name once resolved to

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -218,7 +218,15 @@ export function ConnectMcpDialog({
   // time, and a team-owned one was refused for want of an auth_type hint.
   //
   // Entries with can_attach false keep their card-click route to the detail
-  // modal, where Connect starts the flow repaired in #1323.
+  // modal, where Connect starts the flow repaired in #1323 — for the entries
+  // that carry an auth_type to dispatch on. One population does not: an
+  // association deactivated *before* any consent completed is listed with
+  // is_connected: false and no auth_type, so the modal's Connect falls through
+  // handleConnectApp's dispatch to the mis-authored-entry toast, and nothing
+  // in the frontend calls the toggle endpoint that would re-enable it. That
+  // dead end predates this gate (the backend withholds auth_type there because
+  // "a deactivated server needs re-enabling, not re-authorization") and is
+  // tracked separately; keep it recorded here so it stays discoverable.
   const isAttachable = (app: AppIntegration) => Boolean(app.can_attach)
 
   // Whether the card may advertise interactive authorization. Separate from
@@ -976,10 +984,16 @@ export function ConnectMcpDialog({
     mcpOauthPollTimersRef.current.add(checkPopup)
   }
 
-  // Whether this entry is in the working selection, by the same id-OR-name
-  // check the card's own isSelected uses.
+  // The one id-OR-name selection check, previously written out at three
+  // sites. List-taking rather than closing over localSelectedServers, because
+  // the toggle below runs inside a functional updater and must read `prev`,
+  // not the render-time value. Deliberately does not absorb onDisconnect's
+  // case-insensitive variant, which is a different comparison.
+  const selectionMatches = (list: string[], app: AppIntegration) =>
+    list.some(name => name === app.id || name === app.name)
+
   const isLocallySelected = (app: AppIntegration) =>
-    localSelectedServers.some(name => name === app.id || name === app.name)
+    selectionMatches(localSelectedServers, app)
 
   const handleCardClick = (app: AppIntegration) => {
     // Deselection is not gated on can_attach (#1347). An entry can become
@@ -1001,7 +1015,7 @@ export function ConnectMcpDialog({
       // still selected, and clicking again just oscillated between the two
       // states without ever reaching "deselected").
       setLocalSelectedServers(prev =>
-        prev.some(name => name === app.id || name === app.name)
+        selectionMatches(prev, app)
           ? prev.filter(name => name !== app.id && name !== app.name)
           : [...prev, app.name]
       );
@@ -1305,7 +1319,7 @@ export function ConnectMcpDialog({
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                     {apps.map(app => {
                       const isGloballyConnected = isAppConnected(app)
-                      const isSelected = localSelectedServers.includes(app.id) || localSelectedServers.includes(app.name)
+                      const isSelected = isLocallySelected(app)
                       const isLoading = loadingApps.has(app.id)
                       return (
                         <Card

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -206,63 +206,27 @@ export function ConnectMcpDialog({
 
   // Whether select mode may toggle this entry into the agent's selection.
   //
-  // #1332: is_connected must not gate this for a custom mcp_oauth connector.
-  // is_connected is false for one there precisely when *this editor* holds no
-  // completed MCPOAuthGrant — but an embedding application can supply those
-  // access tokens out of band via set_oauth_token_resolver_hook (per end user,
-  // provisioned server-to-server), and then there is no interactive consent, no
-  // identity the editor could sign in as, and therefore never a grant row. The
-  // connector was permanently unattachable from the picker even though the
-  // agent create/update endpoints accept its `mcp:<name>` selector with no
-  // connected-state check and the runtime resolves credentials without a grant.
+  // Read straight off the listing, never re-derived (#1347). The decision
+  // depends on facts only the backend holds — whether the runtime will see the
+  // connector (an active association, or a team link the runtime overlays) and
+  // whether its credentials will plausibly resolve (an active MCPOAuthGrant,
+  // or a deployment-installed OAuth token resolver hook that supplies tokens
+  // out of band). This predicate previously reconstructed all of that from
+  // is_connected + is_custom + auth_type, which made three unstated backend
+  // emission rules load-bearing here and still got two populations wrong: a
+  // never-authorized custom mcp_oauth server attached and then failed at run
+  // time, and a team-owned one was refused for want of an auth_type hint.
   //
-  // A custom mcp_oauth server whose consent was simply never started, or was
-  // abandoned partway, is indistinguishable in this listing from a
-  // hook-resolved one — create_mcp_server writes the association row at
-  // creation time, long before any consent, so is_connected is false either
-  // way. This predicate makes that server attachable too: the card shows no
-  // checkmark and offers Authorize as a one-click recovery, and the agent
-  // create/update endpoints never validated connected state to begin with.
-  //
-  // Both conjuncts are load-bearing, and neither can be widened:
-  //
-  // - is_custom, because a *catalog* mcp_oauth app (e.g. Granola) carries the
-  //   same auth_type while is_connected: false there means the user has no
-  //   association row for it at all. Connecting really is a prerequisite, so
-  //   attaching it would select a connector that does not exist for them.
-  // - auth_type, because the backend emits it on a local entry only when a
-  //   personal association exists, is active, and the server is the
-  //   mcp_oauth shape (see list_mcp_apps). One consequence, once #1338's team
-  //   visibility overlay is in the tree (it is on main, but landed after this
-  //   branch was cut, so the population is not reproducible from this
-  //   branch's own backend): a team-owned connector the overlay surfaces has
-  //   no personal association, so it gets no auth_type either, and this
-  //   predicate routes it to the detail modal instead of making it
-  //   attachable. #1347 tracks expressing that case as attachable-but-not-
-  //   authorizable rather than deciding it by an absent hint.
-  //
-  //   An association deactivated before any grant completed is likewise
-  //   listed with is_connected: false and no auth_type, so it keeps its
-  //   existing card-click route to the detail modal — and that route offers
-  //   no recovery today: the modal's Connect button has no auth_type to
-  //   dispatch on, so it falls through to the mis-authored-entry toast, and
-  //   nothing in the frontend calls the toggle endpoint that would
-  //   reactivate the association. (list_mcp_apps withholds auth_type here
-  //   because, in its own words, "a deactivated server needs re-enabling,
-  //   not re-authorization" — that is the backend's rationale for omitting
-  //   the field, not a recovery this modal actually offers.) Regardless, the
-  //   runtime's server query drops inactive associations outright, so
-  //   attaching one would have loaded zero tools.
-  //
-  //   Deactivation *after* consent is a different, pre-existing story:
-  //   toggle_mcp_server only flips is_active and never revokes the grant, so
-  //   such an entry lists as is_connected: true and is attachable through the
-  //   first conjunct regardless of this one — showing the checkmark plus
-  //   Configure, never Authorize. The runtime still drops it, but the old gate
-  //   was is_connected alone, so that card behaves here exactly as it did
-  //   before this predicate existed.
-  const isAttachable = (app: AppIntegration) =>
-    isAppConnected(app) || (Boolean(app.is_custom) && app.auth_type === "mcp_oauth")
+  // Entries with can_attach false keep their card-click route to the detail
+  // modal, where Connect starts the flow repaired in #1323.
+  const isAttachable = (app: AppIntegration) => Boolean(app.can_attach)
+
+  // Whether the card may advertise interactive authorization. Separate from
+  // isAttachable because the two genuinely diverge: a hook-resolved connector
+  // (#1332) and a team-owned one (#1338) are both attachable while neither has
+  // a consent flow this editor could complete — the first has none at all, the
+  // second would 404 on /{server_id}/oauth/connect.
+  const canAuthorize = (app: AppIntegration) => Boolean(app.can_authorize)
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300)
@@ -1403,22 +1367,26 @@ export function ConnectMcpDialog({
                                   >
                                     <Settings className="h-3 w-3 mr-1" /> {t('tools.mcp.dialog.configure')}
                                   </Button>
-                                ) : isSelectMode && isAttachable(app) ? (
-                                  // #1332: in select mode the card click now
-                                  // toggles selection for these entries, so it
-                                  // no longer opens the detail modal — which is
-                                  // where the per-server OAuth flow repaired in
-                                  // #1323 is started from. Keep that route
-                                  // reachable with its own trigger instead of
-                                  // dropping it, for editors who do authorize
-                                  // personally.
+                                ) : isSelectMode && canAuthorize(app) ? (
+                                  // One-click entry to the per-server OAuth
+                                  // flow repaired in #1323, kept from #1332
+                                  // where the card click stopped reaching the
+                                  // detail modal it is started from.
                                   //
-                                  // Keyed on isAttachable, not its own
-                                  // predicate, so this stays exactly the set of
-                                  // cards whose click was diverted to selection:
-                                  // every entry that loses the modal route gets
-                                  // this trigger, and no entry that kept the
-                                  // route gets a redundant second one.
+                                  // Driven by can_authorize alone (#1347), not
+                                  // by the attach gate: those two now select
+                                  // disjoint populations. An entry that is
+                                  // attachable-but-unconnected got there
+                                  // through hook-supplied credentials or a team
+                                  // link, and has no consent this editor could
+                                  // complete — the button asserted "needs
+                                  // authorization" and opened a popup that
+                                  // could never finish. What is left is the
+                                  // connector whose consent was never started:
+                                  // not attachable until it is, so its card
+                                  // click still opens the modal, and this
+                                  // labels that route rather than leaving the
+                                  // one card in a grid of toggles unexplained.
                                   <Button
                                     variant="ghost"
                                     size="sm"

--- a/frontend/src/components/mcp/types.ts
+++ b/frontend/src/components/mcp/types.ts
@@ -32,6 +32,20 @@ export interface AppIntegration {
   user_env_configured?: boolean
   // Key-based apps: the user's current env-source pick, if any.
   env_source?: "own" | "shared" | "platform" | null
+  // Whether this entry may be selected into an agent, decided by the backend
+  // (list_mcp_apps._local_mcp_can_attach) rather than re-derived here from
+  // is_connected/is_custom/auth_type. It answers "the runtime will see this
+  // connector and its credentials will plausibly resolve", which depends on
+  // backend-only facts — grant state, team links, and whether the deployment
+  // installed an OAuth token resolver hook (#1347).
+  can_attach?: boolean
+  // Whether starting the per-server MCP OAuth flow is meaningful for this
+  // entry. False for catalog entries (they connect through
+  // /apps/{id}/oauth/connect, dispatched on auth_type), for a connector with
+  // no active personal association (the per-server route would 404), and for
+  // a deployment whose tokens arrive through the resolver hook, where no
+  // interactive consent exists at all.
+  can_authorize?: boolean
   // Team-sharing status (from POST /api/connectors/status), merged in after list load.
   shared?: boolean
   is_owner?: boolean

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1863,39 +1863,23 @@ def _local_mcp_can_attach(
 ) -> bool:
     """Whether a local entry may be selected into an agent (#1347).
 
-    Two independent conditions:
+    Visible to the runtime AND credentials that plausibly resolve. Visibility
+    is delegated, never restated -- ``connector_visible_to_user`` is where the
+    "``is_active`` gates only the personal arm" corner lives. Credentials gate
+    only the mcp_oauth shape; every other shape carries them on the server row
+    and its env layers.
 
-    - The runtime must see the connector at all. Delegated to
-      ``connector_visible_to_user``, the in-Python twin of the
-      ``visible_*_clause`` predicates, so this endpoint expresses the
-      visibility rule the same way the runtime loader and the SQL clauses do
-      instead of restating it. Restating it is what produced the bug this
-      argument exists to fix: ``is_active`` gates only the *personal* arm, so
-      a team-visible connector stays attachable through a deactivated personal
-      link, which a bare ``user_mcp.is_active`` check refused while
-      ``_load_visible_runtime_connectors`` loaded it.
-    - Credentials must plausibly resolve. Only the mcp_oauth shape can fail
-      this: every other shape carries its credentials on the server row and its
-      env layers. An mcp_oauth server needs an active ``MCPOAuthGrant`` for the
-      requesting user, or a resolver hook that may supply tokens out of band --
-      the latter being deployment-level and coarse by necessity, see
-      ``oauth_token_resolver_installed``.
+    Both credential terms are approximations, loose in one direction only
+    (may say yes where the runtime later says no, never no where it would have
+    succeeded):
 
-    Two approximations, both deliberate and both loose in the same direction
-    (this may say yes where the runtime later says no; it never says no where
-    the runtime would have succeeded):
-
-    - The grant check accepts any active ``MCPOAuthGrant`` for the user, while
-      the runtime's ``select_mcp_oauth_grants`` additionally matches
-      canonicalized resource, issuer, ``resource_owner_key``, configured
-      ``client_id``, and a required-scope subset. Editing a server's auth
-      config does not reconcile existing grants, so an edited server can
-      report attachable and still fail at run time. Narrowing this belongs at
-      the source (revoking grants the edit invalidates), not in a fourth copy
-      of that six-term predicate here.
+    - Any active ``MCPOAuthGrant`` counts, while the runtime's
+      ``select_mcp_oauth_grants`` also matches resource, issuer,
+      ``resource_owner_key``, ``client_id`` and a scope subset. Auth-config
+      edits do not reconcile grants (#1388); narrowing belongs there, not in a
+      fourth copy of that predicate here.
     - The resolver hook is probed for presence, not for this provider and
-      user; a truthful answer would mean one embedder round-trip per listed
-      connector on a list request.
+      user -- see ``oauth_token_resolver_installed``.
     """
     from ..services.connector_team_scope import connector_visible_to_user
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -12,6 +12,7 @@ import json
 import logging
 import secrets
 import shlex
+from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Callable, Dict, List, Literal, Optional, Union, cast
@@ -1856,20 +1857,23 @@ def _local_mcp_can_attach(
     server: MCPServer,
     user_mcp: Optional[UserMCPServer],
     *,
+    team_mcp_ids: Collection[int],
     active_grant_server_ids: set[int],
     token_resolver_installed: bool,
 ) -> bool:
     """Whether a local entry may be selected into an agent (#1347).
 
-    Two independent conditions, matching what the runtime actually does with
-    the selection in ``_load_visible_runtime_connectors``:
+    Two independent conditions:
 
-    - The runtime resolves a server through the user's own *active*
-      association, or through the team link the visibility hook reports. A
-      deactivated personal association is dropped there, so attaching it would
-      load zero tools; ``user_mcp is None`` means the entry reached this
-      listing through the team overlay alone (#1338), which the runtime
-      overlays identically.
+    - The runtime must see the connector at all. Delegated to
+      ``connector_visible_to_user``, the in-Python twin of the
+      ``visible_*_clause`` predicates, so this endpoint expresses the
+      visibility rule the same way the runtime loader and the SQL clauses do
+      instead of restating it. Restating it is what produced the bug this
+      argument exists to fix: ``is_active`` gates only the *personal* arm, so
+      a team-visible connector stays attachable through a deactivated personal
+      link, which a bare ``user_mcp.is_active`` check refused while
+      ``_load_visible_runtime_connectors`` loaded it.
     - Credentials must plausibly resolve. Only the mcp_oauth shape can fail
       this: every other shape carries its credentials on the server row and its
       env layers. An mcp_oauth server needs an active ``MCPOAuthGrant`` for the
@@ -1877,20 +1881,55 @@ def _local_mcp_can_attach(
       the latter being deployment-level and coarse by necessity, see
       ``oauth_token_resolver_installed``.
 
-    Before this field the picker re-derived the decision from
-    ``is_connected``/``is_custom``/``auth_type`` and got a strictly looser
-    answer: a custom mcp_oauth server whose consent was never started was
-    attachable in every deployment and failed at run time with "MCP server
-    credentials are unavailable". Standalone xagent installs no resolver, so
-    that population now fails early instead, with the detail modal's Connect
-    (#1323) as its recovery.
+    Two approximations, both deliberate and both loose in the same direction
+    (this may say yes where the runtime later says no; it never says no where
+    the runtime would have succeeded):
+
+    - The grant check accepts any active ``MCPOAuthGrant`` for the user, while
+      the runtime's ``select_mcp_oauth_grants`` additionally matches
+      canonicalized resource, issuer, ``resource_owner_key``, configured
+      ``client_id``, and a required-scope subset. Editing a server's auth
+      config does not reconcile existing grants, so an edited server can
+      report attachable and still fail at run time. Narrowing this belongs at
+      the source (revoking grants the edit invalidates), not in a fourth copy
+      of that six-term predicate here.
+    - The resolver hook is probed for presence, not for this provider and
+      user; a truthful answer would mean one embedder round-trip per listed
+      connector on a list request.
     """
-    association_ok = user_mcp is None or bool(user_mcp.is_active)
-    if not association_ok:
+    from ..services.connector_team_scope import connector_visible_to_user
+
+    if not connector_visible_to_user(
+        association=user_mcp,
+        connector_id=cast(int, server.id),
+        team_ids=team_mcp_ids,
+    ):
         return False
     if not _is_mcp_oauth_server(server):
         return True
     return cast(int, server.id) in active_grant_server_ids or token_resolver_installed
+
+
+def _local_mcp_consent_association_ok(
+    server: MCPServer, user_mcp: Optional[UserMCPServer]
+) -> bool:
+    """Whether ``POST /api/mcp/{server_id}/oauth/connect`` would resolve.
+
+    The endpoint calls ``_get_user_mcp_server_or_404(..., require_active=True)``
+    on the mcp_oauth shape, so all three terms are the endpoint's own
+    preconditions. Deliberately *not* the visibility rule above: a team-owned
+    row (``user_mcp is None``) is visible and attachable, yet has no personal
+    association for that route to resolve, so consent there would 404.
+
+    Shared by ``can_authorize`` and the ``auth_type`` hint below, which is the
+    same condition plus, respectively, the resolver term and nothing -- they
+    used to be two textual copies that could drift apart silently.
+    """
+    return (
+        user_mcp is not None
+        and bool(user_mcp.is_active)
+        and _is_mcp_oauth_server(server)
+    )
 
 
 def _local_mcp_can_authorize(
@@ -1907,17 +1946,14 @@ def _local_mcp_can_authorize(
     on ``auth_type`` as they always have, and deliberately report ``False``
     here rather than having this field restate that dispatch.
 
-    Three ways the flow is not meaningful:
-
-    - The server is not the mcp_oauth shape, so there is no consent to give.
-    - The user holds no active personal association. The endpoint resolves one
-      with ``require_active=True`` and 404s otherwise, so both a team-owned row
-      (``user_mcp is None``, #1338) and a deactivated one would dead-end in a
-      failed popup -- the latter needs re-enabling, not re-authorization.
-    - A resolver hook supplies this deployment's tokens out of band. There is
-      then no interactive consent and no identity the editor could sign in as,
-      so the trigger would assert "needs authorization" against a connector
-      that has no authorization step at all (#1332).
+    False in three cases: the endpoint's own preconditions fail (see
+    ``_local_mcp_consent_association_ok`` -- not the mcp_oauth shape, no
+    personal association, or a deactivated one, which needs re-enabling rather
+    than re-authorization); or a resolver hook supplies this deployment's
+    tokens out of band, where there is no interactive consent and no identity
+    the editor could sign in as, so the trigger would assert "needs
+    authorization" against a connector that has no authorization step at all
+    (#1332).
 
     Unlike ``can_attach`` this does not consider grant state: re-consenting an
     already-granted server is legitimate, and the picker gates the trigger on
@@ -1925,9 +1961,7 @@ def _local_mcp_can_authorize(
     """
     if token_resolver_installed:
         return False
-    if user_mcp is None or not user_mcp.is_active:
-        return False
-    return _is_mcp_oauth_server(server)
+    return _local_mcp_consent_association_ok(server, user_mcp)
 
 
 @mcp_router.get("/apps", response_model=List[dict])
@@ -2108,7 +2142,10 @@ def list_mcp_apps(
         # me*", which only a personal association can establish. Standalone
         # deployments install no hook, resolve empty, and take the same path
         # they always did.
-        from ..services.connector_team_scope import visible_team_connector_ids
+        from ..services.connector_team_scope import (
+            connector_visible_to_user,
+            visible_team_connector_ids,
+        )
 
         team_ids = visible_team_connector_ids(db, cast(int, current_user.id))
 
@@ -2166,6 +2203,7 @@ def list_mcp_apps(
                 "can_attach": _local_mcp_can_attach(
                     server,
                     user_mcp,
+                    team_mcp_ids=team_ids["mcp"],
                     active_grant_server_ids=active_grant_server_ids,
                     token_resolver_installed=token_resolver_installed,
                 ),
@@ -2198,11 +2236,7 @@ def list_mcp_apps(
             # advertise consent" and additionally goes false when a resolver
             # hook supplies the tokens. Keeping them separate is what let the
             # picker stop reading auth_type as an attachability hint (#1347).
-            if (
-                user_mcp is not None
-                and user_mcp.is_active
-                and _is_mcp_oauth_server(server)
-            ):
+            if _local_mcp_consent_association_ok(server, user_mcp):
                 entry["auth_type"] = "mcp_oauth"
 
             results.append(entry)
@@ -2261,11 +2295,15 @@ def list_mcp_apps(
                     # has no OAuth consent step of any kind, so credentials
                     # never gate it and consent is never meaningful -- which is
                     # also why this loop reports is_connected: True
-                    # unconditionally. Only the association gate applies, and
-                    # for the same reason as the MCP half: the runtime's own
-                    # query filters UserCustomApi.is_active, so a deactivated
-                    # API would load zero tools if attached.
-                    "can_attach": user_api is None or bool(user_api.is_active),
+                    # unconditionally. Only visibility applies, through the
+                    # same shared predicate as the MCP half: the runtime drops
+                    # a deactivated personal link, but re-adds the team arm, so
+                    # a team-visible API stays attachable through one.
+                    "can_attach": connector_visible_to_user(
+                        association=user_api,
+                        connector_id=cast(int, api.id),
+                        team_ids=team_ids["custom_api"],
+                    ),
                     "can_authorize": False,
                     "runtime_input_schema": api.runtime_input_schema,
                     "runtime_bindings": api.runtime_bindings,

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1852,6 +1852,84 @@ def _mcp_oauth_server_is_actually_connected(
     return cast(int, server.id) in active_grant_server_ids
 
 
+def _local_mcp_can_attach(
+    server: MCPServer,
+    user_mcp: Optional[UserMCPServer],
+    *,
+    active_grant_server_ids: set[int],
+    token_resolver_installed: bool,
+) -> bool:
+    """Whether a local entry may be selected into an agent (#1347).
+
+    Two independent conditions, matching what the runtime actually does with
+    the selection in ``_load_visible_runtime_connectors``:
+
+    - The runtime resolves a server through the user's own *active*
+      association, or through the team link the visibility hook reports. A
+      deactivated personal association is dropped there, so attaching it would
+      load zero tools; ``user_mcp is None`` means the entry reached this
+      listing through the team overlay alone (#1338), which the runtime
+      overlays identically.
+    - Credentials must plausibly resolve. Only the mcp_oauth shape can fail
+      this: every other shape carries its credentials on the server row and its
+      env layers. An mcp_oauth server needs an active ``MCPOAuthGrant`` for the
+      requesting user, or a resolver hook that may supply tokens out of band --
+      the latter being deployment-level and coarse by necessity, see
+      ``oauth_token_resolver_installed``.
+
+    Before this field the picker re-derived the decision from
+    ``is_connected``/``is_custom``/``auth_type`` and got a strictly looser
+    answer: a custom mcp_oauth server whose consent was never started was
+    attachable in every deployment and failed at run time with "MCP server
+    credentials are unavailable". Standalone xagent installs no resolver, so
+    that population now fails early instead, with the detail modal's Connect
+    (#1323) as its recovery.
+    """
+    association_ok = user_mcp is None or bool(user_mcp.is_active)
+    if not association_ok:
+        return False
+    if not _is_mcp_oauth_server(server):
+        return True
+    return cast(int, server.id) in active_grant_server_ids or token_resolver_installed
+
+
+def _local_mcp_can_authorize(
+    server: MCPServer,
+    user_mcp: Optional[UserMCPServer],
+    *,
+    token_resolver_installed: bool,
+) -> bool:
+    """Whether starting the per-server MCP OAuth flow is meaningful (#1347).
+
+    Scoped to ``POST /api/mcp/{server_id}/oauth/connect``, the route the
+    picker's card-level Authorize trigger starts. Catalog entries connect
+    through ``/apps/{app_id}/oauth/connect`` (or the provider login) dispatched
+    on ``auth_type`` as they always have, and deliberately report ``False``
+    here rather than having this field restate that dispatch.
+
+    Three ways the flow is not meaningful:
+
+    - The server is not the mcp_oauth shape, so there is no consent to give.
+    - The user holds no active personal association. The endpoint resolves one
+      with ``require_active=True`` and 404s otherwise, so both a team-owned row
+      (``user_mcp is None``, #1338) and a deactivated one would dead-end in a
+      failed popup -- the latter needs re-enabling, not re-authorization.
+    - A resolver hook supplies this deployment's tokens out of band. There is
+      then no interactive consent and no identity the editor could sign in as,
+      so the trigger would assert "needs authorization" against a connector
+      that has no authorization step at all (#1332).
+
+    Unlike ``can_attach`` this does not consider grant state: re-consenting an
+    already-granted server is legitimate, and the picker gates the trigger on
+    unconnected state itself.
+    """
+    if token_resolver_installed:
+        return False
+    if user_mcp is None or not user_mcp.is_active:
+        return False
+    return _is_mcp_oauth_server(server)
+
+
 @mcp_router.get("/apps", response_model=List[dict])
 def list_mcp_apps(
     search: Optional[str] = None,
@@ -1932,6 +2010,12 @@ def list_mcp_apps(
         .all()
     }
 
+    # Read once for the whole response: the hook is a process-global, so every
+    # entry in one listing must be decided against the same answer.
+    from ..tools.config import oauth_token_resolver_installed
+
+    token_resolver_installed = oauth_token_resolver_installed()
+
     if location in ["remote", "all"]:
         for app in library_apps:
             if app.get("auth_type") == "builtin_oauth":
@@ -1992,6 +2076,12 @@ def list_mcp_apps(
 
             app_copy = app.copy()
             app_copy["is_connected"] = is_connected
+            # A catalog app the user never connected has no association row at
+            # all, so there is no connector to attach -- connecting really is
+            # the prerequisite. Stating that here is what stops the picker from
+            # inferring it from is_custom's absence on this branch (#1347).
+            app_copy["can_attach"] = is_connected
+            app_copy["can_authorize"] = False
             app_copy["shared_env_available"] = app_shared_env
             app_copy["platform_env_available"] = app_platform_env
             app_copy["user_env_configured"] = app_user_env
@@ -2073,6 +2163,17 @@ def list_mcp_apps(
                 "is_local": True,
                 "server_id": server.id,
                 "is_custom": True,
+                "can_attach": _local_mcp_can_attach(
+                    server,
+                    user_mcp,
+                    active_grant_server_ids=active_grant_server_ids,
+                    token_resolver_installed=token_resolver_installed,
+                ),
+                "can_authorize": _local_mcp_can_authorize(
+                    server,
+                    user_mcp,
+                    token_resolver_installed=token_resolver_installed,
+                ),
             }
             # The picker dispatches its Connect button on auth_type, and custom
             # entries used to omit the field entirely — so an mcp_oauth server
@@ -2090,6 +2191,13 @@ def list_mcp_apps(
             # excluded for the same reason, more strongly: the member holds no
             # association at all, so /{server_id}/oauth/connect would 404 and
             # the advertised flow would dead-end in a failed popup.
+            #
+            # can_authorize above repeats those last two exclusions on purpose:
+            # this field still answers "which Connect flow does the settings
+            # dialog dispatch", while can_authorize answers "may the picker
+            # advertise consent" and additionally goes false when a resolver
+            # hook supplies the tokens. Keeping them separate is what let the
+            # picker stop reading auth_type as an attachability hint (#1347).
             if (
                 user_mcp is not None
                 and user_mcp.is_active
@@ -2108,19 +2216,23 @@ def list_mcp_apps(
         )
 
         # Same overlay as the MCP half above: a team-owned Custom API has no
-        # UserCustomApi row for the member. Nothing in the entry below reads
-        # the association, so team-owned APIs need no stand-in — only the id.
-        local_custom_apis: list[CustomApi] = [
-            api for _user_api, api in user_custom_apis
+        # UserCustomApi row for the member, so it is carried as (api, None).
+        # The association is read only for can_attach below — a team-owned API
+        # is one the runtime overlays by id, exactly like the MCP half.
+        local_custom_apis: list[tuple[CustomApi, UserCustomApi | None]] = [
+            (api, user_api) for user_api, api in user_custom_apis
         ]
-        own_api_ids = {cast(int, api.id) for api in local_custom_apis}
+        own_api_ids = {cast(int, api.id) for api, _ in local_custom_apis}
         missing_api = [aid for aid in team_ids["custom_api"] if aid not in own_api_ids]
         if missing_api:
             local_custom_apis.extend(
-                db.query(CustomApi).filter(CustomApi.id.in_(missing_api)).all()
+                (api, None)
+                for api in db.query(CustomApi)
+                .filter(CustomApi.id.in_(missing_api))
+                .all()
             )
 
-        for api in local_custom_apis:
+        for api, user_api in local_custom_apis:
             if search:
                 search_lower = search.lower()
                 if search_lower not in api.name.lower() and (
@@ -2145,6 +2257,16 @@ def list_mcp_apps(
                     "is_local": True,
                     "server_id": api.id,
                     "is_custom": True,
+                    # A Custom API carries its own credentials on the row and
+                    # has no OAuth consent step of any kind, so credentials
+                    # never gate it and consent is never meaningful -- which is
+                    # also why this loop reports is_connected: True
+                    # unconditionally. Only the association gate applies, and
+                    # for the same reason as the MCP half: the runtime's own
+                    # query filters UserCustomApi.is_active, so a deactivated
+                    # API would load zero tools if attached.
+                    "can_attach": user_api is None or bool(user_api.is_active),
+                    "can_authorize": False,
                     "runtime_input_schema": api.runtime_input_schema,
                     "runtime_bindings": api.runtime_bindings,
                     "allow_delegated_authorization": bool(

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -252,6 +252,30 @@ def resolve_team_connector_ids_or_raise(
         ) from exc
 
 
+def connector_visible_to_user(
+    *, association: Any, connector_id: int, team_ids: Collection[int]
+) -> bool:
+    """In-Python twin of the ``visible_*_clause`` predicates below.
+
+    Same rule, expressed for callers that hold already-loaded ORM rows rather
+    than a query to filter: an active personal association, unioned with the
+    team-owned ids. ``is_active`` gates only the personal arm, so a
+    team-visible connector stays visible through a deactivated personal link
+    -- the corner that separates this from a naive ``association.is_active``
+    check, and the one ``/api/mcp/apps`` got wrong before #1384.
+
+    ``association`` is the ``UserMCPServer``/``UserCustomApi`` row, or None
+    when the caller resolved the connector through the team overlay alone.
+    Kept beside the clauses so the three expressions of this rule (here, the
+    clauses, and ``_load_visible_runtime_connectors``) live in one module and
+    move together.
+    """
+
+    if association is not None and bool(association.is_active):
+        return True
+    return connector_id in set(team_ids)
+
+
 def visible_mcp_server_clause(
     owner_user_id: int | None, team_mcp_ids: Collection[int]
 ) -> ColumnElement[bool]:

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Collection
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from sqlalchemy.sql.elements import ColumnElement
+
+if TYPE_CHECKING:
+    from ..models.custom_api import UserCustomApi
+    from ..models.mcp import UserMCPServer
 
 from ...core.tools.adapters.vibe.connector_runtime import (
     ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
@@ -253,7 +257,10 @@ def resolve_team_connector_ids_or_raise(
 
 
 def connector_visible_to_user(
-    *, association: Any, connector_id: int, team_ids: Collection[int]
+    *,
+    association: "UserMCPServer | UserCustomApi | None",
+    connector_id: int,
+    team_ids: Collection[int],
 ) -> bool:
     """In-Python twin of the ``visible_*_clause`` predicates below.
 
@@ -264,16 +271,16 @@ def connector_visible_to_user(
     -- the corner that separates this from a naive ``association.is_active``
     check, and the one ``/api/mcp/apps`` got wrong before #1384.
 
-    ``association`` is the ``UserMCPServer``/``UserCustomApi`` row, or None
-    when the caller resolved the connector through the team overlay alone.
-    Kept beside the clauses so the three expressions of this rule (here, the
-    clauses, and ``_load_visible_runtime_connectors``) live in one module and
-    move together.
+    ``association`` is None when the caller resolved the connector through the
+    team overlay alone. Kept beside the clauses it mirrors so the declarative
+    and imperative forms of the rule move together;
+    ``_load_visible_runtime_connectors`` expresses the same union a third time
+    in connector_runtime.py, against its own queries.
     """
 
     if association is not None and bool(association.is_active):
         return True
-    return connector_id in set(team_ids)
+    return connector_id in team_ids
 
 
 def visible_mcp_server_clause(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -174,6 +174,25 @@ def _get_oauth_token_resolver_hook() -> tuple[TokenResolver | None, int]:
     return _oauth_token_resolver_hook, _oauth_token_resolver_generation
 
 
+def oauth_token_resolver_installed() -> bool:
+    """Whether an embedding application registered a token resolver hook.
+
+    Deployment-level, not per-connector: the resolver is keyed on provider and
+    end user and is embedder-implemented, so the only question answerable
+    without calling it -- once per listed connector, on a list request, with
+    unknown side effects -- is whether one exists at all. Read by
+    ``list_mcp_apps`` to decide whether an mcp_oauth connector can plausibly
+    obtain credentials without an ``MCPOAuthGrant``, and whether advertising
+    interactive consent for it is meaningful (#1347).
+
+    Selection is on hook presence, mirroring ``team_env_hook_installed``: an
+    installed resolver that answers ``None`` for a given provider is a
+    legitimate answer, not an absent hook.
+    """
+    resolver, _ = _get_oauth_token_resolver_hook()
+    return resolver is not None
+
+
 def _oauth_token_resolver_registration_matches(
     resolver: TokenResolver, registration_generation: int
 ) -> bool:

--- a/tests/web/api/test_mcp_apps_attachability.py
+++ b/tests/web/api/test_mcp_apps_attachability.py
@@ -475,6 +475,83 @@ def test_a_team_owned_connector_is_never_authorizable_even_holding_a_grant(
     assert entry["can_authorize"] is False
 
 
+def test_a_team_link_survives_a_deactivated_personal_association(db_session):
+    """`is_active` gates only the *personal* arm of the visibility rule.
+
+    A member who holds both a (deactivated) personal association and a team
+    link is carried into the listing as (server, inactive_user_mcp) -- the
+    overlay skips ids already covered personally -- so a bare
+    `user_mcp.is_active` check refuses it. The runtime does the opposite:
+    `_load_visible_runtime_connectors` drops the inactive personal link and
+    then re-adds the team ids, which `visible_mcp_server_clause` states
+    outright. Refusing here would be a fail-early on a connector that loads
+    fine."""
+    db, owner, member = db_session
+    server = _add_stdio_server(db, owner)
+    db.add(
+        UserMCPServer(
+            user_id=member.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=False,
+        )
+    )
+    db.commit()
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    assert _entry(db, member, "files")["can_attach"] is True
+
+    # Without the team link the same row is refused -- the personal arm still
+    # gates, so this pins the team arm rather than the removal of the check.
+    connector_team_scope.set_connector_team_hooks()
+    assert _entry(db, member, "files")["can_attach"] is False
+
+
+def test_a_team_link_survives_a_deactivated_custom_api_association(db_session):
+    """The Custom API half of the same rule (`visible_custom_api_clause`)."""
+    db, owner, member = db_session
+    api = _add_custom_api(db, owner)
+    db.add(
+        UserCustomApi(
+            user_id=member.id,
+            custom_api_id=api.id,
+            is_owner=False,
+            is_active=False,
+        )
+    )
+    db.commit()
+    _install_visibility({int(member.id): {"mcp": set(), "custom_api": {int(api.id)}}})
+
+    assert _entry(db, member, "billing")["can_attach"] is True
+
+    connector_team_scope.set_connector_team_hooks()
+    assert _entry(db, member, "billing")["can_attach"] is False
+
+
+def test_auth_type_and_can_authorize_agree_on_the_consent_preconditions(db_session):
+    """`auth_type` and `can_authorize` share one predicate and must not drift.
+
+    They answer different questions -- which Connect flow the settings dialog
+    dispatches, and whether the picker may advertise consent -- but the second
+    is exactly the first plus the resolver term. Pinned as an algebraic
+    relation so an edit to either condition alone fails here."""
+    db, owner, _member = db_session
+    _add_oauth_server(db, owner)
+
+    entry = _entry(db, owner, "records")
+    assert entry["auth_type"] == "mcp_oauth"
+    assert entry["can_authorize"] is True
+
+    # Installing the resolver must move can_authorize alone: auth_type keeps
+    # answering the dispatch question, which the hook does not change.
+    _install_token_resolver()
+    entry = _entry(db, owner, "records")
+    assert entry["auth_type"] == "mcp_oauth"
+    assert entry["can_authorize"] is False
+
+
 def test_a_team_owned_non_oauth_connector_is_attachable_standalone_of_any_hook(
     db_session,
 ):
@@ -497,6 +574,56 @@ def test_a_team_owned_custom_api_is_attachable(db_session):
     _install_visibility({int(member.id): {"mcp": set(), "custom_api": {int(api.id)}}})
 
     assert _entry(db, member, "billing")["can_attach"] is True
+
+
+def test_a_connected_catalog_app_is_attachable(db_session):
+    """The positive half of the catalog rule, and the branch's largest
+    population by far. `is_connected` there means an active association to the
+    server row the connect route writes under the catalog app id -- a stdio
+    app, so no grant is involved and the credential gate cannot mask a
+    regression in the association half. The app id must stay outside the
+    builtin registry: `_app_to_dict` lets a builtin entry override the stored
+    transport and launch_config, which would silently reshape this fixture."""
+    db, owner, _member = db_session
+    app = PublicMCPApp(
+        app_id="acme-docs",
+        name="Acme Docs",
+        description="A catalog app",
+        icon="",
+        category="Productivity",
+        transport="stdio",
+        launch_config={"command": "acme-docs-mcp"},
+        is_visible_in_connector=True,
+    )
+    db.add(app)
+    db.commit()
+    # The connect route stores the row under the catalog app_id, which is how
+    # _connected_non_oauth_server_for_app resolves it back.
+    server = MCPServer.from_config(
+        {
+            "name": "acme-docs",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "acme-docs-mcp",
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=owner.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    entry = _entry(db, owner, "acme-docs", location="remote")
+    assert entry["is_connected"] is True
+    assert entry["can_attach"] is True
+    assert entry["can_authorize"] is False
 
 
 # --- Every entry carries both fields ---------------------------------------

--- a/tests/web/api/test_mcp_apps_attachability.py
+++ b/tests/web/api/test_mcp_apps_attachability.py
@@ -1,0 +1,518 @@
+"""`/api/mcp/apps` must emit its attachability decisions, not their inputs
+(#1347).
+
+The connector picker used to reconstruct two decisions from
+`is_connected` + `is_custom` + `auth_type`, which made three unstated backend
+emission rules load-bearing on the client: that `is_connected` for an
+mcp_oauth entry requires an active grant, that `auth_type` appears on a local
+entry only alongside an active personal association, and that `is_custom` is
+never set by the catalog branch. These tests pin `can_attach` and
+`can_authorize` directly, so changing any of those rules fails here instead of
+silently mis-gating the picker.
+
+The two fields answer different questions and diverge on real populations:
+a team-owned mcp_oauth connector is attachable but has no consent flow the
+member could start, and a hook-resolved connector is attachable with no
+consent flow existing at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api.mcp import list_mcp_apps
+from xagent.web.models.custom_api import CustomApi, UserCustomApi
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.mcp_oauth import MCPOAuthClient, MCPOAuthGrant
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.services import connector_team_scope
+from xagent.web.tools.config import TokenRequest, set_oauth_token_resolver_hook
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "mcp-apps-attachability.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    owner = User(username="alice", password_hash="x", is_admin=False)
+    member = User(username="bob", password_hash="x", is_admin=False)
+    db.add_all([owner, member])
+    db.commit()
+    db.refresh(owner)
+    db.refresh(member)
+
+    yield db, owner, member
+    db.close()
+    engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_global_hooks():
+    """Both hooks are process-global; never leak one into a sibling test."""
+    yield
+    connector_team_scope.set_connector_team_hooks()
+    set_oauth_token_resolver_hook(None)
+
+
+def _install_token_resolver() -> None:
+    """Install a resolver hook shaped like an embedder's.
+
+    Its answers are irrelevant: `can_attach`/`can_authorize` are decided on
+    hook *presence*, because a truthful per-connector answer would mean one
+    embedder round-trip per listed connector on every list request.
+    """
+
+    def resolver(_request: TokenRequest) -> None:
+        raise AssertionError("list_mcp_apps must never invoke the resolver")
+
+    set_oauth_token_resolver_hook(resolver)
+
+
+def _install_visibility(mapping: dict[int, dict[str, set[int]]]) -> None:
+    def visibility(_db, user_id: int) -> dict[str, set[int]]:
+        answer = mapping.get(int(user_id))
+        if answer is None:
+            return {"mcp": set(), "custom_api": set()}
+        return {"mcp": set(answer["mcp"]), "custom_api": set(answer["custom_api"])}
+
+    connector_team_scope.set_connector_team_hooks(visibility=visibility)
+
+
+def _add_oauth_server(
+    db,
+    owner: User | None,
+    name: str = "records",
+    *,
+    is_active: bool = True,
+) -> MCPServer:
+    """An mcp_oauth-shaped custom server. ``owner=None`` writes no association
+    at all, which is how a team-owned connector reaches a member."""
+    server = MCPServer.from_config(
+        {
+            "name": name,
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://mcp.example.com/mcp",
+            "auth": {
+                "type": "mcp_oauth",
+                "resource": "https://mcp.example.com/mcp",
+                "issuer": "https://auth.example.com",
+                "scope": "records.read",
+            },
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    if owner is not None:
+        db.add(
+            UserMCPServer(
+                user_id=owner.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                is_active=is_active,
+            )
+        )
+        db.commit()
+    return server
+
+
+def _add_stdio_server(
+    db, owner: User, name: str = "files", *, is_active: bool = True
+) -> MCPServer:
+    """A non-mcp_oauth custom server: credentials live on the row and its env
+    layers, so nothing but the association can gate it."""
+    server = MCPServer.from_config(
+        {
+            "name": name,
+            "managed": "external",
+            "transport": "stdio",
+            "command": f"{name}-mcp",
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=owner.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=is_active,
+        )
+    )
+    db.commit()
+    return server
+
+
+def _grant(db, server: MCPServer, user: User, *, status: str = "active") -> None:
+    client = MCPOAuthClient(
+        mcp_server_id=server.id,
+        issuer="https://auth.example.com",
+        authorization_endpoint="https://auth.example.com/authorize",
+        token_endpoint="https://auth.example.com/token",
+        client_id="client-123",
+        token_endpoint_auth_method="none",
+        redirect_uri="https://xagent.example.com/api/mcp/oauth/callback",
+    )
+    db.add(client)
+    db.flush()
+    db.add(
+        MCPOAuthGrant(
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=f"xagent:user:{user.id}",
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            access_token=encrypt_value("runtime-token"),
+            status=status,
+        )
+    )
+    db.commit()
+
+
+def _add_custom_api(
+    db, owner: User, name: str = "billing", *, is_active: bool = True
+) -> CustomApi:
+    api = CustomApi(
+        name=name,
+        description=f"{name} API",
+        url="https://api.example.com/v1",
+        method="GET",
+    )
+    db.add(api)
+    db.commit()
+    db.refresh(api)
+    db.add(
+        UserCustomApi(
+            user_id=owner.id,
+            custom_api_id=api.id,
+            is_owner=True,
+            is_active=is_active,
+        )
+    )
+    db.commit()
+    return api
+
+
+def _add_catalog_oauth_app(db, app_id: str = "granola") -> PublicMCPApp:
+    """A catalog app carrying the same mcp_oauth auth_type as the custom
+    population — the entry that used to be gated only by `is_custom` being
+    absent from this branch."""
+    app = PublicMCPApp(
+        app_id=app_id,
+        name="Granola",
+        description="A catalog app",
+        icon="",
+        category="Productivity",
+        # classify_app_auth derives auth_type from the entry's own fields: a
+        # remote transport with no launch command is the mcp_oauth shape.
+        transport="streamable_http",
+        is_visible_in_connector=True,
+    )
+    db.add(app)
+    db.commit()
+    db.refresh(app)
+    return app
+
+
+def _entry(db, user: User, entry_id: str, *, location: str = "local") -> dict:
+    return next(
+        a
+        for a in list_mcp_apps(location=location, current_user=user, db=db)
+        if a["id"] == entry_id
+    )
+
+
+# --- AC: the picker's gate is emitted, not re-derived -----------------------
+
+
+def test_an_mcp_oauth_connector_with_an_active_grant_is_attachable(db_session):
+    db, owner, _member = db_session
+    server = _add_oauth_server(db, owner)
+    _grant(db, server, owner)
+
+    entry = _entry(db, owner, "records")
+    assert entry["can_attach"] is True
+    # Consent already given is not consent that cannot be given again: the
+    # picker suppresses the trigger on connected state itself.
+    assert entry["can_authorize"] is True
+    assert entry["is_connected"] is True
+
+
+def test_a_never_authorized_mcp_oauth_connector_is_not_attachable_standalone(
+    db_session,
+):
+    """Standalone installs no resolver, so nothing can supply this server's
+    tokens: attaching it would fail at run time with "MCP server credentials
+    are unavailable". Fail early instead, and keep consent advertised as the
+    recovery."""
+    db, owner, _member = db_session
+    _add_oauth_server(db, owner)
+
+    entry = _entry(db, owner, "records")
+    assert entry["can_attach"] is False
+    assert entry["can_authorize"] is True
+
+
+def test_a_revoked_grant_does_not_make_a_connector_attachable(db_session):
+    """The grant query filters status == "active"; a revoked row must not read
+    as credentials."""
+    db, owner, _member = db_session
+    server = _add_oauth_server(db, owner)
+    _grant(db, server, owner, status="revoked")
+
+    assert _entry(db, owner, "records")["can_attach"] is False
+
+
+def test_another_users_grant_does_not_make_a_connector_attachable(db_session):
+    """Grants are per (server, user). The requesting user's own grant is the
+    only one that resolves at run time."""
+    db, owner, member = db_session
+    server = _add_oauth_server(db, owner, is_active=True)
+    db.add(
+        UserMCPServer(
+            user_id=member.id, mcpserver_id=server.id, is_owner=False, is_active=True
+        )
+    )
+    db.commit()
+    _grant(db, server, owner)
+
+    assert _entry(db, owner, "records")["can_attach"] is True
+    assert _entry(db, member, "records")["can_attach"] is False
+
+
+def test_a_non_oauth_custom_connector_is_attachable_without_any_grant(db_session):
+    """Only the mcp_oauth shape has a credential gate; a stdio server carries
+    its credentials on the row and its env layers."""
+    db, owner, _member = db_session
+    _add_stdio_server(db, owner)
+
+    entry = _entry(db, owner, "files")
+    assert entry["can_attach"] is True
+    assert entry["can_authorize"] is False
+
+
+# --- AC: an inactive association is not attachable -------------------------
+
+
+def test_an_inactive_association_is_not_attachable(db_session):
+    """The runtime's server query filters UserMCPServer.is_active, so a
+    deactivated connector would load zero tools. This is the case the old
+    predicate got wrong in one direction: deactivating *after* consent leaves
+    is_connected true, so it stayed attachable."""
+    db, owner, _member = db_session
+    server = _add_stdio_server(db, owner, is_active=False)
+    assert _entry(db, owner, "files")["can_attach"] is False
+
+    # Including when a completed grant exists: toggle_mcp_server never revokes
+    # one, so is_connected stays true and cannot carry this decision.
+    oauth = _add_oauth_server(db, owner, "records", is_active=False)
+    _grant(db, oauth, owner)
+    entry = _entry(db, owner, "records")
+    assert entry["is_connected"] is True
+    assert entry["can_attach"] is False
+    assert entry["can_authorize"] is False
+    assert server.id != oauth.id
+
+
+def test_an_inactive_custom_api_association_is_not_attachable(db_session):
+    """The Custom API half of the runtime query filters is_active identically,
+    while this listing reports is_connected: True unconditionally."""
+    db, owner, _member = db_session
+    _add_custom_api(db, owner, is_active=False)
+
+    entry = _entry(db, owner, "billing")
+    assert entry["is_connected"] is True
+    assert entry["can_attach"] is False
+
+
+def test_an_active_custom_api_is_attachable_and_never_authorizable(db_session):
+    db, owner, _member = db_session
+    _add_custom_api(db, owner)
+
+    entry = _entry(db, owner, "billing")
+    assert entry["can_attach"] is True
+    assert entry["can_authorize"] is False
+
+
+# --- AC: catalog apps no longer depend on is_custom being absent ------------
+
+
+def test_an_unconnected_catalog_oauth_app_is_not_attachable(db_session):
+    """The entry the picker used to gate purely on `is_custom` being absent
+    from this branch. It carries auth_type mcp_oauth exactly like the custom
+    population, and is_connected: false here means no association row exists
+    at all."""
+    db, owner, _member = db_session
+    _add_catalog_oauth_app(db)
+
+    entry = _entry(db, owner, "granola", location="remote")
+    # Load-bearing: without this the fixture could drift to some other shape
+    # and the test would stop discriminating the case it exists for.
+    assert entry["auth_type"] == "mcp_oauth"
+    assert entry["is_connected"] is False
+    assert entry["can_attach"] is False
+    # Catalog entries connect through /apps/{app_id}/oauth/connect, dispatched
+    # on auth_type; can_authorize deliberately does not restate that.
+    assert entry["can_authorize"] is False
+
+
+def test_a_catalog_app_stays_unattachable_even_with_a_resolver_installed(db_session):
+    """The resolver relaxes the *credential* gate, never the association gate:
+    a catalog app the user never connected is not their connector to attach,
+    whatever can supply tokens for it."""
+    db, owner, _member = db_session
+    _add_catalog_oauth_app(db)
+    _install_token_resolver()
+
+    assert _entry(db, owner, "granola", location="remote")["can_attach"] is False
+
+
+# --- AC: hook-supplied credentials -----------------------------------------
+
+
+def test_a_resolver_hook_makes_a_never_authorized_connector_attachable(db_session):
+    """#1332's population: tokens arrive through set_oauth_token_resolver_hook,
+    so no MCPOAuthGrant is ever written and is_connected stays false forever.
+    The connector is nonetheless attachable and the runtime resolves it."""
+    db, owner, _member = db_session
+    _add_oauth_server(db, owner)
+    _install_token_resolver()
+
+    entry = _entry(db, owner, "records")
+    assert entry["is_connected"] is False
+    assert entry["can_attach"] is True
+
+
+def test_a_resolver_hook_suppresses_the_interactive_consent_flow(db_session):
+    """There is no interactive consent and no identity the editor could sign
+    in as, so advertising authorization asserts a step that does not exist."""
+    db, owner, _member = db_session
+    _add_oauth_server(db, owner)
+    _install_token_resolver()
+
+    assert _entry(db, owner, "records")["can_authorize"] is False
+
+
+def test_a_resolver_hook_does_not_relax_the_association_gate(db_session):
+    """Credentials resolving is not the same as the runtime seeing the server:
+    its query still drops the inactive association."""
+    db, owner, _member = db_session
+    _add_oauth_server(db, owner, is_active=False)
+    _install_token_resolver()
+
+    assert _entry(db, owner, "records")["can_attach"] is False
+
+
+# --- AC: the #1338 team overlay --------------------------------------------
+
+
+def test_a_team_owned_mcp_oauth_connector_is_attachable_but_not_authorizable(
+    db_session,
+):
+    """The case the two fields exist to separate. The member holds no personal
+    association, so /{server_id}/oauth/connect would 404 — but the overlay
+    listed the connector precisely so members could attach it, and the runtime
+    overlays the same team ids. Withholding auth_type was the only way to say
+    "not authorizable", and it said "not attachable" too."""
+    db, _owner, member = db_session
+    server = _add_oauth_server(db, None)
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+    _install_token_resolver()
+
+    entry = _entry(db, member, "records")
+    assert entry["can_attach"] is True
+    assert entry["can_authorize"] is False
+    assert "auth_type" not in entry
+
+
+def test_a_team_owned_mcp_oauth_connector_needs_credentials_like_any_other(db_session):
+    """Without a resolver the member has no way to obtain tokens for it — a
+    team link shares the server definition, not anyone's grant — so the
+    credential gate applies to the overlay population too."""
+    db, _owner, member = db_session
+    server = _add_oauth_server(db, None)
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    assert _entry(db, member, "records")["can_attach"] is False
+
+
+def test_a_team_owned_connector_is_never_authorizable_even_holding_a_grant(
+    db_session,
+):
+    """The association half of can_authorize, pinned without a resolver
+    installed so the resolver short-circuit cannot carry the assertion. A grant
+    outlives the association row it was created under, so credentials can
+    resolve for a connector the member now reaches only through the team link
+    — and /{server_id}/oauth/connect would still 404 on the missing
+    association."""
+    db, _owner, member = db_session
+    server = _add_oauth_server(db, None)
+    _grant(db, server, member)
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    entry = _entry(db, member, "records")
+    assert entry["can_attach"] is True
+    assert entry["can_authorize"] is False
+
+
+def test_a_team_owned_non_oauth_connector_is_attachable_standalone_of_any_hook(
+    db_session,
+):
+    """The common team case: no credential gate, so the team link alone
+    carries it."""
+    db, owner, member = db_session
+    server = _add_stdio_server(db, owner)
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+
+    entry = _entry(db, member, "files")
+    assert entry["can_attach"] is True
+    assert entry["can_authorize"] is False
+
+
+def test_a_team_owned_custom_api_is_attachable(db_session):
+    db, owner, member = db_session
+    api = _add_custom_api(db, owner)
+    _install_visibility({int(member.id): {"mcp": set(), "custom_api": {int(api.id)}}})
+
+    assert _entry(db, member, "billing")["can_attach"] is True
+
+
+# --- Every entry carries both fields ---------------------------------------
+
+
+def test_every_listed_entry_carries_both_decisions(db_session):
+    """A consumer reading `can_attach` must never see undefined and silently
+    treat an entry as unattachable, whichever branch emitted it."""
+    db, owner, _member = db_session
+    _add_stdio_server(db, owner)
+    _add_oauth_server(db, owner)
+    _add_custom_api(db, owner)
+    _add_catalog_oauth_app(db)
+
+    entries = list_mcp_apps(location="all", current_user=owner, db=db)
+    assert {"files", "records", "billing", "granola"} <= {e["id"] for e in entries}
+    for entry in entries:
+        assert isinstance(entry.get("can_attach"), bool), entry["id"]
+        assert isinstance(entry.get("can_authorize"), bool), entry["id"]

--- a/tests/web/api/test_mcp_apps_attachability.py
+++ b/tests/web/api/test_mcp_apps_attachability.py
@@ -228,6 +228,26 @@ def _add_catalog_oauth_app(db, app_id: str = "granola") -> PublicMCPApp:
     return app
 
 
+def _add_catalog_builtin_oauth_app(db, app_id: str = "acme-crm") -> PublicMCPApp:
+    """A provider-redirect catalog app. `transport == "oauth"` is what
+    classify_app_auth keys on, and it takes its own branch in list_mcp_apps --
+    the one the other catalog fixtures never reach."""
+    app = PublicMCPApp(
+        app_id=app_id,
+        name="Acme CRM",
+        description="A builtin-oauth catalog app",
+        icon="",
+        category="Productivity",
+        transport="oauth",
+        provider_name="acme",
+        is_visible_in_connector=True,
+    )
+    db.add(app)
+    db.commit()
+    db.refresh(app)
+    return app
+
+
 def _entry(db, user: User, entry_id: str, *, location: str = "local") -> dict:
     return next(
         a
@@ -367,6 +387,22 @@ def test_an_unconnected_catalog_oauth_app_is_not_attachable(db_session):
     assert entry["can_attach"] is False
     # Catalog entries connect through /apps/{app_id}/oauth/connect, dispatched
     # on auth_type; can_authorize deliberately does not restate that.
+    assert entry["can_authorize"] is False
+
+
+def test_an_unconnected_builtin_oauth_catalog_app_is_not_attachable(db_session):
+    """The builtin_oauth branch resolves connected state through
+    `_connected_oauth_server_for_app` and the user's UserOAuth accounts, not
+    through the association lookups the other catalog fixtures exercise. Its
+    `can_attach` is emitted by the same line, but nothing else in this file
+    routes through that branch."""
+    db, owner, _member = db_session
+    _add_catalog_builtin_oauth_app(db)
+
+    entry = _entry(db, owner, "acme-crm", location="remote")
+    assert entry["auth_type"] == "builtin_oauth"
+    assert entry["is_connected"] is False
+    assert entry["can_attach"] is False
     assert entry["can_authorize"] is False
 
 
@@ -637,9 +673,12 @@ def test_every_listed_entry_carries_both_decisions(db_session):
     _add_oauth_server(db, owner)
     _add_custom_api(db, owner)
     _add_catalog_oauth_app(db)
+    _add_catalog_builtin_oauth_app(db)
 
     entries = list_mcp_apps(location="all", current_user=owner, db=db)
-    assert {"files", "records", "billing", "granola"} <= {e["id"] for e in entries}
+    assert {"files", "records", "billing", "granola", "acme-crm"} <= {
+        e["id"] for e in entries
+    }
     for entry in entries:
         assert isinstance(entry.get("can_attach"), bool), entry["id"]
         assert isinstance(entry.get("can_authorize"), bool), entry["id"]


### PR DESCRIPTION
Closes #1347

## Problem

The connector picker reconstructed two separate decisions — may this entry be attached to an agent, and is interactive OAuth consent meaningful for it — from `is_connected` + `is_custom` + `auth_type`. That made three unstated backend emission rules load-bearing on the client, and still got two populations wrong:

- A custom `mcp_oauth` server whose consent was never started was attachable and then failed at run time with "MCP server credentials are unavailable".
- A team-owned one was refused, because the only way #1338 had to say "not authorizable" was to withhold `auth_type` — which also said "not attachable".

## Fix

`/api/mcp/apps` now emits `can_attach` and `can_authorize` on every entry, and the picker reads them instead of re-deriving anything.

**`can_attach`** mirrors what the runtime does with the selection in `_load_visible_runtime_connectors`: an active personal association **or** a team link the runtime overlays, AND credentials that plausibly resolve — an active `MCPOAuthGrant`, or an installed OAuth token resolver hook.

The hook check is deployment-level by necessity (issue option 1). The resolver is keyed per provider and per user, is async, and is embedder-implemented, so probing it once per listed connector on a list request is not available. New `oauth_token_resolver_installed()` mirrors the existing `team_env_hook_installed()`: selection is on hook *presence*, never on an empty answer.

**`can_authorize`** is scoped to `POST /api/mcp/{server_id}/oauth/connect`, the route the card's Authorize trigger starts. False without an active personal association (the endpoint resolves one with `require_active=True` and would 404), and false when a resolver hook supplies the deployment's tokens, where no interactive consent and no signable-in identity exist. Catalog entries report `false` and keep dispatching Connect on `auth_type` exactly as before — this field deliberately does not restate that dispatch.

`auth_type` is left untouched. It still answers "which Connect flow does the settings dialog dispatch"; it is simply no longer read as an attachability hint.

## Behaviour changes

Three, all fail-late becoming fail-early:

1. **A never-authorized custom `mcp_oauth` connector is no longer attachable in a standalone deployment.** Its card keeps the detail-modal route and the Authorize trigger as one-click recovery.
2. **A connector whose association was deactivated is no longer attachable** — including deactivation *after* consent, where it still lists as `is_connected: true` while the runtime's `is_active` filter drops it, so attaching loaded zero tools.
3. **The Custom API half of the local branch gets the same association gate.** Not in the issue's acceptance criteria, but emitting `can_attach: true` for a connector the runtime demonstrably drops would be writing a false contract in the PR whose point is to make the contract truthful.

### Deviation from an acceptance criterion

> Standalone xagent, which installs no resolver hook and no visibility hook, behaves exactly as today.

Change 1 above violates this as literally written. It cannot hold together with the issue's own option 1, which "fixes consequence 2 and only narrows 1" — the narrowing *is* standalone behaviour changing. Implemented as fail-early on purpose; suggest rewording that criterion to "catalog apps and connected connectors behave as today, and a refused connector still reaches consent in one click".

## Known residues

- **A resolver hook suppresses the Authorize trigger deployment-wide.** An embedder that installs the resolver as a partial fallback leaves connectors it does not cover attachable with no in-picker consent route. This is the acknowledged cost of the coarse check; closing it needs issue option 2 (a capability probe) or option 3 (deployment-declared hook-managed connectors).
- **The settings dialog's Connect button is unchanged.** In a hook deployment it can still start an OAuth popup that cannot complete. This predates #1332 and is not a regression here; gating it needs a third field (`can_connect`) rather than widening `can_authorize`, which would break Connect for every catalog entry.

## Review fix included

Second commit: `isSelected` is computed from the working selection alone, so a connector that becomes unattachable *while already attached* — disabled on the Tools page after the fact, or attached before this gate existed — rendered with the selected ring while its click routed to the detail modal. Visibly selected and removable only from the agent builder's own list: the same un-removable state #1280 was filed for. Attaching stays gated; detaching is now always allowed.

## Tests

New `tests/web/api/test_mcp_apps_attachability.py` — 24 tests, one per acceptance criterion plus the divergent populations (`can_attach: true` / `can_authorize: false` for both the hook-resolved and the team-owned case), the revoked-grant and other-user-grant negatives, and a sweep asserting every listed entry carries both fields as booleans.

**Mutation-checked** against twelve independent weakenings of the two helpers and the shared visibility predicate — dropping the association gate, dropping the credential gate, ignoring the resolver in either field, making catalog entries or Custom APIs unconditionally attachable. Each is caught by at least one test.

Frontend picker tests updated: fixtures now carry the pair `list_mcp_apps` emits for each shape, and the attach-gate block pins the hook-resolved, never-authorized, team-owned, deactivated, and catalog populations separately.

Verified: `tests/web/api`, `tests/web/tools`, `tests/web/test_team_sharing_hooks.py` all pass; `ruff` and `mypy src/xagent/web/api/mcp.py src/xagent/web/tools/config.py` clean; frontend 2136 tests across 135 files pass and `tsc --noEmit` is clean.

## Not addressed

#1346 (the local branch's dedupe key) is a separate listing bug in the same endpoint and should be fixed on its own.

