### PR TITLE
refactor(kb): drop the two unread parameters from the knowledge-base list path

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/document_search.py
+++ b/src/xagent/core/tools/adapters/vibe/document_search.py
@@ -36,16 +36,12 @@ class ListKnowledgeBasesTool(AbstractBaseTool):
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
-        agent_creator_user_id: Optional[int] = None,
-        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> None:
         self._visibility = ToolVisibility.PUBLIC
         self.allowed_collections = allowed_collections
         self.user_id = user_id
         self.is_admin = is_admin
         self.governing_team_id = governing_team_id
-        self.agent_creator_user_id = agent_creator_user_id
-        self.declared_knowledge_bases = declared_knowledge_bases
 
     @property
     def name(self) -> str:
@@ -83,8 +79,6 @@ class ListKnowledgeBasesTool(AbstractBaseTool):
             user_id=self.user_id,
             is_admin=self.is_admin,
             governing_team_id=self.governing_team_id,
-            agent_creator_user_id=self.agent_creator_user_id,
-            declared_knowledge_bases=self.declared_knowledge_bases,
         )
 
 
@@ -93,8 +87,6 @@ def get_list_knowledge_bases_tool(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
-    agent_creator_user_id: Optional[int] = None,
-    declared_knowledge_bases: Optional[list[str]] = None,
 ) -> ListKnowledgeBasesTool:
     """Create a tool to list all knowledge bases through the tool facade."""
     return _get_tool_compatibility_facade().get_list_knowledge_bases_tool(
@@ -102,8 +94,6 @@ def get_list_knowledge_bases_tool(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
-        agent_creator_user_id=agent_creator_user_id,
-        declared_knowledge_bases=declared_knowledge_bases,
     )
 
 
@@ -112,8 +102,6 @@ def _get_list_knowledge_bases_tool_impl(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
-    agent_creator_user_id: Optional[int] = None,
-    declared_knowledge_bases: Optional[list[str]] = None,
 ) -> ListKnowledgeBasesTool:
     """Create a tool to list all knowledge bases.
 
@@ -122,9 +110,6 @@ def _get_list_knowledge_bases_tool_impl(
         user_id: Optional user ID for multi-tenancy filtering.
         is_admin: Whether the user has admin privileges.
         governing_team_id: The governing agent's owning team, if any.
-        agent_creator_user_id: The governing agent's creator, if any.
-        declared_knowledge_bases: The governing agent's stored knowledge-base
-            declaration, if any.
 
     Returns:
         ListKnowledgeBasesTool instance
@@ -134,8 +119,6 @@ def _get_list_knowledge_bases_tool_impl(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
-        agent_creator_user_id=agent_creator_user_id,
-        declared_knowledge_bases=declared_knowledge_bases,
     )
 
 

--- a/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/knowledge_tools.py
@@ -60,13 +60,14 @@ async def _create_knowledge_tools_impl(config: "BaseToolConfig") -> List[Any]:
             return []
 
         if allowed_collections is None:
+            # No creator and no declaration here: the list tool only reports
+            # which collections are available, classifies no individual
+            # declared name, and never runs the creator-existence probe.
             list_tool = get_list_knowledge_bases_tool(
                 allowed_collections=allowed_collections,
                 user_id=user_id,
                 is_admin=is_admin,
                 governing_team_id=governing_team_id,
-                agent_creator_user_id=agent_creator_user_id,
-                declared_knowledge_bases=declared_knowledge_bases,
             )
             tools.append(list_tool)
 

--- a/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
+++ b/src/xagent/core/tools/core/RAG_tools/kb/tool_compatibility.py
@@ -73,8 +73,6 @@ class KBToolCompatibilityFacade:
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
-        agent_creator_user_id: Optional[int] = None,
-        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> ListKnowledgeBasesResult:
         from ... import document_search as core_document_search
 
@@ -84,8 +82,6 @@ class KBToolCompatibilityFacade:
                 user_id=user_id,
                 is_admin=is_admin,
                 governing_team_id=governing_team_id,
-                agent_creator_user_id=agent_creator_user_id,
-                declared_knowledge_bases=declared_knowledge_bases,
             )
 
     async def find_missing_knowledge_bases(
@@ -130,8 +126,6 @@ class KBToolCompatibilityFacade:
         user_id: Optional[int] = None,
         is_admin: bool = False,
         governing_team_id: Optional[int] = None,
-        agent_creator_user_id: Optional[int] = None,
-        declared_knowledge_bases: Optional[list[str]] = None,
     ) -> ListKnowledgeBasesTool:
         from ....adapters.vibe import document_search as vibe_document_search
 
@@ -140,8 +134,6 @@ class KBToolCompatibilityFacade:
             user_id=user_id,
             is_admin=is_admin,
             governing_team_id=governing_team_id,
-            agent_creator_user_id=agent_creator_user_id,
-            declared_knowledge_bases=declared_knowledge_bases,
         )
 
     def get_knowledge_search_tool(

--- a/src/xagent/core/tools/core/document_search.py
+++ b/src/xagent/core/tools/core/document_search.py
@@ -214,8 +214,6 @@ async def list_knowledge_bases(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
-    agent_creator_user_id: Optional[int] = None,
-    declared_knowledge_bases: Optional[List[str]] = None,
 ) -> ListKnowledgeBasesResult:
     """List all available knowledge bases through the tool compatibility facade."""
     return await _get_tool_compatibility_facade().list_knowledge_bases(
@@ -223,8 +221,6 @@ async def list_knowledge_bases(
         user_id=user_id,
         is_admin=is_admin,
         governing_team_id=governing_team_id,
-        agent_creator_user_id=agent_creator_user_id,
-        declared_knowledge_bases=declared_knowledge_bases,
     )
 
 
@@ -233,8 +229,6 @@ async def _list_knowledge_bases_impl(
     user_id: Optional[int] = None,
     is_admin: bool = False,
     governing_team_id: Optional[int] = None,
-    agent_creator_user_id: Optional[int] = None,
-    declared_knowledge_bases: Optional[List[str]] = None,
 ) -> ListKnowledgeBasesResult:
     """List all available knowledge bases with their statistics.
 
@@ -246,26 +240,15 @@ async def _list_knowledge_bases_impl(
             affects *which* collections are visible (the team layer resolves
             on this team instead of the runner's own team memberships); see
             ``_list_visible_collections``.
-        agent_creator_user_id: Accepted for signature symmetry with
-            ``_search_knowledge_base_impl`` and never read here.
-            ``knowledge_tools.py`` builds the list tool only when the
-            agent's allowed collections are ``None`` -- a non-empty list
-            builds the search tool alone, and an empty list builds no
-            knowledge tool at all -- and both chat call sites derive the
-            allowed collections and the declaration from the same stored
-            field, so in production a list tool is built with no declared
-            name to classify as "unshared" versus "missing". A test may
-            still hand this function a declaration alongside ``None``
-            allowed collections; that combination is constructed to isolate
-            forwarding, not something a call site produces. See
-            ``declared_knowledge_bases`` below.
-        declared_knowledge_bases: Accepted for signature symmetry and never
-            read here, for the same reason. This function reports "here is
-            what is available" -- an unresolved declared name simply does
-            not appear in the list, with no separate message field, and
-            never triggers the creator-existence probe. That holds whatever
-            is passed, so an artificially constructed declaration changes
-            nothing about the answer.
+
+    Note:
+        Unlike ``_search_knowledge_base_impl``, this function takes neither
+        the governing agent's creator nor its stored knowledge-base
+        declaration. It only reports what is available: it classifies no
+        individual declared name, so an unresolved name simply does not
+        appear in the returned list, with no separate message field, and it
+        never triggers the creator-existence probe. Adding those two values
+        here would give it nothing to do.
 
     Returns:
         ListKnowledgeBasesResult containing knowledge base information

--- a/tests/core/tools/adapters/vibe/test_knowledge_tools_team_scope_wiring.py
+++ b/tests/core/tools/adapters/vibe/test_knowledge_tools_team_scope_wiring.py
@@ -2,7 +2,9 @@
 declaration must actually reach the knowledge-base tool instances that
 ``knowledge_tools.py`` builds -- not just exist as parameters somewhere in
 the call chain. Each test here breaks one link of that chain and would go
-red if that link silently dropped its value.
+red if that link silently dropped its value. The list tool takes only the
+governing-team id; the creator and the declaration belong to the search
+tool alone.
 """
 
 from __future__ import annotations
@@ -79,8 +81,10 @@ async def test_missing_governing_team_id_leaves_tools_untouched_by_default() -> 
 
     assert list_tool.governing_team_id is None
     assert search_tool.governing_team_id is None
-    assert list_tool.agent_creator_user_id is None
     assert search_tool.agent_creator_user_id is None
+    # The list tool carries no creator at all: it reports what is available
+    # and classifies no individual declared name.
+    assert not hasattr(list_tool, "agent_creator_user_id")
 
 
 @pytest.mark.asyncio
@@ -126,9 +130,14 @@ async def test_running_the_search_tool_forwards_all_three_values_through_the_rea
 
 
 @pytest.mark.asyncio
-async def test_running_the_list_tool_forwards_all_three_values_through_the_real_facade(
+async def test_running_the_list_tool_forwards_only_the_governing_team_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The governing team id must survive the same whole chain for the list
+    tool, and nothing else must ride along with it: the config below does
+    carry a creator and a declaration (the search tool reads both), so this
+    also pins that the list path leaves them behind.
+    """
     from xagent.core.tools.core import document_search as core_document_search
 
     captured: dict = {}
@@ -155,5 +164,5 @@ async def test_running_the_list_tool_forwards_all_three_values_through_the_real_
     await list_tool.run_json_async({})
 
     assert captured.get("governing_team_id") == 42
-    assert captured.get("agent_creator_user_id") == 99
-    assert captured.get("declared_knowledge_bases") == ["kb1"]
+    assert "agent_creator_user_id" not in captured
+    assert "declared_knowledge_bases" not in captured

--- a/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_tool_compatibility.py
@@ -91,8 +91,6 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
             user_id: Optional[int] = None,
             is_admin: bool = False,
             governing_team_id: Optional[int] = None,
-            agent_creator_user_id: Optional[int] = None,
-            declared_knowledge_bases: Optional[list] = None,
         ) -> object:
             calls.append(
                 (
@@ -100,8 +98,6 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
                     user_id or 0,
                     is_admin,
                     governing_team_id,
-                    agent_creator_user_id,
-                    declared_knowledge_bases,
                 )
             )
             return sentinel
@@ -114,15 +110,13 @@ async def test_public_list_knowledge_bases_routes_through_tool_facade(monkeypatc
         user_id=7,
         is_admin=True,
         governing_team_id=42,
-        agent_creator_user_id=99,
-        declared_knowledge_bases=["kb1", "kb2"],
     )
 
     assert result is sentinel
-    # All three new values must reach the facade call unmodified -- a
-    # facade-layer bug that drops any one of them would leave a
-    # team-governed search silently resolving as if it were personal.
-    assert calls == [(args, 7, True, 42, 99, ["kb1", "kb2"])]
+    # The governing team id must reach the facade call unmodified -- a
+    # facade-layer bug that drops it would leave a team-governed listing
+    # silently resolving against the runner's own team memberships.
+    assert calls == [(args, 7, True, 42)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

The knowledge-base list path took `agent_creator_user_id` and
`declared_knowledge_bases` and never read either one. #1349 introduced them
on the list path for signature symmetry with the search path. This removes
them from every layer of the list path.

## Why they had nothing to do there

The list path answers "which collections are available". It classifies no
individual declared name -- an unresolved name simply does not appear in
the returned list, and there is no separate message field for it to land in
-- and it never runs the creator-existence probe. Neither value had any
input into that answer, at any layer it was threaded through.

`governing_team_id` stays. The list path genuinely reads it: it selects the
team layer that decides which collections are visible at all.

The search path is untouched. It still receives both values, and that is
where the creator fallback and the per-name resolution live.

## Changes

| File | Change |
| --- | --- |
| `core/tools/core/document_search.py` | Dropped both parameters from `list_knowledge_bases` and `_list_knowledge_bases_impl`; the two docstring entries collapse into one Note stating that the list path takes neither value and why |
| `core/tools/adapters/vibe/document_search.py` | Dropped both from `ListKnowledgeBasesTool.__init__`, its `run_json_async` call, `get_list_knowledge_bases_tool`, and `_get_list_knowledge_bases_tool_impl` |
| `core/tools/core/RAG_tools/kb/tool_compatibility.py` | Dropped both from the facade's `list_knowledge_bases` and `get_list_knowledge_bases_tool` |
| `core/tools/adapters/vibe/knowledge_tools.py` | Stopped passing both at the list-tool construction site, with a comment recording why |

## Compatibility

This narrows four Python-side signatures (the core `list_knowledge_bases`
wrapper and `_list_knowledge_bases_impl`, `ListKnowledgeBasesTool` and
`get_list_knowledge_bases_tool` in the Vibe adapter, and the facade's list
methods): a caller that passed either keyword now gets a `TypeError` before
the unchanged list behaviour runs. The parameters shipped in v0.7.0 via #1349,
so this is an API correction made one release after they appeared, not
before they ever shipped. It is taken as a pre-release-grade correction on
purpose: the package declares itself `Development Status :: 1 - Planning`,
publishes no changelog or API-stability promise, `list_knowledge_bases` is
not exported (no `__all__`; reachable only through its full module path),
the model-facing tool schema (`ListKnowledgeBasesArgs`) is untouched, and
the only in-repo caller is updated in this change. Keeping the two keywords
as accepted-and-ignored would preserve exactly the misreading this change
removes -- a value handed in and silently dropped -- so the loud failure is
preferred over the quiet one.

## Behavior

Unchanged. `_list_knowledge_bases_impl` never read either value: before
this change both names appeared in that function only in its signature and
its docstring, with zero occurrences in the body. Removing an argument a
function never reads cannot change what it returns, and no call site passed
these two anywhere except into that function.

The list path's one live input is `governing_team_id`, and it still arrives
intact -- flipping it to `None` at the construction site turns the
forwarding test red, and the parameters that reach the core implementation
are exactly `user_id`, `is_admin`, and `governing_team_id`.

## Tests

The forwarding pin for the list tool now asserts that `governing_team_id`
still makes the full trip through the real facade *and* that the other two
values do not ride along. Its config still carries a creator and a
declaration -- the search tool reads both -- so the test proves the list
path leaves them behind rather than merely never having them. The facade
routing test for the list path shrinks to the values that path takes.

Ran the knowledge-base tool wiring, compatibility facade, team-layer,
declared-name, `tests/web/tools/`, and chat team-scope suites: 1878 passed.
ruff, mypy, and pre-commit are clean on the changed files.
