### PR TITLE
fix(frontend): stop the toolNames fixture from re-narrowing Locale

### DIFF
--- a/frontend/src/components/chat/trace-event-processing.test.ts
+++ b/frontend/src/components/chat/trace-event-processing.test.ts
@@ -348,12 +348,22 @@ describe("every toolNames entry resolves through getFriendlyToolName", () => {
   // would go unnoticed. Iterate every key actually in the source file
   // (self-referential, so no per-key value needs hand-copying here) and
   // assert getFriendlyToolName resolves it exactly.
-  const toolNames: Record<Locale, Record<string, string>> = {
+  //
+  // Typed with `satisfies Partial<…>` rather than annotated
+  // `Record<Locale, …>`: a downstream build can replace @/i18n/translations
+  // with one that adds locales, widening Locale beyond the source objects
+  // this repo ships (src/lib/time-utils.ts types displayDateLocales as a
+  // Partial for the same reason, and its test pins that annotation). An
+  // exhaustive Record here would demand an entry for a locale core has no
+  // module to import, breaking their type-check on a file only this repo
+  // owns. `satisfies` still rejects a wrong value shape or a key that is not
+  // a Locale at all.
+  const toolNames = {
     en: en.traceEventRenderer.toolNames,
     zh: zh.traceEventRenderer.toolNames,
-  }
+  } satisfies Partial<Record<Locale, Record<string, string>>>
 
-  for (const locale of Object.keys(toolNames) as Locale[]) {
+  for (const locale of Object.keys(toolNames) as (keyof typeof toolNames)[]) {
     it(`resolves all ${Object.keys(toolNames[locale]).length} ${locale} entries to their literal source value`, () => {
       const tDynamic = (key: string, fallback: string) =>
         resolveDynamicTranslation(locale, key, fallback)

--- a/frontend/src/components/chat/trace-event-processing.test.ts
+++ b/frontend/src/components/chat/trace-event-processing.test.ts
@@ -7,6 +7,7 @@
  * "last running tool" (which mis-attributes output/status the moment completion
  * order differs from reverse-start order).
  */
+import { readFileSync } from "node:fs"
 import { describe, it, expect, vi } from "vitest"
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }))
@@ -375,5 +376,23 @@ describe("every toolNames entry resolves through getFriendlyToolName", () => {
 
   it("keeps the same set of tool names mapped in both locales", () => {
     expect(Object.keys(toolNames.en).sort()).toEqual(Object.keys(toolNames.zh).sort())
+  })
+
+  it("keeps the fixture's Locale boundary a Partial", () => {
+    // Everything above iterates only the keys the fixture actually has, so it
+    // would all still pass if the annotation regressed to an exhaustive
+    // `Record<Locale, …>`: while Locale is exactly en | zh the two types are
+    // interchangeable here, and no runtime assertion can tell them apart. The
+    // difference only surfaces in a build that widens Locale, which this repo
+    // never runs -- so pin the boundary in the source text, the way
+    // src/lib/time-utils.test.ts pins displayDateLocales' Partial.
+    //
+    // The needle is assembled from fragments rather than written out whole:
+    // this guard sits in the file it guards, so a single literal would match
+    // its own occurrence and keep passing after the fixture had regressed.
+    const boundary = ["} satisfies Partial<Record<Locale, ", "Record<string, string>>>"].join("")
+    const source = readFileSync("src/components/chat/trace-event-processing.test.ts", "utf8")
+
+    expect(source).toContain(boundary)
   })
 })


### PR DESCRIPTION
## Problem

`trace-event-processing.test.ts` (added in #1356) annotates its fixture as

```ts
const toolNames: Record<Locale, Record<string, string>> = {
  en: en.traceEventRenderer.toolNames,
  zh: zh.traceEventRenderer.toolNames,
}
```

`Record<Locale, …>` is exhaustive over `Locale`, so the object must carry an entry for every member of the union. That holds while `Locale` is exactly `"en" | "zh"`, but a downstream build that replaces `@/i18n/translations` with a module exporting additional locales widens `Locale` — and the annotation then demands an entry for a locale this repo ships no source object for:

```
src/components/chat/trace-event-processing.test.ts(351,9): error TS2741:
Property 'vi' is missing in type '{ en: …; zh: … }'
but required in type 'Record<"zh" | "en" | "vi", Record<string, string>>'
```

The failure lands on a file only this repo owns, so there is nothing the downstream build can reasonably patch.

## Why this shape

This is a known constraint, not a new one: `src/lib/time-utils.ts` types `displayDateLocales` as `Partial<Record<Locale, string>>` for precisely this reason, and `time-utils.test.ts` asserts that annotation against the source text so it cannot be narrowed back:

```ts
expect(source).toContain("const displayDateLocales: Partial<Record<Locale, string>> = {")
```

This change applies the same convention to the new fixture.

## The change

`satisfies Partial<Record<Locale, Record<string, string>>>` instead of the exhaustive annotation, and `keyof typeof toolNames` instead of `Locale` for the loop variable.

`satisfies` keeps every check that mattered here — a wrong value shape is still rejected, and a key that is not a `Locale` is still rejected — it just drops the exhaustiveness requirement the fixture was never trying to express. Iterating `keyof typeof toolNames` (`"en" | "zh"`) keeps the loop variable assignable to `Locale`, so `resolveDynamicTranslation(locale, …)` is unchanged, and `Object.keys(toolNames[locale]).length` no longer needs a possibly-undefined guard the way a `Partial`-annotated binding would.

## Testing

- `npx tsc --noEmit` — no error on this file.
- `npx eslint src/components/chat/trace-event-processing.test.ts` — clean.
- `npx vitest run src/components/chat/trace-event-processing.test.ts` — 20 passed. No behaviour change; the same 56 entries per locale are still asserted.
- Also type-checked against a build that widens `Locale` with a third locale, which is where the error originally surfaced: clean, tests still 20 passed.