### PR TITLE
fix(mcp): dedupe the connector picker's local branch on app_id too

### DIFF
--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2038,9 +2038,24 @@ def list_mcp_apps(
                 .all()
             )
 
-        library_names = {app["name"].lower() for app in library_apps}
+        # Skip the rows the catalog branch already speaks for, matching a row to
+        # an app on the same keys that branch does (_app_lookup_keys, via
+        # _connected_non_oauth_server_for_app). Two conventions name a catalog
+        # app's shared row: the app_id (_ensure_catalog_app_server,
+        # _ensure_catalog_mcp_oauth_server) and the display name
+        # (_ensure_user_mcp_server, for builtin_oauth). Keying the skip on names
+        # alone let every app whose app_id and name differ — google-maps/"Google
+        # Maps" and chrome-devtools/"Chrome" ship that way — through as a second,
+        # is_custom entry: a Configure button pointed at the custom-server edit
+        # form, and, for the mcp_oauth shape, an entry the picker considered
+        # attachable with no grant behind it (#1346).
+        library_keys = {
+            key
+            for app in library_apps
+            for key in _app_lookup_keys(app.get("id"), app.get("name"))
+        }
         for server, user_mcp in local_mcps:
-            if server.name.lower() in library_names:
+            if _normalize_app_key(server.name) in library_keys:
                 continue
 
             if search:

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1581,8 +1581,11 @@ def _catalog_app_keys(app: dict) -> list[str]:
     listing must not re-emit, and the rows that carry a platform key — cannot
     drift apart; one such drift is exactly what #1346 was.
 
-    The raw (un-normalized) id/name strings still have one caller: the query
-    that fetches shared rows by name, since the DB stores names unnormalized.
+    Normalized keys only. The raw id/name strings stay in use where a value
+    reaches the database — the shared-row prefetch query below, and the two
+    provisioning helpers that write `MCPServer.name` — because rows store names
+    unnormalized; those spellings are what this function's keys are derived
+    from, not a competing definition of them.
     """
     return _app_lookup_keys(app.get("id"), app.get("name"))
 
@@ -1597,6 +1600,14 @@ def _server_catalog_keys(server: MCPServer) -> list[str]:
     name key alone would stop matching. Scoped to transport == "oauth" because
     that shape's auth is written by us; a custom row's auth is caller-authored
     and must not be able to claim a catalog identity.
+
+    That borrows _oauth_server_lookup_keys' provider fallback, which reaches
+    across namespaces: a legacy row carrying only `auth.provider` is matched
+    against catalog *ids*, so one whose provider happens to equal some app's id
+    is skipped even if it belongs to another app. Kept on purpose, because the
+    catalog branch claims such a row by provider too (_is_oauth_server_for_app)
+    — a key this misses is a #1346 duplicate, while a key it over-matches only
+    moves a legacy row to the Remote tab, still editable via /api/mcp/servers.
     """
     if _normalize_app_key(server.transport) != "oauth":
         return _app_lookup_keys(server.name)
@@ -1646,7 +1657,6 @@ def _is_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
         return False
 
     app_id = _normalize_app_key(app.get("id"))
-    app_name = _normalize_app_key(app.get("name"))
     provider = _normalize_app_key(app.get("provider"))
     server_name = _normalize_app_key(server.name)
 
@@ -1662,8 +1672,9 @@ def _is_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
         if auth_app_id or auth_provider:
             return True
 
-    # Legacy OAuth server rows created before app metadata was stored in auth.
-    return bool(server_name and server_name in {app_id, app_name})
+    # Legacy OAuth server rows created before app metadata was stored in auth,
+    # matched on the same key set every other caller uses.
+    return bool(server_name and server_name in _catalog_app_keys(app))
 
 
 def _connected_oauth_server_for_app(
@@ -2089,6 +2100,12 @@ def list_mcp_apps(
         # suppressed here rather than falling through to a custom entry. Hiding
         # it is the point for the hidden-app case ("Strong hide mode" above),
         # and /api/mcp/servers still lists, edits and deletes every such row.
+        # The cost lands on legacy rows only: one on the wrong transport is
+        # suppressed here while the catalog entry still offers Connect, which
+        # 409s on the config mismatch (_ensure_catalog_app_server) — visible and
+        # fixable from the Tools page, unreachable from the picker. A team-shared
+        # catalog connector loses its only picker entry the same way, which is
+        # pre-existing for most apps and tracked in #1387.
         library_keys = {key for app in library_apps for key in _catalog_app_keys(app)}
         for server, user_mcp in local_mcps:
             if library_keys.intersection(_server_catalog_keys(server)):

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1569,6 +1569,40 @@ def _app_lookup_keys(*values: object) -> list[str]:
     return keys
 
 
+def _catalog_app_keys(app: dict) -> list[str]:
+    """The normalized keys a catalog app's shared server row may be named after.
+
+    Both, because two provisioning paths disagree: the catalog-connect helpers
+    name the row after the app_id (_ensure_catalog_app_server,
+    _ensure_catalog_mcp_oauth_server) while the builtin_oauth path names it
+    after the display name (_ensure_user_mcp_server). Single-sourced so every
+    caller asking "which row is this app's" — the connected-state and shared-row
+    lookups, the names a custom server may not take, the rows the connector
+    listing must not re-emit, and the rows that carry a platform key — cannot
+    drift apart; one such drift is exactly what #1346 was.
+
+    The raw (un-normalized) id/name strings still have one caller: the query
+    that fetches shared rows by name, since the DB stores names unnormalized.
+    """
+    return _app_lookup_keys(app.get("id"), app.get("name"))
+
+
+def _server_catalog_keys(server: MCPServer) -> list[str]:
+    """The keys a stored row could be some catalog app's shared row under.
+
+    The row's name covers both naming conventions above. An oauth row also
+    carries its app_id in `auth`, which is what the catalog branch resolves it
+    by (_oauth_server_lookup_keys), so include that too: an admin renaming a
+    non-builtin oauth app leaves the row under its old display name, which the
+    name key alone would stop matching. Scoped to transport == "oauth" because
+    that shape's auth is written by us; a custom row's auth is caller-authored
+    and must not be able to claim a catalog identity.
+    """
+    if _normalize_app_key(server.transport) != "oauth":
+        return _app_lookup_keys(server.name)
+    return _app_lookup_keys(server.name, *_oauth_server_lookup_keys(server))
+
+
 def _is_reserved_catalog_name(db: Session, name: object) -> bool:
     """Whether a server name collides (normalized) with a catalog app id/name.
 
@@ -1579,10 +1613,7 @@ def _is_reserved_catalog_name(db: Session, name: object) -> bool:
     key = _normalize_app_key(name)
     if not key:
         return False
-    return any(
-        key in _app_lookup_keys(app.get("id"), app.get("name"))
-        for app in get_all_mcp_apps(db)
-    )
+    return any(key in _catalog_app_keys(app) for app in get_all_mcp_apps(db))
 
 
 def _oauth_account_can_connect(oauth_account: object) -> bool:
@@ -1741,7 +1772,7 @@ def _shared_server_for_app(
 ) -> Optional[MCPServer]:
     """Resolve an app's shared server via the same normalized id/name keys the
     connected-state lookup uses, so key-source flags stay consistent with it."""
-    for app_key in _app_lookup_keys(app.get("id"), app.get("name")):
+    for app_key in _catalog_app_keys(app):
         server = server_by_key.get(app_key)
         if server is not None:
             return server
@@ -1812,7 +1843,7 @@ def _connected_non_oauth_server_for_app(
     server = next(
         (
             non_oauth_server_lookup[(app_transport, app_key)]
-            for app_key in _app_lookup_keys(app.get("id"), app.get("name"))
+            for app_key in _catalog_app_keys(app)
             if (app_transport, app_key) in non_oauth_server_lookup
         ),
         None,
@@ -2038,24 +2069,29 @@ def list_mcp_apps(
                 .all()
             )
 
-        # Skip the rows the catalog branch already speaks for, matching a row to
-        # an app on the same keys that branch does (_app_lookup_keys, via
-        # _connected_non_oauth_server_for_app). Two conventions name a catalog
-        # app's shared row: the app_id (_ensure_catalog_app_server,
-        # _ensure_catalog_mcp_oauth_server) and the display name
-        # (_ensure_user_mcp_server, for builtin_oauth). Keying the skip on names
-        # alone let every app whose app_id and name differ — google-maps/"Google
-        # Maps" and chrome-devtools/"Chrome" ship that way — through as a second,
-        # is_custom entry: a Configure button pointed at the custom-server edit
-        # form, and, for the mcp_oauth shape, an entry the picker considered
-        # attachable with no grant behind it (#1346).
-        library_keys = {
-            key
-            for app in library_apps
-            for key in _app_lookup_keys(app.get("id"), app.get("name"))
-        }
+        # Skip the rows a catalog app's entry already speaks for, resolving the
+        # row's connector identity the way _catalog_app_keys defines it. The old
+        # skip compared raw lowercased names against display names only, which
+        # missed a catalog row on two independent counts (#1346): the row is
+        # named after the app_id, which normalizes whitespace to hyphens, so
+        # "Google Maps" never matched its own row named `google-maps`; and an
+        # app_id that is not a hyphenated spelling of its name (chrome-devtools/
+        # "Chrome") has no name to match at all. Either miss re-emitted the app
+        # as a second, is_custom entry: a Configure button pointed at the
+        # custom-server edit form, a Delete surfaced as "Delete Service", and,
+        # for the mcp_oauth shape, an entry the picker treats as attachable with
+        # no grant behind it.
+        #
+        # Deliberately broader than the catalog branch's own claim, which is
+        # further qualified by transport, is_active and is_visible_in_connector:
+        # a row under a catalog key that the branch declines to claim (a legacy
+        # row on the wrong transport, or one belonging to a hidden app) is
+        # suppressed here rather than falling through to a custom entry. Hiding
+        # it is the point for the hidden-app case ("Strong hide mode" above),
+        # and /api/mcp/servers still lists, edits and deletes every such row.
+        library_keys = {key for app in library_apps for key in _catalog_app_keys(app)}
         for server, user_mcp in local_mcps:
-            if _normalize_app_key(server.name) in library_keys:
+            if library_keys.intersection(_server_catalog_keys(server)):
                 continue
 
             if search:
@@ -3111,7 +3147,7 @@ def _catalog_server_has_platform_key(db: Session, server: MCPServer) -> bool:
     if not key:
         return False
     for app in get_all_mcp_apps(db):
-        if key in _app_lookup_keys(app.get("id"), app.get("name")):
+        if key in _catalog_app_keys(app):
             required = (app.get("launch_config") or {}).get("required_env") or []
             return _env_covers_required(env, required)
     return False

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -665,8 +665,8 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             # seeded app uses. Known, accepted caveat: api/mcp.py couples
             # catalog apps to user-server names by normalized id AND display
             # name (_is_reserved_catalog_name rejects creating/renaming a
-            # server to either; library_names hides user servers whose name
-            # matches a catalog app name) -- and the display name below is
+            # server to either; the local branch's library_keys skip hides
+            # user servers matching either key) -- and the display name below is
             # deliberately kept as the friendlier "Chrome", so a user-created
             # server literally named "chrome"/"Chrome" is still rejected on
             # create/rename and suppressed from the local listing. Product

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -669,7 +669,11 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             # user servers matching either key) -- and the display name below is
             # deliberately kept as the friendlier "Chrome", so a user-created
             # server literally named "chrome"/"Chrome" is still rejected on
-            # create/rename and suppressed from the local listing. Product
+            # create/rename and suppressed from the local listing. Note the two
+            # halves differ in reach: create/rename rejection is prospective,
+            # while the listing skip is retroactive, so a row named after this
+            # id or name that predates either guard is hidden from the picker's
+            # Local tab (never from /api/mcp/servers) once it lands. Product
             # chose the display name over freeing that (plausible but niche)
             # name; scoping the id at least keeps the shared server row and
             # connect-flow naming collision-free.

--- a/tests/web/api/test_mcp_apps_catalog_dedupe.py
+++ b/tests/web/api/test_mcp_apps_catalog_dedupe.py
@@ -1,19 +1,28 @@
 """`/api/mcp/apps`'s local branch must not re-emit a connected catalog app
 (#1346).
 
-The catalog branch matches a stored server row to its app on *both* the app_id
-and the display name (`_connected_non_oauth_server_for_app` ->
-`_app_lookup_keys`), but the local branch's skip compared the row's name against
-display names only. Catalog connects name the shared row after the app_id
-(`_ensure_catalog_app_server`, `_ensure_catalog_mcp_oauth_server`), so every app
-whose app_id and name differ escaped the skip and was emitted a second time as
-an `is_custom: true` "Local" entry.
+Catalog connects name the shared row after the app_id
+(`_ensure_catalog_app_server`, `_ensure_catalog_mcp_oauth_server`) while the
+builtin_oauth path names it after the display name (`_ensure_user_mcp_server`).
+The local branch's skip compared the row's raw lowercased name against display
+names only, so it missed a catalog row on two independent counts, each covered
+by its own test below:
 
-Two app shapes appear below. Built-in ids (`google-maps`) take their name,
-transport and launch_config from `builtin_mcp_registry` regardless of what the
-row stores, so they pin the duplicate a user reaches on a stock deployment.
-Fictional ids (`acme*`) are admin-created apps, whose stored fields are used
-as-is — the only way to vary the shape under test.
+* **normalization** — `_normalize_app_key` folds whitespace to hyphens, so the
+  row `google-maps` never matched its app's name "Google Maps" under `.lower()`.
+  This is the miss reachable on a stock deployment.
+* **the app_id key** — an app_id that is not a hyphenated spelling of its name
+  (`chrome-devtools`/"Chrome") has no name for the row to match at all.
+
+Either miss emitted the app a second time as an `is_custom: true` "Local" entry.
+Because most catalog pairs collapse to a single key, a suite built only from
+those would stay green with either half of `_catalog_app_keys` deleted; the
+`acme-crm`/"Widget Hub" pair exists to keep both halves under test.
+
+Built-in ids (`google-maps`) take their name, transport and launch_config from
+`builtin_mcp_registry` regardless of what the row stores. Fictional ids
+(`acme*`) are admin-created apps, whose stored fields are used as-is — the only
+way to vary the shape under test.
 """
 
 from __future__ import annotations
@@ -24,9 +33,11 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from xagent.core.utils.encryption import encrypt_value
 from xagent.web.api.mcp import list_mcp_apps
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.mcp_oauth import MCPOAuthClient, MCPOAuthGrant
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.services import connector_team_scope
@@ -56,9 +67,15 @@ def db_session(tmp_path):
     db.commit()
     db.refresh(user)
 
-    yield db, user
-    db.close()
-    engine.dispose()
+    try:
+        yield db, user
+    finally:
+        # Nested so the engine is disposed even if closing the session raises,
+        # while the first failure still propagates.
+        try:
+            db.close()
+        finally:
+            engine.dispose()
 
 
 @pytest.fixture(autouse=True)
@@ -178,6 +195,36 @@ def _associate(db, user: User, server: MCPServer, *, is_owner: bool = False) -> 
     db.commit()
 
 
+def _add_active_grant(db, user: User, server: MCPServer) -> None:
+    """An mcp_oauth app counts as connected only with a completed grant behind
+    the association (`_mcp_oauth_server_is_actually_connected`)."""
+    client = MCPOAuthClient(
+        mcp_server_id=server.id,
+        issuer="https://auth.example.com",
+        authorization_endpoint="https://auth.example.com/authorize",
+        token_endpoint="https://auth.example.com/token",
+        client_id="client-123",
+        token_endpoint_auth_method="none",
+        redirect_uri="https://xagent.example.com/api/mcp/oauth/callback",
+    )
+    db.add(client)
+    db.flush()
+    db.add(
+        MCPOAuthGrant(
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=f"xagent:user:{user.id}",
+            issuer="https://auth.example.com",
+            resource=_MCP_OAUTH_LAUNCH["url"],
+            scope="",
+            access_token=encrypt_value("runtime-token"),
+            status="active",
+        )
+    )
+    db.commit()
+
+
 def _install_visibility(user: User, server_ids: set[int]) -> None:
     def visibility(_db, user_id: int) -> dict[str, set[int]]:
         if int(user_id) != int(user.id):
@@ -187,11 +234,51 @@ def _install_visibility(user: User, server_ids: set[int]) -> None:
     connector_team_scope.set_connector_team_hooks(visibility=visibility)
 
 
+def test_a_row_matching_only_the_app_id_key_is_listed_once(db_session):
+    """The app_id half of `_catalog_app_keys`: "Widget Hub" normalizes to
+    `widget-hub`, which the row named `acme-crm` cannot match, so only the
+    app_id key can resolve this row to its app.
+
+    Admin-created because no *connectable* shipped app diverges this way today:
+    `facebook`/"Facebook Pages" is builtin_oauth (row named after the display
+    name, so the name key already covers it) and `chrome-devtools`/"Chrome" is
+    hidden, with `_reject_hidden_catalog_app` 404ing new connects. The id key is
+    forward cover for admin-created apps and for legacy `chrome-devtools`
+    rows."""
+    db, user = db_session
+    _add_key_based_app(db, "acme-crm", "Widget Hub")
+    server = _add_catalog_server(db, "acme-crm")
+    _associate(db, user, server)
+
+    entries = [
+        a
+        for a in list_mcp_apps(location="all", current_user=user, db=db)
+        if a["id"] == "acme-crm"
+    ]
+    assert len(entries) == 1
+    assert entries[0]["name"] == "Widget Hub"
+    assert entries[0].get("is_custom") is not True
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
+def test_a_row_matching_only_the_display_name_key_is_listed_once(db_session):
+    """The mirror of the test above, and the reason the name key cannot simply
+    be replaced by the app_id: the builtin_oauth convention names the row after
+    the display name, which `acme-crm` does not match."""
+    db, user = db_session
+    _add_key_based_app(db, "acme-crm", "Widget Hub")
+    server = _add_custom_server(db, "Widget Hub")
+    _associate(db, user, server)
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
 def test_a_connected_catalog_app_with_a_mismatched_id_is_listed_once(db_session):
     """AC1: `location=all` emits the app from the catalog branch only.
 
-    `google-maps`/"Google Maps" is a shipped built-in pair, so this is the
-    duplicate a user reaches today with no admin action at all."""
+    The normalization half of the fix: `google-maps`/"Google Maps" is a shipped
+    built-in pair whose keys agree only *after* whitespace folding, so this is
+    the duplicate a user reaches today with no admin action at all."""
     db, user = db_session
     _add_key_based_app(db, "google-maps", "Google Maps")
     server = _add_catalog_server(db, "google-maps")
@@ -254,7 +341,17 @@ def test_an_mcp_oauth_catalog_app_produces_no_ungranted_local_twin(db_session):
 def test_a_team_overlaid_catalog_row_is_skipped_too(db_session):
     """The overlay feeds the same loop as `(server, user_mcp)` pairs, so a
     catalog row reaching the branch through team visibility (#1321) — with no
-    personal association at all — must obey the same skip."""
+    personal association at all — must obey the same skip.
+
+    This costs a team member the only picker entry they had for a team-shared
+    catalog connector, which is a deliberate alignment rather than a new
+    limitation: the same is already true of every catalog app whose id and name
+    collapse to one key, pinned by
+    test_mcp_apps_team_visibility.py::test_a_team_owned_server_named_like_a_catalog_app_is_skipped.
+    The entry this removes was the #1346 duplicate itself — `is_custom`, so its
+    Configure and Delete were misrouted. Giving team-shared catalog connectors a
+    correctly-shaped entry is #1321 follow-up work, not something to recover by
+    letting the duplicate back through."""
     db, user = db_session
     _add_key_based_app(db, "google-maps", "Google Maps")
     server = _add_catalog_server(db, "google-maps")
@@ -304,6 +401,74 @@ def test_an_unrelated_custom_server_is_still_listed(db_session):
     entries = list_mcp_apps(location="local", current_user=user, db=db)
     assert [a["id"] for a in entries] == ["records"]
     assert entries[0]["is_custom"] is True
+
+
+def test_a_granted_mcp_oauth_catalog_app_is_emitted_once_and_connected(db_session):
+    """The positive counterpart to the twin test above: consent completed, so
+    the app must still be emitted exactly once — by the catalog branch, marked
+    connected — rather than the skip swallowing the connector entirely."""
+    db, user = db_session
+    _add_mcp_oauth_app(db, "acme-notes", "Acme Notes")
+    server = _add_mcp_oauth_server(db, "acme-notes")
+    _associate(db, user, server)
+    _add_active_grant(db, user, server)
+
+    entries = [
+        a
+        for a in list_mcp_apps(location="all", current_user=user, db=db)
+        if a["id"] == "acme-notes"
+    ]
+    assert len(entries) == 1
+    assert entries[0]["is_connected"] is True
+    assert entries[0]["server_id"] == server.id
+    assert entries[0].get("is_custom") is not True
+
+
+def test_an_oauth_row_left_under_an_old_display_name_is_still_skipped(db_session):
+    """A third naming convention the name key alone cannot follow: an oauth row
+    records its app in `auth.app_id`, and renaming a non-builtin app (permitted
+    — `_BUILTIN_PROTECTED_FIELDS` guards built-ins only) leaves already-created
+    rows under the old display name. The catalog branch keeps resolving such a
+    row through `_oauth_server_lookup_keys`, so the skip must follow the same
+    key or the `is_custom` twin returns."""
+    db, user = db_session
+    # Renamed to "Widget Portal"; the row still carries the pre-rename name.
+    _add_app(db, "acme-portal", "Widget Portal", transport="oauth", launch_config={})
+    server = _add_server_row(
+        db,
+        {
+            "name": "Legacy Portal",
+            "managed": "external",
+            "transport": "oauth",
+            "auth": {"app_id": "acme-portal", "provider": "acme"},
+        },
+    )
+    _associate(db, user, server)
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
+def test_a_custom_row_cannot_claim_a_catalog_identity_through_auth(db_session):
+    """`auth.app_id` is only honored for the oauth transport, whose auth we
+    write ourselves. A custom server's auth is caller-authored, so a claim made
+    there must not remove the row from its owner's Local tab."""
+    db, user = db_session
+    _add_key_based_app(db, "acme-crm", "Widget Hub")
+    server = _add_server_row(
+        db,
+        {
+            "name": "records",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://records.example.com/mcp",
+            "auth": {"app_id": "acme-crm"},
+        },
+    )
+    _associate(db, user, server, is_owner=True)
+
+    assert [
+        a["id"] for a in list_mcp_apps(location="local", current_user=user, db=db)
+    ] == ["records"]
 
 
 def test_remote_results_are_unchanged(db_session):

--- a/tests/web/api/test_mcp_apps_catalog_dedupe.py
+++ b/tests/web/api/test_mcp_apps_catalog_dedupe.py
@@ -1,0 +1,320 @@
+"""`/api/mcp/apps`'s local branch must not re-emit a connected catalog app
+(#1346).
+
+The catalog branch matches a stored server row to its app on *both* the app_id
+and the display name (`_connected_non_oauth_server_for_app` ->
+`_app_lookup_keys`), but the local branch's skip compared the row's name against
+display names only. Catalog connects name the shared row after the app_id
+(`_ensure_catalog_app_server`, `_ensure_catalog_mcp_oauth_server`), so every app
+whose app_id and name differ escaped the skip and was emitted a second time as
+an `is_custom: true` "Local" entry.
+
+Two app shapes appear below. Built-in ids (`google-maps`) take their name,
+transport and launch_config from `builtin_mcp_registry` regardless of what the
+row stores, so they pin the duplicate a user reaches on a stock deployment.
+Fictional ids (`acme*`) are admin-created apps, whose stored fields are used
+as-is — the only way to vary the shape under test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.web.api.mcp import list_mcp_apps
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.services import connector_team_scope
+
+_MCP_OAUTH_LAUNCH: dict[str, Any] = {
+    "url": "https://mcp.example.com/mcp",
+    "auth": {
+        "type": "mcp_oauth",
+        "resource": "https://mcp.example.com/mcp",
+        "issuer": "https://auth.example.com",
+    },
+}
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "mcp-apps-dedupe.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_connector_team_hooks():
+    """The hooks are process-global; never leak one into a sibling test."""
+    yield
+    connector_team_scope.set_connector_team_hooks()
+
+
+def _add_key_based_app(db, app_id: str, name: str) -> PublicMCPApp:
+    """A catalog app classified `api_key` — the shape connected through
+    `_ensure_catalog_app_server`, which names the shared row after the app_id."""
+    return _add_app(
+        db,
+        app_id,
+        name,
+        transport="stdio",
+        launch_config={
+            "command": "npx",
+            "args": ["-y", f"{app_id}-mcp"],
+            "required_env": ["API_KEY"],
+        },
+    )
+
+
+def _add_mcp_oauth_app(db, app_id: str, name: str) -> PublicMCPApp:
+    return _add_app(
+        db, app_id, name, transport="streamable_http", launch_config=_MCP_OAUTH_LAUNCH
+    )
+
+
+def _add_app(
+    db, app_id: str, name: str, *, transport: str, launch_config: dict
+) -> PublicMCPApp:
+    app = PublicMCPApp(
+        app_id=app_id,
+        name=name,
+        description="A catalog app",
+        icon="",
+        category="Productivity",
+        transport=transport,
+        launch_config=launch_config,
+        is_visible_in_connector=True,
+    )
+    db.add(app)
+    db.commit()
+    db.refresh(app)
+    return app
+
+
+def _add_catalog_server(db, app_id: str) -> MCPServer:
+    """The shared stdio row a key-based/keyless connect writes: named after the
+    app_id, carrying no `auth.app_id` back-reference."""
+    return _add_server_row(
+        db,
+        {
+            "name": app_id,
+            "description": "A catalog app",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["-y", f"{app_id}-mcp"],
+        },
+    )
+
+
+def _add_mcp_oauth_server(db, app_id: str) -> MCPServer:
+    """The shared remote row `_ensure_catalog_mcp_oauth_server` writes: also
+    named after the app_id, and its `auth` carries the connector's OAuth
+    metadata rather than an app_id back-reference."""
+    return _add_server_row(
+        db,
+        {
+            "name": app_id,
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": _MCP_OAUTH_LAUNCH["url"],
+            "auth": dict(_MCP_OAUTH_LAUNCH["auth"]),
+        },
+    )
+
+
+def _add_custom_server(db, name: str) -> MCPServer:
+    return _add_server_row(
+        db,
+        {
+            "name": name,
+            "description": f"{name} MCP server",
+            "managed": "external",
+            "transport": "stdio",
+            "command": f"{name}-mcp",
+        },
+    )
+
+
+def _add_server_row(db, config: dict) -> MCPServer:
+    server = MCPServer.from_config(config)
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    return server
+
+
+def _associate(db, user: User, server: MCPServer, *, is_owner: bool = False) -> None:
+    """The association a catalog connect writes: the connecting user never owns
+    the shared row (`is_owner=False`)."""
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=is_owner,
+            can_edit=is_owner,
+            can_delete=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+
+def _install_visibility(user: User, server_ids: set[int]) -> None:
+    def visibility(_db, user_id: int) -> dict[str, set[int]]:
+        if int(user_id) != int(user.id):
+            return {"mcp": set(), "custom_api": set()}
+        return {"mcp": set(server_ids), "custom_api": set()}
+
+    connector_team_scope.set_connector_team_hooks(visibility=visibility)
+
+
+def test_a_connected_catalog_app_with_a_mismatched_id_is_listed_once(db_session):
+    """AC1: `location=all` emits the app from the catalog branch only.
+
+    `google-maps`/"Google Maps" is a shipped built-in pair, so this is the
+    duplicate a user reaches today with no admin action at all."""
+    db, user = db_session
+    _add_key_based_app(db, "google-maps", "Google Maps")
+    server = _add_catalog_server(db, "google-maps")
+    _associate(db, user, server)
+
+    entries = [
+        a
+        for a in list_mcp_apps(location="all", current_user=user, db=db)
+        if a["id"] == "google-maps"
+    ]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["name"] == "Google Maps"
+    assert entry.get("is_custom") is not True
+    assert entry.get("is_local") is not True
+    assert entry["is_connected"] is True
+
+
+def test_a_connected_catalog_app_with_a_mismatched_id_is_absent_from_local(db_session):
+    """AC2: the app belongs to the Remote tab, so `location=local` has no entry
+    for it at all — not even a correctly-shaped one."""
+    db, user = db_session
+    _add_key_based_app(db, "google-maps", "Google Maps")
+    server = _add_catalog_server(db, "google-maps")
+    _associate(db, user, server)
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
+def test_an_mcp_oauth_catalog_app_produces_no_ungranted_local_twin(db_session):
+    """AC4: the local branch tags an active association `auth_type:
+    "mcp_oauth"`, and the picker treats `is_custom && mcp_oauth` as attachable
+    (#1332). A duplicate therefore made a catalog OAuth app attachable with no
+    completed grant behind it; the fix removes the duplicate, so no entry
+    carries that pair.
+
+    Admin-created (non-built-in) app on purpose: the two shipped `mcp_oauth`
+    entries have matching id/name, and renaming one is refused —
+    `_BUILTIN_PROTECTED_FIELDS` 409s a `name` change for a built-in app, and
+    `_app_to_dict` would take the registry's name regardless. An admin-created
+    connector is where an id/name mismatch is actually authored."""
+    db, user = db_session
+    _add_mcp_oauth_app(db, "acme-notes", "Acme Notes")
+    server = _add_mcp_oauth_server(db, "acme-notes")
+    _associate(db, user, server)
+
+    results = list_mcp_apps(location="all", current_user=user, db=db)
+    assert not [
+        a
+        for a in results
+        if a.get("is_custom") is True and a.get("auth_type") == "mcp_oauth"
+    ]
+    notes = [a for a in results if a["id"] == "acme-notes"]
+    assert len(notes) == 1
+    # No grant was issued, so the catalog entry stays disconnected — the
+    # duplicate was the only route to attaching it.
+    assert notes[0]["is_connected"] is False
+
+
+def test_a_team_overlaid_catalog_row_is_skipped_too(db_session):
+    """The overlay feeds the same loop as `(server, user_mcp)` pairs, so a
+    catalog row reaching the branch through team visibility (#1321) — with no
+    personal association at all — must obey the same skip."""
+    db, user = db_session
+    _add_key_based_app(db, "google-maps", "Google Maps")
+    server = _add_catalog_server(db, "google-maps")
+    _install_visibility(user, {int(server.id)})
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
+def test_a_catalog_app_whose_id_matches_its_name_is_listed_as_before(db_session):
+    """AC5: the already-skipped convention keeps working. This differs from the
+    mismatch cases above only in that the app's two keys agree."""
+    db, user = db_session
+    _add_key_based_app(db, "acme", "Acme")
+    server = _add_catalog_server(db, "acme")
+    _associate(db, user, server)
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+    acme = [
+        a
+        for a in list_mcp_apps(location="all", current_user=user, db=db)
+        if a["id"] == "acme"
+    ]
+    assert len(acme) == 1
+    assert acme[0]["is_connected"] is True
+
+
+def test_a_server_row_named_after_the_display_name_is_still_skipped(db_session):
+    """The built-in OAuth convention (`_ensure_user_mcp_server` names the row
+    after the display name) must keep matching — widening the skip to app_ids
+    must not narrow it away from names."""
+    db, user = db_session
+    _add_key_based_app(db, "acme-tools", "Acme Tools")
+    server = _add_custom_server(db, "Acme Tools")
+    _associate(db, user, server, is_owner=True)
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
+def test_an_unrelated_custom_server_is_still_listed(db_session):
+    """The skip must stay keyed on the catalog: a custom server that resembles
+    no catalog app keeps its Local entry."""
+    db, user = db_session
+    _add_key_based_app(db, "google-maps", "Google Maps")
+    server = _add_custom_server(db, "records")
+    _associate(db, user, server, is_owner=True)
+
+    entries = list_mcp_apps(location="local", current_user=user, db=db)
+    assert [a["id"] for a in entries] == ["records"]
+    assert entries[0]["is_custom"] is True
+
+
+def test_remote_results_are_unchanged(db_session):
+    """AC6: the skip lives in the local branch; the catalog branch's own
+    connection state is untouched by it."""
+    db, user = db_session
+    _add_key_based_app(db, "google-maps", "Google Maps")
+    server = _add_catalog_server(db, "google-maps")
+    _associate(db, user, server)
+
+    remote = list_mcp_apps(location="remote", current_user=user, db=db)
+    assert [a["id"] for a in remote] == ["google-maps"]
+    assert remote[0]["is_connected"] is True
+    assert remote[0]["server_id"] == server.id

--- a/tests/web/api/test_mcp_apps_catalog_dedupe.py
+++ b/tests/web/api/test_mcp_apps_catalog_dedupe.py
@@ -448,6 +448,62 @@ def test_an_oauth_row_left_under_an_old_display_name_is_still_skipped(db_session
     assert list_mcp_apps(location="local", current_user=user, db=db) == []
 
 
+def test_an_oauth_row_carrying_only_a_provider_is_skipped(db_session):
+    """`_server_catalog_keys` borrows `_oauth_server_lookup_keys`' fallback, so
+    a legacy row recording only `auth.provider` is matched against catalog ids.
+
+    Pinned because it is the one direction where the skip's key set crosses
+    namespaces: the catalog branch claims such a row by provider too, so the
+    alternative is the #1346 twin returning for rows too old to carry an
+    app_id."""
+    db, user = db_session
+    _add_app(db, "acme", "Widget Suite", transport="oauth", launch_config={})
+    server = _add_server_row(
+        db,
+        {
+            "name": "Legacy Suite",
+            "managed": "external",
+            "transport": "oauth",
+            "auth": {"provider": "acme"},
+        },
+    )
+    _associate(db, user, server)
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
+def test_a_row_named_after_a_hyphenated_display_name_is_skipped(db_session):
+    """The whitespace-folding half of `_normalize_app_key`, isolated: the row
+    spells "Widget Hub" as `widget-hub` and the app_id (`acme-crm`) matches
+    neither, so only folding the app's display name resolves it. Under the old
+    raw `.lower()` comparison this row was emitted as a twin."""
+    db, user = db_session
+    _add_key_based_app(db, "acme-crm", "Widget Hub")
+    server = _add_custom_server(db, "widget-hub")
+    _associate(db, user, server)
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
+def test_a_user_owned_row_named_after_a_catalog_app_id_is_suppressed(db_session):
+    """Pins the behavior change this fix declines to avoid, so it is a decision
+    on record rather than a silent side effect (#1346's AC3).
+
+    A row owned by a user (`is_owner=True`) under a catalog app_id is a legacy
+    squatter — `_is_reserved_catalog_name` refuses to create or rename one
+    today. Ownership would tell it apart from an official shared row, but only
+    for the id key: the builtin_oauth rows that are legitimately `is_owner=True`
+    are matched by the *name* key, so an ownership-qualified skip would have to
+    be transport-scoped as well, and it would restore the row only for its
+    owner. It stays listed, editable and deletable via /api/mcp/servers."""
+    db, user = db_session
+    _add_key_based_app(db, "acme-crm", "Widget Hub")
+    server = _add_custom_server(db, "acme-crm")
+    _associate(db, user, server, is_owner=True)
+
+    assert list_mcp_apps(location="local", current_user=user, db=db) == []
+
+
 def test_a_custom_row_cannot_claim_a_catalog_identity_through_auth(db_session):
     """`auth.app_id` is only honored for the oauth transport, whose auth we
     write ourselves. A custom server's auth is caller-authored, so a claim made


### PR DESCRIPTION
## Problem

`GET /api/mcp/apps`'s `location in ["local", "all"]` branch skips associations that back a catalog app, so a connected catalog app is emitted once — by the catalog branch. The skip was keyed on the app **name**, but the shared `MCPServer` row a catalog connect creates is named after the **app_id**:

- `_ensure_catalog_app_server` / `_ensure_catalog_mcp_oauth_server` → `server_name = str(app_info["id"])`
- `_ensure_user_mcp_server` (builtin_oauth only) → named after the display name

The old skip therefore missed a catalog row on **two independent counts**:

1. **Normalization.** `_normalize_app_key` folds whitespace to hyphens, so `google-maps`/"Google Maps" resolves to a single key — but the old skip compared raw `.lower()` strings, where `"google maps"` never matched the row named `google-maps`. This is the miss reachable on a stock deployment with no admin action.
2. **The app_id key.** An app_id that is not a hyphenated spelling of its name (`chrome-devtools`/"Chrome") has no display name for the row to match at all.

Either miss emitted the app a second time as an `is_custom: true` "Local" entry. The catalog branch itself already matches on both keys (`_connected_non_oauth_server_for_app` → `_app_lookup_keys`); only the local branch's skip did not.

### Impact

1. **Duplicate listing** — the app shows in the picker's Remote tab as its catalog entry and in the Local tab as a spurious custom entry; `serversFound` counts it twice under `location=all`.
2. **The duplicate misroutes its actions** — `is_custom: true` points the settings dialog's Configure button at the custom MCP edit form, and its Delete surfaces as "Delete Service" rather than "Disconnect".
3. **For the `mcp_oauth` shape it is attachable without a grant** — the local branch tags an active association `auth_type: "mcp_oauth"`, and the picker's `isAttachable` predicate is `is_connected || (is_custom && auth_type === "mcp_oauth")` (#1332). The duplicate satisfies the second disjunct, so a catalog OAuth app the editor never consented to could be attached.

## Fix

Key the local branch's skip on the same normalized id/name pair the catalog branch already matches on, so every naming convention resolves to the same connector identity:

```python
library_keys = {key for app in library_apps for key in _catalog_app_keys(app)}
for server, user_mcp in local_mcps:
    if library_keys.intersection(_server_catalog_keys(server)):
        continue
```

`_catalog_app_keys` is extracted so all five callers share one definition of "which row is this app's" — `_connected_non_oauth_server_for_app`, `_shared_server_for_app`, `_is_reserved_catalog_name`, `_catalog_server_has_platform_key`, and this skip. Drift between those spellings is the bug class this PR belongs to.

`_server_catalog_keys` additionally follows `auth.app_id` for `transport == "oauth"` rows: renaming a non-builtin oauth app leaves already-created rows under the old display name, which the catalog branch keeps resolving through `_oauth_server_lookup_keys`. It is scoped to that transport because we write its auth ourselves — a custom row's auth is caller-authored and must not be able to claim a catalog identity.

The skip is deliberately broader than the catalog branch's own claim, which is further qualified by transport, `is_active` and `is_visible_in_connector`; a row under a catalog key the branch declines to claim is suppressed rather than falling through to a custom entry. For a hidden app that is the point ("Strong hide mode"), and `/api/mcp/servers` still lists, edits and deletes every such row.

Team-overlaid rows (#1321) reach the same loop as `(server, None)` pairs and are covered by the same predicate. That costs a team member the only picker entry they had for a team-shared *catalog* connector — a deliberate alignment, not a new gap: the same has been true since #1321 for every catalog app whose id and name collapse to one key (pinned by `test_a_team_owned_server_named_like_a_catalog_app_is_skipped`), and the entry removed here is the #1346 duplicate itself. Giving team-shared catalog connectors a correctly-shaped entry is #1321 follow-up work.

## Notes on the reported reachability

Two details in #1346 did not survive verification:

- **`get_app_for_mcp_server` would not fix this.** The issue suggests it as the "exact" option, but `_ensure_catalog_app_server` writes the stdio row with no `auth` at all, and `_ensure_catalog_mcp_oauth_server` writes only the connector's OAuth metadata — neither stores an `auth.app_id` back-reference. The helper would fall back to an exact-name lookup, return `None` for `google-maps`, and leave the skip inert. Only builtin_oauth rows carry `app_id`, and those are already named after the display name and were already skipped.
- **Impact 3 is not reachable by renaming `granola`/`notion`.** `_BUILTIN_PROTECTED_FIELDS` 409s a `name` change for a built-in app, and `_app_to_dict` takes the registry's name regardless of what the row stores. The reachable path is an admin-*created* `mcp_oauth` catalog app whose `app_id` and `name` differ, which is what the test covers.

## Acceptance criteria

- [x] A connected catalog app whose `app_id` and `name` differ is emitted exactly once by `location=all`, from the catalog branch, with no `is_custom: true` twin.
- [x] The same holds for `location=local`: no entry at all for that app.
- [ ] A user-created custom server whose name equals a catalog app's `app_id` is still listed — **deliberately not implemented**, see below.
- [x] An `mcp_oauth` catalog app the user has not consented to cannot be attached via a local-branch duplicate.
- [x] Apps whose `app_id` and `name` already match are listed exactly as today.
- [x] `location=remote` results are unchanged.

On the third criterion: satisfying it requires keying the skip on the *resolved server id* rather than on names, which is a larger change best done on its own. Association ownership is a real signal (`_reject_user_owned_catalog_squat` documents that an official shared row never has an `is_owner=True` association), but it does not carry this: 21 of 23 built-ins have `id key == name key`, so an id-key-only qualifier is undefined for them, and applying it to the whole skip re-lists every builtin_oauth row, which carries `is_owner=True` — strictly worse than the bug being fixed. Since `_is_reserved_catalog_name` already rejects creating or renaming a server onto either key, only rows predating an app's seeding are affected; the catalog branch already claims such a row as that app's connection, and `/api/mcp/servers` (the Tools page) applies no skip, so the row stays visible, editable and deletable there. The registry already records the name-keyed half of this as a known, accepted trade-off (see the `chrome-devtools` entry's comment); this extends the same trade-off to the id key.

## Tests

`tests/web/api/test_mcp_apps_catalog_dedupe.py` — 13 tests, mutation-checked so each half of the key set is genuinely guarded (an earlier revision of this suite stayed green with *either* half deleted, because nearly every catalog pair collapses to one key):

| mutation | fails |
| --- | --- |
| drop `app.get("id")` from `_catalog_app_keys` | `test_a_row_matching_only_the_app_id_key_is_listed_once`, `test_an_oauth_row_left_under_an_old_display_name_is_still_skipped` |
| drop `app.get("name")` | `test_a_row_matching_only_the_display_name_key_is_listed_once` |
| restore the raw `.lower()` skip | `test_a_team_overlaid_catalog_row_is_skipped_too` (+3) |
| drop `auth.app_id` for oauth rows | `test_an_oauth_row_left_under_an_old_display_name_is_still_skipped` |

Also covered: the granted `mcp_oauth` path emitted once and connected, a custom row unable to claim a catalog identity through hand-written `auth`, and the existing guards (an unrelated custom server still listed, `location=remote` unchanged).

Verification: new tests 13/13; the whole `tests/web/api` suite passes (PostgreSQL cases skipped, `XAGENT_TEST_POSTGRES_URL` unset); `ruff format --check`, `ruff check`, and `mypy src/xagent/web/api/mcp.py` are clean.

Fixes #1346
