### PR TITLE
fix(model): avoid blocking event loop in Xinference streams

### DIFF
--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -211,6 +211,7 @@ class XinferenceLLM(BaseLLM):
 
         Raises:
             RuntimeError: If the API call fails
+            LLMTimeoutError: If the request times out
         """
         # Sanitize messages
         sanitized_messages = self._sanitize_unicode_content(messages)
@@ -236,19 +237,25 @@ class XinferenceLLM(BaseLLM):
             # Auto-enable thinking mode for models that support it
             enable_thinking = True
 
-        try:
+        async def call_model() -> Any:
             model_handle = await self._ensure_client()
-            response = await asyncio.wait_for(
-                model_handle.chat(
-                    messages=sanitized_messages,
-                    tools=tools,
-                    enable_thinking=enable_thinking,
-                    generate_config=generate_config,
-                ),
-                timeout=self.timeout,
+            return await model_handle.chat(
+                messages=sanitized_messages,
+                tools=tools,
+                enable_thinking=enable_thinking,
+                generate_config=generate_config,
             )
 
+        try:
+            response = await asyncio.wait_for(call_model(), timeout=self.timeout)
+
             return self._process_chat_response(response)
+
+        except asyncio.TimeoutError as exc:
+            logger.error("Xinference chat timeout after %ss", self.timeout)
+            raise LLMTimeoutError(
+                f"Xinference chat timeout: exceeded {self.timeout}s"
+            ) from exc
 
         except Exception as e:
             logger.error(f"Xinference chat failed: {e}")
@@ -455,66 +462,65 @@ class XinferenceLLM(BaseLLM):
         elif self.supports_thinking_mode:
             enable_thinking = True
 
+        iterator: Optional[AsyncIterator[Any]] = None
         try:
-            model_handle = await self._ensure_client()
-            stream = await model_handle.chat(
-                messages=sanitized_messages,
-                tools=tools,
-                enable_thinking=enable_thinking,
-                generate_config=generate_config,
-            )
-            if not hasattr(stream, "__aiter__"):
-                raise RuntimeError(
-                    "Xinference streaming response is not an async iterator"
-                )
-
-            iterator = stream.__aiter__()
-            first_token = True
+            try:
+                async with asyncio.timeout(self.timeout_config.first_token_timeout):
+                    model_handle = await self._ensure_client()
+                    stream = await model_handle.chat(
+                        messages=sanitized_messages,
+                        tools=tools,
+                        enable_thinking=enable_thinking,
+                        generate_config=generate_config,
+                    )
+                    if not hasattr(stream, "__aiter__"):
+                        raise RuntimeError(
+                            "Xinference streaming response is not an async iterator"
+                        )
+                    iterator = stream.__aiter__()
+                    first_item = await iterator.__anext__()
+            except StopAsyncIteration:
+                return
+            except asyncio.TimeoutError as exc:
+                timeout = self.timeout_config.first_token_timeout
+                logger.error("First token timeout after %ss", timeout)
+                raise LLMTimeoutError(
+                    f"First token timeout: exceeded {timeout}s"
+                ) from exc
 
             # Accumulated tool calls across chunks
             accumulated_tool_calls: Dict[str, Dict] = {}
+            parsed_chunk = self._parse_stream_chunk(first_item, accumulated_tool_calls)
+            if parsed_chunk:
+                yield parsed_chunk
 
-            try:
-                while True:
-                    timeout = (
-                        self.timeout_config.first_token_timeout
-                        if first_token
-                        else self.timeout_config.token_interval_timeout
-                    )
-                    try:
-                        item = await asyncio.wait_for(
-                            iterator.__anext__(), timeout=timeout
-                        )
-                    except StopAsyncIteration:
-                        break
-                    except asyncio.TimeoutError as exc:
-                        timeout_name = (
-                            "First token" if first_token else "Token interval"
-                        )
-                        logger.error("%s timeout after %ss", timeout_name, timeout)
-                        raise LLMTimeoutError(
-                            f"{timeout_name} timeout: exceeded {timeout}s"
-                        ) from exc
+            while True:
+                timeout = self.timeout_config.token_interval_timeout
+                try:
+                    item = await asyncio.wait_for(iterator.__anext__(), timeout=timeout)
+                except StopAsyncIteration:
+                    break
+                except asyncio.TimeoutError as exc:
+                    logger.error("Token interval timeout after %ss", timeout)
+                    raise LLMTimeoutError(
+                        f"Token interval timeout: exceeded {timeout}s"
+                    ) from exc
 
-                    if first_token:
-                        first_token = False
-
-                    parsed_chunk = self._parse_stream_chunk(
-                        item, accumulated_tool_calls
-                    )
-                    if parsed_chunk:
-                        yield parsed_chunk
-            finally:
-                close_stream = getattr(iterator, "aclose", None)
-                if callable(close_stream):
-                    await close_stream()
-
+                parsed_chunk = self._parse_stream_chunk(item, accumulated_tool_calls)
+                if parsed_chunk:
+                    yield parsed_chunk
         except LLMTimeoutError:
             raise
 
         except Exception as e:
             logger.error(f"Xinference stream chat failed: {e}")
             raise RuntimeError(f"Xinference stream chat failed: {str(e)}") from e
+
+        finally:
+            if iterator is not None:
+                close_stream = getattr(iterator, "aclose", None)
+                if callable(close_stream):
+                    await close_stream()
 
     def _parse_stream_chunk(
         self, raw_chunk: Any, accumulated_tool_calls: Dict

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -4,8 +4,6 @@ import asyncio
 import logging
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
-from xinference_client import RESTfulClient as XinferenceClient
-
 from ..exceptions import LLMTimeoutError
 from ..timeout_config import TimeoutConfig
 from ..token_context import add_token_usage, extract_cached_input_tokens
@@ -14,14 +12,51 @@ from .base import BaseLLM
 
 logger = logging.getLogger(__name__)
 
+_MODEL_DISCOVERY_TIMEOUT_SECONDS = 30.0
+
+
+async def _await_with_timeout(
+    awaitable: Any, *, timeout: float, timeout_message: str
+) -> Any:
+    if timeout <= 0:
+        close = getattr(awaitable, "close", None)
+        if callable(close):
+            close()
+        logger.error(timeout_message)
+        raise LLMTimeoutError(timeout_message) from asyncio.TimeoutError()
+
+    async def preserve_transport_timeout() -> Any:
+        try:
+            return await awaitable
+        except asyncio.TimeoutError as exc:
+            logger.error("Xinference transport timeout: %s", exc)
+            raise LLMTimeoutError("Xinference transport timeout") from exc
+
+    try:
+        return await asyncio.wait_for(preserve_transport_timeout(), timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        logger.error(timeout_message)
+        raise LLMTimeoutError(timeout_message) from exc
+
+
+async def _await_before_deadline(
+    awaitable: Any, *, deadline: float, timeout_message: str
+) -> Any:
+    remaining = deadline - asyncio.get_running_loop().time()
+    return await _await_with_timeout(
+        awaitable,
+        timeout=remaining,
+        timeout_message=timeout_message,
+    )
+
 
 def _create_async_client(base_url: str, api_key: Optional[str]) -> Any:
     try:
-        from xinference.client.restful.async_restful_client import AsyncClient
-    except ImportError:
         from xinference_client.client.restful.async_restful_client import (  # type: ignore
             AsyncClient,
         )
+    except ImportError:
+        from xinference.client.restful.async_restful_client import AsyncClient
 
     class NonBlockingAuthProbeAsyncClient(AsyncClient):  # type: ignore[valid-type,misc]
         """Avoid the SDK's synchronous auth probe during construction."""
@@ -247,15 +282,16 @@ class XinferenceLLM(BaseLLM):
             )
 
         try:
-            response = await asyncio.wait_for(call_model(), timeout=self.timeout)
+            response = await _await_with_timeout(
+                call_model(),
+                timeout=self.timeout,
+                timeout_message=f"Xinference chat timeout: exceeded {self.timeout}s",
+            )
 
             return self._process_chat_response(response)
 
-        except asyncio.TimeoutError as exc:
-            logger.error("Xinference chat timeout after %ss", self.timeout)
-            raise LLMTimeoutError(
-                f"Xinference chat timeout: exceeded {self.timeout}s"
-            ) from exc
+        except LLMTimeoutError:
+            raise
 
         except Exception as e:
             logger.error(f"Xinference chat failed: {e}")
@@ -467,34 +503,37 @@ class XinferenceLLM(BaseLLM):
 
         iterator: Optional[AsyncIterator[Any]] = None
         try:
-            try:
-                async with asyncio.timeout(self.timeout_config.first_token_timeout):
-                    model_handle = await self._ensure_client()
-                    stream = await model_handle.chat(
-                        messages=sanitized_messages,
-                        tools=tools,
-                        enable_thinking=enable_thinking,
-                        generate_config=generate_config,
-                    )
-                    if not hasattr(stream, "__aiter__"):
-                        raise RuntimeError(
-                            "Xinference streaming response is not an async iterator"
-                        )
-                    iterator = stream.__aiter__()
-                    first_item = await iterator.__anext__()
-            except StopAsyncIteration:
-                return
-            except asyncio.TimeoutError as exc:
-                timeout = self.timeout_config.first_token_timeout
-                logger.error("First token timeout after %ss", timeout)
-                raise LLMTimeoutError(
-                    f"First token timeout: exceeded {timeout}s"
-                ) from exc
+            loop = asyncio.get_running_loop()
+            first_timeout = self.timeout_config.first_token_timeout
+            first_deadline = loop.time() + first_timeout
+            first_timeout_message = f"First token timeout: exceeded {first_timeout}s"
+            model_handle = await _await_before_deadline(
+                self._ensure_client(),
+                deadline=first_deadline,
+                timeout_message=first_timeout_message,
+            )
+            stream = await _await_before_deadline(
+                model_handle.chat(
+                    messages=sanitized_messages,
+                    tools=tools,
+                    enable_thinking=enable_thinking,
+                    generate_config=generate_config,
+                ),
+                deadline=first_deadline,
+                timeout_message=first_timeout_message,
+            )
+            if not hasattr(stream, "__aiter__"):
+                raise RuntimeError(
+                    "Xinference streaming response is not an async iterator"
+                )
+            iterator = stream.__aiter__()
 
             # Accumulated tool calls across chunks
             accumulated_tool_calls: Dict[str, Dict] = {}
             last_usage: Optional[Dict[str, Any]] = None
             usage_emitted = False
+            first_payload_seen = False
+            next_payload_deadline = first_deadline
 
             def parse_item(item: Any) -> Optional[StreamChunk]:
                 nonlocal last_usage, usage_emitted
@@ -507,24 +546,33 @@ class XinferenceLLM(BaseLLM):
                     usage_emitted = True
                 return chunk
 
-            parsed_chunk = parse_item(first_item)
-            if parsed_chunk:
-                yield parsed_chunk
-
             while True:
-                timeout = self.timeout_config.token_interval_timeout
+                if first_payload_seen:
+                    timeout = self.timeout_config.token_interval_timeout
+                    timeout_message = f"Token interval timeout: exceeded {timeout}s"
+                else:
+                    timeout = first_timeout
+                    timeout_message = first_timeout_message
                 try:
-                    item = await asyncio.wait_for(iterator.__anext__(), timeout=timeout)
+                    item = await _await_before_deadline(
+                        iterator.__anext__(),
+                        deadline=next_payload_deadline,
+                        timeout_message=timeout_message,
+                    )
                 except StopAsyncIteration:
                     break
-                except asyncio.TimeoutError as exc:
-                    logger.error("Token interval timeout after %ss", timeout)
-                    raise LLMTimeoutError(
-                        f"Token interval timeout: exceeded {timeout}s"
-                    ) from exc
 
                 parsed_chunk = parse_item(item)
                 if parsed_chunk:
+                    if parsed_chunk.type in {
+                        ChunkType.TOKEN,
+                        ChunkType.TOOL_CALL,
+                        ChunkType.END,
+                    }:
+                        first_payload_seen = True
+                        next_payload_deadline = (
+                            loop.time() + self.timeout_config.token_interval_timeout
+                        )
                     yield parsed_chunk
 
             if last_usage and not usage_emitted:
@@ -758,19 +806,21 @@ class XinferenceLLM(BaseLLM):
                     f"Fetching models from Xinference: {base_url} (attempt {attempt + 1}/{max_retries})"
                 )
 
-                def fetch_models() -> Any:
-                    client = XinferenceClient(base_url=base_url, api_key=api_key)
+                client = _create_async_client(base_url, api_key)
+                try:
+                    model_list = await _await_with_timeout(
+                        client.list_models(),
+                        timeout=_MODEL_DISCOVERY_TIMEOUT_SECONDS,
+                        timeout_message=(
+                            "Xinference model discovery timeout: exceeded "
+                            f"{_MODEL_DISCOVERY_TIMEOUT_SECONDS}s"
+                        ),
+                    )
+                finally:
                     try:
-                        return client.list_models()
-                    finally:
-                        try:
-                            client.close()
-                        except Exception:
-                            pass
-
-                # The SDK is synchronous; model discovery must not block other
-                # API requests while Xinference is slow or unavailable.
-                model_list = await asyncio.to_thread(fetch_models)
+                        await client.close()
+                    except Exception:
+                        pass
                 normalized_models = _normalize_model_list_response(model_list)
 
                 result = []

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -493,7 +493,21 @@ class XinferenceLLM(BaseLLM):
 
             # Accumulated tool calls across chunks
             accumulated_tool_calls: Dict[str, Dict] = {}
-            parsed_chunk = self._parse_stream_chunk(first_item, accumulated_tool_calls)
+            last_usage: Optional[Dict[str, Any]] = None
+            usage_emitted = False
+
+            def parse_item(item: Any) -> Optional[StreamChunk]:
+                nonlocal last_usage, usage_emitted
+                item_dict = dict(item) if not isinstance(item, dict) else item
+                usage = item_dict.get("usage")
+                if usage:
+                    last_usage = dict(usage)
+                chunk = self._parse_stream_chunk(item_dict, accumulated_tool_calls)
+                if chunk is not None and chunk.is_usage():
+                    usage_emitted = True
+                return chunk
+
+            parsed_chunk = parse_item(first_item)
             if parsed_chunk:
                 yield parsed_chunk
 
@@ -509,9 +523,17 @@ class XinferenceLLM(BaseLLM):
                         f"Token interval timeout: exceeded {timeout}s"
                     ) from exc
 
-                parsed_chunk = self._parse_stream_chunk(item, accumulated_tool_calls)
+                parsed_chunk = parse_item(item)
                 if parsed_chunk:
                     yield parsed_chunk
+
+            if last_usage and not usage_emitted:
+                self._record_stream_usage(last_usage)
+                yield StreamChunk(
+                    type=ChunkType.USAGE,
+                    usage=last_usage,
+                    raw={"choices": [], "usage": last_usage},
+                )
         except LLMTimeoutError:
             raise
 
@@ -542,20 +564,12 @@ class XinferenceLLM(BaseLLM):
 
         # Check for usage information
         usage = chunk_dict.get("usage")
-        if usage:
-            add_token_usage(
-                input_tokens=usage.get("prompt_tokens", 0),
-                output_tokens=usage.get("completion_tokens", 0),
-                model=self._model_name,
-                model_id=self.model_id,
-                call_type="stream_chat",
-                cached_input_tokens=extract_cached_input_tokens(usage),
-            )
 
         # Check choices
         choices = chunk_dict.get("choices", [])
         if not choices:
             if usage:
+                self._record_stream_usage(usage)
                 return StreamChunk(
                     type=ChunkType.USAGE,
                     usage=dict(usage),
@@ -655,6 +669,16 @@ class XinferenceLLM(BaseLLM):
             )
 
         return None
+
+    def _record_stream_usage(self, usage: Dict[str, Any]) -> None:
+        add_token_usage(
+            input_tokens=usage.get("prompt_tokens", 0),
+            output_tokens=usage.get("completion_tokens", 0),
+            model=self._model_name,
+            model_id=self.model_id,
+            call_type="stream_chat",
+            cached_input_tokens=extract_cached_input_tokens(usage),
+        )
 
     @property
     def supports_thinking_mode(self) -> bool:

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -1,7 +1,7 @@
 """Xinference LLM provider implementation."""
 
+import asyncio
 import logging
-import time
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from xinference_client import RESTfulClient as XinferenceClient
@@ -13,6 +13,31 @@ from ..types import ChunkType, StreamChunk
 from .base import BaseLLM
 
 logger = logging.getLogger(__name__)
+
+
+def _create_async_client(base_url: str, api_key: Optional[str]) -> Any:
+    try:
+        from xinference.client.restful.async_restful_client import AsyncClient
+    except ImportError:
+        from xinference_client.client.restful.async_restful_client import (  # type: ignore
+            AsyncClient,
+        )
+
+    class NonBlockingAuthProbeAsyncClient(AsyncClient):  # type: ignore[valid-type,misc]
+        """Avoid the SDK's synchronous auth probe during construction."""
+
+        def __init__(self, client_base_url: str, client_api_key: Optional[str]) -> None:
+            self._api_key_configured = client_api_key is not None
+            super().__init__(client_base_url, api_key=client_api_key)
+
+        def _check_cluster_authenticated(self) -> None:
+            # The stock AsyncClient performs this probe with requests.get(),
+            # which blocks the event loop. Sending the Authorization header
+            # whenever an API key is configured works for both authenticated
+            # clusters and clusters that ignore authentication.
+            self._cluster_authed = self._api_key_configured
+
+    return NonBlockingAuthProbeAsyncClient(base_url, api_key)
 
 
 def _normalize_model_list_response(
@@ -90,8 +115,9 @@ class XinferenceLLM(BaseLLM):
             self._abilities = ["chat", "tool_calling"]
 
         # Initialize the Xinference client (lazy initialization)
-        self._client: Optional[XinferenceClient] = None
+        self._client: Optional[Any] = None
         self._model_handle: Optional[Any] = None
+        self._client_lock = asyncio.Lock()
 
     @property
     def model_name(self) -> str:
@@ -103,20 +129,21 @@ class XinferenceLLM(BaseLLM):
         """Get the list of abilities supported by this LLM implementation."""
         return self._abilities
 
-    def _ensure_client(self) -> None:
+    async def _ensure_client(self) -> Any:
         """Ensure the Xinference client and model handle are initialized."""
-        if self._client is None:
-            self._client = XinferenceClient(
-                base_url=self.base_url, api_key=self.api_key
-            )
+        async with self._client_lock:
+            if self._client is None:
+                self._client = _create_async_client(self.base_url, self.api_key)
 
-        client = self._client
-        if client is None:
-            raise RuntimeError("Failed to initialize Xinference client")
+            client = self._client
+            if client is None:
+                raise RuntimeError("Failed to initialize Xinference client")
 
-        if self._model_handle is None:
-            # Get the model handle (assumes model is already launched on the server)
-            self._model_handle = client.get_model(self._model_uid)
+            if self._model_handle is None:
+                # Get the model handle (assumes model is already launched on the server)
+                self._model_handle = await client.get_model(self._model_uid)
+
+            return self._model_handle
 
     def _build_generate_config(
         self,
@@ -185,9 +212,6 @@ class XinferenceLLM(BaseLLM):
         Raises:
             RuntimeError: If the API call fails
         """
-        self._ensure_client()
-        assert self._model_handle is not None
-
         # Sanitize messages
         sanitized_messages = self._sanitize_unicode_content(messages)
 
@@ -213,12 +237,15 @@ class XinferenceLLM(BaseLLM):
             enable_thinking = True
 
         try:
-            # Make the chat call
-            response = self._model_handle.chat(
-                messages=sanitized_messages,
-                tools=tools,
-                enable_thinking=enable_thinking,
-                generate_config=generate_config,
+            model_handle = await self._ensure_client()
+            response = await asyncio.wait_for(
+                model_handle.chat(
+                    messages=sanitized_messages,
+                    tools=tools,
+                    enable_thinking=enable_thinking,
+                    generate_config=generate_config,
+                ),
+                timeout=self.timeout,
             )
 
             return self._process_chat_response(response)
@@ -405,9 +432,6 @@ class XinferenceLLM(BaseLLM):
             RuntimeError: If API call fails
             LLMTimeoutError: If timeout occurs
         """
-        self._ensure_client()
-        assert self._model_handle is not None
-
         # Sanitize messages
         sanitized_messages = self._sanitize_unicode_content(messages)
 
@@ -432,51 +456,58 @@ class XinferenceLLM(BaseLLM):
             enable_thinking = True
 
         try:
-            # Make the streaming chat call
-            stream = self._model_handle.chat(
+            model_handle = await self._ensure_client()
+            stream = await model_handle.chat(
                 messages=sanitized_messages,
                 tools=tools,
                 enable_thinking=enable_thinking,
                 generate_config=generate_config,
             )
+            if not hasattr(stream, "__aiter__"):
+                raise RuntimeError(
+                    "Xinference streaming response is not an async iterator"
+                )
 
-            # Timeout control
+            iterator = stream.__aiter__()
             first_token = True
-            last_token_time = None
-            start_time = time.time()
 
             # Accumulated tool calls across chunks
             accumulated_tool_calls: Dict[str, Dict] = {}
 
-            for chunk in stream:
-                current_time = time.time()
-
-                # First token timeout check
-                if first_token:
-                    elapsed = current_time - start_time
-                    if elapsed > self.timeout_config.first_token_timeout:
-                        logger.error(f"First token timeout after {elapsed}s")
-                        raise LLMTimeoutError(
-                            f"First token timeout: {elapsed}s > {self.timeout_config.first_token_timeout}s"
+            try:
+                while True:
+                    timeout = (
+                        self.timeout_config.first_token_timeout
+                        if first_token
+                        else self.timeout_config.token_interval_timeout
+                    )
+                    try:
+                        item = await asyncio.wait_for(
+                            iterator.__anext__(), timeout=timeout
                         )
-                    first_token = False
-                    logger.debug(f"First token received after {elapsed:.2f}s")
-
-                # Token interval timeout check
-                if last_token_time is not None:
-                    interval = current_time - last_token_time
-                    if interval > self.timeout_config.token_interval_timeout:
-                        logger.error(f"Token interval timeout: {interval}s")
-                        raise LLMTimeoutError(
-                            f"Token interval timeout: {interval}s > {self.timeout_config.token_interval_timeout}s"
+                    except StopAsyncIteration:
+                        break
+                    except asyncio.TimeoutError as exc:
+                        timeout_name = (
+                            "First token" if first_token else "Token interval"
                         )
+                        logger.error("%s timeout after %ss", timeout_name, timeout)
+                        raise LLMTimeoutError(
+                            f"{timeout_name} timeout: exceeded {timeout}s"
+                        ) from exc
 
-                last_token_time = current_time
+                    if first_token:
+                        first_token = False
 
-                # Parse and yield the chunk
-                parsed_chunk = self._parse_stream_chunk(chunk, accumulated_tool_calls)
-                if parsed_chunk:
-                    yield parsed_chunk
+                    parsed_chunk = self._parse_stream_chunk(
+                        item, accumulated_tool_calls
+                    )
+                    if parsed_chunk:
+                        yield parsed_chunk
+            finally:
+                close_stream = getattr(iterator, "aclose", None)
+                if callable(close_stream):
+                    await close_stream()
 
         except LLMTimeoutError:
             raise
@@ -622,19 +653,20 @@ class XinferenceLLM(BaseLLM):
 
     async def close(self) -> None:
         """Close the Xinference client and cleanup resources."""
-        if self._model_handle is not None:
-            try:
-                self._model_handle.close()
-            except Exception:
-                pass
-            self._model_handle = None
+        async with self._client_lock:
+            if self._model_handle is not None:
+                try:
+                    await self._model_handle.close()
+                except Exception:
+                    pass
+                self._model_handle = None
 
-        if self._client is not None:
-            try:
-                self._client.close()
-            except Exception:
-                pass
-            self._client = None
+            if self._client is not None:
+                try:
+                    await self._client.close()
+                except Exception:
+                    pass
+                self._client = None
 
     async def __aenter__(self) -> "XinferenceLLM":
         """Async context manager entry."""
@@ -662,8 +694,6 @@ class XinferenceLLM(BaseLLM):
             ...     base_url="http://localhost:9997"
             ... )
         """
-        import time
-
         # Ensure base_url doesn't have trailing slash
         base_url = base_url.rstrip("/")
 
@@ -685,15 +715,23 @@ class XinferenceLLM(BaseLLM):
 
         for attempt in range(max_retries):
             try:
-                # Use xinference-client SDK to list models
-                client = XinferenceClient(base_url=base_url, api_key=api_key)
-
                 logger.debug(
                     f"Fetching models from Xinference: {base_url} (attempt {attempt + 1}/{max_retries})"
                 )
 
-                # Use SDK's list_models method
-                model_list = client.list_models()
+                def fetch_models() -> Any:
+                    client = XinferenceClient(base_url=base_url, api_key=api_key)
+                    try:
+                        return client.list_models()
+                    finally:
+                        try:
+                            client.close()
+                        except Exception:
+                            pass
+
+                # The SDK is synchronous; model discovery must not block other
+                # API requests while Xinference is slow or unavailable.
+                model_list = await asyncio.to_thread(fetch_models)
                 normalized_models = _normalize_model_list_response(model_list)
 
                 result = []
@@ -741,7 +779,7 @@ class XinferenceLLM(BaseLLM):
                     logger.warning(
                         f"Error connecting to Xinference, retrying in {retry_delay}s: {e}"
                     )
-                    time.sleep(retry_delay)
+                    await asyncio.sleep(retry_delay)
                     continue
                 else:
                     logger.error(

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -443,10 +443,13 @@ class XinferenceLLM(BaseLLM):
         sanitized_messages = self._sanitize_unicode_content(messages)
 
         # Build generate config with streaming enabled
+        stream_options = dict(kwargs.pop("stream_options", {}) or {})
+        stream_options["include_usage"] = True
         generate_config = self._build_generate_config(
             temperature=temperature,
             max_tokens=max_tokens,
             stream=True,
+            stream_options=stream_options,
             **kwargs,
         )
 
@@ -552,6 +555,12 @@ class XinferenceLLM(BaseLLM):
         # Check choices
         choices = chunk_dict.get("choices", [])
         if not choices:
+            if usage:
+                return StreamChunk(
+                    type=ChunkType.USAGE,
+                    usage=dict(usage),
+                    raw=chunk_dict,
+                )
             # No choices, might be a metadata chunk
             return None
 

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -165,7 +164,6 @@ class TestXinferenceLLM:
         llm._client = MagicMock()
         llm._model_handle = BlockingModelHandle()
 
-        started_at = time.monotonic()
         try:
             with pytest.raises(LLMTimeoutError, match="First token timeout"):
                 async for _ in llm.stream_chat(
@@ -174,8 +172,6 @@ class TestXinferenceLLM:
                     pass
         finally:
             release_stream.set()
-
-        assert time.monotonic() - started_at < 0.15
 
     @pytest.mark.asyncio
     async def test_chat_timeout_is_retryable(self) -> None:

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -1,12 +1,112 @@
+import asyncio
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from xagent.core.model.chat.basic.xinference import XinferenceLLM
+from xagent.core.model.chat.exceptions import LLMTimeoutError
+from xagent.core.model.chat.timeout_config import TimeoutConfig
 from xagent.core.model.chat.types import ChunkType
 
 
 class TestXinferenceLLM:
+    @pytest.mark.asyncio
+    async def test_stream_chat_does_not_block_event_loop_before_first_token(
+        self,
+    ) -> None:
+        release_stream = asyncio.Event()
+
+        class BlockingModelHandle:
+            async def chat(self, **kwargs: object):
+                async def generate():
+                    await release_stream.wait()
+                    yield {
+                        "choices": [
+                            {
+                                "delta": {"content": "ok"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    }
+
+                return generate()
+
+        llm = XinferenceLLM(model_name="qwen3.8")
+        llm._client = MagicMock()
+        llm._model_handle = BlockingModelHandle()
+
+        started_at = time.monotonic()
+
+        async def heartbeat() -> float:
+            await asyncio.sleep(0)
+            return time.monotonic() - started_at
+
+        heartbeat_task = asyncio.create_task(heartbeat())
+
+        async def release_later() -> None:
+            await asyncio.sleep(0.2)
+            release_stream.set()
+
+        release_task = asyncio.create_task(release_later())
+        try:
+            chunks = [
+                chunk
+                async for chunk in llm.stream_chat(
+                    messages=[{"role": "user", "content": "hello"}]
+                )
+            ]
+        finally:
+            release_stream.set()
+            await release_task
+
+        heartbeat_delay = await heartbeat_task
+        assert heartbeat_delay < 0.1
+        assert [chunk.delta for chunk in chunks] == ["ok"]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_enforces_timeout_while_waiting_for_first_token(
+        self,
+    ) -> None:
+        release_stream = asyncio.Event()
+
+        class BlockingModelHandle:
+            async def chat(self, **kwargs: object):
+                async def generate():
+                    await release_stream.wait()
+                    yield {
+                        "choices": [
+                            {
+                                "delta": {"content": "late"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    }
+
+                return generate()
+
+        llm = XinferenceLLM(
+            model_name="qwen3.8",
+            timeout_config=TimeoutConfig(
+                first_token_timeout=0.02,
+                token_interval_timeout=0.02,
+            ),
+        )
+        llm._client = MagicMock()
+        llm._model_handle = BlockingModelHandle()
+
+        started_at = time.monotonic()
+        try:
+            with pytest.raises(LLMTimeoutError, match="First token timeout"):
+                async for _ in llm.stream_chat(
+                    messages=[{"role": "user", "content": "hello"}]
+                ):
+                    pass
+        finally:
+            release_stream.set()
+
+        assert time.monotonic() - started_at < 0.15
+
     def test_parse_stream_chunk_accumulates_tool_arguments_by_index(self) -> None:
         llm = XinferenceLLM(model_name="qwen3.5")
         accumulated_tool_calls: dict[str, dict] = {}

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from xagent.core.model.chat.basic.xinference import XinferenceLLM
+from xagent.core.model.chat.basic.xinference import XinferenceLLM, _create_async_client
+from xagent.core.model.chat.error import retry_on
 from xagent.core.model.chat.exceptions import LLMTimeoutError
 from xagent.core.model.chat.timeout_config import TimeoutConfig
 from xagent.core.model.chat.types import ChunkType
@@ -32,20 +33,26 @@ class TestXinferenceLLM:
 
                 return generate()
 
-        llm = XinferenceLLM(model_name="qwen3.8")
+        llm = XinferenceLLM(
+            model_name="qwen3.8",
+            timeout_config=TimeoutConfig(
+                first_token_timeout=1,
+                token_interval_timeout=1,
+            ),
+        )
         llm._client = MagicMock()
         llm._model_handle = BlockingModelHandle()
 
-        started_at = time.monotonic()
+        heartbeat_completed = asyncio.Event()
 
-        async def heartbeat() -> float:
+        async def heartbeat() -> None:
             await asyncio.sleep(0)
-            return time.monotonic() - started_at
+            heartbeat_completed.set()
 
         heartbeat_task = asyncio.create_task(heartbeat())
 
         async def release_later() -> None:
-            await asyncio.sleep(0.2)
+            await asyncio.wait_for(heartbeat_completed.wait(), timeout=0.5)
             release_stream.set()
 
         release_task = asyncio.create_task(release_later())
@@ -60,8 +67,8 @@ class TestXinferenceLLM:
             release_stream.set()
             await release_task
 
-        heartbeat_delay = await heartbeat_task
-        assert heartbeat_delay < 0.1
+        await heartbeat_task
+        assert heartbeat_completed.is_set()
         assert [chunk.delta for chunk in chunks] == ["ok"]
 
     @pytest.mark.asyncio
@@ -106,6 +113,126 @@ class TestXinferenceLLM:
             release_stream.set()
 
         assert time.monotonic() - started_at < 0.15
+
+    @pytest.mark.asyncio
+    async def test_chat_timeout_is_retryable(self) -> None:
+        class BlockingModelHandle:
+            async def chat(self, **kwargs: object):
+                await asyncio.Event().wait()
+
+        llm = XinferenceLLM(model_name="qwen3.8", timeout=0.02)
+        llm._client = MagicMock()
+        llm._model_handle = BlockingModelHandle()
+
+        with pytest.raises(LLMTimeoutError, match="Xinference chat timeout") as exc:
+            await llm.chat(messages=[{"role": "user", "content": "hello"}])
+
+        assert retry_on(exc.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("blocking_phase", ["get_model", "chat"])
+    async def test_stream_first_token_timeout_bounds_request_initiation(
+        self, blocking_phase: str
+    ) -> None:
+        class BlockingClient:
+            async def get_model(self, model_uid: str):
+                await asyncio.Event().wait()
+
+        class BlockingModelHandle:
+            async def chat(self, **kwargs: object):
+                await asyncio.Event().wait()
+
+        llm = XinferenceLLM(
+            model_name="qwen3.8",
+            timeout_config=TimeoutConfig(
+                first_token_timeout=0.02,
+                token_interval_timeout=1,
+            ),
+        )
+        if blocking_phase == "get_model":
+            llm._client = BlockingClient()
+        else:
+            llm._client = MagicMock()
+            llm._model_handle = BlockingModelHandle()
+
+        with pytest.raises(LLMTimeoutError, match="First token timeout"):
+            async for _ in llm.stream_chat(
+                messages=[{"role": "user", "content": "hello"}]
+            ):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_enforces_token_interval_timeout_and_closes_stream(
+        self,
+    ) -> None:
+        class TrackingStream:
+            def __init__(self) -> None:
+                self._first = True
+                self.closed = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._first:
+                    self._first = False
+                    return {
+                        "choices": [
+                            {
+                                "delta": {"content": "first"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    }
+                await asyncio.Event().wait()
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        stream = TrackingStream()
+
+        class ModelHandle:
+            async def chat(self, **kwargs: object):
+                return stream
+
+        llm = XinferenceLLM(
+            model_name="qwen3.8",
+            timeout_config=TimeoutConfig(
+                first_token_timeout=1,
+                token_interval_timeout=0.02,
+            ),
+        )
+        llm._client = MagicMock()
+        llm._model_handle = ModelHandle()
+
+        chunks = []
+        with pytest.raises(LLMTimeoutError, match="Token interval timeout"):
+            async for chunk in llm.stream_chat(
+                messages=[{"role": "user", "content": "hello"}]
+            ):
+                chunks.append(chunk)
+
+        assert [chunk.delta for chunk in chunks] == ["first"]
+        assert stream.closed
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("api_key", "expected_authorization"),
+        [(None, None), ("secret", "Bearer secret")],
+    )
+    async def test_async_client_skips_sync_auth_probe(
+        self, api_key: str | None, expected_authorization: str | None
+    ) -> None:
+        with patch(
+            "requests.Session.get",
+            side_effect=AssertionError("synchronous auth probe must not run"),
+        ):
+            client = _create_async_client("http://localhost:9997", api_key)
+
+        try:
+            assert client._headers.get("Authorization") == expected_authorization
+        finally:
+            await client.close()
 
     def test_parse_stream_chunk_accumulates_tool_arguments_by_index(self) -> None:
         llm = XinferenceLLM(model_name="qwen3.5")

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -72,8 +72,17 @@ class TestXinferenceLLM:
         assert [chunk.delta for chunk in chunks] == ["ok"]
 
     @pytest.mark.asyncio
-    async def test_stream_chat_requests_and_surfaces_usage(self) -> None:
+    @pytest.mark.parametrize("separate_usage_chunk", [False, True])
+    async def test_stream_chat_requests_and_surfaces_usage(
+        self, separate_usage_chunk: bool
+    ) -> None:
         captured_generate_config: dict[str, object] = {}
+        usage = {
+            "prompt_tokens": 100,
+            "completion_tokens": 5,
+            "total_tokens": 105,
+            "prompt_tokens_details": {"cached_tokens": 60},
+        }
 
         class ModelHandle:
             async def chat(self, **kwargs: object):
@@ -83,14 +92,19 @@ class TestXinferenceLLM:
 
                 async def generate():
                     yield {
-                        "choices": [],
-                        "usage": {
-                            "prompt_tokens": 100,
-                            "completion_tokens": 5,
-                            "total_tokens": 105,
-                            "prompt_tokens_details": {"cached_tokens": 60},
-                        },
+                        "choices": [
+                            {
+                                "delta": {"content": ""},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": usage,
                     }
+                    if separate_usage_chunk:
+                        yield {
+                            "choices": [],
+                            "usage": usage,
+                        }
 
                 return generate()
 
@@ -98,22 +112,27 @@ class TestXinferenceLLM:
         llm._client = MagicMock()
         llm._model_handle = ModelHandle()
 
-        chunks = [
-            chunk
-            async for chunk in llm.stream_chat(
-                messages=[{"role": "user", "content": "hello"}]
-            )
-        ]
+        with patch(
+            "xagent.core.model.chat.basic.xinference.add_token_usage"
+        ) as add_usage:
+            chunks = [
+                chunk
+                async for chunk in llm.stream_chat(
+                    messages=[{"role": "user", "content": "hello"}]
+                )
+            ]
 
         assert captured_generate_config["stream_options"] == {"include_usage": True}
-        assert len(chunks) == 1
-        assert chunks[0].type == ChunkType.USAGE
-        assert chunks[0].usage == {
-            "prompt_tokens": 100,
-            "completion_tokens": 5,
-            "total_tokens": 105,
-            "prompt_tokens_details": {"cached_tokens": 60},
-        }
+        assert [chunk.type for chunk in chunks] == [ChunkType.END, ChunkType.USAGE]
+        assert chunks[-1].usage == usage
+        add_usage.assert_called_once_with(
+            input_tokens=100,
+            output_tokens=5,
+            model="qwen3.8",
+            model_id="",
+            call_type="stream_chat",
+            cached_input_tokens=60,
+        )
 
     @pytest.mark.asyncio
     async def test_stream_chat_enforces_timeout_while_waiting_for_first_token(

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -279,6 +279,139 @@ class TestXinferenceLLM:
         assert stream.closed
 
     @pytest.mark.asyncio
+    async def test_stream_chat_keeps_first_deadline_until_payload(self) -> None:
+        class DelayedPayloadStream:
+            def __init__(self) -> None:
+                self._index = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                self._index += 1
+                if self._index == 1:
+                    return {
+                        "choices": [
+                            {
+                                "delta": {"role": "assistant", "content": ""},
+                                "finish_reason": None,
+                            }
+                        ]
+                    }
+                if self._index == 2:
+                    await asyncio.sleep(0.05)
+                    return {
+                        "choices": [
+                            {
+                                "delta": {"content": "first payload"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    }
+                raise StopAsyncIteration
+
+            async def aclose(self) -> None:
+                pass
+
+        class ModelHandle:
+            async def chat(self, **kwargs: object):
+                return DelayedPayloadStream()
+
+        llm = XinferenceLLM(
+            model_name="qwen3.8",
+            timeout_config=TimeoutConfig(
+                first_token_timeout=0.2,
+                token_interval_timeout=0.02,
+            ),
+        )
+        llm._client = MagicMock()
+        llm._model_handle = ModelHandle()
+
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+        ]
+
+        assert [chunk.delta for chunk in chunks] == ["first payload"]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_preserves_transport_timeout_cause(self) -> None:
+        transport_error = asyncio.TimeoutError("SDK read timed out")
+
+        class TransportTimeoutStream:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise transport_error
+
+            async def aclose(self) -> None:
+                pass
+
+        class ModelHandle:
+            async def chat(self, **kwargs: object):
+                return TransportTimeoutStream()
+
+        llm = XinferenceLLM(
+            model_name="qwen3.8",
+            timeout_config=TimeoutConfig(
+                first_token_timeout=1,
+                token_interval_timeout=1,
+            ),
+        )
+        llm._client = MagicMock()
+        llm._model_handle = ModelHandle()
+
+        with pytest.raises(LLMTimeoutError, match="transport timeout") as exc:
+            async for _ in llm.stream_chat(
+                messages=[{"role": "user", "content": "hello"}]
+            ):
+                pass
+
+        assert exc.value.__cause__ is transport_error
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_outer_close_closes_inner_iterator(self) -> None:
+        class TrackingStream:
+            def __init__(self) -> None:
+                self.closed = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return {
+                    "choices": [
+                        {
+                            "delta": {"content": "first"},
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+
+            async def aclose(self) -> None:
+                self.closed += 1
+
+        stream = TrackingStream()
+
+        class ModelHandle:
+            async def chat(self, **kwargs: object):
+                return stream
+
+        llm = XinferenceLLM(model_name="qwen3.8")
+        llm._client = MagicMock()
+        llm._model_handle = ModelHandle()
+        outer = llm.stream_chat(messages=[{"role": "user", "content": "hello"}])
+
+        chunk = await outer.__anext__()
+        await outer.aclose()
+
+        assert chunk.delta == "first"
+        assert stream.closed == 1
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("api_key", "expected_authorization"),
         [(None, None), ("secret", "Bearer secret")],
@@ -479,26 +612,29 @@ class TestXinferenceLLM:
         ]
 
     @pytest.mark.asyncio
-    @patch("xagent.core.model.chat.basic.xinference.XinferenceClient")
+    @patch("xagent.core.model.chat.basic.xinference._create_async_client")
     async def test_list_available_models_handles_dict_response(
-        self, mock_client_class: MagicMock
+        self, mock_client_factory: MagicMock
     ) -> None:
         mock_client = MagicMock()
-        mock_client.list_models.return_value = {
-            "qwen-chat-uid": {
-                "model_name": "Qwen3-8B-Instruct",
-                "model_type": "LLM",
-                "model_ability": ["chat", "vision", "tool_calling"],
-                "model_description": "Qwen chat model",
-            },
-            "whisper-uid": {
-                "model_name": "whisper-large-v3",
-                "model_type": "audio",
-                "model_ability": ["audio2text"],
-                "model_description": "ASR model",
-            },
-        }
-        mock_client_class.return_value = mock_client
+        mock_client.list_models = AsyncMock(
+            return_value={
+                "qwen-chat-uid": {
+                    "model_name": "Qwen3-8B-Instruct",
+                    "model_type": "LLM",
+                    "model_ability": ["chat", "vision", "tool_calling"],
+                    "model_description": "Qwen chat model",
+                },
+                "whisper-uid": {
+                    "model_name": "whisper-large-v3",
+                    "model_type": "audio",
+                    "model_ability": ["audio2text"],
+                    "model_description": "ASR model",
+                },
+            }
+        )
+        mock_client.close = AsyncMock()
+        mock_client_factory.return_value = mock_client
 
         models = await XinferenceLLM.list_available_models(
             base_url="http://localhost:9997", api_key="test-key"
@@ -521,22 +657,26 @@ class TestXinferenceLLM:
             "abilities": ["asr"],
             "description": "ASR model",
         }
+        mock_client.close.assert_awaited_once()
 
     @pytest.mark.asyncio
-    @patch("xagent.core.model.chat.basic.xinference.XinferenceClient")
+    @patch("xagent.core.model.chat.basic.xinference._create_async_client")
     async def test_list_available_models_preserves_embedding_ability(
-        self, mock_client_class: MagicMock
+        self, mock_client_factory: MagicMock
     ) -> None:
         mock_client = MagicMock()
-        mock_client.list_models.return_value = {
-            "embedding-uid": {
-                "model_name": "Qwen3-Embedding-8B",
-                "model_type": "embedding",
-                "model_ability": ["embedding"],
-                "model_description": "Embedding model",
+        mock_client.list_models = AsyncMock(
+            return_value={
+                "embedding-uid": {
+                    "model_name": "Qwen3-Embedding-8B",
+                    "model_type": "embedding",
+                    "model_ability": ["embedding"],
+                    "model_description": "Embedding model",
+                }
             }
-        }
-        mock_client_class.return_value = mock_client
+        )
+        mock_client.close = AsyncMock()
+        mock_client_factory.return_value = mock_client
 
         models = await XinferenceLLM.list_available_models(
             base_url="http://localhost:9997", api_key="test-key"
@@ -554,21 +694,24 @@ class TestXinferenceLLM:
         ]
 
     @pytest.mark.asyncio
-    @patch("xagent.core.model.chat.basic.xinference.XinferenceClient")
+    @patch("xagent.core.model.chat.basic.xinference._create_async_client")
     async def test_list_available_models_handles_legacy_list_response(
-        self, mock_client_class: MagicMock
+        self, mock_client_factory: MagicMock
     ) -> None:
         mock_client = MagicMock()
-        mock_client.list_models.return_value = [
-            {
-                "id": "legacy-chat-uid",
-                "model_name": "legacy-chat",
-                "model_type": "LLM",
-                "model_ability": ["chat"],
-                "model_description": "Legacy chat model",
-            }
-        ]
-        mock_client_class.return_value = mock_client
+        mock_client.list_models = AsyncMock(
+            return_value=[
+                {
+                    "id": "legacy-chat-uid",
+                    "model_name": "legacy-chat",
+                    "model_type": "LLM",
+                    "model_ability": ["chat"],
+                    "model_description": "Legacy chat model",
+                }
+            ]
+        )
+        mock_client.close = AsyncMock()
+        mock_client_factory.return_value = mock_client
 
         models = await XinferenceLLM.list_available_models(
             base_url="http://localhost:9997", api_key="test-key"
@@ -584,6 +727,81 @@ class TestXinferenceLLM:
                 "description": "Legacy chat model",
             }
         ]
+
+    @pytest.mark.asyncio
+    @patch("xagent.core.model.chat.basic.xinference._create_async_client")
+    async def test_list_available_models_remains_responsive_and_closes_client(
+        self, mock_client_factory: MagicMock
+    ) -> None:
+        discovery_started = asyncio.Event()
+        release_discovery = asyncio.Event()
+
+        async def list_models():
+            discovery_started.set()
+            await release_discovery.wait()
+            return {}
+
+        mock_client = MagicMock()
+        mock_client.list_models = list_models
+        mock_client.close = AsyncMock()
+        mock_client_factory.return_value = mock_client
+
+        discovery_task = asyncio.create_task(
+            XinferenceLLM.list_available_models("http://localhost:9997")
+        )
+        await asyncio.wait_for(discovery_started.wait(), timeout=0.1)
+        heartbeat = asyncio.create_task(asyncio.sleep(0))
+        await asyncio.wait_for(heartbeat, timeout=0.1)
+        release_discovery.set()
+
+        assert await discovery_task == []
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch(
+        "xagent.core.model.chat.basic.xinference.asyncio.sleep", new_callable=AsyncMock
+    )
+    @patch("xagent.core.model.chat.basic.xinference._create_async_client")
+    async def test_list_available_models_closes_client_after_errors(
+        self, mock_client_factory: MagicMock, _mock_sleep: AsyncMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.list_models = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_client.close = AsyncMock()
+        mock_client_factory.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="Cannot connect to Xinference"):
+            await XinferenceLLM.list_available_models("http://localhost:9997")
+
+        assert mock_client_factory.call_count == 3
+        assert mock_client.close.await_count == 3
+
+    @pytest.mark.asyncio
+    @patch(
+        "xagent.core.model.chat.basic.xinference._MODEL_DISCOVERY_TIMEOUT_SECONDS",
+        0.01,
+    )
+    @patch(
+        "xagent.core.model.chat.basic.xinference.asyncio.sleep", new_callable=AsyncMock
+    )
+    @patch("xagent.core.model.chat.basic.xinference._create_async_client")
+    async def test_list_available_models_bounds_and_cleans_up_slow_discovery(
+        self, mock_client_factory: MagicMock, _mock_sleep: AsyncMock
+    ) -> None:
+        async def list_models():
+            await asyncio.Event().wait()
+
+        mock_client = MagicMock()
+        mock_client.list_models = list_models
+        mock_client.close = AsyncMock()
+        mock_client_factory.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="Cannot connect to Xinference") as exc:
+            await XinferenceLLM.list_available_models("http://localhost:9997")
+
+        assert isinstance(exc.value.__cause__, LLMTimeoutError)
+        assert mock_client_factory.call_count == 3
+        assert mock_client.close.await_count == 3
 
 
 class TestProcessChatResponse:

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -72,6 +72,50 @@ class TestXinferenceLLM:
         assert [chunk.delta for chunk in chunks] == ["ok"]
 
     @pytest.mark.asyncio
+    async def test_stream_chat_requests_and_surfaces_usage(self) -> None:
+        captured_generate_config: dict[str, object] = {}
+
+        class ModelHandle:
+            async def chat(self, **kwargs: object):
+                generate_config = kwargs["generate_config"]
+                assert isinstance(generate_config, dict)
+                captured_generate_config.update(generate_config)
+
+                async def generate():
+                    yield {
+                        "choices": [],
+                        "usage": {
+                            "prompt_tokens": 100,
+                            "completion_tokens": 5,
+                            "total_tokens": 105,
+                            "prompt_tokens_details": {"cached_tokens": 60},
+                        },
+                    }
+
+                return generate()
+
+        llm = XinferenceLLM(model_name="qwen3.8")
+        llm._client = MagicMock()
+        llm._model_handle = ModelHandle()
+
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+        ]
+
+        assert captured_generate_config["stream_options"] == {"include_usage": True}
+        assert len(chunks) == 1
+        assert chunks[0].type == ChunkType.USAGE
+        assert chunks[0].usage == {
+            "prompt_tokens": 100,
+            "completion_tokens": 5,
+            "total_tokens": 105,
+            "prompt_tokens_details": {"cached_tokens": 60},
+        }
+
+    @pytest.mark.asyncio
     async def test_stream_chat_enforces_timeout_while_waiting_for_first_token(
         self,
     ) -> None:


### PR DESCRIPTION
## What changed

- use Xinference's async client for chat and streaming requests
- avoid the async client's synchronous authentication probe while preserving API-key authentication
- enforce first-token and token-interval timeouts while awaiting stream data
- move synchronous model discovery off the application event loop
- add regression coverage for event-loop responsiveness and first-token timeout handling

## Why

`XinferenceLLM.stream_chat()` was an async generator but consumed the synchronous Xinference SDK iterator directly. A slow or long-running generation could therefore block the FastAPI event loop, freezing unrelated HTTP requests, WebSocket updates, and task lease heartbeats until the model request finished.

The previous timeout checks also ran only after a synchronous iterator yielded, so they could not interrupt a stalled read.

## Impact

Xinference generations can now wait for tokens without making the rest of Xagent unresponsive. Streaming cancellation and timeout handling also propagate through the async iterator instead of leaving a blocked reader thread behind.

## Validation

- `pytest -q tests/core/model/chat/basic/test_xinference.py` (16 passed)
- `pre-commit run --files src/xagent/core/model/chat/basic/xinference.py tests/core/model/chat/basic/test_xinference.py`
- live Xinference request confirmed the event-loop heartbeat continued throughout a first-token timeout
