### PR TITLE
fix(mcp): offer a team-shared catalog connector in the connector picker

### DIFF
--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -2073,4 +2073,61 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     fireEvent.click(screen.getByText("Records MCP"))
     expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
   })
+
+  // A catalog app a team shared with this member (#1387). Nobody connected it
+  // *for them*, so is_connected stays false, while the shared row carries the
+  // credentials this shape needs — the third state the backend now emits, and
+  // one the old is_connected/is_custom/auth_type derivation had no way to
+  // express.
+  const teamSharedCatalogApp = () => ({
+    ...keylessApp("acme-notes", "Acme Notes"),
+    is_team_shared: true,
+    can_attach: true,
+  })
+
+  it("attaches a team-shared catalog connector and labels it as the team's", async () => {
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([teamSharedCatalogApp()], onConnectSelected)
+    await screen.findByText("Acme Notes")
+
+    const card = screen.getByTestId("connector-card-acme-notes")
+    // Not connected: no checkmark, and no Configure button to imply ownership.
+    expect(within(card).queryByTestId("connected-check")).toBeNull()
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+    // The provenance label is not gated on the auth context's inTeam (false
+    // here) the way the sibling badge is: that one reads the separate
+    // /api/connectors/status fetch the picker only makes for a team, while
+    // this one reads a backend-authoritative field that cannot be true for a
+    // user no team shared anything with.
+    expect(within(card).getByText("tools.mcp.sharing.teamTool")).toBeTruthy()
+
+    fireEvent.click(screen.getByText("Acme Notes"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith(["Acme Notes"])
+  })
+
+  it("keeps the Connect route for a team-shared connector authorized per user", async () => {
+    // mcp_oauth and builtin_oauth authorization is the member's own, and no
+    // team link supplies it — the backend reports can_attach false, so the card
+    // click must still reach the detail modal where Connect is dispatched on
+    // auth_type ("connect it for yourself") rather than toggling a selection
+    // that would fail at run time.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith(
+      [{ ...mcpOauthApp(), is_team_shared: true }],
+      onConnectSelected,
+    )
+    await screen.findByText("Granola")
+
+    expect(
+      within(screen.getByTestId("connector-card-granola")).getByText(
+        "tools.mcp.sharing.teamTool",
+      ),
+    ).toBeTruthy()
+    fireEvent.click(screen.getByText("Granola"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Granola")
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
 })

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -1373,6 +1373,22 @@ export function ConnectMcpDialog({
                                         : t('tools.mcp.sharing.teamTool')}
                                   </Badge>
                                 )}
+                                {app.is_team_shared && !isGloballyConnected && (
+                                  // The one case the badge above cannot reach:
+                                  // it reads /api/connectors/status, which the
+                                  // picker fetches only for connected entries
+                                  // (and only when inTeam), so a connector the
+                                  // team shared with a member holding no
+                                  // connection of their own rendered exactly
+                                  // like an app nobody had connected at all
+                                  // (#1387). This one needs no inTeam gate of
+                                  // its own: is_team_shared arrives with the
+                                  // listing and cannot be true for a user no
+                                  // team shared anything with.
+                                  <Badge variant="secondary" className="font-medium px-2 py-0.5 rounded-md border border-blue-200 bg-blue-50 text-blue-700 shadow-none">
+                                    {t('tools.mcp.sharing.teamTool')}
+                                  </Badge>
+                                )}
                                 {app.needs_config && (
                                   <Badge variant="secondary" className="font-medium px-2 py-0.5 rounded-md border border-amber-200 bg-amber-50 text-amber-700 shadow-none">
                                     {t('tools.mcp.sharing.needsConfig')}

--- a/frontend/src/components/mcp/types.ts
+++ b/frontend/src/components/mcp/types.ts
@@ -50,8 +50,10 @@ export interface AppIntegration {
   // a connection of their own (#1387). A third state, not a synonym for
   // is_connected: the connector is usable without the viewer owning it, so the
   // card labels it as the team's and — for the shapes whose credentials are
-  // per-user — still offers the Connect route. Emitted on every entry of
-  // /api/mcp/apps, and always false where no team-visibility hook is installed.
+  // per-user — still offers the Connect route. Absent entirely on deployments
+  // without a team-visibility hook (standalone payloads stay pre-#1387);
+  // present-false means teams exist and nothing is shared with this viewer.
+  // Read absence as false, which Boolean() already does.
   is_team_shared?: boolean
   // Team-sharing status (from POST /api/connectors/status), merged in after list load.
   shared?: boolean

--- a/frontend/src/components/mcp/types.ts
+++ b/frontend/src/components/mcp/types.ts
@@ -46,6 +46,13 @@ export interface AppIntegration {
   // a deployment whose tokens arrive through the resolver hook, where no
   // interactive consent exists at all.
   can_authorize?: boolean
+  // Whether this connector reached the viewer through a team link rather than
+  // a connection of their own (#1387). A third state, not a synonym for
+  // is_connected: the connector is usable without the viewer owning it, so the
+  // card labels it as the team's and — for the shapes whose credentials are
+  // per-user — still offers the Connect route. Emitted on every entry of
+  // /api/mcp/apps, and always false where no team-visibility hook is installed.
+  is_team_shared?: boolean
   // Team-sharing status (from POST /api/connectors/status), merged in after list load.
   shared?: boolean
   is_owner?: boolean

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -36,7 +36,7 @@ from ...core.utils.encryption import decrypt_value, encrypt_value
 from ..auth_dependencies import get_current_user, is_admin_user
 from ..mcp_apps import (
     get_all_mcp_apps,
-    get_app_by_name,
+    get_app_for_mcp_server,
     restrict_to_app_scoped_oauth_grant,
 )
 from ..models.custom_api import CustomApi, UserCustomApi
@@ -1539,7 +1539,15 @@ def _enrich_oauth_server_info(
     if server.transport != "oauth":
         return None, None, None
 
-    app_info = get_app_by_name(db, str(server.name))
+    # By stable identity (auth.app_id) with a name fallback for legacy rows,
+    # not by name alone: an admin renaming an app leaves its provisioned row
+    # under the old name, and a name-only lookup then reports app_id None for
+    # exactly the row the catalog resolves through auth.app_id. The picker's
+    # selector resolution keys on this app_id to map the catalog entry back to
+    # its real row (findMatchingMcpServer), so losing it here persisted the
+    # display name of a row the runtime knows by another name — a selector
+    # that silently loads zero tools (#1403 review round 3).
+    app_info = get_app_for_mcp_server(db, server)
     if not app_info:
         return None, None, None
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2014,6 +2014,34 @@ def _local_mcp_can_authorize(
     return _local_mcp_consent_association_ok(server, user_mcp)
 
 
+def _team_row_matches_catalog_launch(app: dict, server: MCPServer) -> bool:
+    """Whether a name-matched team row really runs the app's official launch.
+
+    The connect endpoints refuse to adopt a same-named row whose configuration
+    differs (_ensure_catalog_app_server, _ensure_catalog_mcp_oauth_server:
+    "a victim would run a foreign command with their own key attached"), so the
+    personal path can never bind catalog branding to a foreign row. The team
+    path has no write-time gate -- the visibility hook shares whatever rows the
+    application names -- so the same comparison runs here, at read time, before
+    a row is rendered under the catalog's name and icon (#1403 review N1).
+
+    Transport equality is already enforced upstream: the non-oauth lookup keys
+    on ``(transport, name)``. What the lookup cannot see is the launch itself,
+    which is what each arm compares. Unknown shapes (``unconnectable``) decline
+    rather than claim -- there is no official launch to compare against.
+    """
+    launch = app.get("launch_config") or {}
+    auth_type = app.get("auth_type")
+    if auth_type in ("api_key", "keyless"):
+        return bool(
+            server.command == launch.get("command")
+            and (server.args or []) == (launch.get("args") or [])
+        )
+    if auth_type == "mcp_oauth":
+        return bool(server.url == launch.get("url"))
+    return False
+
+
 def _team_shared_server_for_app(
     app: dict,
     team_oauth_server_lookup: dict[str, list[MCPServer]],
@@ -2032,10 +2060,21 @@ def _team_shared_server_for_app(
     personal association and a team link resolves a row here too, and gets one
     entry that is connected and team-shared -- not a second entry, and not a
     connected entry that hides where the connector came from.
+
+    The non-oauth arm additionally requires the row to run the app's official
+    launch config (see _team_row_matches_catalog_launch); a same-named foreign
+    row yields no team-shared entry, falling back to the pre-#1387 state --
+    still listed by /api/mcp/servers, just never rendered in catalog shape. The
+    builtin_oauth arm needs no such check: _is_oauth_server_for_app matches on
+    the app_id/provider metadata our own provisioning writes, and the row
+    carries no caller-authored launch to misrepresent.
     """
     if app.get("auth_type") == "builtin_oauth":
         return _lookup_oauth_server_for_app(app, team_oauth_server_lookup)
-    return _non_oauth_server_for_app(app, team_non_oauth_server_lookup)
+    server = _non_oauth_server_for_app(app, team_non_oauth_server_lookup)
+    if server is not None and not _team_row_matches_catalog_launch(app, server):
+        return None
+    return server
 
 
 def _catalog_team_shared_can_attach(
@@ -2062,6 +2101,16 @@ def _catalog_team_shared_can_attach(
     unattachable and its card keeps the catalog Connect route -- "connect it for
     yourself", the same answer the ``mcp_oauth`` shape gets from
     ``_local_mcp_can_attach``'s grant term.
+
+    ``api_key`` is deliberately NOT credential-gated, mirroring every existing
+    path (a personally connected key app reports can_attach on the association
+    alone, and the local branch gates no shape but mcp_oauth). The key the
+    runtime will use may live on the row's platform env, the shared layer, or
+    -- when the team-env hook is installed -- the *governing agent's* team row,
+    which this user-scoped endpoint cannot see; refusing on "the member set no
+    key of their own" would say no where the runtime succeeds, the one
+    direction ``_local_mcp_can_attach``'s contract forbids. The env-source
+    flags (shared/platform/user_env) carry the needs-config signal instead.
     """
     if not _local_mcp_can_attach(
         server,
@@ -2177,6 +2226,23 @@ def list_mcp_apps(
 
     team_ids = visible_team_connector_ids(db, cast(int, current_user.id))
 
+    # Rows for team-visible ids the member holds no personal association for,
+    # fetched once for the whole response: the catalog branch indexes them
+    # below and the local branch overlays them as (server, None) rows, so
+    # neither branch re-queries what the other already loaded. The filter is
+    # the local branch's own membership rule -- "in the team answer, not in
+    # user_mcp_by_server_id" -- written once so the two branches cannot
+    # resolve different row sets.
+    team_only_mcp_rows: list[MCPServer] = []
+    if team_ids["mcp"]:
+        missing_team_mcp = [
+            sid for sid in team_ids["mcp"] if sid not in user_mcp_by_server_id
+        ]
+        if missing_team_mcp:
+            team_only_mcp_rows = (
+                db.query(MCPServer).filter(MCPServer.id.in_(missing_team_mcp)).all()
+            )
+
     # The team-visible rows, indexed by the same identity rules the personal
     # lookups above use. Deliberately a *second* pair of indexes rather than
     # extra entries in the first: the personal ones answer "is this catalog app
@@ -2185,23 +2251,16 @@ def list_mcp_apps(
     # does not have. Rows the member also holds an association for are included
     # -- ``is_team_shared`` describes the connector, not the absence of a
     # personal link -- and are read from ``user_mcps`` rather than re-queried.
+    # Skipped for location=local, whose branch never consults these indexes.
     team_oauth_server_lookup: dict[str, list[MCPServer]] = {}
     team_non_oauth_server_lookup: dict[tuple[str, str], MCPServer] = {}
-    if team_ids["mcp"]:
+    if team_ids["mcp"] and location in ["remote", "all"]:
         team_servers: list[tuple[MCPServer, Optional[UserMCPServer]]] = [
             (server, None)
             for server, _um in user_mcps
             if cast(int, server.id) in team_ids["mcp"]
         ]
-        already_loaded = {cast(int, server.id) for server, _um in team_servers}
-        missing_team_mcp = [sid for sid in team_ids["mcp"] if sid not in already_loaded]
-        if missing_team_mcp:
-            team_servers.extend(
-                (server, None)
-                for server in db.query(MCPServer)
-                .filter(MCPServer.id.in_(missing_team_mcp))
-                .all()
-            )
+        team_servers.extend((server, None) for server in team_only_mcp_rows)
         team_oauth_server_lookup = _build_active_oauth_server_lookup(team_servers)
         team_non_oauth_server_lookup = _build_active_non_oauth_server_lookup(
             team_servers
@@ -2343,20 +2402,13 @@ def list_mcp_apps(
         # (#1387).
         #
         # (server, user_mcp) for a personal row; (server, None) for a
-        # team-owned connector the user holds no association for. Excluding the
-        # ids already covered personally is what keeps a member who holds both
-        # from seeing the connector twice.
+        # team-owned connector the user holds no association for -- the rows
+        # already fetched above, since team_only_mcp_rows applies this branch's
+        # exact membership rule. Excluding the ids already covered personally
+        # is what keeps a member who holds both from seeing the connector
+        # twice.
         local_mcps: list[tuple[MCPServer, UserMCPServer | None]] = list(user_mcps)
-        missing_mcp = [
-            sid for sid in team_ids["mcp"] if sid not in user_mcp_by_server_id
-        ]
-        if missing_mcp:
-            local_mcps.extend(
-                (server, None)
-                for server in db.query(MCPServer)
-                .filter(MCPServer.id.in_(missing_mcp))
-                .all()
-            )
+        local_mcps.extend((server, None) for server in team_only_mcp_rows)
 
         # Skip the rows a catalog app's entry already speaks for, resolving the
         # row's connector identity the way _catalog_app_keys defines it. The old
@@ -2382,8 +2434,8 @@ def list_mcp_apps(
         # suppressed here while the catalog entry still offers Connect, which
         # 409s on the config mismatch (_ensure_catalog_app_server) — visible and
         # fixable from the Tools page, unreachable from the picker. A team-shared
-        # catalog connector loses its only picker entry the same way, which is
-        # pre-existing for most apps and tracked in #1387.
+        # catalog connector is skipped here the same way; its entry is the
+        # catalog branch's, which recognizes the team link (#1387).
         library_keys = {key for app in library_apps for key in _catalog_app_keys(app)}
         for server, user_mcp in local_mcps:
             if library_keys.intersection(_server_catalog_keys(server)):

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1733,8 +1733,33 @@ def _oauth_server_lookup_keys(server: MCPServer) -> list[str]:
     return _app_lookup_keys(server.name)
 
 
+def _team_oauth_server_lookup_keys(server: MCPServer) -> list[str]:
+    """``_oauth_server_lookup_keys`` minus the bare-provider fallback.
+
+    Providers are deliberately non-unique across apps (the meta/Instagram
+    siblings), so on the team path a row whose ``auth.app_id`` is blank or
+    absent must not be indexed under its provider: one malformed provider-only
+    row would satisfy *every* catalog app on that provider, branding them all
+    team-shared (#1403 review round 6). Team identity is the nonblank stable
+    app_id, or the row's own name for legacy rows that predate the metadata --
+    an exact match either way. The personal lookup keeps the provider fallback
+    it always had: there it answers "connected for me" against the member's own
+    rows, where over-matching moves a legacy row's tab rather than granting
+    another app's branding, and _is_oauth_server_for_app still gates the final
+    claim in both paths.
+    """
+    auth = getattr(server, "auth", None)
+    if isinstance(auth, dict):
+        auth_app_id = _normalize_app_key(auth.get("app_id"))
+        if auth_app_id:
+            return [auth_app_id]
+    return _app_lookup_keys(server.name)
+
+
 def _build_active_oauth_server_lookup(
     user_mcps: list[tuple[MCPServer, Optional[UserMCPServer]]],
+    *,
+    keys_for: Callable[[MCPServer], list[str]] = _oauth_server_lookup_keys,
 ) -> dict[str, list[MCPServer]]:
     """Index oauth-transport rows by the keys a catalog app resolves them under.
 
@@ -1743,7 +1768,9 @@ def _build_active_oauth_server_lookup(
     that gate belongs to the personal arm alone (``connector_visible_to_user``).
     Callers pass one population or the other, never both in one dict — a
     personal lookup answers "connected for me", a team lookup answers "shared
-    with me", and #1387 is what happens when those two are conflated.
+    with me", and #1387 is what happens when those two are conflated. The key
+    rule differs with the population too (``keys_for``): the team path indexes
+    without the bare-provider fallback (see _team_oauth_server_lookup_keys).
     """
     lookup: dict[str, list[MCPServer]] = {}
     for server, user_mcp in user_mcps:
@@ -1751,7 +1778,7 @@ def _build_active_oauth_server_lookup(
             continue
         if _normalize_app_key(server.transport) != "oauth":
             continue
-        for key in _oauth_server_lookup_keys(server):
+        for key in keys_for(server):
             lookup.setdefault(key, []).append(server)
     return lookup
 
@@ -2273,7 +2300,41 @@ def list_mcp_apps(
         visible_team_connector_ids,
     )
 
-    team_ids = visible_team_connector_ids(db, cast(int, current_user.id))
+    # The hook is optional application code, and hoisting the overlay above
+    # both branches means the default remote picker now runs it on every load
+    # -- so a raising hook or a malformed outer answer must surface as this
+    # seam's typed 503, the way resolve_team_connector_ids_or_raise already
+    # converts failures at the team-keyed boundary, not as a bare 500.
+    # Outer shape only: element-level id validation stays with the accessor
+    # (#1244), where it can land uniformly across every legacy call site.
+    try:
+        team_ids = visible_team_connector_ids(db, cast(int, current_user.id))
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve team connector visibility for user %s",
+            current_user.id,
+            exc_info=True,
+        )
+        # 503 literal: this function's `status` query param shadows
+        # fastapi.status in this scope.
+        raise HTTPException(
+            status_code=503,
+            detail="Connector team scope is unavailable.",
+        ) from exc
+    if (
+        not isinstance(team_ids, dict)
+        or not isinstance(team_ids.get("mcp"), set)
+        or not isinstance(team_ids.get("custom_api"), set)
+    ):
+        logger.warning(
+            "Team visibility hook returned a malformed answer for user %s: %r",
+            current_user.id,
+            type(team_ids).__name__,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Connector team scope is unavailable.",
+        )
     # is_team_shared is emitted only where the concept exists: an installed
     # hook answering "no teams shared anything with this user" is a real
     # present-false, while a standalone deployment gets no field at all, so
@@ -2317,7 +2378,9 @@ def list_mcp_apps(
             if cast(int, server.id) in team_ids["mcp"]
         ]
         team_servers.extend((server, None) for server in team_only_mcp_rows)
-        team_oauth_server_lookup = _build_active_oauth_server_lookup(team_servers)
+        team_oauth_server_lookup = _build_active_oauth_server_lookup(
+            team_servers, keys_for=_team_oauth_server_lookup_keys
+        )
         # Read-time analog of _reject_user_owned_catalog_squat: a user-owned
         # row must not render under catalog branding even when its launch
         # currently matches -- its owner keeps edit rights and could swap in a

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1765,11 +1765,19 @@ def _lookup_oauth_server_for_app(
 
 def _build_active_non_oauth_server_lookup(
     user_mcps: list[tuple[MCPServer, Optional[UserMCPServer]]],
-) -> dict[tuple[str, str], MCPServer]:
+) -> dict[tuple[str, str], list[MCPServer]]:
     """``(transport, name)`` index of non-oauth rows. ``None`` association means
     the row was reached through the team overlay — see the oauth twin above for
-    why that arm carries no ``is_active`` gate."""
-    lookup: dict[tuple[str, str], MCPServer] = {}
+    why that arm carries no ``is_active`` gate.
+
+    List-valued like that twin: distinct raw names can normalize to one key
+    ("Acme Notes"/`acme-notes`), and keeping only the first arrival would let
+    whichever row happens to sort earlier mask the rest from any consumer that
+    can tell them apart (the team resolution scans candidates against the
+    app's official launch config). Consumers that cannot — the personal
+    connected-state path — take the first candidate, preserving the exact
+    first-wins semantics the old single-valued index had."""
+    lookup: dict[tuple[str, str], list[MCPServer]] = {}
     for server, user_mcp in user_mcps:
         transport = _normalize_app_key(server.transport)
         server_name = _normalize_app_key(server.name)
@@ -1777,7 +1785,7 @@ def _build_active_non_oauth_server_lookup(
             continue
         if not transport or transport == "oauth" or not server_name:
             continue
-        lookup.setdefault((transport, server_name), server)
+        lookup.setdefault((transport, server_name), []).append(server)
     return lookup
 
 
@@ -1856,38 +1864,43 @@ def _app_user_env_configured(
     return _env_covers_required(getattr(assoc, "env", None), required)
 
 
-def _non_oauth_server_for_app(
-    app: dict, non_oauth_server_lookup: dict[tuple[str, str], MCPServer]
-) -> Optional[MCPServer]:
-    """The row in ``non_oauth_server_lookup`` that backs this catalog app.
+def _non_oauth_servers_for_app(
+    app: dict, non_oauth_server_lookup: dict[tuple[str, str], list[MCPServer]]
+) -> list[MCPServer]:
+    """The rows in ``non_oauth_server_lookup`` that could back this catalog app.
 
     The identity rule alone — transport plus one of ``_catalog_app_keys`` — with
-    no claim about *why* the row is in the lookup. What the answer means is the
-    caller's: the same rule resolves "connected for me" against the personal
-    index and "shared with me" against the team one (#1387).
+    no claim about *why* a row is in the lookup or which candidate is the right
+    one. What the answer means is the caller's: the personal connected-state
+    path takes the first candidate ("connected for me", first-wins as always),
+    while the team resolution scans them against the official launch config
+    ("shared with me", #1387). Candidates keep key order and dedupe by object,
+    mirroring ``_lookup_oauth_server_for_app``.
     """
     app_transport = _normalize_app_key(app.get("transport"))
     if not app_transport or app_transport == "oauth":
-        return None
+        return []
 
-    return next(
-        (
-            non_oauth_server_lookup[(app_transport, app_key)]
-            for app_key in _catalog_app_keys(app)
-            if (app_transport, app_key) in non_oauth_server_lookup
-        ),
-        None,
-    )
+    seen_servers: set[int] = set()
+    candidates: list[MCPServer] = []
+    for app_key in _catalog_app_keys(app):
+        for server in non_oauth_server_lookup.get((app_transport, app_key), []):
+            marker = id(server)
+            if marker in seen_servers:
+                continue
+            seen_servers.add(marker)
+            candidates.append(server)
+    return candidates
 
 
 def _connected_non_oauth_server_for_app(
-    app: dict, non_oauth_server_lookup: dict[tuple[str, str], MCPServer]
+    app: dict, non_oauth_server_lookup: dict[tuple[str, str], list[MCPServer]]
 ) -> Optional[int]:
-    server = _non_oauth_server_for_app(app, non_oauth_server_lookup)
-    if not server:
+    servers = _non_oauth_servers_for_app(app, non_oauth_server_lookup)
+    if not servers:
         return None
 
-    return cast(int, server.id)
+    return cast(int, servers[0].id)
 
 
 def _is_mcp_oauth_server(server: MCPServer) -> bool:
@@ -2038,14 +2051,24 @@ def _team_row_matches_catalog_launch(app: dict, server: MCPServer) -> bool:
             and (server.args or []) == (launch.get("args") or [])
         )
     if auth_type == "mcp_oauth":
-        return bool(server.url == launch.get("url"))
+        # The auth shape is part of the identity, not just the URL: a same-URL
+        # row whose auth is bearer/api-key/absent would otherwise claim the
+        # mcp_oauth identity while _local_mcp_can_attach, seeing a non-oauth
+        # shape, skips the grant gate every real mcp_oauth row is subject to.
+        # A legitimately provisioned row always passes -- the ensure helper
+        # writes the catalog's auth (type "mcp_oauth" by classification), and
+        # encryption touches only SENSITIVE_AUTH_FIELDS values, never `type`.
+        # Deliberately not full auth-dict equality: the catalog syncs a row's
+        # auth at connect time only, so a row that predates a catalog auth
+        # edit is stale but still the app's own row.
+        return bool(server.url == launch.get("url") and _is_mcp_oauth_server(server))
     return False
 
 
 def _team_shared_server_for_app(
     app: dict,
     team_oauth_server_lookup: dict[str, list[MCPServer]],
-    team_non_oauth_server_lookup: dict[tuple[str, str], MCPServer],
+    team_non_oauth_server_lookup: dict[tuple[str, str], list[MCPServer]],
 ) -> Optional[MCPServer]:
     """The team-visible row backing this catalog app, if the member has one.
 
@@ -2062,19 +2085,26 @@ def _team_shared_server_for_app(
     connected entry that hides where the connector came from.
 
     The non-oauth arm additionally requires the row to run the app's official
-    launch config (see _team_row_matches_catalog_launch); a same-named foreign
-    row yields no team-shared entry, falling back to the pre-#1387 state --
-    still listed by /api/mcp/servers, just never rendered in catalog shape. The
+    launch config (see _team_row_matches_catalog_launch), scanning every
+    same-key candidate rather than only the first: two team-visible rows can
+    normalize to one key, and giving the earlier-sorted foreign row a veto
+    would mask the app's own row behind it. A key with no matching candidate
+    yields no team-shared entry, falling back to the pre-#1387 state -- still
+    listed by /api/mcp/servers, just never rendered in catalog shape. The
     builtin_oauth arm needs no such check: _is_oauth_server_for_app matches on
     the app_id/provider metadata our own provisioning writes, and the row
     carries no caller-authored launch to misrepresent.
     """
     if app.get("auth_type") == "builtin_oauth":
         return _lookup_oauth_server_for_app(app, team_oauth_server_lookup)
-    server = _non_oauth_server_for_app(app, team_non_oauth_server_lookup)
-    if server is not None and not _team_row_matches_catalog_launch(app, server):
-        return None
-    return server
+    return next(
+        (
+            server
+            for server in _non_oauth_servers_for_app(app, team_non_oauth_server_lookup)
+            if _team_row_matches_catalog_launch(app, server)
+        ),
+        None,
+    )
 
 
 def _catalog_team_shared_can_attach(
@@ -2096,8 +2126,9 @@ def _catalog_team_shared_can_attach(
     ``builtin_oauth`` authorization is the member's own provider login, held on
     ``UserOAuth`` and never on the shared row, so sharing the connector shares
     no credential for it: attachable only once the member has a usable account
-    of their own, which is also the state ``is_connected`` would report if they
-    additionally held a personal association. Without one the entry stays
+    of their own (or a resolver hook supplies the deployment's tokens out of
+    band -- see below), which is also the state ``is_connected`` would report
+    if they additionally held a personal association. Without one the entry stays
     unattachable and its card keeps the catalog Connect route -- "connect it for
     yourself", the same answer the ``mcp_oauth`` shape gets from
     ``_local_mcp_can_attach``'s grant term.
@@ -2121,6 +2152,15 @@ def _catalog_team_shared_can_attach(
     ):
         return False
     if app.get("auth_type") != "builtin_oauth":
+        return True
+    # The resolver hook outranks the account check, mirroring how
+    # _local_mcp_can_attach treats it for the mcp_oauth shape: the runtime
+    # resolves every transport=="oauth" server's token through the installed
+    # hook first and falls back to UserOAuth only without one, so on a
+    # resolver deployment the row runs with no account at all. Same
+    # approximation as there -- the hook is probed for presence, not for this
+    # provider and user.
+    if token_resolver_installed:
         return True
     return any(key in oauth_account_lookup for key in _oauth_keys_for_app(app))
 
@@ -2253,7 +2293,7 @@ def list_mcp_apps(
     # personal link -- and are read from ``user_mcps`` rather than re-queried.
     # Skipped for location=local, whose branch never consults these indexes.
     team_oauth_server_lookup: dict[str, list[MCPServer]] = {}
-    team_non_oauth_server_lookup: dict[tuple[str, str], MCPServer] = {}
+    team_non_oauth_server_lookup: dict[tuple[str, str], list[MCPServer]] = {}
     if team_ids["mcp"] and location in ["remote", "all"]:
         team_servers: list[tuple[MCPServer, Optional[UserMCPServer]]] = [
             (server, None)

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1784,7 +1784,10 @@ def _build_active_oauth_server_lookup(
 
 
 def _lookup_oauth_server_for_app(
-    app: dict, oauth_server_lookup: dict[str, list[MCPServer]]
+    app: dict,
+    oauth_server_lookup: dict[str, list[MCPServer]],
+    *,
+    matches: Callable[[MCPServer, dict], bool] = _is_oauth_server_for_app,
 ) -> Optional[MCPServer]:
     seen_servers: set[int] = set()
     for key in _app_lookup_keys(app.get("id"), app.get("provider"), app.get("name")):
@@ -1793,9 +1796,35 @@ def _lookup_oauth_server_for_app(
             if marker in seen_servers:
                 continue
             seen_servers.add(marker)
-            if _is_oauth_server_for_app(server, app):
+            if matches(server, app):
                 return server
     return None
+
+
+def _is_team_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
+    """``_is_oauth_server_for_app`` without the provider-metadata acceptance.
+
+    The team index already refuses to key rows by bare provider
+    (_team_oauth_server_lookup_keys), but a row *named* the provider string
+    itself (name "acme", blank app_id, provider "acme") lands under that key
+    through its name — and the shared matcher would then accept it for every
+    same-provider app via its provider metadata (#1403 review round 7). On the
+    team path identity must be exact: a nonblank ``auth.app_id`` equal to the
+    app's id, or a row name that is one of the app's own catalog keys. The
+    personal matcher keeps its provider tolerance, where the population is the
+    member's own rows and over-matching is cosmetic.
+    """
+    if server.transport != "oauth":
+        return False
+
+    auth = getattr(server, "auth", None)
+    if isinstance(auth, dict):
+        auth_app_id = _normalize_app_key(auth.get("app_id"))
+        if auth_app_id:
+            return auth_app_id == _normalize_app_key(app.get("id"))
+
+    server_name = _normalize_app_key(server.name)
+    return bool(server_name and server_name in _catalog_app_keys(app))
 
 
 def _build_active_non_oauth_server_lookup(
@@ -2126,12 +2155,16 @@ def _team_shared_server_for_app(
     would mask the app's own row behind it. A key with no matching candidate
     yields no team-shared entry, falling back to the pre-#1387 state -- still
     listed by /api/mcp/servers, just never rendered in catalog shape. The
-    builtin_oauth arm needs no such check: _is_oauth_server_for_app matches on
-    the app_id/provider metadata our own provisioning writes, and the row
-    carries no caller-authored launch to misrepresent.
+    builtin_oauth arm needs no launch check -- the row carries no
+    caller-authored launch to misrepresent -- but matches on exact identity
+    only (_is_team_oauth_server_for_app): a nonblank auth.app_id equal to the
+    app's id, or a row named one of the app's own catalog keys, never the
+    provider metadata the personal matcher tolerates.
     """
     if app.get("auth_type") == "builtin_oauth":
-        return _lookup_oauth_server_for_app(app, team_oauth_server_lookup)
+        return _lookup_oauth_server_for_app(
+            app, team_oauth_server_lookup, matches=_is_team_oauth_server_for_app
+        )
     return next(
         (
             server
@@ -2507,7 +2540,8 @@ def list_mcp_apps(
             # api_key resolves at runtime from the platform/shared/user/
             # governing-team env layers, and the oauth shapes are further gated
             # in _catalog_team_shared_can_attach on the member's own grant or
-            # account (#1387).
+            # account -- or on an installed token-resolver hook, which supplies
+            # the deployment's tokens out of band and satisfies both (#1387).
             app_copy["can_attach"] = is_connected or (
                 team_server is not None
                 and _catalog_team_shared_can_attach(

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2310,8 +2310,34 @@ def list_mcp_apps(
         ]
         team_servers.extend((server, None) for server in team_only_mcp_rows)
         team_oauth_server_lookup = _build_active_oauth_server_lookup(team_servers)
+        # Read-time analog of _reject_user_owned_catalog_squat: a user-owned
+        # row must not render under catalog branding even when its launch
+        # currently matches -- its owner keeps edit rights and could swap in a
+        # foreign command *after* a member attaches the officially-branded
+        # entry, which the persisted selection would keep executing. The
+        # legitimate shared row for these shapes never has an owner (catalog
+        # connects write is_owner=False; the row itself is created
+        # association-less). Non-oauth arm only, deliberately: builtin_oauth
+        # provisioning makes the first connector an owner by design
+        # (_ensure_user_mcp_server), and that row carries no caller-authored
+        # launch for the runtime to execute.
+        owned_team_ids = {
+            row[0]
+            for row in db.query(UserMCPServer.mcpserver_id)
+            .filter(
+                UserMCPServer.mcpserver_id.in_(
+                    [cast(int, server.id) for server, _um in team_servers]
+                ),
+                UserMCPServer.is_owner.is_(True),
+            )
+            .all()
+        }
         team_non_oauth_server_lookup = _build_active_non_oauth_server_lookup(
-            team_servers
+            [
+                (server, um)
+                for server, um in team_servers
+                if cast(int, server.id) not in owned_team_ids
+            ]
         )
 
     if location in ["remote", "all"]:
@@ -2404,8 +2430,11 @@ def list_mcp_apps(
             # A team link is the one way that prerequisite is met without a
             # personal association: the runtime resolves team-owned rows by the
             # same overlay (_load_visible_runtime_connectors), so the connector
-            # really does run -- for the shapes whose credentials ride on the
-            # shared row rather than on the member (#1387).
+            # really does run. Credentials are per-shape: keyless needs none,
+            # api_key resolves at runtime from the platform/shared/user/
+            # governing-team env layers, and the oauth shapes are further gated
+            # in _catalog_team_shared_can_attach on the member's own grant or
+            # account (#1387).
             app_copy["can_attach"] = is_connected or (
                 team_server is not None
                 and _catalog_team_shared_can_attach(

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2268,11 +2268,19 @@ def list_mcp_apps(
     # branch (#1387). Standalone deployments install no hook, resolve empty, and
     # take exactly the path they always did.
     from ..services.connector_team_scope import (
+        connector_visibility_hook_installed,
         connector_visible_to_user,
         visible_team_connector_ids,
     )
 
     team_ids = visible_team_connector_ids(db, cast(int, current_user.id))
+    # is_team_shared is emitted only where the concept exists: an installed
+    # hook answering "no teams shared anything with this user" is a real
+    # present-false, while a standalone deployment gets no field at all, so
+    # its payloads stay exactly what they were before #1387 (the #1321/#1387
+    # compatibility line). Consumers already read absence as false
+    # (types.ts marks the field optional).
+    team_hook_installed = connector_visibility_hook_installed()
 
     # Rows for team-visible ids the member holds no personal association for,
     # fetched once for the whole response: the catalog branch indexes them
@@ -2421,8 +2429,10 @@ def list_mcp_apps(
             # personal association establishes; a team-shared connector is
             # usable without one, and folding the two together would claim an
             # ownership the member does not have and hide the Connect route the
-            # oauth shapes still need.
-            app_copy["is_team_shared"] = is_team_shared
+            # oauth shapes still need. Absent on standalone deployments (see
+            # team_hook_installed above).
+            if team_hook_installed:
+                app_copy["is_team_shared"] = is_team_shared
             # A catalog app the user never connected has no association row at
             # all, so there is no connector to attach -- connecting really is
             # the prerequisite. Stating that here is what stops the picker from
@@ -2548,13 +2558,17 @@ def list_mcp_apps(
                 "is_local": True,
                 "server_id": server.id,
                 "is_custom": True,
-                # Same meaning the catalog branch gives it (#1387): the
-                # connector reached this member through a team link. Emitted on
-                # both branches so a consumer never has to read the field's
-                # absence as "no", and computed from the ids rather than from
-                # `user_mcp is None`, which would go false the moment a member
-                # also connected the connector for themselves.
-                "is_team_shared": cast(int, server.id) in team_ids["mcp"],
+                # Same meaning and same presence rule as the catalog branch
+                # (#1387): the connector reached this member through a team
+                # link; absent on standalone deployments. Computed from the
+                # ids rather than from `user_mcp is None`, which would go
+                # false the moment a member also connected the connector for
+                # themselves.
+                **(
+                    {"is_team_shared": cast(int, server.id) in team_ids["mcp"]}
+                    if team_hook_installed
+                    else {}
+                ),
                 "can_attach": _local_mcp_can_attach(
                     server,
                     user_mcp,
@@ -2646,7 +2660,11 @@ def list_mcp_apps(
                     "is_local": True,
                     "server_id": api.id,
                     "is_custom": True,
-                    "is_team_shared": cast(int, api.id) in team_ids["custom_api"],
+                    **(
+                        {"is_team_shared": cast(int, api.id) in team_ids["custom_api"]}
+                        if team_hook_installed
+                        else {}
+                    ),
                     # A Custom API carries its own credentials on the row and
                     # has no OAuth consent step of any kind, so credentials
                     # never gate it and consent is never meaningful -- which is

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1726,11 +1726,22 @@ def _oauth_server_lookup_keys(server: MCPServer) -> list[str]:
 
 
 def _build_active_oauth_server_lookup(
-    user_mcps: list[tuple[MCPServer, UserMCPServer]],
+    user_mcps: list[tuple[MCPServer, Optional[UserMCPServer]]],
 ) -> dict[str, list[MCPServer]]:
+    """Index oauth-transport rows by the keys a catalog app resolves them under.
+
+    ``user_mcp`` is ``None`` for a row reached through the team overlay rather
+    than a personal association, and such a row is never gated on ``is_active``:
+    that gate belongs to the personal arm alone (``connector_visible_to_user``).
+    Callers pass one population or the other, never both in one dict — a
+    personal lookup answers "connected for me", a team lookup answers "shared
+    with me", and #1387 is what happens when those two are conflated.
+    """
     lookup: dict[str, list[MCPServer]] = {}
     for server, user_mcp in user_mcps:
-        if not user_mcp.is_active or _normalize_app_key(server.transport) != "oauth":
+        if user_mcp is not None and not user_mcp.is_active:
+            continue
+        if _normalize_app_key(server.transport) != "oauth":
             continue
         for key in _oauth_server_lookup_keys(server):
             lookup.setdefault(key, []).append(server)
@@ -1753,18 +1764,18 @@ def _lookup_oauth_server_for_app(
 
 
 def _build_active_non_oauth_server_lookup(
-    user_mcps: list[tuple[MCPServer, UserMCPServer]],
+    user_mcps: list[tuple[MCPServer, Optional[UserMCPServer]]],
 ) -> dict[tuple[str, str], MCPServer]:
+    """``(transport, name)`` index of non-oauth rows. ``None`` association means
+    the row was reached through the team overlay — see the oauth twin above for
+    why that arm carries no ``is_active`` gate."""
     lookup: dict[tuple[str, str], MCPServer] = {}
     for server, user_mcp in user_mcps:
         transport = _normalize_app_key(server.transport)
         server_name = _normalize_app_key(server.name)
-        if (
-            not user_mcp.is_active
-            or not transport
-            or transport == "oauth"
-            or not server_name
-        ):
+        if user_mcp is not None and not user_mcp.is_active:
+            continue
+        if not transport or transport == "oauth" or not server_name:
             continue
         lookup.setdefault((transport, server_name), server)
     return lookup
@@ -1845,14 +1856,21 @@ def _app_user_env_configured(
     return _env_covers_required(getattr(assoc, "env", None), required)
 
 
-def _connected_non_oauth_server_for_app(
+def _non_oauth_server_for_app(
     app: dict, non_oauth_server_lookup: dict[tuple[str, str], MCPServer]
-) -> Optional[int]:
+) -> Optional[MCPServer]:
+    """The row in ``non_oauth_server_lookup`` that backs this catalog app.
+
+    The identity rule alone — transport plus one of ``_catalog_app_keys`` — with
+    no claim about *why* the row is in the lookup. What the answer means is the
+    caller's: the same rule resolves "connected for me" against the personal
+    index and "shared with me" against the team one (#1387).
+    """
     app_transport = _normalize_app_key(app.get("transport"))
     if not app_transport or app_transport == "oauth":
         return None
 
-    server = next(
+    return next(
         (
             non_oauth_server_lookup[(app_transport, app_key)]
             for app_key in _catalog_app_keys(app)
@@ -1860,6 +1878,12 @@ def _connected_non_oauth_server_for_app(
         ),
         None,
     )
+
+
+def _connected_non_oauth_server_for_app(
+    app: dict, non_oauth_server_lookup: dict[tuple[str, str], MCPServer]
+) -> Optional[int]:
+    server = _non_oauth_server_for_app(app, non_oauth_server_lookup)
     if not server:
         return None
 
@@ -1990,6 +2014,68 @@ def _local_mcp_can_authorize(
     return _local_mcp_consent_association_ok(server, user_mcp)
 
 
+def _team_shared_server_for_app(
+    app: dict,
+    team_oauth_server_lookup: dict[str, list[MCPServer]],
+    team_non_oauth_server_lookup: dict[tuple[str, str], MCPServer],
+) -> Optional[MCPServer]:
+    """The team-visible row backing this catalog app, if the member has one.
+
+    Resolved by the same two rules the catalog branch's own connected-state
+    lookups use, against team-keyed indexes instead of personal ones -- which is
+    the whole of #1387: the branch could answer "connected for me" and nothing
+    else, so a connector a team shared with a member had no entry at all (the
+    local branch drops every catalog-keyed row, deliberately, to stay free of
+    the #1346 duplicate).
+
+    Independent of connection state on purpose. A member holding *both* a
+    personal association and a team link resolves a row here too, and gets one
+    entry that is connected and team-shared -- not a second entry, and not a
+    connected entry that hides where the connector came from.
+    """
+    if app.get("auth_type") == "builtin_oauth":
+        return _lookup_oauth_server_for_app(app, team_oauth_server_lookup)
+    return _non_oauth_server_for_app(app, team_non_oauth_server_lookup)
+
+
+def _catalog_team_shared_can_attach(
+    app: dict,
+    server: MCPServer,
+    *,
+    oauth_account_lookup: dict[str, object],
+    team_mcp_ids: Collection[int],
+    active_grant_server_ids: set[int],
+    token_resolver_installed: bool,
+) -> bool:
+    """Whether a team-shared catalog entry may be selected into an agent (#1387).
+
+    ``_local_mcp_can_attach``'s rule -- visible to the runtime AND credentials
+    that plausibly resolve -- delegated rather than restated, plus the one term
+    that rule never needed: ``builtin_oauth``. A catalog-keyed row never reaches
+    the local branch, so that shape had no attachability rule anywhere.
+
+    ``builtin_oauth`` authorization is the member's own provider login, held on
+    ``UserOAuth`` and never on the shared row, so sharing the connector shares
+    no credential for it: attachable only once the member has a usable account
+    of their own, which is also the state ``is_connected`` would report if they
+    additionally held a personal association. Without one the entry stays
+    unattachable and its card keeps the catalog Connect route -- "connect it for
+    yourself", the same answer the ``mcp_oauth`` shape gets from
+    ``_local_mcp_can_attach``'s grant term.
+    """
+    if not _local_mcp_can_attach(
+        server,
+        None,
+        team_mcp_ids=team_mcp_ids,
+        active_grant_server_ids=active_grant_server_ids,
+        token_resolver_installed=token_resolver_installed,
+    ):
+        return False
+    if app.get("auth_type") != "builtin_oauth":
+        return True
+    return any(key in oauth_account_lookup for key in _oauth_keys_for_app(app))
+
+
 @mcp_router.get("/apps", response_model=List[dict])
 def list_mcp_apps(
     search: Optional[str] = None,
@@ -2076,6 +2162,51 @@ def list_mcp_apps(
 
     token_resolver_installed = oauth_token_resolver_installed()
 
+    # Sharing a connector with a team writes a team link row and no per-member
+    # association, so every personal query above resolves nothing for every
+    # member but the creator. Resolved once for the whole response, above both
+    # branches: the local branch overlays these ids to list team-owned custom
+    # connectors (#1321), and the catalog branch resolves the same ids to
+    # recognize a team-shared *catalog* connector, which had no entry on either
+    # branch (#1387). Standalone deployments install no hook, resolve empty, and
+    # take exactly the path they always did.
+    from ..services.connector_team_scope import (
+        connector_visible_to_user,
+        visible_team_connector_ids,
+    )
+
+    team_ids = visible_team_connector_ids(db, cast(int, current_user.id))
+
+    # The team-visible rows, indexed by the same identity rules the personal
+    # lookups above use. Deliberately a *second* pair of indexes rather than
+    # extra entries in the first: the personal ones answer "is this catalog app
+    # connected for me", which only a personal association can establish, and
+    # folding a team link into that answer would report a connection the member
+    # does not have. Rows the member also holds an association for are included
+    # -- ``is_team_shared`` describes the connector, not the absence of a
+    # personal link -- and are read from ``user_mcps`` rather than re-queried.
+    team_oauth_server_lookup: dict[str, list[MCPServer]] = {}
+    team_non_oauth_server_lookup: dict[tuple[str, str], MCPServer] = {}
+    if team_ids["mcp"]:
+        team_servers: list[tuple[MCPServer, Optional[UserMCPServer]]] = [
+            (server, None)
+            for server, _um in user_mcps
+            if cast(int, server.id) in team_ids["mcp"]
+        ]
+        already_loaded = {cast(int, server.id) for server, _um in team_servers}
+        missing_team_mcp = [sid for sid in team_ids["mcp"] if sid not in already_loaded]
+        if missing_team_mcp:
+            team_servers.extend(
+                (server, None)
+                for server in db.query(MCPServer)
+                .filter(MCPServer.id.in_(missing_team_mcp))
+                .all()
+            )
+        team_oauth_server_lookup = _build_active_oauth_server_lookup(team_servers)
+        team_non_oauth_server_lookup = _build_active_non_oauth_server_lookup(
+            team_servers
+        )
+
     if location in ["remote", "all"]:
         for app in library_apps:
             if app.get("auth_type") == "builtin_oauth":
@@ -2115,6 +2246,22 @@ def list_mcp_apps(
                 )
                 app_env_source = getattr(_assoc, "env_source", None)
             is_connected = server_id is not None
+            team_server = _team_shared_server_for_app(
+                app, team_oauth_server_lookup, team_non_oauth_server_lookup
+            )
+            # Delegated to the overlay's own predicate rather than settled by
+            # the lookup hit alone. The two can disagree: the row query that
+            # fills those indexes is a SQL `IN`, which SQLite's numeric affinity
+            # lets a hook's *string* id match, while this predicate compares in
+            # Python and does not. `can_attach` below already resolves that
+            # disagreement the strict way (through _local_mcp_can_attach), so
+            # deciding the flag any other way would badge a card "Team tool"
+            # that the same response refuses to attach.
+            is_team_shared = team_server is not None and connector_visible_to_user(
+                association=None,
+                connector_id=cast(int, team_server.id),
+                team_ids=team_ids["mcp"],
+            )
             is_visible_in_connector = app.get("is_visible_in_connector", True)
 
             # Strong hide mode: hidden public apps are removed from the
@@ -2136,11 +2283,33 @@ def list_mcp_apps(
 
             app_copy = app.copy()
             app_copy["is_connected"] = is_connected
+            # A third state, distinct from is_connected on purpose (#1387).
+            # is_connected keeps answering "connected *for me*", which only a
+            # personal association establishes; a team-shared connector is
+            # usable without one, and folding the two together would claim an
+            # ownership the member does not have and hide the Connect route the
+            # oauth shapes still need.
+            app_copy["is_team_shared"] = is_team_shared
             # A catalog app the user never connected has no association row at
             # all, so there is no connector to attach -- connecting really is
             # the prerequisite. Stating that here is what stops the picker from
             # inferring it from is_custom's absence on this branch (#1347).
-            app_copy["can_attach"] = is_connected
+            # A team link is the one way that prerequisite is met without a
+            # personal association: the runtime resolves team-owned rows by the
+            # same overlay (_load_visible_runtime_connectors), so the connector
+            # really does run -- for the shapes whose credentials ride on the
+            # shared row rather than on the member (#1387).
+            app_copy["can_attach"] = is_connected or (
+                team_server is not None
+                and _catalog_team_shared_can_attach(
+                    app,
+                    team_server,
+                    oauth_account_lookup=oauth_account_lookup,
+                    team_mcp_ids=team_ids["mcp"],
+                    active_grant_server_ids=active_grant_server_ids,
+                    token_resolver_installed=token_resolver_installed,
+                )
+            )
             app_copy["can_authorize"] = False
             app_copy["shared_env_available"] = app_shared_env
             app_copy["platform_env_available"] = app_platform_env
@@ -2153,28 +2322,26 @@ def list_mcp_apps(
                 if connected_account:
                     app_copy["connected_account"] = connected_account
 
-            if status == "verified" and not app_copy["is_connected"]:
+            # The picker's status filter narrows to "connectors backing a real
+            # connection", which a team-shared one does even though no personal
+            # association records it -- withholding it here would put the
+            # connector back out of reach for any member browsing under the
+            # filter, which is the reach #1387 is about. The local branch
+            # applies no status filter at all, so this keeps the two consistent
+            # for team-shared connectors rather than splitting them again.
+            if status == "verified" and not (is_connected or is_team_shared):
                 continue
 
             results.append(app_copy)
 
     if location in ["local", "all"]:
-        # Sharing a connector with a team writes a team link row and no
-        # per-member association, so the personal queries above resolve nothing
-        # for every member but the creator. Overlay the team-owned ids the way
-        # get_mcp_servers does, or the Tools page would list a connector the
-        # picker cannot offer (#1321). Scoped to this branch on purpose: the
-        # remote branch's lookups answer "is this catalog app connected *for
-        # me*", which only a personal association can establish. Standalone
-        # deployments install no hook, resolve empty, and take the same path
-        # they always did.
-        from ..services.connector_team_scope import (
-            connector_visible_to_user,
-            visible_team_connector_ids,
-        )
-
-        team_ids = visible_team_connector_ids(db, cast(int, current_user.id))
-
+        # Overlay the team-owned ids resolved above the way get_mcp_servers
+        # does, or the Tools page would list a connector the picker cannot
+        # offer (#1321). The catalog branch reads the same ids but never the
+        # same answer: there they establish "shared with me", a state distinct
+        # from the "connected for me" only a personal association can give
+        # (#1387).
+        #
         # (server, user_mcp) for a personal row; (server, None) for a
         # team-owned connector the user holds no association for. Excluding the
         # ids already covered personally is what keeps a member who holds both
@@ -2252,6 +2419,13 @@ def list_mcp_apps(
                 "is_local": True,
                 "server_id": server.id,
                 "is_custom": True,
+                # Same meaning the catalog branch gives it (#1387): the
+                # connector reached this member through a team link. Emitted on
+                # both branches so a consumer never has to read the field's
+                # absence as "no", and computed from the ids rather than from
+                # `user_mcp is None`, which would go false the moment a member
+                # also connected the connector for themselves.
+                "is_team_shared": cast(int, server.id) in team_ids["mcp"],
                 "can_attach": _local_mcp_can_attach(
                     server,
                     user_mcp,
@@ -2343,6 +2517,7 @@ def list_mcp_apps(
                     "is_local": True,
                     "server_id": api.id,
                     "is_custom": True,
+                    "is_team_shared": cast(int, api.id) in team_ids["custom_api"],
                     # A Custom API carries its own credentials on the row and
                     # has no OAuth consent step of any kind, so credentials
                     # never gate it and consent is never meaningful -- which is

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -142,6 +142,20 @@ def visible_team_connector_ids(db: Any, user_id: int) -> dict[str, set[int]]:
     return _connector_visibility_hook(db, int(user_id))
 
 
+def connector_visibility_hook_installed() -> bool:
+    """Whether an application installed the user-keyed visibility hook.
+
+    The twin of ``team_connector_hook_installed`` for the legacy hook.
+    Callers select on this, never on an empty return value: an installed hook
+    legitimately answers with empty sets for a user no team shared anything
+    with. What separates the two states is meaning, not content — "this
+    deployment has no team sharing at all" versus "team sharing exists and
+    this user has none" — and a response field that should be absent in the
+    first state but present-false in the second needs the distinction.
+    """
+    return _connector_visibility_hook is not None
+
+
 def _validate_team_connector_answer(answer: Any) -> dict[str, set[int]]:
     """Validate the team-visibility hook's answer shape.
 

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -84,6 +84,18 @@ def _reset_connector_team_hooks():
     connector_team_scope.set_connector_team_hooks()
 
 
+@pytest.fixture()
+def _token_resolver_installed():
+    """Install a token-resolver hook for the test's duration. Presence is all
+    the listing probes (`oauth_token_resolver_installed`), so the body never
+    runs."""
+    from xagent.web.tools.config import set_oauth_token_resolver_hook
+
+    set_oauth_token_resolver_hook(lambda **_kwargs: None)
+    yield
+    set_oauth_token_resolver_hook(None)
+
+
 def _install_visibility(
     user: User, server_ids: set[int], custom_api_ids: set[int] | None = None
 ) -> None:
@@ -456,6 +468,61 @@ def test_a_team_row_pointing_at_a_foreign_url_is_not_claimed(db_session):
     assert entry["can_attach"] is False
 
 
+@pytest.mark.parametrize(
+    "auth",
+    [{"type": "bearer", "bearer_token": "shared-token"}, None],
+    ids=["bearer", "no-auth"],
+)
+def test_a_team_row_with_a_foreign_auth_shape_is_not_claimed(db_session, auth):
+    """The same URL is not enough for the mcp_oauth identity: the auth shape is
+    part of it. A same-URL row whose auth is bearer or absent reads as a
+    non-oauth shape to _local_mcp_can_attach, which would skip the grant gate
+    every real mcp_oauth row is subject to — catalog branding on different
+    credential semantics (#1403 review, F1 round 2)."""
+    db, _creator, member = db_session
+    _add_mcp_oauth_app(db, "acme-remote", "Acme Remote")
+    config = {
+        "name": "acme-remote",
+        "managed": "external",
+        "transport": "streamable_http",
+        "url": _MCP_OAUTH_LAUNCH["url"],
+    }
+    if auth is not None:
+        config["auth"] = auth
+    row = _add_server_row(db, config)
+    _install_visibility(member, {int(row.id)})
+
+    entry = _entry(db, member, "acme-remote")
+    assert entry["is_team_shared"] is False
+    assert entry["can_attach"] is False
+
+
+def test_a_colliding_foreign_row_does_not_mask_the_official_row(db_session):
+    """Two team-visible rows can normalize to one (transport, name) key —
+    "Acme Notes" and `acme-notes` — and the index keeps every candidate, so
+    the earlier-sorted foreign row gets no veto: the team resolution scans
+    candidates against the official launch config and claims the row that
+    actually runs it (#1403 review round 2)."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    # Inserted first, so it sorts first in every candidate list.
+    foreign = _add_server_row(
+        db,
+        {
+            "name": "Acme Notes",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "evil-mcp",
+        },
+    )
+    official = _add_catalog_server(db, "acme-notes")
+    _install_visibility(member, {int(foreign.id), int(official.id)})
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+
+
 def test_a_team_shared_mcp_oauth_connector_is_not_attachable_without_a_grant(
     db_session,
 ):
@@ -515,6 +582,27 @@ def test_a_team_shared_builtin_oauth_connector_needs_the_members_own_account(
     assert entry["can_attach"] is True
     # Still not a personal connection: the member has an account but no
     # association, which is what is_connected reports on.
+    assert entry["is_connected"] is False
+
+
+def test_a_team_shared_builtin_oauth_connector_attaches_through_a_resolver_hook(
+    db_session, _token_resolver_installed
+):
+    """The resolver hook outranks the account check: the runtime resolves every
+    transport=="oauth" server's token through the installed hook first and
+    falls back to UserOAuth only without one, so on a resolver deployment the
+    row runs with no account at all. Refusing here would say no where the
+    runtime succeeds — the one direction the attachability contract forbids
+    (#1403 review round 2)."""
+    db, _creator, member = db_session
+    _add_builtin_oauth_app(db, "acme-drive", "Acme Drive")
+    server = _add_builtin_oauth_server(db, "acme-drive", "Acme Drive")
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-drive")
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+    # The hook supplies tokens, not a personal connection.
     assert entry["is_connected"] is False
 
 

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -11,9 +11,15 @@ in the Remote tab, while `/api/mcp/servers` listed the connector all along.
 
 The fix gives the catalog branch a third state. `is_connected` still means
 "connected for me"; `is_team_shared` means "reached me through a team link";
-and `can_attach` unions the two, gated on whether the shape's credentials ride
-on the shared row (stdio/key-based: yes) or on the member (`mcp_oauth`,
-`builtin_oauth`: only once they have their own grant or account).
+and `can_attach` unions the two, gated by shape. Keyless needs no credential
+at all. `api_key` is deliberately not credential-gated: the key the runtime
+resolves may live on the row's platform env, the application-injected shared
+layer, or the governing agent's team row — none visible to this user-scoped
+endpoint — so the answer is optimistic and the env-source flags carry the
+needs-config signal. The OAuth shapes gate on the member's own credential
+(`mcp_oauth`: an active grant; `builtin_oauth`: a usable provider account),
+except where an installed token-resolver hook supplies the deployment's
+tokens out of band, which satisfies both.
 
 Fictional app ids (`acme*`) are admin-created apps, whose stored transport and
 launch_config are used as-is — built-in ids would take theirs from
@@ -138,8 +144,8 @@ def _add_app(
 
 
 def _add_keyless_app(db, app_id: str, name: str, **kwargs) -> PublicMCPApp:
-    """The shape whose credentials ride entirely on the shared row, so sharing
-    the connector really does share a working one."""
+    """The shape with no credential at all — the shared row's launch config is
+    everything, so sharing the connector really does share a working one."""
     return _add_app(
         db,
         app_id,
@@ -416,6 +422,39 @@ def test_a_team_shared_api_key_connector_is_attachable_without_the_members_own_k
     assert entry["platform_env_available"] is False
 
 
+def test_env_source_flags_report_the_layer_that_covers_a_team_shared_key_app(
+    db_session,
+):
+    """The needs-config signal the optimistic can_attach leans on: when a key
+    layer this endpoint *can* see covers required_env, the matching flag says
+    so. The platform layer is the row's own env; the shared layer is the
+    application-injected per-user hook. (The governing agent's team layer is
+    runtime-side and deliberately untested here — that basis question is
+    #1366's.)"""
+    from xagent.core.utils.encryption import encrypt_env_dict
+    from xagent.web.services.mcp_runtime import set_mcp_shared_env_hook
+
+    db, _creator, member = db_session
+    _add_api_key_app(db, "acme-crm", "Acme CRM")
+    server = _add_catalog_server(db, "acme-crm")
+    _install_visibility(member, {int(server.id)})
+
+    server.env = encrypt_env_dict({"API_KEY": "platform-key"})
+    db.commit()
+    entry = _entry(db, member, "acme-crm")
+    assert entry["platform_env_available"] is True
+    assert entry["shared_env_available"] is False
+    assert entry["can_attach"] is True
+    assert entry["is_connected"] is False
+
+    set_mcp_shared_env_hook(lambda _db, _uid: {int(server.id): {"API_KEY": "team-key"}})
+    try:
+        entry = _entry(db, member, "acme-crm")
+        assert entry["shared_env_available"] is True
+    finally:
+        set_mcp_shared_env_hook(None)
+
+
 def test_a_team_row_running_a_foreign_command_is_not_claimed(db_session):
     """The connect endpoints 409 on a same-named row whose launch config
     differs ("a victim would run a foreign command with their own key
@@ -583,6 +622,27 @@ def test_a_team_shared_builtin_oauth_connector_needs_the_members_own_account(
     # Still not a personal connection: the member has an account but no
     # association, which is what is_connected reports on.
     assert entry["is_connected"] is False
+
+
+def test_a_renamed_builtin_oauth_apps_row_still_reports_its_app_id(db_session):
+    """/api/mcp/servers enrichment resolves by stable auth.app_id (with a name
+    fallback for legacy rows), not by name alone: an admin renaming an app
+    leaves the provisioned row under the old display name, and the name-only
+    lookup reported app_id None for exactly the row the catalog entry resolves
+    through auth.app_id. The picker's selector resolution keys on this app_id
+    to map the entry back to its real row; without it, the persisted selector
+    was the new display name of a row the runtime knows by the old one — zero
+    tools, silently (#1403 review round 3)."""
+    db, _creator, member = db_session
+    _add_builtin_oauth_app(db, "acme-drive", "Acme Drive v2")
+    server = _add_builtin_oauth_server(db, "acme-drive", "Acme Drive")
+    _install_visibility(member, {int(server.id)})
+
+    listed = get_mcp_servers(current_user=member, db=db)
+    row = next(s for s in listed if s.name == "Acme Drive")
+    assert row.app_id == "acme-drive"
+    # The catalog entry keeps resolving the renamed row through auth.app_id.
+    assert _entry(db, member, "acme-drive")["is_team_shared"] is True
 
 
 def test_a_team_shared_builtin_oauth_connector_attaches_through_a_resolver_hook(

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -893,6 +893,34 @@ def test_a_provider_only_row_does_not_brand_every_same_provider_app(db_session):
     assert entry["can_attach"] is False
 
 
+def test_a_provider_named_row_does_not_brand_every_same_provider_app(db_session):
+    """The collision the provider-key removal alone cannot close (#1403 review
+    round 7): a malformed row *named* the provider string itself lands under
+    that key through its own name. The team matcher therefore accepts exact
+    identity only — a nonblank auth.app_id equal to the app's id, or a name
+    among the app's own catalog keys — never the provider metadata the personal
+    matcher tolerates, so this row brands nothing."""
+    db, _creator, member = db_session
+    _add_app(db, "acme-drive", "Acme Drive", transport="oauth", provider_name="acme")
+    _add_app(db, "acme-mail", "Acme Mail", transport="oauth", provider_name="acme")
+    row = _add_server_row(
+        db,
+        {
+            "name": "acme",
+            "managed": "external",
+            "transport": "oauth",
+            "auth": {"app_id": "   ", "provider": "acme"},
+        },
+    )
+    _add_oauth_account(db, member, "acme")
+    _install_visibility(member, {int(row.id)})
+
+    for app_id in ("acme-drive", "acme-mail"):
+        entry = _entry(db, member, app_id)
+        assert entry["is_team_shared"] is False
+        assert entry["can_attach"] is False
+
+
 def test_a_raising_visibility_hook_yields_a_typed_503(db_session):
     """The hook is optional application code and the default remote picker now
     runs it on every load; a raising hook must surface as this seam's typed

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -650,7 +650,7 @@ def test_the_local_branch_flags_a_team_shared_custom_connector(db_session):
     )
     _associate(db, member, personal)
     shared_api = _add_custom_api(db, "reports")
-    personal_api = _add_custom_api(db, "billing", owner=member)
+    _add_custom_api(db, "billing", owner=member)
     _install_visibility(member, {int(shared.id)}, {int(shared_api.id)})
 
     local = {

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -30,6 +30,7 @@ from sqlalchemy.orm import sessionmaker
 
 from xagent.core.utils.encryption import encrypt_value
 from xagent.web.api.mcp import get_mcp_servers, list_mcp_apps
+from xagent.web.models.custom_api import CustomApi, UserCustomApi
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.mcp_oauth import MCPOAuthClient, MCPOAuthGrant
@@ -83,14 +84,16 @@ def _reset_connector_team_hooks():
     connector_team_scope.set_connector_team_hooks()
 
 
-def _install_visibility(user: User, server_ids: set[int]) -> None:
+def _install_visibility(
+    user: User, server_ids: set[int], custom_api_ids: set[int] | None = None
+) -> None:
     """Answer for ``user`` only, so a test can tell "the overlay ran" apart from
     "the overlay ignored who asked"."""
 
     def visibility(_db, user_id: int) -> dict[str, set[int]]:
         if int(user_id) != int(user.id):
             return {"mcp": set(), "custom_api": set()}
-        return {"mcp": set(server_ids), "custom_api": set()}
+        return {"mcp": set(server_ids), "custom_api": set(custom_api_ids or set())}
 
     connector_team_scope.set_connector_team_hooks(visibility=visibility)
 
@@ -132,6 +135,22 @@ def _add_keyless_app(db, app_id: str, name: str, **kwargs) -> PublicMCPApp:
         transport="stdio",
         launch_config={"command": "npx", "args": ["-y", f"{app_id}-mcp"]},
         **kwargs,
+    )
+
+
+def _add_api_key_app(db, app_id: str, name: str) -> PublicMCPApp:
+    """The key-based shape: same shared stdio row as keyless, plus required_env
+    the runtime resolves from the row/shared/team/user env layers."""
+    return _add_app(
+        db,
+        app_id,
+        name,
+        transport="stdio",
+        launch_config={
+            "command": "npx",
+            "args": ["-y", f"{app_id}-mcp"],
+            "required_env": ["API_KEY"],
+        },
     )
 
 
@@ -357,6 +376,86 @@ def test_a_deactivated_personal_row_does_not_revoke_team_visibility(db_session):
     assert entry["can_attach"] is True
 
 
+def test_a_team_shared_api_key_connector_is_attachable_without_the_members_own_key(
+    db_session,
+):
+    """Deliberate, not an oversight (#1403 review N2): api_key is not
+    credential-gated, mirroring every existing path — a personally connected
+    key app reports can_attach on the association alone, and the local branch
+    gates no shape but mcp_oauth. The key the runtime resolves may live on the
+    row's platform env, the shared layer, or the governing agent's team row,
+    none of which this user-scoped endpoint can rule out; saying no on "the
+    member set no key of their own" would refuse where the runtime succeeds,
+    the one direction _local_mcp_can_attach's contract forbids. The env-source
+    flags carry the needs-config signal instead."""
+    db, _creator, member = db_session
+    _add_api_key_app(db, "acme-crm", "Acme CRM")
+    server = _add_catalog_server(db, "acme-crm")
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-crm")
+    assert entry["auth_type"] == "api_key"
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+    assert entry["is_connected"] is False
+    # No key anywhere in this fixture — the flags say so; attachability doesn't.
+    assert entry["user_env_configured"] is False
+    assert entry["shared_env_available"] is False
+    assert entry["platform_env_available"] is False
+
+
+def test_a_team_row_running_a_foreign_command_is_not_claimed(db_session):
+    """The connect endpoints 409 on a same-named row whose launch config
+    differs ("a victim would run a foreign command with their own key
+    attached"), so the personal path can never bind catalog branding to a
+    foreign row. The team path has no write-time gate — the hook shares
+    whatever rows the application names — so the same comparison runs at read
+    time (#1403 review N1): the mismatched row yields no team-shared entry,
+    falling back to the pre-#1387 state (listed by /api/mcp/servers, never
+    rendered in catalog shape)."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    foreign = _add_server_row(
+        db,
+        {
+            "name": "acme-notes",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "evil-mcp",
+        },
+    )
+    _install_visibility(member, {int(foreign.id)})
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_team_shared"] is False
+    assert entry["can_attach"] is False
+    # The local branch's catalog skip still suppresses the raw row, so the
+    # foreign command never reaches the picker under any name.
+    assert _entries(db, member, "acme-notes", location="local") == []
+
+
+def test_a_team_row_pointing_at_a_foreign_url_is_not_claimed(db_session):
+    """The mcp_oauth arm of the same guard: identity is the remote URL, the
+    field _ensure_catalog_mcp_oauth_server refuses to adopt when it differs."""
+    db, _creator, member = db_session
+    _add_mcp_oauth_app(db, "acme-remote", "Acme Remote")
+    foreign = _add_server_row(
+        db,
+        {
+            "name": "acme-remote",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://mcp.evil.example.com/mcp",
+            "auth": dict(_MCP_OAUTH_LAUNCH["auth"]),
+        },
+    )
+    _install_visibility(member, {int(foreign.id)})
+
+    entry = _entry(db, member, "acme-remote")
+    assert entry["is_team_shared"] is False
+    assert entry["can_attach"] is False
+
+
 def test_a_team_shared_mcp_oauth_connector_is_not_attachable_without_a_grant(
     db_session,
 ):
@@ -501,9 +600,35 @@ def test_a_standalone_deployment_is_unchanged(db_session):
         assert app["can_attach"] is app["is_connected"]
 
 
+def _add_custom_api(db, name: str, *, owner: User | None = None) -> CustomApi:
+    """A Custom API row; associated to ``owner`` when given, otherwise reachable
+    only through the team overlay."""
+    api = CustomApi(
+        name=name,
+        description=f"{name} API",
+        url="https://api.example.com/v1",
+        method="GET",
+    )
+    db.add(api)
+    db.commit()
+    db.refresh(api)
+    if owner is not None:
+        db.add(
+            UserCustomApi(
+                user_id=owner.id,
+                custom_api_id=api.id,
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+    return api
+
+
 def test_the_local_branch_flags_a_team_shared_custom_connector(db_session):
-    """The field means the same thing on both branches, so a consumer never has
-    to read its absence as "no"."""
+    """The field means the same thing on both branches and both local loops
+    (MCP servers and Custom APIs), so a consumer never has to read its absence
+    as "no"."""
     db, _creator, member = db_session
     shared = _add_server_row(
         db,
@@ -524,10 +649,15 @@ def test_the_local_branch_flags_a_team_shared_custom_connector(db_session):
         },
     )
     _associate(db, member, personal)
-    _install_visibility(member, {int(shared.id)})
+    shared_api = _add_custom_api(db, "reports")
+    personal_api = _add_custom_api(db, "billing", owner=member)
+    _install_visibility(member, {int(shared.id)}, {int(shared_api.id)})
 
     local = {
         a["id"]: a for a in list_mcp_apps(location="local", current_user=member, db=db)
     }
     assert local["records"]["is_team_shared"] is True
     assert local["ledger"]["is_team_shared"] is False
+    assert local["reports"]["is_team_shared"] is True
+    assert local["reports"]["transport"] == "custom_api"
+    assert local["billing"]["is_team_shared"] is False

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -1,0 +1,533 @@
+"""`/api/mcp/apps` must offer a team-shared *catalog* connector (#1387).
+
+A connector shared with a team writes a team link row and no per-member
+association, and before this change neither branch of the listing claimed the
+catalog-backed ones: the catalog branch resolves connection state from personal
+associations alone ("is this app connected *for me*"), and the local branch —
+the only one applying the team overlay (#1321) — skips every row a catalog app
+speaks for, which is what keeps it free of #1346's `is_custom` duplicate. The
+member ended up with no entry in the Local tab and an unconnected catalog entry
+in the Remote tab, while `/api/mcp/servers` listed the connector all along.
+
+The fix gives the catalog branch a third state. `is_connected` still means
+"connected for me"; `is_team_shared` means "reached me through a team link";
+and `can_attach` unions the two, gated on whether the shape's credentials ride
+on the shared row (stdio/key-based: yes) or on the member (`mcp_oauth`,
+`builtin_oauth`: only once they have their own grant or account).
+
+Fictional app ids (`acme*`) are admin-created apps, whose stored transport and
+launch_config are used as-is — built-in ids would take theirs from
+`builtin_mcp_registry` instead, leaving the shape under test unauthorable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api.mcp import get_mcp_servers, list_mcp_apps
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.mcp_oauth import MCPOAuthClient, MCPOAuthGrant
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.services import connector_team_scope
+
+_MCP_OAUTH_LAUNCH: dict[str, Any] = {
+    "url": "https://mcp.example.com/mcp",
+    "auth": {
+        "type": "mcp_oauth",
+        "resource": "https://mcp.example.com/mcp",
+        "issuer": "https://auth.example.com",
+    },
+}
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "mcp-apps-team-catalog.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    creator = User(username="alice", password_hash="x", is_admin=False)
+    member = User(username="bob", password_hash="x", is_admin=False)
+    db.add_all([creator, member])
+    db.commit()
+    db.refresh(creator)
+    db.refresh(member)
+
+    try:
+        yield db, creator, member
+    finally:
+        # Nested so the engine is disposed even if closing the session raises,
+        # while the first failure still propagates.
+        try:
+            db.close()
+        finally:
+            engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_connector_team_hooks():
+    """The hooks are process-global; never leak one into a sibling test."""
+    yield
+    connector_team_scope.set_connector_team_hooks()
+
+
+def _install_visibility(user: User, server_ids: set[int]) -> None:
+    """Answer for ``user`` only, so a test can tell "the overlay ran" apart from
+    "the overlay ignored who asked"."""
+
+    def visibility(_db, user_id: int) -> dict[str, set[int]]:
+        if int(user_id) != int(user.id):
+            return {"mcp": set(), "custom_api": set()}
+        return {"mcp": set(server_ids), "custom_api": set()}
+
+    connector_team_scope.set_connector_team_hooks(visibility=visibility)
+
+
+def _add_app(
+    db,
+    app_id: str,
+    name: str,
+    *,
+    transport: str,
+    launch_config: dict | None = None,
+    provider_name: str | None = None,
+    is_visible_in_connector: bool = True,
+) -> PublicMCPApp:
+    app = PublicMCPApp(
+        app_id=app_id,
+        name=name,
+        description="A catalog app",
+        icon="https://example.com/icon.png",
+        category="Productivity",
+        transport=transport,
+        provider_name=provider_name,
+        launch_config=launch_config,
+        is_visible_in_connector=is_visible_in_connector,
+    )
+    db.add(app)
+    db.commit()
+    db.refresh(app)
+    return app
+
+
+def _add_keyless_app(db, app_id: str, name: str, **kwargs) -> PublicMCPApp:
+    """The shape whose credentials ride entirely on the shared row, so sharing
+    the connector really does share a working one."""
+    return _add_app(
+        db,
+        app_id,
+        name,
+        transport="stdio",
+        launch_config={"command": "npx", "args": ["-y", f"{app_id}-mcp"]},
+        **kwargs,
+    )
+
+
+def _add_mcp_oauth_app(db, app_id: str, name: str) -> PublicMCPApp:
+    return _add_app(
+        db, app_id, name, transport="streamable_http", launch_config=_MCP_OAUTH_LAUNCH
+    )
+
+
+def _add_builtin_oauth_app(db, app_id: str, name: str) -> PublicMCPApp:
+    return _add_app(db, app_id, name, transport="oauth", provider_name=app_id)
+
+
+def _add_server_row(db, config: dict) -> MCPServer:
+    server = MCPServer.from_config(config)
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    return server
+
+
+def _add_catalog_server(db, app_id: str) -> MCPServer:
+    """The shared stdio row a key-based/keyless connect writes: named after the
+    app_id (`_ensure_catalog_app_server`), with no association of its own."""
+    return _add_server_row(
+        db,
+        {
+            "name": app_id,
+            "description": "A catalog app",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["-y", f"{app_id}-mcp"],
+        },
+    )
+
+
+def _add_mcp_oauth_server(db, app_id: str) -> MCPServer:
+    """The shared remote row `_ensure_catalog_mcp_oauth_server` writes."""
+    return _add_server_row(
+        db,
+        {
+            "name": app_id,
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": _MCP_OAUTH_LAUNCH["url"],
+            "auth": dict(_MCP_OAUTH_LAUNCH["auth"]),
+        },
+    )
+
+
+def _add_builtin_oauth_server(db, app_id: str, name: str) -> MCPServer:
+    """The row `_ensure_user_mcp_server` writes: named after the *display name*,
+    transport "oauth", carrying the app_id back-reference in `auth`."""
+    return _add_server_row(
+        db,
+        {
+            "name": name,
+            "managed": "external",
+            "transport": "oauth",
+            "auth": {"app_id": app_id, "provider": app_id},
+        },
+    )
+
+
+def _associate(db, user: User, server: MCPServer, *, is_active: bool = True) -> None:
+    """The association a catalog connect writes: the connecting user never owns
+    the shared row (`is_owner=False`)."""
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            can_edit=False,
+            can_delete=True,
+            is_active=is_active,
+        )
+    )
+    db.commit()
+
+
+def _add_active_grant(db, user: User, server: MCPServer) -> None:
+    client = MCPOAuthClient(
+        mcp_server_id=server.id,
+        issuer="https://auth.example.com",
+        authorization_endpoint="https://auth.example.com/authorize",
+        token_endpoint="https://auth.example.com/token",
+        client_id="client-123",
+        token_endpoint_auth_method="none",
+        redirect_uri="https://xagent.example.com/api/mcp/oauth/callback",
+    )
+    db.add(client)
+    db.flush()
+    db.add(
+        MCPOAuthGrant(
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=f"xagent:user:{user.id}",
+            issuer="https://auth.example.com",
+            resource=_MCP_OAUTH_LAUNCH["url"],
+            scope="",
+            access_token=encrypt_value("runtime-token"),
+            status="active",
+        )
+    )
+    db.commit()
+
+
+def _add_oauth_account(db, user: User, provider: str) -> None:
+    db.add(
+        UserOAuth(
+            user_id=user.id,
+            provider=provider,
+            access_token="provider-token",
+            refresh_token="provider-refresh",
+            email="bob@example.com",
+        )
+    )
+    db.commit()
+
+
+def _entries(db, user: User, app_id: str, *, location: str = "all", **kwargs) -> list:
+    return [
+        a
+        for a in list_mcp_apps(location=location, current_user=user, db=db, **kwargs)
+        if a["id"] == app_id
+    ]
+
+
+def _entry(db, user: User, app_id: str, *, location: str = "all", **kwargs) -> dict:
+    found = _entries(db, user, app_id, location=location, **kwargs)
+    assert len(found) == 1, f"expected exactly one {app_id} entry, got {len(found)}"
+    return found[0]
+
+
+def test_a_team_shared_catalog_connector_is_offered_in_catalog_shape(db_session):
+    """AC1: exactly once, in catalog shape, with no `is_custom` twin.
+
+    The Local tab stays empty on purpose — the catalog skip that keeps #1346
+    fixed is what removes the duplicate, and this is the entry that replaces it.
+    """
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    server = _add_catalog_server(db, "acme-notes")
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+    assert entry.get("is_custom") is not True
+    assert entry["name"] == "Acme Notes"
+    assert entry["icon"] == "https://example.com/icon.png"
+    assert entry["category"] == "Productivity"
+    assert entry["auth_type"] == "keyless"
+
+    assert _entries(db, member, "acme-notes", location="local") == []
+    assert len(_entries(db, member, "acme-notes", location="remote")) == 1
+
+
+def test_a_team_shared_catalog_connector_is_not_reported_connected(db_session):
+    """`is_connected` keeps answering "connected *for me*", which only a personal
+    association establishes. Claiming otherwise would show the member a
+    Configure button for a connector they do not own, and hide the Connect route
+    the per-member auth shapes still need."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    server = _add_catalog_server(db, "acme-notes")
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_connected"] is False
+    assert entry["can_authorize"] is False
+    assert "server_id" not in entry
+
+
+def test_the_picker_and_the_tools_page_agree_on_a_team_shared_connector(db_session):
+    """AC2: `/api/mcp/servers` overlays team ids with no catalog skip, so it has
+    always listed this connector. The disagreement that opened #1387 was the
+    picker having no *usable* entry for what the Tools page showed — the catalog
+    entry was always rendered, as an app the member would have to connect for
+    themselves, so agreement is asserted on attachability rather than on the
+    entry's mere presence."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    server = _add_catalog_server(db, "acme-notes")
+    _install_visibility(member, {int(server.id)})
+
+    listed = get_mcp_servers(current_user=member, db=db)
+    assert [s.name for s in listed] == ["acme-notes"]
+    assert _entry(db, member, "acme-notes")["can_attach"] is True
+
+
+def test_a_member_holding_both_a_personal_row_and_a_team_link_sees_one_entry(
+    db_session,
+):
+    """AC3: the two states coexist on one entry rather than producing two."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    server = _add_catalog_server(db, "acme-notes")
+    _associate(db, member, server)
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_connected"] is True
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+    assert entry["server_id"] == server.id
+
+
+def test_a_deactivated_personal_row_does_not_revoke_team_visibility(db_session):
+    """`is_active` gates the personal arm alone (`connector_visible_to_user`), so
+    a member who turned their own connection off keeps the team's."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    server = _add_catalog_server(db, "acme-notes")
+    _associate(db, member, server, is_active=False)
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_connected"] is False
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+
+
+def test_a_team_shared_mcp_oauth_connector_is_not_attachable_without_a_grant(
+    db_session,
+):
+    """AC4: authorization is per user. The shared row carries no token for the
+    member, so the entry is offered but not attachable — its card keeps the
+    catalog Connect route ("connect it for yourself"), dispatched on
+    `auth_type`, rather than the per-server route that would 404 for want of a
+    personal association."""
+    db, _creator, member = db_session
+    _add_mcp_oauth_app(db, "acme-remote", "Acme Remote")
+    server = _add_mcp_oauth_server(db, "acme-remote")
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-remote")
+    assert entry["is_team_shared"] is True
+    assert entry["is_connected"] is False
+    assert entry["can_attach"] is False
+    assert entry["can_authorize"] is False
+    assert entry["auth_type"] == "mcp_oauth"
+
+
+def test_a_team_shared_mcp_oauth_connector_is_attachable_once_the_member_consents(
+    db_session,
+):
+    """The grant is the credential term, and it is the member's own."""
+    db, _creator, member = db_session
+    _add_mcp_oauth_app(db, "acme-remote", "Acme Remote")
+    server = _add_mcp_oauth_server(db, "acme-remote")
+    _associate(db, member, server)
+    _add_active_grant(db, member, server)
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-remote")
+    assert entry["is_connected"] is True
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+
+
+def test_a_team_shared_builtin_oauth_connector_needs_the_members_own_account(
+    db_session,
+):
+    """The provider login is held on `UserOAuth`, never on the shared row, so
+    sharing the connector shares no credential for this shape either — the term
+    `_local_mcp_can_attach` never needed, because a catalog-keyed row never
+    reaches the local branch."""
+    db, _creator, member = db_session
+    _add_builtin_oauth_app(db, "acme-drive", "Acme Drive")
+    server = _add_builtin_oauth_server(db, "acme-drive", "Acme Drive")
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-drive")
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is False
+
+    _add_oauth_account(db, member, "acme-drive")
+    entry = _entry(db, member, "acme-drive")
+    assert entry["can_attach"] is True
+    # Still not a personal connection: the member has an account but no
+    # association, which is what is_connected reports on.
+    assert entry["is_connected"] is False
+
+
+def test_a_hidden_catalog_app_stays_hidden_when_team_shared(db_session):
+    """Strong hide mode removes the app for everyone, connected or not. The
+    local branch's catalog skip is deliberately broader than the catalog
+    branch's claim so a hidden app cannot fall through to a custom entry."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes", is_visible_in_connector=False)
+    server = _add_catalog_server(db, "acme-notes")
+    _install_visibility(member, {int(server.id)})
+
+    assert _entries(db, member, "acme-notes") == []
+
+
+def test_the_verified_filter_keeps_a_team_shared_catalog_connector(db_session):
+    """The filter narrows to connectors backing a real connection, which a
+    team-shared one does. Withholding it would put the connector back out of
+    reach for a member browsing under the filter."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    _add_keyless_app(db, "acme-other", "Acme Other")
+    server = _add_catalog_server(db, "acme-notes")
+    _install_visibility(member, {int(server.id)})
+
+    ids = [
+        a["id"]
+        for a in list_mcp_apps(
+            location="remote", status="verified", current_user=member, db=db
+        )
+    ]
+    assert ids == ["acme-notes"]
+
+
+def test_a_connector_shared_with_another_team_is_not_offered(db_session):
+    """AC5's other half: the overlay is keyed on the requesting user, so a
+    connector a live hook reports for someone else must not reach this member."""
+    db, creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    server = _add_catalog_server(db, "acme-notes")
+    _install_visibility(creator, {int(server.id)})
+
+    assert _entry(db, creator, "acme-notes")["is_team_shared"] is True
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_team_shared"] is False
+    assert entry["can_attach"] is False
+
+
+def test_a_hook_answering_string_ids_flags_nothing_it_cannot_attach(db_session):
+    """Element types are the hook's contract (`dict[str, set[int]]`), and
+    `visible_team_connector_ids` does not yet validate them. SQLite's numeric
+    affinity makes `id IN ('1')` match an INTEGER primary key, so a string id
+    still reaches the row query that fills the team indexes — the same fail-open
+    `test_mcp_apps_team_visibility.py` pins for the local branch.
+
+    What this pins is that the entry stays *coherent* under that answer:
+    `is_team_shared` and `can_attach` both resolve through the in-Python
+    predicate, which compares int to str and says no, so the response never
+    labels a connector as the team's while refusing to attach it."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    server = _add_catalog_server(db, "acme-notes")
+    _install_visibility(member, {str(server.id)})  # type: ignore[arg-type]
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_team_shared"] is False
+    assert entry["can_attach"] is False
+
+
+def test_a_standalone_deployment_is_unchanged(db_session):
+    """AC5: no hook installed resolves empty, so every entry keeps the
+    pre-#1387 answer — `can_attach` is exactly `is_connected`."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    _add_mcp_oauth_app(db, "acme-remote", "Acme Remote")
+    server = _add_catalog_server(db, "acme-notes")
+    _associate(db, member, server)
+
+    remote = list_mcp_apps(location="remote", current_user=member, db=db)
+    assert {a["id"] for a in remote} == {"acme-notes", "acme-remote"}
+    for app in remote:
+        assert app["is_team_shared"] is False
+        assert app["can_attach"] is app["is_connected"]
+
+
+def test_the_local_branch_flags_a_team_shared_custom_connector(db_session):
+    """The field means the same thing on both branches, so a consumer never has
+    to read its absence as "no"."""
+    db, _creator, member = db_session
+    shared = _add_server_row(
+        db,
+        {
+            "name": "records",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "records-mcp",
+        },
+    )
+    personal = _add_server_row(
+        db,
+        {
+            "name": "ledger",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "ledger-mcp",
+        },
+    )
+    _associate(db, member, personal)
+    _install_visibility(member, {int(shared.id)})
+
+    local = {
+        a["id"]: a for a in list_mcp_apps(location="local", current_user=member, db=db)
+    }
+    assert local["records"]["is_team_shared"] is True
+    assert local["ledger"]["is_team_shared"] is False

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -854,6 +855,78 @@ def test_a_hook_answering_string_ids_flags_nothing_it_cannot_attach(db_session):
     entry = _entry(db, member, "acme-notes")
     assert entry["is_team_shared"] is False
     assert entry["can_attach"] is False
+
+
+def test_a_provider_only_row_does_not_brand_every_same_provider_app(db_session):
+    """Providers are non-unique across apps, so the team oauth index carries no
+    bare-provider fallback (#1403 review round 6): a row whose auth.app_id is
+    blank must not satisfy every catalog app on its provider. Only the row
+    whose stable app_id names an app claims that app; the malformed sibling
+    claims nothing."""
+    db, _creator, member = db_session
+    _add_app(db, "acme-drive", "Acme Drive", transport="oauth", provider_name="acme")
+    _add_app(db, "acme-mail", "Acme Mail", transport="oauth", provider_name="acme")
+    malformed = _add_server_row(
+        db,
+        {
+            "name": "legacy-acme",
+            "managed": "external",
+            "transport": "oauth",
+            "auth": {"app_id": "   ", "provider": "acme"},
+        },
+    )
+    proper = _add_server_row(
+        db,
+        {
+            "name": "Acme Drive",
+            "managed": "external",
+            "transport": "oauth",
+            "auth": {"app_id": "acme-drive", "provider": "acme"},
+        },
+    )
+    _add_oauth_account(db, member, "acme")
+    _install_visibility(member, {int(malformed.id), int(proper.id)})
+
+    assert _entry(db, member, "acme-drive")["is_team_shared"] is True
+    entry = _entry(db, member, "acme-mail")
+    assert entry["is_team_shared"] is False
+    assert entry["can_attach"] is False
+
+
+def test_a_raising_visibility_hook_yields_a_typed_503(db_session):
+    """The hook is optional application code and the default remote picker now
+    runs it on every load; a raising hook must surface as this seam's typed
+    503 (mirroring resolve_team_connector_ids_or_raise), not a bare 500
+    (#1403 review round 6)."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+
+    def raising(_db, _user_id):
+        raise RuntimeError("hook exploded")
+
+    connector_team_scope.set_connector_team_hooks(visibility=raising)
+    with pytest.raises(HTTPException) as exc_info:
+        list_mcp_apps(location="remote", current_user=member, db=db)
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [None, {"mcp": set()}, {"mcp": [1], "custom_api": set()}],
+    ids=["none", "missing-key", "list-not-set"],
+)
+def test_a_malformed_outer_hook_answer_yields_a_typed_503(db_session, answer):
+    """Outer shape only — element-level id validation stays with the accessor
+    (#1244). A hook answering something that is not {mcp: set, custom_api: set}
+    is malformed authorization input and fails loudly with the typed 503,
+    never a KeyError-shaped 500."""
+    db, _creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    connector_team_scope.set_connector_team_hooks(visibility=lambda _db, _uid: answer)
+
+    with pytest.raises(HTTPException) as exc_info:
+        list_mcp_apps(location="remote", current_user=member, db=db)
+    assert exc_info.value.status_code == 503
 
 
 def test_a_standalone_deployment_is_unchanged(db_session):

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -455,6 +455,75 @@ def test_env_source_flags_report_the_layer_that_covers_a_team_shared_key_app(
         set_mcp_shared_env_hook(None)
 
 
+def test_a_members_own_key_flags_user_env_on_a_team_shared_key_app(db_session):
+    """The user layer: a member who additionally connected the app with their
+    own key sees user_env_configured, alongside — not instead of — the team
+    provenance."""
+    from xagent.core.utils.encryption import encrypt_env_dict
+
+    db, _creator, member = db_session
+    _add_api_key_app(db, "acme-crm", "Acme CRM")
+    server = _add_catalog_server(db, "acme-crm")
+    _associate(db, member, server)
+    assoc = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == member.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    assoc.env = encrypt_env_dict({"API_KEY": "member-key"})
+    db.commit()
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-crm")
+    assert entry["user_env_configured"] is True
+    assert entry["is_connected"] is True
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+
+
+def test_a_partially_covered_required_env_does_not_flag_the_layer(db_session):
+    """_env_covers_required is all-or-nothing: a layer that covers one of two
+    required keys advertises nothing, so the picker never offers "use the
+    platform key" for a key set that would fail at launch."""
+    from xagent.core.utils.encryption import encrypt_env_dict
+
+    db, _creator, member = db_session
+    _add_app(
+        db,
+        "acme-crm",
+        "Acme CRM",
+        transport="stdio",
+        launch_config={
+            "command": "npx",
+            "args": ["-y", "acme-crm-mcp"],
+            "required_env": ["API_KEY", "REGION"],
+        },
+    )
+    server = _add_server_row(
+        db,
+        {
+            "name": "acme-crm",
+            "description": "A catalog app",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["-y", "acme-crm-mcp"],
+        },
+    )
+    server.env = encrypt_env_dict({"API_KEY": "platform-key"})
+    db.commit()
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-crm")
+    assert entry["platform_env_available"] is False
+    assert entry["is_team_shared"] is True
+    # Attachability stays optimistic by contract; the flags carry the truth.
+    assert entry["can_attach"] is True
+
+
 def test_a_team_row_running_a_foreign_command_is_not_claimed(db_session):
     """The connect endpoints 409 on a same-named row whose launch config
     differs ("a victim would run a foreign command with their own key
@@ -789,7 +858,11 @@ def test_a_hook_answering_string_ids_flags_nothing_it_cannot_attach(db_session):
 
 def test_a_standalone_deployment_is_unchanged(db_session):
     """AC5: no hook installed resolves empty, so every entry keeps the
-    pre-#1387 answer — `can_attach` is exactly `is_connected`."""
+    pre-#1387 answer — `can_attach` is exactly `is_connected`, and the
+    is_team_shared field is absent entirely, keeping standalone payloads
+    identical to what they were before this change. Present-false is reserved
+    for deployments where the concept exists (hook installed, nothing shared
+    with this user)."""
     db, _creator, member = db_session
     _add_keyless_app(db, "acme-notes", "Acme Notes")
     _add_mcp_oauth_app(db, "acme-remote", "Acme Remote")
@@ -799,8 +872,28 @@ def test_a_standalone_deployment_is_unchanged(db_session):
     remote = list_mcp_apps(location="remote", current_user=member, db=db)
     assert {a["id"] for a in remote} == {"acme-notes", "acme-remote"}
     for app in remote:
-        assert app["is_team_shared"] is False
+        assert "is_team_shared" not in app
         assert app["can_attach"] is app["is_connected"]
+
+    local = list_mcp_apps(location="local", current_user=member, db=db)
+    for app in local:
+        assert "is_team_shared" not in app
+
+
+def test_an_installed_hook_answering_empty_still_emits_the_field(db_session):
+    """The field's absence means "this deployment has no team sharing", never
+    "nothing is shared with you" — an installed hook answering empty is the
+    latter, and consumers may rely on present-false to tell the two apart."""
+    db, creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    server = _add_catalog_server(db, "acme-notes")
+    _associate(db, member, server)
+    # Hook answers only for the creator; the member gets empty sets.
+    _install_visibility(creator, {int(server.id)})
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_team_shared"] is False
+    assert entry["is_connected"] is True
 
 
 def _add_custom_api(db, name: str, *, owner: User | None = None) -> CustomApi:

--- a/tests/web/api/test_mcp_apps_team_catalog.py
+++ b/tests/web/api/test_mcp_apps_team_catalog.py
@@ -536,6 +536,61 @@ def test_a_team_row_with_a_foreign_auth_shape_is_not_claimed(db_session, auth):
     assert entry["can_attach"] is False
 
 
+def test_a_user_owned_row_is_not_rendered_under_catalog_branding(db_session):
+    """Read-time analog of _reject_user_owned_catalog_squat (#1403 review
+    round 4): the legitimate shared row for the non-oauth shapes never has an
+    owner, so a user-owned row squatting a catalog identity — creatable only
+    before the app was seeded — must not be officialized even while its launch
+    happens to match: its owner keeps edit rights and could swap in a foreign
+    command *after* a member attaches the branded entry. Falls back to the
+    pre-#1387 state (Tools page only)."""
+    db, creator, member = db_session
+    _add_keyless_app(db, "acme-notes", "Acme Notes")
+    squatter = _add_catalog_server(db, "acme-notes")
+    db.add(
+        UserMCPServer(
+            user_id=creator.id,
+            mcpserver_id=squatter.id,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+    _install_visibility(member, {int(squatter.id)})
+
+    entry = _entry(db, member, "acme-notes")
+    assert entry["is_team_shared"] is False
+    assert entry["can_attach"] is False
+    assert _entries(db, member, "acme-notes", location="local") == []
+
+
+def test_an_owned_builtin_oauth_row_keeps_its_team_entry(db_session):
+    """The owner filter is scoped to the non-oauth arm on purpose:
+    builtin_oauth provisioning makes the first connector an owner by design
+    (_ensure_user_mcp_server writes is_owner=True), so filtering that arm
+    would break every legitimately team-shared builtin_oauth connector."""
+    db, creator, member = db_session
+    _add_builtin_oauth_app(db, "acme-drive", "Acme Drive")
+    server = _add_builtin_oauth_server(db, "acme-drive", "Acme Drive")
+    db.add(
+        UserMCPServer(
+            user_id=creator.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+    _add_oauth_account(db, member, "acme-drive")
+    _install_visibility(member, {int(server.id)})
+
+    entry = _entry(db, member, "acme-drive")
+    assert entry["is_team_shared"] is True
+    assert entry["can_attach"] is True
+
+
 def test_a_colliding_foreign_row_does_not_mask_the_official_row(db_session):
     """Two team-visible rows can normalize to one (transport, name) key —
     "Acme Notes" and `acme-notes` — and the index keeps every candidate, so


### PR DESCRIPTION
## Problem

`GET /api/mcp/apps` has two branches and neither claimed a connector a team shares with a member when that connector is backed by a **catalog app**.

* The catalog branch resolves connection state from personal associations only — it answers "is this app connected *for me*", which a team link cannot establish — so it reported `is_connected: false` and emitted no `server_id`.
* The local branch, the only one applying the team-visibility overlay (#1321), skips every row a catalog app speaks for. That skip is deliberate: it is what keeps the branch free of #1346's `is_custom` duplicate.

The member saw nothing in the Local tab and an unconnected catalog entry in the Remote tab — an app they would have to connect for themselves — even though the team had already shared a working connector with them. `GET /api/mcp/servers` applies the same overlay with no catalog skip, so the Tools page and the picker disagreed for exactly this subset, which is the disagreement #1321 set out to remove.

Reachable only in a deployment with a `connector_team_scope` visibility hook installed; standalone resolves empty and is unaffected.

## Fix

Give the catalog branch the third state the existing two cannot express.

* `is_connected` keeps meaning "connected **for me**", so a member is never shown Configure, a sharing badge, or a `server_id` for a connector they do not own.
* `is_team_shared` (new, emitted on every entry of `/api/mcp/apps`) means "reached me through a team link".
* `can_attach` unions the two, delegating to `_local_mcp_can_attach` rather than restating its rule.

Attachability is gated on where each shape's credentials live:

| Shape | Team-shared and attachable? |
| --- | --- |
| stdio / keyless / `api_key` | Yes — keyless needs no credential, and an `api_key` app's key resolves at runtime from the platform/shared/user/governing-team env layers (deliberately optimistic; the env-source flags carry the needs-config signal). The runtime resolves team-owned rows by the same overlay (`_load_visible_runtime_connectors`). |
| `mcp_oauth` | Only with the member's own active `MCPOAuthGrant` (or a deployment token-resolver hook). |
| `builtin_oauth` | Only with the member's own provider account on `UserOAuth` (or a deployment token-resolver hook). |

`builtin_oauth` is the term `_local_mcp_can_attach` never needed, because a catalog-keyed row never reaches the local branch. Its token is the member's own provider login and never rides on the shared row, so sharing the connector shares no credential for it — the same conclusion the issue reached for `mcp_oauth`, extended to the shape its design notes did not enumerate. Neither shape is presented as attachable without the member's own credential — except on deployments whose token-resolver hook supplies tokens out of band, where both are — and both keep the catalog Connect route their `auth_type` dispatches: "connect it for yourself", not a selection that fails at run time. That route works — `_ensure_catalog_mcp_oauth_server` reuses the existing shared row, and a catalog connect never writes `is_owner`, so the squat guard does not fire.

The local branch is otherwise unchanged and still skips every catalog-keyed row, so no path re-emits a catalog app as a second `is_custom` entry.

## Decisions

Three questions the issue left open, settled here and reversible:

1. **Which tab.** The entry is catalog-shaped, so it lands in Remote; the Local tab stays empty. Agreement with `/api/mcp/servers` therefore holds at the `/apps` level, not per tab.
2. **The `verified` status filter** now keeps team-shared entries. Withholding them would put the connector back out of reach for a member browsing under the filter, which is the reach this issue is about; the local branch applies no status filter at all, so this keeps the two consistent rather than splitting them again.
3. **No `server_id` when only team-shared.** This preserves the catalog branch's existing "`server_id` implies connected" invariant, which `connectorRef` documents and the sharing endpoints rely on. The picker attaches by name, so nothing needs it.

`is_team_shared` is decided by `connector_visible_to_user` — the same predicate behind `can_attach` — rather than by the index hit alone. The two can disagree: the row query filling those indexes is a SQL `IN`, which SQLite's numeric affinity lets a hook's *string* id match, while the in-Python predicate does not. Deciding the flag any other way would badge a card "Team tool" that the same response refuses to attach.

## Frontend

`AppIntegration.is_team_shared`, plus a "Team tool" badge for the unconnected case. The existing badge cannot cover it: it reads `POST /api/connectors/status`, which the picker fetches only for connected entries. Reuses the existing `tools.mcp.sharing.teamTool` string — no new i18n keys. The agent builder needed no change; it reads `/api/mcp/servers`, which already listed these connectors.

## Acceptance criteria

- [x] A team-visible catalog connector with no personal association appears exactly once, in catalog shape, with no `is_custom: true` twin.
- [x] `/api/mcp/apps` and `/api/mcp/servers` agree on which connectors a member can see.
- [x] A member who additionally holds a personal association still sees exactly one entry.
- [x] A team-shared `mcp_oauth` connector without a personal grant is not presented as attachable.
- [x] Non-team (standalone) responses are unchanged.
- [x] #1346 stays fixed: no path re-emits a catalog app as a second `is_custom` entry.

## Testing

New `tests/web/api/test_mcp_apps_team_catalog.py` — 33 collected cases as of the latest review round (grown from the original 14) covering every criterion above, plus the `builtin_oauth` shape (with and without a token-resolver hook), a deactivated personal row alongside a team link (`is_active` gates only the personal arm), strong-hide mode, the string-id hook answer, foreign-launch and foreign-auth rows, normalized-name collisions, env-source flag layers, a renamed app's `app_id` enrichment, and Custom API provenance.

Verified the suite is meaningful rather than tautological: against pre-fix `main`, 10 of the original 14 cases fail (later rounds' cases pin review follow-ups and are not counted in that claim).

Two frontend tests in `connect-mcp-dialog.test.tsx`: the badge renders and the entry attaches; the per-user-auth shape still routes to the detail modal's Connect.

`tests/web/api` (full), the four connector-picker suites, 261 frontend tests, `tsc --noEmit`, ruff and mypy all pass. The wider `tests/web` run has 5 pre-existing failures in the SVG-preview tests, from `libcairo` missing on the dev machine — unrelated to this change.

## Related

* Closes #1387
* Follows #1385 (fixes #1346), the dedupe fix that made this gap uniform
* Builds on #1384 (fixes #1347), whose `can_attach`/`can_authorize` split is where the new state lands — the issue's note that attachability policy still had to be settled is already resolved by that PR
* The overlay itself: #1321



