### PR TITLE
ref(skills): trim static-visual-design and fix its truncated index entries

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -27,8 +27,8 @@ class DownloadWebAssetArgs(BaseModel):
     url: str = Field(
         description=(
             "Exact HTTP or HTTPS image URL discovered on an authoritative page. "
-            "For a brand asset, only an official domain the user directed you to "
-            "counts as authoritative."
+            "For a brand asset, authoritative means the brand's own domain or "
+            "its CDN, reached while carrying out a retrieval the user asked for."
         )
     )
     filename: str | None = Field(
@@ -76,11 +76,12 @@ class DownloadWebAssetTool(AbstractBaseTool):
         return (
             "Download an exact PNG, JPEG, WebP, GIF, BMP, or SVG asset from a "
             "known URL and register it in the current workspace. Use this after "
-            "fetch_web_content(include_assets=true) surfaced the asset you were "
-            "sent to retrieve; a downloaded image is not proof that it is a "
+            "fetch_web_content(include_assets=true) surfaced the asset the user "
+            "asked you to retrieve; a downloaded image is not proof that it is a "
             "brand's authentic asset, so do not treat one as verified identity "
-            "material the user did not ask for. It returns a trusted FileRef, so "
-            "do not reproduce the asset through api_call plus write_file."
+            "material for a retrieval nobody requested. It returns a trusted "
+            "FileRef, so do not reproduce the asset through api_call plus "
+            "write_file."
         )
 
     @property

--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -27,7 +27,8 @@ class DownloadWebAssetArgs(BaseModel):
     url: str = Field(
         description=(
             "Exact HTTP or HTTPS image URL discovered on an authoritative page. "
-            "Prefer the official brand domain for logos."
+            "For a brand asset, only an official domain the user directed you to "
+            "counts as authoritative."
         )
     )
     filename: str | None = Field(
@@ -75,9 +76,11 @@ class DownloadWebAssetTool(AbstractBaseTool):
         return (
             "Download an exact PNG, JPEG, WebP, GIF, BMP, or SVG asset from a "
             "known URL and register it in the current workspace. Use this after "
-            "fetch_web_content(include_assets=true) discovers an official logo or "
-            "brand image. It returns a trusted FileRef, so do not reproduce the "
-            "asset through api_call plus write_file."
+            "fetch_web_content(include_assets=true) surfaced the asset you were "
+            "sent to retrieve; a downloaded image is not proof that it is a "
+            "brand's authentic asset, so do not treat one as verified identity "
+            "material the user did not ask for. It returns a trusted FileRef, so "
+            "do not reproduce the asset through api_call plus write_file."
         )
 
     @property

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -16,8 +16,9 @@ class FetchWebContentArgs(BaseModel):
         default=False,
         description=(
             "Also discover image, icon, manifest, script, and stylesheet URLs. "
-            "Enable it when the user pointed you at this page for an asset it "
-            "holds."
+            "Enable it when the user asked you to obtain an asset and this page "
+            "is where you traced it to — whether they named the page or you "
+            "found it. Do not enable it to go asset-hunting on your own."
         ),
     )
     asset_query: str | None = Field(
@@ -81,12 +82,13 @@ class FetchWebContentTool(AbstractBaseTool):
             "to markdown. Use this after web_search finds a promising source, or "
             "when the user provides a URL that needs to be read. This is for "
             "retrieving page content; use web_search first when you need to "
-            "discover sources. When the user directed you to a page for an exact "
-            "asset, set include_assets=true and asset_query to match it; going "
-            "after a brand's identity assets uninstructed is not a use for this "
-            "tool. The returned assets preserve official page URLs; pass the "
-            "chosen URL to download_web_asset instead of recreating it with "
-            "api_call/write_file."
+            "discover sources. When the user asked you to obtain an exact asset, "
+            "set include_assets=true and asset_query to match it — the page may "
+            "be one they named or one web_search found for that request. What "
+            "the tool is not for is going after a brand's identity assets "
+            "uninstructed. The returned assets preserve official page URLs; "
+            "pass the chosen URL to download_web_asset instead of recreating it "
+            "with api_call/write_file."
         )
 
     @property

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -16,7 +16,8 @@ class FetchWebContentArgs(BaseModel):
         default=False,
         description=(
             "Also discover image, icon, manifest, script, and stylesheet URLs. "
-            "Enable this when looking for logos, brand assets, or images."
+            "Enable it when the user pointed you at this page for an asset it "
+            "holds."
         ),
     )
     asset_query: str | None = Field(
@@ -80,10 +81,12 @@ class FetchWebContentTool(AbstractBaseTool):
             "to markdown. Use this after web_search finds a promising source, or "
             "when the user provides a URL that needs to be read. This is for "
             "retrieving page content; use web_search first when you need to "
-            "discover sources. When the task needs a logo or other exact web "
-            "asset, set include_assets=true and usually asset_query='logo'. The "
-            "returned assets preserve official page URLs; pass the chosen URL to "
-            "download_web_asset instead of recreating it with api_call/write_file."
+            "discover sources. When the user directed you to a page for an exact "
+            "asset, set include_assets=true and asset_query to match it; going "
+            "after a brand's identity assets uninstructed is not a use for this "
+            "tool. The returned assets preserve official page URLs; pass the "
+            "chosen URL to download_web_asset instead of recreating it with "
+            "api_call/write_file."
         )
 
     @property

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -51,11 +51,11 @@ When given a user request, rewrite and enrich the prompt into a **professional i
   2. Quote required copy clearly and keep unnecessary text out.
   3. Reference images can guide product identity, visual language, palette, and
      composition. Use only references the user supplied, the task already
-     produced, or an asset retrieved from the brand's own official source; do
-     not go looking for reference material from any other origin, and never take
-     one from the user's other tasks. A plausible-looking search result is not
-     proof that an asset is the brand's; when nothing verifiable is available,
-     ask the user for it. Pass such a reference by path, URL, or
+     produced, or an asset the user directed you to retrieve; do not retrieve
+     one on your own initiative, not even from a brand's official site, and
+     never take one from the user's other tasks. A plausible-looking search
+     result is not proof that an asset is the brand's; when nothing verifiable
+     is available, ask the user for it. Pass such a reference by path, URL, or
      file_id through the images parameter. Mentioning a reference only in the
      prompt does not attach it to the model request.
   4. Generated depictions are not suitable when a supplied logo, QR code,
@@ -139,11 +139,12 @@ Text handling in edited images:
   exact fidelity is required, explain the limitation and ask the user to arrange
   deterministic post-processing — never present a generative edit as exact.
 
-Use only images the user supplied, the task already produced, or an asset
-retrieved from the brand's own official source; do not go looking for source or
-reference material from any other origin, and never take one from the user's
-other tasks. A plausible-looking search result is not proof that an asset is the
-brand's; when nothing verifiable is available, ask the user for it.
+Use only images the user supplied, the task already produced, or an asset the
+user directed you to retrieve; do not retrieve source or reference material on
+your own initiative, not even from a brand's official site, and never take one
+from the user's other tasks. A plausible-looking search result is not proof that
+an asset is the brand's; when nothing verifiable is available, ask the user for
+it.
 
 Available models (⭐[DEFAULT] marks the configured default model):
 {}

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -54,6 +54,13 @@ asks for exactly one final asset, compare directions internally and render the
 strongest. The reference explains how to invent a direction's visual device and
 how far apart a set should sit.
 
+One creative lead defines and compares the whole set sequentially, in one pass.
+Do not split ideation across independent agents or parallel plan nodes —
+independent ideation converges on the same obvious brand cues and varies only the
+decoration. Parallel execution is available only after every brief and
+specification is locked, and each parallel executor then holds one distinct
+proposition it may not reinterpret.
+
 Order the work, and represent that order in any execution plan: brand and
 reference acquisition is a shared prerequisite, creative direction depends on it,
 and every render depends on the locked specification. Never plan a render, or an
@@ -154,6 +161,11 @@ most two per asset and four per run. Calls on optional assets, re-renders of a
 direction already delivered, and anything you would call a variant or retry all
 cost a repair.
 
+Where both definitions fit one call, coverage wins. A required placement with no
+candidate of its own is free coverage even when the same direction was already
+delivered at another placement — the 4:5 feed asset does not make the 9:16 story
+asset a repair. Only a second render of that same placement costs one.
+
 Regenerate from the design specification when the organizing idea, focal
 subject, hierarchy, or canvas structure is wrong; use `edit_image` for a
 localized defect on an otherwise strong candidate. When a limit is reached,
@@ -164,9 +176,13 @@ named, not retried on a fresh budget.
 ## Finish
 
 Coverage is unconditional: every required asset must exist as a successful tool
-result before you finish. One thing overrides it — a brand-specific brief with
-no verified logo ends in the question above, with nothing rendered, and that
-counts as finished. Quality is what the budget releases — when the budget
+result before you finish. One thing overrides it — a brand-specific *final* with
+no verified logo. Before the user has chosen, that turn ends in the question
+above with nothing rendered, and that counts as finished. After they choose a
+reserved-space or unbranded route, render it, inspect it, and hand it back as a
+concept draft; coverage then applies to the drafts they chose, and what stays
+unfinished is the branded final, not this turn. Quality is what the budget
+releases — when the budget
 is spent and an asset still fails inspection, deliver its best candidate, name
 the defect concretely (which text is misspelled, which element is clipped, which
 logo is not authentic), and mark the answer's outcome `partial` so the user can

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -150,6 +150,7 @@ the defect concretely (which text is misspelled, which element is clipped, which
 logo is not authentic), and mark the answer's outcome `partial` so the user can
 decide whether to spend another round.
 
-Return only PNG or JPEG files that were actually created. Lead with the files,
-then give one concise line per asset identifying its communication angle and
-dimensions.
+Return only PNG or JPEG files that were actually created. When the run ends in a
+question there are none, and the question is the whole answer — do not list or
+describe files that do not exist. Otherwise lead with the files, then give one
+concise line per asset identifying its communication angle and dimensions.

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: static-visual-design
 description: |
-  Create polished commercial and brand-facing static visual designs as complete
-  PNG or JPEG assets. Use only for advertising creatives, campaign posters,
-  promotional social posts, event or announcement cards, banners, and placement
-  variants where art direction, typography, hierarchy, brand fidelity, and
-  visual quality matter.
+  Design a finished ad, poster, banner, social post, or invitation as one
+  PNG/JPEG with layout, headline, and brand styling rendered in.
 when_to_use: |
-  Use only for marketing, campaign, event, or brand communication. Do not use
-  for educational infographics, technical diagrams, concept explainers, charts,
-  data visualizations, or standalone illustrations or photos.
+  Any marketing, promotion, campaign, event, or brand-facing image, including
+  ones naming a real brand. Not for explanatory diagrams, charts, infographics,
+  or plain illustrations.
 ---
 
 # Static Visual Design

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -14,454 +14,145 @@ when_to_use: |
 
 # Static Visual Design
 
-## Stay within the commercial-creative scope
+## Scope
 
-Use this skill only when the requested deliverable communicates marketing,
-promotional, campaign, event, or brand-facing material. A request to explain a
-concept with an image, comparison graphic, educational infographic, technical
-diagram, chart, or data visualization is outside this skill even when the user
-asks for a polished PNG or JPEG. Use the general image-generation workflow or a
-more specific explanatory-visual skill instead.
+Use this skill when the deliverable is marketing, promotional, campaign, event,
+or brand-facing material. Explanatory work — concept images, comparison
+graphics, educational infographics, technical diagrams, charts, data
+visualizations — belongs to the general image-generation workflow instead, even
+when a polished PNG is requested. Logo invention, video, ad-account management,
+standalone illustration with no designed layout, and copy-only requests are all
+out of scope.
 
-Do not use this skill to invent a logo, create video, manage ad accounts,
-generate a standalone illustration or photo with no designed commercial
-layout, or answer copy-only requests.
+Produce the finished visual with `generate_image` and `edit_image`. Let the
+image model solve composition, type, atmosphere, and graphic language together.
+Reserve HTML/CSS plus browser screenshots for when the user explicitly asks for
+an editable HTML deliverable.
 
-Produce the finished visual with image generation and editing. Let the image
-model solve the composition, type treatment, atmosphere, and graphic language
-together instead of reducing the work to a generated background plus an HTML
-layout.
+## Read the art direction reference
 
-For advertising creatives, campaign posters, promotional social posts,
-announcement graphics, and other commercially designed static visuals, read
-`references/static-ad-art-direction.md` with `read_skill_doc` before defining
-directions or rendering. Use its communication structures, layout specification,
-one-canvas contract, and rejection rules. Do not treat the reference as a menu
-of decorative styles.
+Before defining directions or rendering, read
+`references/static-ad-art-direction.md` with `read_skill_doc`. It carries the
+communication structures, layout specification, depth stack, copy budget,
+render-prompt form, and review checklist this skill relies on.
 
 ## Establish the brief
 
-Identify the minimum useful brief before generating:
-
-- communication goal, audience, and intended response;
-- primary message, supporting copy, CTA, and required disclaimer;
-- output channel and target aspect ratio or dimensions;
-- available logo, QR code, product, brand-guide, campaign, and reference assets.
-
-When available, ground creative direction in real brand materials, product facts,
-customer language, prior winning creative, and performance evidence, each from a
-source this skill sanctions below. Treat those inputs as evidence, not as
-permission to invent adjacent claims.
-
-Distinguish exact supplied copy from facts that still need copywriting. Preserve
-copy the user marks as exact. When the user supplies facts but not final wording,
-write concise, idiomatic campaign copy instead of mechanically restating the
-brief. Avoid defensive or generic claims such as "you cannot be wrong," vague
-superlatives, and urgency unsupported by the offer.
-
-Do not create a separate brief document unless the user asks for one. Infer
-low-risk creative choices, but never invent prices, milestones, performance
-claims, offer mechanics, eligibility, dates, URLs, legal copy, or brand rules.
-Verify time-sensitive claims when necessary. If exact campaign terms are absent,
-keep the visual to the claims the user actually supplied.
-
-## Develop campaign directions before rendering
-
-For an open-ended brand campaign, poster, promotion, or advertising request,
-turn the brief into two or three genuinely different communication angles
-before committing to a visual. Useful angle families include milestone pride or
-social proof, offer-led value, product benefit, emotional identity, and urgency,
-but choose only those supported by the brief.
-
-Keep this initial direction-setting in one coherent planning pass. One creative
-lead should define and compare the full set of directions; do not delegate
-open-ended ideation to independent agents or parallel nodes. Independent
-ideation tends to converge on the same obvious brand cues while changing only
-surface decoration. Parallel execution is useful only after the briefs are
-locked: each executor receives a distinct proposition, structure, focal device,
-production finish, and explicit exclusions, and must not reinterpret the other
-directions.
-
-Represent this order in the execution plan. Brand/reference acquisition is a
-shared prerequisite, creative direction and design specification depend on that
-grounding, and every render depends on the locked specification. Do not search
-for identity assets in parallel with artifact generation. Inspection depends on
-the render results. Independent renders may run in parallel only after all
-shared inputs are resolved.
-
-Never bake asset-availability conclusions into planned work before the
-acquisition step has run. Do not write instructions such as "use the brand name
-in typography since no logo asset is available" into a step definition; whether
-a verified logo exists is an outcome of asset resolution, and how the brand is
-represented must stay open until that outcome is known.
-
-Give every direction one single-minded proposition, one visual device, and one
-structural approach. The proposition explains why the audience should care;
-the visual device creates the memorable image; the structure controls how the
-message is scanned. Evaluate directions for brand fit, stopping power,
-glance-level clarity, offer comprehension, and factual safety. Do not let a
-creative become two disconnected ads stacked in one canvas.
-
-Invent each direction's visual device deliberately instead of jumping from an
-angle name to a layout. Use generative moves — dramatize the verb in the
-proposition, give the proof number physical form in a real place, literalize
-the offer as an object or event, stage a recognizable cultural moment, shift
-scale, or cast a brand asset as the protagonist — and sketch more device
-candidates in writing than you have direction slots before keeping the
-strongest. Those sketches are sentences, not renders, so they cost no budget. An
-angle name like "milestone pride" is not a device; "the milestone staged as a
-rally the viewer is invited to join" is. The art-direction reference expands
-these moves.
-
-Do not create directions by accumulating a universal blacklist of subjects or
-styles. No device is inherently right or wrong: a person, product, phone,
-mascot, gradient, confetti field, typographic composition, or empty color field
-can all work when it performs a clear role in the proposition. Exclude an
-element only when it conflicts with the chosen direction, brand evidence, or
-message—not because it appeared in a generic list.
-
-When client taste is unknown, build a creative-risk ladder instead of betting
-everything on one aesthetic:
-
-1. **Brand-safe evolution** — immediately recognizable, with a cleaner and more
-   disciplined use of familiar brand cues.
-2. **Contemporary reinterpretation** — preserves identity while changing the
-   composition, image language, or type system meaningfully.
-3. **Bold exploration** — uses a more ownable campaign metaphor or unexpected
-   art direction while remaining factually and strategically on brief.
-
-Do not make every option safe or every option experimental. The ladder gives a
-client a comfortable choice and reveals how much change they will accept.
-
-Do not interpret the singular nouns "an ad," "a poster," or "a social post" as
-an instruction to explore only one direction. When the creative direction is
-open, render two or three candidates so the user can choose. When the user
-explicitly requests exactly one final asset, still compare possible directions
-and render the strongest one without exposing unnecessary internal deliberation.
-
-## Choose a designed structure
-
-Do not default every request to a stock portrait or product mockup beside large
-headline text. Select a structure that serves the message, such as a dominant
-stat, a single hero scene, a product or object spotlight with callouts, a
-before/after contrast, a problem/solution transition, an editorial typographic
-composition, a proof or quote card, or an information-rich event poster. Treat
-these as a varied vocabulary, not fixed templates.
-
-Make the headline and image divide the communication work. The image should add
-proof, tension, emotion, scale, contrast, or surprise instead of literally
-captioning the headline. Prefer one ownable campaign device over a collage of
-unrelated symbols. Match information density to the placement: feed ads and
-banners usually need a short hook and one support line; event and information
-posters may carry more detail if the hierarchy remains obvious.
-
-Treat the visual device as a mechanism, not a medium label. Photography,
-illustration, objects, characters, expressive type, spatial relationships, and
-material treatments are all valid, but the direction must state what the
-device makes the audience notice or understand. “Bold typography,” “brand
-gradient,” “large number,” and “premium styling” are treatments, not complete
-ideas on their own.
-
-Before rendering, turn each direction into a compact design specification:
-canvas and placement, communication structure, focal subject, visual-weight
-distribution, three-level information hierarchy, scan path, the depth stack
-(environment, atmosphere, focal subject, supporting graphics, typography,
-brand — each layer decided, not defaulted to empty), typography character and
-line count, color roles, production finish, reference responsibilities, and
-explicit exclusions. If the scan order is not
-clear in the specification, the direction is not ready to generate. Keep the
-specification compact enough to survive intact into the render prompt. Do not
-create a separate directions or strategy artifact unless the user asks for it,
-and do not make reading a required reference document its own deliverable step.
-
-## Use brand and reference assets intentionally
-
-Inspect the reference images this task provides with `understand_media`. Pass
-useful product, campaign, style, or layout references to image generation or
-editing so the result belongs to the intended visual world.
-
-For work naming a real brand, resolve the brand identity before rendering final
-candidates. Three sources are legitimate: an asset the user gave you in this task
-— including one attached in an earlier turn, whose file_id is no longer in context
-and which you recover by finding it with `list_all_user_files` — the current task
-workspace, and the brand's own official web presence, retrieved with the web
-tools available to you. If none of them yields a verified asset, ask the user for
-it; a visually plausible search result is not proof that a logo is authentic.
-
-The user's other tasks and earlier outputs are not a source. Do not list them
-looking for brand material, and do not reverse-engineer a brand's identity by
-reading images found that way — a file that turned up in a listing proves nothing
-about whose brand it shows.
-
-Treat identity-critical assets differently:
-
-- Use an official supplied logo as the source of truth. Include it as a
-  generation reference whenever the image tool supports references so palette,
-  brand language, proportions, and reserved placement influence the whole
-  design. Pass the actual path, URL, or file_id through the image tool's
-  `images` argument (or use `edit_image` directly); naming the asset only in the
-  prompt does not attach it. Still do not trust a generated or edited recreation
-  as the final logo.
-- Treat QR codes, certification marks, sponsor marks, UI screenshots, and other
-  exact assets as non-generative inputs: generative rendering cannot preserve them
-  pixel-for-pixel. No image tool composites deterministically. If the final
-  placement requires exact reproduction, say so plainly and ask the user to
-  arrange deterministic post-processing; never claim a generated candidate is one.
-- Unless the user explicitly requests an unbranded or logo-free concept, a
-  brand-specific final requires a verified logo. If none is available, ask for
-  it and keep any interim output clearly labeled as a concept draft. Do not mark
-  the requested branded asset complete, and never typeset or invent a substitute
-  logo.
-
-Separate stable identity cues from temporary campaign styling. Stable cues may
-include the official logo, recurring color relationships, typography character,
-product imagery, graphic proportions, and tone of voice. Temporary styling may
-include a particular gradient, metallic 3D type, bevel, glow, ribbon, confetti,
-swoosh, or seasonal campaign motif. Use several recent official references when
-available to infer what recurs; do not copy every effect from one old banner.
-
-When official references look dated, familiarity still matters, but datedness
-is not a brand requirement. Preserve recognition through the stable cues and
-modernize hierarchy, whitespace, type discipline, image quality, depth, and the
-number of competing effects. A brand-safe direction should feel like the next
-campaign from the same brand, not a replica of its oldest promotion.
-
-## Generate the complete creative
-
-Use `generate_image` to create the full designed asset, including the intended
-composition, typography, hierarchy, graphic elements, and user-supplied copy.
-Prompt with:
-
-- the organizing visual idea and emotional tone;
-- the chosen structure, focal subject, and specific visual device;
-- exact text to render, quoted clearly;
-- hierarchy and approximate placement, without over-constraining every pixel;
-- target aspect ratio and viewing context;
-- relevant brand, product, campaign, and style references, with a clear statement
-  of what to borrow from each;
-- the intended production finish, such as documentary photography, tactile
-  collage, screen print, editorial type, clean product render, or bold flat art;
-- any quiet zones required around identity-critical asset placement;
-- exclusions such as fake logos, fake QR codes, watermarks, and unrelated text.
-
-Each call must request one finished placement on one continuous canvas. Render
-each direction separately. Explicitly exclude contact sheets, moodboards,
-option grids, multiple versions, presentation mockups, repeated layouts,
-split-frame compositions, and duplicated headlines. Do not put words such as
-"variations," "option A/B," or "layout exploration" in a render prompt.
-
-Keep copy load proportional to the format. A typical feed ad should have one
-exact headline of no more than two short lines, at most one short support line,
-one concise CTA, and only required fine print. The offer is expressed through
-the headline or the CTA, never as an additional standalone "offer highlight"
-element; if a brief or step description enumerates headline, support, offer,
-and CTA as four separate text blocks, merge them back into this budget before
-rendering. Never send alternative copy, strategy labels, markdown, rationale,
-or production notes for rendering.
-
-Write a concept-specific prompt for every direction. Do not reuse a generic
-"modern professional ad" prompt with only the colors and headline changed.
-
-Before generation, compare the locked briefs as a set. Each direction must
-differ on at least three of these axes: focal subject, structural approach,
-visual metaphor, production finish, palette balance, and type strategy. Do not
-reuse the same gradient, display treatment, and decorative motif across the
-set. Compare the actual render prompts, not merely their direction names or
-strategy labels. If the prompts describe the same focal mechanism and layout,
-revise them before rendering. Distinct propositions do not make distinct
-directions when every focal subject is the same device: a set in which each
-direction's hero is a large typographic number or headline is one direction
-wearing three copy variations. For an open brief, at most one direction in a
-set may use pure typography as its focal subject; the others must be carried
-by a scene, person, place, object, or material device. The same limit applies
-to production depth: a deliberately flat, minimal treatment with an empty
-environment and atmosphere is one direction at most, never the unexamined
-default for the whole set. When the user explicitly requests a typographic,
-minimalist, or otherwise constrained system, follow the brief and create the
-variation inside that system — through composition, scale, material, and
-color — instead of forcing scenes into it.
-
-For campaign directions developed above and for plural creative requests, make
-the concepts materially different before making size variants. Vary the idea,
-composition, subject, image treatment, and hierarchy—not merely crop or accent
-color. Cosmetic resizes are not distinct concepts.
-
-Choose each aspect ratio from the actual placement, never as a habit, and let
-the medium set the vocabulary: social campaigns default to 4:5 feed and 9:16
-story (1:1 only when a channel specifically requires square); print, poster,
-out-of-home, and display work follows its placement's actual dimensions, such
-as standard banner and billboard sizes. When the user has not named channels,
-either ask or cover the likely placements deliberately and say which asset
-serves which placement. Do not silently default every render to one square
-canvas. Compose natively for the chosen ratio: a square
-canvas wants a centered or radial composition built around its focal device,
-not a vertical poster stack with dead side margins.
-
-Generate each materially different aspect ratio for that format. Do not force a
-landscape master into square, portrait, or story placements when a fresh
-composition would be stronger.
-
-Do not forbid familiar devices merely because they are common in generated ads.
-A gradient, portrait, phone, giant headline, glow, wave, confetti field, or
-sparkle can be the right choice. Reject it only when it is an unexamined default,
-does no communication work, or could move unchanged to a competitor. Favor one
-clear focal point, a recognizable silhouette at thumbnail size, and a visual
-idea specific enough that another brand could not use it unchanged.
-
-Treat stacked display effects as a warning sign: metallic 3D lettering plus
-bevels, glow, drop shadows, ribbons, swooshes, confetti, and multiple headline
-blocks rarely become stronger by accumulation. Keep only the effects that serve
-the chosen visual device and remove the rest.
-
-## Inspect and iterate with image tools
-
-Inspect every candidate with `understand_media`, checking:
-
-- exact spelling, numbers, dates, CTA, offer, and disclaimer;
-- whether the copy reads naturally and expresses the intended campaign angle;
-- hierarchy, contrast, and thumbnail-size legibility;
-- whether the headline and image complement rather than repeat each other;
-- whether the visual device feels ownable instead of stock or interchangeable;
-- crop, balance, edge clearance, and platform safe zones;
-- consistency with the supplied references and recognizable brand language;
-- accidental pseudo-logos, fake QR codes, watermarks, malformed objects, or
-  unrelated lettering.
-
-Only one failure is a coverage failure: a required asset with no candidate at all.
-That one is not budgeted — render it.
-
-Everything else is a quality failure, including every structural one: a contact
-sheet or several ads in one image, duplicated layouts or headlines, fake or
-duplicated logos, a missing required brand asset, a specification layer the render
-dropped, wrong or invented copy, unverified claims, unclear hierarchy, clipped or
-overlapping essentials. Reject them while the repair budget lasts, and never
-rationalize them as stylistic choices. When the budget runs out, name the defect
-in your answer rather than accepting it silently — and do not reclassify a defect
-as missing coverage to buy another render.
-
-Use `edit_image` only to refine a strong, single-canvas candidate with a
-localized defect. While the budget lasts, regenerate from the locked design
-specification when the organizing idea, focal subject, hierarchy, copy load, or
-canvas structure is wrong, or when several text errors appear. Correct permitted
-copy errors and inspect again. A successful generation call alone is not proof
-that the asset is finished. Compare the candidates side by side and discard the
-safest generic option even when it is technically clean.
-
-### Required assets, coverage, and repairs
-
-Three definitions govern every rule in this skill, so that no rule has to restate
-them.
-
-A **required asset** is one deliverable this work must produce: one design
-direction at one placement, either named by the brief or required by this skill —
-the two or three directions an open brief calls for, at the placements this skill
-lists for the channel. Anything past that count is an **optional asset**, whether
-you frame it as another direction, another variant, or another crop.
-
-**Coverage** is producing the first candidate for a required asset that has none.
-Coverage is never budgeted; it is what the deliverable is. Coverage means an asset
-is *absent* — not that an existing candidate is wrong, however badly. A render
-that merged several required assets into one image leaves the others absent, so
-rendering those is coverage; fixing the merged image itself is not.
-
-A **repair** is any `generate_image` or `edit_image` call on an asset that already
-has a candidate. Repairs are budgeted: at most two on the same asset, and four
-across the run. Three things also cost a repair, so that no relabeling buys a free
-render: any call on an optional asset, including its first; re-rendering a
-direction you already delivered in order to get a better version of it, even at
-another required placement; and any call you would otherwise describe as a
-variant, a fresh angle, or a retry.
-
-Where the two definitions both fit one call, coverage wins: a required placement
-with no candidate is covered free even when the direction it reuses was already
-delivered elsewhere. Charge it as a repair only once that placement has its own
-candidate and you are rendering it again.
-
-When the per-asset limit is reached, stop repairing that asset and deliver its
-best candidate. When the run budget is spent, stop repairing altogether and
-deliver the best candidates you have, whatever the per-asset counts say. Neither
-limit ever stops you from covering a required asset that has no candidate at all.
-
-Count within the run you are in; no counter is shared between plan steps. That is
-a limitation, not an allowance. Do not spend a step's fresh budget on an asset an
-earlier step already tried to repair, and do not split one asset's repairs across
-steps to buy more attempts. An asset that failed inspection in an earlier step is
-delivered with its defects named, not retried.
-
-## Handle identity assets without blind post-processing
-
-Use official logos and other brand assets as generation or editing references
-when the image model supports them. Inspect the result closely. Never add a
-second logo over a generated pseudo-logo, and never treat a generic typed brand
-name as proof of fidelity; while the repair budget lasts, remove the artifact or
-regenerate the creative. Once it is spent, hand the candidate back with the
-unfaithful mark named — and, because a brand-specific final still requires a
-verified logo, hand it back as a concept draft, not as the finished branded
-asset.
-
-Do not add a deterministic compositing step for ordinary branded visuals.
-Apply the identity-asset rule above whenever exact reproduction is required;
-do not pretend a generative result is exact.
-
-Do not use HTML/CSS plus browser screenshots for ordinary poster, ad, banner,
-or social-creative generation. Use HTML only when the user explicitly requests
-an editable HTML/template deliverable; it is not the default fallback for text
-layout.
-
-## Apply the completion gate
-
-The gate has two halves and the budget touches only one of them.
-
-**Coverage is unconditional.** Do not enter `final_answer` until every required
-asset exists as a successful tool result, including every direction and placement
-the brief or this skill asks for. A spent budget is never a reason an asset is
-absent, because coverage is not budgeted: if one has no candidate, render it. A
-brand-specific final also needs its verified logo — when none was ever obtained,
-ask the user rather than shipping a substitute, and keep the interim output
-labeled a concept draft rather than marking the branded asset complete.
-
-**Quality is what the budget releases.** Every asset should pass
-`understand_media` inspection with no automatic rejection; a successful
-`generate_image` or `edit_image` call is never completion evidence by itself.
-When the budget is spent and an asset still fails, deliver its best candidate and
-name the defect concretely — which text is misspelled, which element is clipped,
-which logo is not authentic — and let the user decide whether to spend another
-round. Handing back a flawed asset with its flaws stated is a valid outcome;
-looping until the task runs out of iterations is not. While the budget lasts,
-keep rejecting: identity marks that are fake, duplicated, misspelled or visibly
-distorted; a render that omits a required brand asset; output that is merely
-polished but generic, that carries two disconnected visual ideas, or that weakens
-the supplied fact into awkward copy. When the user explicitly requires an exact
-logo, a brand name rendered as ordinary text does not satisfy the requirement.
-
-When render work is a plan step, write both halves into the step's completion
-criteria and termination condition, so that the step completes either on a clean
-pass or on a spent budget with the defects named. A stop rule you were handed
-cannot be edited: when it admits only a clean pass and the budget is spent,
-finish the step and report the condition as unmet with the defects named, rather
-than repairing past the budget to satisfy it. When no plan is involved, apply the
-same rule to the direct decision to stop.
-
-A completion check may ask whether work remains before you finish, and its own
-instructions treat any named defect as remaining work. Answer it for what the
-budget settled — repairs are done, coverage is complete — and put the defects in
-the answer text, where the user reads them, with the answer's outcome `partial`
-rather than `completed`, not in the check's `missing_verification` field, which
-reopens the loop the budget just closed. This is a workaround, not a supported
-path: nothing in the runtime yet distinguishes a budget-exhausted hand-back from
-an unfinished run, so expect the check to push back and hold the budget anyway.
-
-That check is the one inside your own run. When your run is one step of a plan, a
-separate assessment decides whether the whole task is complete; it cannot see this
-skill, it can send work back for more rounds, and it gives up after a few. Name
-the defects in the step result anyway, but expect no better than that: a
-defect-named hand-back may be replanned and the task may still fail on the replan
-limit. Complete coverage is what gives it the best chance, not a guarantee.
-
-## Deliver
-
-Return only final PNG or JPEG files that were actually created successfully.
-Lead with the files, then identify the communication angle and dimensions of
-each asset in one concise line so the user can compare candidates. Do not
-present a prompt, brief, HTML intermediate, or claimed file path instead of the
-requested image.
+Settle the minimum useful brief before generating: communication goal and
+audience; primary message, supporting copy, CTA, and any required disclaimer;
+output channel with its aspect ratio; and the logo, QR, product, or brand-guide
+assets available.
+
+Preserve copy the user marks as exact. Where the user supplies facts but not
+final wording, write concise campaign copy from those facts. Every price,
+date, milestone, performance claim, offer mechanic, eligibility rule, URL, and
+piece of legal copy must come from the user or a sanctioned source below —
+keep the visual to the claims you were actually given.
+
+## Develop directions
+
+For an open-ended brief, develop two or three directions that differ in
+proposition, focal subject, and structure, then render each one. When the user
+asks for exactly one final asset, compare directions internally and render the
+strongest. The reference explains how to invent a direction's visual device and
+how far apart a set should sit.
+
+## Brand and identity assets
+
+Inspect any reference images this task provides with `understand_media`, and
+pass the useful ones into generation so the result belongs to the intended
+visual world.
+
+For work naming a real brand, resolve the identity before rendering finals. Two
+sources need no permission: an asset supplied in this task — including one
+attached in an earlier turn, recoverable with `list_all_user_files` — and the
+current task workspace. When neither has the logo, stop before rendering finals
+and ask the user how to proceed — offer to take the asset from them, to reserve
+clean space where the logo will go, or to build the concept unbranded — and let
+them choose. Going to look for it yourself is a third path that belongs to the
+user, not to you: take it only when they tell you to, because a plausible
+search result is not proof of authenticity, and one question costs a turn while
+an unverified mark costs the asset.
+
+The user's other tasks and earlier outputs are never a source: a file found by
+listing them proves nothing about whose brand it shows. Neither is a reference
+image, a competitor's material, or your own memory of what the brand looks
+like — a logo you reconstruct is a logo you invented.
+
+Attach an official logo through the image tool's `images` argument (or use
+`edit_image`); naming it in the prompt text does not attach it. A generated or
+edited recreation is never the final logo. QR codes, certification marks,
+sponsor marks, and UI screenshots cannot survive generative rendering
+pixel-for-pixel — when exact reproduction matters, say so and ask the user to
+arrange deterministic post-processing.
+
+Unless the user asked for an unbranded concept, a brand-specific final requires
+a verified logo. Asking how to proceed without one is a complete answer to a
+blocked brief, not a failure to work around: it is the outcome this skill wants,
+and no amount of searching, reconstructing, or typesetting a substitute is a
+better one. Render a reserved-space or unbranded draft only once the user has
+chosen it, and label it a concept draft when you hand it back.
+
+## Generate
+
+Each `generate_image` call renders one finished placement on one continuous
+canvas, one direction at a time. Exclude contact sheets, option grids, split
+frames, presentation mockups, repeated layouts, and duplicated headlines, and
+keep words like "variations" or "option A/B" out of the prompt.
+
+Send only the exact text that should appear on the canvas — never alternative
+copy, strategy labels, markdown, or rationale.
+
+Pick each aspect ratio from the actual placement: social campaigns default to
+4:5 feed and 9:16 story, print and out-of-home follow their placement's real
+dimensions, and 1:1 applies when a channel requires it. When the user has not
+named channels, either ask or cover the likely placements and say which asset
+serves which. Compose natively for the ratio you chose.
+
+Write a concept-specific prompt for every direction, following the render-prompt
+form in the reference.
+
+## Inspect
+
+Inspect every candidate with `understand_media`. Reject: misspelled or invented
+text, wrong numbers, dates, CTA, offer, or disclaimer; unclear hierarchy or
+illegible thumbnail-size type; clipped or overlapping essentials; several ads
+merged into one image; fake, duplicated, or distorted logos; fake QR codes,
+watermarks, and unrelated lettering. A successful tool call is not evidence the
+asset is finished.
+
+## Repair budget
+
+A **required asset** is one direction at one placement that the brief or this
+skill calls for. Anything beyond that count is optional.
+
+**Coverage** — producing the first candidate for a required asset that has none
+— is never budgeted. Coverage means the asset is absent, not that an existing
+candidate is bad.
+
+A **repair** is any render call on an asset that already has a candidate: at
+most two per asset and four per run. Calls on optional assets, re-renders of a
+direction already delivered, and anything you would call a variant or retry all
+cost a repair.
+
+Regenerate from the design specification when the organizing idea, focal
+subject, hierarchy, or canvas structure is wrong; use `edit_image` for a
+localized defect on an otherwise strong candidate. When a limit is reached,
+deliver that asset's best candidate. Counters do not carry across plan steps —
+an asset that failed inspection in an earlier step is delivered with its defects
+named, not retried on a fresh budget.
+
+## Finish
+
+Coverage is unconditional: every required asset must exist as a successful tool
+result before you finish. One thing overrides it — a brand-specific brief with
+no verified logo ends in the question above, with nothing rendered, and that
+counts as finished. Quality is what the budget releases — when the budget
+is spent and an asset still fails inspection, deliver its best candidate, name
+the defect concretely (which text is misspelled, which element is clipped, which
+logo is not authentic), and mark the answer's outcome `partial` so the user can
+decide whether to spend another round.
+
+Return only PNG or JPEG files that were actually created. Lead with the files,
+then give one concise line per asset identifying its communication angle and
+dimensions.

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -2,7 +2,8 @@
 name: static-visual-design
 description: |
   Design a finished ad, poster, banner, social post, or invitation as one
-  PNG/JPEG with layout, headline, and brand styling rendered in.
+  PNG/JPEG with layout, headline, and brand styling rendered in, or adapt one
+  into another placement size or aspect ratio.
 when_to_use: |
   Any marketing, promotion, campaign, event, or brand-facing image, including
   ones naming a real brand. Not for explanatory diagrams, charts, infographics,
@@ -63,10 +64,16 @@ proposition it may not reinterpret.
 
 Order the work, and represent that order in any execution plan: brand and
 reference acquisition is a shared prerequisite, creative direction depends on it,
-and every render depends on the locked specification. Never plan a render, or an
-identity search, to run alongside acquisition. Leave asset availability out of
-planned step definitions — whether a verified logo exists is an outcome of the
-acquisition step, so how the brand gets represented stays open until it runs.
+and every render depends on the locked specification. Never plan a render to run
+alongside acquisition.
+
+Searching for identity assets is never a planned step, sequential or otherwise.
+A plan step carries no authorization, so a step that exists will run — and
+acquisition reporting no verified logo is the trigger for the question, not for a
+search. Plan the question instead; a search only ever follows the user answering
+it by asking for one. Leave asset availability out of step definitions too:
+whether a verified logo exists is an outcome of acquisition, so how the brand
+gets represented stays open until that step runs.
 
 ## Brand and identity assets
 

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -54,6 +54,13 @@ asks for exactly one final asset, compare directions internally and render the
 strongest. The reference explains how to invent a direction's visual device and
 how far apart a set should sit.
 
+Order the work, and represent that order in any execution plan: brand and
+reference acquisition is a shared prerequisite, creative direction depends on it,
+and every render depends on the locked specification. Never plan a render, or an
+identity search, to run alongside acquisition. Leave asset availability out of
+planned step definitions — whether a verified logo exists is an outcome of the
+acquisition step, so how the brand gets represented stays open until it runs.
+
 ## Brand and identity assets
 
 Inspect any reference images this task provides with `understand_media`, and
@@ -83,12 +90,21 @@ sponsor marks, and UI screenshots cannot survive generative rendering
 pixel-for-pixel — when exact reproduction matters, say so and ask the user to
 arrange deterministic post-processing.
 
+Separate stable identity cues from temporary campaign styling. Stable cues
+recur across several recent official materials: the logo, colour relationships,
+typography character, product imagery, graphic proportions. A gradient, metallic
+treatment, bevel, glow, ribbon, or confetti field appearing in one old banner is
+that campaign's styling, not the brand's identity — do not promote it into a
+permanent cue. Preserve recognition through the stable cues while modernizing
+hierarchy, whitespace, type discipline, and the number of competing effects.
+
 Unless the user asked for an unbranded concept, a brand-specific final requires
-a verified logo. Asking how to proceed without one is a complete answer to a
-blocked brief, not a failure to work around: it is the outcome this skill wants,
-and no amount of searching, reconstructing, or typesetting a substitute is a
-better one. Render a reserved-space or unbranded draft only once the user has
-chosen it, and label it a concept draft when you hand it back.
+a verified logo. Ask with `ask_user_question` so the turn ends waiting for the
+user and resumes on their choice; that is a complete answer to a blocked brief,
+not a failure to work around, and no amount of searching, reconstructing, or
+typesetting a substitute is a better one. Render a reserved-space or unbranded
+draft only once the user has chosen it, and label it a concept draft when you
+hand it back.
 
 ## Generate
 
@@ -117,6 +133,12 @@ illegible thumbnail-size type; clipped or overlapping essentials; several ads
 merged into one image; fake, duplicated, or distorted logos; fake QR codes,
 watermarks, and unrelated lettering. A successful tool call is not evidence the
 asset is finished.
+
+A render that omits a required brand asset is a rejection too. Passing a verified
+logo as a reference does not prove the image model placed it, so confirm the mark
+is present and faithful in the result. Re-render within the repair budget; if the
+budget runs out with the asset still missing, name the omission in the hand-back
+rather than presenting the render as branded.
 
 ## Repair budget
 
@@ -149,6 +171,12 @@ is spent and an asset still fails inspection, deliver its best candidate, name
 the defect concretely (which text is misspelled, which element is clipped, which
 logo is not authentic), and mark the answer's outcome `partial` so the user can
 decide whether to spend another round.
+
+A spent budget with complete coverage is terminal. The defects belong in the
+answer text where the user reads them, and `missing_verification` stays empty —
+naming a defect there reopens the loop the budget just closed, and another render
+or replan is not the correct response to it. Call `final_answer` with
+`outcome=partial` and stop.
 
 Return only PNG or JPEG files that were actually created. When the run ends in a
 question there are none, and the question is the whole answer — do not list or

--- a/src/xagent/skills/builtin/static-visual-design/references/static-ad-art-direction.md
+++ b/src/xagent/skills/builtin/static-visual-design/references/static-ad-art-direction.md
@@ -51,6 +51,56 @@ that merely decorate. A kept direction states its device in one sentence, such
 as "the 1.4M milestone staged as a rally the viewer is invited to join." Every device must still
 pass the competitor-substitution test and carry verified claims only.
 
+## Build a set of directions
+
+Keep direction-setting in one coherent pass. One creative lead defines and
+compares the whole set; independent ideation converges on the same obvious brand
+cues and changes only surface decoration. Parallel execution earns its place
+only after the briefs are locked, with each executor holding a distinct
+proposition, structure, focal device, production finish, and exclusions.
+
+Represent that order in any execution plan: brand and reference acquisition is
+a shared prerequisite, creative direction depends on it, and every render
+depends on the locked specification. Leave asset-availability conclusions out
+of planned step definitions — whether a verified logo exists is an outcome of
+the acquisition step, so how the brand is represented stays open until it runs.
+
+When client taste is unknown, spread the set across a creative-risk ladder
+rather than betting on one aesthetic:
+
+1. **Brand-safe evolution** — immediately recognizable, with cleaner and more
+   disciplined use of familiar brand cues.
+2. **Contemporary reinterpretation** — preserves identity while meaningfully
+   changing composition, image language, or type system.
+3. **Bold exploration** — reaches for a more ownable campaign metaphor or
+   unexpected art direction while staying factually and strategically on brief.
+
+A ladder gives the client a comfortable choice and reveals how much change they
+will accept. Making every option safe, or every option experimental, reveals
+nothing.
+
+Compare the locked briefs as a set before rendering. Each direction should
+differ on at least three of: focal subject, structural approach, visual
+metaphor, production finish, palette balance, type strategy. Compare the actual
+render prompts, not the direction names — prompts describing the same focal
+mechanism and layout are one direction wearing three copy variations, and a set
+whose every hero is a large typographic number is the most common way this
+happens. For an open brief, at most one direction may take pure typography as
+its focal subject and at most one may take a deliberately flat treatment with an
+empty environment; the rest are carried by a scene, person, place, object, or
+material device. When the user explicitly asks for a typographic or minimalist
+system, work the variation inside that system through composition, scale,
+material, and color.
+
+Familiar devices are not disqualified by being familiar. A gradient, portrait,
+phone, giant headline, glow, or confetti field can be the right choice — reject
+one when it does no communication work, or when it could move unchanged to a
+competitor, not because it appears on a blacklist. Judge stacked display effects
+the same way: keep the ones serving the chosen device, drop the rest.
+
+Vary concepts before varying sizes. A crop change or accent-color swap is not a
+second concept.
+
 ## Choose a communication structure
 
 Choose one structure because it serves the proposition. Do not combine several

--- a/tests/core/tools/core/test_image_tool_core.py
+++ b/tests/core/tools/core/test_image_tool_core.py
@@ -115,7 +115,10 @@ class TestImageGenerationToolCore:
     """Test cases for ImageGenerationToolCore class"""
 
     def test_generate_description_enforces_single_canvas_and_copy_budget(self):
-        description = ImageGenerationToolCore.GENERATE_IMAGE_DESCRIPTION
+        # Normalized: these anchors are sentences, and the source wraps them.
+        description = " ".join(
+            ImageGenerationToolCore.GENERATE_IMAGE_DESCRIPTION.split()
+        )
 
         assert "one single final" in description
         assert "one continuous canvas" in description
@@ -125,10 +128,12 @@ class TestImageGenerationToolCore:
         assert "file_id through the images parameter" in description
         assert "Use only references the user supplied" in description
         # The curb this description exists for.
-        assert "not go looking" in description
-        # The official source is the third origin static-visual-design sanctions;
-        # dropping it here would forbid what the skill requires.
-        assert "brand's own official source" in description
+        assert "do not retrieve one on your own initiative" in description
+        # An official site is no longer a standing origin: static-visual-design
+        # requires the user to direct the retrieval, and this description is in
+        # context even when the skill is not, so it cannot offer a wider route.
+        assert "an asset the user directed you to retrieve" in description
+        assert "brand's own official source" not in description
         # Without the authenticity guard the carve-out reads as "go fetch a logo"
         # in every run where the skill is not loaded.
         assert "plausible-looking search result" in description
@@ -137,11 +142,12 @@ class TestImageGenerationToolCore:
     def test_edit_description_restricts_reference_sources(self):
         # generate_image routes reference-based work here, so the restriction has
         # to hold on both descriptions or the model just switches tools.
-        description = ImageGenerationToolCore.EDIT_IMAGE_DESCRIPTION
+        description = " ".join(ImageGenerationToolCore.EDIT_IMAGE_DESCRIPTION.split())
 
         assert "Use only images the user supplied" in description
-        assert "not go looking" in description
-        assert "brand's own official source" in description
+        assert "do not retrieve source or reference material on" in description
+        assert "an asset the user directed you to retrieve" in description
+        assert "brand's own official source" not in description
         assert "plausible-looking search result" in description
         assert "never take" in description and "other tasks" in description
         assert "never present a generative edit as exact" in description

--- a/tests/skills/test_builtin_static_visual_design.py
+++ b/tests/skills/test_builtin_static_visual_design.py
@@ -41,6 +41,8 @@ def test_static_visual_design_skill_routes_only_commercial_creatives() -> None:
     # Positive triggers and exclusions both have to sit in the routing surface.
     assert "ad, poster, banner" in description
     assert "PNG/JPEG" in description
+    # Terse resize requests ("adapt this to 9:16") route through the index too.
+    assert "adapt one into another placement size or aspect ratio" in description
     assert "marketing, promotion, campaign, event, or brand-facing" in when_to_use
     assert "Not for explanatory diagrams" in when_to_use
     assert "infographics" in when_to_use
@@ -85,7 +87,7 @@ def test_static_visual_design_skill_routes_only_commercial_creatives() -> None:
     # body but not the reference, which is only read later (#1411 review C1).
     assert "represent that order in any execution plan" in content
     assert "acquisition is a shared prerequisite" in content
-    assert "Never plan a render, or an identity search, to run alongside" in content
+    assert "Never plan a render to run alongside acquisition" in content
 
     # Coverage means absent, not wrong — otherwise any defect can be relabeled
     # into an unbudgeted render.
@@ -200,16 +202,38 @@ def test_asset_retrieval_surfaces_do_not_invite_unprompted_logo_search() -> None
             assert phrase not in lowered, f"{name} reintroduced: {phrase!r}"
 
 
+# One exact phrase per surface. An aggregate count would pass on a coincidental
+# "directly" elsewhere in a description (#1411 review P7).
+REQUIRED_AUTHORIZATION_WORDING = {
+    "fetch_web_content.description": "When the user asked you to obtain an exact asset",
+    "fetch_web_content.include_assets": "Enable it when the user asked you to obtain an "
+    "asset",
+    "download_web_asset.description": "surfaced the asset the user asked you to retrieve",
+    "download_web_asset.url": "reached while carrying out a retrieval the user asked for",
+    "generate_image.description": "an asset the user directed you to retrieve",
+    "edit_image.description": "an asset the user directed you to retrieve",
+}
+
+
 def test_asset_retrieval_surfaces_require_user_direction() -> None:
-    """The positive half: retrieval is conditioned on the user asking for it."""
+    """The positive half, asserted per surface rather than in aggregate."""
     surfaces = _asset_retrieval_surfaces()
 
-    directed = [t for t in surfaces.values() if "direct" in t.lower()]
-    assert len(directed) >= 4, (
-        "each retrieval surface should condition on the user having directed it; "
-        f"only {len(directed)} of {len(surfaces)} do"
+    assert set(surfaces) == set(REQUIRED_AUTHORIZATION_WORDING), (
+        "a retrieval surface was added or renamed without its authorization wording"
     )
-    joined = " ".join(surfaces.values()).lower()
+    for name, phrase in REQUIRED_AUTHORIZATION_WORDING.items():
+        assert phrase in " ".join(surfaces[name].split()), (
+            f"{name} no longer conditions retrieval on the user asking: {phrase!r}"
+        )
+
+    # Authorization follows the request, not the URL: a page web_search found for
+    # a retrieval the user asked for is in scope (#1411 review N1).
+    fetch = " ".join(surfaces["fetch_web_content.description"].split())
+    assert "one they named or one web_search found for that request" in fetch
+    assert "uninstructed" in fetch
+
+    joined = " ".join(" ".join(t.split()) for t in surfaces.values())
     assert "ask the user for it" in joined
 
 
@@ -264,4 +288,4 @@ def test_static_visual_design_keeps_planner_visible_topology() -> None:
     )
     assert "only after every brief and specification is locked" in content
     assert "represent that order in any execution plan" in content
-    assert "Never plan a render, or an identity search, to run alongside" in content
+    assert "Never plan a render to run alongside acquisition" in content

--- a/tests/skills/test_builtin_static_visual_design.py
+++ b/tests/skills/test_builtin_static_visual_design.py
@@ -101,7 +101,7 @@ def test_static_visual_design_skill_routes_only_commercial_creatives() -> None:
     assert "omits a required brand asset is a rejection" in content
     assert "does not prove the image model placed it" in content
     # The one case where finishing with nothing rendered is correct.
-    assert "ends in the question above, with nothing rendered" in content
+    assert "ends in the question above with nothing rendered" in content
     assert "do not list or describe files that do not exist" in content
     # A spent budget hands the asset back with its defect named, not silently,
     # and the hand-back is terminal rather than a replan trigger (C3).
@@ -146,29 +146,122 @@ def test_static_visual_design_includes_art_direction_reference() -> None:
     assert "differ on at least three of" in content
 
 
-def test_web_asset_tool_descriptions_do_not_invite_unprompted_logo_search() -> None:
-    """Tool descriptions are always in context; the skill policy is not.
-
-    A description that tells the model to go find a brand's logo overrides the
-    skill's ask-the-user rule, because the skill is only present once loaded
-    (#1411 review C2).
-    """
-    from xagent.core.tools.adapters.vibe.download_web_asset import DownloadWebAssetArgs
+def _asset_retrieval_surfaces() -> dict[str, str]:
+    """Every description that reaches the model alongside an asset-fetch route."""
+    from xagent.core.tools.adapters.vibe.download_web_asset import (
+        DownloadWebAssetArgs,
+        DownloadWebAssetTool,
+    )
     from xagent.core.tools.adapters.vibe.fetch_web_content import (
         FetchWebContentArgs,
         FetchWebContentTool,
     )
+    from xagent.core.tools.core.image_tool import ImageGenerationToolCore
 
     def field_text(model: type, name: str) -> str:
         return model.model_fields[name].description or ""
 
-    surfaces = [
-        FetchWebContentTool().description,
-        field_text(FetchWebContentArgs, "include_assets"),
-        field_text(DownloadWebAssetArgs, "url"),
-    ]
-    for text in surfaces:
+    image_texts = {
+        "generate_image.description": ImageGenerationToolCore.GENERATE_IMAGE_DESCRIPTION,
+        "edit_image.description": ImageGenerationToolCore.EDIT_IMAGE_DESCRIPTION,
+    }
+
+    return {
+        "fetch_web_content.description": FetchWebContentTool().description,
+        "fetch_web_content.include_assets": field_text(
+            FetchWebContentArgs, "include_assets"
+        ),
+        "download_web_asset.description": DownloadWebAssetTool.description.fget(  # type: ignore[attr-defined]
+            DownloadWebAssetTool.__new__(DownloadWebAssetTool)
+        ),
+        "download_web_asset.url": field_text(DownloadWebAssetArgs, "url"),
+        **image_texts,
+    }
+
+
+def test_asset_retrieval_surfaces_do_not_invite_unprompted_logo_search() -> None:
+    """Tool descriptions are always in context; the skill policy is not.
+
+    A description that tells the model to go find a brand's logo, or that lists an
+    official source as a sanctioned origin, overrides the skill's ask-the-user
+    rule — the skill is only present once loaded (#1411 review C2/R1). Covers
+    fetch, download, generate, and edit together so no single surface regresses.
+    """
+    banned = (
+        "when looking for logos",
+        "usually asset_query='logo'",
+        "prefer the official brand domain",
+        "retrieved from the brand's own official source",
+        "discovers an official logo",
+    )
+    for name, text in _asset_retrieval_surfaces().items():
         lowered = text.lower()
-        assert "when looking for logos" not in lowered
-        assert "usually asset_query='logo'" not in lowered
-        assert "prefer the official brand domain" not in lowered
+        for phrase in banned:
+            assert phrase not in lowered, f"{name} reintroduced: {phrase!r}"
+
+
+def test_asset_retrieval_surfaces_require_user_direction() -> None:
+    """The positive half: retrieval is conditioned on the user asking for it."""
+    surfaces = _asset_retrieval_surfaces()
+
+    directed = [t for t in surfaces.values() if "direct" in t.lower()]
+    assert len(directed) >= 4, (
+        "each retrieval surface should condition on the user having directed it; "
+        f"only {len(directed)} of {len(surfaces)} do"
+    )
+    joined = " ".join(surfaces.values()).lower()
+    assert "ask the user for it" in joined
+
+
+def test_static_visual_design_no_logo_branch_is_ordered() -> None:
+    """no logo → ask → wait → render only after the user chooses (#1411 R4)."""
+    content = " ".join(_skill()["content"].split())
+    brand = content.split("## Brand and identity assets", 1)[1].split("## Generate", 1)[
+        0
+    ]
+
+    ask = brand.index("stop before rendering finals")
+    tool = brand.index("`ask_user_question`")
+    after = brand.index("only once the user has")
+    assert ask < tool < after, "the ask must precede the conditional render"
+    assert "ends waiting for the user and resumes on their choice" in brand
+
+    finish = content.split("## Finish", 1)[1]
+    # The gate blocks the branded *final*, not the whole brief, so a chosen
+    # fallback draft can still be rendered and handed back.
+    assert "a brand-specific *final* with no verified logo" in finish
+    assert "Before the user has chosen" in finish
+    assert "After they choose a reserved-space or unbranded route" in finish
+
+
+def test_static_visual_design_coverage_wins_across_placements() -> None:
+    """A new placement of a delivered direction is coverage, not a repair (R5)."""
+    content = " ".join(_skill()["content"].split())
+    budget = content.split("## Repair budget", 1)[1].split("## Finish", 1)[0]
+
+    assert "Where both definitions fit one call, coverage wins" in budget
+    assert "no candidate of its own is free coverage" in budget
+    assert "Only a second render of that same placement costs one" in budget
+    assert budget.index("A **repair** is") < budget.index("coverage wins"), (
+        "the precedence rule has to follow the repair definition it overrides"
+    )
+
+
+def test_static_visual_design_keeps_planner_visible_topology() -> None:
+    """LLMPlanGenerator only sees SKILL.md, so DAG-shaping rules live there.
+
+    `plan_generator.py` passes `selected_skill_context` — the skill body — into
+    plan generation; a reference read later by `read_skill_doc` cannot reshape a
+    frozen DAG (#1411 review C1/R2).
+    """
+    content = " ".join(_skill()["content"].split())
+
+    assert (
+        "One creative lead defines and compares the whole set sequentially" in content
+    )
+    assert "Do not split ideation across independent agents or parallel plan nodes" in (
+        content
+    )
+    assert "only after every brief and specification is locked" in content
+    assert "represent that order in any execution plan" in content
+    assert "Never plan a render, or an identity search, to run alongside" in content

--- a/tests/skills/test_builtin_static_visual_design.py
+++ b/tests/skills/test_builtin_static_visual_design.py
@@ -1,105 +1,98 @@
 from pathlib import Path
 
-from xagent.core.agent.context.skill_tool import _index_text
+from xagent.core.agent.context.skill_tool import INDEX_ENTRY_MAX_CHARS, _index_text
 from xagent.skills.parser import SkillParser
+
+SKILL_DIR = (
+    Path(__file__).parents[2]
+    / "src"
+    / "xagent"
+    / "skills"
+    / "builtin"
+    / "static-visual-design"
+)
+
+
+def _skill() -> dict:
+    return SkillParser.parse(SKILL_DIR)
+
+
+def test_static_visual_design_index_entries_survive_truncation() -> None:
+    """The index line is the only routing surface; a cut field loses triggers."""
+    skill = _skill()
+
+    for field in ("description", "when_to_use"):
+        raw = " ".join(skill[field].split())
+        assert raw, f"{field} must not be empty"
+        assert len(raw) <= INDEX_ENTRY_MAX_CHARS, (
+            f"{field} is {len(raw)} chars; the skill index truncates at "
+            f"{INDEX_ENTRY_MAX_CHARS} and the tail never reaches the model"
+        )
+        assert raw == _index_text(skill[field])
 
 
 def test_static_visual_design_skill_routes_only_commercial_creatives() -> None:
-    skill_dir = (
-        Path(__file__).parents[2]
-        / "src"
-        / "xagent"
-        / "skills"
-        / "builtin"
-        / "static-visual-design"
-    )
-
-    skill = SkillParser.parse(skill_dir)
+    skill = _skill()
 
     assert skill["name"] == "static-visual-design"
     description = " ".join(skill["description"].split())
     when_to_use = " ".join(skill["when_to_use"].split())
-    assert "complete PNG or JPEG assets" in description
-    assert "commercial and brand-facing" in description
-    assert "campaign posters" in description
-    assert "advertising creatives" in description
-    assert "placement variants" in description
-    assert "marketing, campaign, event, or brand communication" in when_to_use
-    assert "educational infographics" in when_to_use
-    assert "technical diagrams" in when_to_use
-    assert "concept explainers" in when_to_use
 
-    # Auto routing sees bounded one-line versions of these fields. Keep the
-    # positive commercial scope and the important exclusions inside that
-    # actual routing surface instead of only in the full skill body.
-    routing_description = _index_text(skill["description"])
-    routing_when_to_use = _index_text(skill["when_to_use"])
-    assert "commercial and brand-facing" in routing_description
-    assert "advertising creatives" in routing_description
-    assert "Use only for marketing" in routing_when_to_use
-    assert "educational infographics" in routing_when_to_use
-    assert "concept explainers" in routing_when_to_use
+    # Positive triggers and exclusions both have to sit in the routing surface.
+    assert "ad, poster, banner" in description
+    assert "PNG/JPEG" in description
+    assert "marketing, promotion, campaign, event, or brand-facing" in when_to_use
+    assert "Not for explanatory diagrams" in when_to_use
+    assert "infographics" in when_to_use
 
     content = " ".join(skill["content"].split())
-    assert "Stay within the commercial-creative scope" in content
-    assert "Use `generate_image` to create the full designed asset" in content
+
+    # Scope and medium.
+    assert "belongs to the general image-generation workflow instead" in content
+    assert (
+        "Produce the finished visual with `generate_image` and `edit_image`" in content
+    )
+    assert "Reserve HTML/CSS plus browser screenshots" in content
     assert "references/static-ad-art-direction.md" in content
-    assert "two or three genuinely different communication angles" in content
+    assert "two or three directions that differ" in content
     assert "one finished placement on one continuous canvas" in content
-    assert "a brand-specific final requires a verified logo" in content
-    assert "No image tool composites deterministically" in content
+
     # #942 removed logo_overlay as brittle; hand-rolled compositing is the same work.
+    assert "cannot survive generative rendering pixel-for-pixel" in content
     assert "composite it yourself" not in content
-    assert "download_web_asset" not in content
     assert "SVG is source text" not in content
-    assert "Do not use HTML/CSS plus browser screenshots" in content
-    assert "Do not enter `final_answer`" in content
-    assert "Return only final PNG or JPEG files" in content
-    assert "The user's other tasks and earlier outputs are not a source" in content
-    assert "recover by finding it with `list_all_user_files`" in content
-    # One anchor per behavior an earlier round had to fix and a later rewrite lost.
+
+    # Brand provenance: sanctioned sources, and every substitute path closed.
+    assert "a brand-specific final requires a verified logo" in content
+    assert "recoverable with `list_all_user_files`" in content
+    assert "other tasks and earlier outputs are never a source" in content
+    assert "a logo you reconstruct is a logo you invented" in content
+    assert "label it a concept draft" in content
+    # Searching belongs to the user, and the run stops rather than guessing.
+    assert "stop before rendering finals" in content
+    assert "take it only when they tell you to" in content
+    assert "download_web_asset" not in content
+
     # Coverage means absent, not wrong — otherwise any defect can be relabeled
     # into an unbudgeted render.
     assert "producing the first candidate for a required asset that has none" in content
-    assert "Only one failure is a coverage failure" in content
-    assert "do not reclassify a defect as missing coverage" in content
-    # Repairs are what the budget counts, and three relabeling routes stay closed.
-    assert "any `generate_image` or `edit_image` call on an asset that" in content
-    assert "any call on an optional asset, including its first" in content
-    assert "even at another required placement" in content
-    # The gate's coverage half never yields to the budget.
-    assert "**Coverage is unconditional.**" in content
-    # Two rejection reasons a rewrite dropped, and the brand rule they serve.
-    assert "a render that omits a required brand asset" in content
-    assert "labeled a concept draft" in content
-    # The hand-back has to pass the completion check that precedes it.
-    assert "not in the check's `missing_verification` field" in content
-    assert "let the user decide whether to spend another round" in content
-    assert "Reject them while the repair budget lasts" in content
-    assert "While the budget lasts, regenerate from the locked design" in content
-    assert "while the repair budget lasts, remove the artifact or" in content
-    assert "iterations is not. While the budget lasts," in content
-    assert "at most two on the same asset, and four across the run" in content
-    assert "a variant, a fresh angle, or a retry" in content
-    assert "When the run budget is spent, stop repairing altogether" in content
-    assert "Where the two definitions both fit one call, coverage wins" in content
-    assert "sketches are sentences, not renders" in content
-    # The hand-back is a workaround around the gate, not a supported path.
-    assert "This is a workaround, not a supported" in content
-    assert "may be replanned and the task may still fail" in content
+    assert "Coverage means the asset is absent, not that an existing" in content
+    assert "Coverage is unconditional" in content
+    # Repairs are what the budget counts, and the relabeling routes stay closed.
+    assert "any render call on an asset that already has a candidate" in content
+    assert "at most two per asset and four per run" in content
+    assert "anything you would call a variant or retry" in content
+    assert "Counters do not carry across plan steps" in content
+    # The one case where finishing with nothing rendered is correct.
+    assert "ends in the question above, with nothing rendered" in content
+    assert "do not list or describe files that do not exist" in content
+    # A spent budget hands the asset back with its defect named, not silently.
+    assert "name the defect concretely" in content
+    assert "decide whether to spend another round" in content
 
 
 def test_static_visual_design_includes_art_direction_reference() -> None:
-    reference_path = (
-        Path(__file__).parents[2]
-        / "src"
-        / "xagent"
-        / "skills"
-        / "builtin"
-        / "static-visual-design"
-        / "references"
-        / "static-ad-art-direction.md"
-    )
+    reference_path = SKILL_DIR / "references" / "static-ad-art-direction.md"
 
     content = " ".join(reference_path.read_text().split())
 
@@ -119,3 +112,7 @@ def test_static_visual_design_includes_art_direction_reference() -> None:
     assert "While the repair budget lasts, regenerate from the locked design" in content
     # `generate ... sketches` read as a render-driving instruction with no budget.
     assert "one-sentence sketches for a set of three, none of them rendered" in content
+    # Craft guidance demoted out of SKILL.md keeps its anchors here.
+    assert "Build a set of directions" in content
+    assert "creative-risk ladder" in content
+    assert "differ on at least three of" in content

--- a/tests/skills/test_builtin_static_visual_design.py
+++ b/tests/skills/test_builtin_static_visual_design.py
@@ -62,16 +62,30 @@ def test_static_visual_design_skill_routes_only_commercial_creatives() -> None:
     assert "composite it yourself" not in content
     assert "SVG is source text" not in content
 
-    # Brand provenance: sanctioned sources, and every substitute path closed.
+    # Brand provenance: both sanctioned sources named, every substitute closed.
     assert "a brand-specific final requires a verified logo" in content
     assert "recoverable with `list_all_user_files`" in content
+    assert "current task workspace" in content
     assert "other tasks and earlier outputs are never a source" in content
     assert "a logo you reconstruct is a logo you invented" in content
     assert "label it a concept draft" in content
+    # Stable brand cues are not one campaign's effects (#1411 review C7).
+    assert "Separate stable identity cues from temporary campaign styling" in content
     # Searching belongs to the user, and the run stops rather than guessing.
     assert "stop before rendering finals" in content
     assert "take it only when they tell you to" in content
+    assert "`ask_user_question`" in content
+    # No wording may reintroduce unprompted retrieval as a sanctioned route.
     assert "download_web_asset" not in content
+    assert "official web presence" not in content
+    assert "fetch_web_content" not in content
+    assert "web tools available to you" not in content
+
+    # Planning order has to survive in SKILL.md: LLMPlanGenerator sees the skill
+    # body but not the reference, which is only read later (#1411 review C1).
+    assert "represent that order in any execution plan" in content
+    assert "acquisition is a shared prerequisite" in content
+    assert "Never plan a render, or an identity search, to run alongside" in content
 
     # Coverage means absent, not wrong — otherwise any defect can be relabeled
     # into an unbudgeted render.
@@ -83,12 +97,26 @@ def test_static_visual_design_skill_routes_only_commercial_creatives() -> None:
     assert "at most two per asset and four per run" in content
     assert "anything you would call a variant or retry" in content
     assert "Counters do not carry across plan steps" in content
+    # A supplied logo the render dropped is a rejection (#1411 review C4).
+    assert "omits a required brand asset is a rejection" in content
+    assert "does not prove the image model placed it" in content
     # The one case where finishing with nothing rendered is correct.
     assert "ends in the question above, with nothing rendered" in content
     assert "do not list or describe files that do not exist" in content
-    # A spent budget hands the asset back with its defect named, not silently.
+    # A spent budget hands the asset back with its defect named, not silently,
+    # and the hand-back is terminal rather than a replan trigger (C3).
     assert "name the defect concretely" in content
     assert "decide whether to spend another round" in content
+    assert "spent budget with complete coverage is terminal" in content
+    assert "`missing_verification` stays empty" in content
+    assert "`outcome=partial`" in content
+
+    # The file list is conditional on files existing, never unconditional.
+    finish = content.split("## Finish", 1)[1]
+    assert "Otherwise lead with the files" in finish
+    assert finish.index(
+        "do not list or describe files that do not exist"
+    ) < finish.index("Otherwise lead with the files")
 
 
 def test_static_visual_design_includes_art_direction_reference() -> None:
@@ -116,3 +144,31 @@ def test_static_visual_design_includes_art_direction_reference() -> None:
     assert "Build a set of directions" in content
     assert "creative-risk ladder" in content
     assert "differ on at least three of" in content
+
+
+def test_web_asset_tool_descriptions_do_not_invite_unprompted_logo_search() -> None:
+    """Tool descriptions are always in context; the skill policy is not.
+
+    A description that tells the model to go find a brand's logo overrides the
+    skill's ask-the-user rule, because the skill is only present once loaded
+    (#1411 review C2).
+    """
+    from xagent.core.tools.adapters.vibe.download_web_asset import DownloadWebAssetArgs
+    from xagent.core.tools.adapters.vibe.fetch_web_content import (
+        FetchWebContentArgs,
+        FetchWebContentTool,
+    )
+
+    def field_text(model: type, name: str) -> str:
+        return model.model_fields[name].description or ""
+
+    surfaces = [
+        FetchWebContentTool().description,
+        field_text(FetchWebContentArgs, "include_assets"),
+        field_text(DownloadWebAssetArgs, "url"),
+    ]
+    for text in surfaces:
+        lowered = text.lower()
+        assert "when looking for logos" not in lowered
+        assert "usually asset_query='logo'" not in lowered
+        assert "prefer the official brand domain" not in lowered


### PR DESCRIPTION
## Background

`static-visual-design`'s SKILL.md had grown to 467 lines / 27.4 KB. Once a skill
is loaded via `load_skill`, its body is injected verbatim into the system context
of every subsequent step (`build_skill_context`, `context/enrichment.py:101`, no
truncation), so that file was costing roughly 7k tokens per step for as long as
it stayed loaded.

While looking into that, a more consequential problem turned up: both frontmatter
fields exceeded the 200-character cap applied to skill index entries
(`INDEX_ENTRY_MAX_CHARS`, `context/skill_tool.py:26`) and were being silently
truncated. The index line is the only thing the model sees when deciding whether
to load a skill at all, so everything past the cut — including trigger wording —
never reached it.

## Changes

### 1. SKILL.md: 467 → 155 lines

Mostly deduplication rather than relocation. `references/static-ad-art-direction.md`
already carried a fuller version of the communication structures, layout
specification, depth stack, copy budget, render-prompt form and review checklist;
four sections of SKILL.md were condensed restatements of those, so they were
removed outright. The existing "read the reference before rendering" pointer stays.

What remains is the guardrails — the rules whose absence produces a defect rather
than a less polished result: scope boundaries, no invented facts, logo provenance
and verification, QR/certification marks not being reproducible generatively,
one finished placement per render call, aspect ratio driven by placement,
`understand_media` inspection, the repair budget (introduced in #1339), and
unconditional coverage vs budget-released quality.

Also dropped: two passages that described themselves as a workaround against the
runtime's completion check ("expect the check to push back"). Fighting runtime
behaviour from inside a prompt does not fix it, and the contradiction gave the
model something to hesitate over at the end of a run.

Craft guidance that was demoted rather than deleted — the creative-risk ladder,
the three-axis differentiation test, single-threaded ideation, planning order —
moved into a new `## Build a set of directions` section in the reference.

### 2. Ask the user when no logo is available, instead of going to look for one

The previous text listed "the brand's own official web presence" as a legitimate
source while also requiring a verified logo before an asset could be marked
complete. Together those form an incentive to search: not finding one means not
finishing, and asking means stopping. The model consistently chose to search.

- Sources that need no permission are now the current task's attachments and the
  task workspace. Searching for the asset is a third path that requires the user
  to ask for it.
- With no logo available, the run stops **before** rendering finals and asks how
  to proceed, offering three options (supply the asset / reserve clean space for
  the logo / build the concept unbranded) for the user to choose between.
- The completion gate gained an explicit exception: a brand-specific brief with
  no verified logo ends in that question, with nothing rendered, and counts as
  finished.

The third point is load-bearing. "Every required asset must exist as a successful
tool result before you finish" directly contradicted "stop and ask", and faced
with the contradiction the model fell back to rendering — which routed straight
back into hunting for a logo.

A few substitute paths that were previously uncovered are now named as invalid
sources: reference images, competitor material, and the model's own recollection
of what a brand looks like.

### 3. Frontmatter rewrite (separate commit)

```
description:  325 → 134 chars  (previously lost "banners, placement variants" entirely)
when_to_use:  213 → 177 chars  (previously all prohibitions, no positive trigger)
```

## Verification

Three Chinese-language brand prompts with no logo supplied, run through real
agent executions in react mode — DeepSeek as the main model, DashScope
`qwen-image` for generation and `qwen-vl-plus` for `understand_media`:

| Metric | Before | After |
| --- | --- | --- |
| skill loaded | 0.67 | **1.00** |
| asked before rendering | 0.00 | **1.00** (3/3) |
| searched externally | — | **0.00** |
| render calls | 0.67 | 0.00 |

Out-of-scope prompts (a TCP handshake diagram, a quarterly revenue comparison)
still report `skill_loaded` 0, so the broader description did not cause
over-triggering.

The three changes can be attributed separately: the trim saves resident tokens
but does not by itself change behaviour; the logo wording works once the skill is
loaded; **fixing the truncated index entries raised the load rate from ~0.6 to
1.0**, which was the decisive part. The first two were tuning something that was
absent from roughly half the runs.

A control run also showed that adding Chinese trigger words to the description
gave no additional benefit (English-only scored the same 3/3), so they were not
kept. Whether skills should carry Chinese trigger words at all — `pptx-editorial`
and `html-deck-editorial` currently do — is left for a separate discussion.

## Limitations

n=3, one run per prompt, a single model. Enough to establish that the truncation
was a real bug and that behaviour improved once fixed; not enough to treat the
numbers as stable. The evaluation harness was a throwaway and is not included here.

## Follow-up

The same scan across all eight built-in skills found **six with truncated index
entries**. The worst are `pptx-editorial` (description 979 chars, 780 lost),
`html-deck-editorial` (814, 615 lost) and `presentation-generator` (599, 400 lost,
and an empty `when_to_use`). What gets cut is precisely the trigger vocabulary and
the "use skill X instead when…" cross-references — and those three skills overlap
heavily in purpose, which makes them the most likely to trigger on each other's
requests. Worth a separate PR.
