### PR TITLE
feat: auto-opening DAG execution progress panel

### DIFF
--- a/frontend/src/app/task/[id]/page-client.test.tsx
+++ b/frontend/src/app/task/[id]/page-client.test.tsx
@@ -166,4 +166,40 @@ describe("TaskDetailPage progress panel lifecycle", () => {
     fireEvent.click(screen.getByTitle("Show execution progress"))
     expect(screen.getByText("Progress")).toBeInTheDocument()
   })
+
+  it("freezes the elapsed time at dagTerminatedAt instead of the live-ticking now", () => {
+    // dagTerminatedAt (not the mutable currentTask.updatedAt) is what this
+    // page passes through as ProgressPanel's endedAt - it's stamped once when
+    // the run actually finishes and survives later, unrelated task metadata
+    // refreshes untouched. Start the task "running" so the panel auto-opens
+    // (a terminal status from the very first render is deliberately excluded
+    // from auto-open - see the effect above - so this exercises the realistic
+    // sequence: open while live, then the run ends under it).
+    app.state = baseState({
+      dagExecution: { phase: "executing", current_plan: {}, created_at: "2026-05-27T05:00:00Z", updated_at: "2026-05-27T05:00:00Z", turn_id: "turn-A" },
+    })
+    const { rerender } = renderPage()
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+
+    app.state = baseState({
+      currentTask: {
+        id: "1",
+        title: "Test task",
+        status: "completed",
+        description: "Test task",
+        createdAt: "2026-05-27T05:00:00Z",
+        updatedAt: "2026-05-27T05:05:00Z",
+        dagTerminatedAt: "2026-05-27T05:01:05Z",
+      },
+      dagExecution: { phase: "completed", current_plan: {}, created_at: "2026-05-27T05:00:00Z", updated_at: "2026-05-27T05:01:05Z", turn_id: "turn-A" },
+    })
+    rerender(
+      <I18nProvider initialLocale="en">
+        <TaskDetailPage />
+      </I18nProvider>
+    )
+    // 05:01:05 - 05:00:00 = 65s -> "1m 05s". If the page fell back to
+    // currentTask.updatedAt (05:05:00) instead, this would read "5m 00s".
+    expect(screen.getByText("1m 05s")).toBeInTheDocument()
+  })
 })

--- a/frontend/src/app/task/[id]/page-client.test.tsx
+++ b/frontend/src/app/task/[id]/page-client.test.tsx
@@ -202,4 +202,98 @@ describe("TaskDetailPage progress panel lifecycle", () => {
     // currentTask.updatedAt (05:05:00) instead, this would read "5m 00s".
     expect(screen.getByText("1m 05s")).toBeInTheDocument()
   })
+
+  it("does not auto-open for state populated by history/replay or an already-terminal task", () => {
+    // A finished task's page load populates dagExecution/progressRunKey from
+    // history through the exact same state the auto-open effect watches -
+    // without the history/terminal gates, just VIEWING a finished task would
+    // pop the panel open unprompted.
+    app.state = baseState({
+      currentTask: {
+        id: "1",
+        title: "Test task",
+        status: "completed",
+        description: "Test task",
+        createdAt: "2026-05-27T05:00:00Z",
+        updatedAt: "2026-05-27T05:01:00Z",
+        dagTerminatedAt: "2026-05-27T05:01:00Z",
+      },
+      dagExecution: { phase: "completed", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-A" },
+    })
+    renderPage()
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+    // The header toggle still works - the gate only stops AUTO-opening.
+    fireEvent.click(screen.getByTitle("Show execution progress"))
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+  })
+
+  it("hides superseded step rows while a replan is generating the replacement plan", () => {
+    // A replanning event carries no replacement steps and shares the run's
+    // turn_id, so the old plan's rows survive in state.steps - the panel
+    // must not keep presenting them as current (the graph view already hides
+    // the old plan for this phase).
+    app.state = baseState({
+      dagExecution: { phase: "executing", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-A" },
+      steps: [{
+        id: "step-one",
+        name: "Old step",
+        description: "",
+        status: "completed",
+        dependencies: [],
+      }],
+    })
+    const { rerender } = renderPage()
+    expect(screen.getByText("Old step")).toBeInTheDocument()
+
+    app.state = baseState({
+      dagExecution: { phase: "replanning", current_plan: {}, created_at: "t", updated_at: "t2", turn_id: "turn-A" },
+      steps: [{
+        id: "step-one",
+        name: "Old step",
+        description: "",
+        status: "completed",
+        dependencies: [],
+      }],
+    })
+    rerender(
+      <I18nProvider initialLocale="en">
+        <TaskDetailPage />
+      </I18nProvider>
+    )
+    expect(screen.queryByText("Old step")).not.toBeInTheDocument()
+  })
+
+  it("still shows the last known steps when the task has already ended while stuck in replanning", () => {
+    // The backend's phase can get stuck at "replanning" if the task ends via
+    // a path that never syncs dagExecution.phase, or a malformed/dropped
+    // executing-transition event is dropped outright by the normalizer.
+    // ProgressPanel itself renders NOTHING for zero steps once endedAt is
+    // set (no spinner, no rows) - hiding steps here too would blank the
+    // entire panel body for a finished run instead of showing its last
+    // known state, which is strictly worse than a rare stale-plan flash.
+    app.state = baseState({
+      currentTask: {
+        id: "1",
+        title: "Test task",
+        status: "completed",
+        description: "Test task",
+        createdAt: "2026-05-27T05:00:00Z",
+        updatedAt: "2026-05-27T05:02:00Z",
+        dagTerminatedAt: "2026-05-27T05:02:00Z",
+      },
+      dagExecution: { phase: "replanning", current_plan: {}, created_at: "t", updated_at: "t2", turn_id: "turn-A" },
+      steps: [{
+        id: "step-one",
+        name: "Old step",
+        description: "",
+        status: "completed",
+        dependencies: [],
+      }],
+    })
+    renderPage()
+    // A terminal task from the very first render doesn't auto-open (see the
+    // history/terminal auto-open test above) - open it via the header toggle.
+    fireEvent.click(screen.getByTitle("Show execution progress"))
+    expect(screen.getByText("Old step")).toBeInTheDocument()
+  })
 })

--- a/frontend/src/app/task/[id]/page-client.test.tsx
+++ b/frontend/src/app/task/[id]/page-client.test.tsx
@@ -1,0 +1,169 @@
+import React from "react"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { I18nProvider } from "@/contexts/i18n-context"
+import type { AppState } from "@/contexts/app-context-chat"
+
+const navigation = vi.hoisted(() => ({
+  params: { id: "1" },
+  push: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useParams: () => navigation.params,
+  useRouter: () => ({ push: navigation.push }),
+}))
+
+vi.mock("@/components/task/task-conversation-panel", () => ({
+  TaskConversationPanel: () => <div data-testid="conversation-panel" />,
+}))
+
+const app = vi.hoisted(() => ({
+  state: {} as Partial<AppState>,
+  setTaskId: vi.fn(),
+  closeFilePreview: vi.fn(),
+}))
+
+vi.mock("@/contexts/app-context-chat", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/contexts/app-context-chat")>()
+  return {
+    ...actual,
+    useApp: () => ({
+      state: app.state,
+      setTaskId: app.setTaskId,
+      closeFilePreview: app.closeFilePreview,
+    }),
+  }
+})
+
+import TaskDetailPage from "./page-client"
+
+function baseState(overrides: Partial<AppState> = {}): Partial<AppState> {
+  return {
+    taskId: 1,
+    currentTask: {
+      id: "1",
+      title: "Test task",
+      status: "running",
+      description: "Test task",
+      createdAt: "2026-05-27T05:00:00Z",
+      updatedAt: "2026-05-27T05:00:00Z",
+    },
+    dagExecution: null,
+    steps: [],
+    ...overrides,
+  } as Partial<AppState>
+}
+
+function renderPage() {
+  return render(
+    <I18nProvider initialLocale="en">
+      <TaskDetailPage />
+    </I18nProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  navigation.params = { id: "1" }
+  navigation.push.mockReset()
+  app.setTaskId.mockReset()
+  app.closeFilePreview.mockReset()
+})
+
+describe("TaskDetailPage progress panel lifecycle", () => {
+  beforeEach(() => {
+    app.state = baseState()
+  })
+
+  it("does not render the panel toggle or panel while there is no dagExecution", () => {
+    renderPage()
+    expect(screen.queryByTitle("Show execution progress")).not.toBeInTheDocument()
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+  })
+
+  it("auto-opens the panel the moment dagExecution first appears", () => {
+    const { rerender } = renderPage()
+    app.state = baseState({
+      dagExecution: { phase: "planning", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-A" },
+    })
+    rerender(
+      <I18nProvider initialLocale="en">
+        <TaskDetailPage />
+      </I18nProvider>
+    )
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+  })
+
+  it("suppresses re-opening for the SAME run once manually dismissed, but reopens for a new run", () => {
+    app.state = baseState({
+      dagExecution: { phase: "planning", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-A" },
+    })
+    const { rerender } = renderPage()
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+
+    // Manually collapse via the header toggle.
+    fireEvent.click(screen.getByTitle("Collapse"))
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+
+    // A further event for the SAME run (turn_id unchanged) must not reopen it.
+    app.state = baseState({
+      dagExecution: { phase: "executing", current_plan: {}, created_at: "t", updated_at: "t2", turn_id: "turn-A" },
+    })
+    rerender(
+      <I18nProvider initialLocale="en">
+        <TaskDetailPage />
+      </I18nProvider>
+    )
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+
+    // A NEW run (different turn_id) must reopen it.
+    app.state = baseState({
+      dagExecution: { phase: "planning", current_plan: {}, created_at: "t3", updated_at: "t3", turn_id: "turn-B" },
+    })
+    rerender(
+      <I18nProvider initialLocale="en">
+        <TaskDetailPage />
+      </I18nProvider>
+    )
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+  })
+
+  it("closes the panel when the backdrop is clicked", () => {
+    app.state = baseState({
+      dagExecution: { phase: "planning", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-A" },
+    })
+    const { container } = renderPage()
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+
+    const backdrop = container.querySelector('[aria-hidden="true"]')
+    expect(backdrop).not.toBeNull()
+    fireEvent.click(backdrop as Element)
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+  })
+
+  it("closes the panel on Escape", () => {
+    app.state = baseState({
+      dagExecution: { phase: "planning", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-A" },
+    })
+    renderPage()
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" })
+    })
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+  })
+
+  it("reopens via the header toggle after a manual collapse", () => {
+    app.state = baseState({
+      dagExecution: { phase: "planning", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-A" },
+    })
+    renderPage()
+    fireEvent.click(screen.getByTitle("Collapse"))
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle("Show execution progress"))
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/task/[id]/page-client.test.tsx
+++ b/frontend/src/app/task/[id]/page-client.test.tsx
@@ -203,6 +203,62 @@ describe("TaskDetailPage progress panel lifecycle", () => {
     expect(screen.getByText("1m 05s")).toBeInTheDocument()
   })
 
+  it("does not carry an open panel over to a different task navigated to without a remount", () => {
+    // progressPanelOpen/dismissedProgressRunKeyRef are mount-local, not
+    // scoped to the viewed task - without a reset on taskId change, task A's
+    // open panel would still be "open" the instant task B's own
+    // dagExecution repopulates (e.g. from B's terminal history), showing it
+    // without any new user action for B.
+    app.state = baseState({
+      dagExecution: { phase: "executing", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-A" },
+    })
+    const { rerender } = renderPage()
+    expect(screen.getByText("Progress")).toBeInTheDocument()
+
+    // Soft navigation to task B - no dagExecution yet.
+    app.state = baseState({
+      taskId: 2,
+      currentTask: {
+        id: "2",
+        title: "Task B",
+        status: "completed",
+        description: "Task B",
+        createdAt: "2026-05-27T05:00:00Z",
+        updatedAt: "2026-05-27T05:01:00Z",
+        dagTerminatedAt: "2026-05-27T05:01:00Z",
+      },
+      dagExecution: null,
+    })
+    rerender(
+      <I18nProvider initialLocale="en">
+        <TaskDetailPage />
+      </I18nProvider>
+    )
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+
+    // Task B's own (terminal, historical) dagExecution repopulates - must NOT
+    // reopen the panel just because it carried over from task A.
+    app.state = baseState({
+      taskId: 2,
+      currentTask: {
+        id: "2",
+        title: "Task B",
+        status: "completed",
+        description: "Task B",
+        createdAt: "2026-05-27T05:00:00Z",
+        updatedAt: "2026-05-27T05:01:00Z",
+        dagTerminatedAt: "2026-05-27T05:01:00Z",
+      },
+      dagExecution: { phase: "completed", current_plan: {}, created_at: "t", updated_at: "t", turn_id: "turn-B" },
+    })
+    rerender(
+      <I18nProvider initialLocale="en">
+        <TaskDetailPage />
+      </I18nProvider>
+    )
+    expect(screen.queryByText("Progress")).not.toBeInTheDocument()
+  })
+
   it("does not auto-open for state populated by history/replay or an already-terminal task", () => {
     // A finished task's page load populates dagExecution/progressRunKey from
     // history through the exact same state the auto-open effect watches -

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -57,12 +57,24 @@ function TaskDetailContent() {
   // reason to wait for the user to click the header toggle. A manual
   // collapse only suppresses re-opening for *this* run (tracked by
   // progressRunKey); the next DAG run gets a fresh key and opens again.
+  //
+  // Gated to LIVE runs only: history replay (reconnect, or simply opening an
+  // already-finished task's page) populates dagExecution/progressRunKey too,
+  // via the exact same state this effect watches - without these guards,
+  // just viewing a finished task's history would pop the panel open
+  // unprompted. isHistoryLoading/isReplaying skip the population that
+  // happens WHILE replay is in flight; the terminal-status check catches the
+  // case where replay has already finished (or the page was opened directly
+  // on an already-finished task) and progressRunKey is simply sitting there
+  // populated from history, no live transition ever having occurred.
   useEffect(() => {
     if (progressRunKey === undefined || progressRunKey === null) return
+    if (state.isHistoryLoading || state.isReplaying) return
+    if (isTerminalTaskStatus(state.currentTask?.status)) return
     const key = String(progressRunKey)
     if (dismissedProgressRunKeyRef.current === key) return
     setProgressPanelOpen(true)
-  }, [progressRunKey])
+  }, [progressRunKey, state.isHistoryLoading, state.isReplaying, state.currentTask?.status])
 
   // Scrolls the chat's trace log to a step when a Progress panel row is
   // clicked (TraceEventRenderer.tsx tags each DAG step group with

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -71,22 +71,16 @@ function TaskDetailContent() {
       // rather than the first, which querySelector would otherwise return.
       // Step ids are LLM-generated plan identifiers with no schema
       // constraint on their content (see plan_generator.py's tool schema),
-      // so they can legitimately contain quotes/backslashes - CSS.escape
-      // handles that, but is absent in some test/DOM-shim environments (e.g.
-      // jsdom without the polyfill); querySelectorAll throws a SyntaxError on
-      // an unescaped special character, so wrap in try/catch rather than
-      // letting that escape this window event listener uncaught.
-      const escapedStepId = typeof CSS !== "undefined" && typeof CSS.escape === "function"
-        ? CSS.escape(stepId)
-        : stepId.replace(/["\\]/g, "\\$&")
-      try {
-        const matches = document.querySelectorAll(`[data-step-id="${escapedStepId}"]`)
-        const target = matches[matches.length - 1]
-        target?.scrollIntoView({ behavior: "smooth", block: "center" })
-      } catch {
-        // Malformed selector (unescaped special char with no CSS.escape) -
-        // nothing to scroll to safely; fail silently.
-      }
+      // so they can legitimately contain quotes/backslashes. Only backslash
+      // and double-quote need escaping inside a double-quoted attribute
+      // selector value - CSS.escape is for identifier syntax (e.g. it
+      // hex-escapes a leading digit), not string-literal content, and is
+      // also absent in some test/DOM-shim environments, so a plain regex
+      // replace is both simpler and correct here.
+      const escapedStepId = stepId.replace(/["\\]/g, "\\$&")
+      const matches = document.querySelectorAll(`[data-step-id="${escapedStepId}"]`)
+      const target = matches[matches.length - 1]
+      target?.scrollIntoView({ behavior: "smooth", block: "center" })
     }
     window.addEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)
     return () => window.removeEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -65,32 +65,20 @@ function TaskDetailContent() {
     const handleScrollToTraceStep = (event: Event) => {
       const stepId = (event as CustomEvent<{ stepId?: string }>).detail?.stepId
       if (!stepId) return
-      // A replan reuses the same step ids, and a multi-turn task's history
-      // can render more than one trace group tagged with the same
-      // data-step-id - take the LAST match (the current/most recent one)
-      // rather than the first, which querySelector would otherwise return.
-      // Step ids are LLM-generated plan identifiers with no schema
-      // constraint on their content (see plan_generator.py's tool schema),
-      // so they can legitimately contain quotes/backslashes/control
-      // characters. Backslash and double-quote need a literal backslash
-      // escape inside a double-quoted attribute selector value; any other
-      // control character (e.g. a raw newline) is not valid inside a quoted
-      // CSS string at all and must use a hex escape instead, or
-      // querySelectorAll throws a SyntaxError. CSS.escape is for identifier
-      // syntax (e.g. it hex-escapes a leading digit), not string-literal
-      // content, and is also absent in some test/DOM-shim environments, so a
-      // plain regex replace is both simpler and correct here. NUL (\x00) is
-      // dropped rather than hex-escaped: per the CSS syntax spec, a hex
-      // escape for value zero decodes back to U+FFFD, not U+0000, so it
-      // could never match a real NUL character in the DOM attribute anyway.
-      const escapedStepId = stepId.replace(/["\\\x00-\x1f]/g, (ch) => {
-        if (ch === '"' || ch === "\\") return `\\${ch}`
-        if (ch === "\0") return ""
-        return `\\${ch.charCodeAt(0).toString(16)} `
-      })
-      const matches = document.querySelectorAll(`[data-step-id="${escapedStepId}"]`)
-      const target = matches[matches.length - 1]
-      target?.scrollIntoView({ behavior: "smooth", block: "center" })
+      // Step ids are LLM-generated plan identifiers with no schema constraint
+      // on their content (see plan_generator.py's tool schema), so they can
+      // legitimately contain characters that aren't safe to interpolate into
+      // a CSS attribute selector (quotes, backslashes, control characters
+      // including NUL). Matching by actual attribute value instead of
+      // building a selector string sidesteps escaping entirely - there's
+      // nothing here for a pathological id to break. A replan reuses the same
+      // step ids, and a multi-turn task's history can render more than one
+      // trace group tagged with the same data-step-id - take the LAST match
+      // (the current/most recent one) rather than the first.
+      const matches = Array.from(document.querySelectorAll("[data-step-id]")).filter(
+        (el) => el.getAttribute("data-step-id") === stepId
+      )
+      matches[matches.length - 1]?.scrollIntoView({ behavior: "smooth", block: "center" })
     }
     window.addEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)
     return () => window.removeEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)
@@ -158,7 +146,7 @@ function TaskDetailContent() {
                 size="icon"
                 className={cn("rounded-full flex-shrink-0", progressPanelOpen ? "bg-muted text-primary" : "hover:bg-muted")}
                 onClick={() => (progressPanelOpen ? handleCollapseProgressPanel() : setProgressPanelOpen(true))}
-                title={t("chatPage.progressPanel.toggleTooltip")}
+                title={progressPanelOpen ? t("chatPage.progressPanel.collapse") : t("chatPage.progressPanel.toggleTooltip")}
                 aria-pressed={progressPanelOpen}
               >
                 <PanelRight className="w-5 h-5" />

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -34,6 +34,23 @@ function TaskDetailContent() {
     }
   }, [closeFilePreview])
 
+  // progressPanelOpen/dismissedProgressRunKeyRef are mount-local state, not
+  // scoped to the viewed task - a soft A-to-B navigation (setTaskId without a
+  // remount) would otherwise carry task A's open/dismissed state straight
+  // into task B. Task A's dagExecution/steps are already cleared on a task
+  // switch (see app-context-chat.tsx's SET_TASK_ID taskChanged branch), but
+  // the moment task B's OWN history/live data repopulates a dagExecution,
+  // `progressPanelVisible` only checks `progressPanelOpen && Boolean(dagExecution)`
+  // - if it was left true from viewing A, B's panel would appear without any
+  // new user action, bypassing the auto-open effect's own gating below
+  // entirely (that effect decides whether to OPEN it, not whether it's
+  // already open). Resetting on every taskId change (including the very
+  // first one) is harmless: both start already at their default values.
+  useEffect(() => {
+    setProgressPanelOpen(false)
+    dismissedProgressRunKeyRef.current = null
+  }, [state.taskId])
+
   // Prefer turn_id (a stable per-turn identity - see DAGExecution's own
   // comment) over created_at for identifying "this run" - created_at can get
   // rebuilt with a fresh value on a replan re-arrival while still being the

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -106,8 +106,8 @@ function TaskDetailContent() {
   const progressEndedAt = isDagFinished ? state.currentTask?.updatedAt : undefined
 
   return (
-    <div className="h-full flex bg-background">
-      <div className="flex-1 min-w-0 flex flex-col">
+    <div className="h-full flex flex-col md:flex-row bg-background">
+      <div className="flex-1 min-w-0 min-h-0 flex flex-col">
         {(state.currentTask?.agentId || state.dagExecution) && (
           <div className="flex-none flex items-center justify-between gap-3 px-4 py-3 bg-background/95 backdrop-blur z-50 sticky top-0">
             <div className="flex items-center gap-3 min-w-0">
@@ -163,9 +163,15 @@ function TaskDetailContent() {
           above, not nested under it) so it visually pops out from the right
           edge of the entire page rather than just the content area below
           the header - and stays independent of the file/graph preview's
-          draggable PreviewSheet layout inside TaskConversationPanel. */}
+          draggable PreviewSheet layout inside TaskConversationPanel. Below
+          `md` there's no room for a fixed 360px side-by-side column without
+          squeezing the chat unusably narrow, so it stacks below the chat
+          instead - the same stack-on-mobile/side-column-on-desktop idea as
+          resizable-three-column-layout.tsx, capped to a fraction of the
+          viewport height (shrink-0 so that cap holds) rather than taking the
+          full remaining width. */}
       {progressPanelVisible && (
-        <div className="flex-shrink-0 w-[360px] h-full border-l border-border">
+        <div className="w-full md:w-[360px] shrink-0 h-[45vh] md:h-full border-t md:border-t-0 md:border-l border-border">
           <ProgressPanel
             steps={progressSteps}
             startedAt={state.dagExecution?.created_at}

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Suspense, useCallback, useEffect, useRef, useState } from "react"
+import React, { Suspense, useCallback, useEffect, useRef, useState } from "react"
 import { ArrowLeft, Loader2, PanelRight } from "lucide-react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -6,7 +6,7 @@ import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
 import { ProgressPanel, type ProgressStepView } from "@/components/task/progress-panel"
-import { useApp } from "@/contexts/app-context-chat"
+import { isTerminalTaskStatus, useApp } from "@/contexts/app-context-chat"
 import { useI18n } from "@/contexts/i18n-context"
 import { cn, getApiUrl } from "@/lib/utils"
 
@@ -34,11 +34,19 @@ function TaskDetailContent() {
     }
   }, [closeFilePreview])
 
+  // Prefer turn_id (a stable per-turn identity - see DAGExecution's own
+  // comment) over created_at for identifying "this run" - created_at can get
+  // rebuilt with a fresh value on a replan re-arrival while still being the
+  // SAME run, which would incorrectly reopen a panel the user just dismissed
+  // and restart its elapsed timer. Falls back to created_at only when
+  // turn_id is absent (an older backend, or some other pattern that doesn't
+  // set it).
+  const progressRunKey = state.dagExecution?.turn_id ?? state.dagExecution?.created_at
+
   const handleCollapseProgressPanel = useCallback(() => {
-    const key = state.dagExecution?.created_at
-    dismissedProgressRunKeyRef.current = key !== undefined && key !== null ? String(key) : null
+    dismissedProgressRunKeyRef.current = progressRunKey !== undefined && progressRunKey !== null ? String(progressRunKey) : null
     setProgressPanelOpen(false)
-  }, [state.dagExecution?.created_at])
+  }, [progressRunKey])
 
   const handleProgressStepClick = useCallback((stepId: string) => {
     window.dispatchEvent(new CustomEvent("scrollToTraceStep", { detail: { stepId } }))
@@ -48,15 +56,13 @@ function TaskDetailContent() {
   // the plan's step list is known as soon as planning starts, so there is no
   // reason to wait for the user to click the header toggle. A manual
   // collapse only suppresses re-opening for *this* run (tracked by
-  // dagExecution.created_at); the next DAG run gets a fresh created_at and
-  // opens again.
+  // progressRunKey); the next DAG run gets a fresh key and opens again.
   useEffect(() => {
-    const createdAt = state.dagExecution?.created_at
-    if (createdAt === undefined || createdAt === null) return
-    const key = String(createdAt)
+    if (progressRunKey === undefined || progressRunKey === null) return
+    const key = String(progressRunKey)
     if (dismissedProgressRunKeyRef.current === key) return
     setProgressPanelOpen(true)
-  }, [state.dagExecution?.created_at])
+  }, [progressRunKey])
 
   // Scrolls the chat's trace log to a step when a Progress panel row is
   // clicked (TraceEventRenderer.tsx tags each DAG step group with
@@ -84,6 +90,20 @@ function TaskDetailContent() {
     return () => window.removeEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)
   }, [])
 
+  // Between `md` and `xl` the panel renders as a dismissible overlay (see the
+  // render below) rather than a static column - Escape should close it the
+  // same way clicking the backdrop does. Harmless above `xl`, where the panel
+  // is a static sibling and there's no backdrop to match: closing it there
+  // via Escape is just the same action the header toggle already offers.
+  useEffect(() => {
+    if (!progressPanelOpen) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") handleCollapseProgressPanel()
+    }
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [progressPanelOpen, handleCollapseProgressPanel])
+
   const progressSteps: ProgressStepView[] = state.steps.map((step) => ({
     id: step.id,
     title: step.name,
@@ -100,10 +120,16 @@ function TaskDetailContent() {
   // at all (only planning/replanning/executing/completion_assessment) nor an
   // updated_at - so freezing off dagExecution would freeze early on a
   // recoverable step failure, or never freeze, or un-freeze on a later
-  // in-flight dag_execution event. The task's own status/updatedAt is the one
-  // signal that's actually authoritative for "this run is truly over."
-  const isDagFinished = state.currentTask?.status === "completed" || state.currentTask?.status === "failed"
-  const progressEndedAt = isDagFinished ? state.currentTask?.updatedAt : undefined
+  // in-flight dag_execution event. The task's own status is the one signal
+  // that's actually authoritative for "this run is truly over."
+  const isDagFinished = isTerminalTaskStatus(state.currentTask?.status)
+  // dagTerminatedAt, not updatedAt: the latter is general task metadata that
+  // keeps changing after this run ends for unrelated reasons (a title edit,
+  // another field update via a later task_info refresh), which would make
+  // the frozen elapsed time silently drift on revisit. dagTerminatedAt is
+  // stamped once by UPDATE_TASK_STATUS specifically for this and preserved
+  // across those unrelated refreshes.
+  const progressEndedAt = isDagFinished ? state.currentTask?.dagTerminatedAt : undefined
 
   return (
     <div className="h-full flex flex-col md:flex-row bg-background">
@@ -159,34 +185,53 @@ function TaskDetailContent() {
         </div>
       </div>
 
-      {/* Spans the whole page's height (siblings the header+chat column
-          above, not nested under it) so it visually pops out from the right
-          edge of the entire page rather than just the content area below
-          the header - and stays independent of the file/graph preview's
-          draggable PreviewSheet layout inside TaskConversationPanel. Below
-          `md` there's no room for a fixed side-by-side column without
-          squeezing the chat unusably narrow, so it stacks below the chat
-          instead - the same stack-on-mobile/side-column-on-desktop idea as
-          resizable-three-column-layout.tsx, capped to a fraction of the
-          viewport height (shrink-0 so that cap holds) rather than taking the
-          full remaining width. Between `md` and `xl` the rail narrows to
-          280px rather than jumping straight to 360px - at ~1024px,
-          TaskConversationPanel's own chat/PreviewSheet split (when a
-          file/graph preview is also open) already halves what's left, so the
-          full 360px here would leave that split unusably narrow. This isn't a
-          full fix for that interaction (the two panels don't coordinate
-          widths - see PR review) but meaningfully softens it at the specific
-          width band that's tightest. */}
+      {/* Three responsive treatments, since a fixed side column has nowhere
+          good to go at every width once TaskConversationPanel's own
+          chat/PreviewSheet split is also in play:
+          - Below `md`: no room for a side-by-side column at all, so it
+            stacks below the chat instead, capped to a fraction of the
+            viewport height (shrink-0 so that cap holds) - unchanged from
+            before.
+          - `md` to below `xl` (tablet/narrow desktop): a fixed overlay
+            sliding in from the right edge, with a dismissible backdrop -
+            this is the "overlay/collapse mode at constrained widths" the PR
+            review asked for, specifically because this is the range where
+            TaskConversationPanel's own PreviewSheet split (when a file/graph
+            preview is also open) leaves too little room for a permanent
+            side-by-side rail; an overlay draws on top instead of taking flex
+            space from that split, so the two no longer compete for width.
+          - `xl` and up: reverts to a normal static sibling column (siblings
+            the header+chat column above, not nested under it, so it visually
+            pops out from the right edge of the entire page) - there's
+            finally enough width for both panels to coexist without either
+            being squeezed. */}
       {progressPanelVisible && (
-        <div className="w-full md:w-[280px] xl:w-[360px] shrink-0 h-[45vh] md:h-full border-t md:border-t-0 md:border-l border-border">
-          <ProgressPanel
-            steps={progressSteps}
-            startedAt={state.dagExecution?.created_at}
-            endedAt={progressEndedAt}
-            onCollapse={handleCollapseProgressPanel}
-            onStepClick={handleProgressStepClick}
+        <>
+          {/* z-[110]/z-[120], above every other fixed/high-z-index element on
+              this page: the header sits at z-50, TaskConversationPanel's own
+              PreviewSheet column-resize handle at z-[100] (its wide invisible
+              hit area would otherwise still capture drag clicks meant for
+              this panel), and the floating voice-input mic button at z-[70]
+              (which would otherwise float visibly on top of the dimmed
+              backdrop) - all need to render underneath this overlay, not just
+              the header. */}
+          <div
+            className="hidden md:block xl:hidden fixed inset-0 z-[110] bg-black/20"
+            onClick={handleCollapseProgressPanel}
+            aria-hidden="true"
           />
-        </div>
+          <div
+            className="w-full shrink-0 h-[45vh] border-t border-border md:fixed md:inset-y-0 md:right-0 md:z-[120] md:h-full md:w-[360px] md:border-t-0 md:border-l md:shadow-2xl xl:static xl:z-auto xl:shadow-none"
+          >
+            <ProgressPanel
+              steps={progressSteps}
+              startedAt={state.dagExecution?.created_at}
+              endedAt={progressEndedAt}
+              onCollapse={handleCollapseProgressPanel}
+              onStepClick={handleProgressStepClick}
+            />
+          </div>
+        </>
       )}
     </div>
   )

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -69,9 +69,24 @@ function TaskDetailContent() {
       // can render more than one trace group tagged with the same
       // data-step-id - take the LAST match (the current/most recent one)
       // rather than the first, which querySelector would otherwise return.
-      const matches = document.querySelectorAll(`[data-step-id="${CSS.escape(stepId)}"]`)
-      const target = matches[matches.length - 1]
-      target?.scrollIntoView({ behavior: "smooth", block: "center" })
+      // Step ids are LLM-generated plan identifiers with no schema
+      // constraint on their content (see plan_generator.py's tool schema),
+      // so they can legitimately contain quotes/backslashes - CSS.escape
+      // handles that, but is absent in some test/DOM-shim environments (e.g.
+      // jsdom without the polyfill); querySelectorAll throws a SyntaxError on
+      // an unescaped special character, so wrap in try/catch rather than
+      // letting that escape this window event listener uncaught.
+      const escapedStepId = typeof CSS !== "undefined" && typeof CSS.escape === "function"
+        ? CSS.escape(stepId)
+        : stepId.replace(/["\\]/g, "\\$&")
+      try {
+        const matches = document.querySelectorAll(`[data-step-id="${escapedStepId}"]`)
+        const target = matches[matches.length - 1]
+        target?.scrollIntoView({ behavior: "smooth", block: "center" })
+      } catch {
+        // Malformed selector (unescaped special char with no CSS.escape) -
+        // nothing to scroll to safely; fail silently.
+      }
     }
     window.addEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)
     return () => window.removeEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)
@@ -139,7 +154,7 @@ function TaskDetailContent() {
                 variant="ghost"
                 size="icon"
                 className={cn("rounded-full flex-shrink-0", progressPanelOpen ? "bg-muted text-primary" : "hover:bg-muted")}
-                onClick={() => setProgressPanelOpen((open) => !open)}
+                onClick={() => (progressPanelOpen ? handleCollapseProgressPanel() : setProgressPanelOpen(true))}
                 title={t("chatPage.progressPanel.toggleTooltip")}
                 aria-pressed={progressPanelOpen}
               >

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -79,10 +79,15 @@ function TaskDetailContent() {
       // querySelectorAll throws a SyntaxError. CSS.escape is for identifier
       // syntax (e.g. it hex-escapes a leading digit), not string-literal
       // content, and is also absent in some test/DOM-shim environments, so a
-      // plain regex replace is both simpler and correct here.
-      const escapedStepId = stepId.replace(/["\\\x00-\x1f]/g, (ch) => (
-        ch === '"' || ch === "\\" ? `\\${ch}` : `\\${ch.charCodeAt(0).toString(16)} `
-      ))
+      // plain regex replace is both simpler and correct here. NUL (\x00) is
+      // dropped rather than hex-escaped: per the CSS syntax spec, a hex
+      // escape for value zero decodes back to U+FFFD, not U+0000, so it
+      // could never match a real NUL character in the DOM attribute anyway.
+      const escapedStepId = stepId.replace(/["\\\x00-\x1f]/g, (ch) => {
+        if (ch === '"' || ch === "\\") return `\\${ch}`
+        if (ch === "\0") return ""
+        return `\\${ch.charCodeAt(0).toString(16)} `
+      })
       const matches = document.querySelectorAll(`[data-step-id="${escapedStepId}"]`)
       const target = matches[matches.length - 1]
       target?.scrollIntoView({ behavior: "smooth", block: "center" })

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -1,13 +1,14 @@
 "use client"
 
-import { Suspense, useEffect } from "react"
-import { ArrowLeft, Loader2 } from "lucide-react"
+import { Suspense, useCallback, useEffect, useRef, useState } from "react"
+import { ArrowLeft, Loader2, PanelRight } from "lucide-react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
+import { ProgressPanel, type ProgressStepView } from "@/components/task/progress-panel"
 import { useApp } from "@/contexts/app-context-chat"
 import { useI18n } from "@/contexts/i18n-context"
-import { getApiUrl } from "@/lib/utils"
+import { cn, getApiUrl } from "@/lib/utils"
 
 function TaskDetailContent() {
   const { state, setTaskId, closeFilePreview } = useApp()
@@ -15,6 +16,8 @@ function TaskDetailContent() {
   const params = useParams()
   const router = useRouter()
   const taskIdFromUrl = params.id
+  const [progressPanelOpen, setProgressPanelOpen] = useState(false)
+  const dismissedProgressRunKeyRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (taskIdFromUrl && typeof taskIdFromUrl === "string") {
@@ -31,41 +34,143 @@ function TaskDetailContent() {
     }
   }, [closeFilePreview])
 
+  const handleCollapseProgressPanel = useCallback(() => {
+    const key = state.dagExecution?.created_at
+    dismissedProgressRunKeyRef.current = key !== undefined && key !== null ? String(key) : null
+    setProgressPanelOpen(false)
+  }, [state.dagExecution?.created_at])
+
+  const handleProgressStepClick = useCallback((stepId: string) => {
+    window.dispatchEvent(new CustomEvent("scrollToTraceStep", { detail: { stepId } }))
+  }, [])
+
+  // Auto-open the panel the moment this turn enters DAG/plan_execute mode -
+  // the plan's step list is known as soon as planning starts, so there is no
+  // reason to wait for the user to click the header toggle. A manual
+  // collapse only suppresses re-opening for *this* run (tracked by
+  // dagExecution.created_at); the next DAG run gets a fresh created_at and
+  // opens again.
+  useEffect(() => {
+    const createdAt = state.dagExecution?.created_at
+    if (createdAt === undefined || createdAt === null) return
+    const key = String(createdAt)
+    if (dismissedProgressRunKeyRef.current === key) return
+    setProgressPanelOpen(true)
+  }, [state.dagExecution?.created_at])
+
+  // Scrolls the chat's trace log to a step when a Progress panel row is
+  // clicked (TraceEventRenderer.tsx tags each DAG step group with
+  // `data-step-id`).
+  useEffect(() => {
+    const handleScrollToTraceStep = (event: Event) => {
+      const stepId = (event as CustomEvent<{ stepId?: string }>).detail?.stepId
+      if (!stepId) return
+      // A replan reuses the same step ids, and a multi-turn task's history
+      // can render more than one trace group tagged with the same
+      // data-step-id - take the LAST match (the current/most recent one)
+      // rather than the first, which querySelector would otherwise return.
+      const matches = document.querySelectorAll(`[data-step-id="${CSS.escape(stepId)}"]`)
+      const target = matches[matches.length - 1]
+      target?.scrollIntoView({ behavior: "smooth", block: "center" })
+    }
+    window.addEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)
+    return () => window.removeEventListener("scrollToTraceStep", handleScrollToTraceStep as EventListener)
+  }, [])
+
+  const progressSteps: ProgressStepView[] = state.steps.map((step) => ({
+    id: step.id,
+    title: step.name,
+    description: step.description,
+    status: step.status,
+    startedAt: step.started_at,
+    completedAt: step.completed_at,
+  }))
+  const progressPanelVisible = progressPanelOpen && Boolean(state.dagExecution)
+  const isProgressPlanning = progressSteps.length === 0 && state.dagExecution?.phase === "planning"
+  // Deliberately keyed off the TASK's own status, not dagExecution.phase:
+  // a single step failing (dag_step_failed) sets the whole dagExecution.phase
+  // to "failed" even when the DAG goes on to replan and keep running, and the
+  // raw backend dag_execution payload never carries phase "completed"/"failed"
+  // at all (only planning/replanning/executing/completion_assessment) nor an
+  // updated_at - so freezing off dagExecution would freeze early on a
+  // recoverable step failure, or never freeze, or un-freeze on a later
+  // in-flight dag_execution event. The task's own status/updatedAt is the one
+  // signal that's actually authoritative for "this run is truly over."
+  const isDagFinished = state.currentTask?.status === "completed" || state.currentTask?.status === "failed"
+  const progressEndedAt = isDagFinished ? state.currentTask?.updatedAt : undefined
+
   return (
-    <div className="h-full flex flex-col bg-background">
-      {state.currentTask?.agentId && (
-        <div className="flex-none flex items-center gap-3 px-4 py-3 border-b bg-background/95 backdrop-blur z-50 sticky top-0">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="rounded-full hover:bg-muted flex-shrink-0"
-            onClick={() => {
-              const agentId = state.currentTask?.agentId
-              router.push(agentId ? `/agent/${agentId}` : "/task")
-            }}
-            title={t("common.back")}
-          >
-            <ArrowLeft className="w-5 h-5" />
-          </Button>
-          {(state.currentTask?.agentName || state.currentTask?.agentLogoUrl) && (
-            <div className="flex items-center gap-3 overflow-hidden">
-              {state.currentTask?.agentLogoUrl ? (
-                <img
-                  src={state.currentTask.agentLogoUrl.startsWith('http') ? state.currentTask.agentLogoUrl : `${getApiUrl()}${state.currentTask.agentLogoUrl}`}
-                  alt={state.currentTask.agentName || t("agent.logo")}
-                  className="w-8 h-8 object-cover rounded-sm flex-shrink-0"
-                />
-              ) : null}
-              {state.currentTask?.agentName ? (
-                <span className="text-lg font-bold text-foreground truncate">{state.currentTask.agentName}</span>
-              ) : null}
+    <div className="h-full flex bg-background">
+      <div className="flex-1 min-w-0 flex flex-col">
+        {(state.currentTask?.agentId || state.dagExecution) && (
+          <div className="flex-none flex items-center justify-between gap-3 px-4 py-3 bg-background/95 backdrop-blur z-50 sticky top-0">
+            <div className="flex items-center gap-3 min-w-0">
+              {state.currentTask?.agentId && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="rounded-full hover:bg-muted flex-shrink-0"
+                  onClick={() => {
+                    const agentId = state.currentTask?.agentId
+                    router.push(agentId ? `/agent/${agentId}` : "/task")
+                  }}
+                  title={t("common.back")}
+                >
+                  <ArrowLeft className="w-5 h-5" />
+                </Button>
+              )}
+              {(state.currentTask?.agentName || state.currentTask?.agentLogoUrl) && (
+                <div className="flex items-center gap-3 overflow-hidden">
+                  {state.currentTask?.agentLogoUrl ? (
+                    <img
+                      src={state.currentTask.agentLogoUrl.startsWith('http') ? state.currentTask.agentLogoUrl : `${getApiUrl()}${state.currentTask.agentLogoUrl}`}
+                      alt={state.currentTask.agentName || t("agent.logo")}
+                      className="w-8 h-8 object-cover rounded-sm flex-shrink-0"
+                    />
+                  ) : null}
+                  {state.currentTask?.agentName ? (
+                    <span className="text-lg font-bold text-foreground truncate">{state.currentTask.agentName}</span>
+                  ) : null}
+                </div>
+              )}
             </div>
-          )}
+            {state.dagExecution && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn("rounded-full flex-shrink-0", progressPanelOpen ? "bg-muted text-primary" : "hover:bg-muted")}
+                onClick={() => setProgressPanelOpen((open) => !open)}
+                title={t("chatPage.progressPanel.toggleTooltip")}
+                aria-pressed={progressPanelOpen}
+              >
+                <PanelRight className="w-5 h-5" />
+              </Button>
+            )}
+          </div>
+        )}
+        <div className="flex-1 min-h-0 relative">
+          <TaskConversationPanel mode="page" />
+        </div>
+      </div>
+
+      {/* Spans the whole page's height (siblings the header+chat column
+          above, not nested under it) so it visually pops out from the right
+          edge of the entire page rather than just the content area below
+          the header - and stays independent of the file/graph preview's
+          draggable PreviewSheet layout inside TaskConversationPanel. */}
+      {progressPanelVisible && (
+        <div className="flex-shrink-0 w-[360px] h-full border-l border-border">
+          <ProgressPanel
+            steps={progressSteps}
+            totalKnown
+            startedAt={state.dagExecution?.created_at}
+            endedAt={progressEndedAt}
+            isPlanning={isProgressPlanning}
+            onCollapse={handleCollapseProgressPanel}
+            onStepClick={handleProgressStepClick}
+          />
         </div>
       )}
-      <div className="flex-1 min-h-0 relative">
-        <TaskConversationPanel mode="page" />
-      </div>
     </div>
   )
 }

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -116,15 +116,6 @@ function TaskDetailContent() {
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [progressPanelOpen, handleCollapseProgressPanel])
 
-  const progressSteps: ProgressStepView[] = state.steps.map((step) => ({
-    id: step.id,
-    title: step.name,
-    description: step.description,
-    status: step.status,
-    startedAt: step.started_at,
-    completedAt: step.completed_at,
-  }))
-  const progressPanelVisible = progressPanelOpen && Boolean(state.dagExecution)
   // Deliberately keyed off the TASK's own status, not dagExecution.phase:
   // a single step failing (dag_step_failed) sets the whole dagExecution.phase
   // to "failed" even when the DAG goes on to replan and keep running, and the
@@ -135,6 +126,40 @@ function TaskDetailContent() {
   // in-flight dag_execution event. The task's own status is the one signal
   // that's actually authoritative for "this run is truly over."
   const isDagFinished = isTerminalTaskStatus(state.currentTask?.status)
+  // During a mid-run replan the old plan's steps are superseded but still
+  // sitting in state.steps (a replanning event carries no replacement list,
+  // and it's the SAME run, so nothing resets them) - the graph view already
+  // hides the old plan for this phase (task-conversation-panel.tsx's
+  // isPlanning), and the panel must apply the same policy rather than keep
+  // presenting superseded rows as if they were current. An empty list
+  // renders the panel's own planning/empty state; the rows come back with
+  // the replacement plan's first executing event. completion_assessment is
+  // deliberately NOT gated the same way: at that point the just-executed
+  // plan is still the current one (assessment may well conclude
+  // "completed"), so hiding it would blank the panel after every normal
+  // execution round.
+  //
+  // Excludes an already-finished task (isDagFinished): the backend's phase
+  // never advances out of "replanning" on its own once the task ends (a
+  // task can go terminal via a path - e.g. an assistant message settling the
+  // turn - that never syncs dagExecution.phase; a dropped/malformed
+  // executing-transition event leaves it stuck too), and ProgressPanel
+  // itself renders nothing at all for zero steps once endedAt is set (no
+  // spinner, no rows - see its own runEnded comment). Hiding here would then
+  // blank the whole panel body permanently instead of showing the run's last
+  // known steps, which is strictly worse than a rare stale-superseded-plan
+  // flash mid-replan.
+  const progressSteps: ProgressStepView[] = (state.dagExecution?.phase === "replanning" && !isDagFinished)
+    ? []
+    : state.steps.map((step) => ({
+      id: step.id,
+      title: step.name,
+      description: step.description,
+      status: step.status,
+      startedAt: step.started_at,
+      completedAt: step.completed_at,
+    }))
+  const progressPanelVisible = progressPanelOpen && Boolean(state.dagExecution)
   // dagTerminatedAt, not updatedAt: the latter is general task metadata that
   // keeps changing after this run ends for unrelated reasons (a title edit,
   // another field update via a later task_info refresh), which would make

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -164,14 +164,21 @@ function TaskDetailContent() {
           edge of the entire page rather than just the content area below
           the header - and stays independent of the file/graph preview's
           draggable PreviewSheet layout inside TaskConversationPanel. Below
-          `md` there's no room for a fixed 360px side-by-side column without
+          `md` there's no room for a fixed side-by-side column without
           squeezing the chat unusably narrow, so it stacks below the chat
           instead - the same stack-on-mobile/side-column-on-desktop idea as
           resizable-three-column-layout.tsx, capped to a fraction of the
           viewport height (shrink-0 so that cap holds) rather than taking the
-          full remaining width. */}
+          full remaining width. Between `md` and `xl` the rail narrows to
+          280px rather than jumping straight to 360px - at ~1024px,
+          TaskConversationPanel's own chat/PreviewSheet split (when a
+          file/graph preview is also open) already halves what's left, so the
+          full 360px here would leave that split unusably narrow. This isn't a
+          full fix for that interaction (the two panels don't coordinate
+          widths - see PR review) but meaningfully softens it at the specific
+          width band that's tightest. */}
       {progressPanelVisible && (
-        <div className="w-full md:w-[360px] shrink-0 h-[45vh] md:h-full border-t md:border-t-0 md:border-l border-border">
+        <div className="w-full md:w-[280px] xl:w-[360px] shrink-0 h-[45vh] md:h-full border-t md:border-t-0 md:border-l border-border">
           <ProgressPanel
             steps={progressSteps}
             startedAt={state.dagExecution?.created_at}

--- a/frontend/src/app/task/[id]/page-client.tsx
+++ b/frontend/src/app/task/[id]/page-client.tsx
@@ -71,13 +71,18 @@ function TaskDetailContent() {
       // rather than the first, which querySelector would otherwise return.
       // Step ids are LLM-generated plan identifiers with no schema
       // constraint on their content (see plan_generator.py's tool schema),
-      // so they can legitimately contain quotes/backslashes. Only backslash
-      // and double-quote need escaping inside a double-quoted attribute
-      // selector value - CSS.escape is for identifier syntax (e.g. it
-      // hex-escapes a leading digit), not string-literal content, and is
-      // also absent in some test/DOM-shim environments, so a plain regex
-      // replace is both simpler and correct here.
-      const escapedStepId = stepId.replace(/["\\]/g, "\\$&")
+      // so they can legitimately contain quotes/backslashes/control
+      // characters. Backslash and double-quote need a literal backslash
+      // escape inside a double-quoted attribute selector value; any other
+      // control character (e.g. a raw newline) is not valid inside a quoted
+      // CSS string at all and must use a hex escape instead, or
+      // querySelectorAll throws a SyntaxError. CSS.escape is for identifier
+      // syntax (e.g. it hex-escapes a leading digit), not string-literal
+      // content, and is also absent in some test/DOM-shim environments, so a
+      // plain regex replace is both simpler and correct here.
+      const escapedStepId = stepId.replace(/["\\\x00-\x1f]/g, (ch) => (
+        ch === '"' || ch === "\\" ? `\\${ch}` : `\\${ch.charCodeAt(0).toString(16)} `
+      ))
       const matches = document.querySelectorAll(`[data-step-id="${escapedStepId}"]`)
       const target = matches[matches.length - 1]
       target?.scrollIntoView({ behavior: "smooth", block: "center" })
@@ -95,7 +100,6 @@ function TaskDetailContent() {
     completedAt: step.completed_at,
   }))
   const progressPanelVisible = progressPanelOpen && Boolean(state.dagExecution)
-  const isProgressPlanning = progressSteps.length === 0 && state.dagExecution?.phase === "planning"
   // Deliberately keyed off the TASK's own status, not dagExecution.phase:
   // a single step failing (dag_step_failed) sets the whole dagExecution.phase
   // to "failed" even when the DAG goes on to replan and keep running, and the
@@ -171,10 +175,8 @@ function TaskDetailContent() {
         <div className="flex-shrink-0 w-[360px] h-full border-l border-border">
           <ProgressPanel
             steps={progressSteps}
-            totalKnown
             startedAt={state.dagExecution?.created_at}
             endedAt={progressEndedAt}
-            isPlanning={isProgressPlanning}
             onCollapse={handleCollapseProgressPanel}
             onStepClick={handleProgressStepClick}
           />

--- a/frontend/src/app/workforces/[id]/run/page-client.tsx
+++ b/frontend/src/app/workforces/[id]/run/page-client.tsx
@@ -18,7 +18,7 @@ import "@xyflow/react/dist/style.css"
 import { AlertCircle, ArrowLeft, Bot, Crown, FileText, GitBranch, History, Loader2, MessageSquare, Pencil, Plus, Users, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useI18n, type Translate } from "@/contexts/i18n-context"
-import { useApp } from "@/contexts/app-context-chat"
+import { isTerminalTaskStatus, useApp } from "@/contexts/app-context-chat"
 import type { Task } from "@/contexts/app-context-chat"
 import { normalizeTaskStatus, type TaskStatus } from "@/lib/task-status"
 import { getWorkforce, getWorkforceAgentExecution, getWorkforceRun, runWorkforce } from "@/lib/workforces-api"
@@ -564,10 +564,7 @@ function WorkforceRunPageInner() {
       if (event.event_type === "workforce_delegation_end") status = "completed"
       if (event.event_type === "workforce_delegation_error") status = "failed"
     }
-    if (
-      status === "running" &&
-      (taskStatus === "completed" || taskStatus === "failed")
-    ) {
+    if (status === "running" && isTerminalTaskStatus(taskStatus)) {
       status = "interrupted"
     }
     return status

--- a/frontend/src/app/workforces/workforces-routes.test.tsx
+++ b/frontend/src/app/workforces/workforces-routes.test.tsx
@@ -85,6 +85,7 @@ vi.mock("@/contexts/app-context-chat", () => ({
     getFileDownloadUrl: (fileId: string) => `/api/files/${fileId}/download`,
     state: workforceAppState,
   }),
+  isTerminalTaskStatus: (status: string | null | undefined) => status === "completed" || status === "failed",
 }))
 
 vi.mock("@/components/task/task-conversation-panel", () => ({

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -179,6 +179,17 @@ function formatActionContent(value: unknown, filesDisabled = false): string {
   }
 }
 
+// Deliberately narrower than (and not the same union as) StepStatus in
+// app-context-chat.tsx / ProgressPanel's ProgressStepView / center-panel.tsx's
+// DAGNode.data: this status is derived locally from the trace event stream
+// itself (dag_step_start/dag_step_end/etc.), not read off StepExecution, and
+// mixes in whole-TASK states ("paused", "waiting_for_user") that the other
+// three don't carry at the step level. No trace event currently distinguishes
+// a step being "interrupted" or "clarification_invalidated" from plain
+// "running" the way StepExecution's own field does, so this view can't
+// represent those two states without new derivation logic to detect them from
+// the event stream - a step in either state renders here as "running" rather
+// than reporting an unknown/wrong status.
 interface ProcessedStep {
   stepId: string;
   stepName: string;

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -1657,6 +1657,7 @@ function StepItem({
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 0.1 * (index + 1) }}
       className="space-y-3"
+      data-step-id={step.stepId}
     >
       {/* Step Title */}
       <div className="flex w-full items-start gap-2 rounded-lg px-2 py-1 -ml-2 transition-colors hover:bg-muted/50 group/step">

--- a/frontend/src/components/layout/center-panel.tsx
+++ b/frontend/src/components/layout/center-panel.tsx
@@ -28,14 +28,19 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { JsonRenderer } from "@/components/ui/markdown-renderer"
 import { formatTime, getTimeDuration, formatDuration } from "@/lib/time-utils"
-import { Loader2, Brain, Network, Sparkles, Timer, XCircle, AlertCircle, RefreshCw, RotateCcw, LayoutDashboard,LayoutPanelLeft, Wrench, GitBranch, CheckCircle2 } from "lucide-react"
+import { Loader2, Brain, Network, Sparkles, Timer, XCircle, AlertCircle, RefreshCw, RotateCcw, LayoutDashboard,LayoutPanelLeft, Wrench, GitBranch, CheckCircle2, PauseCircle } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context";
+import type { DAGExecution } from "@/contexts/app-context-chat"
 
 
 interface DAGNode extends Node {
   data: {
     label: string
-    status: "pending" | "running" | "completed" | "failed" | "skipped"
+    // "interrupted"/"clarification_invalidated" are real, non-terminal
+    // backend step statuses (dag.py) - previously omitted here, so a step in
+    // either state fell through every status check below to the generic
+    // "not started" look, indistinguishable from a step that hasn't run yet.
+    status: "pending" | "running" | "completed" | "failed" | "skipped" | "interrupted" | "clarification_invalidated"
     description?: string
     tool_names?: string[]
     started_at?: string | number
@@ -53,12 +58,6 @@ interface DAGEdge extends Edge {
   }
 }
 
-interface DAGExecution {
-  phase: "planning" | "executing" | "completed" | "failed"
-  current_plan: Record<string, unknown>
-  created_at: string | number
-  updated_at: string | number
-}
 
 interface CenterPanelProps {
   dagExecution: DAGExecution | null
@@ -273,6 +272,8 @@ const nodeTypes: NodeTypes = {
       completed: "",
       failed: "",
       skipped: "border-dashed border-gray-500/50 opacity-60 bg-gray-500/5",
+      interrupted: "border-amber-500/40",
+      clarification_invalidated: "border-amber-500/40",
     }
 
     const statusBadges = {
@@ -281,6 +282,8 @@ const nodeTypes: NodeTypes = {
       completed: { variant: "default" as const, label: t("agent.layout.status.completed") },
       failed: { variant: "destructive" as const, label: t("agent.layout.status.failed") },
       skipped: { variant: "secondary" as const, label: t("agent.layout.status.skipped") },
+      interrupted: { variant: "secondary" as const, label: t("agent.layout.status.interrupted") },
+      clarification_invalidated: { variant: "secondary" as const, label: t("agent.layout.status.clarification_invalidated") },
     }
 
     const getDuration = () => {
@@ -350,12 +353,14 @@ const nodeTypes: NodeTypes = {
                 data.status === 'running' ? 'bg-blue-500/10 text-blue-600' :
                 data.status === 'failed' ? 'bg-red-500/10 text-red-600' :
                 data.status === 'skipped' ? 'bg-gray-500/10 text-gray-500' :
+                (data.status === 'interrupted' || data.status === 'clarification_invalidated') ? 'bg-amber-500/10 text-amber-600' :
                 'bg-primary/10 text-primary'
               )}>
                 {data.status === 'completed' ? <CheckCircle2 className="w-4 h-4" /> :
                  data.status === 'running' ? <Loader2 className="w-4 h-4 animate-spin" /> :
                  data.status === 'failed' ? <XCircle className="w-4 h-4 text-red-500" /> :
                  data.status === 'skipped' ? <RotateCcw className="w-4 h-4 text-gray-500" /> :
+                 (data.status === 'interrupted' || data.status === 'clarification_invalidated') ? <PauseCircle className="w-4 h-4" /> :
                  <Brain className="w-4 h-4" />}
               </div>
               <div className="font-bold text-sm text-foreground tracking-wide leading-tight">{data.label}</div>
@@ -503,21 +508,27 @@ function CenterPanelInner({
   const getPhaseBadge = (phase: DAGExecution["phase"]) => {
     const variants = {
       planning: "secondary",
+      replanning: "secondary",
       executing: "default",
+      completion_assessment: "default",
       completed: "default",
       failed: "destructive",
     } as const
 
     const labels = {
       planning: t("agent.layout.common.inProgress"),
+      replanning: t("agent.layout.common.inProgress"),
       executing: t("agent.layout.common.inProgress"),
+      completion_assessment: t("agent.layout.common.inProgress"),
       completed: t("agent.status.completed"),
       failed: t("agent.status.failed"),
     }
 
     const customStyles = {
       planning: "bg-muted/50 text-muted-foreground border-border",
+      replanning: "bg-muted/50 text-muted-foreground border-border",
       executing: "bg-primary/10 text-primary border-primary/20",
+      completion_assessment: "bg-primary/10 text-primary border-primary/20",
       completed: "bg-green-500/10 text-green-500 border-green-500/20",
       failed: "bg-destructive/10 text-destructive border-destructive/20",
     }
@@ -628,6 +639,8 @@ function CenterPanelInner({
                 completed: 'hsl(142, 76%, 36%)',
                 failed: 'hsl(var(--destructive))',
                 skipped: 'hsl(220, 10%, 50%)',
+                interrupted: 'hsl(38, 92%, 50%)',
+                clarification_invalidated: 'hsl(38, 92%, 50%)',
               }
               return colors[data.status] || colors.pending
             }}

--- a/frontend/src/components/layout/center-panel.tsx
+++ b/frontend/src/components/layout/center-panel.tsx
@@ -551,8 +551,13 @@ function CenterPanelInner({
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-foreground">{t("agent.layout.center.titles.dag")}</h2>
 
-          {/* Layout Controls */}
-          {dagNodes.length > 0 && (
+          {/* Layout Controls - gated on the graph actually being visible,
+              not just nodes existing: during a mid-run replan, isPlanning is
+              true even while the prior plan's nodes are still in state (the
+              canvas shows the planning loader instead of the graph - see
+              task-conversation-panel.tsx's isPlanning), and orphaned TB/LR
+              buttons over a loading spinner would do nothing. */}
+          {dagNodes.length > 0 && !isPlanning && !hasError && (
             <div className="flex items-center gap-2">
               <div className="flex items-center gap-1 bg-muted/50 rounded-md p-1">
                 <Button

--- a/frontend/src/components/layout/center-panel.tsx
+++ b/frontend/src/components/layout/center-panel.tsx
@@ -30,17 +30,13 @@ import { JsonRenderer } from "@/components/ui/markdown-renderer"
 import { formatTime, getTimeDuration, formatDuration } from "@/lib/time-utils"
 import { Loader2, Brain, Network, Sparkles, Timer, XCircle, AlertCircle, RefreshCw, RotateCcw, LayoutDashboard,LayoutPanelLeft, Wrench, GitBranch, CheckCircle2, PauseCircle } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context";
-import type { DAGExecution } from "@/contexts/app-context-chat"
+import type { DAGExecution, StepStatus } from "@/contexts/app-context-chat"
 
 
 interface DAGNode extends Node {
   data: {
     label: string
-    // "interrupted"/"clarification_invalidated" are real, non-terminal
-    // backend step statuses (dag.py) - previously omitted here, so a step in
-    // either state fell through every status check below to the generic
-    // "not started" look, indistinguishable from a step that hasn't run yet.
-    status: "pending" | "running" | "completed" | "failed" | "skipped" | "interrupted" | "clarification_invalidated"
+    status: StepStatus
     description?: string
     tool_names?: string[]
     started_at?: string | number

--- a/frontend/src/components/task/progress-panel.test.tsx
+++ b/frontend/src/components/task/progress-panel.test.tsx
@@ -1,0 +1,189 @@
+import React from "react"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { I18nProvider } from "@/contexts/i18n-context"
+import { ProgressPanel, type ProgressStepView } from "./progress-panel"
+
+afterEach(() => {
+  cleanup()
+})
+
+const NOW = "2026-05-27T05:10:00Z"
+
+function renderPanel(props: Partial<React.ComponentProps<typeof ProgressPanel>> = {}) {
+  const onCollapse = vi.fn()
+  const onStepClick = vi.fn()
+  const defaults: React.ComponentProps<typeof ProgressPanel> = {
+    steps: [],
+    startedAt: undefined,
+    endedAt: undefined,
+    onCollapse,
+    onStepClick,
+  }
+  render(
+    <I18nProvider initialLocale="en">
+      <ProgressPanel {...defaults} {...props} />
+    </I18nProvider>
+  )
+  return { onCollapse, onStepClick }
+}
+
+const step = (overrides: Partial<ProgressStepView> = {}): ProgressStepView => ({
+  id: "step-one",
+  title: "Step one",
+  status: "pending",
+  ...overrides,
+})
+
+describe("ProgressPanel", () => {
+  it("shows the planning placeholder when there are no steps and the run hasn't ended", () => {
+    renderPanel({ steps: [], endedAt: undefined })
+    expect(screen.getByText("Generating plan…")).toBeInTheDocument()
+  })
+
+  it("hides the planning placeholder once the run has ended, even with no steps", () => {
+    // A plan-time failure can end a run before any step ever started - the
+    // placeholder must not spin forever over a run that's already over.
+    renderPanel({ steps: [], endedAt: "2026-05-27T05:00:05Z" })
+    expect(screen.queryByText("Generating plan…")).not.toBeInTheDocument()
+  })
+
+  it("counts completed/skipped/failed as resolved but not interrupted/pending/running", () => {
+    renderPanel({
+      steps: [
+        step({ id: "a", status: "completed" }),
+        step({ id: "b", status: "skipped" }),
+        step({ id: "c", status: "failed" }),
+        step({ id: "d", status: "interrupted" }),
+        step({ id: "e", status: "pending" }),
+        step({ id: "f", status: "running" }),
+      ],
+    })
+    expect(screen.getByText("3/6")).toBeInTheDocument()
+  })
+
+  it("does not render a step-count fraction when there are no steps yet", () => {
+    renderPanel({ steps: [] })
+    expect(screen.queryByText(/^\d+\/\d+$/)).not.toBeInTheDocument()
+  })
+
+  it("renders distinct sr-only status text for interrupted and clarification_invalidated steps", () => {
+    renderPanel({
+      steps: [
+        step({ id: "a", status: "interrupted", title: "Interrupted step" }),
+        step({ id: "b", status: "clarification_invalidated", title: "Invalidated step" }),
+      ],
+    })
+    expect(screen.getByText("Interrupted:")).toBeInTheDocument()
+    expect(screen.getByText("Waiting on a new answer:")).toBeInTheDocument()
+  })
+
+  it("disables a step row with no startedAt and never calls onStepClick for it", () => {
+    // A disabled button is excluded from the accessible role/name query by
+    // default, so find it via its text content instead of getByRole.
+    const { onStepClick } = renderPanel({
+      steps: [step({ id: "never-started", status: "pending", startedAt: undefined })],
+    })
+    const button = screen.getByText("Step one").closest("button")
+    expect(button).toBeDisabled()
+    fireEvent.click(button as HTMLButtonElement)
+    expect(onStepClick).not.toHaveBeenCalled()
+  })
+
+  it("calls onStepClick with the step id for a step that has started", () => {
+    const { onStepClick } = renderPanel({
+      steps: [step({ id: "started", status: "completed", startedAt: "2026-05-27T05:00:00Z" })],
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Completed: Step one" }))
+    expect(onStepClick).toHaveBeenCalledWith("started")
+  })
+
+  it("calls onCollapse when the collapse button is clicked", () => {
+    const { onCollapse } = renderPanel()
+    fireEvent.click(screen.getByLabelText("Collapse"))
+    expect(onCollapse).toHaveBeenCalledOnce()
+  })
+
+  describe("elapsed time", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ now: new Date(NOW) })
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it("shows a live, ticking total elapsed time while the run hasn't ended", () => {
+      // Started 90s before the fixed "now".
+      renderPanel({ startedAt: "2026-05-27T05:08:30Z", endedAt: undefined })
+      expect(screen.getByText("1m 30s")).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(screen.getByText("1m 35s")).toBeInTheDocument()
+    })
+
+    it("freezes the total elapsed time at endedAt - startedAt once the run has ended", () => {
+      renderPanel({ startedAt: "2026-05-27T05:00:00Z", endedAt: "2026-05-27T05:05:00Z" })
+      expect(screen.getByText("5m 00s")).toBeInTheDocument()
+
+      // Time passing after the freeze must not change the displayed value.
+      act(() => {
+        vi.advanceTimersByTime(60_000)
+      })
+      expect(screen.getByText("5m 00s")).toBeInTheDocument()
+    })
+
+    it("keeps ticking a running step's own duration even when the panel's own startedAt is missing", () => {
+      // Regression coverage for the shared-clock coupling bug: the clock must
+      // stay active off a running row's own startedAt, not just the panel's.
+      renderPanel({
+        startedAt: undefined,
+        endedAt: undefined,
+        steps: [step({ id: "running-step", status: "running", startedAt: "2026-05-27T05:09:00Z" })],
+      })
+      expect(screen.getByText("1m 00s")).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(screen.getByText("1m 01s")).toBeInTheDocument()
+    })
+
+    it("freezes a still-running step's duration at the run's own endedAt once the run ends", () => {
+      // The backend cancels sibling steps without a terminal event when a run
+      // ends, so a step stuck "running" must freeze against endedAt, not keep
+      // counting against "now".
+      renderPanel({
+        startedAt: "2026-05-27T05:00:00Z",
+        endedAt: "2026-05-27T05:03:00Z",
+        steps: [step({ id: "orphaned", status: "running", startedAt: "2026-05-27T05:01:00Z" })],
+      })
+      expect(screen.getByText("2m 00s")).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(60_000)
+      })
+      expect(screen.getByText("2m 00s")).toBeInTheDocument()
+    })
+
+    it("shows a static (non-ticking) duration for a step with both startedAt and completedAt", () => {
+      renderPanel({
+        steps: [step({
+          id: "done",
+          status: "completed",
+          startedAt: "2026-05-27T05:00:00Z",
+          completedAt: "2026-05-27T05:00:42Z",
+        })],
+      })
+      expect(screen.getByText("42s")).toBeInTheDocument()
+    })
+
+    it("treats epoch zero as a real timestamp rather than as absent", () => {
+      renderPanel({ startedAt: 0, endedAt: undefined })
+      // now (fixed at NOW) - epoch 0 is a huge duration, not "0s"/absent.
+      expect(screen.queryByText("Elapsed")).toBeInTheDocument()
+      expect(screen.queryByText("0s")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/task/progress-panel.test.tsx
+++ b/frontend/src/components/task/progress-panel.test.tsx
@@ -185,5 +185,44 @@ describe("ProgressPanel", () => {
       expect(screen.queryByText("Elapsed")).toBeInTheDocument()
       expect(screen.queryByText("0s")).not.toBeInTheDocument()
     })
+
+    it("treats malformed timestamp strings as absent instead of freezing or corrupting the clock", () => {
+      // "Infinity"/"NaN"/broken ISO text parse to nothing usable - treating
+      // them as present would mark the run "ended" at a bogus instant
+      // (freezing the clock) or push a non-finite value into the duration
+      // arithmetic. As absent, a malformed endedAt leaves the clock live.
+      renderPanel({ startedAt: "2026-05-27T05:08:30Z", endedAt: "Infinity" })
+      expect(screen.getByText("1m 30s")).toBeInTheDocument()
+      // Still ticking - the malformed endedAt did NOT freeze the run.
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(screen.getByText("1m 35s")).toBeInTheDocument()
+    })
+
+    it("renders no duration at all for a step whose only timestamp is malformed", () => {
+      renderPanel({
+        steps: [step({
+          id: "broken",
+          status: "completed",
+          startedAt: "not a real date",
+          completedAt: "NaN",
+        })],
+      })
+      // No "NaNs"/"Infinitys" text sneaks into the row - the malformed
+      // timestamps read as absent, so the row simply has no duration.
+      expect(screen.queryByText(/NaN/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Infinity/)).not.toBeInTheDocument()
+    })
+
+    it("still accepts a numeric-string timestamp as present", () => {
+      // The string branch must reject malformed text without also rejecting
+      // the numeric-string form the wire legitimately uses.
+      renderPanel({
+        startedAt: String(new Date("2026-05-27T05:05:00Z").getTime()),
+        endedAt: String(new Date("2026-05-27T05:07:30Z").getTime()),
+      })
+      expect(screen.getByText("2m 30s")).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -100,7 +100,7 @@ export function ProgressPanel({
           <h2 className="text-sm font-semibold text-foreground">
             {t("chatPage.progressPanel.title")}
           </h2>
-          {totalKnown && (
+          {totalKnown && steps.length > 0 && (
             <span className="text-xs text-muted-foreground">
               {resolvedCount}/{steps.length}
             </span>

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -127,10 +127,18 @@ export function ProgressPanel({
 
       <div className="flex-1 overflow-y-auto px-2 py-3">
         {steps.length === 0 ? (
-          <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            {t("chatPage.progressPanel.planning")}
-          </div>
+          // A run can end (a plan-time failure, for example) before any step
+          // ever started, leaving steps permanently empty - `endedAt` (only
+          // set once the run has actually finished) is what distinguishes
+          // that from "still planning/about to execute", so this doesn't show
+          // an indefinitely-spinning "generating plan" placeholder for a run
+          // that's already over.
+          !endedAt && (
+            <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t("chatPage.progressPanel.planning")}
+            </div>
+          )
         ) : (
           <ol className="space-y-1">
             {steps.map((step, index) => (

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -5,16 +5,13 @@ import { CheckCircle2, ChevronLeft, Clock, Loader2, PauseCircle, RotateCcw, XCir
 import { cn } from "@/lib/utils"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 import { useI18n } from "@/contexts/i18n-context"
+import type { StepStatus } from "@/contexts/app-context-chat"
 
 export interface ProgressStepView {
   id: string
   title: string
   description?: string
-  // "interrupted"/"clarification_invalidated" are non-terminal - the backend
-  // resumes them back to "running" once their blocking condition clears
-  // (dag.py) - so they must not be treated as done, but also aren't "not
-  // started yet" like pending.
-  status: "pending" | "running" | "completed" | "failed" | "skipped" | "interrupted" | "clarification_invalidated"
+  status: StepStatus
   startedAt?: string | number
   completedAt?: string | number
 }

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -155,6 +155,7 @@ function ProgressStepRow({
   index: number
   onClick?: (stepId: string) => void
 }) {
+  const { t } = useI18n()
   const liveElapsed = useElapsed(step.status === "running" ? step.startedAt : undefined)
   // Completed/failed steps already have both endpoints - a static duration,
   // not another ticking timer, is all that's needed once a step is done.
@@ -207,6 +208,7 @@ function ProgressStepRow({
               step.status === "failed" && "text-foreground",
             )}
           >
+            <span className="sr-only">{t(`agent.layout.status.${step.status}`)}: </span>
             {step.title}
           </span>
           {step.description && (

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -39,11 +39,14 @@ function formatElapsedCompact(ms: number): string {
 // Distinguishes a genuinely missing timestamp (undefined/null, or the empty
 // string upstream data uses for "not set yet" - see stepsFromPlanData's
 // `getString` fallback) from a valid-but-falsy one: epoch 0 is a real instant
-// in this type's `string | number` contract, and normalizeTimestampMs itself
-// falls back to "now" for any falsy input, so a plain truthiness check would
-// treat a genuine (if unlikely) zero timestamp as absent.
+// in this type's `string | number` contract, and a plain truthiness check
+// would treat a genuine (if unlikely) zero timestamp as absent. Also excludes
+// NaN - normalizeTimestampMs treats NaN as absent (falls back to "now"), and
+// this must agree with it, or a NaN value would read as "present" here while
+// resolving to the current instant there, producing a bogus, constantly
+// shifting duration instead of surfacing the anomaly.
 function hasTimestamp(value: string | number | undefined): value is string | number {
-  return value !== undefined && value !== null && value !== ""
+  return value !== undefined && value !== null && value !== "" && !Number.isNaN(value)
 }
 
 // Ticks once a second for as long as `active` is true, shared by the header

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -46,16 +46,25 @@ function formatElapsedCompact(ms: number): string {
 // `getString` fallback) from a valid-but-falsy one: epoch 0 is a real instant
 // in this type's `string | number` contract, and a plain truthiness check
 // would treat a genuine (if unlikely) zero timestamp as absent. Also excludes
-// non-finite numbers (NaN, +/-Infinity): normalizeTimestampMs deliberately
-// lets those propagate unchanged (so formatTime/getTimeDuration's own
-// isNaN(date.getTime()) guards can catch them as malformed input), which
-// means it does nothing to stop a non-finite value from reaching duration
-// arithmetic here - this predicate is this component's own filter for that,
-// treating both as "present" would produce a bogus, constantly shifting or
-// permanently non-numeric duration instead of surfacing the anomaly.
+// MALFORMED values - non-finite numbers (NaN, +/-Infinity) and strings that
+// parse to nothing usable ("Infinity", "NaN", broken ISO text):
+// normalizeTimestampMs deliberately lets non-finite numbers propagate
+// unchanged and falls back to Date.now() for unparsable strings (so
+// formatTime/getTimeDuration's own guards handle them as display concerns),
+// which means it does nothing to stop such a value from reaching this
+// panel's duration arithmetic - where it would mark a run as "ended" at a
+// bogus instant, freeze the clock against a fake now, or render a
+// permanently non-numeric duration. This predicate is this component's own
+// filter for that: a timestamp only counts as present if it parses to a
+// finite millisecond value, mirroring the branch order normalizeTimestampMs
+// itself uses (numeric string first, then date string) so the two can't
+// disagree about what a string means.
 function hasTimestamp(value: string | number | undefined): value is string | number {
   if (value === undefined || value === null || value === "") return false
-  return typeof value !== "number" || Number.isFinite(value)
+  if (typeof value === "number") return Number.isFinite(value)
+  const numeric = Number(value)
+  if (value.trim() !== "" && !Number.isNaN(numeric)) return Number.isFinite(numeric)
+  return Number.isFinite(new Date(value).getTime())
 }
 
 // Ticks once a second for as long as `active` is true, shared by the header

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -46,10 +46,12 @@ function formatElapsedCompact(ms: number): string {
 // `getString` fallback) from a valid-but-falsy one: epoch 0 is a real instant
 // in this type's `string | number` contract, and a plain truthiness check
 // would treat a genuine (if unlikely) zero timestamp as absent. Also excludes
-// non-finite numbers (NaN, +/-Infinity) - normalizeTimestampMs treats NaN as
-// absent (falls back to "now") and does no better with Infinity (arithmetic
-// on it stays infinite), so this must exclude both too, or such a value would
-// read as "present" here while producing a bogus, constantly shifting or
+// non-finite numbers (NaN, +/-Infinity): normalizeTimestampMs deliberately
+// lets those propagate unchanged (so formatTime/getTimeDuration's own
+// isNaN(date.getTime()) guards can catch them as malformed input), which
+// means it does nothing to stop a non-finite value from reaching duration
+// arithmetic here - this predicate is this component's own filter for that,
+// treating both as "present" would produce a bogus, constantly shifting or
 // permanently non-numeric duration instead of surfacing the anomaly.
 function hasTimestamp(value: string | number | undefined): value is string | number {
   if (value === undefined || value === null || value === "") return false

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -23,7 +23,7 @@ interface ProgressPanelProps {
   // endedAt - startedAt instead of continuing to count up against "now".
   endedAt?: string | number
   onCollapse: () => void
-  onStepClick?: (stepId: string) => void
+  onStepClick: (stepId: string) => void
 }
 
 function formatElapsedCompact(ms: number): string {
@@ -36,30 +36,34 @@ function formatElapsedCompact(ms: number): string {
   return `${seconds}s`
 }
 
-// Ticks once a second while `startedAt` is set, so callers get a live
-// "elapsed since startedAt" string without each one re-implementing a timer.
-// Checked for truthiness, not just `!== undefined`: upstream data can hand
-// this an empty string for "no timestamp yet" (see stepsFromPlanData's
-// `getString` fallback), and normalizeTimestampMs treats any falsy value as
-// "now" - so a strict `!== undefined` check would let "" through and render
-// a bogus "0s" instead of hiding the timer.
-function useElapsed(startedAt: string | number | undefined): string | null {
+// Distinguishes a genuinely missing timestamp (undefined/null, or the empty
+// string upstream data uses for "not set yet" - see stepsFromPlanData's
+// `getString` fallback) from a valid-but-falsy one: epoch 0 is a real instant
+// in this type's `string | number` contract, and normalizeTimestampMs itself
+// falls back to "now" for any falsy input, so a plain truthiness check would
+// treat a genuine (if unlikely) zero timestamp as absent.
+function hasTimestamp(value: string | number | undefined): value is string | number {
+  return value !== undefined && value !== null && value !== ""
+}
+
+// Ticks once a second for as long as `active` is true, shared by the header
+// and every running step row - a run with R running rows previously mounted
+// R+1 independent one-second timers (one per `useElapsed` call) all doing
+// the same job; one shared clock at the panel level does it once.
+function useLiveNow(active: boolean): number {
   const [now, setNow] = useState(() => Date.now())
 
   useEffect(() => {
-    if (!startedAt) return
-    // Re-seed immediately: `now` may still hold a value from long before this
-    // particular `startedAt` became truthy (e.g. a step that sat pending for
-    // minutes before going "running"), and the first tick is a full second
-    // away - without this the first render briefly shows an elapsed time
-    // computed against a stale `now`.
+    if (!active) return
+    // Re-seed immediately rather than waiting for the first tick (a full
+    // second away): `now` may still hold a stale value from before the panel
+    // had anything to tick for.
     setNow(Date.now())
     const timer = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(timer)
-  }, [startedAt])
+  }, [active])
 
-  if (!startedAt) return null
-  return formatElapsedCompact(now - normalizeTimestampMs(startedAt))
+  return now
 }
 
 export function ProgressPanel({
@@ -70,9 +74,24 @@ export function ProgressPanel({
   onStepClick,
 }: ProgressPanelProps) {
   const { t } = useI18n()
-  const liveTotalElapsed = useElapsed(endedAt ? undefined : startedAt)
+  const runEnded = hasTimestamp(endedAt)
+  const headerIsLive = !runEnded && hasTimestamp(startedAt)
+  // The shared clock must stay active for as long as EITHER the header or any
+  // individual row needs to tick - not just whenever the panel's own
+  // `startedAt` is set. A row's own `step.startedAt` is what actually gates
+  // its ticking (see ProgressStepRow below), and the two aren't guaranteed to
+  // agree: a dagExecution constructed via a legacy/malformed event that never
+  // got a `created_at` backfill would leave the panel's `startedAt` (and thus
+  // `headerIsLive`) false even while a step with its own valid `startedAt` is
+  // genuinely running - gating the whole clock on `headerIsLive` alone would
+  // silently freeze that row's timer instead of just hiding the header's.
+  const anyRowLive = !runEnded && steps.some((step) => step.status === "running" && hasTimestamp(step.startedAt))
+  const now = useLiveNow(headerIsLive || anyRowLive)
+  const liveTotalElapsed = headerIsLive
+    ? formatElapsedCompact(now - normalizeTimestampMs(startedAt))
+    : null
   const finishedTotalElapsed =
-    endedAt && startedAt
+    runEnded && hasTimestamp(startedAt)
       ? formatElapsedCompact(normalizeTimestampMs(endedAt) - normalizeTimestampMs(startedAt))
       : null
   const totalElapsed = liveTotalElapsed ?? finishedTotalElapsed
@@ -130,7 +149,7 @@ export function ProgressPanel({
           // that from "still planning/about to execute", so this doesn't show
           // an indefinitely-spinning "generating plan" placeholder for a run
           // that's already over.
-          !endedAt && (
+          !runEnded && (
             <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
               {t("chatPage.progressPanel.planning")}
@@ -139,7 +158,14 @@ export function ProgressPanel({
         ) : (
           <ol className="space-y-1">
             {steps.map((step, index) => (
-              <ProgressStepRow key={step.id} step={step} index={index} endedAt={endedAt} onClick={onStepClick} />
+              <ProgressStepRow
+                key={step.id}
+                step={step}
+                index={index}
+                endedAt={endedAt}
+                now={now}
+                onClick={onStepClick}
+              />
             ))}
           </ol>
         )}
@@ -152,15 +178,20 @@ function ProgressStepRow({
   step,
   index,
   endedAt,
+  now,
   onClick,
 }: {
   step: ProgressStepView
   index: number
   endedAt?: string | number
-  onClick?: (stepId: string) => void
+  now: number
+  onClick: (stepId: string) => void
 }) {
   const { t } = useI18n()
-  const liveElapsed = useElapsed(!endedAt && step.status === "running" ? step.startedAt : undefined)
+  const liveElapsed =
+    !hasTimestamp(endedAt) && step.status === "running" && hasTimestamp(step.startedAt)
+      ? formatElapsedCompact(now - normalizeTimestampMs(step.startedAt))
+      : null
   // Completed/failed steps already have both endpoints - a static duration,
   // not another ticking timer, is all that's needed once a step is done. Once
   // the whole run has ended (`endedAt` set), no row should keep ticking
@@ -168,14 +199,11 @@ function ProgressStepRow({
   // own terminal event when a run finishes, so a step that's still "running"
   // at that point never gets its own completedAt - freeze it at the run's end
   // time instead, rather than letting it keep counting up against "now".
-  // Checked for truthiness, not `!== undefined`: a step still running/pending
-  // when a replan snapshot arrives gets `completed_at: ""` (see
-  // stepsFromPlanData's `getString` fallback), and `??` would treat that
-  // empty string as "already have a real endpoint" and never fall through to
-  // `endedAt`.
-  const frozenEndpoint = step.completedAt || (step.status === "running" ? endedAt : undefined)
+  const frozenEndpoint = hasTimestamp(step.completedAt)
+    ? step.completedAt
+    : (step.status === "running" ? endedAt : undefined)
   const finishedDuration =
-    step.startedAt && frozenEndpoint
+    hasTimestamp(step.startedAt) && hasTimestamp(frozenEndpoint)
       ? formatElapsedCompact(normalizeTimestampMs(frozenEndpoint) - normalizeTimestampMs(step.startedAt))
       : null
   const duration = liveElapsed ?? finishedDuration
@@ -187,14 +215,14 @@ function ProgressStepRow({
   // activation logic can still have a startedAt preserved from before that
   // (see stepsFromPlanData's existingStep merge), and its trace group is
   // still there to scroll to even though its final status isn't "running".
-  const hasTraceTarget = Boolean(step.startedAt)
+  const hasTraceTarget = hasTimestamp(step.startedAt)
 
   return (
     <li>
       <button
         type="button"
         disabled={!hasTraceTarget}
-        onClick={hasTraceTarget ? () => onClick?.(step.id) : undefined}
+        onClick={hasTraceTarget ? () => onClick(step.id) : undefined}
         className={cn(
           "flex w-full items-start gap-3 rounded-lg px-2 py-2 text-left transition-colors",
           step.status === "running" ? "bg-primary/10" : "hover:bg-muted/50",

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -179,15 +179,26 @@ function ProgressStepRow({
       ? formatElapsedCompact(normalizeTimestampMs(frozenEndpoint) - normalizeTimestampMs(step.startedAt))
       : null
   const duration = liveElapsed ?? finishedDuration
+  // TraceEventRenderer only tags a step's trace group with data-step-id once
+  // it's actually started (a ProcessedStep) - a step with no startedAt has no
+  // corresponding group in the chat log, so clicking it would silently do
+  // nothing. Keyed off startedAt itself (the actual precondition) rather than
+  // re-deriving it from status: a step forced to "skipped" by branch-
+  // activation logic can still have a startedAt preserved from before that
+  // (see stepsFromPlanData's existingStep merge), and its trace group is
+  // still there to scroll to even though its final status isn't "running".
+  const hasTraceTarget = Boolean(step.startedAt)
 
   return (
     <li>
       <button
         type="button"
-        onClick={() => onClick?.(step.id)}
+        disabled={!hasTraceTarget}
+        onClick={hasTraceTarget ? () => onClick?.(step.id) : undefined}
         className={cn(
           "flex w-full items-start gap-3 rounded-lg px-2 py-2 text-left transition-colors",
           step.status === "running" ? "bg-primary/10" : "hover:bg-muted/50",
+          !hasTraceTarget && "cursor-default hover:bg-transparent",
         )}
       >
         <span

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { CheckCircle2, ChevronLeft, Clock, Loader2, RotateCcw, XCircle } from "lucide-react"
+import React, { useEffect, useState } from "react"
+import { CheckCircle2, ChevronLeft, Clock, Loader2, PauseCircle, RotateCcw, XCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { normalizeTimestampMs } from "@/lib/time-utils"
 import { useI18n } from "@/contexts/i18n-context"
@@ -10,7 +10,11 @@ export interface ProgressStepView {
   id: string
   title: string
   description?: string
-  status: "pending" | "running" | "completed" | "failed" | "skipped"
+  // "interrupted"/"clarification_invalidated" are non-terminal - the backend
+  // resumes them back to "running" once their blocking condition clears
+  // (dag.py) - so they must not be treated as done, but also aren't "not
+  // started yet" like pending.
+  status: "pending" | "running" | "completed" | "failed" | "skipped" | "interrupted" | "clarification_invalidated"
   startedAt?: string | number
   completedAt?: string | number
 }
@@ -27,6 +31,7 @@ interface ProgressPanelProps {
 }
 
 function formatElapsedCompact(ms: number): string {
+  if (!Number.isFinite(ms)) return "0s"
   const totalSeconds = Math.max(0, Math.floor(ms / 1000))
   const hours = Math.floor(totalSeconds / 3600)
   const minutes = Math.floor((totalSeconds % 3600) / 60)
@@ -41,12 +46,14 @@ function formatElapsedCompact(ms: number): string {
 // `getString` fallback) from a valid-but-falsy one: epoch 0 is a real instant
 // in this type's `string | number` contract, and a plain truthiness check
 // would treat a genuine (if unlikely) zero timestamp as absent. Also excludes
-// NaN - normalizeTimestampMs treats NaN as absent (falls back to "now"), and
-// this must agree with it, or a NaN value would read as "present" here while
-// resolving to the current instant there, producing a bogus, constantly
-// shifting duration instead of surfacing the anomaly.
+// non-finite numbers (NaN, +/-Infinity) - normalizeTimestampMs treats NaN as
+// absent (falls back to "now") and does no better with Infinity (arithmetic
+// on it stays infinite), so this must exclude both too, or such a value would
+// read as "present" here while producing a bogus, constantly shifting or
+// permanently non-numeric duration instead of surfacing the anomaly.
 function hasTimestamp(value: string | number | undefined): value is string | number {
-  return value !== undefined && value !== null && value !== "" && !Number.isNaN(value)
+  if (value === undefined || value === null || value === "") return false
+  return typeof value !== "number" || Number.isFinite(value)
 }
 
 // Ticks once a second for as long as `active` is true, shared by the header
@@ -238,6 +245,7 @@ function ProgressStepRow({
             step.status === "completed" && "bg-green-500/10 text-green-600",
             step.status === "running" && "bg-primary text-primary-foreground",
             step.status === "failed" && "bg-red-500/10 text-red-600",
+            (step.status === "interrupted" || step.status === "clarification_invalidated") && "bg-amber-500/10 text-amber-600",
             (step.status === "pending" || step.status === "skipped") && "bg-muted text-muted-foreground",
           )}
         >
@@ -249,6 +257,8 @@ function ProgressStepRow({
             <Loader2 className="h-3 w-3 animate-spin" />
           ) : step.status === "skipped" ? (
             <RotateCcw className="h-3 w-3" />
+          ) : step.status === "interrupted" || step.status === "clarification_invalidated" ? (
+            <PauseCircle className="h-3.5 w-3.5" />
           ) : (
             index + 1
           )}
@@ -261,6 +271,7 @@ function ProgressStepRow({
               (step.status === "completed" || step.status === "pending" || step.status === "skipped")
                 && "text-muted-foreground",
               step.status === "failed" && "text-foreground",
+              (step.status === "interrupted" || step.status === "clarification_invalidated") && "text-amber-600",
             )}
           >
             <span className="sr-only">{t(`agent.layout.status.${step.status}`)}: </span>

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -17,15 +17,11 @@ export interface ProgressStepView {
 
 interface ProgressPanelProps {
   steps: ProgressStepView[]
-  // true when the total step count is known upfront (DAG plans always know
-  // it; a future dynamic ReAct panel would not, hence this flag).
-  totalKnown: boolean
   startedAt: string | number | undefined
   // Set once the run has actually finished (completed/failed). While this is
   // undefined, the total elapsed keeps ticking; once set, it freezes at
   // endedAt - startedAt instead of continuing to count up against "now".
   endedAt?: string | number
-  isPlanning?: boolean
   onCollapse: () => void
   onStepClick?: (stepId: string) => void
 }
@@ -68,10 +64,8 @@ function useElapsed(startedAt: string | number | undefined): string | null {
 
 export function ProgressPanel({
   steps,
-  totalKnown,
   startedAt,
   endedAt,
-  isPlanning = false,
   onCollapse,
   onStepClick,
 }: ProgressPanelProps) {
@@ -85,7 +79,10 @@ export function ProgressPanel({
   // "Resolved" rather than strictly "succeeded" - a plan with conditional
   // branches can have steps that finish as "skipped" and will never become
   // "completed", so counting only completed would leave the header stuck
-  // below the total (e.g. "4/6") even once the whole plan is done.
+  // below the total (e.g. "4/6") even once the whole plan is done. "failed"
+  // is counted for the same reason: a failed step is also terminal (it will
+  // never transition to "completed"), so excluding it would leave the same
+  // "4/6" stuck header on a plan that has actually finished running.
   const resolvedCount = useMemo(
     () => steps.filter((step) => (
       step.status === "completed" || step.status === "skipped" || step.status === "failed"
@@ -100,7 +97,7 @@ export function ProgressPanel({
           <h2 className="text-sm font-semibold text-foreground">
             {t("chatPage.progressPanel.title")}
           </h2>
-          {totalKnown && steps.length > 0 && (
+          {steps.length > 0 && (
             <span className="text-xs text-muted-foreground">
               {resolvedCount}/{steps.length}
             </span>
@@ -129,7 +126,7 @@ export function ProgressPanel({
       )}
 
       <div className="flex-1 overflow-y-auto px-2 py-3">
-        {steps.length === 0 && isPlanning ? (
+        {steps.length === 0 ? (
           <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
             {t("chatPage.progressPanel.planning")}

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -1,0 +1,231 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { CheckCircle2, ChevronLeft, Clock, Loader2, RotateCcw, XCircle } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { normalizeTimestampMs } from "@/lib/time-utils"
+import { useI18n } from "@/contexts/i18n-context"
+
+export interface ProgressStepView {
+  id: string
+  title: string
+  description?: string
+  status: "pending" | "running" | "completed" | "failed" | "skipped"
+  startedAt?: string | number
+  completedAt?: string | number
+}
+
+interface ProgressPanelProps {
+  steps: ProgressStepView[]
+  // true when the total step count is known upfront (DAG plans always know
+  // it; a future dynamic ReAct panel would not, hence this flag).
+  totalKnown: boolean
+  startedAt: string | number | undefined
+  // Set once the run has actually finished (completed/failed). While this is
+  // undefined, the total elapsed keeps ticking; once set, it freezes at
+  // endedAt - startedAt instead of continuing to count up against "now".
+  endedAt?: string | number
+  isPlanning?: boolean
+  onCollapse: () => void
+  onStepClick?: (stepId: string) => void
+}
+
+function formatElapsedCompact(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) return `${hours}h ${String(minutes).padStart(2, "0")}m`
+  if (minutes > 0) return `${minutes}m ${String(seconds).padStart(2, "0")}s`
+  return `${seconds}s`
+}
+
+// Ticks once a second while `startedAt` is set, so callers get a live
+// "elapsed since startedAt" string without each one re-implementing a timer.
+// Checked for truthiness, not just `!== undefined`: upstream data can hand
+// this an empty string for "no timestamp yet" (see stepsFromPlanData's
+// `getString` fallback), and normalizeTimestampMs treats any falsy value as
+// "now" - so a strict `!== undefined` check would let "" through and render
+// a bogus "0s" instead of hiding the timer.
+function useElapsed(startedAt: string | number | undefined): string | null {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!startedAt) return
+    // Re-seed immediately: `now` may still hold a value from long before this
+    // particular `startedAt` became truthy (e.g. a step that sat pending for
+    // minutes before going "running"), and the first tick is a full second
+    // away - without this the first render briefly shows an elapsed time
+    // computed against a stale `now`.
+    setNow(Date.now())
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(timer)
+  }, [startedAt])
+
+  if (!startedAt) return null
+  return formatElapsedCompact(now - normalizeTimestampMs(startedAt))
+}
+
+export function ProgressPanel({
+  steps,
+  totalKnown,
+  startedAt,
+  endedAt,
+  isPlanning = false,
+  onCollapse,
+  onStepClick,
+}: ProgressPanelProps) {
+  const { t } = useI18n()
+  const liveTotalElapsed = useElapsed(endedAt ? undefined : startedAt)
+  const finishedTotalElapsed =
+    endedAt && startedAt
+      ? formatElapsedCompact(normalizeTimestampMs(endedAt) - normalizeTimestampMs(startedAt))
+      : null
+  const totalElapsed = liveTotalElapsed ?? finishedTotalElapsed
+  // "Resolved" rather than strictly "succeeded" - a plan with conditional
+  // branches can have steps that finish as "skipped" and will never become
+  // "completed", so counting only completed would leave the header stuck
+  // below the total (e.g. "4/6") even once the whole plan is done.
+  const resolvedCount = useMemo(
+    () => steps.filter((step) => (
+      step.status === "completed" || step.status === "skipped" || step.status === "failed"
+    )).length,
+    [steps],
+  )
+
+  return (
+    <div className="flex h-full flex-col bg-background/80">
+      <div className="flex items-center justify-between border-b border-border bg-card/50 px-4 py-3 backdrop-blur-sm">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-foreground">
+            {t("chatPage.progressPanel.title")}
+          </h2>
+          {totalKnown && (
+            <span className="text-xs text-muted-foreground">
+              {resolvedCount}/{steps.length}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onCollapse}
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            aria-label={t("chatPage.progressPanel.collapse")}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {totalElapsed && (
+        <div className="flex items-center justify-between px-4 py-2 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <Clock className="h-3.5 w-3.5" />
+            {t("chatPage.progressPanel.elapsed")}
+          </span>
+          <span className="font-mono tabular-nums">{totalElapsed}</span>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto px-2 py-3">
+        {steps.length === 0 && isPlanning ? (
+          <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t("chatPage.progressPanel.planning")}
+          </div>
+        ) : (
+          <ol className="space-y-1">
+            {steps.map((step, index) => (
+              <ProgressStepRow key={step.id} step={step} index={index} onClick={onStepClick} />
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ProgressStepRow({
+  step,
+  index,
+  onClick,
+}: {
+  step: ProgressStepView
+  index: number
+  onClick?: (stepId: string) => void
+}) {
+  const liveElapsed = useElapsed(step.status === "running" ? step.startedAt : undefined)
+  // Completed/failed steps already have both endpoints - a static duration,
+  // not another ticking timer, is all that's needed once a step is done.
+  const finishedDuration =
+    (step.status === "completed" || step.status === "failed")
+    && step.startedAt
+    && step.completedAt
+      ? formatElapsedCompact(normalizeTimestampMs(step.completedAt) - normalizeTimestampMs(step.startedAt))
+      : null
+  const duration = liveElapsed ?? finishedDuration
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onClick?.(step.id)}
+        className={cn(
+          "flex w-full items-start gap-3 rounded-lg px-2 py-2 text-left transition-colors",
+          step.status === "running" ? "bg-primary/10" : "hover:bg-muted/50",
+        )}
+      >
+        <span
+          className={cn(
+            "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] font-medium",
+            step.status === "completed" && "bg-green-500/10 text-green-600",
+            step.status === "running" && "bg-primary text-primary-foreground",
+            step.status === "failed" && "bg-red-500/10 text-red-600",
+            (step.status === "pending" || step.status === "skipped") && "bg-muted text-muted-foreground",
+          )}
+        >
+          {step.status === "completed" ? (
+            <CheckCircle2 className="h-3.5 w-3.5" />
+          ) : step.status === "failed" ? (
+            <XCircle className="h-3.5 w-3.5" />
+          ) : step.status === "running" ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : step.status === "skipped" ? (
+            <RotateCcw className="h-3 w-3" />
+          ) : (
+            index + 1
+          )}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span
+            className={cn(
+              "block truncate text-sm",
+              step.status === "running" && "font-medium text-primary",
+              (step.status === "completed" || step.status === "pending" || step.status === "skipped")
+                && "text-muted-foreground",
+              step.status === "failed" && "text-foreground",
+            )}
+          >
+            {step.title}
+          </span>
+          {step.description && (
+            <span className="mt-0.5 line-clamp-2 block text-xs text-muted-foreground/80">
+              {step.description}
+            </span>
+          )}
+        </span>
+        {duration && (
+          <span
+            className={cn(
+              "mt-0.5 shrink-0 text-xs tabular-nums",
+              step.status === "running" ? "text-primary/80" : "text-muted-foreground",
+            )}
+          >
+            {duration}
+          </span>
+        )}
+      </button>
+    </li>
+  )
+}

--- a/frontend/src/components/task/progress-panel.tsx
+++ b/frontend/src/components/task/progress-panel.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 import { CheckCircle2, ChevronLeft, Clock, Loader2, RotateCcw, XCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { normalizeTimestampMs } from "@/lib/time-utils"
@@ -83,12 +83,9 @@ export function ProgressPanel({
   // is counted for the same reason: a failed step is also terminal (it will
   // never transition to "completed"), so excluding it would leave the same
   // "4/6" stuck header on a plan that has actually finished running.
-  const resolvedCount = useMemo(
-    () => steps.filter((step) => (
-      step.status === "completed" || step.status === "skipped" || step.status === "failed"
-    )).length,
-    [steps],
-  )
+  const resolvedCount = steps.filter((step) => (
+    step.status === "completed" || step.status === "skipped" || step.status === "failed"
+  )).length
 
   return (
     <div className="flex h-full flex-col bg-background/80">
@@ -142,7 +139,7 @@ export function ProgressPanel({
         ) : (
           <ol className="space-y-1">
             {steps.map((step, index) => (
-              <ProgressStepRow key={step.id} step={step} index={index} onClick={onStepClick} />
+              <ProgressStepRow key={step.id} step={step} index={index} endedAt={endedAt} onClick={onStepClick} />
             ))}
           </ol>
         )}
@@ -154,21 +151,32 @@ export function ProgressPanel({
 function ProgressStepRow({
   step,
   index,
+  endedAt,
   onClick,
 }: {
   step: ProgressStepView
   index: number
+  endedAt?: string | number
   onClick?: (stepId: string) => void
 }) {
   const { t } = useI18n()
-  const liveElapsed = useElapsed(step.status === "running" ? step.startedAt : undefined)
+  const liveElapsed = useElapsed(!endedAt && step.status === "running" ? step.startedAt : undefined)
   // Completed/failed steps already have both endpoints - a static duration,
-  // not another ticking timer, is all that's needed once a step is done.
+  // not another ticking timer, is all that's needed once a step is done. Once
+  // the whole run has ended (`endedAt` set), no row should keep ticking
+  // either: the backend cancels pending sibling steps without emitting their
+  // own terminal event when a run finishes, so a step that's still "running"
+  // at that point never gets its own completedAt - freeze it at the run's end
+  // time instead, rather than letting it keep counting up against "now".
+  // Checked for truthiness, not `!== undefined`: a step still running/pending
+  // when a replan snapshot arrives gets `completed_at: ""` (see
+  // stepsFromPlanData's `getString` fallback), and `??` would treat that
+  // empty string as "already have a real endpoint" and never fall through to
+  // `endedAt`.
+  const frozenEndpoint = step.completedAt || (step.status === "running" ? endedAt : undefined)
   const finishedDuration =
-    (step.status === "completed" || step.status === "failed")
-    && step.startedAt
-    && step.completedAt
-      ? formatElapsedCompact(normalizeTimestampMs(step.completedAt) - normalizeTimestampMs(step.startedAt))
+    step.startedAt && frozenEndpoint
+      ? formatElapsedCompact(normalizeTimestampMs(frozenEndpoint) - normalizeTimestampMs(step.startedAt))
       : null
   const duration = liveElapsed ?? finishedDuration
 

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -696,7 +696,11 @@ export function TaskConversationPanel({
     })
   }
 
-  const isPlanning = dagNodes.length === 0 && state.dagExecution?.phase === "planning"
+  // "replanning" is a real, live phase the backend emits for a mid-run
+  // replan (dag.py's on_dag_execution) - it's planning-like in exactly the
+  // same way "planning" is (no plan/graph to show yet), so it must show the
+  // same in-progress indicator rather than falling through unrecognized.
+  const isPlanning = dagNodes.length === 0 && (state.dagExecution?.phase === "planning" || state.dagExecution?.phase === "replanning")
   const hasError = dagNodes.length === 0 && (state.dagExecution?.phase === "failed" || state.currentTask?.status === "failed")
   const shouldShowHistoryLoading =
     timelineItems.length === 0 &&

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -698,9 +698,18 @@ export function TaskConversationPanel({
 
   // "replanning" is a real, live phase the backend emits for a mid-run
   // replan (dag.py's on_dag_execution) - it's planning-like in exactly the
-  // same way "planning" is (no plan/graph to show yet), so it must show the
-  // same in-progress indicator rather than falling through unrecognized.
-  const isPlanning = dagNodes.length === 0 && (state.dagExecution?.phase === "planning" || state.dagExecution?.phase === "replanning")
+  // same way "planning" is (no NEW plan/graph to show yet), so it must show
+  // the same in-progress indicator rather than falling through unrecognized.
+  // Unlike "planning" (the very first plan, where dagNodes is naturally
+  // still empty), a mid-run replan keeps the SAME turn_id as the run it's
+  // revising, so app-context-chat's turn_id-based reset never clears the
+  // prior plan's dagNodes - gating on dagNodes.length === 0 the same way
+  // "planning" does would let the OLD, about-to-be-superseded graph keep
+  // rendering as if it were still current for the whole replan. Show the
+  // loading state unconditionally for "replanning" instead.
+  const isPlanning =
+    (dagNodes.length === 0 && state.dagExecution?.phase === "planning")
+    || state.dagExecution?.phase === "replanning"
   const hasError = dagNodes.length === 0 && (state.dagExecution?.phase === "failed" || state.currentTask?.status === "failed")
   const shouldShowHistoryLoading =
     timelineItems.length === 0 &&

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1145,6 +1145,10 @@ describe("AppProvider websocket message routing", () => {
       expect(screen.getByTestId("task-status").textContent).toBe("failed")
       expect(screen.getByTestId("processing").textContent).toBe("false")
     })
+    // This task never entered DAG mode (no dagExecution was ever seeded) -
+    // a failed non-DAG task completion must not fabricate one just because
+    // the completion payload includes a status.
+    expect(screen.getByTestId("dag-phase").textContent).toBe("")
   })
 
   it("surfaces the failure reason from a failed task_completed payload", async () => {
@@ -1460,6 +1464,17 @@ describe("AppProvider websocket message routing", () => {
           },
         },
       })
+      // A real task_completed broadcast nests the task id at task.id, and
+      // useWebSocket's normalizer (use-websocket.ts) lifts it into a
+      // top-level task_id - exercise that exact shape too, not just the
+      // trace_event envelope above.
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 2,
+        task: { id: 2, status: "completed" },
+        success: true,
+      } as TestWebSocketMessage)
     })
     await waitFor(() => {
       // dagBurst's dag_step_failed would otherwise flip this to "failed".

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1422,6 +1422,65 @@ describe("AppProvider websocket message routing", () => {
     })
   })
 
+  it("drops DAG/chat/task events for a background task while viewing a different one", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    // A background task (2) is still running while the viewer stays on task
+    // 1 (seeded by SeedRunningTask) - its DAG burst, chat reply, and task_info
+    // must not repaint task 1's view.
+    act(() => {
+      dagBurst(2).forEach((message) => onMessage?.(message))
+      onMessage?.(assistantMessage("Stray reply from task 2", 2))
+      // Unlike the shared taskInfoMessage() helper (which several
+      // session-adoption tests rely on omitting), a real task_info frame for
+      // task 2 also carries a top-level task_id (see
+      // ws_trace_handlers.py's create_stream_event) - set it explicitly here
+      // so this exercises the same envelope shape the guard actually checks.
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 2,
+        data: {
+          event_id: "task-info-2",
+          event_type: "task_info",
+          data: {
+            id: 2,
+            title: "Task 2",
+            status: "completed",
+            description: "Session task",
+            created_at: "2026-05-27T05:00:00Z",
+            updated_at: "2026-05-27T05:00:00Z",
+          },
+        },
+      })
+    })
+    await waitFor(() => {
+      // dagBurst's dag_step_failed would otherwise flip this to "failed".
+      expect(screen.getByTestId("dag-phase").textContent).toBe("")
+    })
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
+    expect(screen.getByTestId("task-status").textContent).toBe("running")
+    expect(screen.getByTestId("task-title").textContent).toBe("Test task")
+    expect(screen.getByTestId("messages").textContent).not.toContain("Stray reply from task 2")
+
+    // The viewed task's own events must still apply normally - the guard
+    // isn't blanket-dropping DAG/chat state, only cross-task events.
+    act(() => {
+      dagBurst(1).forEach((message) => onMessage?.(message))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-phase").textContent).toBe("failed")
+    })
+    expect(screen.getByTestId("steps-count").textContent).toBe("1")
+  })
+
   it("normalizes uppercase task info status before syncing processing state", async () => {
     render(
       <AppProvider token="token">

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1634,6 +1634,66 @@ describe("AppProvider websocket message routing", () => {
     expect(screen.getByTestId("steps-count").textContent).toBe("1")
   })
 
+  it("drops a foreign task_completed sent in the real production wire shape, not just the flat test shape", async () => {
+    // use-websocket.ts's own normalizer (the "type": "task_completed" branch)
+    // never hands handleMessage a flat message - it wraps the ENTIRE raw
+    // frame under `.data` and lifts only `task_id` (from `data.task.id ??
+    // data.task_id`) to the top level. The flat shape used elsewhere in this
+    // file happens to also work (normalizeTaskCompletedMessage falls back to
+    // the root object when `.data` is absent), but it never actually
+    // exercises that `.data` fallback branch, or proves the top-level
+    // ownership guard (which only ever reads the top-level task_id) still
+    // works once task/success/file_outputs move under `.data` instead of
+    // sitting next to it.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 2,
+        data: {
+          type: "task_completed",
+          timestamp: "2026-05-27T05:00:03Z",
+          task: { id: 2, status: "completed" },
+          success: true,
+          file_outputs: [{ file_id: "task-2-report", filename: "report.pdf" }],
+        },
+      } as unknown as TestWebSocketMessage)
+    })
+    // Give the (would-be, if the guard failed) dispatches a tick to land.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("running")
+    expect(screen.getByTestId("preview-open").textContent).toBe("false")
+
+    // The viewed task's own production-shaped completion must still apply.
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:04Z",
+        task_id: 1,
+        data: {
+          type: "task_completed",
+          timestamp: "2026-05-27T05:00:04Z",
+          task: { id: 1, status: "completed" },
+          success: true,
+        },
+      } as unknown as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    })
+  })
+
   it("resets created_at/steps for a new turn_id instead of inheriting the prior run's", async () => {
     render(
       <AppProvider token="token">
@@ -1695,6 +1755,85 @@ describe("AppProvider websocket message routing", () => {
     expect(screen.getByTestId("steps-count").textContent).toBe("0")
   })
 
+  it("does not treat a one-sided missing turn_id as a new run, in either direction", async () => {
+    // A turn_id present on only one side (a legacy/history event that
+    // predates this field, mixed with a modern one) can't be reliably
+    // compared - both directions must fall back to "not a new run" rather
+    // than guessing, or a legacy event arriving mid-run would wipe live
+    // steps out from under it.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    const dagExecutionMessage = (
+      timestamp: string,
+      data: Record<string, unknown>,
+    ): TestWebSocketMessage => ({
+      type: "trace_event",
+      timestamp,
+      task_id: 1,
+      data: {
+        event_id: `dag-execution-${timestamp}`,
+        event_type: "dag_execution",
+        data,
+      },
+    })
+
+    // Tracked turn_id present ("turn-A"), incoming event has none (legacy
+    // shape) - must not reset, AND must not wipe the tracked turn_id either
+    // (SET_DAG_EXECUTION replaces the whole object, so without an explicit
+    // carry-forward the legacy event would silently erase the run's
+    // identity, blinding the new-run detection for the rest of the run).
+    act(() => {
+      onMessage?.(dagExecutionMessage("2026-05-27T05:00:02Z", {
+        phase: "executing",
+        turn_id: "turn-A",
+        steps: [{ id: "step-one", name: "Step one", dependencies: [] }],
+      }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("steps-count").textContent).toBe("1")
+    })
+    act(() => {
+      onMessage?.(dagExecutionMessage("2026-05-27T05:00:03Z", { phase: "executing" }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:02Z")
+    })
+    expect(screen.getByTestId("steps-count").textContent).toBe("1")
+    expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-A")
+
+    // The tracked identity survived the legacy event above, so a further
+    // same-run event must still read as a continuation...
+    act(() => {
+      onMessage?.(dagExecutionMessage("2026-05-27T05:00:04Z", { phase: "executing", turn_id: "turn-A" }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-A")
+    })
+    expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:02Z")
+    expect(screen.getByTestId("steps-count").textContent).toBe("1")
+
+    // ...and a genuinely NEW run must still be detected as new - the exact
+    // regression the carry-forward exists to prevent: had the legacy event
+    // wiped the tracked turn_id, this differing id would compare against
+    // undefined and fall back to "not a new run", inheriting turn-A's
+    // created_at (a wildly wrong elapsed time) and stale steps.
+    act(() => {
+      onMessage?.(dagExecutionMessage("2026-05-27T05:00:05Z", { phase: "planning", turn_id: "turn-B" }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-B")
+    })
+    expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:05Z")
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
+  })
+
   it("resets created_at/steps for a new turn_id via the bare dag_execution message type too", async () => {
     // The trace_event-wrapped shape above and this bare-message-type shape
     // are handled by two SEPARATE branches in handleMessage (this one is
@@ -1740,6 +1879,295 @@ describe("AppProvider websocket message routing", () => {
       expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-B")
     })
     expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:05Z")
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
+  })
+
+  it("resets dagExecution/steps once an ordinary new send's ack resolves on an existing DAG task", async () => {
+    // The plain-path counterpart to the race-condition test below: no
+    // task_completed clone in the middle, just an existing task with a
+    // finished DAG plan and a normal new message sent into it - the ack
+    // resolving alone must be enough to clear the stale run.
+    let acknowledgeDelivery: (() => void) | undefined
+    sendChatMessageMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          acknowledgeDelivery = () =>
+            resolve({ client_message_id: "turn-2", turn_id: "turn-2" })
+        })
+    )
+
+    let sendTurnTwo: (() => Promise<void> | undefined) | undefined
+    let markTaskOneCompleted: (() => void) | undefined
+    function OrdinaryResetProbe() {
+      const { sendMessage, dispatch } = useApp()
+      sendTurnTwo = () => sendMessage("A plain follow-up", { clientMessageId: "turn-2" })
+      markTaskOneCompleted = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "completed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <OrdinaryResetProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      markTaskOneCompleted?.()
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        data: {
+          event_id: "dag-execution-1",
+          event_type: "dag_execution",
+          data: {
+            phase: "completed",
+            turn_id: "turn-1",
+            steps: [{ id: "step-one", name: "Step one", dependencies: [] }],
+          },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-1")
+    })
+    expect(screen.getByTestId("steps-count").textContent).toBe("1")
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = sendTurnTwo?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(sendChatMessageMock).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      acknowledgeDelivery?.()
+      await delivery
+    })
+    expect(screen.getByTestId("dag-turn-id").textContent).toBe("")
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
+  })
+
+  it("does not wipe a turn_id-less DAG run that arrives before the ack of the send that started it", async () => {
+    // turn_id is optional (older backends/patterns never set it), and with
+    // no dagExecution at all before the send, both the pre-send capture and
+    // the post-ack read of `?.turn_id` are undefined - "undefined ===
+    // undefined" can't tell "nothing happened" apart from "a genuinely new,
+    // turn_id-less run just arrived". The guard must fall back to object
+    // reference equality for that case (the pre-turn_id behavior), which
+    // correctly sees the newly-arrived object as new and skips the reset.
+    let acknowledgeDelivery: (() => void) | undefined
+    sendChatMessageMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          acknowledgeDelivery = () =>
+            resolve({ client_message_id: "turn-legacy", turn_id: "turn-legacy" })
+        })
+    )
+
+    let sendTurn: (() => Promise<void> | undefined) | undefined
+    let markTaskOneCompleted: (() => void) | undefined
+    function LegacyRunProbe() {
+      const { sendMessage, dispatch } = useApp()
+      sendTurn = () => sendMessage("Start a DAG task", { clientMessageId: "turn-legacy" })
+      markTaskOneCompleted = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "completed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <LegacyRunProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    // Terminal status so the send exercises the reset path (a running/paused
+    // task short-circuits it as a continuation), and NO dagExecution at all.
+    act(() => {
+      markTaskOneCompleted?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    })
+    expect(screen.getByTestId("dag-phase").textContent).toBe("")
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = sendTurn?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(sendChatMessageMock).toHaveBeenCalledOnce()
+
+    // The new turn's own DAG run starts broadcasting before the ack resolves,
+    // from a backend that doesn't set turn_id.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        data: {
+          event_id: "dag-execution-legacy-1",
+          event_type: "dag_execution",
+          data: {
+            phase: "executing",
+            steps: [{ id: "step-one", name: "Step one", dependencies: [] }],
+          },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("steps-count").textContent).toBe("1")
+    })
+
+    await act(async () => {
+      acknowledgeDelivery?.()
+      await delivery
+    })
+    // The freshly-arrived run survives the ack's reset attempt.
+    expect(screen.getByTestId("dag-phase").textContent).toBe("executing")
+    expect(screen.getByTestId("steps-count").textContent).toBe("1")
+  })
+
+  it("still resets stale dagExecution when a task_completed clone races ahead of a new turn's ack", async () => {
+    // Regression coverage for the sendMessage reset guard: it used to compare
+    // dagExecution by OBJECT REFERENCE, which the (unrelated, unmodified)
+    // task_completed handler defeats - that handler unconditionally clones
+    // currentState.dagExecution into a NEW object whenever it's truthy, even
+    // for a turn that isn't a DAG turn at all. If that clone lands before this
+    // send's own ack resolves, reference equality would wrongly read as
+    // "something new arrived" and skip the reset, leaving turn 1's stale
+    // plan/steps stuck in view. Comparing turn_id instead of the object
+    // itself isn't fooled by the clone, since the id doesn't change.
+    let acknowledgeDelivery: (() => void) | undefined
+    sendChatMessageMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          acknowledgeDelivery = () =>
+            resolve({ client_message_id: "turn-2", turn_id: "turn-2" })
+        })
+    )
+
+    let sendTurnTwo: (() => Promise<void> | undefined) | undefined
+    let markTaskOneCompleted: (() => void) | undefined
+    function StaleCloneProbe() {
+      const { sendMessage, dispatch } = useApp()
+      sendTurnTwo = () => sendMessage("A plain follow-up", { clientMessageId: "turn-2" })
+      markTaskOneCompleted = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "completed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <StaleCloneProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    // Turn 1's DAG run finished, and the task is now done - the state a
+    // second, unrelated turn would be sent into.
+    act(() => {
+      markTaskOneCompleted?.()
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        data: {
+          event_id: "dag-execution-1",
+          event_type: "dag_execution",
+          data: {
+            phase: "completed",
+            turn_id: "turn-1",
+            steps: [{ id: "step-one", name: "Step one", dependencies: [] }],
+          },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-1")
+    })
+    expect(screen.getByTestId("steps-count").textContent).toBe("1")
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = sendTurnTwo?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(sendChatMessageMock).toHaveBeenCalledOnce()
+
+    // Before turn 2's ack resolves, a task_completed broadcast for task 1
+    // arrives (e.g. a duplicate/replayed completion notice) - the existing
+    // task_completed handler clones the still-turn-1 dagExecution into a new
+    // object purely to sync its phase, without changing its turn_id.
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 1,
+        task: { id: 1, status: "completed" },
+        success: true,
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-phase").textContent).toBe("completed")
+    })
+    // Still turn 1's data - the clone didn't introduce a new run.
+    expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-1")
+    expect(screen.getByTestId("steps-count").textContent).toBe("1")
+
+    // Turn 2's ack now resolves - since nothing turn-2-specific arrived (no
+    // new turn_id), the guard must still recognize turn 1's data as stale and
+    // reset it, despite the object having been recloned in between.
+    await act(async () => {
+      acknowledgeDelivery?.()
+      await delivery
+    })
+    expect(screen.getByTestId("dag-turn-id").textContent).toBe("")
     expect(screen.getByTestId("steps-count").textContent).toBe("0")
   })
 

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -2520,6 +2520,124 @@ describe("AppProvider websocket message routing", () => {
     expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T05:01:00Z")
   })
 
+  it("lets a task-level trace_error replace a provisional dagTerminatedAt on an ALREADY-failed task, but never decides the outcome itself", async () => {
+    // trace_error alone must never be what marks a task failed (a global
+    // trace_error can be logged without the task actually stopping) - it
+    // only backstops the TIMESTAMP once the task is independently already
+    // known failed (task_info established that on cold history load,
+    // backfilling dagTerminatedAt from mutable updatedAt as a provisional
+    // guess) and no proper terminal broadcast ever arrived to replace it.
+    let seedColdFailedTask: (() => void) | undefined
+    let seedColdRunningTask: (() => void) | undefined
+    function ColdTraceErrorProbe() {
+      const { dispatch } = useApp()
+      seedColdFailedTask = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "failed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T09:00:00Z",
+          },
+        })
+      }
+      seedColdRunningTask = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "running",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <ColdTraceErrorProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    // A task-level trace_error arriving while the task is still RUNNING must
+    // not flip it to failed - some other event decides that, not this one.
+    act(() => {
+      seedColdRunningTask?.()
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:30Z",
+        task_id: 1,
+        data: {
+          event_id: "trace-error-recoverable",
+          event_type: "trace_error",
+          data: { error_message: "a recoverable hiccup" },
+        },
+      })
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("running")
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("")
+
+    // Now the task is independently known failed (cold history's task_info),
+    // with a provisional dagTerminatedAt backfilled from mutable updatedAt.
+    act(() => {
+      seedColdFailedTask?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T09:00:00Z")
+    })
+
+    // The replayed global trace_error carries the REAL failure timestamp -
+    // it must replace the provisional backfill.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:01:15Z",
+        task_id: 1,
+        data: {
+          event_id: "trace-error-global",
+          event_type: "trace_error",
+          data: { error_message: "fatal error" },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T05:01:15Z")
+    })
+
+    // A second trace_error afterward must not push the now-authoritative
+    // value forward (first-write-wins).
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:03:00Z",
+        task_id: 1,
+        data: {
+          event_id: "trace-error-duplicate",
+          event_type: "trace_error",
+          data: { error_message: "fatal error" },
+        },
+      })
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T05:01:15Z")
+  })
+
   it("does not let replayed liveness events flip a terminal task back to running during a history load", async () => {
     // Replayed activity events (llm_call_start & co) optimistically infer
     // "running" from the fact that work is happening - but during a history

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -176,6 +176,7 @@ function StateProbe() {
         )}
       </div>
       <div data-testid="task-status">{state.currentTask?.status || ""}</div>
+      <div data-testid="task-dag-terminated-at">{state.currentTask?.dagTerminatedAt ?? ""}</div>
       <div data-testid="task-title">{state.currentTask?.title || ""}</div>
       <div data-testid="task-id">{state.taskId ?? ""}</div>
       <div data-testid="task-runtime-extensions">
@@ -193,6 +194,8 @@ function StateProbe() {
         completed_at: step.completed_at,
       })))}</div>
       <div data-testid="dag-phase">{state.dagExecution?.phase ?? ""}</div>
+      <div data-testid="dag-created-at">{state.dagExecution?.created_at ?? ""}</div>
+      <div data-testid="dag-turn-id">{state.dagExecution?.turn_id ?? ""}</div>
       <div data-testid="history-loading">{String(state.isHistoryLoading)}</div>
       <div data-testid="preview-open">{String(state.filePreview.isOpen)}</div>
       <div data-testid="processing">{String(state.isProcessing)}</div>
@@ -888,6 +891,131 @@ describe("AppProvider websocket message routing", () => {
     expect(messages).toEqual([])
   })
 
+  it("does not retarget a different task's status when a failed-retry ack arrives after switching away", async () => {
+    let acknowledgeDelivery: (() => void) | undefined
+    sendChatMessageMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          acknowledgeDelivery = () =>
+            resolve({ client_message_id: "turn-retry", turn_id: "turn-retry" })
+        })
+    )
+
+    let retry: (() => Promise<void>) | undefined
+    let markTaskOneFailed: (() => void) | undefined
+    let switchToTaskTwo: (() => void) | undefined
+    function RetryAckProbe() {
+      const { sendMessage, dispatch, setTaskId } = useApp()
+      retry = () => sendMessage("Retry the failed turn", { clientMessageId: "turn-retry" })
+      markTaskOneFailed = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "failed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      switchToTaskTwo = () => {
+        setTaskId(2, { navigate: false })
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "2",
+            title: "Task two",
+            status: "completed",
+            description: "Task two",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <RetryAckProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    // SeedExistingTask starts task 1 as "running" - flip it to "failed" so
+    // the retry's optimistic completed/failed -> running branch is armed.
+    act(() => {
+      markTaskOneFailed?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("failed")
+    })
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = retry?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(sendChatMessageMock).toHaveBeenCalledOnce()
+
+    // The user navigates to task 2 (already completed) while task 1's retry
+    // is still in flight.
+    act(() => {
+      switchToTaskTwo?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-id").textContent).toBe("2")
+      expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    })
+
+    // Task 1's delayed ack now resolves - it must not flip task 2 (the task
+    // actually being viewed) to "running".
+    await act(async () => {
+      acknowledgeDelivery?.()
+      await delivery
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("completed")
+  })
+
+  it("clears a stale dagTerminatedAt once a rerun's task_info reports running again", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    // Run 1 completes via UPDATE_TASK_STATUS, which stamps dagTerminatedAt.
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        task: { id: 1, status: "completed" },
+        success: true,
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    })
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).not.toBe("")
+
+    // Run 2 starts, observed only via a task_info event (SET_CURRENT_TASK,
+    // not UPDATE_TASK_STATUS) - the stale run-1 timestamp must not survive.
+    act(() => {
+      onMessage?.(taskInfoMessage(1, { status: "running" }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("")
+  })
+
   it("rejects a queued message once the conversation is reset before delivery", async () => {
     let send: (() => Promise<void> | undefined) | undefined
     let reset: (() => void) | undefined
@@ -1504,6 +1632,151 @@ describe("AppProvider websocket message routing", () => {
       expect(screen.getByTestId("dag-phase").textContent).toBe("failed")
     })
     expect(screen.getByTestId("steps-count").textContent).toBe("1")
+  })
+
+  it("resets created_at/steps for a new turn_id instead of inheriting the prior run's", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    const dagExecutionMessage = (
+      timestamp: string,
+      data: Record<string, unknown>,
+    ): TestWebSocketMessage => ({
+      type: "trace_event",
+      timestamp,
+      task_id: 1,
+      data: {
+        event_id: `dag-execution-${timestamp}`,
+        event_type: "dag_execution",
+        data,
+      },
+    })
+
+    // Run A: planning, then executing with one step.
+    act(() => {
+      onMessage?.(dagExecutionMessage("2026-05-27T05:00:02Z", { phase: "planning", turn_id: "turn-A" }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-A")
+    })
+    expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:02Z")
+
+    act(() => {
+      onMessage?.(dagExecutionMessage("2026-05-27T05:00:03Z", {
+        phase: "executing",
+        turn_id: "turn-A",
+        steps: [{ id: "step-one", name: "Step one", dependencies: [] }],
+      }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("steps-count").textContent).toBe("1")
+    })
+    // Later events for the SAME run must not reset created_at, even though
+    // this event's own timestamp differs from run A's first event.
+    expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:02Z")
+
+    // Run B starts (e.g. sendMessage's RESET_DAG_STATE guard raced and lost,
+    // so the reducer never got to clear run A's dagExecution/steps first) -
+    // a DIFFERENT turn_id must reset created_at to this event's own timestamp
+    // and clear run A's steps, not inherit either.
+    act(() => {
+      onMessage?.(dagExecutionMessage("2026-05-27T05:00:04Z", { phase: "planning", turn_id: "turn-B" }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-B")
+    })
+    expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:04Z")
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
+  })
+
+  it("resets created_at/steps for a new turn_id via the bare dag_execution message type too", async () => {
+    // The trace_event-wrapped shape above and this bare-message-type shape
+    // are handled by two SEPARATE branches in handleMessage (this one is
+    // what a live single-connection tracer actually sends while a task is
+    // running) - a past version of this fix updated only the trace_event
+    // branch and missed this one, so this exercises it directly.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    const bareDagExecutionMessage = (
+      timestamp: string,
+      data: Record<string, unknown>,
+    ): TestWebSocketMessage => ({
+      type: "dag_execution",
+      timestamp,
+      task_id: 1,
+      data,
+    })
+
+    act(() => {
+      onMessage?.(bareDagExecutionMessage("2026-05-27T05:00:02Z", {
+        phase: "executing",
+        turn_id: "turn-A",
+        steps: [{ id: "step-one", name: "Step one", dependencies: [] }],
+      }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("steps-count").textContent).toBe("1")
+    })
+    expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-A")
+    expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:02Z")
+
+    act(() => {
+      onMessage?.(bareDagExecutionMessage("2026-05-27T05:00:05Z", { phase: "planning", turn_id: "turn-B" }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-turn-id").textContent).toBe("turn-B")
+    })
+    expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:05Z")
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
+  })
+
+  it("clears dagExecution/steps when switching to a different task", async () => {
+    let switchTask: (() => void) | undefined
+    function SwitchingTaskProbe() {
+      const { setTaskId } = useApp()
+      switchTask = () => setTaskId(2, { navigate: false })
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <SwitchingTaskProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      dagBurst(1).forEach((message) => onMessage?.(message))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("steps-count").textContent).toBe("1")
+    })
+    expect(screen.getByTestId("dag-phase").textContent).toBe("failed")
+
+    act(() => {
+      switchTask?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-id").textContent).toBe("2")
+    })
+    expect(screen.getByTestId("dag-phase").textContent).toBe("")
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
   })
 
   it("normalizes uppercase task info status before syncing processing state", async () => {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1476,7 +1476,13 @@ describe("AppProvider websocket message routing", () => {
         task_id: 2,
         task: { id: 2, status: "completed" },
         success: true,
-        file_outputs: ["report.pdf"],
+        // Must be object-shaped ({file_id, filename}), matching what the
+        // real backend broadcast sends (websocket.py's normalized_outputs) -
+        // normalizeGeneratedPreviewFiles filters out any entry without a
+        // file_id, so a bare string here would silently never reach
+        // dispatchAutoOpenPreview at all, making the assertion below pass
+        // even if the OPEN_FILE_PREVIEW guard were broken.
+        file_outputs: [{ file_id: "task-2-report", filename: "report.pdf" }],
       } as TestWebSocketMessage)
     })
     await waitFor(() => {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -426,6 +426,12 @@ function SeedRunningTask() {
   const { dispatch } = useApp()
 
   React.useEffect(() => {
+    // Real navigation always sets taskId alongside currentTask (setTaskId,
+    // ADOPT_SESSION_TASK, and every builder/workforce dispatch site do both
+    // together) - seed both here too, matching SeedExistingTask below, so
+    // this fixture doesn't exercise a "viewing task 1 but taskId is null"
+    // shape that never happens in production.
+    dispatch({ type: "SET_TASK_ID", payload: 1 })
     dispatch({
       type: "SET_CURRENT_TASK",
       payload: {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -2171,6 +2171,509 @@ describe("AppProvider websocket message routing", () => {
     expect(screen.getByTestId("steps-count").textContent).toBe("0")
   })
 
+  it("still resets a turn_id-LESS stale dagExecution when a task_completed clone races ahead of the ack", async () => {
+    // The no-turn_id twin of the clone-race test above: with no turn_id on
+    // either side, the reset guard falls back to comparing created_at (NOT
+    // object reference - the clone changes the reference while keeping
+    // created_at, which is exactly how a reference fallback wrongly read the
+    // clone as "something new arrived" and skipped the reset).
+    let acknowledgeDelivery: (() => void) | undefined
+    sendChatMessageMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          acknowledgeDelivery = () =>
+            resolve({ client_message_id: "turn-2", turn_id: "turn-2" })
+        })
+    )
+
+    let sendTurnTwo: (() => Promise<void> | undefined) | undefined
+    let markTaskOneCompleted: (() => void) | undefined
+    function LegacyStaleCloneProbe() {
+      const { sendMessage, dispatch } = useApp()
+      sendTurnTwo = () => sendMessage("A plain follow-up", { clientMessageId: "turn-2" })
+      markTaskOneCompleted = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "completed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <LegacyStaleCloneProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    // Turn 1's DAG finished - as a legacy event with NO turn_id.
+    act(() => {
+      markTaskOneCompleted?.()
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        data: {
+          event_id: "dag-execution-1",
+          event_type: "dag_execution",
+          data: {
+            phase: "completed",
+            steps: [{ id: "step-one", name: "Step one", dependencies: [] }],
+          },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("steps-count").textContent).toBe("1")
+    })
+    expect(screen.getByTestId("dag-turn-id").textContent).toBe("")
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = sendTurnTwo?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(sendChatMessageMock).toHaveBeenCalledOnce()
+
+    // The racing task_completed clones the (no-id) dagExecution into a new
+    // object before the ack resolves.
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 1,
+        task: { id: 1, status: "completed" },
+        success: true,
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-phase").textContent).toBe("completed")
+    })
+    expect(screen.getByTestId("steps-count").textContent).toBe("1")
+
+    await act(async () => {
+      acknowledgeDelivery?.()
+      await delivery
+    })
+    expect(screen.getByTestId("dag-phase").textContent).toBe("")
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
+  })
+
+  it("does not wipe a turn_id-less dagExecution that newly arrived from nothing during the ack await", async () => {
+    // The case the no-turn_id fallback exists to protect: nothing was in
+    // state when the send began, and the new turn's own (legacy, no-id) DAG
+    // events land before the ack resolves. created_at going from undefined
+    // to a value reads as "something new arrived" - the reset must skip.
+    let acknowledgeDelivery: (() => void) | undefined
+    sendChatMessageMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          acknowledgeDelivery = () =>
+            resolve({ client_message_id: "turn-2", turn_id: "turn-2" })
+        })
+    )
+
+    let sendTurnTwo: (() => Promise<void> | undefined) | undefined
+    let markTaskOneCompleted: (() => void) | undefined
+    function FreshArrivalProbe() {
+      const { sendMessage, dispatch } = useApp()
+      sendTurnTwo = () => sendMessage("Kick off a new run", { clientMessageId: "turn-2" })
+      markTaskOneCompleted = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "completed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <FreshArrivalProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      markTaskOneCompleted?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    })
+    expect(screen.getByTestId("dag-phase").textContent).toBe("")
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = sendTurnTwo?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(sendChatMessageMock).toHaveBeenCalledOnce()
+
+    // The new turn's own DAG starts broadcasting (legacy shape, no turn_id)
+    // before the ack resolves.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:05Z",
+        task_id: 1,
+        data: {
+          event_id: "dag-execution-new",
+          event_type: "dag_execution",
+          data: {
+            phase: "planning",
+          },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-phase").textContent).toBe("planning")
+    })
+
+    await act(async () => {
+      acknowledgeDelivery?.()
+      await delivery
+    })
+    // The freshly-arrived run survived the ack's reset attempt.
+    expect(screen.getByTestId("dag-phase").textContent).toBe("planning")
+    expect(screen.getByTestId("dag-created-at").textContent).toBe("2026-05-27T05:00:05Z")
+  })
+
+  it("does not flip a task back to running when its own terminal event landed during the ack await", async () => {
+    // The optimistic terminal->running flip is a pre-send GUESS - a terminal
+    // event accepted during the await (a fast non-DAG turn completing before
+    // the ack resolves) is newer truth. Flipping over it would mark the
+    // finished run as running again and clear the dagTerminatedAt the
+    // reducer just stamped, unfreezing the Progress panel's elapsed clock.
+    let acknowledgeDelivery: (() => void) | undefined
+    sendChatMessageMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          acknowledgeDelivery = () =>
+            resolve({ client_message_id: "turn-2", turn_id: "turn-2" })
+        })
+    )
+
+    let sendTurnTwo: (() => Promise<void> | undefined) | undefined
+    let markTaskOneFailed: (() => void) | undefined
+    function TerminalDuringAwaitProbe() {
+      const { sendMessage, dispatch } = useApp()
+      sendTurnTwo = () => sendMessage("Run it again", { clientMessageId: "turn-2" })
+      markTaskOneFailed = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "failed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <TerminalDuringAwaitProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      markTaskOneFailed?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("failed")
+    })
+
+    let delivery: Promise<void> | undefined
+    await act(async () => {
+      delivery = sendTurnTwo?.()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(sendChatMessageMock).toHaveBeenCalledOnce()
+
+    // The new turn completes (fast non-DAG run) BEFORE the ack resolves.
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:00:07Z",
+        task_id: 1,
+        task: { id: 1, status: "completed" },
+        success: true,
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    })
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T05:00:07Z")
+
+    await act(async () => {
+      acknowledgeDelivery?.()
+      await delivery
+    })
+    // The ack must NOT override the newer terminal truth.
+    expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T05:00:07Z")
+  })
+
+  it("lets a terminal event's own timestamp replace a provisional task-metadata dagTerminatedAt", async () => {
+    // Cold history load: the Task row arrives first, already terminal, and
+    // dagTerminatedAt gets backfilled from mutable updatedAt (which may by
+    // then reflect a post-execution title edit, NOT the real end time). The
+    // replayed terminal event knows the real end time - it must replace the
+    // provisional guess, while a second terminal delivery afterwards must
+    // NOT push the now-authoritative value forward (first-write-wins).
+    let seedColdCompletedTask: (() => void) | undefined
+    function ColdHistoryProbe() {
+      const { dispatch } = useApp()
+      seedColdCompletedTask = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task (renamed after completion)",
+            status: "completed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            // A post-execution title edit bumped this well past the run's
+            // actual 05:01:00 end.
+            updatedAt: "2026-05-27T09:00:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <ColdHistoryProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      seedColdCompletedTask?.()
+    })
+    // Backfilled (provisionally) from updatedAt - the only value available
+    // before any terminal event replays.
+    await waitFor(() => {
+      expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T09:00:00Z")
+    })
+
+    // The terminal event replays with the run's REAL end time.
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:01:00Z",
+        task_id: 1,
+        task: { id: 1, status: "completed" },
+        success: true,
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T05:01:00Z")
+    })
+
+    // A duplicate terminal delivery must not move it again.
+    act(() => {
+      onMessage?.({
+        type: "task_completed",
+        timestamp: "2026-05-27T05:02:30Z",
+        task_id: 1,
+        task: { id: 1, status: "completed" },
+        success: true,
+      } as TestWebSocketMessage)
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T05:01:00Z")
+  })
+
+  it("does not let replayed liveness events flip a terminal task back to running during a history load", async () => {
+    // Replayed activity events (llm_call_start & co) optimistically infer
+    // "running" from the fact that work is happening - but during a history
+    // load that work already finished. Flipping the authoritative terminal
+    // status would clear dagTerminatedAt and let the Progress panel auto-open
+    // for a task that is merely being VIEWED.
+    let seedCompletedTask: (() => void) | undefined
+    function TerminalHistoryProbe() {
+      const { dispatch } = useApp()
+      seedCompletedTask = () => {
+        dispatch({
+          type: "SET_CURRENT_TASK",
+          payload: {
+            id: "1",
+            title: "Test task",
+            status: "completed",
+            description: "Test task",
+            createdAt: "2026-05-27T05:00:00Z",
+            updatedAt: "2026-05-27T05:01:00Z",
+          },
+        })
+      }
+      return null
+    }
+
+    render(
+      <AppProvider token="token">
+        <SeedExistingTask />
+        <TerminalHistoryProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      seedCompletedTask?.()
+      // Connecting is what arms the history load (isHistoricalDataLoadingRef).
+      webSocketOptions.current?.onConnect?.()
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    })
+
+    // A replayed llm_call_start lands mid-history-load.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:30Z",
+        task_id: 1,
+        data: {
+          event_id: "llm-start-replayed",
+          event_type: "llm_call_start",
+          data: { model_name: "test-model" },
+        },
+      })
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    expect(screen.getByTestId("task-dag-terminated-at").textContent).toBe("2026-05-27T05:01:00Z")
+
+    // Once the history load actually completes, LIVE activity events must
+    // still be able to flip a (genuinely re-run) terminal task to running -
+    // the gate is scoped to the load, not to terminal tasks forever.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:02:00Z",
+        task_id: 1,
+        data: {
+          event_id: "history-done",
+          event_type: "historical_data_complete",
+          data: {},
+        },
+      })
+    })
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:02:01Z",
+        task_id: 1,
+        data: {
+          event_id: "llm-start-live",
+          event_type: "llm_call_start",
+          data: { model_name: "test-model" },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("running")
+    })
+  })
+
+  it("drops a dag_execution update whose phase is absent or unknown instead of synthesizing an active run", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    // A bare legacy dag_execution frame with an EMPTY payload - an earlier
+    // version normalized this to phase "executing", conjuring a blank
+    // in-progress DAG (and an auto-opened Progress panel) out of nothing.
+    act(() => {
+      onMessage?.({
+        type: "dag_execution",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        data: {},
+      } as TestWebSocketMessage)
+    })
+    // An unknown future/malformed phase string must be dropped too.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 1,
+        data: {
+          event_id: "dag-execution-mystery",
+          event_type: "dag_execution",
+          data: { phase: "mystery_phase", steps: [{ id: "s1", name: "Step", dependencies: [] }] },
+        },
+      })
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(screen.getByTestId("dag-phase").textContent).toBe("")
+    expect(screen.getByTestId("steps-count").textContent).toBe("0")
+
+    // A well-formed update right after still applies - the drop is per-frame,
+    // not sticky.
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:04Z",
+        task_id: 1,
+        data: {
+          event_id: "dag-execution-valid",
+          event_type: "dag_execution",
+          data: { phase: "executing", turn_id: "turn-A" },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("dag-phase").textContent).toBe("executing")
+    })
+  })
+
   it("clears dagExecution/steps when switching to a different task", async () => {
     let switchTask: (() => void) | undefined
     function SwitchingTaskProbe() {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1467,13 +1467,16 @@ describe("AppProvider websocket message routing", () => {
       // A real task_completed broadcast nests the task id at task.id, and
       // useWebSocket's normalizer (use-websocket.ts) lifts it into a
       // top-level task_id - exercise that exact shape too, not just the
-      // trace_event envelope above.
+      // trace_event envelope above. Also carries a file output that would
+      // auto-open the file preview (dispatchAutoOpenPreview) if the stray
+      // dispatch weren't dropped - OPEN_FILE_PREVIEW must be task-scoped too.
       onMessage?.({
         type: "task_completed",
         timestamp: "2026-05-27T05:00:03Z",
         task_id: 2,
         task: { id: 2, status: "completed" },
         success: true,
+        file_outputs: ["report.pdf"],
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
@@ -1484,6 +1487,7 @@ describe("AppProvider websocket message routing", () => {
     expect(screen.getByTestId("task-status").textContent).toBe("running")
     expect(screen.getByTestId("task-title").textContent).toBe("Test task")
     expect(screen.getByTestId("messages").textContent).not.toContain("Stray reply from task 2")
+    expect(screen.getByTestId("preview-open").textContent).toBe("false")
 
     // The viewed task's own events must still apply normally - the guard
     // isn't blanket-dropping DAG/chat state, only cross-task events.

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -781,18 +781,34 @@ const getSessionTaskInfoData = (
   return Object.keys(nestedData).length > 0 ? nestedData : data
 }
 
+// The backend's DAG step status contract, shared verbatim by every UI model
+// that projects a step (StepExecution here, progress-panel.tsx's
+// ProgressStepView, center-panel.tsx's DAGNode.data) - previously each
+// redeclared the same seven-value union independently, so a future backend
+// status could be accepted by one and silently fall through to an "unknown"
+// rendering in another. Import this instead of redeclaring the union.
+//
+// "interrupted" and "clarification_invalidated" are both non-terminal (a
+// step in either state transitions back to "running" once its blocking
+// condition clears - see dag.py's _ready_steps/_invalidate_batch_siblings)
+// - they must render and count distinctly from "pending" (never started)
+// and from the terminal statuses. "skipped" has no current backend producer
+// (dag_step_skipped is never emitted) but is kept for the branch-derivation
+// path that can still locally construct it.
+export type StepStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "skipped"
+  | "interrupted"
+  | "clarification_invalidated"
+
 interface StepExecution {
   id: string
   name: string
   description: string
-  // "interrupted" and "clarification_invalidated" are both non-terminal (a
-  // step in either state transitions back to "running" once its blocking
-  // condition clears - see dag.py's _ready_steps/_invalidate_batch_siblings)
-  // - they must render and count distinctly from "pending" (never started)
-  // and from the terminal statuses. "skipped" has no current backend
-  // producer (dag_step_skipped is never emitted) but is kept for the branch-
-  // derivation path that can still locally construct it.
-  status: "pending" | "running" | "completed" | "failed" | "skipped" | "interrupted" | "clarification_invalidated"
+  status: StepStatus
   tool_names?: string[]
   dependencies: string[]
   started_at?: string | number
@@ -4301,6 +4317,22 @@ export function AppProvider({
                   status: "failed",
                 }
               })
+              // This event alone never decides the task failed (a global
+              // trace_error can be logged without the task actually stopping,
+              // and some OTHER terminal event - task_completed/agent_error -
+              // is what actually settles that) - but if the task is ALREADY
+              // known failed (task_info established that on cold history
+              // load, backfilling dagTerminatedAt from mutable updatedAt as a
+              // PROVISIONAL guess) and no proper terminal broadcast ever
+              // followed this trace_error to replace that guess, the frozen
+              // elapsed time would stay wrong forever. Re-stamping the
+              // ALREADY-failed status with this event's own timestamp lets it
+              // replace a provisional value (see UPDATE_TASK_STATUS) without
+              // ever using this event to newly decide the outcome.
+              if (currentState.currentTask?.status === "failed") {
+                dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "failed" } })
+                dispatch({ type: "TRIGGER_TASK_UPDATE" })
+              }
             }
           }
 

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1972,6 +1972,11 @@ export function AppProvider({
       })
       dispatch({ type: "SET_TRACE_EVENTS", payload: [] })
       dispatch({ type: "SET_STEPS", payload: [] })
+      // Clear dagExecution alongside steps - otherwise the Progress panel
+      // stays open (it only needs dagExecution to be non-null) rendering an
+      // empty step list for the gap between reconnecting and history replay
+      // repopulating both together.
+      dispatch({ type: "SET_DAG_EXECUTION", payload: null })
     } else {
       // New task connection -> Update tracker, Don't clear (handled by setTaskId)
       lastConnectedTaskId.current = stateRef.current.taskId
@@ -2198,13 +2203,51 @@ export function AppProvider({
 
   const handleMessage = useCallback((
     message: WebSocketMessage,
-    dispatch: React.Dispatch<AppAction>,
+    rawDispatch: React.Dispatch<AppAction>,
     currentState: AppState,
     options?: {
       skipHistory?: boolean
       filesDisabled?: boolean
     },
   ) => {
+    // A task's WebSocket connection is per-task (or, for session transports,
+    // multiplexes a sequence of tasks over one socket) - either way, a
+    // just-superseded socket/task can still have events in flight after the
+    // app has moved on to a different task (e.g. the user starts a new chat
+    // while a previous DAG run is still executing in the background). Those
+    // stray events must not repaint the DAG plan/step state for whatever task
+    // is now on screen, or the Progress panel would auto-open showing another
+    // task's steps. Scope just the DAG-state actions to the message's own
+    // task_id (present on every event type that feeds this state - see
+    // use-websocket.ts's per-type message normalization); every other action
+    // type is unaffected. UPDATE_TASK_STATUS is included too: the Progress
+    // panel's "is this run finished" check reads state.currentTask.status/
+    // updatedAt (there is no reliable per-run "completed" signal on
+    // dagExecution itself - see isDagFinished in page-client.tsx), and
+    // UPDATE_TASK_STATUS unconditionally overwrites currentTask, which
+    // inherently only ever describes the task actually being viewed - so a
+    // stale cross-task status update must not borrow that task's completion
+    // into the currently-viewed task's "finished" signal.
+    const messageTaskId = (message as unknown as { task_id?: unknown }).task_id
+    const isStaleCrossTaskDagAction = (action: AppAction): boolean => {
+      if (
+        action.type !== "SET_DAG_EXECUTION"
+        && action.type !== "SET_STEPS"
+        && action.type !== "ADD_STEP"
+        && action.type !== "UPDATE_STEP"
+        && action.type !== "UPDATE_TASK_STATUS"
+      ) return false
+      if (messageTaskId === undefined || messageTaskId === null || messageTaskId === "") return false
+      // No task is even being viewed (currentState.taskId null/undefined) but
+      // this message names a specific task - that can only be a stray event
+      // for a task other than "the current view", so it must be dropped too
+      // (not just the "viewing a *different* task" case).
+      return String(messageTaskId) !== String(currentState.taskId)
+    }
+    const dispatch: React.Dispatch<AppAction> = (action) => {
+      if (isStaleCrossTaskDagAction(action)) return
+      rawDispatch(action)
+    }
     // If we're in replay mode, don't process immediately - collect for delayed playback
     if (
       !options?.skipHistory
@@ -2365,7 +2408,23 @@ export function AppProvider({
             if (steps) {
               dispatch({ type: "SET_STEPS", payload: steps })
             }
-            dispatch({ type: "SET_DAG_EXECUTION", payload: eventData })
+            // The backend's dag_execution payload (dag.py's on_dag_execution)
+            // never actually carries a created_at - only completed_step_count/
+            // plan_step_count/steps. Without a fallback here, the DAG run
+            // never gets a stable "started at" timestamp, so the Progress
+            // panel's total elapsed time never renders. Keep whatever
+            // created_at this run already established (planning's first event
+            // sets it; later phase updates for the same run must not reset
+            // it), falling back to this event's own timestamp only the first
+            // time.
+            const dagCreatedAt =
+              currentState.dagExecution?.created_at
+              ?? (eventData as { created_at?: string | number }).created_at
+              ?? message.timestamp
+            dispatch({
+              type: "SET_DAG_EXECUTION",
+              payload: { ...eventData, created_at: dagCreatedAt } as DAGExecution,
+            })
           } else if (eventType === "dag_step_info") {
             dispatch({ type: "SET_HISTORY_LOADING", payload: false })
             const stepInfo = eventData
@@ -4806,7 +4865,13 @@ export function AppProvider({
           }
         }
 
-        // Update DAG execution status to completed
+        // Sync DAG execution status to completed/failed - but only for a
+        // task that actually had a DAG plan running (currentState.dagExecution
+        // already set by an earlier dag_execution/dag_step_* event this turn).
+        // Fabricating a fresh DAGExecution for every completed task regardless
+        // of pattern (the previous `else` branch here) made every flash/ReAct
+        // task look like a completed zero-step DAG run to any DAG-only UI
+        // (e.g. the Progress panel), popping it open for plain replies.
         if (currentState.dagExecution) {
           const updatedDAGExecution = {
             ...currentState.dagExecution,
@@ -4814,14 +4879,6 @@ export function AppProvider({
             updated_at: new Date().toISOString()
           }
           dispatch({ type: "SET_DAG_EXECUTION", payload: updatedDAGExecution })
-        } else {
-          const dagExecution: DAGExecution = {
-            phase: taskData.status,
-            current_plan: {},
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString()
-          }
-          dispatch({ type: "SET_DAG_EXECUTION", payload: dagExecution })
         }
 
         // Mark that historical data should not be requested again for completed/failed tasks
@@ -4967,7 +5024,15 @@ export function AppProvider({
         if (dagSteps) {
           dispatch({ type: "SET_STEPS", payload: dagSteps })
         }
-        dispatch({ type: "SET_DAG_EXECUTION", payload: message.data as DAGExecution })
+        {
+          const legacyDagData = (message.data ?? {}) as { created_at?: string | number }
+          const legacyDagCreatedAt =
+            currentState.dagExecution?.created_at ?? legacyDagData.created_at ?? message.timestamp
+          dispatch({
+            type: "SET_DAG_EXECUTION",
+            payload: { ...(message.data as DAGExecution), created_at: legacyDagCreatedAt },
+          })
+        }
         break
 
 
@@ -5387,6 +5452,26 @@ export function AppProvider({
   const sendMessage = useCallback(async (message: string, config?: any, files?: File[]) => {
     console.log('🚀 sendMessage called:', { message, files: files?.map(f => f.name), taskId: state.taskId })
 
+    // A prior turn's DAG plan/steps must not linger into this turn - otherwise
+    // the Progress panel would auto-open (or stay open) showing stale steps
+    // from a different execution mode/run before this turn's own dag_execution
+    // event (if any) arrives. But sending into a run that's still actively
+    // going - answering a mid-run clarification, or the "live guidance" input
+    // ChatInput allows while running/paused/waiting_for_user (see
+    // ChatInput.tsx's `allowsLiveGuidanceInput`; the task page never passes
+    // onSend/onSendInteraction, so all of these fall back to this same
+    // sendMessage) - is a CONTINUATION of that run, not a new turn. Clearing
+    // here would wipe out the in-progress DAG plan/steps the Progress panel
+    // is actively showing.
+    const isContinuingActiveRun =
+      state.currentTask?.status === "running"
+      || state.currentTask?.status === "paused"
+      || state.currentTask?.status === "waiting_for_user"
+    if (!isContinuingActiveRun) {
+      dispatch({ type: "SET_DAG_EXECUTION", payload: null })
+      dispatch({ type: "SET_STEPS", payload: [] })
+    }
+
     if (sessionTransport && !mountedRef.current) {
       throw new Error("Message not sent: the Session chat is closed.")
     }
@@ -5783,7 +5868,7 @@ export function AppProvider({
       // composer keeps both its text and attached files.
       await sendChatMessage(message, files, config?.force, clientMessageId)
 
-      if (state.currentTask?.status === 'completed') {
+      if (state.currentTask?.status === 'completed' || state.currentTask?.status === 'failed') {
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: { status: 'running' }
@@ -5997,6 +6082,12 @@ export function AppProvider({
       dispatch({ type: "CLEAR_MESSAGES" })
       dispatch({ type: "SET_TRACE_EVENTS", payload: [] })
       dispatch({ type: "SET_STEPS", payload: [] })
+      // Also clear the previous task's DAG plan/phase - otherwise switching
+      // tasks via the sidebar (no page reload) leaves the Progress panel
+      // showing the OLD task's steps and elapsed time until the new task's
+      // own dag_execution history replay arrives (or the page is refreshed,
+      // which happens to force a clean re-init).
+      dispatch({ type: "SET_DAG_EXECUTION", payload: null })
     }
 
     if (options?.navigate !== false) {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -70,13 +70,20 @@ const VERSIONED_TASK_EVENT_TYPES = new Set([
 // actually being viewed - see the wrapper's own comment for why. Kept at
 // module scope (built once) rather than inside handleMessage, matching
 // VERSIONED_TASK_EVENT_TYPES above.
+// TRIGGER_TASK_UPDATE is deliberately NOT in this set: it only bumps
+// lastTaskUpdate to tell the sidebar's task list to refetch (sidebar.tsx),
+// which should happen for ANY task's status change regardless of which task
+// is currently being viewed - unlike every action below, it isn't part of
+// the viewed task's own displayed state.
 const TASK_SCOPED_ACTION_TYPES = new Set<AppAction["type"]>([
   "SET_DAG_EXECUTION",
   "SET_STEPS",
   "ADD_STEP",
   "UPDATE_STEP",
   "UPDATE_TASK_STATUS",
+  "SET_CURRENT_TASK",
   "SET_PROCESSING",
+  "SET_HISTORY_LOADING",
   "ADD_MESSAGE",
   "UPSERT_STREAMING_FINAL_ANSWER",
   "ADD_TRACE_EVENT",
@@ -1000,12 +1007,20 @@ function projectAppState(state: AppState, action: AppAction): AppState {
       const messages = taskChanged ? [] : state.messages
       const contextUsage = taskChanged ? null : state.contextUsage
       const taskRuntimeExtensions = taskChanged ? {} : state.taskRuntimeExtensions
+      // Also clear the previous task's DAG plan/phase here - otherwise
+      // switching tasks via the sidebar (no page reload) leaves the Progress
+      // panel showing the OLD task's steps and elapsed time until the new
+      // task's own dag_execution history replay arrives.
+      const dagExecution = taskChanged ? null : state.dagExecution
+      const steps = taskChanged ? [] : state.steps
       const newState = {
         ...state,
         taskId: action.payload,
         messages,
         contextUsage,
         taskRuntimeExtensions,
+        dagExecution,
+        steps,
       }
       console.log('🔄 Reducer returning new state:', newState)
       return newState
@@ -6107,13 +6122,8 @@ export function AppProvider({
       // by the connection effect AFTER the new task's history has already arrived.
       dispatch({ type: "CLEAR_MESSAGES" })
       dispatch({ type: "SET_TRACE_EVENTS", payload: [] })
-      dispatch({ type: "SET_STEPS", payload: [] })
-      // Also clear the previous task's DAG plan/phase - otherwise switching
-      // tasks via the sidebar (no page reload) leaves the Progress panel
-      // showing the OLD task's steps and elapsed time until the new task's
-      // own dag_execution history replay arrives (or the page is refreshed,
-      // which happens to force a clean re-init).
-      dispatch({ type: "SET_DAG_EXECUTION", payload: null })
+      // steps/dagExecution are cleared by the SET_TASK_ID dispatch below (its
+      // reducer case resets them whenever taskChanged) rather than here.
     }
 
     if (options?.navigate !== false) {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -678,6 +678,15 @@ export interface Task {
   // when this execution actually ended, and the Progress panel's frozen
   // elapsed time must not drift when that happens.
   dagTerminatedAt?: string | number
+  // True when dagTerminatedAt was BACKFILLED from mutable task metadata
+  // (updatedAt, by withDagTerminatedAt below) rather than stamped by an
+  // actual terminal event - a cold history load fetches the Task row before
+  // any terminal event replays, and updatedAt may by then reflect a
+  // post-execution metadata change (a title edit) rather than the real end
+  // time. A later authoritative terminal event may replace a provisional
+  // value (see UPDATE_TASK_STATUS); a non-provisional one stays
+  // first-write-wins.
+  dagTerminatedAtProvisional?: boolean
 }
 
 // Exported so every consumer of dagTerminatedAt's "is this task done" gate
@@ -699,15 +708,23 @@ export const isTerminalTaskStatus = (status: TaskStatus | null | undefined): boo
 // individually forget a rule the other already gets right.
 const withDagTerminatedAt = (task: Task | null): Task | null => {
   if (!task) return task
-  // Checked for presence, not truthiness, when preserving/backfilling: updatedAt
-  // (what this backfills from) is a real epoch value that can legitimately be
+  if (!isTerminalTaskStatus(task.status)) {
+    return task.dagTerminatedAt === undefined && task.dagTerminatedAtProvisional === undefined
+      ? task
+      : { ...task, dagTerminatedAt: undefined, dagTerminatedAtProvisional: undefined }
+  }
+  // Checked for presence, not truthiness, when preserving: updatedAt (what
+  // the backfill below uses) is a real epoch value that can legitimately be
   // 0 - a truthy check would treat that as "absent" and re-derive it from a
   // LATER updatedAt on every subsequent refresh, drifting the frozen time
   // exactly the way this field exists to prevent.
-  const dagTerminatedAt = isTerminalTaskStatus(task.status)
-    ? task.dagTerminatedAt ?? task.updatedAt
-    : undefined
-  return task.dagTerminatedAt === dagTerminatedAt ? task : { ...task, dagTerminatedAt }
+  if (task.dagTerminatedAt !== undefined) return task
+  // Backfill from updatedAt, but MARKED provisional: updatedAt is mutable
+  // metadata, so this is only the best available guess until (if ever) an
+  // actual terminal event replays with its own timestamp - which
+  // UPDATE_TASK_STATUS lets replace a provisional value, unlike a
+  // non-provisional one.
+  return { ...task, dagTerminatedAt: task.updatedAt, dagTerminatedAtProvisional: true }
 }
 
 type SessionTaskBinding =
@@ -935,12 +952,20 @@ export interface DAGExecution {
 // would otherwise flow through unchecked). Normalizes a raw wire payload
 // before it's ever cast to DAGExecution, rather than trusting `as
 // DAGExecution` to paper over the mismatch.
-const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecution => {
+//
+// Returns null for a payload whose phase is absent, non-string, or unknown -
+// callers must DROP that update rather than dispatch it. An earlier version
+// defaulted unknown phases to "executing", which synthesized an active DAG
+// run out of malformed data (an empty `{}` payload on the bare legacy
+// message type was enough to conjure a blank in-progress Progress panel and
+// auto-open it); keeping the previous state untouched loses at most one
+// unrecognized update, while fabricating "executing" invents a whole run. A
+// deliberate future backend phase addition should extend
+// DAG_EXECUTION_PHASES and its consumers, not lean on a silent default.
+const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecution | null => {
   const rawPhase = raw.phase
-  const phase: DAGExecutionPhase =
-    typeof rawPhase === "string" && DAG_EXECUTION_PHASES.has(rawPhase)
-      ? rawPhase as DAGExecutionPhase
-      : "executing"
+  if (typeof rawPhase !== "string" || !DAG_EXECUTION_PHASES.has(rawPhase)) return null
+  const phase = rawPhase as DAGExecutionPhase
   const currentPlan =
     raw.current_plan && typeof raw.current_plan === "object" && !Array.isArray(raw.current_plan)
       ? raw.current_plan as Record<string, unknown>
@@ -1335,6 +1360,38 @@ function projectAppState(state: AppState, action: AppAction): AppState {
       }
 
       const isWaitingForUser = nextStatus === "waiting_for_user"
+      // Set once, on the transition into a terminal status - and cleared
+      // when the task starts running again, so a stale prior run's terminal
+      // time doesn't linger into the next one. Deliberately NOT recomputed
+      // from `updatedAt`: unlike this field, `updatedAt` keeps changing
+      // after termination for reasons unrelated to this execution (see the
+      // Task.dagTerminatedAt comment), so it can't double as the frozen end
+      // time itself. An already-set AUTHORITATIVE (non-provisional) value is
+      // preserved (first-write-wins): a second terminal event for the same
+      // episode - a duplicate delivery, or an agent_error followed by the
+      // formal task_completed broadcast - must not push the frozen elapsed
+      // time forward. A PROVISIONAL value (withDagTerminatedAt's backfill
+      // from mutable task metadata on a cold history load) is the one thing
+      // a terminal event's own timestamp is allowed to replace - the event
+      // knows when the run actually ended; the backfill only guessed.
+      let dagTerminatedAt: Task["dagTerminatedAt"]
+      let dagTerminatedAtProvisional: boolean | undefined
+      if (isTerminalTaskStatus(nextStatus)) {
+        const previous = state.currentTask.dagTerminatedAt
+        const previousProvisional = state.currentTask.dagTerminatedAtProvisional === true
+        if (previous !== undefined && !previousProvisional) {
+          dagTerminatedAt = previous
+        } else if (action.payload.updatedAt !== undefined) {
+          dagTerminatedAt = action.payload.updatedAt
+        } else if (previous !== undefined) {
+          // Still provisional: a terminal event with no timestamp of its own
+          // is no more authoritative than the backfill it would replace.
+          dagTerminatedAt = previous
+          dagTerminatedAtProvisional = true
+        } else {
+          dagTerminatedAt = new Date().toISOString()
+        }
+      }
       return {
         ...state,
         isProcessing: shouldStopProcessingForTaskStatus(nextStatus)
@@ -1350,22 +1407,8 @@ function projectAppState(state: AppState, action: AppAction): AppState {
           // its elapsed time against the moment it was REPLAYED, not the
           // moment it actually completed.
           updatedAt: action.payload.updatedAt ?? new Date().toISOString(),
-          // Set once, on the transition into a terminal status - and cleared
-          // when the task starts running again, so a stale prior run's
-          // terminal time doesn't linger into the next one. Deliberately
-          // NOT recomputed from `updatedAt` above: unlike this field,
-          // `updatedAt` keeps changing after termination for reasons
-          // unrelated to this execution (see the Task.dagTerminatedAt
-          // comment), so it can't double as the frozen end time itself.
-          // Preserves an already-set value (matching withDagTerminatedAt's
-          // first-write-wins rule) rather than re-stamping it: a second
-          // terminal event for the same episode - a duplicate delivery, or an
-          // agent_error followed by the formal task_completed broadcast -
-          // must not push the frozen elapsed time forward.
-          dagTerminatedAt:
-            isTerminalTaskStatus(nextStatus)
-              ? state.currentTask.dagTerminatedAt ?? action.payload.updatedAt ?? new Date().toISOString()
-              : undefined,
+          dagTerminatedAt,
+          dagTerminatedAtProvisional,
           waitingQuestion: isWaitingForUser
             ? action.payload.waitingQuestion ?? state.currentTask.waitingQuestion
             : undefined,
@@ -2466,6 +2509,13 @@ export function AppProvider({
       rawEventData: Record<string, unknown>,
       sourceTimestamp: string | number,
     ) => {
+      // Malformed frame (absent/unknown phase): drop the WHOLE update -
+      // including its steps - before any dispatch, matching the normalizer's
+      // own contract. Applying the steps but not the execution object would
+      // leave the two halves of DAG state describing different events.
+      if (typeof rawEventData.phase !== "string" || !DAG_EXECUTION_PHASES.has(rawEventData.phase)) {
+        return
+      }
       const incomingTurnId = (rawEventData as { turn_id?: string }).turn_id
       const trackedTurnId = currentState.dagExecution?.turn_id
       const isNewRun = Boolean(incomingTurnId) && Boolean(trackedTurnId) && incomingTurnId !== trackedTurnId
@@ -2518,15 +2568,42 @@ export function AppProvider({
       // incomingTurnId is absent, so the fallback only ever applies to
       // continuations.)
       const dagTurnId = incomingTurnId ?? trackedTurnId
-      dispatch({
-        type: "SET_DAG_EXECUTION",
-        payload: normalizeDagExecutionPayload({
-          ...rawEventData,
-          created_at: dagCreatedAt,
-          updated_at: dagUpdatedAt,
-          turn_id: dagTurnId,
-        }),
+      // Can't be null here (the phase was already validated at the top of
+      // this function), but the normalizer's null-on-malformed contract is
+      // typed, so honor it rather than asserting it away.
+      const normalizedDagExecution = normalizeDagExecutionPayload({
+        ...rawEventData,
+        created_at: dagCreatedAt,
+        updated_at: dagUpdatedAt,
+        turn_id: dagTurnId,
       })
+      if (normalizedDagExecution) {
+        dispatch({ type: "SET_DAG_EXECUTION", payload: normalizedDagExecution })
+      }
+    }
+    // Activity events (dag_execute_start, llm_call_start, react_task_start,
+    // skill_select_start) optimistically infer "the task is running" from the
+    // fact that work is happening. During a history load those same events
+    // are REPLAYED for work that already finished - letting them flip an
+    // authoritative terminal task back to "running" makes the page briefly
+    // believe a finished task is live again (clearing dagTerminatedAt,
+    // unfreezing the Progress panel's elapsed clock, and passing the panel's
+    // auto-open terminal gate) until the terminal event replays. A terminal
+    // task's status during history load comes from task_info/terminal
+    // events, never from inferred liveness. Keyed off the REF, not
+    // state.isHistoryLoading: several handlers clear the state flag early
+    // (to show live UI as soon as anything renders) while the ref stays true
+    // until historical_data_complete actually arrives. Scoped to terminal
+    // tasks only, so a stuck ref (a backend that never sends
+    // historical_data_complete) can't permanently suppress liveness for a
+    // task that was never finished in the first place.
+    const dispatchInferredRunningStatus = () => {
+      if (
+        isHistoricalDataLoadingRef.current
+        && isTerminalTaskStatus(currentState.currentTask?.status)
+      ) return
+      dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
+      dispatch({ type: "SET_PROCESSING", payload: true })
     }
     // If we're in replay mode, don't process immediately - collect for delayed playback
     if (
@@ -3007,8 +3084,15 @@ export function AppProvider({
                   }
                 })
 
-                // Set DAG execution state to show loading state
-                dispatch({ type: "SET_DAG_EXECUTION", payload: dagExecution })
+                // Set DAG execution state to show loading state - unless the
+                // event carried an unrecognized phase string, in which case
+                // the normalizer returned null and only the chat message
+                // above is kept (fabricating an "executing" run out of an
+                // unknown phase is exactly what the normalizer exists to
+                // prevent).
+                if (dagExecution) {
+                  dispatch({ type: "SET_DAG_EXECUTION", payload: dagExecution })
+                }
               }
             }
           } else if (eventType === "dag_plan_end") {
@@ -3112,8 +3196,7 @@ export function AppProvider({
             const taskPreview = eventData.task_preview || t('agent.header.badge.task')
 
             // Set processing state to true when task execution starts
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
-            dispatch({ type: "SET_PROCESSING", payload: true })
+            dispatchInferredRunningStatus()
 
             // Update DAG execution state to executing phase
             if (currentState.dagExecution) {
@@ -3585,8 +3668,7 @@ export function AppProvider({
 
           // Step-level LLM Call Events - add to traceEvents for step execution logs
           else if (eventType === "llm_call_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
-            dispatch({ type: "SET_PROCESSING", payload: true })
+            dispatchInferredRunningStatus()
             if (Number.isFinite(eventData.context_tokens) && Number.isFinite(eventData.context_threshold) && eventData.context_threshold > 0) {
               dispatch({
                 type: "SET_CONTEXT_USAGE",
@@ -4243,8 +4325,7 @@ export function AppProvider({
 
           // ReAct Pattern Events - these should be displayed in the right panel
           else if (eventType === "react_task_start" || eventType === "task_start_react") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
-            dispatch({ type: "SET_PROCESSING", payload: true })
+            dispatchInferredRunningStatus()
 
             // Add to trace events for displaying execution logs
             const traceEvent: TraceEvent = {
@@ -4323,8 +4404,7 @@ export function AppProvider({
             }
             dispatch({ type: "ADD_TRACE_EVENT", payload: traceEvent })
           } else if (eventType === "llm_call_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
-            dispatch({ type: "SET_PROCESSING", payload: true })
+            dispatchInferredRunningStatus()
             const stepId = message.step_id || traceEventData.step_id
             const traceEvent: TraceEvent = {
               event_id: generateMessageId("llm-call-start"),
@@ -4475,8 +4555,7 @@ export function AppProvider({
           }
           // Skill Selection Events
           else if (eventType === "skill_select_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
-            dispatch({ type: "SET_PROCESSING", payload: true })
+            dispatchInferredRunningStatus()
 
             const traceEvent: TraceEvent = {
               event_id: generateMessageId("skill-select-start"),
@@ -6134,12 +6213,15 @@ export function AppProvider({
 
       // The backend executes the turn as an independent background task and
       // can start broadcasting its own dag_execution/trace events before this
-      // ack resolves - capture the pre-send dagExecution (both its object
-      // identity AND its turn_id) so the reset below can detect that case and
-      // skip clearing, rather than wiping out the new turn's own
-      // freshly-arrived state.
+      // ack resolves - capture the pre-send dagExecution (its turn_id and its
+      // created_at) so the reset below can detect that case and skip
+      // clearing, rather than wiping out the new turn's own freshly-arrived
+      // state. The pre-send currentTask is captured for the optimistic
+      // status flip further below, for the same reason: events landing
+      // during the await must be able to veto it.
       const dagExecutionBeforeSend = stateRef.current.dagExecution
       const dagTurnIdBeforeSend = dagExecutionBeforeSend?.turn_id
+      const currentTaskBeforeSend = stateRef.current.currentTask
 
       // Wait for the server's durable-delivery acknowledgement. If the socket
       // is disconnected or the backend rejects the turn, this throws and the
@@ -6169,33 +6251,54 @@ export function AppProvider({
       // makes a NEW object with the SAME turn_id, see that handler above),
       // where reference equality alone would wrongly look like "something
       // new arrived" and skip the reset. But turn_id is optional (older
-      // backends/patterns that never set it), and comparing "undefined ===
-      // undefined" can't tell "nothing happened" apart from "a genuinely new,
-      // turn_id-less dagExecution just arrived" - falling back to reference
-      // equality for that case (matching the pre-turn_id behavior) avoids
-      // wiping a real new run just because it happens to lack a turn_id.
+      // backends/patterns that never set it), so a no-turn_id fallback is
+      // still needed - and it compares created_at, not object reference:
+      // the same clone-for-phase-sync problem applies on this path too (a
+      // no-turn_id dagExecution recloned by a racing task_completed changed
+      // reference but kept its created_at, so it still correctly reads as
+      // stale), while the case the fallback exists to protect - a genuinely
+      // new dagExecution arriving from NOTHING during the await - still
+      // reads as fresh (created_at went from undefined to a value). A new
+      // no-turn_id run arriving OVER an existing old one inherits the old
+      // created_at (applyDagExecutionUpdate can't tell legacy runs apart -
+      // that's #1433) and so gets reset here; that's the right bias, since a
+      // live run repopulates itself on its next event, whereas a wrongly
+      // retained stale panel has no later event to ever correct it.
       const dagExecutionStillStale =
         dagTurnIdBeforeSend && stateRef.current.dagExecution?.turn_id
           ? stateRef.current.dagExecution.turn_id === dagTurnIdBeforeSend
-          : stateRef.current.dagExecution === dagExecutionBeforeSend
+          : stateRef.current.dagExecution?.created_at === dagExecutionBeforeSend?.created_at
       if (!isContinuingActiveRun && dagExecutionStillStale) {
         dispatch({ type: "RESET_DAG_STATE" })
       }
 
-      // Guarded the same way addOptimisticUserMessage guards its own
-      // dispatch: the user can navigate to a different task while this send
-      // is in flight, and this optimistic flip has no task id of its own for
-      // the reducer to validate against - without this check, a delayed
-      // acknowledgement for task A's retried send would mark whatever task
-      // the user has since navigated to as "running". Reads live status from
-      // stateRef, not the closure's `state`: a live event can legitimately
-      // re-settle THIS SAME task's status (e.g. this very retry completing)
-      // while the ack is still in flight, and re-checking against the stale
-      // closure value would otherwise clobber that fresh, correct status
-      // back to "running".
+      // Optimistically flips a terminal task back to "running" once its
+      // retry/new-turn send is acked, so the user isn't staring at a
+      // "completed"/"failed" badge while the backend spins the turn up.
+      // Three fences, because this dispatch has no task id of its own for
+      // the reducer to validate against:
+      // - taskId still matches: the user can navigate to a different task
+      //   while this send is in flight, and a delayed ack for task A's
+      //   retried send must not mark whatever task the user has since
+      //   navigated to as "running" (same guard addOptimisticUserMessage
+      //   applies to its own dispatch).
+      // - the send began FROM a terminal status: the flip is only meaningful
+      //   for a rerun of a finished task - a send into an active run has
+      //   nothing to flip.
+      // - currentTask is untouched since the send began (reference
+      //   equality): ANY task update landing during the await - most
+      //   critically this new turn's OWN terminal event, when a fast
+      //   non-DAG turn completes before the ack resolves - is newer truth
+      //   than this optimistic guess. Flipping over it would mark a
+      //   genuinely finished run as running again AND clear the
+      //   dagTerminatedAt the reducer just stamped, unfreezing the Progress
+      //   panel's elapsed clock. Skipping the flip is always safe: if the
+      //   turn really is running, the backend's own status events say so
+      //   moments later.
       if (
         state.taskId === stateRef.current.taskId
-        && isTerminalTaskStatus(stateRef.current.currentTask?.status)
+        && stateRef.current.currentTask === currentTaskBeforeSend
+        && isTerminalTaskStatus(currentTaskBeforeSend?.status)
       ) {
         dispatch({
           type: "UPDATE_TASK_STATUS",

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -78,6 +78,12 @@ const VERSIONED_TASK_EVENT_TYPES = new Set([
 const TASK_SCOPED_ACTION_TYPES = new Set<AppAction["type"]>([
   "SET_DAG_EXECUTION",
   "SET_STEPS",
+  // Not currently dispatched from inside handleMessage (its only two call
+  // sites use the raw, unwrapped dispatch), so this has no effect today -
+  // included so a future call site inside handleMessage inherits the same
+  // scoping SET_DAG_EXECUTION/SET_STEPS already get individually, instead of
+  // silently bypassing it.
+  "RESET_DAG_STATE",
   "ADD_STEP",
   "UPDATE_STEP",
   "UPDATE_TASK_STATUS",
@@ -89,6 +95,7 @@ const TASK_SCOPED_ACTION_TYPES = new Set<AppAction["type"]>([
   "ADD_TRACE_EVENT",
   "SET_CONTEXT_USAGE",
   "SET_PLAN_MEMORY_INFO",
+  "OPEN_FILE_PREVIEW",
 ])
 const MAX_TRACKED_TASK_STATE_VERSIONS = 500
 // A Session may reset repeatedly during its absolute lifetime. Retired ids are
@@ -901,6 +908,7 @@ type AppAction =
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; runId?: string | null; stateVersion?: number; controlState?: TaskControlState; updatedAt?: string } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
+  | { type: "RESET_DAG_STATE" }
   | { type: "SET_CONTEXT_USAGE"; payload: { tokens: number; threshold: number } | null }
   | { type: "ADD_STEP"; payload: StepExecution }
   | { type: "UPDATE_STEP"; payload: { stepId: string; updates: Partial<StepExecution> } }
@@ -1241,6 +1249,14 @@ function projectAppState(state: AppState, action: AppAction): AppState {
 
     case "SET_DAG_EXECUTION":
       return { ...state, dagExecution: action.payload }
+
+    // Single action for the "clear dagExecution + steps together" couplet
+    // needed at every site that isn't a task switch (task switches already
+    // get this via SET_TASK_ID's own taskChanged branch) - same-task
+    // reconnect and a successful new turn on the same task both need it, and
+    // a single action keeps them from drifting out of sync with each other.
+    case "RESET_DAG_STATE":
+      return { ...state, dagExecution: null, steps: [] }
 
     case "SET_CONTEXT_USAGE":
       return { ...state, contextUsage: action.payload }
@@ -2011,12 +2027,11 @@ export function AppProvider({
         },
       })
       dispatch({ type: "SET_TRACE_EVENTS", payload: [] })
-      dispatch({ type: "SET_STEPS", payload: [] })
       // Clear dagExecution alongside steps - otherwise the Progress panel
       // stays open (it only needs dagExecution to be non-null) rendering an
       // empty step list for the gap between reconnecting and history replay
       // repopulating both together.
-      dispatch({ type: "SET_DAG_EXECUTION", payload: null })
+      dispatch({ type: "RESET_DAG_STATE" })
     } else {
       // New task connection -> Update tracker, Don't clear (handled by setTaskId)
       lastConnectedTaskId.current = stateRef.current.taskId
@@ -2276,6 +2291,18 @@ export function AppProvider({
       && String(messageTaskId) !== String(currentState.taskId)
     const dispatch: React.Dispatch<AppAction> = (action) => {
       if (TASK_SCOPED_ACTION_TYPES.has(action.type) && isMessageForOtherTask) return
+      // Stamp every UPDATE_TASK_STATUS dispatched from this handler with the
+      // originating event's own timestamp here, once, rather than relying on
+      // each call site to remember to pass it - a forgotten `updatedAt` at a
+      // future call site would otherwise silently fall back to client-now in
+      // the reducer, quietly reintroducing the wrong-elapsed-time-on-replay
+      // bug this field exists to fix. External UI callers of UPDATE_TASK_STATUS
+      // (outside this handler, e.g. sendMessage's optimistic status flip)
+      // don't go through this wrapper and keep their own client-now fallback.
+      if (action.type === "UPDATE_TASK_STATUS" && action.payload.updatedAt === undefined) {
+        rawDispatch({ ...action, payload: { ...action.payload, updatedAt: message.timestamp } })
+        return
+      }
       rawDispatch(action)
     }
     // The 30s dedup cache below is keyed on message content/type only, not
@@ -2290,11 +2317,7 @@ export function AppProvider({
     const isDuplicateMessageForViewedTask = (
       content: string | React.ReactNode,
       type = "general",
-      force = false,
-      shouldCache = true,
-    ) => isDuplicateMessage(content, type, force, shouldCache && !isMessageForOtherTask)
-    const isDuplicateResultForViewedTask = (content: string) =>
-      isDuplicateMessage(content, "result", false, !isMessageForOtherTask)
+    ) => isDuplicateMessage(content, type, false, !isMessageForOtherTask)
     // If we're in replay mode, don't process immediately - collect for delayed playback
     if (
       !options?.skipHistory
@@ -2347,7 +2370,6 @@ export function AppProvider({
               runId: controlEnvelope.runId,
               stateVersion: controlEnvelope.stateVersion,
               controlState: controlEnvelope.controlState,
-              updatedAt: message.timestamp,
             },
           })
         }
@@ -2465,6 +2487,23 @@ export function AppProvider({
             // sets it; later phase updates for the same run must not reset
             // it), falling back to this event's own timestamp only the first
             // time.
+            //
+            // There's no stable run id on this event stream, so distinguishing
+            // "this dagExecution is from a finished prior turn" from "this
+            // dagExecution is the SAME run mid-replan" can't be done reliably
+            // from phase alone: dag_execute_end (below) sets phase "completed"
+            // at the end of every DAGPattern round, not just at whole-task
+            // completion, so a mid-task replan can also observe a terminal
+            // phase while the run is still very much in progress. Treating
+            // terminal phase as "prior run over" was tried and reverted - it
+            // fixed a stale-created_at bug across turns but caused the total-
+            // elapsed timer to reset mid-task on every replan instead, which
+            // is worse. The reset-after-send-success flow in sendMessage
+            // (RESET_DAG_STATE, guarded against racing this turn's own
+            // events) is the actual fix for the cross-turn case; this handler
+            // deliberately stays a plain "keep the existing run's created_at"
+            // preservation, accepting the narrow pre-existing race where a
+            // fast-arriving event beats that reset.
             const dagCreatedAt =
               currentState.dagExecution?.created_at
               ?? (eventData as { created_at?: string | number }).created_at
@@ -2529,7 +2568,7 @@ export function AppProvider({
             // legacy events without either identity fall back to short-lived
             // content-based deduplication.
             const isDuplicate = userMessageId === null
-              ? isDuplicateMessageForViewedTask(messageContent, 'user-message', false, true)
+              ? isDuplicateMessageForViewedTask(messageContent, 'user-message')
               : false
             console.log('🔍 Duplicate check:', {
               messageContent,
@@ -2713,7 +2752,6 @@ export function AppProvider({
                   status: "waiting_for_user",
                   waitingQuestion: messageContent,
                   waitingInteractions: interactions.length > 0 ? interactions : undefined,
-                  updatedAt: message.timestamp,
                 }
               })
             }
@@ -2743,7 +2781,7 @@ export function AppProvider({
               }
             })
             if (eventData.status === "completed") {
-              dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed", updatedAt: message.timestamp } })
+              dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed" } })
               dispatch({ type: "SET_PROCESSING", payload: false })
             }
           }
@@ -2888,7 +2926,7 @@ export function AppProvider({
             const taskPreview = eventData.task_preview || t('agent.header.badge.task')
 
             // Set processing state to true when task execution starts
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
             dispatch({ type: "SET_PROCESSING", payload: true })
 
             // Update DAG execution state to executing phase
@@ -3361,7 +3399,7 @@ export function AppProvider({
 
           // Step-level LLM Call Events - add to traceEvents for step execution logs
           else if (eventType === "llm_call_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
             dispatch({ type: "SET_PROCESSING", payload: true })
             if (Number.isFinite(eventData.context_tokens) && Number.isFinite(eventData.context_threshold) && eventData.context_threshold > 0) {
               dispatch({
@@ -3811,7 +3849,7 @@ export function AppProvider({
                   </div>
                 </div>
               )
-              if (!isDuplicateResultForViewedTask(`📋 ${t('agent.logs.event.messages.metaTitle')}: ${JSON.stringify(metaInfo)}`)) {
+              if (!isDuplicateMessageForViewedTask(`📋 ${t('agent.logs.event.messages.metaTitle')}: ${JSON.stringify(metaInfo)}`, "result")) {
                 dispatch({
                   type: "ADD_MESSAGE",
                   payload: {
@@ -3880,7 +3918,7 @@ export function AppProvider({
                 </>
               )
 
-              if (!isDuplicateResultForViewedTask(`📁 ${t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}`)) {
+              if (!isDuplicateMessageForViewedTask(`📁 ${t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}`, "result")) {
                 dispatch({
                   type: "ADD_MESSAGE",
                   payload: {
@@ -3902,7 +3940,7 @@ export function AppProvider({
             // Update task status and trigger sidebar update
             dispatch({
               type: "UPDATE_TASK_STATUS",
-              payload: { status: success ? "completed" : "failed", updatedAt: message.timestamp }
+              payload: { status: success ? "completed" : "failed" }
             })
           }
 
@@ -4019,7 +4057,7 @@ export function AppProvider({
 
           // ReAct Pattern Events - these should be displayed in the right panel
           else if (eventType === "react_task_start" || eventType === "task_start_react") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
             dispatch({ type: "SET_PROCESSING", payload: true })
 
             // Add to trace events for displaying execution logs
@@ -4099,7 +4137,7 @@ export function AppProvider({
             }
             dispatch({ type: "ADD_TRACE_EVENT", payload: traceEvent })
           } else if (eventType === "llm_call_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
             dispatch({ type: "SET_PROCESSING", payload: true })
             const stepId = message.step_id || traceEventData.step_id
             const traceEvent: TraceEvent = {
@@ -4251,7 +4289,7 @@ export function AppProvider({
           }
           // Skill Selection Events
           else if (eventType === "skill_select_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
             dispatch({ type: "SET_PROCESSING", payload: true })
 
             const traceEvent: TraceEvent = {
@@ -4856,7 +4894,6 @@ export function AppProvider({
             runId: controlEnvelope.runId,
             stateVersion: controlEnvelope.stateVersion,
             controlState: controlEnvelope.controlState,
-            updatedAt: message.timestamp,
           }
         })
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
@@ -4988,7 +5025,7 @@ export function AppProvider({
             </>
           )
 
-          if (!isDuplicateResultForViewedTask(`📁 ${t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}`)) {
+          if (!isDuplicateMessageForViewedTask(`📁 ${t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}`, "result")) {
             dispatch({
               type: "ADD_MESSAGE",
               payload: {
@@ -5095,7 +5132,6 @@ export function AppProvider({
             runId: controlEnvelope.runId,
             stateVersion: controlEnvelope.stateVersion,
             controlState: controlEnvelope.controlState || "paused",
-            updatedAt: message.timestamp,
           },
         })
         dispatch({ type: "SET_PROCESSING", payload: false })
@@ -5110,7 +5146,6 @@ export function AppProvider({
               runId: controlEnvelope.runId,
               stateVersion: controlEnvelope.stateVersion,
               controlState: controlEnvelope.controlState || "pause_requested",
-              updatedAt: message.timestamp,
             },
           })
         }
@@ -5130,7 +5165,6 @@ export function AppProvider({
             runId: controlEnvelope.runId,
             stateVersion: controlEnvelope.stateVersion,
             controlState: controlEnvelope.controlState || "waiting_for_user",
-            updatedAt: message.timestamp,
           }
         })
         dispatch({ type: "SET_PROCESSING", payload: false })
@@ -5164,7 +5198,6 @@ export function AppProvider({
             runId: controlEnvelope.runId,
             stateVersion: controlEnvelope.stateVersion,
             controlState: controlEnvelope.controlState || "running",
-            updatedAt: message.timestamp,
           },
         })
         break
@@ -5182,7 +5215,6 @@ export function AppProvider({
               runId: controlEnvelope.runId,
               stateVersion: controlEnvelope.stateVersion,
               controlState: controlEnvelope.controlState,
-              updatedAt: message.timestamp,
             },
           })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })
@@ -5220,7 +5252,7 @@ export function AppProvider({
         const websocketTaskStatus = getWebSocketTaskStatus(message)
 
         if (websocketTaskStatus) {
-          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: websocketTaskStatus, updatedAt: message.timestamp } })
+          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: websocketTaskStatus } })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })
         }
         if (shouldStopProcessingForTaskStatus(websocketTaskStatus)) {
@@ -5929,8 +5961,7 @@ export function AppProvider({
         || state.currentTask?.status === "paused"
         || state.currentTask?.status === "waiting_for_user"
       if (!isContinuingActiveRun && stateRef.current.dagExecution === dagExecutionBeforeSend) {
-        dispatch({ type: "SET_DAG_EXECUTION", payload: null })
-        dispatch({ type: "SET_STEPS", payload: [] })
+        dispatch({ type: "RESET_DAG_STATE" })
       }
 
       if (state.currentTask?.status === 'completed' || state.currentTask?.status === 'failed') {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1708,10 +1708,6 @@ export function AppProvider({
     }
     return false
   }, [])
-  const isDuplicateResult = useCallback(
-    (content: string) => isDuplicateMessage(content, "result"),
-    [isDuplicateMessage],
-  )
   // All actions are projected synchronously so each action observes the state
   // produced by the preceding action before React commits the batch.
   const stateRef = useRef(state)

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -2451,20 +2451,24 @@ export function AppProvider({
     // message type) - duplicating this logic per call site is exactly how a
     // past version of this fix ended up only covering one of the two and
     // missing the other, so it stays a single function both branches call.
-    // A turn_id present on the incoming event that DIFFERS from the one
-    // already tracked means this event belongs to a genuinely different DAG
-    // execution - e.g. turn 2's DAG starting while turn 1's dagExecution/
-    // steps are still in state because sendMessage's RESET_DAG_STATE guard
-    // raced and lost. When turn_id is absent on either side (an older
-    // backend, or some other pattern that never sets it), this compares as
-    // "not a new run" - inequality between two undefined values is false -
-    // preserving the same behavior as before turn_id existed.
+    // A turn_id present on BOTH sides that DIFFERS means this event belongs
+    // to a genuinely different DAG execution - e.g. turn 2's DAG starting
+    // while turn 1's dagExecution/steps are still in state because
+    // sendMessage's RESET_DAG_STATE guard raced and lost. Only that specific
+    // case counts as a new run: if turn_id is missing on EITHER side (an
+    // older backend, a legacy/history event that predates this field, or
+    // some other pattern that never sets it), there's no reliable identity to
+    // compare, so this falls back to "not a new run" rather than guessing -
+    // a false "new run" here would wipe live steps out from under a mid-run
+    // legacy event, which is worse than occasionally missing a real
+    // transition this fallback can't detect.
     const applyDagExecutionUpdate = (
       rawEventData: Record<string, unknown>,
       sourceTimestamp: string | number,
     ) => {
       const incomingTurnId = (rawEventData as { turn_id?: string }).turn_id
-      const isNewRun = incomingTurnId !== currentState.dagExecution?.turn_id
+      const trackedTurnId = currentState.dagExecution?.turn_id
+      const isNewRun = Boolean(incomingTurnId) && Boolean(trackedTurnId) && incomingTurnId !== trackedTurnId
       const steps = stepsFromPlanData(rawEventData, isNewRun ? [] : currentState.steps)
       if (steps) {
         dispatch({ type: "SET_STEPS", payload: steps })
@@ -2492,9 +2496,36 @@ export function AppProvider({
             ?? sourceTimestamp
           : (rawEventData as { created_at?: string | number }).created_at
             ?? sourceTimestamp
+      // Same gap as created_at above: the backend's dag_execution payload
+      // never carries updated_at either, so without this fallback every
+      // phase update after the first would leave it undefined despite
+      // DAGExecution declaring it required - center-panel.tsx uses it both
+      // as a React key and as displayed text. Unlike created_at, this
+      // always takes the event's own timestamp - it's meant to track "last
+      // touched," not "run started," so a continuation must still advance it.
+      const dagUpdatedAt =
+        (rawEventData as { updated_at?: string | number }).updated_at ?? sourceTimestamp
+      // SET_DAG_EXECUTION replaces the whole object, so a turn_id-less
+      // continuation event (a legacy/history shape mid-run) would otherwise
+      // silently WIPE the tracked turn_id - and once it's gone, the next
+      // genuinely new run's differing turn_id can no longer be recognized as
+      // new (the both-sides-present rule above would see tracked=undefined
+      // and fall back to "not a new run"), inheriting the old run's
+      // created_at and steps. Carrying the tracked id forward through such
+      // events keeps the run's identity stable for as long as it lives.
+      // (When incomingTurnId is present it always wins - including on a new
+      // run, where it IS the new identity; isNewRun can never be true while
+      // incomingTurnId is absent, so the fallback only ever applies to
+      // continuations.)
+      const dagTurnId = incomingTurnId ?? trackedTurnId
       dispatch({
         type: "SET_DAG_EXECUTION",
-        payload: normalizeDagExecutionPayload({ ...rawEventData, created_at: dagCreatedAt }),
+        payload: normalizeDagExecutionPayload({
+          ...rawEventData,
+          created_at: dagCreatedAt,
+          updated_at: dagUpdatedAt,
+          turn_id: dagTurnId,
+        }),
       })
     }
     // If we're in replay mode, don't process immediately - collect for delayed playback
@@ -4909,7 +4940,15 @@ export function AppProvider({
           // Handle direct trace events (without event_type wrapper) - infer type from content
           // Check if this is DAG execution data
           if (traceEventData.phase && (traceEventData.current_plan !== undefined)) {
-            dispatch({ type: "SET_DAG_EXECUTION", payload: traceEventData })
+            // Same shared handler the two explicit dag_execution shapes use -
+            // this legacy, unwrapped shape predates it and used to dispatch
+            // the raw payload directly, bypassing the phase/current_plan
+            // normalizer, the created_at/updated_at backfill, and the
+            // turn_id-based new-run detection all at once.
+            applyDagExecutionUpdate(
+              traceEventData as Record<string, unknown>,
+              message.timestamp,
+            )
           }
           // Check if this is step data (has id and status)
           else if (traceEventData.id && traceEventData.status) {
@@ -6095,10 +6134,12 @@ export function AppProvider({
 
       // The backend executes the turn as an independent background task and
       // can start broadcasting its own dag_execution/trace events before this
-      // ack resolves - capture the pre-send dagExecution reference so the
-      // reset below can detect that case and skip clearing, rather than
-      // wiping out the new turn's own freshly-arrived state.
+      // ack resolves - capture the pre-send dagExecution (both its object
+      // identity AND its turn_id) so the reset below can detect that case and
+      // skip clearing, rather than wiping out the new turn's own
+      // freshly-arrived state.
       const dagExecutionBeforeSend = stateRef.current.dagExecution
+      const dagTurnIdBeforeSend = dagExecutionBeforeSend?.turn_id
 
       // Wait for the server's durable-delivery acknowledgement. If the socket
       // is disconnected or the backend rejects the turn, this throws and the
@@ -6123,7 +6164,21 @@ export function AppProvider({
         state.currentTask?.status === "running"
         || state.currentTask?.status === "paused"
         || state.currentTask?.status === "waiting_for_user"
-      if (!isContinuingActiveRun && stateRef.current.dagExecution === dagExecutionBeforeSend) {
+      // Prefer turn_id equality when BOTH sides actually have one - it sees
+      // through the task_completed handler's clone-for-phase-sync (which
+      // makes a NEW object with the SAME turn_id, see that handler above),
+      // where reference equality alone would wrongly look like "something
+      // new arrived" and skip the reset. But turn_id is optional (older
+      // backends/patterns that never set it), and comparing "undefined ===
+      // undefined" can't tell "nothing happened" apart from "a genuinely new,
+      // turn_id-less dagExecution just arrived" - falling back to reference
+      // equality for that case (matching the pre-turn_id behavior) avoids
+      // wiping a real new run just because it happens to lack a turn_id.
+      const dagExecutionStillStale =
+        dagTurnIdBeforeSend && stateRef.current.dagExecution?.turn_id
+          ? stateRef.current.dagExecution.turn_id === dagTurnIdBeforeSend
+          : stateRef.current.dagExecution === dagExecutionBeforeSend
+      if (!isContinuingActiveRun && dagExecutionStillStale) {
         dispatch({ type: "RESET_DAG_STATE" })
       }
 

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -952,7 +952,7 @@ const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecutio
   } as DAGExecution
 }
 
-interface AppState {
+export interface AppState {
   messages: Message[]
   currentTask: Task | null
   taskRuntimeExtensions: TaskRuntimeExtensions

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -64,6 +64,25 @@ const VERSIONED_TASK_EVENT_TYPES = new Set([
   "task_started",
   "task_waiting_for_user",
 ])
+// Action types that describe state scoped to one specific task's
+// conversation (chat/trace/DAG/status). Used by handleMessage's dispatch
+// wrapper to drop these when a message's task_id doesn't match the task
+// actually being viewed - see the wrapper's own comment for why. Kept at
+// module scope (built once) rather than inside handleMessage, matching
+// VERSIONED_TASK_EVENT_TYPES above.
+const TASK_SCOPED_ACTION_TYPES = new Set<AppAction["type"]>([
+  "SET_DAG_EXECUTION",
+  "SET_STEPS",
+  "ADD_STEP",
+  "UPDATE_STEP",
+  "UPDATE_TASK_STATUS",
+  "SET_PROCESSING",
+  "ADD_MESSAGE",
+  "UPSERT_STREAMING_FINAL_ANSWER",
+  "ADD_TRACE_EVENT",
+  "SET_CONTEXT_USAGE",
+  "SET_PLAN_MEMORY_INFO",
+])
 const MAX_TRACKED_TASK_STATE_VERSIONS = 500
 // A Session may reset repeatedly during its absolute lifetime. Retired ids are
 // retained only to reject late frames, so bound this lineage guard separately
@@ -2215,39 +2234,46 @@ export function AppProvider({
     // just-superseded socket/task can still have events in flight after the
     // app has moved on to a different task (e.g. the user starts a new chat
     // while a previous DAG run is still executing in the background). Those
-    // stray events must not repaint the DAG plan/step state for whatever task
-    // is now on screen, or the Progress panel would auto-open showing another
-    // task's steps. Scope just the DAG-state actions to the message's own
-    // task_id (present on every event type that feeds this state - see
-    // use-websocket.ts's per-type message normalization); every other action
-    // type is unaffected. UPDATE_TASK_STATUS is included too: the Progress
-    // panel's "is this run finished" check reads state.currentTask.status/
-    // updatedAt (there is no reliable per-run "completed" signal on
-    // dagExecution itself - see isDagFinished in page-client.tsx), and
-    // UPDATE_TASK_STATUS unconditionally overwrites currentTask, which
-    // inherently only ever describes the task actually being viewed - so a
-    // stale cross-task status update must not borrow that task's completion
-    // into the currently-viewed task's "finished" signal.
+    // stray events must not repaint TASK_SCOPED_ACTION_TYPES's state for
+    // whatever task is now on screen - not just DAG/step state, but the chat
+    // transcript, trace log, context/memory display, and processing/status
+    // flags too, since a background task's reply or tool trace has no
+    // business appearing in a different task's conversation. Deliberately
+    // keyed ONLY off currentState.taskId (not currentTask.id): switching
+    // tasks via setTaskId leaves a real window where taskId has already
+    // advanced to the new task but currentTask still describes the old one
+    // (until that task's own task_info arrives) - matching against
+    // currentTask.id in that window would let the old task's stray events
+    // right back through, defeating the whole guard.
     const messageTaskId = (message as unknown as { task_id?: unknown }).task_id
-    const isStaleCrossTaskDagAction = (action: AppAction): boolean => {
-      if (
-        action.type !== "SET_DAG_EXECUTION"
-        && action.type !== "SET_STEPS"
-        && action.type !== "ADD_STEP"
-        && action.type !== "UPDATE_STEP"
-        && action.type !== "UPDATE_TASK_STATUS"
-      ) return false
-      if (messageTaskId === undefined || messageTaskId === null || messageTaskId === "") return false
-      // No task is even being viewed (currentState.taskId null/undefined) but
-      // this message names a specific task - that can only be a stray event
-      // for a task other than "the current view", so it must be dropped too
-      // (not just the "viewing a *different* task" case).
-      return String(messageTaskId) !== String(currentState.taskId)
-    }
+    // No task is even being viewed (currentState.taskId null/undefined) but
+    // this message names a specific task - that can only be a stray event
+    // for a task other than "the current view", so it counts as "for another
+    // task" too (not just the "viewing a *different* task" case).
+    const isMessageForOtherTask =
+      messageTaskId !== undefined && messageTaskId !== null && messageTaskId !== ""
+      && String(messageTaskId) !== String(currentState.taskId)
     const dispatch: React.Dispatch<AppAction> = (action) => {
-      if (isStaleCrossTaskDagAction(action)) return
+      if (TASK_SCOPED_ACTION_TYPES.has(action.type) && isMessageForOtherTask) return
       rawDispatch(action)
     }
+    // The 30s dedup cache below is keyed on message content/type only, not
+    // task id - several dedupKeys (e.g. dag-execute-end's "task end, this
+    // iteration") are templated purely on generic fields like iteration
+    // count, so a background task and the currently-viewed task can produce
+    // the exact same key. A stale event for another task never reaches
+    // `dispatch` (filtered above), but if it were still allowed to *insert*
+    // into the cache, it would silently swallow the viewed task's own
+    // legitimate ADD_MESSAGE as a "duplicate" moments later. Skip caching
+    // (not skip the check itself) whenever the message belongs elsewhere.
+    const isDuplicateMessageForViewedTask = (
+      content: string | React.ReactNode,
+      type = "general",
+      force = false,
+      shouldCache = true,
+    ) => isDuplicateMessage(content, type, force, shouldCache && !isMessageForOtherTask)
+    const isDuplicateResultForViewedTask = (content: string) =>
+      isDuplicateMessage(content, "result", false, !isMessageForOtherTask)
     // If we're in replay mode, don't process immediately - collect for delayed playback
     if (
       !options?.skipHistory
@@ -2327,7 +2353,7 @@ export function AppProvider({
         const chatData = message as any
         const messageContent = chatData.message || ""
 
-        if (!isDuplicateMessage(messageContent, 'user-message')) {
+        if (!isDuplicateMessageForViewedTask(messageContent, 'user-message')) {
           dispatch({
             type: "ADD_MESSAGE",
             payload: {
@@ -2481,7 +2507,7 @@ export function AppProvider({
             // legacy events without either identity fall back to short-lived
             // content-based deduplication.
             const isDuplicate = userMessageId === null
-              ? isDuplicateMessage(messageContent, 'user-message', false, true)
+              ? isDuplicateMessageForViewedTask(messageContent, 'user-message', false, true)
               : false
             console.log('🔍 Duplicate check:', {
               messageContent,
@@ -2675,7 +2701,7 @@ export function AppProvider({
             if (shouldHideAgentMessage) {
               return
             }
-            if (!streamMessageId && isDuplicateMessage(messageContent, 'agent-message')) {
+            if (!streamMessageId && isDuplicateMessageForViewedTask(messageContent, 'agent-message')) {
               return
             }
             const msgId = generateMessageId("msg-agent")
@@ -2722,7 +2748,7 @@ export function AppProvider({
 
               // Use consistent string format for deduplication
               const dedupKey = `plan-start:${phase}`
-              if (!isDuplicateMessage(dedupKey, 'dag-plan-start')) {
+              if (!isDuplicateMessageForViewedTask(dedupKey, 'dag-plan-start')) {
                 dispatch({
                   type: "ADD_MESSAGE",
                   payload: {
@@ -2808,7 +2834,7 @@ export function AppProvider({
             }
 
             const dedupKey = t('agent.logs.event.messages.planEnd', { planId, stepsCount })
-            if (!isDuplicateMessage(dedupKey, 'plan-end')) {
+            if (!isDuplicateMessageForViewedTask(dedupKey, 'plan-end')) {
               dispatch({
                 type: "ADD_MESSAGE",
                 payload: {
@@ -2862,7 +2888,7 @@ export function AppProvider({
 
             // Use consistent string format for deduplication
             const dedupKey = t('agent.logs.event.messages.taskStart', { iteration })
-            if (!isDuplicateMessage(dedupKey, 'dag-execute-start')) {
+            if (!isDuplicateMessageForViewedTask(dedupKey, 'dag-execute-start')) {
               dispatch({
                 type: "ADD_MESSAGE",
                 payload: {
@@ -2903,7 +2929,7 @@ export function AppProvider({
 
             // Use consistent string format for deduplication
             const dedupKey = t('agent.logs.event.messages.taskEnd', { iteration })
-            if (!isDuplicateMessage(dedupKey, 'dag-execute-end')) {
+            if (!isDuplicateMessageForViewedTask(dedupKey, 'dag-execute-end')) {
               dispatch({
                 type: "ADD_MESSAGE",
                 payload: {
@@ -2975,7 +3001,7 @@ export function AppProvider({
               // the same step, or with identical token counts) each show, while
               // a re-dispatched same event is still deduped.
               const noticeKey = `compact-notice-${stepId}-${message.timestamp}`
-              if (!isDuplicateMessage(noticeText, noticeKey)) {
+              if (!isDuplicateMessageForViewedTask(noticeText, noticeKey)) {
                 dispatch({
                   type: "ADD_MESSAGE",
                   payload: {
@@ -3167,7 +3193,7 @@ export function AppProvider({
             if (eventData.task_type === "final_answer_generation") {
               // Check for duplicate final_answer_generation start events
               const content = t('agent.logs.event.messages.finalAnswerGenerating')
-              if (!isDuplicateMessage(content, 'final_answer_start')) {
+              if (!isDuplicateMessageForViewedTask(content, 'final_answer_start')) {
                 dispatch({
                   type: "ADD_MESSAGE",
                   payload: {
@@ -3227,7 +3253,7 @@ export function AppProvider({
             if (eventData.task_type === "final_answer_generation") {
               // Check for duplicate final_answer_generation end events
               const content = t('agent.logs.event.messages.finalAnswerCompleted')
-              if (!isDuplicateMessage(content, 'final_answer_end')) {
+              if (!isDuplicateMessageForViewedTask(content, 'final_answer_end')) {
                 dispatch({
                   type: "ADD_MESSAGE",
                   payload: {
@@ -3762,7 +3788,7 @@ export function AppProvider({
                   </div>
                 </div>
               )
-              if (!isDuplicateResult(`📋 ${t('agent.logs.event.messages.metaTitle')}: ${JSON.stringify(metaInfo)}`)) {
+              if (!isDuplicateResultForViewedTask(`📋 ${t('agent.logs.event.messages.metaTitle')}: ${JSON.stringify(metaInfo)}`)) {
                 dispatch({
                   type: "ADD_MESSAGE",
                   payload: {
@@ -3831,7 +3857,7 @@ export function AppProvider({
                 </>
               )
 
-              if (!isDuplicateResult(`📁 ${t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}`)) {
+              if (!isDuplicateResultForViewedTask(`📁 ${t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}`)) {
                 dispatch({
                   type: "ADD_MESSAGE",
                   payload: {
@@ -4005,7 +4031,7 @@ export function AppProvider({
               result && typeof result === "object" && result.status === "waiting_for_user"
                 ? result.message || ""
                 : ""
-            if (messageContent && !isDuplicateMessage(messageContent, 'agent-message')) {
+            if (messageContent && !isDuplicateMessageForViewedTask(messageContent, 'agent-message')) {
               const interactions = normalizeInteractions(result.interactions)
               const msgId = generateMessageId("msg-agent")
               dispatch({
@@ -4938,7 +4964,7 @@ export function AppProvider({
             </>
           )
 
-          if (!isDuplicateResult(`📁 ${t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}`)) {
+          if (!isDuplicateResultForViewedTask(`📁 ${t('agent.logs.event.messages.fileOutputsGenerated', { count: fileCount })}`)) {
             dispatch({
               type: "ADD_MESSAGE",
               payload: {
@@ -5084,7 +5110,7 @@ export function AppProvider({
         if (
           waitingMessage &&
           waitingMessage !== "Task waiting for user response" &&
-          !isDuplicateMessage(waitingMessage, 'agent-message')
+          !isDuplicateMessageForViewedTask(waitingMessage, 'agent-message')
         ) {
           dispatch({
             type: "ADD_MESSAGE",
@@ -5172,7 +5198,7 @@ export function AppProvider({
           dispatch({ type: "SET_PROCESSING", payload: false })
         }
 
-        if (!isDuplicateMessage(websocketErrorMessage, "agent-error")) {
+        if (!isDuplicateMessageForViewedTask(websocketErrorMessage, "agent-error")) {
           dispatch({
             type: "ADD_MESSAGE",
             payload: {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -669,6 +669,45 @@ export interface Task {
   runId?: string | null
   stateVersion?: number
   controlState?: TaskControlState
+  // Frontend-only, distinct from updatedAt: stamped once by UPDATE_TASK_STATUS
+  // when this run actually terminates (completed/failed), cleared when it
+  // starts running again, and deliberately preserved across SET_CURRENT_TASK
+  // refreshes for the same task (see that reducer case) - updatedAt is
+  // general task metadata that can legitimately change again later (a title
+  // edit, another field's update) for reasons that have nothing to do with
+  // when this execution actually ended, and the Progress panel's frozen
+  // elapsed time must not drift when that happens.
+  dagTerminatedAt?: string | number
+}
+
+// Exported so every consumer of dagTerminatedAt's "is this task done" gate
+// (currently just page-client.tsx's isDagFinished) shares the exact
+// definition this field is stamped/cleared against - the two must never
+// drift apart, or isDagFinished can read true while dagTerminatedAt was
+// never set (or vice versa), leaving the Progress panel's clock either
+// stuck or never frozen.
+export const isTerminalTaskStatus = (status: TaskStatus | null | undefined): boolean =>
+  status === "completed" || status === "failed"
+
+// Applies dagTerminatedAt's full set of rules to a Task about to be stored:
+// preserve an already-set value (never re-derive it from a later, unrelated
+// updatedAt change), backfill it once from updatedAt if this task arrives
+// already terminal without one, and clear it if the task isn't terminal (a
+// stale value from a prior run must not linger once it starts running
+// again). Shared by every reducer case that can hand the app a whole Task
+// object - SET_CURRENT_TASK and ADOPT_SESSION_TASK - so neither can
+// individually forget a rule the other already gets right.
+const withDagTerminatedAt = (task: Task | null): Task | null => {
+  if (!task) return task
+  // Checked for presence, not truthiness, when preserving/backfilling: updatedAt
+  // (what this backfills from) is a real epoch value that can legitimately be
+  // 0 - a truthy check would treat that as "absent" and re-derive it from a
+  // LATER updatedAt on every subsequent refresh, drifting the frozen time
+  // exactly the way this field exists to prevent.
+  const dagTerminatedAt = isTerminalTaskStatus(task.status)
+    ? task.dagTerminatedAt ?? task.updatedAt
+    : undefined
+  return task.dagTerminatedAt === dagTerminatedAt ? task : { ...task, dagTerminatedAt }
 }
 
 type SessionTaskBinding =
@@ -729,7 +768,14 @@ interface StepExecution {
   id: string
   name: string
   description: string
-  status: "pending" | "running" | "completed" | "failed" | "skipped"
+  // "interrupted" and "clarification_invalidated" are both non-terminal (a
+  // step in either state transitions back to "running" once its blocking
+  // condition clears - see dag.py's _ready_steps/_invalidate_batch_siblings)
+  // - they must render and count distinctly from "pending" (never started)
+  // and from the terminal statuses. "skipped" has no current backend
+  // producer (dag_step_skipped is never emitted) but is kept for the branch-
+  // derivation path that can still locally construct it.
+  status: "pending" | "running" | "completed" | "failed" | "skipped" | "interrupted" | "clarification_invalidated"
   tool_names?: string[]
   dependencies: string[]
   started_at?: string | number
@@ -751,7 +797,14 @@ interface TraceEvent {
 }
 
 const normalizeStepStatus = (status: unknown): StepExecution["status"] => {
-  return status === "running" || status === "completed" || status === "failed" || status === "skipped"
+  return (
+    status === "running"
+    || status === "completed"
+    || status === "failed"
+    || status === "skipped"
+    || status === "interrupted"
+    || status === "clarification_invalidated"
+  )
     ? status
     : "pending"
 }
@@ -842,11 +895,61 @@ const stepsFromPlanData = (planData: unknown, existingSteps: StepExecution[]): S
   })
 }
 
-interface DAGExecution {
-  phase: "planning" | "executing" | "completed" | "failed"
+// "replanning" and "completion_assessment" are real, live phase values the
+// backend emits via on_dag_execution (dag.py) - the type previously omitted
+// them, silently treating a normal mid-run replan or completion check as an
+// unmodeled state for any consumer that read `.phase` directly.
+// "completed"/"failed" are never sent by that backend broadcast (terminal
+// state arrives via a separate dag_execute_end/checkpoint flow) but ARE
+// constructed locally by handleMessage's own dag_execute_end/agent_error
+// handlers below, so they remain valid runtime values of this field.
+export type DAGExecutionPhase = "planning" | "replanning" | "executing" | "completion_assessment" | "completed" | "failed"
+
+const DAG_EXECUTION_PHASES: ReadonlySet<string> = new Set<DAGExecutionPhase>([
+  "planning", "replanning", "executing", "completion_assessment", "completed", "failed",
+])
+
+export interface DAGExecution {
+  phase: DAGExecutionPhase
   current_plan: Record<string, unknown>
   created_at: string | number
   updated_at: string | number
+  // The backend's existing per-turn identity (runtime.py's _dag_turn_id,
+  // read off the current user message's own turn_id - not a new concept,
+  // and NOT the same field as the top-level WebSocketMessage.run_id/
+  // Task.runId lease identity used elsewhere in this file) - undefined for
+  // older backends/patterns that don't set it, or for a dagExecution
+  // constructed locally rather than from a raw wire payload (dag_execute_end/
+  // agent_error's local phase updates below, which spread the EXISTING
+  // dagExecution and so already carry whatever turn_id it had). Lets the
+  // dag_execution handlers tell "still this same run" apart from "a new run
+  // started" instead of assuming every event belongs to whatever run is
+  // already in state.
+  turn_id?: string
+}
+
+// The backend's on_dag_execution broadcast never actually includes
+// current_plan (only counts/step lists depending on phase) despite the
+// frontend type declaring it required, and its phase is a raw string with no
+// guarantee it's one of DAG_EXECUTION_PHASES (a future backend phase addition
+// would otherwise flow through unchecked). Normalizes a raw wire payload
+// before it's ever cast to DAGExecution, rather than trusting `as
+// DAGExecution` to paper over the mismatch.
+const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecution => {
+  const rawPhase = raw.phase
+  const phase: DAGExecutionPhase =
+    typeof rawPhase === "string" && DAG_EXECUTION_PHASES.has(rawPhase)
+      ? rawPhase as DAGExecutionPhase
+      : "executing"
+  const currentPlan =
+    raw.current_plan && typeof raw.current_plan === "object" && !Array.isArray(raw.current_plan)
+      ? raw.current_plan as Record<string, unknown>
+      : {}
+  return {
+    ...raw,
+    phase,
+    current_plan: currentPlan,
+  } as DAGExecution
 }
 
 interface AppState {
@@ -1034,10 +1137,15 @@ function projectAppState(state: AppState, action: AppAction): AppState {
       return newState
 
     case "ADOPT_SESSION_TASK":
+      // A session can adopt a task that's already terminal (e.g. a fast
+      // single-call turn that finishes before the adoption handshake
+      // completes) - route through the same dagTerminatedAt rules
+      // SET_CURRENT_TASK applies, or the Progress panel's elapsed clock would
+      // never freeze for it (isDagFinished true, progressEndedAt undefined).
       return {
         ...state,
         taskId: action.payload.taskId,
-        currentTask: action.payload.task,
+        currentTask: withDagTerminatedAt(action.payload.task),
         taskRuntimeExtensions: {},
       }
 
@@ -1188,9 +1296,17 @@ function projectAppState(state: AppState, action: AppAction): AppState {
         }
         : null
 
-      const currentTask = (state.currentTask && incomingTask && state.currentTask.id === incomingTask.id)
+      const mergedTask = (state.currentTask && incomingTask && state.currentTask.id === incomingTask.id)
         ? { ...state.currentTask, ...incomingTask, agentName: incomingTask.agentName || state.currentTask.agentName, agentLogoUrl: incomingTask.agentLogoUrl || state.currentTask.agentLogoUrl }
         : incomingTask
+      // A task can arrive here already terminal without ever passing through
+      // UPDATE_TASK_STATUS (loading a finished task fresh - page load,
+      // switching to it, history replay's own task_info), and a task_info
+      // reporting this SAME task back to a non-terminal status (a rerun)
+      // never passes through UPDATE_TASK_STATUS either - withDagTerminatedAt
+      // backfills the former and clears the latter so a prior run's
+      // dagTerminatedAt can't linger into this one.
+      const currentTask = withDagTerminatedAt(mergedTask)
 
       return {
         ...state,
@@ -1234,6 +1350,22 @@ function projectAppState(state: AppState, action: AppAction): AppState {
           // its elapsed time against the moment it was REPLAYED, not the
           // moment it actually completed.
           updatedAt: action.payload.updatedAt ?? new Date().toISOString(),
+          // Set once, on the transition into a terminal status - and cleared
+          // when the task starts running again, so a stale prior run's
+          // terminal time doesn't linger into the next one. Deliberately
+          // NOT recomputed from `updatedAt` above: unlike this field,
+          // `updatedAt` keeps changing after termination for reasons
+          // unrelated to this execution (see the Task.dagTerminatedAt
+          // comment), so it can't double as the frozen end time itself.
+          // Preserves an already-set value (matching withDagTerminatedAt's
+          // first-write-wins rule) rather than re-stamping it: a second
+          // terminal event for the same episode - a duplicate delivery, or an
+          // agent_error followed by the formal task_completed broadcast -
+          // must not push the frozen elapsed time forward.
+          dagTerminatedAt:
+            isTerminalTaskStatus(nextStatus)
+              ? state.currentTask.dagTerminatedAt ?? action.payload.updatedAt ?? new Date().toISOString()
+              : undefined,
           waitingQuestion: isWaitingForUser
             ? action.payload.waitingQuestion ?? state.currentTask.waitingQuestion
             : undefined,
@@ -2314,6 +2446,57 @@ export function AppProvider({
       content: string | React.ReactNode,
       type = "general",
     ) => isDuplicateMessage(content, type, false, !isMessageForOtherTask)
+    // Shared by both dag_execution shapes this handler processes below (the
+    // modern trace_event-wrapped one, and the legacy bare "dag_execution"
+    // message type) - duplicating this logic per call site is exactly how a
+    // past version of this fix ended up only covering one of the two and
+    // missing the other, so it stays a single function both branches call.
+    // A turn_id present on the incoming event that DIFFERS from the one
+    // already tracked means this event belongs to a genuinely different DAG
+    // execution - e.g. turn 2's DAG starting while turn 1's dagExecution/
+    // steps are still in state because sendMessage's RESET_DAG_STATE guard
+    // raced and lost. When turn_id is absent on either side (an older
+    // backend, or some other pattern that never sets it), this compares as
+    // "not a new run" - inequality between two undefined values is false -
+    // preserving the same behavior as before turn_id existed.
+    const applyDagExecutionUpdate = (
+      rawEventData: Record<string, unknown>,
+      sourceTimestamp: string | number,
+    ) => {
+      const incomingTurnId = (rawEventData as { turn_id?: string }).turn_id
+      const isNewRun = incomingTurnId !== currentState.dagExecution?.turn_id
+      const steps = stepsFromPlanData(rawEventData, isNewRun ? [] : currentState.steps)
+      if (steps) {
+        dispatch({ type: "SET_STEPS", payload: steps })
+      } else if (isNewRun) {
+        // This specific event (e.g. a bare "planning"/"replanning" phase
+        // update with no steps field) doesn't itself carry step data, but
+        // it's still the first event of a new run - the prior run's steps
+        // must not linger just because this event happened not to include a
+        // fresh list to replace them with.
+        dispatch({ type: "SET_STEPS", payload: [] })
+      }
+      // The backend's dag_execution payload (dag.py's on_dag_execution) never
+      // actually carries a created_at - only completed_step_count/
+      // plan_step_count/steps. Without a fallback here, the DAG run never
+      // gets a stable "started at" timestamp, so the Progress panel's total
+      // elapsed time never renders. Keep whatever created_at this run
+      // already established (planning's first event sets it; later phase
+      // updates for the SAME run must not reset it) whenever turn_id says
+      // this is a continuation; use this event's own timestamp for a
+      // genuinely new run instead of inheriting the prior run's.
+      const dagCreatedAt =
+        !isNewRun
+          ? currentState.dagExecution?.created_at
+            ?? (rawEventData as { created_at?: string | number }).created_at
+            ?? sourceTimestamp
+          : (rawEventData as { created_at?: string | number }).created_at
+            ?? sourceTimestamp
+      dispatch({
+        type: "SET_DAG_EXECUTION",
+        payload: normalizeDagExecutionPayload({ ...rawEventData, created_at: dagCreatedAt }),
+      })
+    }
     // If we're in replay mode, don't process immediately - collect for delayed playback
     if (
       !options?.skipHistory
@@ -2323,6 +2506,15 @@ export function AppProvider({
         message,
       })
     ) {
+      // A stray background task's message reaching this branch would
+      // otherwise get buffered into the VIEWED task's own replay cache (and
+      // its historical_data_complete would flip isHistoricalDataLoadingRef -
+      // a plain ref, not gated by the dispatch wrapper below - ending the
+      // viewed task's history load early based on a different task's data).
+      // None of this branch's effects belong to any task but the one
+      // currently loading history, so drop it outright rather than only
+      // filtering the dispatches inside it.
+      if (isMessageForOtherTask) return
       // Add to replay cache
       dispatch({ type: "ADD_TO_REPLAY_CACHE", payload: message })
 
@@ -2448,8 +2640,12 @@ export function AppProvider({
               statusType: typeof taskData.status
             })
 
-            // Store pending task for auto-execution
-            if (taskStatus === 'pending' && task.description) {
+            // Store pending task for auto-execution - a plain ref write, not
+            // gated by the dispatch wrapper's task scoping, so a stray
+            // background task's own pending task_info must not overwrite
+            // what's about to be auto-sent for the task actually being
+            // viewed/connected.
+            if (taskStatus === 'pending' && task.description && !isMessageForOtherTask) {
               pendingTaskToExecuteRef.current = { description: task.description }
               console.log('💾 Stored pending task for auto-execution:', taskData.description)
             }
@@ -2470,44 +2666,7 @@ export function AppProvider({
             // This prevents the empty state flash when task_info arrives before user_message.
           } else if (eventType === "dag_execution") {
             dispatch({ type: "SET_HISTORY_LOADING", payload: false })
-            const steps = stepsFromPlanData(eventData, currentState.steps)
-            if (steps) {
-              dispatch({ type: "SET_STEPS", payload: steps })
-            }
-            // The backend's dag_execution payload (dag.py's on_dag_execution)
-            // never actually carries a created_at - only completed_step_count/
-            // plan_step_count/steps. Without a fallback here, the DAG run
-            // never gets a stable "started at" timestamp, so the Progress
-            // panel's total elapsed time never renders. Keep whatever
-            // created_at this run already established (planning's first event
-            // sets it; later phase updates for the same run must not reset
-            // it), falling back to this event's own timestamp only the first
-            // time.
-            //
-            // There's no stable run id on this event stream, so distinguishing
-            // "this dagExecution is from a finished prior turn" from "this
-            // dagExecution is the SAME run mid-replan" can't be done reliably
-            // from phase alone: dag_execute_end (below) sets phase "completed"
-            // at the end of every DAGPattern round, not just at whole-task
-            // completion, so a mid-task replan can also observe a terminal
-            // phase while the run is still very much in progress. Treating
-            // terminal phase as "prior run over" was tried and reverted - it
-            // fixed a stale-created_at bug across turns but caused the total-
-            // elapsed timer to reset mid-task on every replan instead, which
-            // is worse. The reset-after-send-success flow in sendMessage
-            // (RESET_DAG_STATE, guarded against racing this turn's own
-            // events) is the actual fix for the cross-turn case; this handler
-            // deliberately stays a plain "keep the existing run's created_at"
-            // preservation, accepting the narrow pre-existing race where a
-            // fast-arriving event beats that reset.
-            const dagCreatedAt =
-              currentState.dagExecution?.created_at
-              ?? (eventData as { created_at?: string | number }).created_at
-              ?? message.timestamp
-            dispatch({
-              type: "SET_DAG_EXECUTION",
-              payload: { ...eventData, created_at: dagCreatedAt } as DAGExecution,
-            })
+            applyDagExecutionUpdate(eventData, message.timestamp)
           } else if (eventType === "dag_step_info") {
             dispatch({ type: "SET_HISTORY_LOADING", payload: false })
             const stepInfo = eventData
@@ -2796,12 +2955,12 @@ export function AppProvider({
 
             // Set DAG execution state to planning phase (only if not already executing or completed)
             if (!currentState.dagExecution || currentState.dagExecution.phase === "planning") {
-              const dagExecution: DAGExecution = {
-                phase: phase as "planning" | "executing" | "completed" | "failed",
+              const dagExecution = normalizeDagExecutionPayload({
+                phase,
                 current_plan: {},
                 created_at: message.timestamp,
                 updated_at: message.timestamp,
-              }
+              })
 
               // Use consistent string format for deduplication
               const dedupKey = `plan-start:${phase}`
@@ -4719,7 +4878,10 @@ export function AppProvider({
 
           // Historical Data Events - handled by the main message handler below
           else if (eventType === "historical_data_complete") {
-            isHistoricalDataLoadingRef.current = false
+            // A plain ref write, not gated by the dispatch wrapper's task
+            // scoping - a stray background task's own historical_data_complete
+            // must not end the VIEWED task's history-loading state early.
+            if (!isMessageForOtherTask) isHistoricalDataLoadingRef.current = false
             dispatch({ type: "SET_HISTORY_LOADING", payload: false })
             dispatch({ type: "SYNC_PROCESSING_STATUS" })
 
@@ -4964,9 +5126,16 @@ export function AppProvider({
           dispatch({ type: "SET_DAG_EXECUTION", payload: updatedDAGExecution })
         }
 
-        // Mark that historical data should not be requested again for completed/failed tasks
-        if (currentState.taskId) {
-          historicalDataRequestMapRef.current.set(currentState.taskId, true)
+        // Mark that historical data should not be requested again for
+        // completed/failed tasks - keyed by this event's OWN task (falling
+        // back to the viewed one only if the envelope doesn't carry its
+        // own id, matching the emitTaskError pattern above), not
+        // unconditionally the viewed task: a background task's own
+        // completion must not mark the currently-viewed task as "done
+        // requesting history" if the two differ.
+        const historicalDataTaskId = controlEnvelope.taskId ?? currentState.taskId
+        if (historicalDataTaskId) {
+          historicalDataRequestMapRef.current.set(historicalDataTaskId, true)
         }
 
         // Handle file outputs
@@ -5103,19 +5272,14 @@ export function AppProvider({
         break
 
       case "dag_execution":
-        const dagSteps = stepsFromPlanData(message.data, currentState.steps)
-        if (dagSteps) {
-          dispatch({ type: "SET_STEPS", payload: dagSteps })
-        }
-        {
-          const legacyDagData = (message.data ?? {}) as { created_at?: string | number }
-          const legacyDagCreatedAt =
-            currentState.dagExecution?.created_at ?? legacyDagData.created_at ?? message.timestamp
-          dispatch({
-            type: "SET_DAG_EXECUTION",
-            payload: { ...(message.data as DAGExecution), created_at: legacyDagCreatedAt },
-          })
-        }
+        // The bare-message-type shape (as opposed to the trace_event-wrapped
+        // one handled above) - this is the one a LIVE single-connection
+        // tracer actually uses while a task is running (see
+        // create_stream_event's callers), not just a replay/legacy path, so
+        // it needs the exact same turn_id-aware reset logic or a live run
+        // transition here reintroduces the stale-steps/stale-created_at bug
+        // this feature exists to fix.
+        applyDagExecutionUpdate((message.data ?? {}) as Record<string, unknown>, message.timestamp)
         break
 
 
@@ -5276,8 +5440,11 @@ export function AppProvider({
         break
 
       case "historical_data_complete":
-        // Historical data loading complete
-        isHistoricalDataLoadingRef.current = false
+        // Historical data loading complete. The ref write is not gated by
+        // the dispatch wrapper's task scoping - a stray background task's
+        // own historical_data_complete must not end the VIEWED task's
+        // history-loading state early.
+        if (!isMessageForOtherTask) isHistoricalDataLoadingRef.current = false
         dispatch({ type: "SET_HISTORY_LOADING", payload: false })
         dispatch({ type: "SYNC_PROCESSING_STATUS" })
 
@@ -5960,7 +6127,21 @@ export function AppProvider({
         dispatch({ type: "RESET_DAG_STATE" })
       }
 
-      if (state.currentTask?.status === 'completed' || state.currentTask?.status === 'failed') {
+      // Guarded the same way addOptimisticUserMessage guards its own
+      // dispatch: the user can navigate to a different task while this send
+      // is in flight, and this optimistic flip has no task id of its own for
+      // the reducer to validate against - without this check, a delayed
+      // acknowledgement for task A's retried send would mark whatever task
+      // the user has since navigated to as "running". Reads live status from
+      // stateRef, not the closure's `state`: a live event can legitimately
+      // re-settle THIS SAME task's status (e.g. this very retry completing)
+      // while the ack is still in flight, and re-checking against the stale
+      // closure value would otherwise clobber that fresh, correct status
+      // back to "running".
+      if (
+        state.taskId === stateRef.current.taskId
+        && isTerminalTaskStatus(stateRef.current.currentTask?.status)
+      ) {
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: { status: 'running' }

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -898,7 +898,7 @@ type AppAction =
   | { type: "UPSERT_STREAMING_FINAL_ANSWER"; payload: { messageId: string; delta?: string; content?: string; status?: Message["status"]; timestamp: string } }
   | { type: "SET_CURRENT_TASK"; payload: Task | null }
   | { type: "SET_TASK_RUNTIME_EXTENSIONS"; payload: { taskId: number; extensions: TaskRuntimeExtensions } }
-  | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; runId?: string | null; stateVersion?: number; controlState?: TaskControlState } }
+  | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; runId?: string | null; stateVersion?: number; controlState?: TaskControlState; updatedAt?: string } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
   | { type: "SET_CONTEXT_USAGE"; payload: { tokens: number; threshold: number } | null }
@@ -1219,7 +1219,13 @@ function projectAppState(state: AppState, action: AppAction): AppState {
         currentTask: {
           ...state.currentTask,
           status: nextStatus,
-          updatedAt: new Date().toISOString(),
+          // Prefer the originating event's own timestamp over the client's
+          // current wall-clock time - during historical replay, every event
+          // gets processed at "now", so stamping updatedAt with the reducer's
+          // own clock would make a long-finished task's Progress panel freeze
+          // its elapsed time against the moment it was REPLAYED, not the
+          // moment it actually completed.
+          updatedAt: action.payload.updatedAt ?? new Date().toISOString(),
           waitingQuestion: isWaitingForUser
             ? action.payload.waitingQuestion ?? state.currentTask.waitingQuestion
             : undefined,
@@ -2341,6 +2347,7 @@ export function AppProvider({
               runId: controlEnvelope.runId,
               stateVersion: controlEnvelope.stateVersion,
               controlState: controlEnvelope.controlState,
+              updatedAt: message.timestamp,
             },
           })
         }
@@ -2706,6 +2713,7 @@ export function AppProvider({
                   status: "waiting_for_user",
                   waitingQuestion: messageContent,
                   waitingInteractions: interactions.length > 0 ? interactions : undefined,
+                  updatedAt: message.timestamp,
                 }
               })
             }
@@ -2735,7 +2743,7 @@ export function AppProvider({
               }
             })
             if (eventData.status === "completed") {
-              dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed" } })
+              dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "completed", updatedAt: message.timestamp } })
               dispatch({ type: "SET_PROCESSING", payload: false })
             }
           }
@@ -2880,7 +2888,7 @@ export function AppProvider({
             const taskPreview = eventData.task_preview || t('agent.header.badge.task')
 
             // Set processing state to true when task execution starts
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
             dispatch({ type: "SET_PROCESSING", payload: true })
 
             // Update DAG execution state to executing phase
@@ -3353,7 +3361,7 @@ export function AppProvider({
 
           // Step-level LLM Call Events - add to traceEvents for step execution logs
           else if (eventType === "llm_call_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
             dispatch({ type: "SET_PROCESSING", payload: true })
             if (Number.isFinite(eventData.context_tokens) && Number.isFinite(eventData.context_threshold) && eventData.context_threshold > 0) {
               dispatch({
@@ -3894,7 +3902,7 @@ export function AppProvider({
             // Update task status and trigger sidebar update
             dispatch({
               type: "UPDATE_TASK_STATUS",
-              payload: { status: success ? "completed" : "failed" }
+              payload: { status: success ? "completed" : "failed", updatedAt: message.timestamp }
             })
           }
 
@@ -4011,7 +4019,7 @@ export function AppProvider({
 
           // ReAct Pattern Events - these should be displayed in the right panel
           else if (eventType === "react_task_start" || eventType === "task_start_react") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
             dispatch({ type: "SET_PROCESSING", payload: true })
 
             // Add to trace events for displaying execution logs
@@ -4091,7 +4099,7 @@ export function AppProvider({
             }
             dispatch({ type: "ADD_TRACE_EVENT", payload: traceEvent })
           } else if (eventType === "llm_call_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
             dispatch({ type: "SET_PROCESSING", payload: true })
             const stepId = message.step_id || traceEventData.step_id
             const traceEvent: TraceEvent = {
@@ -4243,7 +4251,7 @@ export function AppProvider({
           }
           // Skill Selection Events
           else if (eventType === "skill_select_start") {
-            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
+            dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running", updatedAt: message.timestamp } })
             dispatch({ type: "SET_PROCESSING", payload: true })
 
             const traceEvent: TraceEvent = {
@@ -4848,6 +4856,7 @@ export function AppProvider({
             runId: controlEnvelope.runId,
             stateVersion: controlEnvelope.stateVersion,
             controlState: controlEnvelope.controlState,
+            updatedAt: message.timestamp,
           }
         })
         dispatch({ type: "TRIGGER_TASK_UPDATE" })
@@ -4917,7 +4926,7 @@ export function AppProvider({
           const updatedDAGExecution = {
             ...currentState.dagExecution,
             phase: taskData.status,
-            updated_at: new Date().toISOString()
+            updated_at: message.timestamp,
           }
           dispatch({ type: "SET_DAG_EXECUTION", payload: updatedDAGExecution })
         }
@@ -5086,6 +5095,7 @@ export function AppProvider({
             runId: controlEnvelope.runId,
             stateVersion: controlEnvelope.stateVersion,
             controlState: controlEnvelope.controlState || "paused",
+            updatedAt: message.timestamp,
           },
         })
         dispatch({ type: "SET_PROCESSING", payload: false })
@@ -5100,6 +5110,7 @@ export function AppProvider({
               runId: controlEnvelope.runId,
               stateVersion: controlEnvelope.stateVersion,
               controlState: controlEnvelope.controlState || "pause_requested",
+              updatedAt: message.timestamp,
             },
           })
         }
@@ -5119,6 +5130,7 @@ export function AppProvider({
             runId: controlEnvelope.runId,
             stateVersion: controlEnvelope.stateVersion,
             controlState: controlEnvelope.controlState || "waiting_for_user",
+            updatedAt: message.timestamp,
           }
         })
         dispatch({ type: "SET_PROCESSING", payload: false })
@@ -5152,6 +5164,7 @@ export function AppProvider({
             runId: controlEnvelope.runId,
             stateVersion: controlEnvelope.stateVersion,
             controlState: controlEnvelope.controlState || "running",
+            updatedAt: message.timestamp,
           },
         })
         break
@@ -5169,6 +5182,7 @@ export function AppProvider({
               runId: controlEnvelope.runId,
               stateVersion: controlEnvelope.stateVersion,
               controlState: controlEnvelope.controlState,
+              updatedAt: message.timestamp,
             },
           })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })
@@ -5206,7 +5220,7 @@ export function AppProvider({
         const websocketTaskStatus = getWebSocketTaskStatus(message)
 
         if (websocketTaskStatus) {
-          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: websocketTaskStatus } })
+          dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: websocketTaskStatus, updatedAt: message.timestamp } })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })
         }
         if (shouldStopProcessingForTaskStatus(websocketTaskStatus)) {
@@ -5492,26 +5506,6 @@ export function AppProvider({
 
   const sendMessage = useCallback(async (message: string, config?: any, files?: File[]) => {
     console.log('🚀 sendMessage called:', { message, files: files?.map(f => f.name), taskId: state.taskId })
-
-    // A prior turn's DAG plan/steps must not linger into this turn - otherwise
-    // the Progress panel would auto-open (or stay open) showing stale steps
-    // from a different execution mode/run before this turn's own dag_execution
-    // event (if any) arrives. But sending into a run that's still actively
-    // going - answering a mid-run clarification, or the "live guidance" input
-    // ChatInput allows while running/paused/waiting_for_user (see
-    // ChatInput.tsx's `allowsLiveGuidanceInput`; the task page never passes
-    // onSend/onSendInteraction, so all of these fall back to this same
-    // sendMessage) - is a CONTINUATION of that run, not a new turn. Clearing
-    // here would wipe out the in-progress DAG plan/steps the Progress panel
-    // is actively showing.
-    const isContinuingActiveRun =
-      state.currentTask?.status === "running"
-      || state.currentTask?.status === "paused"
-      || state.currentTask?.status === "waiting_for_user"
-    if (!isContinuingActiveRun) {
-      dispatch({ type: "SET_DAG_EXECUTION", payload: null })
-      dispatch({ type: "SET_STEPS", payload: [] })
-    }
 
     if (sessionTransport && !mountedRef.current) {
       throw new Error("Message not sent: the Session chat is closed.")
@@ -5904,10 +5898,40 @@ export function AppProvider({
         taskId: state.taskId
       })
 
+      // The backend executes the turn as an independent background task and
+      // can start broadcasting its own dag_execution/trace events before this
+      // ack resolves - capture the pre-send dagExecution reference so the
+      // reset below can detect that case and skip clearing, rather than
+      // wiping out the new turn's own freshly-arrived state.
+      const dagExecutionBeforeSend = stateRef.current.dagExecution
+
       // Wait for the server's durable-delivery acknowledgement. If the socket
       // is disconnected or the backend rejects the turn, this throws and the
-      // composer keeps both its text and attached files.
+      // composer keeps both its text and attached files. The DAG reset below
+      // deliberately runs only after this succeeds - clearing dagExecution/
+      // steps first and then throwing would remove the Progress panel and its
+      // header toggle for a run that never actually changed.
       await sendChatMessage(message, files, config?.force, clientMessageId)
+
+      // A prior turn's DAG plan/steps must not linger into this turn - otherwise
+      // the Progress panel would auto-open (or stay open) showing stale steps
+      // from a different execution mode/run before this turn's own dag_execution
+      // event (if any) arrives. But sending into a run that's still actively
+      // going - answering a mid-run clarification, or the "live guidance" input
+      // ChatInput allows while running/paused/waiting_for_user (see
+      // ChatInput.tsx's `allowsLiveGuidanceInput`; the task page never passes
+      // onSend/onSendInteraction, so all of these fall back to this same
+      // sendMessage) - is a CONTINUATION of that run, not a new turn. Clearing
+      // here would wipe out the in-progress DAG plan/steps the Progress panel
+      // is actively showing.
+      const isContinuingActiveRun =
+        state.currentTask?.status === "running"
+        || state.currentTask?.status === "paused"
+        || state.currentTask?.status === "waiting_for_user"
+      if (!isContinuingActiveRun && stateRef.current.dagExecution === dagExecutionBeforeSend) {
+        dispatch({ type: "SET_DAG_EXECUTION", payload: null })
+        dispatch({ type: "SET_STEPS", payload: [] })
+      }
 
       if (state.currentTask?.status === 'completed' || state.currentTask?.status === 'failed') {
         dispatch({

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -268,6 +268,13 @@ const en = {
       dagSectionOther: "DAG execution · {count} steps",
       view: "View plan",
     },
+    progressPanel: {
+      title: "Progress",
+      elapsed: "Elapsed",
+      planning: "Generating plan…",
+      toggleTooltip: "Show execution progress",
+      collapse: "Collapse",
+    },
     aiOutput: {
       title: "AI Output",
       subtitle: "Generated response",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2953,6 +2953,8 @@ Build when you need.`,
         completed: "Completed",
         failed: "Failed",
         skipped: "Skipped",
+        interrupted: "Interrupted",
+        clarification_invalidated: "Waiting on a new answer",
       },
       right: {
         titles: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -268,6 +268,13 @@ const zh = {
       dagSectionOther: "DAG 执行 · {count} 个步骤",
       view: "查看计划",
     },
+    progressPanel: {
+      title: "执行进度",
+      elapsed: "已用时",
+      planning: "正在生成计划…",
+      toggleTooltip: "查看执行进度",
+      collapse: "收起",
+    },
     aiOutput: {
       title: "AI 输出",
       subtitle: "生成的响应",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2953,6 +2953,8 @@ const zh = {
         completed: "已完成",
         failed: "失败",
         skipped: "已跳过",
+        interrupted: "已中断",
+        clarification_invalidated: "等待新的回答",
       },
       right: {
         titles: {

--- a/frontend/src/lib/time-utils.test.ts
+++ b/frontend/src/lib/time-utils.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Locale } from "@/i18n/translations"
-import { formatDisplayDate } from "./time-utils"
+import { formatDisplayDate, normalizeTimestampMs } from "./time-utils"
 
 const bigintValue = (globalThis as { BigInt: (value: number) => bigint }).BigInt(1)
 
@@ -114,5 +114,26 @@ describe("formatDisplayDate", () => {
     const helper = source.slice(start, end)
     expect(helper).toContain("const date = new Date(value)")
     expect(helper).not.toMatch(/normalizeTimestampMs|formatTime|toLocaleDateString|utils\.formatDate/)
+  })
+})
+
+describe("normalizeTimestampMs", () => {
+  it("treats epoch zero as a present timestamp, not an absent one", () => {
+    expect(normalizeTimestampMs(0)).toBe(0)
+    // The string form takes a completely different branch (numeric-string
+    // parsing, not the absence check) - assert it independently rather than
+    // assuming it agrees with the numeric case.
+    expect(normalizeTimestampMs("0")).toBe(0)
+  })
+
+  it("falls back to now for genuinely absent values", () => {
+    const before = Date.now()
+    expect(normalizeTimestampMs(undefined)).toBeGreaterThanOrEqual(before)
+    expect(normalizeTimestampMs(null)).toBeGreaterThanOrEqual(before)
+    expect(normalizeTimestampMs("")).toBeGreaterThanOrEqual(before)
+  })
+
+  it("falls back to now for NaN rather than propagating it", () => {
+    expect(normalizeTimestampMs(NaN)).not.toBeNaN()
   })
 })

--- a/frontend/src/lib/time-utils.test.ts
+++ b/frontend/src/lib/time-utils.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Locale } from "@/i18n/translations"
-import { formatDisplayDate, normalizeTimestampMs } from "./time-utils"
+import { formatDisplayDate, formatTime, getTimeDuration, normalizeTimestampMs } from "./time-utils"
 
 const bigintValue = (globalThis as { BigInt: (value: number) => bigint }).BigInt(1)
 
@@ -133,21 +133,24 @@ describe("normalizeTimestampMs", () => {
     expect(normalizeTimestampMs("")).toBeGreaterThanOrEqual(before)
   })
 
-  it("falls back to now for NaN rather than propagating it", () => {
-    expect(normalizeTimestampMs(NaN)).not.toBeNaN()
+  it("propagates NaN/Infinity unchanged rather than disguising them as a valid now", () => {
+    // A prior version of this function collapsed non-finite numbers into
+    // Date.now(), which made a malformed timestamp look like a perfectly
+    // valid "just now" to every caller - regressing the safety net formatTime/
+    // getTimeDuration already have via `isNaN(date.getTime())`. Propagating
+    // the non-finite value unchanged lets `new Date(...)` produce an
+    // actually-invalid Date, which those callers correctly detect.
+    expect(normalizeTimestampMs(NaN)).toBeNaN()
+    expect(normalizeTimestampMs(Infinity)).toBe(Infinity)
+    expect(normalizeTimestampMs(-Infinity)).toBe(-Infinity)
+    expect(normalizeTimestampMs("Infinity")).toBe(Infinity)
+    expect(normalizeTimestampMs("-Infinity")).toBe(-Infinity)
   })
 
-  it("falls back to now for Infinity rather than propagating it", () => {
-    expect(normalizeTimestampMs(Infinity)).not.toBe(Infinity)
-    expect(normalizeTimestampMs(-Infinity)).not.toBe(-Infinity)
-    expect(Number.isFinite(normalizeTimestampMs(Infinity))).toBe(true)
-  })
-
-  it("falls back to now for the string form of Infinity too", () => {
-    // Number("Infinity") is a non-NaN, finite-looking-to-isNaN() value - only
-    // Number.isFinite catches it, exercising the string branch specifically
-    // rather than the numeric-type guard above.
-    expect(Number.isFinite(normalizeTimestampMs("Infinity"))).toBe(true)
-    expect(Number.isFinite(normalizeTimestampMs("-Infinity"))).toBe(true)
+  it("formatTime and getTimeDuration safely fall back for a non-finite timestamp instead of showing a fake current time", () => {
+    expect(formatTime(Infinity)).toBe(String(Infinity))
+    expect(formatTime(NaN)).toBe("")
+    expect(getTimeDuration(Infinity, Infinity)).toBe(0)
+    expect(getTimeDuration(0, NaN)).toBe(0)
   })
 })

--- a/frontend/src/lib/time-utils.test.ts
+++ b/frontend/src/lib/time-utils.test.ts
@@ -136,4 +136,18 @@ describe("normalizeTimestampMs", () => {
   it("falls back to now for NaN rather than propagating it", () => {
     expect(normalizeTimestampMs(NaN)).not.toBeNaN()
   })
+
+  it("falls back to now for Infinity rather than propagating it", () => {
+    expect(normalizeTimestampMs(Infinity)).not.toBe(Infinity)
+    expect(normalizeTimestampMs(-Infinity)).not.toBe(-Infinity)
+    expect(Number.isFinite(normalizeTimestampMs(Infinity))).toBe(true)
+  })
+
+  it("falls back to now for the string form of Infinity too", () => {
+    // Number("Infinity") is a non-NaN, finite-looking-to-isNaN() value - only
+    // Number.isFinite catches it, exercising the string branch specifically
+    // rather than the numeric-type guard above.
+    expect(Number.isFinite(normalizeTimestampMs("Infinity"))).toBe(true)
+    expect(Number.isFinite(normalizeTimestampMs("-Infinity"))).toBe(true)
+  })
 })

--- a/frontend/src/lib/time-utils.ts
+++ b/frontend/src/lib/time-utils.ts
@@ -36,13 +36,17 @@ export function normalizeTimestampMs(ts?: string | number | Date | null): number
   // if unlikely, timestamp - a `!ts` check would collapse it into "now" the
   // same way it does undefined/null/"", silently discarding a real value.
   if (ts === undefined || ts === null || ts === '') return Date.now()
-  if (typeof ts === 'number' && Number.isNaN(ts)) return Date.now()
+  if (typeof ts === 'number' && !Number.isFinite(ts)) return Date.now()
   if (ts instanceof Date) return ts.getTime()
 
   if (typeof ts === 'string') {
     const num = Number(ts)
-    // If it's a valid number string (not empty), treat as numeric timestamp
-    if (!isNaN(num) && ts.trim() !== '') {
+    // If it's a valid, finite number string (not empty), treat as a numeric
+    // timestamp. Number("Infinity")/Number("-Infinity") both parse to a
+    // finite-looking non-NaN value that isNaN() alone wouldn't catch - only
+    // Number.isFinite rejects them, same as the dedicated numeric-type check
+    // above.
+    if (Number.isFinite(num) && ts.trim() !== '') {
       return num < 1e10 ? num * 1000 : num
     }
     // Otherwise try parsing as date string

--- a/frontend/src/lib/time-utils.ts
+++ b/frontend/src/lib/time-utils.ts
@@ -35,18 +35,26 @@ export function normalizeTimestampMs(ts?: string | number | Date | null): number
   // Checked for exact absence, not truthiness: epoch zero (`0`) is a valid,
   // if unlikely, timestamp - a `!ts` check would collapse it into "now" the
   // same way it does undefined/null/"", silently discarding a real value.
+  //
+  // Deliberately NOT special-casing NaN/Infinity here (a prior version of
+  // this function did, then a PR review caught that it was a regression):
+  // this function's callers (formatTime, getTimeDuration) already guard
+  // against an invalid result via `isNaN(date.getTime())` - new Date(NaN)
+  // and new Date(Infinity) both produce an actually-invalid Date, which
+  // those checks correctly treat as "malformed input" and fall back to a
+  // safe default. Converting NaN/Infinity into Date.now() here instead would
+  // make a malformed timestamp look like a perfectly valid "just now" to
+  // every caller, defeating that existing downstream safety net. Callers
+  // that need non-finite values to look like "absent" for their own UI
+  // purposes (e.g. progress-panel.tsx's hasTimestamp) should filter them out
+  // themselves before ever calling this function, as that one already does.
   if (ts === undefined || ts === null || ts === '') return Date.now()
-  if (typeof ts === 'number' && !Number.isFinite(ts)) return Date.now()
   if (ts instanceof Date) return ts.getTime()
 
   if (typeof ts === 'string') {
     const num = Number(ts)
-    // If it's a valid, finite number string (not empty), treat as a numeric
-    // timestamp. Number("Infinity")/Number("-Infinity") both parse to a
-    // finite-looking non-NaN value that isNaN() alone wouldn't catch - only
-    // Number.isFinite rejects them, same as the dedicated numeric-type check
-    // above.
-    if (Number.isFinite(num) && ts.trim() !== '') {
+    // If it's a valid number string (not empty), treat as numeric timestamp
+    if (!isNaN(num) && ts.trim() !== '') {
       return num < 1e10 ? num * 1000 : num
     }
     // Otherwise try parsing as date string

--- a/frontend/src/lib/time-utils.ts
+++ b/frontend/src/lib/time-utils.ts
@@ -32,7 +32,11 @@ export function formatDisplayDate(
  * @returns Timestamp in milliseconds
  */
 export function normalizeTimestampMs(ts?: string | number | Date | null): number {
-  if (!ts) return Date.now()
+  // Checked for exact absence, not truthiness: epoch zero (`0`) is a valid,
+  // if unlikely, timestamp - a `!ts` check would collapse it into "now" the
+  // same way it does undefined/null/"", silently discarding a real value.
+  if (ts === undefined || ts === null || ts === '') return Date.now()
+  if (typeof ts === 'number' && Number.isNaN(ts)) return Date.now()
   if (ts instanceof Date) return ts.getTime()
 
   if (typeof ts === 'string') {

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -1204,6 +1204,14 @@ class PatternRuntime:
         )
         return result
 
+    def _with_dag_turn_id(
+        self, context: Any, data: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        turn_id = self._dag_turn_id(context)
+        if not turn_id:
+            return dict(data or {})
+        return {"turn_id": turn_id, **(data or {})}
+
     async def on_dag_step_start(
         self,
         *,
@@ -1215,7 +1223,7 @@ class PatternRuntime:
             TraceEventType(TraceScope.STEP, TraceAction.START, TraceCategory.DAG),
             task_id=self._task_id(context),
             step_id=step_id,
-            data=data or {},
+            data=self._with_dag_turn_id(context, data),
         )
 
     async def on_dag_step_end(
@@ -1229,7 +1237,7 @@ class PatternRuntime:
             TraceEventType(TraceScope.STEP, TraceAction.END, TraceCategory.DAG),
             task_id=self._task_id(context),
             step_id=step_id,
-            data=data or {},
+            data=self._with_dag_turn_id(context, data),
         )
 
     async def on_dag_execution(
@@ -1242,7 +1250,7 @@ class PatternRuntime:
         await self._emit_trace_event(
             TraceEventType(TraceScope.TASK, TraceAction.UPDATE, TraceCategory.DAG),
             task_id=self._task_id(context),
-            data={"phase": phase, **(data or {})},
+            data={"phase": phase, **self._with_dag_turn_id(context, data)},
         )
 
     def _build_checkpoint_payload(
@@ -1375,6 +1383,28 @@ class PatternRuntime:
 
     def _task_id(self, context: Any) -> str | None:
         return str(getattr(context, "execution_id", None) or self.execution_id or "")
+
+    def _dag_turn_id(self, context: Any) -> str | None:
+        # Identifies "which turn's DAG execution is this" to consumers (the
+        # frontend Progress panel distinguishes one run from the next by
+        # this) - reuses the existing turn_id already established on each
+        # user Message's own metadata (AgentRunner.inject_user_message's
+        # _ensure_user_message_turn_id), which is guaranteed fresh per turn.
+        # Deliberately NOT stashed in context.metadata instead: that dict is
+        # scoped to the whole execution/task, not one turn - it's the SAME
+        # object reused across every follow-up message in the task
+        # (inject_user_message calls context_manager.get_context, never
+        # rebuilding it), so a value stored there would persist unchanged
+        # into turn 2, 3, etc., never actually distinguishing runs.
+        messages = getattr(context, "messages", None) or []
+        for message in reversed(messages):
+            if getattr(message, "role", None) != "user":
+                continue
+            metadata = getattr(message, "metadata", None)
+            if isinstance(metadata, dict) and metadata.get("turn_id"):
+                return str(metadata["turn_id"])
+            return None
+        return None
 
     def _step_id(self, context: Any) -> str:
         metadata = getattr(context, "metadata", None)


### PR DESCRIPTION
## Summary
- Adds a right-side Progress panel showing a DAG plan's step list with live/frozen elapsed timers, auto-opening the moment a task enters DAG (think) mode, toggled independently from the existing execution-plan graph view via a new header button.
- Fixes several bugs found while building/testing this: cross-task WebSocket event leakage into the currently-viewed task's DAG/step/status state; `task_completed` unconditionally fabricating a `DAGExecution` for every finished task (including non-DAG ones); `dag_execution` never carrying a `created_at`, breaking the elapsed timer; stale DAG state left behind (or wiped mid-run) on task switch, reconnect, and various message-send paths; falsy-but-defined timestamps treated as valid instants; a step-click scroll handler that could target a stale DOM match.

## Test plan
- [x] `npm run type-check` / `npm run lint` pass (also enforced by pre-commit)
- [x] Manually verified in-browser: Progress panel auto-opens on DAG (think) mode, updates live, freezes correctly on completion, and does not appear for flash/ReAct replies
- [x] Manually verified: switching tasks via the sidebar and reconnecting mid-run no longer leave stale DAG/progress state
- [x] Manually verified: answering a mid-run clarification / live-guidance input no longer wipes the in-progress plan