### PR TITLE
fix(steps): clear the open dag_execution planning key on any dag_execute_end

### DIFF
--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -494,18 +494,24 @@ class PublicStepProjector:
             # Other phases (e.g. completion_assessment): not exposed.
             return []
 
-        # ===== dag_execute_start / dag_execute_end: close an open
-        # dag_execution planning step on outright plan failure. See
-        # the module docstring's "Pairing rule" section for the full
+        # ===== dag_execute_start / dag_execute_end: clear the
+        # dag_execution planning key at each round boundary, closing
+        # the planning step only on outright plan failure. See the
+        # module docstring's "Pairing rule" section for the full
         # rationale. =====
         if event_type == "dag_execute_start":
             # Drop a stale open key left by a prior round whose
-            # terminal dag_execute_end was itself dropped (never
-            # reached this projector at all). A round whose
-            # dag_execute_end did arrive -- whatever its status --
-            # already cleared its own key below; this guard only
-            # catches the dropped-terminal-event case. The stale
-            # pending step itself is left as-is (still "running").
+            # terminal dag_execute_end never reached this projector.
+            # The only live path to that today is a plan-generation
+            # exception other than RequiredToolCallError escaping
+            # DAGPattern.run(): it re-raises past the try/except
+            # instead of going through on_pattern_end, so no
+            # dag_execute_end is ever emitted for that round. A round
+            # whose dag_execute_end did arrive -- whatever its status
+            # -- already cleared its own key below; this guard only
+            # catches that never-emitted-terminal-event case. The
+            # stale pending step itself is left as-is (still
+            # "running").
             self._open_dag_execution_key = None
             return []
         if event_type == "dag_execute_end":

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -84,30 +84,33 @@ Pairing rule:
       - ``dag_execute_*`` events carry the whole DAGPattern's lifecycle,
         not a single step's, so they never open their own pending
         entry. ``dag_execute_end`` instead reaches into whichever
-        ``dag_execution`` planning key is currently open and closes it
-        as ``"failed"`` -- but only when ``data['status']`` is the
-        literal string ``"failed"``. This branch only has a key left
-        to close while plan generation itself is still open: the
-        ``dag_execution`` ``executing``-phase event already clears
-        the key the moment plan generation finishes, so an
-        ``"interrupted"`` or ``"waiting_for_user"`` round reported
-        from that point on (during step execution) can't reach back
-        here. Only a round that is interrupted (or reports
-        ``"waiting_for_user"``, ``"completed"``, a missing key, or
-        ``None``) *during plan generation* leaves the planning step
-        running, the opposite fallback direction from ``dag_step_*``
-        above (which cannot be reused here for exactly that reason). A plan-
-        generation exception that escapes ``DAGPattern.run()``
-        before it ever calls ``on_pattern_end`` emits no
-        ``dag_execute_end`` at all, so the planning step is left
-        running indefinitely too -- out of scope for this module.
-        ``dag_execute_start`` clears a stale open planning key left by
-        a prior round that ended with any non-``"failed"`` status
-        (typically ``"interrupted"`` -- that round did reach a
-        terminal ``dag_execute_end``, it just wasn't the literal
-        ``"failed"`` this module closes on), or whose terminal event
-        was itself dropped, so a later round's failure can't reach
-        back and close an unrelated stranded step.
+        ``dag_execution`` planning key is currently open and clears
+        that key -- the round it belongs to has now ended, one way or
+        another -- closing the step as ``"failed"`` only when
+        ``data['status']`` is the literal string ``"failed"``. This
+        branch only has a key left to close while plan generation
+        itself is still open: the ``dag_execution`` ``executing``-phase
+        event already clears the key the moment plan generation
+        finishes, so an ``"interrupted"`` or ``"waiting_for_user"``
+        round reported from that point on (during step execution)
+        can't reach back here. Only a round that is interrupted (or
+        reports ``"waiting_for_user"``, ``"completed"``, a missing
+        key, or ``None``) *during plan generation* leaves the planning
+        step running, the opposite fallback direction from
+        ``dag_step_*`` above (which cannot be reused here for exactly
+        that reason) -- but the key is cleared regardless, so a
+        *later* round's ``dag_execute_end`` can never reach back
+        through it and misattribute its own failure to this round's
+        stranded step. A plan-generation exception that escapes
+        ``DAGPattern.run()`` before it ever calls ``on_pattern_end``
+        emits no ``dag_execute_end`` at all, so the planning step is
+        left running indefinitely too -- out of scope for this
+        module. ``dag_execute_start`` additionally clears a stale open
+        planning key left by a prior round whose terminal
+        ``dag_execute_end`` was itself dropped (never observed at
+        all) -- the one case ``dag_execute_end``'s own clearing above
+        cannot already have handled, since there was no such event to
+        clear it.
 
     Orphan ends (end with no matching start) are dropped -- they
     represent malformed data and the SDK contract is "every step has
@@ -496,16 +499,27 @@ class PublicStepProjector:
         # the module docstring's "Pairing rule" section for the full
         # rationale. =====
         if event_type == "dag_execute_start":
-            # Drop a stale open key left by a prior round that ended with
-            # any non-"failed" status (typically "interrupted" -- that
-            # round did reach a terminal dag_execute_end, it just wasn't
-            # the literal "failed" this module closes on), or whose
-            # terminal event was itself dropped. The stale pending step
-            # itself is left as-is (still "running").
+            # Drop a stale open key left by a prior round whose
+            # terminal dag_execute_end was itself dropped (never
+            # reached this projector at all). A round whose
+            # dag_execute_end did arrive -- whatever its status --
+            # already cleared its own key below; this guard only
+            # catches the dropped-terminal-event case. The stale
+            # pending step itself is left as-is (still "running").
             self._open_dag_execution_key = None
             return []
         if event_type == "dag_execute_end":
-            if self._open_dag_execution_key is None:
+            # A round's key is scoped to that round: clear it the
+            # moment this round's terminal event arrives, regardless of
+            # status. Otherwise a non-"failed" end (typically
+            # "interrupted") leaves the key open, and a *later* round's
+            # dag_execute_end -- observed without ever seeing that
+            # round's own dag_execute_start/planning events -- would
+            # reach back through the stale key and misattribute its
+            # failure to this round's still-pending planning step.
+            dag_execution_key = self._open_dag_execution_key
+            self._open_dag_execution_key = None
+            if dag_execution_key is None:
                 return []  # No open planning step to close.
             # Deliberately not _terminal_status_from_event: that
             # helper's fallback direction (anything but "failed"
@@ -516,14 +530,13 @@ class PublicStepProjector:
             finalized = _finalize_pending(
                 self._pending,
                 self._finished,
-                ("thinking", self._open_dag_execution_key),
+                ("thinking", dag_execution_key),
                 end_event=event,
                 status="failed",
                 # No extra_data_fn: data['result'] is the DAG
                 # pattern's full output and must not reach the public
                 # surface. Keeps data == {"phase": "planning"}.
             )
-            self._open_dag_execution_key = None
             return [finalized] if finalized is not None else []
 
         # Everything else (llm_call_*, memory_*, react_task_*,

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -1146,6 +1146,35 @@ _PROJECTOR_EQUIVALENCE_CASES: Dict[str, List[SimpleNamespace]] = {
         _ev("task_completion"),
         _ev("trace_error"),
     ],
+    "dag_execute_end_interrupted_does_not_leak_key_to_next_round": [
+        _ev(
+            "dag_execute_start",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+        _dag_exec_ev(
+            "planning",
+            task_id="t1",
+            timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+        ),
+        _ev(
+            "dag_execute_end",
+            task_id="t1",
+            data={"status": "interrupted"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ),
+        # Round two's dag_execute_start/planning events are lost --
+        # only the terminal failure survives. The interrupted round
+        # one end above must have already cleared the open key, or
+        # this failure would reach back and close round one's
+        # stranded planning step instead of being a no-op.
+        _ev(
+            "dag_execute_end",
+            task_id="t1",
+            data={"status": "failed"},
+            timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+        ),
+    ],
     "empty_event_list": [],
 }
 
@@ -1634,3 +1663,138 @@ def test_dag_execute_start_clears_stale_open_planning_key():
     assert len(steps) == 1
     assert steps[0]["status"] == "running"
     assert steps[0]["completed_at"] is None
+
+
+def test_dag_execute_start_planning_end_failed_closes_within_round():
+    """Pin the in-round production order: start -> planning ->
+    end(failed) closes the planning step opened by that same round.
+    Guards the failed-closes path; complements the non-failed
+    key-clearing coverage in the surrounding tests.
+    """
+    start = _ev(
+        "dag_execute_start",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    planning = _dag_exec_ev(
+        "planning",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+    )
+    end = _ev(
+        "dag_execute_end",
+        task_id="t1",
+        data={"status": "failed"},
+        timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+    )
+    steps = map_trace_events_to_public_steps([start, planning, end])
+    assert len(steps) == 1
+    assert steps[0]["status"] == "failed"
+    assert steps[0]["completed_at"] is not None
+
+
+def test_dag_execute_end_interrupted_does_not_misattribute_next_rounds_failure():
+    """Round one is interrupted (its dag_execute_end status is not the
+    literal "failed", so its planning step is deliberately left
+    running), and round two's own dag_execute_start and planning
+    events are lost -- only round two's terminal dag_execute_end
+    (failed) survives.
+
+    ``_open_dag_execution_key`` is scoped to the round that opened it:
+    any dag_execute_end -- close or not -- clears it, since that
+    round has now ended one way or another. Without that clearing, a
+    non-"failed" end would leave the key pointing at round one's
+    still-pending planning step, and round two's failure would reach
+    back through it and close round one's step as "failed" --
+    attributing round two's failure to round one's stranded step.
+    With the key cleared, round two's failure finds no open key and is
+    a no-op, leaving round one's step running as designed.
+    """
+    round_one_start = _ev(
+        "dag_execute_start",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    round_one_planning = _dag_exec_ev(
+        "planning",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+    )
+    round_one_end = _ev(
+        "dag_execute_end",
+        task_id="t1",
+        data={"status": "interrupted"},
+        timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+    )
+    # Round two's start and planning events are lost -- only its
+    # terminal failure arrives.
+    round_two_end = _ev(
+        "dag_execute_end",
+        task_id="t1",
+        data={"status": "failed"},
+        timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+    )
+    steps = map_trace_events_to_public_steps(
+        [round_one_start, round_one_planning, round_one_end, round_two_end]
+    )
+    assert len(steps) == 1
+    assert steps[0]["status"] == "running"
+    assert steps[0]["completed_at"] is None
+
+
+def test_two_full_rounds_interrupted_then_failed_close_independently():
+    """Two complete rounds -- neither drops any event -- each close on
+    their own terms: round one (interrupted) stays running, round two
+    (failed) closes as failed. Guards the case where both rounds emit
+    their full start/planning/end triple, which the key clearing must
+    leave untouched.
+    """
+    round_one_start = _ev(
+        "dag_execute_start",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    round_one_planning = _dag_exec_ev(
+        "planning",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+    )
+    round_one_end = _ev(
+        "dag_execute_end",
+        task_id="t1",
+        data={"status": "interrupted"},
+        timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+    )
+    round_two_start = _ev(
+        "dag_execute_start",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 3, tzinfo=timezone.utc),
+    )
+    round_two_planning = _dag_exec_ev(
+        "planning",
+        task_id="t1",
+        timestamp=datetime(2026, 1, 1, 12, 0, 4, tzinfo=timezone.utc),
+    )
+    round_two_end = _ev(
+        "dag_execute_end",
+        task_id="t1",
+        data={"status": "failed"},
+        timestamp=datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc),
+    )
+    steps = map_trace_events_to_public_steps(
+        [
+            round_one_start,
+            round_one_planning,
+            round_one_end,
+            round_two_start,
+            round_two_planning,
+            round_two_end,
+        ]
+    )
+    assert len(steps) == 2
+    round_one_step = next(s for s in steps if s["id"] == "thinking:planning:t1:1")
+    round_two_step = next(s for s in steps if s["id"] == "thinking:planning:t1:2")
+    assert round_one_step["status"] == "running"
+    assert round_one_step["completed_at"] is None
+    assert round_two_step["status"] == "failed"
+    assert round_two_step["completed_at"] is not None

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -1693,9 +1693,12 @@ def test_dag_execute_start_planning_end_failed_closes_within_round():
     assert steps[0]["completed_at"] is not None
 
 
-def test_dag_execute_end_interrupted_does_not_misattribute_next_rounds_failure():
-    """Round one is interrupted (its dag_execute_end status is not the
-    literal "failed", so its planning step is deliberately left
+@pytest.mark.parametrize("round_one_status", ["interrupted", "waiting_for_user"])
+def test_dag_execute_end_interrupted_does_not_misattribute_next_rounds_failure(
+    round_one_status,
+):
+    """Round one ends non-"failed" (its dag_execute_end status is not
+    the literal "failed", so its planning step is deliberately left
     running), and round two's own dag_execute_start and planning
     events are lost -- only round two's terminal dag_execute_end
     (failed) survives.
@@ -1708,7 +1711,10 @@ def test_dag_execute_end_interrupted_does_not_misattribute_next_rounds_failure()
     back through it and close round one's step as "failed" --
     attributing round two's failure to round one's stranded step.
     With the key cleared, round two's failure finds no open key and is
-    a no-op, leaving round one's step running as designed.
+    a no-op, leaving round one's step running as designed. Parametrized
+    over the status, since the key clearing is unconditional on status
+    -- a status-scoped clear (e.g. "interrupted" only) would have
+    passed this test just as well.
     """
     round_one_start = _ev(
         "dag_execute_start",
@@ -1723,7 +1729,7 @@ def test_dag_execute_end_interrupted_does_not_misattribute_next_rounds_failure()
     round_one_end = _ev(
         "dag_execute_end",
         task_id="t1",
-        data={"status": "interrupted"},
+        data={"status": round_one_status},
         timestamp=datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
     )
     # Round two's start and planning events are lost -- only its


### PR DESCRIPTION
## Why

The public step projector's `dag_execute_end` branch cleared the open-planning
key only when it closed the step as failed. A round that ended with any other
status (typically interrupted) left the key open — so if a later round's own
`dag_execute_start` and planning events were both lost, that round's failure
could reach back through the stale key and close the previous round's
still-running planning step as failed, attributing the new failure to the old
round.

## What

Any `dag_execute_end` now clears the key immediately — the round it belonged to
is over, however it ended — while only the literal `"failed"` still closes the
step. `dag_execute_start` keeps its own clearing for the one case end-clearing
cannot cover: a round whose `dag_execute_end` never reached the projector at
all. The deliberate stance is unchanged: the projector never resolves a step
from an inference about a missing event, and the public contract already allows
a terminal task to carry running steps.

This also pins the production event ordering, which had no coverage until now:
`dag_execute_start` before the planning emission before `dag_execute_end`,
within a single round and across two.

## Verification

Written test-first: the misattribution case (an interrupted round followed by a
second round whose start and planning events are both lost) fails on the
previous code by closing round one's step as failed, and passes with the
clearing in place. Also added: the single-round production order, two full
rounds closing independently, and an interrupted-end sequence in the
projector/batch equivalence set. The existing six-value parametrized test and
the stale-key test are unchanged and green. `tests/web/api/v1` green (369), and
the wider fast leg `tests/web tests/architecture -m "not slow and not
postgresql"` green locally.

Fixes #1379
