### PR TITLE
fix(mcp): sweep expired mcp_oauth flow states on connect

### DIFF
--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -78,6 +78,13 @@ logger = logging.getLogger(__name__)
 MCP_OAUTH_STATE_COOKIE = "xagent_mcp_oauth_state"
 MCP_OAUTH_STATE_TTL = timedelta(minutes=10)
 MCP_OAUTH_STATE_COOKIE_MAX_AGE_SECONDS = int(MCP_OAUTH_STATE_TTL.total_seconds())
+# How long an expired mcp_oauth_flow_states row is kept before the sweep in
+# connect_mcp_oauth deletes it. A row is already unusable the moment it expires
+# — _claim_mcp_oauth_flow_state requires expires_at > now — so this grace
+# period exists only to keep the sweep well clear of rows a callback may still
+# be racing to claim, and to leave a recent trail for debugging a failed
+# authorization. Matches the Slack OAuth flow-state ledger's retention.
+MCP_OAUTH_FLOW_STATE_RETENTION = timedelta(days=1)
 MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS = frozenset(
     {"none", "client_secret_post", "client_secret_basic"}
 )
@@ -4126,6 +4133,21 @@ async def connect_mcp_oauth(
         redirect_uri=redirect_uri,
         registration_lookup_hash=registration_lookup_hash,
     )
+
+    # Sweep this table's dead rows before adding another, mirroring the Slack
+    # OAuth flow-state ledger in channel.py. Every abandoned, denied or
+    # double-submitted authorization leaves a row that is permanently unusable
+    # once it expires (the claim query requires consumed_at IS NULL and
+    # expires_at > now), but nothing deleted it: the only other deletes are the
+    # per-user purge on disconnect and the FK cascade on server deletion, so
+    # the table grew without bound. Deliberately global rather than scoped to
+    # this user/server — a user who never reconnects would otherwise keep their
+    # rows forever, which is the leak this is meant to close. Filtering on
+    # expires_at alone (an indexed column) also covers consumed rows, since
+    # every row expires within MCP_OAUTH_STATE_TTL of being created.
+    db.query(MCPOAuthFlowState).filter(
+        MCPOAuthFlowState.expires_at < _utc_now() - MCP_OAUTH_FLOW_STATE_RETENTION
+    ).delete(synchronize_session=False)
 
     state_value = secrets.token_urlsafe(32)
     code_verifier = secrets.token_urlsafe(64)

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -85,6 +85,9 @@ MCP_OAUTH_STATE_COOKIE_MAX_AGE_SECONDS = int(MCP_OAUTH_STATE_TTL.total_seconds()
 # be racing to claim, and to leave a recent trail for debugging a failed
 # authorization. Matches the Slack OAuth flow-state ledger's retention.
 MCP_OAUTH_FLOW_STATE_RETENTION = timedelta(days=1)
+# Most stale rows the sweep in connect_mcp_oauth removes per request, so a
+# first-deploy backlog cannot turn one connect into a long transaction.
+MCP_OAUTH_FLOW_STATE_SWEEP_BATCH = 1000
 MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS = frozenset(
     {"none", "client_secret_post", "client_secret_basic"}
 )
@@ -4145,8 +4148,25 @@ async def connect_mcp_oauth(
     # rows forever, which is the leak this is meant to close. Filtering on
     # expires_at alone (an indexed column) also covers consumed rows, since
     # every row expires within MCP_OAUTH_STATE_TTL of being created.
+    #
+    # Bounded per request. The index narrows the scan but does not cap the work,
+    # and this table is precisely the one that has never been swept — the first
+    # connect after this ships meets whatever backlog has accumulated, inside a
+    # user-facing transaction. Draining a fixed batch per connect keeps that
+    # transaction short; the remainder is already dead, so later connects
+    # clearing it costs nothing. Deleting by a bounded id subquery rather than
+    # an IN list of fetched ids keeps it to one statement and clear of any
+    # bound-parameter limit.
+    stale_flow_state_ids = (
+        db.query(MCPOAuthFlowState.id)
+        .filter(
+            MCPOAuthFlowState.expires_at < _utc_now() - MCP_OAUTH_FLOW_STATE_RETENTION
+        )
+        .limit(MCP_OAUTH_FLOW_STATE_SWEEP_BATCH)
+        .scalar_subquery()
+    )
     db.query(MCPOAuthFlowState).filter(
-        MCPOAuthFlowState.expires_at < _utc_now() - MCP_OAUTH_FLOW_STATE_RETENTION
+        MCPOAuthFlowState.id.in_(stale_flow_state_ids)
     ).delete(synchronize_session=False)
 
     state_value = secrets.token_urlsafe(32)

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -131,6 +131,7 @@ def _add_mcp_oauth_server(
     db,
     user: User,
     *,
+    name: str = "records",
     scope: str = "records.read",
     transport: str = "streamable_http",
     client_id: str = "client-123",
@@ -140,7 +141,7 @@ def _add_mcp_oauth_server(
 ) -> MCPServer:
     server = MCPServer.from_config(
         {
-            "name": "records",
+            "name": name,
             "managed": "external",
             "transport": transport,
             "url": "https://mcp.example.com/mcp",
@@ -662,41 +663,80 @@ async def test_connect_sweeps_flow_states_expired_past_the_retention_window(
     db, user, other_user = db_session
     server = _add_mcp_oauth_server(db, user)
     client = _add_oauth_client(db, server)
+    # A second server, so the fixtures below can pin the sweep as global across
+    # servers and not just across users. Its own client row keeps the
+    # mcp_oauth_client_id FK pointing at the matching server.
+    other_server = _add_mcp_oauth_server(db, other_user, name="records-2")
+    other_client = _add_oauth_client(db, other_server)
     db.commit()
 
     now = mcp_api._utc_now()
+    # Deliberately literal rather than derived from
+    # MCP_OAUTH_FLOW_STATE_RETENTION: the one-day policy is the contract under
+    # test, and a fixture computed from the production constant would follow it
+    # anywhere it moved and stay green while the contract silently changed.
+    one_day = timedelta(days=1)
 
-    def _flow_state(state: str, owner: User, expires_at) -> MCPOAuthFlowState:
+    def _flow_state(
+        state: str,
+        owner: User,
+        expires_at,
+        *,
+        target: MCPServer = server,
+        oauth_client: MCPOAuthClient = client,
+        consumed_at=None,
+    ) -> MCPOAuthFlowState:
         return MCPOAuthFlowState(
             state=state,
-            mcp_server_id=server.id,
+            mcp_server_id=target.id,
             user_id=owner.id,
-            mcp_oauth_client_id=client.id,
+            mcp_oauth_client_id=oauth_client.id,
             resource_owner_key=f"xagent:user:{owner.id}",
             issuer="https://auth.example.com",
             resource="https://mcp.example.com/mcp",
             scope="records.read",
             code_verifier=encrypt_value("verifier-123"),
             expires_at=expires_at,
+            consumed_at=consumed_at,
         )
 
     db.add_all(
         [
             # Abandoned past the retention window — the row the sweep exists
-            # for. Owned by the *other* user, so this also pins the sweep as
-            # global: scoping it to the connecting user would leave the rows of
-            # anyone who never reconnects in the table forever, which is the
-            # leak being closed.
+            # for. Owned by the *other* user, so this pins the sweep as global
+            # across users: scoping it to the connecting user would leave the
+            # rows of anyone who never reconnects in the table forever, which
+            # is the leak being closed.
             _flow_state(
-                "stale-other-user",
-                other_user,
-                now - mcp_api.MCP_OAUTH_FLOW_STATE_RETENTION - timedelta(minutes=1),
+                "stale-other-user", other_user, now - one_day - timedelta(hours=1)
             ),
-            # Already unusable (the claim query requires expires_at > now) but
-            # still inside the retention window, so it is kept — the grace
-            # period is what keeps the sweep clear of any callback still
-            # racing to claim its row.
-            _flow_state("recently-expired", user, now - timedelta(minutes=1)),
+            # Same, on a server this connect is not touching — pins the sweep
+            # as global across servers too.
+            _flow_state(
+                "stale-other-server",
+                other_user,
+                now - one_day - timedelta(hours=1),
+                target=other_server,
+                oauth_client=other_client,
+            ),
+            # A completed authorization's row. Nothing filters on consumed_at,
+            # and it must not need to: a consumed row expires on the same
+            # schedule as any other, so the expires_at predicate has to reach
+            # it as well.
+            _flow_state(
+                "stale-consumed",
+                user,
+                now - one_day - timedelta(hours=1),
+                consumed_at=now - one_day - timedelta(hours=1),
+            ),
+            # The fresh side of the same boundary: expired 23 hours ago, so
+            # already unusable (the claim query requires expires_at > now) but
+            # still inside the one-day window, and therefore kept. The grace
+            # period is what keeps the sweep clear of any callback still racing
+            # to claim its row.
+            _flow_state(
+                "expired-inside-window", user, now - one_day + timedelta(hours=1)
+            ),
             # Another authorization still in progress.
             _flow_state("in-flight", other_user, now + mcp_api.MCP_OAUTH_STATE_TTL),
         ]
@@ -717,11 +757,78 @@ async def test_connect_sweeps_flow_states_expired_past_the_retention_window(
 
     assert response.status_code == 303
     surviving = {row.state for row in db.query(MCPOAuthFlowState).all()}
-    assert "stale-other-user" not in surviving
-    assert {"recently-expired", "in-flight"} <= surviving
+    assert not (
+        {"stale-other-user", "stale-other-server", "stale-consumed"} & surviving
+    )
+    assert {"expired-inside-window", "in-flight"} <= surviving
     # The sweep runs in the same transaction as the insert, so the new row must
     # still be there once it commits.
     assert _redirect_query(response)["state"][0] in surviving
+
+
+@pytest.mark.asyncio
+async def test_connect_sweep_is_bounded_and_drains_across_requests(
+    db_session, monkeypatch
+):
+    # The sweep runs inside a user-facing request, and this table is the one
+    # that has never been swept — so the first connect after this ships meets
+    # whatever backlog accumulated. The batch cap is what keeps that from
+    # becoming one long transaction; the leftovers are already dead, so later
+    # connects draining them costs nothing.
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(db, server)
+    db.commit()
+
+    monkeypatch.setattr(mcp_api, "MCP_OAUTH_FLOW_STATE_SWEEP_BATCH", 2)
+    stale_at = mcp_api._utc_now() - timedelta(days=1) - timedelta(hours=1)
+    db.add_all(
+        [
+            MCPOAuthFlowState(
+                state=f"stale-{index}",
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=f"xagent:user:{user.id}",
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                code_verifier=encrypt_value("verifier-123"),
+                expires_at=stale_at,
+            )
+            for index in range(5)
+        ]
+    )
+    db.commit()
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+
+    def _remaining_stale() -> int:
+        return (
+            db.query(MCPOAuthFlowState)
+            .filter(MCPOAuthFlowState.state.like("stale-%"))
+            .count()
+        )
+
+    async def _connect() -> None:
+        await connect_mcp_oauth(
+            server.id,
+            MCPOAuthConnectRequest(redirect_after="/mcp"),
+            user,
+            db,
+        )
+
+    await _connect()
+    assert _remaining_stale() == 3
+
+    await _connect()
+    assert _remaining_stale() == 1
+
+    await _connect()
+    assert _remaining_stale() == 0
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -656,6 +656,75 @@ async def test_connect_creates_pkce_state_and_redirects(db_session, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_connect_sweeps_flow_states_expired_past_the_retention_window(
+    db_session, monkeypatch
+):
+    db, user, other_user = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(db, server)
+    db.commit()
+
+    now = mcp_api._utc_now()
+
+    def _flow_state(state: str, owner: User, expires_at) -> MCPOAuthFlowState:
+        return MCPOAuthFlowState(
+            state=state,
+            mcp_server_id=server.id,
+            user_id=owner.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=f"xagent:user:{owner.id}",
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            code_verifier=encrypt_value("verifier-123"),
+            expires_at=expires_at,
+        )
+
+    db.add_all(
+        [
+            # Abandoned past the retention window — the row the sweep exists
+            # for. Owned by the *other* user, so this also pins the sweep as
+            # global: scoping it to the connecting user would leave the rows of
+            # anyone who never reconnects in the table forever, which is the
+            # leak being closed.
+            _flow_state(
+                "stale-other-user",
+                other_user,
+                now - mcp_api.MCP_OAUTH_FLOW_STATE_RETENTION - timedelta(minutes=1),
+            ),
+            # Already unusable (the claim query requires expires_at > now) but
+            # still inside the retention window, so it is kept — the grace
+            # period is what keeps the sweep clear of any callback still
+            # racing to claim its row.
+            _flow_state("recently-expired", user, now - timedelta(minutes=1)),
+            # Another authorization still in progress.
+            _flow_state("in-flight", other_user, now + mcp_api.MCP_OAUTH_STATE_TTL),
+        ]
+    )
+    db.commit()
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+
+    response = await connect_mcp_oauth(
+        server.id,
+        MCPOAuthConnectRequest(redirect_after="/mcp"),
+        user,
+        db,
+    )
+
+    assert response.status_code == 303
+    surviving = {row.state for row in db.query(MCPOAuthFlowState).all()}
+    assert "stale-other-user" not in surviving
+    assert {"recently-expired", "in-flight"} <= surviving
+    # The sweep runs in the same transaction as the insert, so the new row must
+    # still be there once it commits.
+    assert _redirect_query(response)["state"][0] in surviving
+
+
+@pytest.mark.asyncio
 async def test_connect_dynamically_registers_public_client_when_client_id_is_empty(
     db_session, monkeypatch
 ):


### PR DESCRIPTION
Follow-up to the secondary note in #1330, split out of #1400 (which fixes that issue's actual subject, the duplicate DCR registration). Independent of #1400 — no overlapping files.

## Problem

`mcp_oauth_flow_states` has no expiry sweeper. A row becomes permanently unusable the moment it expires — `_claim_mcp_oauth_flow_state` requires `consumed_at IS NULL` **and** `expires_at > now` — but nothing deletes it. The only deletes are:

- the per-user purge on disconnect (`delete_mcp_server`), and
- the FK cascade on server deletion.

So every abandoned, denied, timed-out, or double-submitted authorization leaves a dead row behind, and the table grows without bound. `SlackOAuthFlowState`, the sibling ledger in `channel.py`, does not have this problem — it purges on each new flow.

## Fix

Sweep rows past a retention window in `connect_mcp_oauth`, just before inserting the new one, in the same transaction. Both connect endpoints funnel through this function (`connect_mcp_oauth_app` delegates to it after ensuring the server row and association), so one sweep covers the catalog and per-server routes alike.

Three deliberate choices, all matching the Slack ledger:

- **Global, not scoped to the connecting user.** A user who never reconnects would otherwise keep their rows forever — which is exactly the leak being closed.
- **One-day retention, not immediate.** A row is already unusable at `expires_at`, so the grace period is not about correctness; it keeps the sweep well clear of any callback still racing to claim its row, and leaves a recent trail for debugging a failed authorization.
- **Filtering on `expires_at` alone.** It is an indexed column, and it also covers consumed rows, since every row expires within `MCP_OAUTH_STATE_TTL` (10 minutes) of being created.

No schema change, no migration.

## Tests

`test_connect_sweeps_flow_states_expired_past_the_retention_window` seeds three rows and asserts which survive a connect:

| Row | Expectation |
| --- | --- |
| expired past the retention window, owned by **another** user | deleted (also pins the sweep as global) |
| expired one minute ago, inside the retention window | kept |
| still in flight | kept |
| the row this connect creates | present |

Verified to fail — on the `stale-other-user` assertion, not on an import error — with only the sweep statement removed.

Verification: `pytest tests/web/api` passes (no failures; the only skips are the Postgres-gated ones that need `XAGENT_TEST_POSTGRES_URL`); `ruff format --check`, `ruff check`, and `mypy src/xagent/web/api/mcp.py` all clean.