### PR TITLE
fix(mcp): gate the create path's auto-select on can_attach (#1390)

### DIFF
--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -105,6 +105,20 @@ vi.mock("./custom-mcp-form", () => ({
       >
         change-mcp-description
       </button>
+      {/* The create path has no detail fetch to hydrate the form, so the
+          #1390 tests fill in the one field handleSaveCustomMcp validates
+          (and the one the post-create lookup matches the listing on). */}
+      <button
+        type="button"
+        onClick={() => setMcpFormData((previous) => ({
+          ...previous,
+          name: "records-mcp",
+          transport: "streamable_http",
+          config: { url: "https://mcp.example.com" },
+        }))}
+      >
+        name-new-mcp
+      </button>
       <button
         type="button"
         onClick={() => setMcpFormData((previous) => ({
@@ -1889,6 +1903,117 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     fireEvent.click(
       within(screen.getByTestId("connector-card-records")).getByText("Records MCP"),
     )
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  // #1390: the create path into the selection, which ignored can_attach
+  // entirely while the click path above enforces it. Saves the Custom MCP
+  // tab's create form and returns `created` as the sole location=local entry
+  // the post-create lookup can find — the filtered listing loadApps() sends
+  // (location=remote, the sidebar default still in force at save time)
+  // deliberately answers empty, which is exactly why the lookup cannot
+  // reuse it.
+  async function createCustomMcpInSelectMode(
+    localListing: object[] | null,
+    onConnectSelected: () => void,
+  ) {
+    apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === "http://api.local/api/mcp/apps?location=local") {
+        // A null listing models the lookup itself failing, the case that
+        // has to read as "not attachable" rather than falling through.
+        return localListing
+          ? Promise.resolve({ ok: true, json: async () => localListing })
+          : Promise.resolve({ ok: false, status: 500, json: async () => ({}) })
+      }
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => [] })
+      }
+      if (url === "http://api.local/api/mcp/servers" && init?.method === "POST") {
+        return Promise.resolve({ ok: true, status: 200, json: async () => ({ id: 9 }) })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    render(
+      <ConnectMcpDialog
+        open
+        onOpenChange={vi.fn()}
+        selectedMcpServers={selectedMcpServers}
+        onConnectSelected={onConnectSelected}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "name-new-mcp" }))
+    await act(async () => {
+      saveMcpEditor()
+    })
+    await waitFor(() =>
+      expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/mcp/apps?location=local"),
+    )
+    // Let the lookup's own response settle, so the selection state the
+    // callers assert on has committed either way.
+    await act(async () => {})
+  }
+
+  it("does not auto-select a just-created connector the listing reports unattachable (#1390)", async () => {
+    // create_mcp_server writes the association long before any grant exists,
+    // so a custom mcp_oauth server lists with can_attach false the moment it
+    // is created. Selecting it here would commit a connector whose run fails
+    // with "MCP server credentials are unavailable" — the failure can_attach
+    // exists to prevent, reached through create instead of a card click.
+    const onConnectSelected = vi.fn()
+    await createCustomMcpInSelectMode(
+      [{ ...unauthorizedCustomMcp(), id: "records-mcp", name: "records-mcp" }],
+      onConnectSelected,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+
+    // Created-but-unselected, not a dead end: the entry carries
+    // can_authorize, so the local tab this switched to offers the recovery.
+    await screen.findByRole("button", { name: "tools.mcp.dialog.authorize" })
+  })
+
+  it("still auto-selects a just-created connector the listing reports attachable (#1390)", async () => {
+    // The other half of the gate: every non-mcp_oauth shape carries its
+    // credentials on the server row, lists attachable immediately, and must
+    // keep landing in the selection without a second click.
+    const onConnectSelected = vi.fn()
+    await createCustomMcpInSelectMode([mcpApp(9, "records-mcp")], onConnectSelected)
+
+    await screen.findByText("tools.mcp.dialog.selected")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith(["records-mcp"])
+  })
+
+  it("reads the created connector's own row when a Custom API shares its name (#1390)", async () => {
+    // Name is unique per table, not across the listing: an MCP server and a
+    // Custom API may both be called records-mcp. Matching on name alone would
+    // let the wrong row answer the attachability question — here the Custom
+    // API, listed first and attachable, would mask the mcp_oauth server this
+    // save actually created. The transport discriminator is what keeps the
+    // two apart.
+    const onConnectSelected = vi.fn()
+    await createCustomMcpInSelectMode(
+      [
+        customApiApp(4, "records-mcp"),
+        { ...unauthorizedCustomMcp(), id: "records-mcp", name: "records-mcp" },
+      ],
+      onConnectSelected,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("leaves a just-created connector unselected when the lookup fails (#1390)", async () => {
+    // No answer is not a yes: the click path needs an affirmative can_attach
+    // too, and the local tab this switches to keeps the card one click away.
+    const onConnectSelected = vi.fn()
+    await createCustomMcpInSelectMode(null, onConnectSelected)
+
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -81,8 +81,30 @@ vi.mock("@/components/ui/tabs", () => ({
 }))
 
 vi.mock("./custom-api-form", () => ({
-  CustomApiForm: ({ mcpFormData }: { mcpFormData: { name?: string } }) => (
-    <output data-testid="custom-api-edit-name">{mcpFormData.name ?? ""}</output>
+  CustomApiForm: ({
+    mcpFormData,
+    setMcpFormData,
+  }: {
+    mcpFormData: { name?: string }
+    setMcpFormData: React.Dispatch<React.SetStateAction<Record<string, unknown>>>
+  }) => (
+    <div>
+      <output data-testid="custom-api-edit-name">{mcpFormData.name ?? ""}</output>
+      {/* Fills the two fields handleSaveCustomMcp requires before it will
+          POST a create (name, url), for the #1390 custom_api create path. */}
+      <button
+        type="button"
+        onClick={() => setMcpFormData((previous) => ({
+          ...previous,
+          name: "records-mcp",
+          transport: "custom_api",
+          url: "https://api.example.com",
+          method: "POST",
+        }))}
+      >
+        name-new-custom-api
+      </button>
+    </div>
   ),
 }))
 
@@ -426,6 +448,17 @@ function renderDialog() {
 function saveMcpEditor() {
   const editor = screen.getByTestId("mcp-edit-state").closest(".max-w-2xl")
   if (!editor) throw new Error("MCP editor container was not rendered")
+  fireEvent.click(within(editor as HTMLElement).getByRole("button", {
+    name: "tools.mcp.buttons.save",
+  }))
+}
+
+// The Custom API tab's own Save, which is a different button under a
+// different container from the MCP editor's — both tabs render at once
+// under the stubbed Tabs, so the container has to be the anchor.
+function saveCustomApiEditor() {
+  const editor = screen.getByTestId("custom-api-edit-name").closest(".max-w-2xl")
+  if (!editor) throw new Error("Custom API editor container was not rendered")
   fireEvent.click(within(editor as HTMLElement).getByRole("button", {
     name: "tools.mcp.buttons.save",
   }))
@@ -1908,28 +1941,52 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
   })
 
   // #1390: the create path into the selection, which ignored can_attach
-  // entirely while the click path above enforces it. Saves the Custom MCP
-  // tab's create form and returns `created` as the sole location=local entry
-  // the post-create lookup can find — the filtered listing loadApps() sends
-  // (location=remote, the sidebar default still in force at save time)
+  // entirely while the click path above enforces it. Saves the create form of
+  // whichever connector type is under test and answers the post-create lookup
+  // with `localListing` — the filtered listing loadApps() sends (location=
+  // remote, the sidebar default still in force when the save starts)
   // deliberately answers empty, which is exactly why the lookup cannot
   // reuse it.
-  async function createCustomMcpInSelectMode(
+  //
+  // `pendingLookup`, when given, holds the lookup open so a caller can assert
+  // on the window in which the save has succeeded but the decision has not
+  // landed yet; its `resolve` finishes the create.
+  async function createInSelectMode(
     localListing: object[] | null,
     onConnectSelected: () => void,
+    options: { customApi?: boolean; pendingLookup?: Deferred<unknown> } = {},
   ) {
+    const listingResponse = localListing
+      ? { ok: true, json: async () => localListing }
+      // A null listing models the lookup itself failing, the case that has to
+      // read as "not attachable" rather than falling through.
+      : { ok: false, status: 500, json: async () => ({}) }
+    const createUrl = options.customApi
+      ? "http://api.local/api/custom-apis"
+      : "http://api.local/api/mcp/servers"
+
     apiRequestMock.mockImplementation((url: string, init?: { method?: string }) => {
+      // Only the lookup carries an abort signal; the sidebar's own refresh of
+      // the same URL does not. Matching on it keeps this stub — and the wait
+      // below — pinned to the request under test.
+      if (url === "http://api.local/api/mcp/apps?location=local" && init && "signal" in init) {
+        return options.pendingLookup
+          ? options.pendingLookup.promise.then(() => listingResponse)
+          : Promise.resolve(listingResponse)
+      }
+      // The sidebar's own refresh of that same URL, fired by the switch to
+      // the local tab. Serves the listing so the cards render, but cannot
+      // stand in for the lookup: every other filter combination this dialog
+      // sends — location=remote before the switch, plus any search/category
+      // narrowing — answers empty, which is the whole reason the lookup
+      // cannot reuse it.
       if (url === "http://api.local/api/mcp/apps?location=local") {
-        // A null listing models the lookup itself failing, the case that
-        // has to read as "not attachable" rather than falling through.
-        return localListing
-          ? Promise.resolve({ ok: true, json: async () => localListing })
-          : Promise.resolve({ ok: false, status: 500, json: async () => ({}) })
+        return Promise.resolve({ ok: true, json: async () => localListing ?? [] })
       }
       if (url.includes("/api/mcp/apps?")) {
         return Promise.resolve({ ok: true, json: async () => [] })
       }
-      if (url === "http://api.local/api/mcp/servers" && init?.method === "POST") {
+      if (url === createUrl && init?.method === "POST") {
         return Promise.resolve({ ok: true, status: 200, json: async () => ({ id: 9 }) })
       }
       throw new Error(`Unexpected request: ${url}`)
@@ -1944,16 +2001,32 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole("button", { name: "name-new-mcp" }))
+    fireEvent.click(screen.getByRole("button", {
+      name: options.customApi ? "name-new-custom-api" : "name-new-mcp",
+    }))
     await act(async () => {
-      saveMcpEditor()
+      options.customApi ? saveCustomApiEditor() : saveMcpEditor()
     })
+    // The create POST must have gone to the endpoint for this connector type,
+    // carrying the name the lookup then matches the listing on.
     await waitFor(() =>
-      expect(apiRequestMock).toHaveBeenCalledWith("http://api.local/api/mcp/apps?location=local"),
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        createUrl,
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"name":"records-mcp"'),
+        }),
+      ),
+    )
+    await waitFor(() =>
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/mcp/apps?location=local",
+        expect.objectContaining({ signal: expect.anything() }),
+      ),
     )
     // Let the lookup's own response settle, so the selection state the
     // callers assert on has committed either way.
-    await act(async () => {})
+    if (!options.pendingLookup) await act(async () => {})
   }
 
   it("does not auto-select a just-created connector the listing reports unattachable (#1390)", async () => {
@@ -1963,7 +2036,7 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     // with "MCP server credentials are unavailable" — the failure can_attach
     // exists to prevent, reached through create instead of a card click.
     const onConnectSelected = vi.fn()
-    await createCustomMcpInSelectMode(
+    await createInSelectMode(
       [{ ...unauthorizedCustomMcp(), id: "records-mcp", name: "records-mcp" }],
       onConnectSelected,
     )
@@ -1981,7 +2054,7 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     // credentials on the server row, lists attachable immediately, and must
     // keep landing in the selection without a second click.
     const onConnectSelected = vi.fn()
-    await createCustomMcpInSelectMode([mcpApp(9, "records-mcp")], onConnectSelected)
+    await createInSelectMode([mcpApp(9, "records-mcp")], onConnectSelected)
 
     await screen.findByText("tools.mcp.dialog.selected")
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
@@ -1996,7 +2069,7 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     // save actually created. The transport discriminator is what keeps the
     // two apart.
     const onConnectSelected = vi.fn()
-    await createCustomMcpInSelectMode(
+    await createInSelectMode(
       [
         customApiApp(4, "records-mcp"),
         { ...unauthorizedCustomMcp(), id: "records-mcp", name: "records-mcp" },
@@ -2008,11 +2081,53 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })
 
+  it("reads the created Custom API's own row when an MCP server shares its name (#1390)", async () => {
+    // The same collision in the direction the backend actually produces:
+    // list_mcp_apps appends every MCP server before the first Custom API, so
+    // a name-only match always reaches the MCP row first. Creating the Custom
+    // API must still be decided by the Custom API's own can_attach, not by
+    // the unattachable mcp_oauth server that happens to share its name.
+    const onConnectSelected = vi.fn()
+    await createInSelectMode(
+      [
+        { ...unauthorizedCustomMcp(), id: "records-mcp", name: "records-mcp" },
+        customApiApp(4, "records-mcp"),
+      ],
+      onConnectSelected,
+      { customApi: true },
+    )
+
+    await screen.findByText("tools.mcp.dialog.selected")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith(["records-mcp"])
+  })
+
+  it("refuses to commit the selection while the attachability lookup is pending (#1390)", async () => {
+    // A successful save returns to the library tab immediately, so the footer
+    // is on screen while the lookup that may still add the new connector is
+    // in flight. Committing there would snapshot the selection one entry
+    // short — the same staleness the catalog-connect guard exists for.
+    const pendingLookup = deferred<unknown>()
+    const onConnectSelected = vi.fn()
+    await createInSelectMode([mcpApp(9, "records-mcp")], onConnectSelected, { pendingLookup })
+
+    expect(screen.getByRole("button", { name: "tools.mcp.dialog.connect" })).toBeDisabled()
+
+    await act(async () => {
+      pendingLookup.resolve(undefined)
+      await pendingLookup.promise
+    })
+
+    await screen.findByText("tools.mcp.dialog.selected")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith(["records-mcp"])
+  })
+
   it("leaves a just-created connector unselected when the lookup fails (#1390)", async () => {
     // No answer is not a yes: the click path needs an affirmative can_attach
     // too, and the local tab this switches to keeps the card one click away.
     const onConnectSelected = vi.fn()
-    await createCustomMcpInSelectMode(null, onConnectSelected)
+    await createInSelectMode(null, onConnectSelected)
 
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -271,11 +271,20 @@ export function ConnectMcpDialog({
   // in handleSaveResponse runs while activeLocation is still the tab the form
   // was opened from ("remote" by default). Null on any failure, so callers can
   // tell "the backend did not answer" apart from "answered, entry absent".
+  //
+  // Bounded, unlike the sidebar's own loadApps(): both callers have work
+  // sequenced behind this request rather than merely rendering its result — a
+  // post-create save that still owes the user its spinner teardown and form
+  // reset, and a post-consent poll callback that owes an apps refresh. A
+  // never-settling GET would strand either one indefinitely, so it fails as a
+  // null answer on the same 30s bound the catalog connect POST uses.
   const fetchAppsByLocation = async (
     location: string,
   ): Promise<AppIntegration[] | null> => {
     try {
-      const response = await apiRequest(`${getApiUrl()}/api/mcp/apps?location=${location}`)
+      const response = await apiRequest(`${getApiUrl()}/api/mcp/apps?location=${location}`, {
+        signal: AbortSignal.timeout(CATALOG_CONNECT_TIMEOUT_MS),
+      })
       if (!response.ok) return null
       return sanitizeAppIntegrations(await response.json())
     } catch (error) {
@@ -1605,7 +1614,16 @@ export function ConnectMcpDialog({
               // wouldn't even close the dialog after committing it. Disable
               // the trigger instead of letting it commit early; same signal
               // requestClose already gates on.
-              disabled={catalogConnectsInFlight > 0}
+              //
+              // isSavingCustom is the same hazard reached the other way
+              // (#1390): a select-mode save switches back to this tab as soon
+              // as it succeeds, so the footer is on screen while the
+              // attachability lookup that decides whether to add the new
+              // connector is still in flight. Committing there would snapshot
+              // the selection one entry short. Not extended to requestClose,
+              // which handleSaveResponse itself calls while this flag is still
+              // set (the tools-page self-close) — that path must keep working.
+              disabled={catalogConnectsInFlight > 0 || isSavingCustom}
               onClick={() => {
                 if (onConnectSelected) {
                   onConnectSelected(localSelectedServers);

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -617,7 +617,14 @@ export function ConnectMcpDialog({
 
       // If in select mode (agent builder), switch to local tab and select the new server
       if (isSelectMode) {
+        // Both view switches run before the lookup below, not after it: they
+        // are what the user is waiting to see once a save succeeds, and
+        // sequencing them behind an unbounded GET would leave them staring at
+        // the form (spinner and all) for as long as that request takes. Only
+        // the selection decision genuinely needs the listing.
+        setActiveTab("library");
         if (!editingCustomServerId) {
+          setActiveLocation("local");
           const newServerName = mcpFormData.name;
           // #1390: this used to append the name unconditionally, while the
           // card-click path gates on the backend's can_attach — and the two
@@ -633,9 +640,10 @@ export function ConnectMcpDialog({
           //
           // Looked up through its own location=local read rather than the
           // loadApps() refresh above: that one sends the library sidebar's
-          // filters, whose location is still "remote" by default at this point
-          // (the switch to "local" happens below), plus any search/category
-          // narrowing — so its response routinely omits the very entry this
+          // filters, whose location was still "remote" by default when it
+          // fired, plus any search/category narrowing — and the refresh the
+          // switch above triggers carries the same search/category narrowing.
+          // Either response routinely omits the very entry this
           // has to decide on. Matching on name is what the listing supports: a
           // local entry's id *is* its name, and both create endpoints store
           // the submitted name verbatim (neither side trims). Name alone is
@@ -657,9 +665,7 @@ export function ConnectMcpDialog({
           if (created && isAttachable(created)) {
             setLocalSelectedServers(prev => prev.includes(newServerName) ? prev : [...prev, newServerName]);
           }
-          setActiveLocation("local");
         }
-        setActiveTab("library");
       } else {
         // If in standalone tools page, just close the dialog
         requestClose();

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -263,6 +263,27 @@ export function ConnectMcpDialog({
     }
   }
 
+  // One-off listing read for a single location, independent of the sidebar
+  // filters loadApps() sends and of the `apps` state it writes. Both callers
+  // need one specific entry that the *current* filters routinely exclude: the
+  // post-consent recheck runs against whichever branch the entry came from
+  // while the user may have narrowed the catalog, and the post-create lookup
+  // in handleSaveResponse runs while activeLocation is still the tab the form
+  // was opened from ("remote" by default). Null on any failure, so callers can
+  // tell "the backend did not answer" apart from "answered, entry absent".
+  const fetchAppsByLocation = async (
+    location: string,
+  ): Promise<AppIntegration[] | null> => {
+    try {
+      const response = await apiRequest(`${getApiUrl()}/api/mcp/apps?location=${location}`)
+      if (!response.ok) return null
+      return sanitizeAppIntegrations(await response.json())
+    } catch (error) {
+      console.error("Failed to load apps:", error)
+      return null
+    }
+  }
+
   // Batch-fetch team-sharing status for connected connectors and merge it into
   // the apps list so cards/settings can show Shared/Private/Needs-config.
   const loadSharingStatus = async (list: AppIntegration[]) => {
@@ -598,7 +619,44 @@ export function ConnectMcpDialog({
       if (isSelectMode) {
         if (!editingCustomServerId) {
           const newServerName = mcpFormData.name;
-          setLocalSelectedServers(prev => prev.includes(newServerName) ? prev : [...prev, newServerName]);
+          // #1390: this used to append the name unconditionally, while the
+          // card-click path gates on the backend's can_attach — and the two
+          // disagreed on exactly one shape. create_mcp_server writes an active
+          // server row with no MCPOAuthGrant (only the OAuth callback writes
+          // one), so a custom mcp_oauth connector lists with can_attach false
+          // the moment it is created; auto-selecting it produced the run-time
+          // "MCP server credentials are unavailable" failure that #1347 added
+          // the field to prevent, reached through the create path rather than
+          // the click path. Not a dead end: the same entry carries
+          // can_authorize, so its card offers Authorize, whose completion
+          // flips can_attach and makes it selectable.
+          //
+          // Looked up through its own location=local read rather than the
+          // loadApps() refresh above: that one sends the library sidebar's
+          // filters, whose location is still "remote" by default at this point
+          // (the switch to "local" happens below), plus any search/category
+          // narrowing — so its response routinely omits the very entry this
+          // has to decide on. Matching on name is what the listing supports: a
+          // local entry's id *is* its name, and both create endpoints store
+          // the submitted name verbatim (neither side trims). Name alone is
+          // not unique across the two halves of that listing though — the MCP
+          // and Custom API tables enforce uniqueness separately, and MCP rows
+          // are appended first — so the same transport discriminator this
+          // function already dispatched the POST on narrows it to one row.
+          //
+          // Silence (request failed, or an entry the listing does not show)
+          // leaves the connector created-but-unselected, same as an explicit
+          // false. The click path also requires an affirmative can_attach, and
+          // the local tab this switches to puts the card one click away.
+          const createdCustomApi = mcpFormData.transport === "custom_api";
+          const listing = await fetchAppsByLocation("local");
+          const created = listing?.find(entry =>
+            entry.name === newServerName
+            && (entry.transport === "custom_api") === createdCustomApi
+          );
+          if (created && isAttachable(created)) {
+            setLocalSelectedServers(prev => prev.includes(newServerName) ? prev : [...prev, newServerName]);
+          }
           setActiveLocation("local");
         }
         setActiveTab("library");
@@ -869,18 +927,13 @@ export function ConnectMcpDialog({
         return
       }
       void (async () => {
-        let connected = false
-        try {
-          const response = await apiRequest(`${getApiUrl()}/api/mcp/apps?location=${refreshLocation}`)
-          if (response.ok) {
-            const data = sanitizeAppIntegrations(await response.json())
-            connected = data.some(
-              (candidate) => candidate.id === app.id && candidate.is_connected,
-            )
-          }
-        } catch (error) {
-          console.error("Failed to refresh apps after the OAuth popup closed:", error)
-        }
+        // A failed recheck reads as "not connected", same as before this
+        // shared helper existed: the success actions below stay gated on a
+        // positive answer, never on the absence of a negative one.
+        const listing = await fetchAppsByLocation(refreshLocation)
+        const connected = (listing ?? []).some(
+          (candidate) => candidate.id === app.id && candidate.is_connected,
+        )
         loadApps()
         if (!connected) return
         if (onSuccess) onSuccess()


### PR DESCRIPTION
Closes #1390.

## Problem

Creating a custom connector from the picker appended it to the agent's selection unconditionally, while the card-click path gates on the `can_attach` decision the backend emits (#1347). The two disagreed on exactly one shape:

- `create_mcp_server` writes an active `UserMCPServer` with **no** `MCPOAuthGrant` — the grant is only written from the OAuth callback.
- So a custom `mcp_oauth` connector lists with `can_attach: false` the moment it is created, yet was already selected and committable through the footer Connect.
- The result is the run-time "MCP server credentials are unavailable" failure that `can_attach` exists to prevent, reached through the create path rather than the click path.

Pre-existing, not a regression from #1384: that PR closed the click route to this failure and left the create route.

## Fix

`handleSaveResponse` now looks the new connector up in the listing and auto-selects only on an affirmative `can_attach`.

Three notes on the approach, which differs from the issue's sketch in ways that matter:

- **Not `await loadApps()`.** That request carries the library sidebar's filters — `location=remote` by default at save time, plus any search/category narrowing — so its response routinely omits the very entry the decision needs. The lookup does its own unfiltered `location=local` read instead, through a small `fetchAppsByLocation` helper shared with the post-consent OAuth recheck, which already did exactly this inline. `loadApps` itself is unchanged, so the existing concurrency tests' timing assumptions (in-flight connect state, cross-app clobber) are untouched.
- **Silence is not a yes.** A failed lookup leaves the connector unselected, the same as an explicit `false`. The click path also requires an affirmative `can_attach`, and the local tab this switches to puts the card one click away.
- **Name match narrowed by transport.** Name is unique per table but not across the listing — the MCP and Custom API tables enforce uniqueness separately and MCP rows are appended first — so the match reuses the same `transport === "custom_api"` discriminator this function already dispatched the POST on.

An unattachable connector is left created-but-unselected, with the Authorize button its listing already advertises (`can_authorize: true`) as the recovery; completing that flow auto-selects it.

## Tests

Four added, driving the real create form through save:

- an unattachable created entry never reaches `onConnectSelected`
- a failed lookup leaves it unselected
- a Custom API sharing the name does not answer for the created MCP row
- an attachable entry is still auto-selected (guards against over-correction)

The first three were verified to fail without the corresponding half of the fix. `tsc --noEmit` clean; full frontend suite 2142 passed / 135 files. No backend changes.