### PR TITLE
fix(mcp): guard OAuth connect against same-tick double clicks (#1330)

### DIFF
--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -771,6 +771,184 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     }
   })
 
+  it("fires exactly one oauth/connect POST when a custom mcp_oauth connect is double-clicked in the same tick", async () => {
+    // #1330: the DCR case. This server has no configured client_id, so each
+    // POST that reaches the backend and finds no MCPOAuthClient row performs a
+    // *real* dynamic client registration at the third-party authorization
+    // server. The loser is discarded locally by the registration_lookup_hash
+    // IntegrityError fallback, but the registration it created at the provider
+    // stays there — which is why the second POST has to be stopped in the
+    // browser, not reconciled afterwards. disabled={isConnecting} can't do it:
+    // it reads loadingApps, React state, so it lags a commit cycle behind two
+    // clicks fired back to back before any render flushes.
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    let connectCalls = 0
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        if (url === "http://api.local/api/mcp/9/oauth/connect") {
+          connectCalls += 1
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.example.com/authorize" }),
+          })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      renderDialog()
+      const connectButton = screen.getByRole("button", { name: "connect-records" })
+      // The settings-dialog mock's trigger carries no disabled prop, so both
+      // clicks reach the handler — which is the point: this asserts the
+      // handler's own guard, the one that exists precisely because the real
+      // trigger's disabled prop cannot be relied on to have committed yet.
+      fireEvent.click(connectButton)
+      fireEvent.click(connectButton)
+
+      await waitFor(() => {
+        expect(popup.location.href).toBe("https://auth.example.com/authorize")
+      })
+      expect(connectCalls).toBe(1)
+      // One popup, not two aliases of the same shared window name.
+      expect(openSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
+  it("fires exactly one oauth/connect POST when a catalog mcp_oauth connect is double-clicked in the same tick", async () => {
+    // Same window as the custom-server case above, through the catalog route.
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    let connectCalls = 0
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        if (url === "http://api.local/api/mcp/apps/granola/oauth/connect") {
+          connectCalls += 1
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.granola.ai/authorize" }),
+          })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      renderDialog()
+      const connectButton = screen.getByRole("button", { name: "connect-granola" })
+      fireEvent.click(connectButton)
+      fireEvent.click(connectButton)
+
+      await waitFor(() => {
+        expect(popup.location.href).toBe("https://auth.granola.ai/authorize")
+      })
+      expect(connectCalls).toBe(1)
+      expect(openSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
+  it("opens one popup and registers one message listener when a builtin_oauth connect is double-clicked in the same tick", async () => {
+    // #1330: the builtin flow has no provider-side registration to duplicate,
+    // but an unguarded second click opens a second provider popup and adds a
+    // second postMessage listener — so one 'oauth-success' message would fire
+    // onSuccess and loadApps() twice.
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    const addListenerSpy = vi.spyOn(window, "addEventListener")
+    const onSuccess = vi.fn()
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      render(
+        <ConnectMcpDialog
+          open
+          onOpenChange={vi.fn()}
+          selectedMcpServers={selectedMcpServers}
+          onSuccess={onSuccess}
+        />,
+      )
+      const connectButton = screen.getByRole("button", { name: "connect-builtin" })
+      fireEvent.click(connectButton)
+      fireEvent.click(connectButton)
+
+      expect(openSpy).toHaveBeenCalledTimes(1)
+      const messageListeners = addListenerSpy.mock.calls.filter(([type]) => type === "message")
+      expect(messageListeners).toHaveLength(1)
+
+      await act(async () => {
+        window.dispatchEvent(
+          Object.assign(new Event("message"), { data: { type: "oauth-success" } }),
+        )
+      })
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    } finally {
+      addListenerSpy.mockRestore()
+      openSpy.mockRestore()
+    }
+  })
+
+  it("frees the app's connect slot when the dialog closes mid-OAuth-flow, so it stays connectable", async () => {
+    // #1330's trap: a bespoke per-handler in-flight ref would be released only
+    // by handleConnectMcpOAuthApp's own exit points, and clearMcpOauthPollState
+    // — which drops loadingApps wholesale when the dialog closes — knows
+    // nothing about one. Abandoning an OAuth flow by closing the dialog would
+    // then leave the app permanently unconnectable until a page reload. The
+    // guard shadows loadingApps precisely so every path that clears the
+    // spinner also frees the slot.
+    const popup = { closed: false, close: vi.fn(), opener: {}, location: { href: "" } }
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+    let connectCalls = 0
+    try {
+      apiRequestMock.mockImplementation((url: string) => {
+        if (url.includes("/api/mcp/apps?")) {
+          return Promise.resolve({ ok: true, json: async () => [] })
+        }
+        if (url === "http://api.local/api/mcp/9/oauth/connect") {
+          connectCalls += 1
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ authorization_url: "https://auth.example.com/authorize" }),
+          })
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      })
+
+      const props = {
+        onOpenChange: vi.fn(),
+        selectedMcpServers,
+      }
+      const { rerender } = render(<ConnectMcpDialog open {...props} />)
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "connect-records" }))
+      })
+      expect(connectCalls).toBe(1)
+
+      // The user closes the dialog while the popup is still waiting for
+      // consent, then reopens it and tries again.
+      rerender(<ConnectMcpDialog open={false} {...props} />)
+      rerender(<ConnectMcpDialog open {...props} />)
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "connect-records" }))
+      })
+      expect(connectCalls).toBe(2)
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
   it("fires exactly one POST when a keyless connect is double-clicked in the same tick", async () => {
     // Round-9: keylessConnectsRef's guard had zero test coverage — removing
     // its .has()/.add() calls would leave every other test green. Without

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -121,16 +121,46 @@ export function ConnectMcpDialog({
   // round 4, round 5 M1) because per-call-site match-guards on a shared slot
   // don't compose; this retires all of them at once.
   const [loadingApps, setLoadingApps] = useState<Set<string>>(new Set())
+  // #1330: synchronous shadow of loadingApps. Every connect handler's first
+  // statement is markAppLoading — a setState — and the only guard on the
+  // triggers is `disabled={isConnecting}`, fed from loadingApps, so it lags a
+  // commit cycle behind two clicks landing in the same tick.
+  // A shadow of the shared slot rather than a per-handler in-flight ref: the
+  // mcp_oauth flow holds its loading state for the entire 5-minute popup wait,
+  // and clearMcpOauthPollState() drops loadingApps wholesale on dialog close
+  // without knowing about any bespoke ref — an app whose connect was released
+  // only by its own handler's six exit points would stay unconnectable until a
+  // page reload if the dialog was closed mid-flow. Writing it from the same
+  // three functions that write loadingApps (here, clearAppLoading, and
+  // clearMcpOauthPollState) is one invariant instead of six, matching the
+  // argument the comment above already makes for the shared slot itself.
+  const loadingAppsRef = React.useRef<Set<string>>(new Set())
   const markAppLoading = (appId: string) => {
+    loadingAppsRef.current.add(appId)
     setLoadingApps(prev => (prev.has(appId) ? prev : new Set(prev).add(appId)))
   }
   const clearAppLoading = (appId: string) => {
+    loadingAppsRef.current.delete(appId)
     setLoadingApps(prev => {
       if (!prev.has(appId)) return prev
       const next = new Set(prev)
       next.delete(appId)
       return next
     })
+  }
+  // Claim this app's connect slot, synchronously. Returns false when a connect
+  // for it is already in flight, so the caller can bail before issuing any
+  // request. The case that justifies it is the mcp_oauth (DCR) path: with no
+  // configured client_id, two concurrent POSTs both find no MCPOAuthClient row
+  // and both call register_mcp_oauth_public_client, so two dynamic client
+  // registrations are really created at the third-party authorization server.
+  // _upsert_mcp_oauth_client's registration_lookup_hash IntegrityError
+  // fallback then discards one — but only the local row; the registration at
+  // the provider is a side effect nothing here can withdraw.
+  const beginAppConnect = (appId: string) => {
+    if (loadingAppsRef.current.has(appId)) return false
+    markAppLoading(appId)
+    return true
   }
   const [isLoadingApps, setIsLoadingApps] = useState(false)
   const [activeCategory, setActiveCategory] = useState("All")
@@ -340,7 +370,10 @@ export function ConnectMcpDialog({
     mcpOauthMessageListenersRef.current.clear()
     // This teardown abandons every timer/listener tracked above regardless
     // of which app(s) they belonged to, so it clears every in-flight app,
-    // not just one.
+    // not just one. The synchronous shadow has to be released here too
+    // (#1330), or an app whose OAuth flow was abandoned by a dialog close
+    // would keep its claimed slot and never be connectable again.
+    loadingAppsRef.current.clear()
     setLoadingApps(new Set())
     // F5 (close case): bump so any handleConnectMcpOAuthApp call that
     // captured the generation before this teardown ran can detect it's
@@ -743,19 +776,16 @@ export function ConnectMcpDialog({
   // can't: loadingApps is React state, so disabled={} lags a commit cycle,
   // and a double-click landing in the same tick would fire two POSTs. The
   // backend recovers idempotently, so this only saves a wasted duplicate
-  // request — a ref is synchronous, closing the window outright.
-  const keylessConnectsRef = React.useRef<Set<string>>(new Set())
+  // request — a ref is synchronous, closing the window outright. It used to
+  // be a keyless-only ref; #1330 needed the same guard on two more handlers,
+  // so it is now the shared loadingAppsRef claim. connectCatalogApp's finally
+  // always runs setLoading(false), which releases the slot on every exit path.
   const submitKeylessConnect = async (app: AppIntegration, autoSelect: boolean) => {
-    if (keylessConnectsRef.current.has(app.id)) return
-    keylessConnectsRef.current.add(app.id)
-    try {
-      await connectCatalogApp(app, { is_active: true }, {
-        autoSelect,
-        setLoading: (loading) => (loading ? markAppLoading(app.id) : clearAppLoading(app.id)),
-      })
-    } finally {
-      keylessConnectsRef.current.delete(app.id)
-    }
+    if (!beginAppConnect(app.id)) return
+    await connectCatalogApp(app, { is_active: true }, {
+      autoSelect,
+      setLoading: (loading) => (loading ? markAppLoading(app.id) : clearAppLoading(app.id)),
+    })
   }
 
   // A user-added (custom) MCP server is authorized per server row, not per
@@ -771,6 +801,9 @@ export function ConnectMcpDialog({
   // custom-mcp-form's handleConnectMcpOAuth. Serves both a catalog app
   // (e.g. Granola), keyed by app_id, and a custom server, keyed by server id.
   const handleConnectMcpOAuthApp = async (app: AppIntegration, autoSelect: boolean) => {
+    // #1330: claim the slot before anything else — this is the DCR path, so a
+    // second same-tick call would register a second client at the provider.
+    if (!beginAppConnect(app.id)) return
     // F5 (close case): captured before the popup opens and before any await,
     // so it reflects poll state as of this click — not a stale closure value
     // read after the dialog has since closed and reopened.
@@ -783,7 +816,6 @@ export function ConnectMcpDialog({
     // entry came from: a custom server only appears under location=local, so
     // asking for remote would report every custom connect as a failure.
     const refreshLocation = serverId === null ? "remote" : "local"
-    markAppLoading(app.id)
     // Open the popup synchronously on the click, before any await — popup
     // blockers reject windows opened outside direct user-gesture handling.
     // The window-features string matters: without it, browsers open a full
@@ -920,7 +952,11 @@ export function ConnectMcpDialog({
       return;
     }
 
-    markAppLoading(app.id)
+    // #1330: same same-tick window as the mcp_oauth handler above. There is no
+    // provider-side registration here (the client is static), but two calls
+    // would open two provider popups and register two postMessage listeners,
+    // each firing its own onSuccess/loadApps.
+    if (!beginAppConnect(app.id)) return
     // Open OAuth in a popup window to handle the callback smoothly
     const width = 600;
     const height = 700;

--- a/frontend/src/components/mcp/custom-mcp-form.test.tsx
+++ b/frontend/src/components/mcp/custom-mcp-form.test.tsx
@@ -231,6 +231,82 @@ describe("CustomMcpForm MCP OAuth", () => {
     expect(popup.location.href).toBe("https://auth.example.com/authorize")
   })
 
+  it("keeps the connect guard closed when an overlapping discover finishes first", async () => {
+    // Review follow-up on #1330: the three OAuth buttons are each gated on
+    // their own action identity, so a discover and a connect are allowed to
+    // overlap. If completion cleared the shared slot unconditionally,
+    // whichever finished first would reopen the other's guard mid-flight —
+    // here, discover's completion would re-admit a second connect POST and
+    // with it a second Dynamic Client Registration at the provider. Only the
+    // action that owns the slot may release it.
+    const popup = {
+      closed: false,
+      opener: window,
+      close: vi.fn(),
+      location: { href: "" },
+    }
+    vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+
+    const discoverResponse = deferredResponse()
+    // The connect POST is left pending for the whole test: the guard is only
+    // ever meant to hold while its own action is genuinely in flight, so a
+    // connect that resolved would reopen it legitimately and prove nothing.
+    const connectResponse = deferredResponse()
+    let connectCalls = 0
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/mcp/42/oauth/status") {
+        return Promise.resolve(okJson({ server_id: 42, grants: [] }))
+      }
+      if (url === "http://api.local/api/mcp/42/oauth/discover") {
+        return discoverResponse.promise
+      }
+      if (url === "http://api.local/api/mcp/42/oauth/connect") {
+        connectCalls += 1
+        return connectResponse.promise
+      }
+      throw new Error(`Unhandled apiRequest: ${url}`)
+    })
+
+    renderMcpOAuthForm()
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/mcp/42/oauth/status"
+      )
+    })
+
+    // Discover starts and stays in flight, then a connect overlaps it.
+    await act(async () => {
+      fireEvent.click(screen.getByText("tools.mcp.dialog.oauthDiscover"))
+    })
+    const connectButton = screen.getByText("tools.mcp.dialog.oauthConnect")
+    await act(async () => {
+      fireEvent.click(connectButton)
+    })
+    expect(connectCalls).toBe(1)
+
+    // Discover now completes. It must not release the connect guard.
+    await act(async () => {
+      discoverResponse.resolve(
+        okJson({
+          resource: "https://mcp.example.com/mcp",
+          issuer: "https://auth.example.com",
+          scopes: ["records.read"],
+        })
+      )
+      await flushPromises()
+    })
+
+    await act(async () => {
+      fireEvent.click(connectButton)
+      fireEvent.click(connectButton)
+    })
+    await act(async () => {
+      await flushPromises()
+    })
+    expect(connectCalls).toBe(1)
+  })
+
   it("treats websocket as an MCP OAuth-capable transport", () => {
     expect(isHttpMcpOAuthTransport("streamable_http")).toBe(true)
     expect(isHttpMcpOAuthTransport("sse")).toBe(true)

--- a/frontend/src/components/mcp/custom-mcp-form.test.tsx
+++ b/frontend/src/components/mcp/custom-mcp-form.test.tsx
@@ -162,6 +162,75 @@ describe("CustomMcpForm MCP OAuth", () => {
     expect(popup.location.href).toBe("https://auth.example.com/authorize")
   })
 
+  it("fires exactly one oauth/connect POST when Connect is double-clicked in the same tick", async () => {
+    // #1330: this button drives the same per-server DCR endpoint the connector
+    // dialog does, and its only guard is disabled={oauthAction === "connect"} —
+    // React state, so it lags a commit cycle behind two clicks landing in the
+    // same tick. The fixture drops client_id to model the DCR case: with no
+    // configured client, each POST that reaches the backend registers a new
+    // client at the third-party authorization server, and the one the local
+    // IntegrityError fallback discards stays registered over there.
+    const popup = {
+      closed: false,
+      opener: window,
+      close: vi.fn(),
+      location: { href: "" },
+    }
+    vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window)
+
+    let connectCalls = 0
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url === "http://api.local/api/mcp/42/oauth/status") {
+        return Promise.resolve(okJson({ server_id: 42, grants: [] }))
+      }
+      if (url === "http://api.local/api/mcp/42/oauth/connect") {
+        connectCalls += 1
+        return Promise.resolve(
+          okJson({ authorization_url: "https://auth.example.com/authorize" })
+        )
+      }
+      throw new Error(`Unhandled apiRequest: ${url}`)
+    })
+
+    renderMcpOAuthForm({
+      config: {
+        url: "https://mcp.example.com/mcp",
+        auth: {
+          type: "mcp_oauth",
+          resource: "https://mcp.example.com/mcp",
+          issuer: "https://auth.example.com",
+          scope: "records.read",
+        },
+      },
+    })
+
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/mcp/42/oauth/status"
+      )
+    })
+
+    vi.useFakeTimers()
+    const connectButton = screen.getByText("tools.mcp.dialog.oauthConnect")
+    // Both clicks are dispatched inside one act() scope so React defers the
+    // re-render until it exits — the second click therefore lands on a button
+    // whose disabled prop has not been committed yet, which is exactly the
+    // window scripted clicks or a client retry hit. Two separate fireEvent
+    // calls would not reproduce it: React flushes discrete-event updates
+    // synchronously, so the second click would find the button already
+    // disabled and this test would pass with or without the guard.
+    await act(async () => {
+      fireEvent.click(connectButton)
+      fireEvent.click(connectButton)
+    })
+    await act(async () => {
+      await flushPromises()
+    })
+
+    expect(connectCalls).toBe(1)
+    expect(popup.location.href).toBe("https://auth.example.com/authorize")
+  })
+
   it("treats websocket as an MCP OAuth-capable transport", () => {
     expect(isHttpMcpOAuthTransport("streamable_http")).toBe(true)
     expect(isHttpMcpOAuthTransport("sse")).toBe(true)

--- a/frontend/src/components/mcp/custom-mcp-form.tsx
+++ b/frontend/src/components/mcp/custom-mcp-form.tsx
@@ -93,13 +93,26 @@ export function CustomMcpForm({
   // compares against the action identity rather than "any action in flight",
   // so this exactly mirrors what each button's disabled prop already claims to
   // do — a Connect fired while a discover is running behaves as it does today.
+  // Note the residual limitation of a scalar slot: a *different* action
+  // starting still takes the slot from an in-flight one. Tracking overlaps
+  // properly needs a set, not a slot — but the slot is what the disabled props
+  // read, so widening it is a UI change, not a guard change, and is left out
+  // of #1330's scope.
   const beginOauthAction = (action: string) => {
     if (oauthActionRef.current === action) return false
     oauthActionRef.current = action
     setOauthAction(action)
     return true
   }
-  const endOauthAction = () => {
+  // Only the action that currently owns the slot may release it. The three
+  // buttons are gated on their own identity, so a discover and a connect are
+  // allowed to overlap; an unconditional clear would let whichever finished
+  // first reopen the other's guard mid-flight. (main cleared oauthAction
+  // unconditionally and had the same clobber, so this is a gap the shadow
+  // inherited rather than introduced — but the ref is what the guard now
+  // reads, so it has to be tighter than the state ever was.)
+  const endOauthAction = (action: string) => {
+    if (oauthActionRef.current !== action) return
     oauthActionRef.current = null
     if (isMountedRef.current) setOauthAction(null)
   }
@@ -266,7 +279,7 @@ export function CustomMcpForm({
       console.error("Failed to discover MCP OAuth metadata:", error)
       if (isMountedRef.current) toast.error(t('tools.mcp.dialog.oauthDiscoveryFailed'))
     } finally {
-      endOauthAction()
+      endOauthAction("discover")
     }
   }
 
@@ -345,7 +358,7 @@ export function CustomMcpForm({
       console.error("Failed to start MCP OAuth authorization:", error)
       if (isMountedRef.current) toast.error(t('tools.mcp.dialog.oauthConnectFailed'))
     } finally {
-      endOauthAction()
+      endOauthAction("connect")
     }
   }
 
@@ -371,7 +384,7 @@ export function CustomMcpForm({
       console.error("Failed to delete MCP OAuth grant:", error)
       if (isMountedRef.current) toast.error(t('tools.mcp.dialog.oauthDisconnectFailed'))
     } finally {
-      endOauthAction()
+      endOauthAction(`delete-${grantId}`)
     }
   }
 

--- a/frontend/src/components/mcp/custom-mcp-form.tsx
+++ b/frontend/src/components/mcp/custom-mcp-form.tsx
@@ -80,6 +80,29 @@ export function CustomMcpForm({
   const [oauthStatusLoading, setOauthStatusLoading] = useState(false)
   const [oauthAction, setOauthAction] = useState<string | null>(null)
   const isMountedRef = useRef(false)
+  // #1330: synchronous shadow of oauthAction. Every action button is guarded
+  // only by `disabled={oauthAction === "..."}`, which is React state and so
+  // lags a commit cycle behind two clicks landing in the same tick. This
+  // matters most for Connect, which drives the same per-server
+  // /api/mcp/{id}/oauth/connect endpoint the connector dialog does: with no
+  // configured client_id, two concurrent POSTs each run Dynamic Client
+  // Registration, leaving a second, orphaned client registered at the
+  // third-party authorization server.
+  const oauthActionRef = useRef<string | null>(null)
+  // Returns false when the same action is already in flight. Deliberately
+  // compares against the action identity rather than "any action in flight",
+  // so this exactly mirrors what each button's disabled prop already claims to
+  // do — a Connect fired while a discover is running behaves as it does today.
+  const beginOauthAction = (action: string) => {
+    if (oauthActionRef.current === action) return false
+    oauthActionRef.current = action
+    setOauthAction(action)
+    return true
+  }
+  const endOauthAction = () => {
+    oauthActionRef.current = null
+    if (isMountedRef.current) setOauthAction(null)
+  }
   const pollingTimeoutRef = useRef<number | null>(null)
   const editedSecretFieldsRef = useRef<Set<string>>(new Set())
   const previousServerIdRef = useRef<number | null | undefined>(serverId)
@@ -217,7 +240,7 @@ export function CustomMcpForm({
       toast.error(t('tools.mcp.dialog.oauthSaveBeforeConnect'))
       return
     }
-    setOauthAction("discover")
+    if (!beginOauthAction("discover")) return
     try {
       const response = await apiRequest(`${getApiUrl()}/api/mcp/${serverId}/oauth/discover`, {
         method: "POST",
@@ -243,7 +266,7 @@ export function CustomMcpForm({
       console.error("Failed to discover MCP OAuth metadata:", error)
       if (isMountedRef.current) toast.error(t('tools.mcp.dialog.oauthDiscoveryFailed'))
     } finally {
-      if (isMountedRef.current) setOauthAction(null)
+      endOauthAction()
     }
   }
 
@@ -252,7 +275,7 @@ export function CustomMcpForm({
       toast.error(t('tools.mcp.dialog.oauthSaveBeforeConnect'))
       return
     }
-    setOauthAction("connect")
+    if (!beginOauthAction("connect")) return
     let popup: Window | null = null
     try {
       clearOAuthPolling()
@@ -322,13 +345,13 @@ export function CustomMcpForm({
       console.error("Failed to start MCP OAuth authorization:", error)
       if (isMountedRef.current) toast.error(t('tools.mcp.dialog.oauthConnectFailed'))
     } finally {
-      if (isMountedRef.current) setOauthAction(null)
+      endOauthAction()
     }
   }
 
   const handleDeleteGrant = async (grantId: number) => {
     if (!serverId) return
-    setOauthAction(`delete-${grantId}`)
+    if (!beginOauthAction(`delete-${grantId}`)) return
     try {
       const response = await apiRequest(`${getApiUrl()}/api/mcp/${serverId}/oauth/grants/${grantId}`, {
         method: "DELETE"
@@ -348,7 +371,7 @@ export function CustomMcpForm({
       console.error("Failed to delete MCP OAuth grant:", error)
       if (isMountedRef.current) toast.error(t('tools.mcp.dialog.oauthDisconnectFailed'))
     } finally {
-      if (isMountedRef.current) setOauthAction(null)
+      endOauthAction()
     }
   }
 


### PR DESCRIPTION
Closes #1330.

## Problem

The MCP OAuth connect handlers have no synchronous double-click guard. Their only protection is `disabled={isConnecting}` in `official-mcp-settings-dialog.tsx` (fed from `loadingApps`) and `disabled={oauthAction === "connect"}` in `custom-mcp-form.tsx` — both React state, so they lag one commit cycle behind two clicks landing in the same tick. Each handler's first statement is the `setState` that feeds them.

The consequence that justifies fixing this is on the DCR path. With no configured `client_id`, two concurrent POSTs to `oauth/connect` both find no `MCPOAuthClient` row and both call `register_mcp_oauth_public_client`, so **two dynamic client registrations are really created at the third-party authorization server**. Only one survives `_upsert_mcp_oauth_client`'s `registration_lookup_hash` `IntegrityError` fallback — the other is a side effect at someone else's authorization server that nothing local can withdraw.

Reachability via the real UI is low (React flushes discrete-event updates synchronously, so two genuine mouse clicks land in separate tasks), but it is reachable via scripted clicks, a stuck pointer, or a client retry.

## Fix

A **synchronous shadow of the existing loading slot** in each component, rather than a per-handler in-flight ref.

A bespoke ref would be worse than the bug in `connect-mcp-dialog.tsx`: `mcp_oauth` holds its loading state for the entire 5-minute popup wait, and `clearMcpOauthPollState()` drops `loadingApps` wholesale on dialog close without knowing about one — so closing the dialog mid-flow would leave the app permanently unconnectable until a page reload. There are six release points that would each need to clear it.

Shadowing `loadingApps` from the same three functions that write it (`markAppLoading`, `clearAppLoading`, `clearMcpOauthPollState`) yields one invariant instead of six. It also:

- subsumes the keyless-only `keylessConnectsRef`, which is retired;
- closes the same window in the `builtin_oauth` handler, which would otherwise open two provider popups and register two `postMessage` listeners.

`custom-mcp-form.tsx`'s Connect button drives the **same per-server DCR endpoint** and had the identical window, so it gets the same treatment via `beginOauthAction` / `endOauthAction`. The guard compares action identity rather than "any action in flight", so cross-action behaviour (e.g. Connect fired while a discover is running) is unchanged from today.

## Scope

This PR is a **frontend admission guard**: it stops duplicate handler invocations inside one mounted component instance. It is not — and does not claim to be — a backend or transport-level at-most-once boundary. Transport retries, close → reopen → retry, second tabs, and remounts can still reach the DCR endpoint concurrently; that boundary is the backend's and is tracked in #1408, with the frontend lifecycle residuals in #1407.

## Tests

Six regression tests, each verified to fail with the source change reverted:

| Test | File |
| --- | --- |
| one `oauth/connect` POST on a double-clicked custom `mcp_oauth` connect (the DCR case) | `connect-mcp-dialog.test.tsx` |
| one `oauth/connect` POST on a double-clicked catalog `mcp_oauth` connect | `connect-mcp-dialog.test.tsx` |
| one popup + one `message` listener on a double-clicked `builtin_oauth` connect | `connect-mcp-dialog.test.tsx` |
| the app stays connectable after the dialog is closed mid-OAuth-flow (guards the trap above) | `connect-mcp-dialog.test.tsx` |
| one `oauth/connect` POST on a double-clicked Connect in the custom MCP form | `custom-mcp-form.test.tsx` |
| an overlapping discover finishing does not release the connect guard (72d0b82) | `custom-mcp-form.test.tsx` |

The custom-form double-click test dispatches both clicks inside a single `act()` scope so React defers the re-render — two separate `fireEvent` calls would find the button already disabled and pass with or without the guard.

Verification: `npm run type-check` clean; `vitest run` full frontend suite 2143 passed; `eslint` reports no new findings on the touched files (the pre-existing count is unchanged).

## Out of scope

- `mcp_oauth_flow_states` had no expiry sweeper — fixed separately in #1402.
- Stale-completion interference with a replacement claim and the shared popup window name — pre-existing, tracked in #1407.
- Serializing `connect_mcp_oauth` at the DCR boundary (the fix that closes duplicate remote registrations for every vector) — tracked in #1408.
- The custom form's scalar action slot: a *different* action starting still takes the slot from an in-flight one, so pending Connect → Discover → Connect can admit a duplicate. Pre-existing, noted in the code, folded into #1407.
