### PR TITLE
fix(agent): make pause_execution stateless so a second stop takes effect

### DIFF
--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -128,9 +128,6 @@ class AgentService:
                     name,
                     exc,
                 )
-        self._is_paused = False
-        self._pause_event = None
-        self._current_runner = None
         self._execution_adapter: Any | None = None
         self._outbound_message_handler: Callable[[dict[str, Any]], Any] | None = None
         self._interrupt_checker: Callable[[], Any] | None = None
@@ -267,16 +264,19 @@ class AgentService:
         return result
 
     async def pause_execution(self) -> bool:
-        if self._is_paused:
-            logger.warning("Agent '%s' is already paused", self.name)
-            return True
+        """Request an interrupt for whichever run is live right now.
+
+        Deliberately stateless: whether a run is interruptible is owned by the
+        runner/registry and is scoped to a single run, while this service is
+        cached per task and outlives every run it starts. Caching that answer
+        here made a second stop short-circuit against the first stop's run.
+        """
 
         execution_id = self._current_task_id or self.id
         paused = self.pause_execution_by_id(
             str(execution_id), reason="paused by websocket"
         )
         if paused:
-            self._is_paused = True
             logger.info(
                 "Agent '%s' agent execution %s pause requested",
                 self.name,
@@ -289,15 +289,6 @@ class AgentService:
             execution_id,
         )
         return False
-
-    async def resume_execution(self) -> None:
-        if not self._is_paused:
-            logger.warning("Agent '%s' is not paused", self.name)
-            return
-        self._is_paused = False
-
-    def is_paused(self) -> bool:
-        return self._is_paused
 
     def handle_websocket_input(self, user_input: str) -> bool:
         logger.info(
@@ -361,7 +352,6 @@ class AgentService:
         execution_id: str,
         **kwargs: Any,
     ) -> dict[str, Any] | None:
-        self._is_paused = False
         await self._ensure_tools_initialized()
         if self._execution_adapter is None:
             self._execution_adapter = self._build_execution_adapter()

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7563,18 +7563,25 @@ async def _handle_pause_task_unserialized(
             logger.info("Agent supports pause_execution, calling it...")
             pause_result = await agent_service.pause_execution()
             if pause_result is False:
-                message_data["_durable_command_error"] = (
-                    "No live execution found to pause"
+                # ``pause_execution`` reports on the live run only, so it says
+                # "no" both for a task that is already paused and for one that
+                # is not running at all. Those read very differently to a user,
+                # so the persisted status picks the message.
+                pause_failure = (
+                    "Task is already paused"
+                    if task_fields.status == TaskStatus.PAUSED
+                    else "No live execution found to pause"
                 )
+                message_data["_durable_command_error"] = pause_failure
                 error_payload = await _read_task_error_payload_offloop(
                     task_id,
-                    "No live execution found to pause",
+                    pause_failure,
                 )
                 await manager.send_personal_message(
                     error_payload,
                     websocket,
                 )
-                logger.warning(f"No live execution found to pause for task {task_id}")
+                logger.warning("%s for task %s", pause_failure, task_id)
                 return
             logger.info("Agent pause_execution completed")
             pause_applied = await run_db_io_cancellation_safe(
@@ -8010,47 +8017,13 @@ async def _handle_resume_task_unserialized(
             logger.info(f"Task {task_id} v2 resume scheduled")
             return
 
-        # Check if agent supports resume functionality
-        if hasattr(agent_service, "resume_execution"):
-            resume_snapshot = await task_execution_controller.transition(
-                task_id,
-                TaskControlState.RESUME_REQUESTED,
-                expected_run_id=task_fields.run_id,
-            )
-            await agent_service.resume_execution()
-            await task_execution_controller.transition(
-                task_id,
-                TaskControlState.RUNNING,
-                status=TaskStatus.RUNNING,
-                expected_run_id=resume_snapshot.run_id,
-            )
-
-            # Send resume confirmation
-            await manager.broadcast_to_task(
-                {
-                    "type": "task_resumed",
-                    "task_id": task_id,
-                    "message": "Task resumed",
-                    "timestamp": datetime.now(timezone.utc).timestamp(),
-                },
-                task_id,
-            )
-            logger.info(f"Task {task_id} resumed successfully")
-        else:
-            # If resume not supported, send error message
-            message_data["_durable_command_error"] = (
-                "Current agent does not support resume functionality"
-            )
-            await manager.send_personal_message(
-                {
-                    "type": "error",
-                    "message": "Current agent does not support resume functionality",
-                },
-                websocket,
-            )
-            logger.warning(
-                f"Agent for task {task_id} does not support resume functionality"
-            )
+        # Unreachable: ``supports_live_control`` is defined once, on
+        # ``AgentService``, and returns True unconditionally, so the block above
+        # always returns or raises. Kept as a loud failure rather than a silent
+        # fallthrough in case a future agent type opts out of live control.
+        raise RuntimeError(
+            f"Agent for task {task_id} does not support live execution control"
+        )
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error

--- a/tests/core/agent/test_agent_service_pause.py
+++ b/tests/core/agent/test_agent_service_pause.py
@@ -1,0 +1,224 @@
+"""Pause semantics for ``AgentService``.
+
+These tests drive the real ``AgentService`` -> ``AgentExecutionAdapter`` ->
+``ExecutionRegistry`` -> ``AgentRunner`` -> ``PatternRuntime`` chain. Only the
+pattern is a test double, which is the same seam ``test_registry.py`` uses.
+``pause_execution`` is never mocked: the regression these tests protect is
+precisely that a mocked ``pause_execution`` hides.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xagent.core.agent import Agent, ContextManager, ExecutionContext, PatternRuntime
+from xagent.core.agent.execution_adapter import (
+    AgentExecutionAdapter,
+    AgentExecutionConfig,
+)
+from xagent.core.agent.registry import ExecutionRegistry
+from xagent.core.agent.runner import AgentRunner
+from xagent.core.agent.service import AgentService
+
+
+@pytest.fixture(autouse=True)
+def reset_context_manager() -> None:
+    manager = ContextManager()
+    manager._contexts.clear()  # type: ignore[attr-defined]
+    yield
+    manager._contexts.clear()  # type: ignore[attr-defined]
+
+
+@dataclass
+class FakeWorkspace:
+    id: str
+    workspace_dir: Path
+    input_dir: Path
+    output_dir: Path
+    temp_dir: Path
+    allowed_external_dirs: list[Path]
+
+
+class FakeWorkspaceManager:
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+
+    def get_or_create_workspace(
+        self,
+        base_dir: str,
+        task_id: str,
+        allowed_external_dirs: list[str] | None = None,
+        scope_segments: tuple[str, ...] = (),
+    ) -> FakeWorkspace:
+        del base_dir, scope_segments
+        workspace_dir = self.tmp_path / task_id
+        return FakeWorkspace(
+            id=task_id,
+            workspace_dir=workspace_dir,
+            input_dir=workspace_dir / "input",
+            output_dir=workspace_dir / "output",
+            temp_dir=workspace_dir / "temp",
+            allowed_external_dirs=[Path(path) for path in allowed_external_dirs or []],
+        )
+
+
+class TracerCheckpointStore:
+    def __init__(self) -> None:
+        self.by_execution_id: dict[str, dict[str, Any]] = {}
+
+    async def checkpoint(self, **payload: Any) -> None:
+        self.by_execution_id[str(payload["execution_id"])] = dict(payload)
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        payload = self.by_execution_id.get(execution_id)
+        return dict(payload) if payload is not None else None
+
+
+class PollingPattern:
+    """Runs until the runtime reports an interrupt, like a real pattern loop."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.observed_interrupt = False
+
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        runtime: PatternRuntime,
+        **_: Any,
+    ) -> dict[str, Any]:
+        self.started.set()
+        while not await runtime.should_interrupt():
+            await asyncio.sleep(0)
+        self.observed_interrupt = True
+        await runtime.checkpoint(
+            "interrupted",
+            context=context,
+            pattern=self,
+            status="interrupted",
+            metadata={"safe_point": "during_pattern"},
+        )
+        return {
+            "success": False,
+            "status": "interrupted",
+            "error": "PollingPattern interrupted.",
+        }
+
+
+class StubLLM:
+    """Only ever inspected for logging / "is an LLM configured" checks."""
+
+    model_name = "stub-model"
+
+
+def _build_service(tmp_path: Path) -> tuple[AgentService, ExecutionRegistry, Any]:
+    """Real service wired to a real registry, sharing one tracer."""
+
+    tracer = TracerCheckpointStore()
+    registry = ExecutionRegistry()
+    service = AgentService(name="stopper", id="svc-1", tools=[], llm=StubLLM())
+    service._current_task_id = "task-1"
+    service._execution_adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="stopper",
+            pattern="react",
+            llm=StubLLM(),
+            tracer=tracer,
+            current_task_id="task-1",
+            service_id=service.id,
+            registry=registry,
+        )
+    )
+    return service, registry, tracer
+
+
+async def _start_live_run(
+    registry: ExecutionRegistry,
+    tracer: Any,
+    tmp_path: Path,
+    *,
+    execution_id: str,
+    task: str,
+) -> tuple[PollingPattern, asyncio.Task]:
+    """Start one real run and wait until its pattern is actually executing."""
+
+    pattern = PollingPattern()
+    runner = AgentRunner(
+        agent=Agent(name="stopper", patterns=[pattern]),
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    handle = registry.start(runner, execution_id=execution_id, task=task)
+    await asyncio.wait_for(pattern.started.wait(), timeout=5)
+    # Hold the asyncio task itself: the registry clears ``handle.task`` from
+    # its done-callback, so it is None by the time a settled run is inspected.
+    assert handle.task is not None
+    return pattern, handle.task
+
+
+async def _settle(run_task: asyncio.Task, *, label: str) -> dict[str, Any]:
+    """Await a run that a pause should have ended, failing loudly if it didn't."""
+
+    done, _pending = await asyncio.wait({run_task}, timeout=5)
+    if not done:
+        run_task.cancel()
+        pytest.fail(f"{label} kept running: the pause never reached the runtime")
+    return run_task.result()
+
+
+@pytest.mark.asyncio
+async def test_second_pause_after_new_turn_interrupts_the_new_run(
+    tmp_path: Path,
+) -> None:
+    """A stop on turn 2 must reach the runtime, even after turn 1 was stopped.
+
+    Regression for the stale ``_is_paused`` flag: turn 1's pause left a
+    service-level flag set, and because a user message on a PAUSED task starts
+    an APPEND turn (not a resume), nothing ever cleared it. The second
+    ``pause_execution`` then short-circuited and never requested an interrupt.
+    """
+
+    service, registry, tracer = _build_service(tmp_path)
+
+    first_pattern, first_run = await _start_live_run(
+        registry, tracer, tmp_path, execution_id="task-1", task="first turn"
+    )
+    assert await service.pause_execution() is True
+    first_result = await _settle(first_run, label="turn 1")
+    assert first_result["status"] == "interrupted"
+    assert first_pattern.observed_interrupt is True
+
+    # The APPEND turn: a brand new run under the same task id, exactly what
+    # ``agent_manager.execute_task`` does for a user message on a PAUSED task.
+    second_pattern, second_run = await _start_live_run(
+        registry, tracer, tmp_path, execution_id="task-1", task="second turn"
+    )
+
+    assert await service.pause_execution() is True
+
+    second_result = await _settle(second_run, label="turn 2")
+    assert second_result["status"] == "interrupted"
+    assert second_pattern.observed_interrupt is True
+
+
+@pytest.mark.asyncio
+async def test_pause_reports_false_when_no_run_is_live(tmp_path: Path) -> None:
+    """With no live execution, pause must report failure rather than success."""
+
+    service, registry, tracer = _build_service(tmp_path)
+
+    _pattern, run_task = await _start_live_run(
+        registry, tracer, tmp_path, execution_id="task-1", task="first turn"
+    )
+    assert await service.pause_execution() is True
+    await _settle(run_task, label="turn 1")
+
+    registry.unregister("task-1")
+
+    assert await service.pause_execution() is False

--- a/tests/web/api/test_websocket_pause_no_live_execution.py
+++ b/tests/web/api/test_websocket_pause_no_live_execution.py
@@ -1,0 +1,99 @@
+"""What the pause handler reports when no live execution can be interrupted.
+
+``AgentService.pause_execution`` is stateless, so it answers "is a run live
+right now" honestly and returns ``False`` for an already-paused task as well as
+for one that is simply not running. Those two cases are very different to a
+user, so the handler distinguishes them from the persisted task status.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from xagent.web.api import chat as chat_api
+from xagent.web.api import websocket as websocket_api
+from xagent.web.models.task import TaskStatus
+from xagent.web.services import task_setup_snapshot as snapshot_module
+
+
+async def _run_pause_with_no_live_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    status: TaskStatus,
+) -> list[str]:
+    """Drive the pause handler for a task whose run cannot be interrupted."""
+
+    task_id = 41
+    owner_id = 7
+    actor = SimpleNamespace(id=owner_id, is_admin=False)
+    runtime_user = SimpleNamespace(id=owner_id, is_admin=False)
+    snapshot = SimpleNamespace(
+        task=SimpleNamespace(user_id=owner_id, status=status, run_id="run-1"),
+        runtime_user=runtime_user,
+    )
+    reported: list[str] = []
+
+    async def read_error_payload(
+        resolved_task_id: int, message: str, *args: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        assert resolved_task_id == task_id
+        reported.append(message)
+        return {"type": "error", "message": message}
+
+    agent_service = MagicMock()
+    agent_service.pause_execution = AsyncMock(return_value=False)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+
+    monkeypatch.setattr(
+        snapshot_module,
+        "load_task_setup_snapshot_sync",
+        lambda *args, **kwargs: snapshot,
+    )
+    monkeypatch.setattr(
+        websocket_api, "resolve_execution_scope_off_turn", lambda _task_id: None
+    )
+    monkeypatch.setattr(
+        websocket_api, "_read_task_error_payload_offloop", read_error_payload
+    )
+    monkeypatch.setattr(chat_api, "get_agent_manager", lambda: agent_manager)
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    try:
+        await websocket_api._handle_pause_task_unserialized(
+            MagicMock(), task_id, {"user": actor}
+        )
+    finally:
+        websocket_api._clear_task_pause_accepted(task_id)
+
+    connection_manager.broadcast_to_task.assert_not_awaited()
+    return reported
+
+
+@pytest.mark.asyncio
+async def test_pause_on_an_already_paused_task_says_so(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reported = await _run_pause_with_no_live_execution(
+        monkeypatch, status=TaskStatus.PAUSED
+    )
+
+    assert reported == ["Task is already paused"]
+
+
+@pytest.mark.asyncio
+async def test_pause_on_a_task_with_no_live_run_reports_that(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reported = await _run_pause_with_no_live_execution(
+        monkeypatch, status=TaskStatus.RUNNING
+    )
+
+    assert reported == ["No live execution found to pause"]


### PR DESCRIPTION
## Problem

Stopping a conversation a second time silently does nothing.

Repro:

1. Send a message, the agent starts running
2. Press stop — works
3. **Without pressing resume**, send another message — a new turn starts
4. Press stop again — no effect

The failure is silent rather than an error: the frontend receives
`task_pause_requested` and shows the stop as accepted, while the run continues
to completion. Worse, the user is then stuck — the `pause_accepted` guard in
`_handle_chat_message_unserialized` calls `background_task_manager.wait_for_previous`,
which blocks on the very run that was supposed to have been stopped. The user can
neither stop it nor send the next message, with no error surfaced anywhere.

## Root cause

`AgentService._is_paused` is a flag describing **one run**, stored on an object
whose lifetime is **one task**.

`AgentService` instances are cached per task in `AgentManager._agents` and are not
evicted when a turn completes (the only eviction conditions are owner mismatch,
scope-fingerprint mismatch, and sandbox reclamation). The flag was cleared in only
two places, `resume_execution()` and `resume_execution_by_id()`, both on the explicit
resume path.

But a user message on a `PAUSED` task is deliberately routed as an APPEND turn, not
a resume:

```python
elif routing.status == TaskStatus.PAUSED:
    turn_kind = TurnKind.APPEND
    turn_force_fresh = False
```

That path runs `agent_manager.execute_task` → `AgentService.execute_task` →
`_execute_agent_task`, none of which touch `_is_paused`. So the flag stayed set into
the next run, and the second stop short-circuited:

```python
if self._is_paused:
    logger.warning("Agent '%s' is already paused", self.name)
    return True          # pause_execution_by_id never called
```

`request_interrupt` was therefore never reached. Because the handler only
special-cases `pause_result is False`, the `True` fell through and still persisted
`PAUSE_REQUESTED`, marked the pause accepted, and broadcast `task_pause_requested`.

The routing split itself is correct and intentional and is left alone: resume reuses
the same `run_id` and restores pattern state from a checkpoint, while APPEND
allocates a fresh `run_id` and clears the checkpoint pointers. Checkpoint reads are
partitioned by `run_id`, so a new run physically cannot see the previous run's
checkpoint. The bug was not the two paths — it was a flag placed on one of them.

### Origin

The flag is a leftover from the v1 runtime, where it *was* the pause state and
`if self._is_paused: return` was a correct idempotency guard. The v2 rewrite moved
the truth to the per-run `request_interrupt` (established in `AgentRunner` and popped
unconditionally in a `finally`), turned `pause_execution` into a delegation, and left
the guard on top — where it changed meaning from "already in the target state" to
"veto a real operation using a stale cache".

Supporting evidence: `is_paused()` had zero callers repo-wide, and the Telegram
channel calls `pause_execution_by_id` directly, bypassing this wrapper — which is
why stop has always worked there.

## Changes

- `pause_execution` delegates unconditionally to `pause_execution_by_id`. Whether a
  run is interruptible is owned, per run, by the runner and registry; it is now asked
  every time instead of cached.
- Remove `_is_paused`, `is_paused()`, `resume_execution()`, and the never-read
  `_pause_event` / `_current_runner` attributes.
- The pause handler distinguishes an already-paused task from one with no live run,
  so the now-honest `False` does not surface a misleading error.
- Replace the legacy resume fallback with an explicit `raise`. It is unreachable:
  every path inside the `supports_live_control()` block returns or raises, and
  `supports_live_control` has a single implementation returning `True` unconditionally.

### User-visible behavior change

Pressing stop on a task with no live run now reports honestly instead of claiming
success. An already-paused task reports "Task is already paused"; a task with no live
run reports the existing "No live execution found to pause". Previously both returned
success, which was the bug.

## Tests

The reason this survived: every `pause_execution` reference in `tests/` was a mock
asserting only "was called", so the real flag logic was never executed. `_is_paused`
appeared nowhere in `tests/`, and there was no unit test of
`AgentService.pause_execution` at all.

Added `tests/core/agent/test_agent_service_pause.py`, driving the real
`AgentService` → `AgentExecutionAdapter` → `ExecutionRegistry` → `AgentRunner` →
`PatternRuntime` chain with only the pattern as a test double (the same seam
`test_registry.py` uses). `pause_execution` is not mocked.

- `test_second_pause_after_new_turn_interrupts_the_new_run` — the regression. Written
  first and confirmed failing with `turn 2 kept running: the pause never reached the
  runtime` before the fix.
- `test_pause_reports_false_when_no_run_is_live`

Added `tests/web/api/test_websocket_pause_no_live_execution.py` covering the two
distinct failure messages.

## Verification

- The 4 new tests pass; the regression test was confirmed red first.
- `tests/core/agent` and `tests/web/api` pass with 0 failures.
- `pre-commit` (ruff, ruff format, mypy, isort, codespell) passes.
- Full `tests/web` shows 6 failures, all pre-existing: the identical 6 fail on
  unmodified `origin/main` (AWS connector literal and SVG rasterization). Separately,
  `tests/web/tools/test_aws_mcp.py` cannot be collected locally because the optional
  `boto3` dependency is absent.

## Follow-ups (not in this PR)

Latent issues of the same family — state keyed by task but describing one run — found
while investigating. None is currently causing a user-visible failure:

- `_pause_accepted_task_ids` is a module-level `set[int]` with no `run_id` fence,
  unlike every DB-side transition. Correct today only by convention.
- The live-control branch in `_handle_chat_message_unserialized` does not roll back
  `RESUME_REQUESTED` on scheduling failure, while the resume handler does. Self-healing
  if the user sends another message, but otherwise leaves the UI stuck on "resuming".
- `ExecutionRegistry._on_task_done` looks the handle back up by `execution_id` rather
  than holding the one it was created with. I could not prove this reachable today.
