### PR TITLE
fix: narrow Google Calendar connector scope to calendar.events

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -360,6 +360,16 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      # The offline (--sql) cast to PostgreSQL's json type is only
+      # meaningfully checked against a real server: sqlite has no
+      # json/jsonb distinction to get wrong.
+      - name: Test Google Calendar scope narrowing PostgreSQL cast/round-trip (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/alembic/test_20260817_narrow_google_calendar_scope.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
       - name: Test legacy resume interaction close rowcount grid (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,55 @@
 # Deployment changes
 
+## 2026-08-17 — Google Calendar connector scope narrowing (`20260817_narrow_google_calendar_scope`)
+
+### Deployment impact
+
+The built-in Google Calendar connector now requests `calendar.events` instead of the full `calendar` scope. The migration also deletes any `user_oauth` row with `provider = 'google-calendar'` whose granted scope still carries the old, full scope (including rows with no scope recorded at all — see the migration's module docstring for why that counts as evidence of the old grant). Affected users lose their Calendar connection and must reconnect through the OAuth flow again; there is no in-place upgrade of an existing token's scope.
+
+This is irreversible. `downgrade()` restores the catalog's requested scope but cannot restore a deleted `user_oauth` row — there is no way to reconstruct a token this migration revoked.
+
+Online (live-connection) upgrades run the cleanup in bounded batches (`REVOKE_BATCH_SIZE = 500`) and log a warning with the number of grants revoked. Offline (`alembic upgrade --sql`) generation emits the equivalent cleanup as one literal, unbatched `DELETE` — running the generated script against a very large `user_oauth` table takes that one statement's lock for as long as it takes to complete, unlike the online path's batching.
+
+### Scope limitation
+
+Only `provider = 'google-calendar'` rows are touched. A bare provider-level `google` row (created by the app_id-less connect flow) is never deleted here even if it happens to carry the old scope too, since other Google connectors (Gmail, Drive, Docs, Slides, Sheets) may depend on that same row as their own fallback credential. That gap is closed separately, at the runtime level: `google-calendar` was added to `APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT` (`web/mcp_apps.py`) in the same change, so a bare `google` row is no longer accepted as a Calendar credential regardless of its scope. Deploy both changes together — the data cleanup and the runtime policy change ship in the same migration/PR, but they are logically separable, and reverting one without the other reopens a gap the other was covering.
+
+This migration does not call Google's token-revocation endpoint. The deleted local row simply stops being usable by this application; Google still considers the underlying token valid (subject to its own expiry) until the user revokes app access directly from their Google Account.
+
+### Prerequisites and configuration
+
+No new environment variable, dependency, or infrastructure requirement. No mixed-version ordering constraint: an older worker reading a `google-calendar` row that was already narrowed (or already deleted) behaves the same as it would against any other disconnected Calendar account — there is no schema shape for an old worker to misinterpret.
+
+Before deployment, get a rough sense of exposure with:
+
+```sql
+SELECT count(*) FROM user_oauth WHERE provider = 'google-calendar';
+```
+
+Every row this returns is a candidate for revocation (not all of them necessarily carry the old scope, but any that do will be deleted).
+
+### Deployment and migration steps
+
+1. Deploy the application version carrying this migration; the migration runs automatically as part of normal startup/migration application.
+2. Expect a log warning (`Revoked %d google-calendar user_oauth grant(s) ...`) if any rows were revoked. No warning means no existing grants carried the old scope.
+3. Communicate to affected users (if the revoked count is non-zero) that they need to reconnect Google Calendar.
+
+### Verification and monitoring
+
+Confirm the catalog row was narrowed:
+
+```sql
+SELECT oauth_scopes FROM public_mcp_apps WHERE app_id = 'google-calendar';
+```
+
+Connect a fresh test account to Calendar and confirm the Google consent screen requests only `calendar.events`, not the full `calendar` scope.
+
+For any user who reports a broken Calendar connection after this deploys, direct them to reconnect — this is the expected, intended effect of the migration, not a bug.
+
+### Rollback
+
+`downgrade()` restores the catalog's requested scope to the full `calendar` scope, but every `user_oauth` row this migration deleted stays deleted — there is no data to roll back to. A rollback only affects what *new* authorizations request; it does not restore anyone's Calendar connection.
+
 ## 2026-08-11 — New public-task File Operation isolation
 
 ### Deployment impact

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,9 @@ This is irreversible. `downgrade()` restores the catalog's requested scope but c
 
 Do not downgrade this revision and re-upgrade it, and do not apply an offline-generated (`--sql`) script for it more than once, once Calendar connections have been made under the narrow scope: the empty/`NULL`-scope branch of the cleanup (see the migration's module docstring) cannot distinguish a genuinely new, narrow grant that omitted its scope echo from a pre-migration broad one, and a replay would delete the new grant too.
 
-Both the online and offline paths run the cleanup as a single, unbatched `DELETE` — this migration commits in one transaction regardless (`transaction_per_migration=True` on PostgreSQL, see `src/xagent/migrations/env.py`), so every revoked row's lock is held until that same commit either way; there is no batching to trade off, and no lock-duration difference between the two paths.
+Both the online and offline paths run the `user_oauth` revoke as a single, unbatched `DELETE` — this migration commits in one transaction regardless (`transaction_per_migration=True` on PostgreSQL, see `src/xagent/migrations/env.py`), so every revoked row's lock is held until that same commit either way; there is no batching to trade off, and no lock-duration difference between the two paths.
+
+The `user_mcpservers` orphaned-association cleanup, however, is **online-only**. Offline (`alembic upgrade --sql`) generation narrows the catalog and revokes `user_oauth` rows, but does not touch `user_mcpservers` at all — see the migration's module docstring for why (identifying the official Calendar server from row content isn't expressible as one portable SQL predicate the way the scope-content match is). An offline-applied upgrade does not reach the same database state as an online one. If a deployment relies on generating and applying `--sql` scripts for this revision, run the online migration path once against the same database afterward (or apply this specific revision online) if the orphaned-association cleanup matters to you; otherwise stale associations for bare-`google`-only Calendar users will persist indefinitely.
 
 ### Scope limitation
 
@@ -24,34 +26,63 @@ This migration does not call Google's token-revocation endpoint. The deleted loc
 
 ### Prerequisites and configuration
 
-No new environment variable, dependency, or infrastructure requirement. No mixed-version ordering constraint: an older worker reading a `google-calendar` row that was already narrowed (or already deleted) behaves the same as it would against any other disconnected Calendar account — there is no schema shape for an old worker to misinterpret.
+No new environment variable, dependency, or infrastructure requirement. The *schema* has no mixed-version ordering constraint: an older worker reading a `google-calendar` row that was already narrowed (or already deleted) behaves the same as it would against any other disconnected Calendar account.
 
-Before deployment, get a rough sense of exposure. Two separate counts matter -- rows the `user_oauth` cleanup can revoke, and users the runtime policy change disconnects regardless of what that cleanup does:
+The *code* policy change is a different story and does have a mixed-version window: `google-calendar`'s membership in `APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT` (`web/mcp_apps.py`) takes effect the moment a given worker process starts running the new code, independent of when the migration runs against the database. During a rolling deploy where old and new worker processes run concurrently, an old worker still accepts a bare `google` row as a valid Calendar credential while a new worker rejects it for the same user -- which worker happens to handle a given request decides whether Calendar works for that user in that window. This resolves itself once every worker runs the new code; it is a transient rollout-window inconsistency, not a persistent one, but it is real and should be expected, not assumed away.
+
+Before deployment, get a precise count of affected users -- everyone who will lose Calendar access from either mechanism this migration/policy change touches, as one distinct set rather than two counts to eyeball and sum (PostgreSQL syntax; a SQLite deployment needs `json_extract(s.auth, '$.app_id')` in place of `s.auth->>'app_id'`):
 
 ```sql
--- Candidates for user_oauth revocation (not all of these necessarily carry
--- the old scope, but any that do will be deleted)
-SELECT count(*) FROM user_oauth WHERE provider = 'google-calendar';
+SELECT DISTINCT user_id FROM (
+  -- Users whose google-calendar grant will be revoked: the migration's
+  -- exact predicate (NULL/empty scope, or scope still containing the old,
+  -- full calendar scope) -- see _revoke_predicate in the migration.
+  SELECT user_id
+  FROM user_oauth
+  WHERE provider = 'google-calendar'
+    AND (
+      scope IS NULL
+      OR scope = ''
+      OR (' ' || scope || ' ') LIKE '% https://www.googleapis.com/auth/calendar %'
+    )
 
--- Users whose ONLY Calendar credential is a bare provider-level row: these
--- lose Calendar access from the APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT policy
--- change alone, whether or not the query above finds anything for them
-SELECT count(DISTINCT um.user_id)
-FROM user_mcpservers um
-JOIN mcp_servers s ON s.id = um.mcpserver_id
-WHERE s.name = 'Google Calendar'
-  AND um.user_id NOT IN (
-    SELECT user_id FROM user_oauth WHERE provider = 'google-calendar'
-  );
+  UNION
+
+  -- Users whose Calendar server association will be orphaned once the
+  -- revoke above runs: they have no google-calendar row that will survive
+  -- it, whether because they never had one (bare-google-only, connected
+  -- via the app_id-less batch flow) or because their only one is being
+  -- revoked by the query above. Matches _calendar_server_ids in the
+  -- migration: prefer auth.app_id, fall back to name only for a legacy
+  -- row with no app_id key, and only ever among transport = 'oauth' rows.
+  SELECT um.user_id
+  FROM user_mcpservers um
+  JOIN mcp_servers s ON s.id = um.mcpserver_id
+  WHERE s.transport = 'oauth'
+    AND (
+      s.auth->>'app_id' = 'google-calendar'
+      OR (s.auth->>'app_id' IS NULL AND s.name = 'Google Calendar')
+    )
+    AND um.user_id NOT IN (
+      SELECT user_id
+      FROM user_oauth
+      WHERE provider = 'google-calendar'
+        AND NOT (
+          scope IS NULL
+          OR scope = ''
+          OR (' ' || scope || ' ') LIKE '% https://www.googleapis.com/auth/calendar %'
+        )
+    )
+) affected_users;
 ```
 
-A zero from the first query does not mean zero affected users -- check both.
+This is the exact set of users this migration disconnects from Calendar -- not an over- or under-count -- and is what to base user communication on.
 
 ### Deployment and migration steps
 
 1. Deploy the application version carrying this migration; the migration runs automatically as part of normal startup/migration application.
-2. Expect up to two log warnings: `Revoked %d google-calendar user_oauth grant(s) ...` and `Removed %d orphaned Calendar user_mcpservers row(s) ...`. Either can fire independently of the other -- a user can be affected by one, both, or neither.
-3. Communicate to affected users (the sum of both preflight counts above, not just the revoked-grant count) that they need to reconnect Google Calendar.
+2. Expect up to two log warnings: `Revoked %d google-calendar user_oauth grant(s) ...` and `Removed %d orphaned Calendar user_mcpservers row(s) ...`. Either can fire independently of the other -- a user can be affected by one, both, or neither. Neither log warning covers the mixed-version code-policy window described above.
+3. Communicate to affected users (the preflight query above, run once before the deploy) that they need to reconnect Google Calendar.
 
 ### Verification and monitoring
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,15 +4,21 @@
 
 ### Deployment impact
 
-The built-in Google Calendar connector now requests `calendar.events` instead of the full `calendar` scope. The migration also deletes any `user_oauth` row with `provider = 'google-calendar'` whose granted scope still carries the old, full scope (including rows with no scope recorded at all — see the migration's module docstring for why that counts as evidence of the old grant). Affected users lose their Calendar connection and must reconnect through the OAuth flow again; there is no in-place upgrade of an existing token's scope.
+The built-in Google Calendar connector now requests `calendar.events` instead of the full `calendar` scope. The migration deletes any `user_oauth` row with `provider = 'google-calendar'` whose granted scope still carries the old, full scope (including rows with no scope recorded at all — see the migration's module docstring for why that counts as evidence of the old grant), then removes the `user_mcpservers` row for any user left with no `google-calendar` credential after that. Affected users lose their Calendar connection and must reconnect through the OAuth flow again; there is no in-place upgrade of an existing token's scope.
 
-This is irreversible. `downgrade()` restores the catalog's requested scope but cannot restore a deleted `user_oauth` row — there is no way to reconstruct a token this migration revoked.
+This is irreversible. `downgrade()` restores the catalog's requested scope but cannot restore a deleted `user_oauth` or `user_mcpservers` row — there is no way to reconstruct a token or a server association this migration removed.
 
-Online (live-connection) upgrades run the cleanup in bounded batches (`REVOKE_BATCH_SIZE = 500`) and log a warning with the number of grants revoked. Offline (`alembic upgrade --sql`) generation emits the equivalent cleanup as one literal, unbatched `DELETE` — running the generated script against a very large `user_oauth` table takes that one statement's lock for as long as it takes to complete, unlike the online path's batching.
+Do not downgrade this revision and re-upgrade it, and do not apply an offline-generated (`--sql`) script for it more than once, once Calendar connections have been made under the narrow scope: the empty/`NULL`-scope branch of the cleanup (see the migration's module docstring) cannot distinguish a genuinely new, narrow grant that omitted its scope echo from a pre-migration broad one, and a replay would delete the new grant too.
+
+Both the online and offline paths run the cleanup as a single, unbatched `DELETE` — this migration commits in one transaction regardless (`transaction_per_migration=True` on PostgreSQL, see `src/xagent/migrations/env.py`), so every revoked row's lock is held until that same commit either way; there is no batching to trade off, and no lock-duration difference between the two paths.
 
 ### Scope limitation
 
-Only `provider = 'google-calendar'` rows are touched. A bare provider-level `google` row (created by the app_id-less connect flow) is never deleted here even if it happens to carry the old scope too, since other Google connectors (Gmail, Drive, Docs, Slides, Sheets) may depend on that same row as their own fallback credential. That gap is closed separately, at the runtime level: `google-calendar` was added to `APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT` (`web/mcp_apps.py`) in the same change, so a bare `google` row is no longer accepted as a Calendar credential regardless of its scope. Deploy both changes together — the data cleanup and the runtime policy change ship in the same migration/PR, but they are logically separable, and reverting one without the other reopens a gap the other was covering.
+Only `provider = 'google-calendar'` rows are touched by the `user_oauth` cleanup. A bare provider-level `google` row (created by the app_id-less connect flow) is never deleted here even if it happens to carry the old scope too, since other Google connectors (Gmail, Drive, Docs, Slides, Sheets) may depend on that same row as their own fallback credential.
+
+That gap is *mitigated*, not fully closed, at the runtime level: `google-calendar` was added to `APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT` (`web/mcp_apps.py`) in the same change, so a bare `google` row is no longer accepted as a Calendar credential regardless of its scope. This has a real, separate consequence covered below: any user whose *only* Calendar connection was ever a bare `google` row is broken by this policy change alone, independently of whether the `user_oauth` cleanup above revokes anything for them. This migration's `user_mcpservers` cleanup step accounts for that -- it runs after the revoke step and removes any Calendar `user_mcpservers` row left with no `google-calendar` credential, whether that's because the row was revoked this run or because it only ever had a bare `google` row and none at all.
+
+This does **not** make a `google-calendar` row's own token trustworthy going forward -- see the migration's module docstring on why a reconnect can still, in principle, receive a token that again carries the old, broad scope. Deploy the data cleanup and the runtime policy change together (they ship in the same migration/PR); reverting one without the other reopens the gap the other was covering.
 
 This migration does not call Google's token-revocation endpoint. The deleted local row simply stops being usable by this application; Google still considers the underlying token valid (subject to its own expiry) until the user revokes app access directly from their Google Account.
 
@@ -20,19 +26,32 @@ This migration does not call Google's token-revocation endpoint. The deleted loc
 
 No new environment variable, dependency, or infrastructure requirement. No mixed-version ordering constraint: an older worker reading a `google-calendar` row that was already narrowed (or already deleted) behaves the same as it would against any other disconnected Calendar account — there is no schema shape for an old worker to misinterpret.
 
-Before deployment, get a rough sense of exposure with:
+Before deployment, get a rough sense of exposure. Two separate counts matter -- rows the `user_oauth` cleanup can revoke, and users the runtime policy change disconnects regardless of what that cleanup does:
 
 ```sql
+-- Candidates for user_oauth revocation (not all of these necessarily carry
+-- the old scope, but any that do will be deleted)
 SELECT count(*) FROM user_oauth WHERE provider = 'google-calendar';
+
+-- Users whose ONLY Calendar credential is a bare provider-level row: these
+-- lose Calendar access from the APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT policy
+-- change alone, whether or not the query above finds anything for them
+SELECT count(DISTINCT um.user_id)
+FROM user_mcpservers um
+JOIN mcp_servers s ON s.id = um.mcpserver_id
+WHERE s.name = 'Google Calendar'
+  AND um.user_id NOT IN (
+    SELECT user_id FROM user_oauth WHERE provider = 'google-calendar'
+  );
 ```
 
-Every row this returns is a candidate for revocation (not all of them necessarily carry the old scope, but any that do will be deleted).
+A zero from the first query does not mean zero affected users -- check both.
 
 ### Deployment and migration steps
 
 1. Deploy the application version carrying this migration; the migration runs automatically as part of normal startup/migration application.
-2. Expect a log warning (`Revoked %d google-calendar user_oauth grant(s) ...`) if any rows were revoked. No warning means no existing grants carried the old scope.
-3. Communicate to affected users (if the revoked count is non-zero) that they need to reconnect Google Calendar.
+2. Expect up to two log warnings: `Revoked %d google-calendar user_oauth grant(s) ...` and `Removed %d orphaned Calendar user_mcpservers row(s) ...`. Either can fire independently of the other -- a user can be affected by one, both, or neither.
+3. Communicate to affected users (the sum of both preflight counts above, not just the revoked-grant count) that they need to reconnect Google Calendar.
 
 ### Verification and monitoring
 
@@ -42,13 +61,13 @@ Confirm the catalog row was narrowed:
 SELECT oauth_scopes FROM public_mcp_apps WHERE app_id = 'google-calendar';
 ```
 
-Connect a fresh test account to Calendar and confirm the Google consent screen requests only `calendar.events`, not the full `calendar` scope.
+Connect a fresh test account to Calendar and confirm the Google consent screen requests only `calendar.events`, not the full `calendar` scope. A fresh test account only exercises the scope-narrowing half of this change -- it has no prior grant history, so it cannot demonstrate the reconnect-regains-broad-scope risk documented in the migration's module docstring; that risk needs an account that previously granted the old, broad scope.
 
 For any user who reports a broken Calendar connection after this deploys, direct them to reconnect — this is the expected, intended effect of the migration, not a bug.
 
 ### Rollback
 
-`downgrade()` restores the catalog's requested scope to the full `calendar` scope, but every `user_oauth` row this migration deleted stays deleted — there is no data to roll back to. A rollback only affects what *new* authorizations request; it does not restore anyone's Calendar connection.
+`downgrade()` restores the catalog's requested scope to the full `calendar` scope, but every `user_oauth` and `user_mcpservers` row this migration removed stays removed — there is no data to roll back to. A rollback only affects what *new* authorizations request; it does not restore anyone's Calendar connection.
 
 ## 2026-08-11 — New public-task File Operation isolation
 

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -16,33 +16,54 @@ calendar scope, forcing those users through the OAuth flow again on their
 next Calendar action.
 
 Deliberately scoped to ``provider == "google-calendar"`` only, not to any
-row whose *scope content* happens to mention the old calendar scope: a bare
-provider-level ``google`` row (no app_id) is also accepted as a Calendar
-credential (web/tools/config.py's ``_resolve_legacy_oauth_access_token``,
-since ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` in web/mcp_apps.py does not
-include ``google-calendar``) and *could* carry the old scope too via
-``include_granted_scopes=true`` -- but that same bare row is the fallback
-credential every other Google connector (Gmail, Drive, Docs, ...) may also
-be relying on, so deleting it on a scope-content match alone would risk
-breaking those too. A ``google-calendar``-provider row exists only because
-this connector's own connect flow created it (``provider=(app_id or
-provider)`` in web/api/auth.py), so it is unambiguously this connector's,
-and only this connector's, credential -- safe to delete outright. One
-narrower row type that gets missed as a result: a bare ``google`` grant
-that already carries the old scope is left untouched here; genuinely
-revoking that would require providers-aware logic this migration doesn't
-attempt.
+row whose *scope content* happens to mention the old calendar scope: that
+same bare "google" row is the fallback credential every other Google
+connector (Gmail, Drive, Docs, ...) may also be relying on, so deleting it
+on a scope-content match alone would risk breaking those too. A
+``google-calendar``-provider row exists only because this connector's own
+connect flow created it (``provider=(app_id or provider)`` in
+web/api/auth.py), so it is unambiguously this connector's, and only this
+connector's, credential -- safe to delete outright.
+
+This leaves one thing this data migration alone can't fix: a bare
+``google`` row (no app_id) could still carry the old scope via
+``include_granted_scopes=true`` without ever being touched here. That gap is
+closed architecturally instead, not by data cleanup: ``google-calendar`` has
+been added to ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` in web/mcp_apps.py,
+so the resolver (web/tools/config.py's
+``_resolve_legacy_oauth_access_token``) and the connected-state display
+(web/api/mcp.py's ``_enrich_oauth_server_info`` /
+``_connected_oauth_server_for_app``) no longer accept a bare ``google`` row
+as a Calendar credential at all, regardless of what scope it carries. A
+stale bare-``google`` row that happens to carry the old scope is therefore
+inert for Calendar going forward even though this migration leaves it
+sitting in the table.
 
 A row that carries *both* the old and the new scope (which
 ``include_granted_scopes=true`` can produce on reconnect once the registry
 requests only the new scope) is still revoked: presence of the old scope
 is grounds enough on its own, regardless of whether the new scope also
-shows up alongside it. Note this is a point-in-time cleanup of rows that
-predate this migration, not a standing guarantee -- a user who reconnects
-after this migration runs can still receive a combined grant the same way,
-since Google's incremental consent is per OAuth client, not per requested
-scope; only actual provider-side revocation (or requesting
-``include_granted_scopes=false``) would close that recurrence.
+shows up alongside it. A ``google-calendar`` row with no scope recorded at
+all (``NULL`` or empty string) is *also* revoked, not skipped: per RFC 6749
+5.1, a provider may omit ``scope`` entirely when the granted scope exactly
+matches what was requested, and the only thing this app_id ever requested
+before this migration was the old, broad scope -- so a missing scope on
+this provider's row is evidence of the broad grant, not proof of a narrow
+one. Note this is a point-in-time cleanup of rows that predate this
+migration, not a standing guarantee against recurrence -- a user who
+reconnects after this migration runs could in principle still receive a
+combined grant the same way, since Google's incremental consent is per
+OAuth client, not per requested scope; the ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT``
+change above is what actually prevents that combined grant from mattering,
+by refusing to trust the bare row for Calendar regardless of its scope.
+
+The online cleanup above runs entirely in the database via a single
+provider-plus-scope predicate, batched by id so a large table is never
+scanned or deleted in one unbounded statement (see ``REVOKE_BATCH_SIZE``
+below). Offline (``--sql``) generation emits the equivalent predicate as one
+literal, unbatched ``DELETE`` -- there is no live connection to page
+through, and an offline-generated script is applied as a single statement
+by whatever runs it, not by this migration walking pages itself.
 
 This is a delete, matching this table's existing disconnect contract
 (``web/api/mcp.py`` deletes the row outright; there is no revoked/active
@@ -123,6 +144,32 @@ def _offline_update(scopes: list[str]) -> None:
     op.execute(statement)
 
 
+def _offline_revoke_statement() -> None:
+    # Mirrors the online predicate exactly (see
+    # _revoke_grants_carrying_the_old_calendar_scope), expressed as SQL the
+    # target database evaluates itself instead of a Python-side fetch loop:
+    # offline (--sql) generation has no live connection to page through.
+    # Padding scope with a leading/trailing space and searching for the old
+    # scope padded the same way turns a token-exact match into a plain
+    # substring search that also matches at the very start or end of the
+    # string, without a false hit on a longer scope that merely contains the
+    # old one as a substring (OLD_SCOPE has no spaces, and the scope
+    # separator is always a single space per RFC 6749).
+    space = op.inline_literal(" ")
+    padded_scope = space.concat(USER_OAUTH_TABLE.c.scope).concat(space)
+    like_pattern = op.inline_literal(f"%{' ' + OLD_SCOPE + ' '}%")
+
+    statement = sa.delete(USER_OAUTH_TABLE).where(
+        USER_OAUTH_TABLE.c.provider == op.inline_literal(APP_ID),
+        sa.or_(
+            USER_OAUTH_TABLE.c.scope.is_(None),
+            USER_OAUTH_TABLE.c.scope == op.inline_literal(""),
+            padded_scope.like(like_pattern),
+        ),
+    )
+    op.execute(statement)
+
+
 def _revoke_grants_carrying_the_old_calendar_scope(bind: sa.engine.Connection) -> None:
     inspector = sa.inspect(bind)
     if "user_oauth" not in inspector.get_table_names():
@@ -155,10 +202,13 @@ def _revoke_grants_carrying_the_old_calendar_scope(bind: sa.engine.Connection) -
         # that merely contains "calendar" as a substring of something else
         # can't collide with the exact grant we're hunting for. Presence of
         # the old scope alone is grounds for revocation, regardless of
-        # whether the new scope is also present in the same grant -- see the
-        # module docstring on combined grants.
+        # whether the new scope is also present in the same grant. A row
+        # with no scope recorded (None or "") is revoked too, not skipped --
+        # see the module docstring for why a missing scope on this provider
+        # is evidence of the old, broad grant rather than proof of a narrow
+        # one.
         ids_to_revoke = [
-            row.id for row in rows if row.scope and OLD_SCOPE in row.scope.split()
+            row.id for row in rows if not row.scope or OLD_SCOPE in row.scope.split()
         ]
         if ids_to_revoke:
             bind.execute(
@@ -180,11 +230,7 @@ def _revoke_grants_carrying_the_old_calendar_scope(bind: sa.engine.Connection) -
 def upgrade() -> None:
     if op.get_context().as_sql:
         _offline_update(NEW_SCOPES)
-        # The revoke step below reads and judges each row's actual granted
-        # scope; offline (--sql) generation runs against a MockConnection,
-        # where neither reflection nor a live SELECT is possible. It is
-        # deliberately skipped here, same as the row-content-dependent
-        # cleanup in 20260813_trace_json_columns_to_jsonb.py's offline path.
+        _offline_revoke_statement()
         return
 
     bind = op.get_bind()

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -45,19 +45,19 @@ def _offline_scopes_literal(scopes: list[str], dialect_name: str):
     return serialized_literal
 
 
-def _upgrade_offline() -> None:
+def _offline_update(scopes: list[str]) -> None:
     dialect_name = op.get_context().dialect.name
     statement = (
         sa.update(PUBLIC_MCP_APPS_TABLE)
         .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
-        .values(oauth_scopes=_offline_scopes_literal(NEW_SCOPES, dialect_name))
+        .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
     )
     op.execute(statement)
 
 
 def upgrade() -> None:
     if op.get_context().as_sql:
-        _upgrade_offline()
+        _offline_update(NEW_SCOPES)
         return
 
     bind = op.get_bind()
@@ -77,6 +77,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    if op.get_context().as_sql:
+        _offline_update(OLD_SCOPES)
+        return
+
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     if "public_mcp_apps" not in inspector.get_table_names():

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -1,0 +1,93 @@
+"""narrow the Google Calendar connector's OAuth scope to calendar.events
+
+The Calendar connector's tools (search/create/get/update/delete) only ever
+operate on events, never on calendar list management, so the full
+``.../auth/calendar`` scope requested more access than the feature set uses.
+This updates the persisted built-in catalog row to match the narrower scope
+now declared in ``builtin_mcp_registry.py``.
+
+Revision ID: 20260817_narrow_google_calendar_scope
+Revises: 20260725_add_uploaded_file_recovery_index
+Create Date: 2026-08-17
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260817_narrow_google_calendar_scope"
+down_revision: Union[str, None] = "20260725_add_uploaded_file_recovery_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "google-calendar"
+OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
+NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+
+
+def _offline_scopes_literal(scopes: list[str], dialect_name: str):
+    # Match the online sa.JSON binding contract (none_as_null=False) used
+    # elsewhere in this migration set: values are stored as JSON, not as a
+    # bare SQL string literal, on every supported dialect.
+    serialized_literal = op.inline_literal(json.dumps(scopes, sort_keys=True))
+    if dialect_name == "postgresql":
+        return sa.cast(serialized_literal, sa.JSON())
+    return serialized_literal
+
+
+def _upgrade_offline() -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(NEW_SCOPES, dialect_name))
+    )
+    op.execute(statement)
+
+
+def upgrade() -> None:
+    if op.get_context().as_sql:
+        _upgrade_offline()
+        return
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
+    if not {"app_id", "oauth_scopes"}.issubset(columns):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=NEW_SCOPES)
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
+    if not {"app_id", "oauth_scopes"}.issubset(columns):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=OLD_SCOPES)
+    )

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -10,15 +10,39 @@ Narrowing the catalog row only changes what *future* authorizations
 request -- Google's OAuth refresh grant returns a new access token for
 whatever scope was originally consented to, it never narrows it (see
 ``refresh_oauth_token`` in ``web/tools/config.py``). So this migration also
-revokes -- deletes -- any ``user_oauth`` row whose granted scope still
-contains the old, full calendar scope, forcing those users through the
-OAuth flow again on their next Calendar action; only then do they get the
-narrower grant. Matching is on granted-scope content, not the ``provider``
-column: ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` (web/mcp_apps.py) does not
-include ``google-calendar``, so a bare provider-level ``google`` row is also
-accepted as a Calendar credential (web/tools/config.py's
-``_resolve_legacy_oauth_access_token``) and would evade a filter on
-``provider == "google-calendar"`` alone.
+revokes -- deletes -- every ``user_oauth`` row with ``provider ==
+"google-calendar"`` whose granted scope still contains the old, full
+calendar scope, forcing those users through the OAuth flow again on their
+next Calendar action.
+
+Deliberately scoped to ``provider == "google-calendar"`` only, not to any
+row whose *scope content* happens to mention the old calendar scope: a bare
+provider-level ``google`` row (no app_id) is also accepted as a Calendar
+credential (web/tools/config.py's ``_resolve_legacy_oauth_access_token``,
+since ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` in web/mcp_apps.py does not
+include ``google-calendar``) and *could* carry the old scope too via
+``include_granted_scopes=true`` -- but that same bare row is the fallback
+credential every other Google connector (Gmail, Drive, Docs, ...) may also
+be relying on, so deleting it on a scope-content match alone would risk
+breaking those too. A ``google-calendar``-provider row exists only because
+this connector's own connect flow created it (``provider=(app_id or
+provider)`` in web/api/auth.py), so it is unambiguously this connector's,
+and only this connector's, credential -- safe to delete outright. One
+narrower row type that gets missed as a result: a bare ``google`` grant
+that already carries the old scope is left untouched here; genuinely
+revoking that would require providers-aware logic this migration doesn't
+attempt.
+
+A row that carries *both* the old and the new scope (which
+``include_granted_scopes=true`` can produce on reconnect once the registry
+requests only the new scope) is still revoked: presence of the old scope
+is grounds enough on its own, regardless of whether the new scope also
+shows up alongside it. Note this is a point-in-time cleanup of rows that
+predate this migration, not a standing guarantee -- a user who reconnects
+after this migration runs can still receive a combined grant the same way,
+since Google's incremental consent is per OAuth client, not per requested
+scope; only actual provider-side revocation (or requesting
+``include_granted_scopes=false``) would close that recurrence.
 
 This is a delete, matching this table's existing disconnect contract
 (``web/api/mcp.py`` deletes the row outright; there is no revoked/active
@@ -30,6 +54,10 @@ Google still considers the token valid until it expires or the user revokes
 app access from their own Google Account -- identical to any other
 local-only disconnect today.
 
+Rows are paged by id (keyset, not OFFSET, matching the parent revision's
+convention) and deleted in bounded batches, so this doesn't load the whole
+table or build one unbounded ``IN`` list on a large deployment.
+
 Revision ID: 20260817_narrow_google_calendar_scope
 Revises: 20260813_trace_json_columns_to_jsonb
 Create Date: 2026-08-17
@@ -37,10 +65,13 @@ Create Date: 2026-08-17
 """
 
 import json
+import logging
 from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+
+logger = logging.getLogger(__name__)
 
 revision: str = "20260817_narrow_google_calendar_scope"
 down_revision: Union[str, None] = "20260813_trace_json_columns_to_jsonb"
@@ -57,6 +88,7 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
 USER_OAUTH_TABLE = sa.table(
     "user_oauth",
     sa.column("id", sa.Integer),
+    sa.column("provider", sa.String),
     sa.column("scope", sa.String),
 )
 
@@ -65,6 +97,10 @@ OLD_SCOPE = "https://www.googleapis.com/auth/calendar"
 NEW_SCOPE = "https://www.googleapis.com/auth/calendar.events"
 OLD_SCOPES = [OLD_SCOPE]
 NEW_SCOPES = [NEW_SCOPE]
+
+# Ids per revoke batch. Bounds a page of (id, scope) rows plus one IN-list
+# of matched ids, not the whole table -- see the module docstring.
+REVOKE_BATCH_SIZE = 500
 
 
 def _offline_scopes_literal(scopes: list[str], dialect_name: str):
@@ -93,30 +129,52 @@ def _revoke_grants_carrying_the_old_calendar_scope(bind: sa.engine.Connection) -
         return
 
     columns = {column["name"] for column in inspector.get_columns("user_oauth")}
-    if not {"id", "scope"}.issubset(columns):
+    if not {"id", "provider", "scope"}.issubset(columns):
         return
 
-    rows = bind.execute(
+    select_page = (
         sa.select(USER_OAUTH_TABLE.c.id, USER_OAUTH_TABLE.c.scope)
-    ).fetchall()
-
-    # Google's token response echoes ``scope`` as a plain space-delimited
-    # string (RFC 6749); split rather than substring-match so a scope that
-    # merely contains "calendar" as a substring of something else can't
-    # collide with the exact grant we're hunting for.
-    ids_to_revoke = [
-        row.id
-        for row in rows
-        if row.scope
-        and OLD_SCOPE in row.scope.split()
-        and NEW_SCOPE not in row.scope.split()
-    ]
-    if not ids_to_revoke:
-        return
-
-    bind.execute(
-        sa.delete(USER_OAUTH_TABLE).where(USER_OAUTH_TABLE.c.id.in_(ids_to_revoke))
+        .where(
+            USER_OAUTH_TABLE.c.provider == APP_ID,
+            USER_OAUTH_TABLE.c.id > sa.bindparam("after"),
+        )
+        .order_by(USER_OAUTH_TABLE.c.id)
+        .limit(REVOKE_BATCH_SIZE)
     )
+
+    revoked_count = 0
+    after = 0
+    while True:
+        rows = bind.execute(select_page, {"after": after}).fetchall()
+        if not rows:
+            break
+        after = rows[-1].id
+
+        # Google's token response echoes ``scope`` as a plain space-delimited
+        # string (RFC 6749); split rather than substring-match so a scope
+        # that merely contains "calendar" as a substring of something else
+        # can't collide with the exact grant we're hunting for. Presence of
+        # the old scope alone is grounds for revocation, regardless of
+        # whether the new scope is also present in the same grant -- see the
+        # module docstring on combined grants.
+        ids_to_revoke = [
+            row.id for row in rows if row.scope and OLD_SCOPE in row.scope.split()
+        ]
+        if ids_to_revoke:
+            bind.execute(
+                sa.delete(USER_OAUTH_TABLE).where(
+                    USER_OAUTH_TABLE.c.id.in_(ids_to_revoke)
+                )
+            )
+            revoked_count += len(ids_to_revoke)
+
+    if revoked_count:
+        logger.warning(
+            "Revoked %d google-calendar user_oauth grant(s) still carrying "
+            "the old '%s' scope; affected users must reconnect Calendar.",
+            revoked_count,
+            OLD_SCOPE,
+        )
 
 
 def upgrade() -> None:

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -112,7 +112,7 @@ unsupported, self-inflicted deployment shape, not a normal one.
 
 After the revoke above, one further cleanup: a user whose *only* historical
 Calendar connection was the app_id-less "Connect Google" flow (batch-connect
-in web/api/auth.py) has a ``user_mcpservers`` row for the shared "Google
+in web/api/auth.py) has a ``user_mcpservers`` row for the official "Google
 Calendar" ``mcp_servers`` row, backed only by a bare ``provider == "google"``
 ``user_oauth`` row -- never a ``google-calendar`` one. Before the
 ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` change above, that bare row was an
@@ -129,6 +129,44 @@ not being offered. ``_remove_orphaned_calendar_server_rows`` deletes the
 ``user_mcpservers`` row for any user who, after the revoke step above, has
 no ``google-calendar`` credential -- mirroring, retroactively, what the
 batch-connect flow now does prospectively.
+
+The official Calendar ``mcp_servers`` row is identified by ``_calendar_
+server_ids`` the same way runtime code already does (``get_app_for_mcp_
+server`` in web/mcp_apps.py): prefer the stable ``auth.app_id`` metadata a
+row carries once it has gone through the OAuth connect flow, falling back
+to matching the display name only for a legacy row that predates that
+metadata entirely -- and only ever among rows with ``transport ==
+"oauth"``, since ``_ensure_server_matches_oauth_app`` (web/api/auth.py)
+already refuses to let the official app share a name with an existing
+non-OAuth server. Matching on name alone, with no ``transport``/``auth``
+check, would both delete unrelated associations for an admin's custom,
+non-OAuth server that happens to share the name "Google Calendar", and miss
+an official row that was renamed while keeping its ``auth.app_id`` --
+``_calendar_server_ids`` returns every row that legitimately matches
+(there can be more than one: an official row can be renamed away from the
+canonical name while keeping ``app_id``, and a later reconnect can then
+create a second, fresh row under that now-free canonical name, since
+``MCPServer.name`` is unique) and logs a warning for a same-named row this
+migration deliberately leaves alone because it isn't OAuth transport.
+
+This server-association cleanup is online-only: it needs a live SELECT
+across ``mcp_servers``, ``user_mcpservers``, and ``user_oauth`` (which
+server is Calendar's, which users are still connected) that offline
+(``--sql``) generation has no connection to run, and unlike the revoke
+step above, deciding this from row content alone is not expressible as a
+single portable SQL predicate the way a scope-content LIKE match is --
+identifying the official row depends on interpreting a JSON column
+(``auth``) whose extraction syntax differs per dialect. An offline-applied
+upgrade therefore reaches this migration's catalog and ``user_oauth``
+state but *not* its ``user_mcpservers`` state: online and offline
+applications of this revision do not converge to the same database. A
+deployment relying on offline-generated SQL for this revision must run
+this cleanup separately (by hand, or by running the online path once
+against the same database) if the orphaned-association state matters to
+it; this migration does not fail closed to force that, since the rest of
+its offline behavior (the scope narrowing and grant revocation that most
+directly answer this PR's motivating Google App Verification requirement)
+remains both correct and complete on its own.
 
 This is a delete, matching this table's existing disconnect contract
 (``web/api/mcp.py`` deletes the row outright; there is no revoked/active
@@ -179,6 +217,8 @@ MCP_SERVERS_TABLE = sa.table(
     "mcp_servers",
     sa.column("id", sa.Integer),
     sa.column("name", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("auth", sa.JSON),
 )
 
 USER_MCPSERVERS_TABLE = sa.table(
@@ -273,6 +313,61 @@ def _revoke_grants_carrying_the_old_calendar_scope(bind: sa.engine.Connection) -
         )
 
 
+def _calendar_server_ids(bind: sa.engine.Connection) -> list[int]:
+    """Official Calendar ``mcp_servers`` rows, identified the same way
+    runtime code already does (``get_app_for_mcp_server`` in
+    web/mcp_apps.py): prefer the stable ``auth.app_id`` metadata a row
+    carries once connected through the OAuth flow, falling back to the
+    display name only for a legacy row that predates that metadata
+    entirely. A row is only eligible at all if ``transport == "oauth"`` --
+    the connect flow itself (``_ensure_server_matches_oauth_app`` in
+    web/api/auth.py) refuses to let the official Calendar app share a name
+    with an existing non-OAuth server, so a same-named row that isn't OAuth
+    transport cannot be the official Calendar connector and must be left
+    alone; log it so an operator can look at the naming collision.
+
+    Returns every match, not one: an official row can be renamed while
+    keeping its ``auth.app_id``, and a later reconnect can then create a
+    second, fresh row under the canonical name (``MCPServer.name`` is
+    unique, so the old, renamed row and the new one coexist) -- both are
+    legitimately "the" Calendar server, and both need their orphaned
+    associations cleaned up.
+    """
+    rows = bind.execute(
+        sa.select(
+            MCP_SERVERS_TABLE.c.id,
+            MCP_SERVERS_TABLE.c.name,
+            MCP_SERVERS_TABLE.c.transport,
+            MCP_SERVERS_TABLE.c.auth,
+        )
+    ).fetchall()
+
+    matched_ids: list[int] = []
+    for row in rows:
+        if row.transport != "oauth":
+            if row.name == CALENDAR_SERVER_NAME:
+                logger.warning(
+                    "mcp_servers row %d is named '%s' but is not an OAuth "
+                    "server (transport=%r); leaving it untouched -- it "
+                    "cannot be the official Calendar connector.",
+                    row.id,
+                    CALENDAR_SERVER_NAME,
+                    row.transport,
+                )
+            continue
+
+        auth = row.auth if isinstance(row.auth, dict) else {}
+        if "app_id" in auth:
+            if auth.get("app_id") == APP_ID:
+                matched_ids.append(row.id)
+            continue
+
+        if row.name == CALENDAR_SERVER_NAME:
+            matched_ids.append(row.id)
+
+    return matched_ids
+
+
 def _remove_orphaned_calendar_server_rows(bind: sa.engine.Connection) -> None:
     inspector = sa.inspect(bind)
     required_tables = {"mcp_servers", "user_mcpservers", "user_oauth"}
@@ -289,18 +384,14 @@ def _remove_orphaned_calendar_server_rows(bind: sa.engine.Connection) -> None:
         column["name"] for column in inspector.get_columns("user_oauth")
     }
     if (
-        not {"id", "name"}.issubset(mcp_servers_columns)
+        not {"id", "name", "transport", "auth"}.issubset(mcp_servers_columns)
         or not {"id", "user_id", "mcpserver_id"}.issubset(user_mcpservers_columns)
         or not {"user_id", "provider"}.issubset(user_oauth_columns)
     ):
         return
 
-    calendar_server_id = bind.execute(
-        sa.select(MCP_SERVERS_TABLE.c.id).where(
-            MCP_SERVERS_TABLE.c.name == CALENDAR_SERVER_NAME
-        )
-    ).scalar_one_or_none()
-    if calendar_server_id is None:
+    calendar_server_ids = _calendar_server_ids(bind)
+    if not calendar_server_ids:
         return
 
     connected_user_ids = sa.select(USER_OAUTH_TABLE.c.user_id).where(
@@ -308,7 +399,7 @@ def _remove_orphaned_calendar_server_rows(bind: sa.engine.Connection) -> None:
     )
     result = bind.execute(
         sa.delete(USER_MCPSERVERS_TABLE).where(
-            USER_MCPSERVERS_TABLE.c.mcpserver_id == calendar_server_id,
+            USER_MCPSERVERS_TABLE.c.mcpserver_id.in_(calendar_server_ids),
             USER_MCPSERVERS_TABLE.c.user_id.not_in(connected_user_ids),
         )
     )

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -7,7 +7,7 @@ This updates the persisted built-in catalog row to match the narrower scope
 now declared in ``builtin_mcp_registry.py``.
 
 Revision ID: 20260817_narrow_google_calendar_scope
-Revises: 20260725_add_uploaded_file_recovery_index
+Revises: 20260813_trace_json_columns_to_jsonb
 Create Date: 2026-08-17
 
 """
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260817_narrow_google_calendar_scope"
-down_revision: Union[str, None] = "20260725_add_uploaded_file_recovery_index"
+down_revision: Union[str, None] = "20260813_trace_json_columns_to_jsonb"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -6,15 +6,29 @@ operate on events, never on calendar list management, so the full
 This updates the persisted built-in catalog row to match the narrower scope
 now declared in ``builtin_mcp_registry.py``.
 
-Scope only, deliberately: this rewrites the built-in catalog row, which
-governs the scope requested by *future* authorizations. It does not touch
-``user_oauth`` rows already issued under the old, broader scope -- Google's
-OAuth refresh grant returns a new access token for whatever scope was
-originally consented to, it never narrows it (see ``refresh_oauth_token`` in
-``web/tools/config.py``). Users who already connected Calendar keep their
-existing grant, broader scope and all, until they disconnect and
-reconnect. Forcibly revoking and re-prompting every existing grant is a
-separate, user-facing rollout decision and is out of scope here.
+Narrowing the catalog row only changes what *future* authorizations
+request -- Google's OAuth refresh grant returns a new access token for
+whatever scope was originally consented to, it never narrows it (see
+``refresh_oauth_token`` in ``web/tools/config.py``). So this migration also
+revokes -- deletes -- any ``user_oauth`` row whose granted scope still
+contains the old, full calendar scope, forcing those users through the
+OAuth flow again on their next Calendar action; only then do they get the
+narrower grant. Matching is on granted-scope content, not the ``provider``
+column: ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` (web/mcp_apps.py) does not
+include ``google-calendar``, so a bare provider-level ``google`` row is also
+accepted as a Calendar credential (web/tools/config.py's
+``_resolve_legacy_oauth_access_token``) and would evade a filter on
+``provider == "google-calendar"`` alone.
+
+This is a delete, matching this table's existing disconnect contract
+(``web/api/mcp.py`` deletes the row outright; there is no revoked/active
+status flag on ``user_oauth`` to flip instead). It does not call Google's
+token-revocation endpoint: no migration in this repo makes outbound network
+calls, and neither does the existing disconnect flow for this table (only
+the separate ``MCPOAuthGrant`` table gets a best-effort external revoke).
+Google still considers the token valid until it expires or the user revokes
+app access from their own Google Account -- identical to any other
+local-only disconnect today.
 
 Revision ID: 20260817_narrow_google_calendar_scope
 Revises: 20260813_trace_json_columns_to_jsonb
@@ -40,9 +54,17 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
     sa.column("oauth_scopes", sa.JSON),
 )
 
+USER_OAUTH_TABLE = sa.table(
+    "user_oauth",
+    sa.column("id", sa.Integer),
+    sa.column("scope", sa.String),
+)
+
 APP_ID = "google-calendar"
-OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
-NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+OLD_SCOPE = "https://www.googleapis.com/auth/calendar"
+NEW_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+OLD_SCOPES = [OLD_SCOPE]
+NEW_SCOPES = [NEW_SCOPE]
 
 
 def _offline_scopes_literal(scopes: list[str], dialect_name: str):
@@ -65,28 +87,69 @@ def _offline_update(scopes: list[str]) -> None:
     op.execute(statement)
 
 
+def _revoke_grants_carrying_the_old_calendar_scope(bind: sa.engine.Connection) -> None:
+    inspector = sa.inspect(bind)
+    if "user_oauth" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("user_oauth")}
+    if not {"id", "scope"}.issubset(columns):
+        return
+
+    rows = bind.execute(
+        sa.select(USER_OAUTH_TABLE.c.id, USER_OAUTH_TABLE.c.scope)
+    ).fetchall()
+
+    # Google's token response echoes ``scope`` as a plain space-delimited
+    # string (RFC 6749); split rather than substring-match so a scope that
+    # merely contains "calendar" as a substring of something else can't
+    # collide with the exact grant we're hunting for.
+    ids_to_revoke = [
+        row.id
+        for row in rows
+        if row.scope
+        and OLD_SCOPE in row.scope.split()
+        and NEW_SCOPE not in row.scope.split()
+    ]
+    if not ids_to_revoke:
+        return
+
+    bind.execute(
+        sa.delete(USER_OAUTH_TABLE).where(USER_OAUTH_TABLE.c.id.in_(ids_to_revoke))
+    )
+
+
 def upgrade() -> None:
     if op.get_context().as_sql:
         _offline_update(NEW_SCOPES)
+        # The revoke step below reads and judges each row's actual granted
+        # scope; offline (--sql) generation runs against a MockConnection,
+        # where neither reflection nor a live SELECT is possible. It is
+        # deliberately skipped here, same as the row-content-dependent
+        # cleanup in 20260813_trace_json_columns_to_jsonb.py's offline path.
         return
 
     bind = op.get_bind()
     inspector = sa.inspect(bind)
-    if "public_mcp_apps" not in inspector.get_table_names():
-        return
+    if "public_mcp_apps" in inspector.get_table_names():
+        columns = {
+            column["name"] for column in inspector.get_columns("public_mcp_apps")
+        }
+        if {"app_id", "oauth_scopes"}.issubset(columns):
+            bind.execute(
+                sa.update(PUBLIC_MCP_APPS_TABLE)
+                .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+                .values(oauth_scopes=NEW_SCOPES)
+            )
 
-    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
-    if not {"app_id", "oauth_scopes"}.issubset(columns):
-        return
-
-    bind.execute(
-        sa.update(PUBLIC_MCP_APPS_TABLE)
-        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
-        .values(oauth_scopes=NEW_SCOPES)
-    )
+    _revoke_grants_carrying_the_old_calendar_scope(bind)
 
 
 def downgrade() -> None:
+    # Restores the catalog row's broader scope. Does not, and cannot,
+    # restore any user_oauth row the upgrade revoked: deleting a grant is
+    # not reversible, and a downgrade certainly shouldn't try to fabricate
+    # a "the old scope was granted after all" credential.
     if op.get_context().as_sql:
         _offline_update(OLD_SCOPES)
         return

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -6,6 +6,16 @@ operate on events, never on calendar list management, so the full
 This updates the persisted built-in catalog row to match the narrower scope
 now declared in ``builtin_mcp_registry.py``.
 
+Scope only, deliberately: this rewrites the built-in catalog row, which
+governs the scope requested by *future* authorizations. It does not touch
+``user_oauth`` rows already issued under the old, broader scope -- Google's
+OAuth refresh grant returns a new access token for whatever scope was
+originally consented to, it never narrows it (see ``refresh_oauth_token`` in
+``web/tools/config.py``). Users who already connected Calendar keep their
+existing grant, broader scope and all, until they disconnect and
+reconnect. Forcibly revoking and re-prompting every existing grant is a
+separate, user-facing rollout decision and is out of scope here.
+
 Revision ID: 20260817_narrow_google_calendar_scope
 Revises: 20260813_trace_json_columns_to_jsonb
 Create Date: 2026-08-17

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -12,8 +12,8 @@ whatever scope was originally consented to, it never narrows it (see
 ``refresh_oauth_token`` in ``web/tools/config.py``). So this migration also
 revokes -- deletes -- every ``user_oauth`` row with ``provider ==
 "google-calendar"`` whose granted scope still contains the old, full
-calendar scope, forcing those users through the OAuth flow again on their
-next Calendar action.
+calendar scope (or has no scope recorded at all -- see below), forcing
+those users through the OAuth flow again on their next Calendar action.
 
 Deliberately scoped to ``provider == "google-calendar"`` only, not to any
 row whose *scope content* happens to mention the old calendar scope: that
@@ -28,42 +28,107 @@ connector's, credential -- safe to delete outright.
 This leaves one thing this data migration alone can't fix: a bare
 ``google`` row (no app_id) could still carry the old scope via
 ``include_granted_scopes=true`` without ever being touched here. That gap is
-closed architecturally instead, not by data cleanup: ``google-calendar`` has
-been added to ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` in web/mcp_apps.py,
-so the resolver (web/tools/config.py's
+mitigated architecturally instead, not by data cleanup: ``google-calendar``
+has been added to ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` in
+web/mcp_apps.py, so the resolver (web/tools/config.py's
 ``_resolve_legacy_oauth_access_token``) and the connected-state display
 (web/api/mcp.py's ``_enrich_oauth_server_info`` /
 ``_connected_oauth_server_for_app``) no longer accept a bare ``google`` row
-as a Calendar credential at all, regardless of what scope it carries. A
-stale bare-``google`` row that happens to carry the old scope is therefore
-inert for Calendar going forward even though this migration leaves it
-sitting in the table.
+as a Calendar credential at all, regardless of what scope it carries.
 
-A row that carries *both* the old and the new scope (which
-``include_granted_scopes=true`` can produce on reconnect once the registry
-requests only the new scope) is still revoked: presence of the old scope
-is grounds enough on its own, regardless of whether the new scope also
-shows up alongside it. A ``google-calendar`` row with no scope recorded at
-all (``NULL`` or empty string) is *also* revoked, not skipped: per RFC 6749
-5.1, a provider may omit ``scope`` entirely when the granted scope exactly
-matches what was requested, and the only thing this app_id ever requested
-before this migration was the old, broad scope -- so a missing scope on
-this provider's row is evidence of the broad grant, not proof of a narrow
-one. Note this is a point-in-time cleanup of rows that predate this
-migration, not a standing guarantee against recurrence -- a user who
-reconnects after this migration runs could in principle still receive a
-combined grant the same way, since Google's incremental consent is per
-OAuth client, not per requested scope; the ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT``
-change above is what actually prevents that combined grant from mattering,
-by refusing to trust the bare row for Calendar regardless of its scope.
+Be precise about what that policy change does and does not establish: it
+only closes the *bare-row* angle. It does **not** make the app-scoped
+``google-calendar`` row's own token trustworthy going forward. Google's
+authorize request still sends ``include_granted_scopes=true``
+(web/api/auth.py), and the callback stores whatever ``scope`` string Google
+echoes back without validating it against the app's registered
+``oauth_scopes`` (web/api/auth.py's token-exchange handler). A user who
+reconnects Calendar after this migration runs can, in principle, receive a
+token whose granted scope again includes the old, full ``calendar`` scope
+alongside ``calendar.events`` -- Google's incremental consent is scoped to
+the OAuth *client*, not to what any one authorization request asked for, and
+nothing here rejects or re-narrows a combined grant returned on reconnect.
+Nothing in this migration, or in the ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT``
+change, prevents that recurrence -- closing it for good would mean either
+requesting ``include_granted_scopes=false`` for this app, or validating (and
+rejecting/stripping) the returned scope at the callback against the app's
+registered ``oauth_scopes``. Neither exists today. This migration is a
+point-in-time cleanup of rows that predate it, not a standing least-privilege
+guarantee.
 
-The online cleanup above runs entirely in the database via a single
-provider-plus-scope predicate, batched by id so a large table is never
-scanned or deleted in one unbounded statement (see ``REVOKE_BATCH_SIZE``
-below). Offline (``--sql``) generation emits the equivalent predicate as one
-literal, unbatched ``DELETE`` -- there is no live connection to page
-through, and an offline-generated script is applied as a single statement
-by whatever runs it, not by this migration walking pages itself.
+A row that carries *both* the old and the new scope (which, per the above,
+can happen on reconnect even after this migration) is still revoked here:
+presence of the old scope is grounds enough on its own, regardless of
+whether the new scope also shows up alongside it -- if this migration is
+ever re-applied against a database with such a row, revoking it again is
+the correct outcome; nothing distinguishes "the same forbidden scope,
+again" from "still first time."
+
+A ``google-calendar`` row with no scope recorded at all (``NULL`` or empty
+string) is *also* revoked, not skipped: per RFC 6749 5.1, a provider may
+omit ``scope`` entirely when the granted scope exactly matches what was
+requested, and the only thing this app_id had ever requested before this
+migration first ran was the old, broad scope -- so a missing scope is
+evidence of that grant, not proof of a narrow one.
+
+That inference only holds looking backward from before this migration first
+ran, which makes the empty/NULL branch the one piece of this cleanup that
+is **not** safe to replay. If this revision is downgraded and re-upgraded
+(or an offline script generated before some Calendar users reconnected is
+applied after), any ``google-calendar`` row created *since* the first run
+with an omitted ``scope`` echo -- itself entirely possible under RFC 6749
+5.1 once the app requests only ``calendar.events`` -- would be revoked all
+over again, even though it never carried the old scope. This migration
+cannot tell the two cases apart from the row alone (there is no reliable
+"created before this migration" marker to key off), so it does not try to.
+Do not downgrade and re-upgrade this revision, and do not apply an
+offline-generated script for it more than once, once Calendar connections
+have been made under the narrow scope.
+
+Online and offline (``--sql``) generation build and apply the exact same
+predicate (see ``_revoke_predicate``) -- there are not two implementations
+of "which rows qualify" to keep in sync. The one difference is how each
+side supplies its literals: online binds ordinary parameters against a live
+connection; offline inlines them into the emitted SQL text, since ``--sql``
+generation has no connection to bind against. Neither path pages or
+batches: a single ``DELETE ... WHERE <predicate>`` is what the offline path
+was always going to emit (there is no way to page through rows without a
+live connection to read from), and it is what the online path now issues
+too -- there is no batching benefit to preserve, since every revoked row's
+lock is held until this migration's single transaction commits either way.
+
+The online path still guards on ``user_oauth`` (and its ``id``/``provider``/
+``scope`` columns) existing before touching it, matching this migration's
+guard on ``public_mcp_apps``. The offline path cannot: ``--sql`` generation
+runs against a mock connection with no live reflection available, so its
+``DELETE`` is unconditional. In the full migration chain this is never a
+problem -- the migration that creates ``user_oauth``
+(``c7dfa28cc67a_add_user_oauth_table``) is an ancestor of this revision, so
+a whole-history offline script always creates the table before this
+``DELETE`` runs against it. It only becomes a problem for a hand-rolled
+partial ``--sql`` range applied to a database in a state the online guard
+was written to tolerate (e.g. ``user_oauth`` manually dropped) -- an
+unsupported, self-inflicted deployment shape, not a normal one.
+
+After the revoke above, one further cleanup: a user whose *only* historical
+Calendar connection was the app_id-less "Connect Google" flow (batch-connect
+in web/api/auth.py) has a ``user_mcpservers`` row for the shared "Google
+Calendar" ``mcp_servers`` row, backed only by a bare ``provider == "google"``
+``user_oauth`` row -- never a ``google-calendar`` one. Before the
+``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT`` change above, that bare row was an
+accepted Calendar credential, so the connection worked. After it, the
+connected-state check correctly reports "disconnected" -- but the stale
+``user_mcpservers`` row itself is not gone, and per web/api/auth.py's own
+comment on why the batch-connect flow now *skips creating* this row for
+apps in ``APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT``, the agent runtime picks
+up an existing ``user_mcpservers`` row directly, bypassing the
+connected-state check, and can never resolve a token for it. Left alone,
+these users would see Calendar as available to attach to an agent, then
+have every tool call fail at token resolution instead of the tool simply
+not being offered. ``_remove_orphaned_calendar_server_rows`` deletes the
+``user_mcpservers`` row for any user who, after the revoke step above, has
+no ``google-calendar`` credential -- mirroring, retroactively, what the
+batch-connect flow now does prospectively.
 
 This is a delete, matching this table's existing disconnect contract
 (``web/api/mcp.py`` deletes the row outright; there is no revoked/active
@@ -75,10 +140,6 @@ Google still considers the token valid until it expires or the user revokes
 app access from their own Google Account -- identical to any other
 local-only disconnect today.
 
-Rows are paged by id (keyset, not OFFSET, matching the parent revision's
-convention) and deleted in bounded batches, so this doesn't load the whole
-table or build one unbounded ``IN`` list on a large deployment.
-
 Revision ID: 20260817_narrow_google_calendar_scope
 Revises: 20260813_trace_json_columns_to_jsonb
 Create Date: 2026-08-17
@@ -87,7 +148,7 @@ Create Date: 2026-08-17
 
 import json
 import logging
-from typing import Sequence, Union
+from typing import Callable, Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
@@ -109,19 +170,30 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
 USER_OAUTH_TABLE = sa.table(
     "user_oauth",
     sa.column("id", sa.Integer),
+    sa.column("user_id", sa.Integer),
     sa.column("provider", sa.String),
     sa.column("scope", sa.String),
 )
 
+MCP_SERVERS_TABLE = sa.table(
+    "mcp_servers",
+    sa.column("id", sa.Integer),
+    sa.column("name", sa.String),
+)
+
+USER_MCPSERVERS_TABLE = sa.table(
+    "user_mcpservers",
+    sa.column("id", sa.Integer),
+    sa.column("user_id", sa.Integer),
+    sa.column("mcpserver_id", sa.Integer),
+)
+
 APP_ID = "google-calendar"
+CALENDAR_SERVER_NAME = "Google Calendar"
 OLD_SCOPE = "https://www.googleapis.com/auth/calendar"
 NEW_SCOPE = "https://www.googleapis.com/auth/calendar.events"
 OLD_SCOPES = [OLD_SCOPE]
 NEW_SCOPES = [NEW_SCOPE]
-
-# Ids per revoke batch. Bounds a page of (id, scope) rows plus one IN-list
-# of matched ids, not the whole table -- see the module docstring.
-REVOKE_BATCH_SIZE = 500
 
 
 def _offline_scopes_literal(scopes: list[str], dialect_name: str):
@@ -144,30 +216,40 @@ def _offline_update(scopes: list[str]) -> None:
     op.execute(statement)
 
 
-def _offline_revoke_statement() -> None:
-    # Mirrors the online predicate exactly (see
-    # _revoke_grants_carrying_the_old_calendar_scope), expressed as SQL the
-    # target database evaluates itself instead of a Python-side fetch loop:
-    # offline (--sql) generation has no live connection to page through.
-    # Padding scope with a leading/trailing space and searching for the old
-    # scope padded the same way turns a token-exact match into a plain
-    # substring search that also matches at the very start or end of the
-    # string, without a false hit on a longer scope that merely contains the
-    # old one as a substring (OLD_SCOPE has no spaces, and the scope
-    # separator is always a single space per RFC 6749).
-    space = op.inline_literal(" ")
-    padded_scope = space.concat(USER_OAUTH_TABLE.c.scope).concat(space)
-    like_pattern = op.inline_literal(f"%{' ' + OLD_SCOPE + ' '}%")
+def _revoke_predicate(literal: Callable[[object], object]):
+    """The one definition of "which user_oauth rows qualify for revocation".
 
-    statement = sa.delete(USER_OAUTH_TABLE).where(
-        USER_OAUTH_TABLE.c.provider == op.inline_literal(APP_ID),
+    ``literal`` wraps each Python value into whatever the caller needs it to
+    compile as: ``sa.literal`` for the online path (an ordinary bound
+    parameter against a live connection), ``op.inline_literal`` for the
+    offline (``--sql``) path (inlined into the emitted SQL text, since that
+    path has no connection to bind against). The predicate shape -- and
+    therefore the exact set of rows it matches -- is identical either way,
+    by construction, not by two implementations being kept manually in sync.
+
+    Padding ``scope`` with a leading/trailing space and searching for the
+    old scope padded the same way turns a token-exact match into a plain
+    substring search that also matches at the very start or end of the
+    string, without a false hit on a longer scope that merely contains the
+    old one as a substring (OLD_SCOPE has no spaces, and RFC 6749's scope
+    separator is always a single space).
+    """
+    space = literal(" ")
+    padded_scope = space.concat(USER_OAUTH_TABLE.c.scope).concat(space)
+    like_pattern = literal(f"% {OLD_SCOPE} %")
+
+    return sa.and_(
+        USER_OAUTH_TABLE.c.provider == literal(APP_ID),
         sa.or_(
             USER_OAUTH_TABLE.c.scope.is_(None),
-            USER_OAUTH_TABLE.c.scope == op.inline_literal(""),
+            USER_OAUTH_TABLE.c.scope == literal(""),
             padded_scope.like(like_pattern),
         ),
     )
-    op.execute(statement)
+
+
+def _offline_revoke_statement() -> None:
+    op.execute(sa.delete(USER_OAUTH_TABLE).where(_revoke_predicate(op.inline_literal)))
 
 
 def _revoke_grants_carrying_the_old_calendar_scope(bind: sa.engine.Connection) -> None:
@@ -179,51 +261,63 @@ def _revoke_grants_carrying_the_old_calendar_scope(bind: sa.engine.Connection) -
     if not {"id", "provider", "scope"}.issubset(columns):
         return
 
-    select_page = (
-        sa.select(USER_OAUTH_TABLE.c.id, USER_OAUTH_TABLE.c.scope)
-        .where(
-            USER_OAUTH_TABLE.c.provider == APP_ID,
-            USER_OAUTH_TABLE.c.id > sa.bindparam("after"),
-        )
-        .order_by(USER_OAUTH_TABLE.c.id)
-        .limit(REVOKE_BATCH_SIZE)
+    result = bind.execute(
+        sa.delete(USER_OAUTH_TABLE).where(_revoke_predicate(sa.literal))
     )
-
-    revoked_count = 0
-    after = 0
-    while True:
-        rows = bind.execute(select_page, {"after": after}).fetchall()
-        if not rows:
-            break
-        after = rows[-1].id
-
-        # Google's token response echoes ``scope`` as a plain space-delimited
-        # string (RFC 6749); split rather than substring-match so a scope
-        # that merely contains "calendar" as a substring of something else
-        # can't collide with the exact grant we're hunting for. Presence of
-        # the old scope alone is grounds for revocation, regardless of
-        # whether the new scope is also present in the same grant. A row
-        # with no scope recorded (None or "") is revoked too, not skipped --
-        # see the module docstring for why a missing scope on this provider
-        # is evidence of the old, broad grant rather than proof of a narrow
-        # one.
-        ids_to_revoke = [
-            row.id for row in rows if not row.scope or OLD_SCOPE in row.scope.split()
-        ]
-        if ids_to_revoke:
-            bind.execute(
-                sa.delete(USER_OAUTH_TABLE).where(
-                    USER_OAUTH_TABLE.c.id.in_(ids_to_revoke)
-                )
-            )
-            revoked_count += len(ids_to_revoke)
-
-    if revoked_count:
+    if result.rowcount:
         logger.warning(
             "Revoked %d google-calendar user_oauth grant(s) still carrying "
             "the old '%s' scope; affected users must reconnect Calendar.",
-            revoked_count,
+            result.rowcount,
             OLD_SCOPE,
+        )
+
+
+def _remove_orphaned_calendar_server_rows(bind: sa.engine.Connection) -> None:
+    inspector = sa.inspect(bind)
+    required_tables = {"mcp_servers", "user_mcpservers", "user_oauth"}
+    if not required_tables.issubset(set(inspector.get_table_names())):
+        return
+
+    mcp_servers_columns = {
+        column["name"] for column in inspector.get_columns("mcp_servers")
+    }
+    user_mcpservers_columns = {
+        column["name"] for column in inspector.get_columns("user_mcpservers")
+    }
+    user_oauth_columns = {
+        column["name"] for column in inspector.get_columns("user_oauth")
+    }
+    if (
+        not {"id", "name"}.issubset(mcp_servers_columns)
+        or not {"id", "user_id", "mcpserver_id"}.issubset(user_mcpservers_columns)
+        or not {"user_id", "provider"}.issubset(user_oauth_columns)
+    ):
+        return
+
+    calendar_server_id = bind.execute(
+        sa.select(MCP_SERVERS_TABLE.c.id).where(
+            MCP_SERVERS_TABLE.c.name == CALENDAR_SERVER_NAME
+        )
+    ).scalar_one_or_none()
+    if calendar_server_id is None:
+        return
+
+    connected_user_ids = sa.select(USER_OAUTH_TABLE.c.user_id).where(
+        USER_OAUTH_TABLE.c.provider == APP_ID
+    )
+    result = bind.execute(
+        sa.delete(USER_MCPSERVERS_TABLE).where(
+            USER_MCPSERVERS_TABLE.c.mcpserver_id == calendar_server_id,
+            USER_MCPSERVERS_TABLE.c.user_id.not_in(connected_user_ids),
+        )
+    )
+    if result.rowcount:
+        logger.warning(
+            "Removed %d orphaned Calendar user_mcpservers row(s) for users "
+            "with no google-calendar credential; those users must reconnect "
+            "to use Calendar again.",
+            result.rowcount,
         )
 
 
@@ -231,6 +325,10 @@ def upgrade() -> None:
     if op.get_context().as_sql:
         _offline_update(NEW_SCOPES)
         _offline_revoke_statement()
+        # The orphaned-server cleanup below needs a live SELECT (which
+        # mcp_servers row is "Google Calendar", which users still have a
+        # google-calendar credential) that offline (--sql) generation has no
+        # connection to run. Skipped here; see the module docstring.
         return
 
     bind = op.get_bind()
@@ -247,13 +345,15 @@ def upgrade() -> None:
             )
 
     _revoke_grants_carrying_the_old_calendar_scope(bind)
+    _remove_orphaned_calendar_server_rows(bind)
 
 
 def downgrade() -> None:
     # Restores the catalog row's broader scope. Does not, and cannot,
-    # restore any user_oauth row the upgrade revoked: deleting a grant is
-    # not reversible, and a downgrade certainly shouldn't try to fabricate
-    # a "the old scope was granted after all" credential.
+    # restore any user_oauth or user_mcpservers row the upgrade removed:
+    # deleting a grant or a server association is not reversible, and a
+    # downgrade certainly shouldn't try to fabricate "the old scope was
+    # granted after all" or "the user was still connected after all".
     if op.get_context().as_sql:
         _offline_update(OLD_SCOPES)
         return

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -267,7 +267,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "transport": "oauth",
             "provider_name": "google",
             "category": "Scheduling",
-            "oauth_scopes": ["https://www.googleapis.com/auth/calendar"],
+            "oauth_scopes": ["https://www.googleapis.com/auth/calendar.events"],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -22,7 +22,20 @@ from .models.public_mcp import PublicMCPApp
 # Only an app-scoped grant (UserOAuth.provider == the app_id) counts for these
 # apps; Instagram is deliberately excluded so its existing bare "meta" grants
 # keep working, since its required scopes haven't changed.
-APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT = frozenset({"facebook"})
+#
+# google-calendar is included for the same reason, not a new one: a bare
+# "google" row (app_id-less connect) never requested calendar.events either,
+# so it can't be trusted to carry Calendar access on its own merit. Without
+# this, Google's incremental consent (include_granted_scopes=true) could
+# still let a bare "google" row satisfy Calendar tool calls if it happened to
+# accumulate the old, broad calendar scope from a separate authorization --
+# exactly the gap the 20260817_narrow_google_calendar_scope.py migration's
+# data cleanup deliberately does not attempt to close by deleting that row
+# (see that migration's docstring), because a scope-content-only match risks
+# collateral damage on Gmail/Drive/Docs credentials sharing the same bare
+# row. This closes it architecturally instead: the bare row is simply never
+# accepted as a Calendar credential, so its scope content stops mattering.
+APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT = frozenset({"facebook", "google-calendar"})
 
 
 def _normalize_oauth_grant_key(value: object) -> str | None:

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -268,8 +268,23 @@ def test_upgrade_revokes_grants_carrying_the_old_calendar_scope(tmp_path) -> Non
                 # fallback credential (config.py's
                 # _resolve_legacy_oauth_access_token), so revoking it on a
                 # scope-content match alone would risk collateral damage
-                # beyond Calendar.
+                # beyond Calendar. mcp_apps.py's
+                # APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT closes the resulting
+                # gap architecturally instead -- see
+                # test_legacy_oauth_provider_scoping.py.
                 {"id": 6, "provider": "google", "scope": old_scope},
+                # A google-calendar row with no scope recorded at all. Per
+                # RFC 6749 5.1 a provider may omit ``scope`` when it exactly
+                # matches what was requested; the only thing ever requested
+                # under this app_id before this migration was the old, broad
+                # scope, so a missing scope here is evidence of that grant,
+                # not proof of a narrow one -- must be revoked, not skipped.
+                {"id": 7, "provider": "google-calendar", "scope": None},
+                # Same reasoning for an empty string, which is what the
+                # callback persists when the provider's response omits
+                # ``scope`` outright (web/api/auth.py's
+                # ``token_data.get("scope", "")``).
+                {"id": 8, "provider": "google-calendar", "scope": ""},
             ],
         )
 
@@ -460,10 +475,14 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
-    # The revoke step needs a live SELECT to judge each row's granted scope,
-    # which offline (--sql) generation can't do; it must not emit anything
-    # touching user_oauth.
-    assert "user_oauth" not in sql
+    # The revoke step has no live connection to page through, so it emits
+    # one literal, unbatched DELETE with the equivalent predicate instead of
+    # a Python-side fetch loop (see test_offline_*_upgrade_revokes_matching_*
+    # for proof it round-trips the same set of rows the online path does).
+    assert sql.count("DELETE FROM user_oauth") == 1
+    assert "user_oauth.provider = 'google-calendar'" in sql
+    assert "user_oauth.scope IS NULL" in sql
+    assert "https://www.googleapis.com/auth/calendar" in sql
 
 
 def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
@@ -533,6 +552,13 @@ def test_offline_sqlite_upgrade_round_trips_json_scope_value() -> None:
     connection.execute(
         "CREATE TABLE public_mcp_apps (app_id TEXT PRIMARY KEY, oauth_scopes JSON)"
     )
+    # The script also carries the revoke DELETE now (see
+    # test_offline_sqlite_upgrade_revokes_matching_user_oauth_rows for that
+    # behavior); this test only cares about the catalog scope, so an empty
+    # table is enough to let the script run.
+    connection.execute(
+        "CREATE TABLE user_oauth (id INTEGER PRIMARY KEY, provider TEXT, scope TEXT)"
+    )
     connection.execute(
         "INSERT INTO public_mcp_apps (app_id, oauth_scopes) VALUES (?, ?)",
         ("google-calendar", json.dumps(OLD_SCOPES)),
@@ -546,6 +572,63 @@ def test_offline_sqlite_upgrade_round_trips_json_scope_value() -> None:
 
     assert stored is not None
     assert json.loads(stored[0]) == NEW_SCOPES
+
+
+def test_offline_sqlite_upgrade_revokes_matching_user_oauth_rows() -> None:
+    """The offline (--sql) path has no live connection to page through, so
+    it emits one literal, unbatched DELETE instead of skipping the revoke
+    step entirely -- this executes that DELETE and checks it matches exactly
+    the same rows the online, Python-side predicate does."""
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="sqlite",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    with Operations.context(context):
+        migration.upgrade()
+
+    old_scope = migration.OLD_SCOPE
+    new_scope = migration.NEW_SCOPE
+
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE public_mcp_apps (app_id TEXT PRIMARY KEY, oauth_scopes JSON)"
+    )
+    connection.execute(
+        "CREATE TABLE user_oauth (id INTEGER PRIMARY KEY, provider TEXT, scope TEXT)"
+    )
+    connection.execute(
+        "INSERT INTO public_mcp_apps (app_id, oauth_scopes) VALUES (?, ?)",
+        ("google-calendar", json.dumps(OLD_SCOPES)),
+    )
+    connection.executemany(
+        "INSERT INTO user_oauth (id, provider, scope) VALUES (?, ?, ?)",
+        [
+            (1, "google-calendar", old_scope),
+            (2, "google-calendar", f"{new_scope} {old_scope}"),
+            (3, "google-calendar", new_scope),
+            (4, "gmail", "https://www.googleapis.com/auth/gmail.modify"),
+            (5, "google-drive", None),
+            (6, "google", old_scope),
+            (7, "google-calendar", None),
+            (8, "google-calendar", ""),
+        ],
+    )
+    connection.executescript(output.getvalue())
+
+    remaining = {
+        row[0]: row[1]
+        for row in connection.execute("SELECT id, provider FROM user_oauth")
+    }
+    connection.close()
+
+    assert remaining == {
+        3: "google-calendar",
+        4: "gmail",
+        5: "google-drive",
+        6: "google",
+    }
 
 
 def test_revision_metadata() -> None:
@@ -637,6 +720,18 @@ def test_postgresql_online_upgrade_narrows_scope_and_revokes_grants(
             text("INSERT INTO user_oauth (id, provider, scope) VALUES (2, :p, :s)"),
             {"p": "gmail", "s": "https://www.googleapis.com/auth/gmail.modify"},
         )
+        # No scope recorded (NULL) on a google-calendar row: RFC 6749 5.1
+        # lets a provider omit `scope` when it matches what was requested,
+        # and the only thing ever requested here before this migration was
+        # the old, broad scope -- must be revoked, not skipped.
+        connection.execute(
+            text("INSERT INTO user_oauth (id, provider, scope) VALUES (3, :p, NULL)"),
+            {"p": "google-calendar"},
+        )
+        connection.execute(
+            text("INSERT INTO user_oauth (id, provider, scope) VALUES (4, :p, :s)"),
+            {"p": "google-calendar", "s": ""},
+        )
 
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
@@ -726,3 +821,60 @@ def test_postgresql_offline_downgrade_sql_executes_and_restores_old_scope(
 
     assert stored_scopes == OLD_SCOPES
     assert _oauth_scopes_column_type(postgres_engine) == "json"
+
+
+@pytest.mark.postgresql
+def test_postgresql_offline_upgrade_revokes_matching_user_oauth_rows(
+    postgres_engine,
+) -> None:
+    """The offline (--sql) DELETE, executed against a real server, must
+    match exactly the same rows the online, Python-side predicate does --
+    including the NULL/empty-scope cases a LIKE-based SQL predicate handles
+    differently from Python's `if row.scope` guard would."""
+    migration = _load_migration_module()
+    old_scope = migration.OLD_SCOPE
+    new_scope = migration.NEW_SCOPE
+
+    with postgres_engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, oauth_scopes) "
+                "VALUES ('google-calendar', :scopes)"
+            ),
+            {"scopes": json.dumps(OLD_SCOPES)},
+        )
+        connection.execute(
+            text(
+                "INSERT INTO user_oauth (id, provider, scope) VALUES "
+                "(1, 'google-calendar', :old), "
+                "(2, 'google-calendar', :combined), "
+                "(3, 'google-calendar', :new), "
+                "(4, 'gmail', :gmail_scope), "
+                "(5, 'google-drive', NULL), "
+                "(6, 'google', :old), "
+                "(7, 'google-calendar', NULL), "
+                "(8, 'google-calendar', '')"
+            ),
+            {
+                "old": old_scope,
+                "combined": f"{new_scope} {old_scope}",
+                "new": new_scope,
+                "gmail_scope": "https://www.googleapis.com/auth/gmail.modify",
+            },
+        )
+
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    with Operations.context(context):
+        migration.upgrade()
+
+    with postgres_engine.begin() as connection:
+        connection.execute(text(output.getvalue()))
+        remaining_ids = {
+            row.id for row in connection.execute(text("SELECT id FROM user_oauth"))
+        }
+
+    assert remaining_ids == {3, 4, 5, 6}

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -85,7 +85,18 @@ def _mcp_servers(metadata: sa.MetaData) -> sa.Table:
         metadata,
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("name", sa.String(100), nullable=False, unique=True),
+        sa.Column("transport", sa.String(50), nullable=False),
+        sa.Column("auth", sa.JSON, nullable=True),
     )
+
+
+def _official_calendar_server_row(id: int) -> dict:
+    return {
+        "id": id,
+        "name": "Google Calendar",
+        "transport": "oauth",
+        "auth": {"app_id": "google-calendar", "provider": "google"},
+    }
 
 
 def _user_mcpservers(metadata: sa.MetaData) -> sa.Table:
@@ -431,9 +442,7 @@ def test_upgrade_removes_orphaned_calendar_server_row_for_bare_google_only_user(
             sa.insert(oauth_table),
             {"id": 1, "user_id": 100, "provider": "google", "scope": None},
         )
-        connection.execute(
-            sa.insert(servers_table), {"id": 1, "name": "Google Calendar"}
-        )
+        connection.execute(sa.insert(servers_table), _official_calendar_server_row(1))
         connection.execute(
             sa.insert(user_servers_table),
             {"id": 1, "user_id": 100, "mcpserver_id": 1},
@@ -468,9 +477,7 @@ def test_upgrade_keeps_calendar_server_row_for_properly_connected_user(
                 "scope": migration.NEW_SCOPE,
             },
         )
-        connection.execute(
-            sa.insert(servers_table), {"id": 1, "name": "Google Calendar"}
-        )
+        connection.execute(sa.insert(servers_table), _official_calendar_server_row(1))
         connection.execute(
             sa.insert(user_servers_table),
             {"id": 1, "user_id": 200, "mcpserver_id": 1},
@@ -510,9 +517,7 @@ def test_upgrade_removes_calendar_server_row_for_a_user_revoked_this_run(
                 "scope": migration.OLD_SCOPE,
             },
         )
-        connection.execute(
-            sa.insert(servers_table), {"id": 1, "name": "Google Calendar"}
-        )
+        connection.execute(sa.insert(servers_table), _official_calendar_server_row(1))
         connection.execute(
             sa.insert(user_servers_table),
             {"id": 1, "user_id": 300, "mcpserver_id": 1},
@@ -541,8 +546,13 @@ def test_upgrade_orphan_cleanup_ignores_other_servers_and_users(tmp_path) -> Non
         connection.execute(
             sa.insert(servers_table),
             [
-                {"id": 1, "name": "Google Calendar"},
-                {"id": 2, "name": "Gmail"},
+                _official_calendar_server_row(1),
+                {
+                    "id": 2,
+                    "name": "Gmail",
+                    "transport": "oauth",
+                    "auth": {"app_id": "gmail", "provider": "google"},
+                },
             ],
         )
         connection.execute(
@@ -569,6 +579,157 @@ def test_upgrade_orphan_cleanup_ignores_other_servers_and_users(tmp_path) -> Non
         }
 
     assert remaining_server_ids == {2}
+
+
+def test_upgrade_orphan_cleanup_ignores_custom_non_oauth_server_with_same_name(
+    tmp_path,
+) -> None:
+    """N1 regression: an admin's custom, non-OAuth server can be named
+    "Google Calendar" too. Identifying the official row by name alone would
+    delete this unrelated server's associations; requiring
+    transport == "oauth" excludes it, since the connect flow itself
+    (_ensure_server_matches_oauth_app) would never let the official app
+    share a name with a non-OAuth row in the first place."""
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table, servers_table, user_servers_table = _calendar_server_setup(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(servers_table),
+            {
+                "id": 1,
+                "name": "Google Calendar",
+                "transport": "stdio",
+                "auth": None,
+            },
+        )
+        connection.execute(
+            sa.insert(user_servers_table),
+            {"id": 1, "user_id": 100, "mcpserver_id": 1},
+        )
+        # This user has no google-calendar credential at all -- if the
+        # custom server were mistaken for the official one, this
+        # association would be (wrongly) removed.
+        connection.execute(
+            sa.insert(oauth_table),
+            {"id": 1, "user_id": 100, "provider": "google", "scope": None},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_servers = connection.execute(
+            sa.select(user_servers_table.c.id)
+        ).fetchall()
+
+    assert len(remaining_servers) == 1
+
+
+def test_upgrade_orphan_cleanup_finds_renamed_official_calendar_server(
+    tmp_path,
+) -> None:
+    """N1 regression: an official Calendar row renamed by an admin keeps its
+    auth.app_id metadata. Matching by name alone would miss it entirely,
+    leaving its orphaned association in place."""
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table, servers_table, user_servers_table = _calendar_server_setup(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(servers_table),
+            {
+                "id": 1,
+                "name": "Calendar (Legacy)",
+                "transport": "oauth",
+                "auth": {"app_id": "google-calendar", "provider": "google"},
+            },
+        )
+        connection.execute(
+            sa.insert(user_servers_table),
+            {"id": 1, "user_id": 100, "mcpserver_id": 1},
+        )
+        connection.execute(
+            sa.insert(oauth_table),
+            {"id": 1, "user_id": 100, "provider": "google", "scope": None},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_servers = connection.execute(
+            sa.select(user_servers_table.c.id)
+        ).fetchall()
+
+    assert remaining_servers == []
+
+
+def test_upgrade_orphan_cleanup_handles_duplicate_logical_calendar_servers(
+    tmp_path,
+) -> None:
+    """N1 regression: after a rename, a reconnect can create a second,
+    fresh mcp_servers row under the now-free canonical name (MCPServer.name
+    is unique, so the renamed row and the new one coexist). Both carry
+    auth.app_id == "google-calendar" and both must be considered when
+    cleaning up orphaned associations."""
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table, servers_table, user_servers_table = _calendar_server_setup(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(servers_table),
+            [
+                {
+                    "id": 1,
+                    "name": "Calendar (old)",
+                    "transport": "oauth",
+                    "auth": {"app_id": "google-calendar", "provider": "google"},
+                },
+                _official_calendar_server_row(2),
+            ],
+        )
+        connection.execute(
+            sa.insert(user_servers_table),
+            [
+                # Bare-google-only user, associated with the renamed row.
+                {"id": 1, "user_id": 100, "mcpserver_id": 1},
+                # Bare-google-only user, associated with the fresh row.
+                {"id": 2, "user_id": 101, "mcpserver_id": 2},
+                # Properly connected user on the fresh row -- must survive.
+                {"id": 3, "user_id": 200, "mcpserver_id": 2},
+            ],
+        )
+        connection.execute(
+            sa.insert(oauth_table),
+            [
+                {"id": 1, "user_id": 100, "provider": "google", "scope": None},
+                {"id": 2, "user_id": 101, "provider": "google", "scope": None},
+                {
+                    "id": 3,
+                    "user_id": 200,
+                    "provider": "google-calendar",
+                    "scope": migration.NEW_SCOPE,
+                },
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_user_ids = {
+            row.user_id
+            for row in connection.execute(sa.select(user_servers_table.c.user_id))
+        }
+
+    assert remaining_user_ids == {200}
 
 
 def test_upgrade_skips_orphan_cleanup_when_calendar_server_row_is_absent(
@@ -918,7 +1079,9 @@ def postgres_engine():
             text(
                 "CREATE TABLE mcp_servers ("
                 "id SERIAL PRIMARY KEY, "
-                "name VARCHAR(100) NOT NULL UNIQUE)"
+                "name VARCHAR(100) NOT NULL UNIQUE, "
+                "transport VARCHAR(50) NOT NULL, "
+                "auth JSON)"
             )
         )
         conn.execute(
@@ -1004,9 +1167,7 @@ def test_postgresql_online_upgrade_removes_orphaned_calendar_server_row(
             sa.insert(oauth_table),
             {"id": 1, "user_id": 100, "provider": "google", "scope": None},
         )
-        connection.execute(
-            sa.insert(servers_table), {"id": 1, "name": "Google Calendar"}
-        )
+        connection.execute(sa.insert(servers_table), _official_calendar_server_row(1))
         connection.execute(
             sa.insert(user_servers_table),
             {"id": 1, "user_id": 100, "mcpserver_id": 1},

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -73,14 +73,95 @@ def _user_oauth(metadata: sa.MetaData) -> sa.Table:
         "user_oauth",
         metadata,
         sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, nullable=True),
         sa.Column("provider", sa.String(50), nullable=False),
         sa.Column("scope", sa.String, nullable=True),
+    )
+
+
+def _mcp_servers(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "mcp_servers",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False, unique=True),
+    )
+
+
+def _user_mcpservers(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "user_mcpservers",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, nullable=False),
+        sa.Column("mcpserver_id", sa.Integer, nullable=False),
     )
 
 
 def _remaining_ids_and_providers(connection, table: sa.Table) -> dict[int, str]:
     rows = connection.execute(sa.select(table.c.id, table.c.provider))
     return {row.id: row.provider for row in rows}
+
+
+# Shared by every test that exercises "which user_oauth rows qualify for
+# revocation" (the online sqlite path, the offline sqlite path, and the
+# offline postgres path): one row set and one expected-survivors set, so the
+# claim that all three produce identical results is structural -- checked
+# against the same fixture -- rather than three independently hand-copied
+# datasets that could quietly drift apart.
+REVOKE_FIXTURE_ROWS = [
+    # App-scoped grant carrying the old, broad scope alongside the identity
+    # scopes every Google grant also carries.
+    {
+        "id": 1,
+        "user_id": 101,
+        "provider": "google-calendar",
+        "scope": f"{OLD_SCOPES[0]} https://www.googleapis.com/auth/userinfo.email",
+    },
+    # A combined grant: include_granted_scopes=true can echo back both the
+    # old and the new scope on reconnect. Presence of the old scope alone
+    # must still trigger revocation -- the new scope also being present is
+    # not evidence of a narrowed credential.
+    {
+        "id": 2,
+        "user_id": 102,
+        "provider": "google-calendar",
+        "scope": f"{NEW_SCOPES[0]} {OLD_SCOPES[0]}",
+    },
+    # Already narrowed (e.g. a user who reconnected since this migration
+    # first ran) -- must survive untouched.
+    {"id": 3, "user_id": 103, "provider": "google-calendar", "scope": NEW_SCOPES[0]},
+    # A different connector's grant; must never be touched even though its
+    # provider column also starts with "google".
+    {
+        "id": 4,
+        "user_id": 104,
+        "provider": "gmail",
+        "scope": "https://www.googleapis.com/auth/gmail.modify",
+    },
+    # No scope recorded at all -- must not raise on a null scope.
+    {"id": 5, "user_id": 105, "provider": "google-drive", "scope": None},
+    # A bare provider-level grant that happens to carry the old scope too --
+    # deliberately left untouched: other Google connectors may be relying on
+    # this exact row as their own fallback credential (config.py's
+    # _resolve_legacy_oauth_access_token), so revoking it on a scope-content
+    # match alone would risk collateral damage beyond Calendar. mcp_apps.py's
+    # APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT closes the resulting gap
+    # architecturally instead -- see test_legacy_oauth_provider_scoping.py.
+    {"id": 6, "user_id": 106, "provider": "google", "scope": OLD_SCOPES[0]},
+    # A google-calendar row with no scope recorded at all. Per RFC 6749 5.1
+    # a provider may omit ``scope`` when it exactly matches what was
+    # requested; the only thing ever requested under this app_id before this
+    # migration was the old, broad scope, so a missing scope here is
+    # evidence of that grant, not proof of a narrow one -- must be revoked,
+    # not skipped.
+    {"id": 7, "user_id": 107, "provider": "google-calendar", "scope": None},
+    # Same reasoning for an empty string, which is what the callback
+    # persists when the provider's response omits ``scope`` outright
+    # (web/api/auth.py's ``token_data.get("scope", "")``).
+    {"id": 8, "user_id": 108, "provider": "google-calendar", "scope": ""},
+]
+REVOKE_FIXTURE_SURVIVING_IDS = {3, 4, 5, 6}
 
 
 def test_migration_target_scope_matches_the_live_registry() -> None:
@@ -226,79 +307,15 @@ def test_upgrade_revokes_grants_carrying_the_old_calendar_scope(tmp_path) -> Non
     table = _user_oauth(metadata)
     metadata.create_all(engine)
 
-    old_scope = migration.OLD_SCOPE
-    new_scope = migration.NEW_SCOPE
-
     with engine.begin() as connection:
-        connection.execute(
-            sa.insert(table),
-            [
-                # App-scoped grant carrying the old, broad scope alongside
-                # the identity scopes every Google grant also carries.
-                {
-                    "id": 1,
-                    "provider": "google-calendar",
-                    "scope": f"{old_scope} https://www.googleapis.com/auth/userinfo.email",
-                },
-                # A combined grant: include_granted_scopes=true can echo
-                # back both the old and the new scope on reconnect. Presence
-                # of the old scope alone must still trigger revocation --
-                # the new scope also being present is not evidence of a
-                # narrowed credential.
-                {
-                    "id": 2,
-                    "provider": "google-calendar",
-                    "scope": f"{new_scope} {old_scope}",
-                },
-                # Already narrowed (e.g. a user who reconnected since this
-                # migration first ran) -- must survive untouched.
-                {"id": 3, "provider": "google-calendar", "scope": new_scope},
-                # A different connector's grant; must never be touched even
-                # though its provider column also starts with "google".
-                {
-                    "id": 4,
-                    "provider": "gmail",
-                    "scope": "https://www.googleapis.com/auth/gmail.modify",
-                },
-                # No scope recorded at all -- must not raise on a null scope.
-                {"id": 5, "provider": "google-drive", "scope": None},
-                # A bare provider-level grant that happens to carry the old
-                # scope too -- deliberately left untouched: other Google
-                # connectors may be relying on this exact row as their own
-                # fallback credential (config.py's
-                # _resolve_legacy_oauth_access_token), so revoking it on a
-                # scope-content match alone would risk collateral damage
-                # beyond Calendar. mcp_apps.py's
-                # APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT closes the resulting
-                # gap architecturally instead -- see
-                # test_legacy_oauth_provider_scoping.py.
-                {"id": 6, "provider": "google", "scope": old_scope},
-                # A google-calendar row with no scope recorded at all. Per
-                # RFC 6749 5.1 a provider may omit ``scope`` when it exactly
-                # matches what was requested; the only thing ever requested
-                # under this app_id before this migration was the old, broad
-                # scope, so a missing scope here is evidence of that grant,
-                # not proof of a narrow one -- must be revoked, not skipped.
-                {"id": 7, "provider": "google-calendar", "scope": None},
-                # Same reasoning for an empty string, which is what the
-                # callback persists when the provider's response omits
-                # ``scope`` outright (web/api/auth.py's
-                # ``token_data.get("scope", "")``).
-                {"id": 8, "provider": "google-calendar", "scope": ""},
-            ],
-        )
+        connection.execute(sa.insert(table), REVOKE_FIXTURE_ROWS)
 
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
 
-        remaining = _remaining_ids_and_providers(connection, table)
+        remaining_ids = set(connection.execute(sa.select(table.c.id)).scalars().all())
 
-    assert remaining == {
-        3: "google-calendar",
-        4: "gmail",
-        5: "google-drive",
-        6: "google",
-    }
+    assert remaining_ids == REVOKE_FIXTURE_SURVIVING_IDS
 
 
 def test_upgrade_revoke_does_not_touch_gmail_watch_state(tmp_path) -> None:
@@ -351,20 +368,25 @@ def test_upgrade_revoke_does_not_touch_gmail_watch_state(tmp_path) -> None:
     assert len(remaining_watch) == 1
 
 
-def test_upgrade_revoke_pages_through_more_than_one_batch(tmp_path) -> None:
+def test_upgrade_revoke_handles_a_large_number_of_matching_rows(tmp_path) -> None:
+    """The revoke DELETE is a single, unbatched statement (see the module
+    docstring on why paging buys nothing under this migration's transaction
+    model) -- this proves a large row count still revokes every matching
+    row and doesn't silently truncate."""
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
     table = _user_oauth(metadata)
     metadata.create_all(engine)
 
-    row_count = migration.REVOKE_BATCH_SIZE + 5
+    row_count = 1000
     with engine.begin() as connection:
         connection.execute(
             sa.insert(table),
             [
                 {
                     "id": i,
+                    "user_id": i,
                     "provider": "google-calendar",
                     "scope": migration.OLD_SCOPE,
                 }
@@ -374,6 +396,217 @@ def test_upgrade_revoke_pages_through_more_than_one_batch(tmp_path) -> None:
 
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
+
+        remaining = _remaining_ids_and_providers(connection, table)
+
+    assert remaining == {}
+
+
+def _calendar_server_setup(metadata: sa.MetaData):
+    return (
+        _user_oauth(metadata),
+        _mcp_servers(metadata),
+        _user_mcpservers(metadata),
+    )
+
+
+def test_upgrade_removes_orphaned_calendar_server_row_for_bare_google_only_user(
+    tmp_path,
+) -> None:
+    """The runtime half of the C1/F2 fix's other shoe: a user who only ever
+    connected Calendar through the app_id-less "Connect Google" batch flow
+    has a user_mcpservers row backed solely by a bare provider='google' row.
+    APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT (mcp_apps.py) means that bare row
+    no longer counts as a Calendar credential, so this stale association
+    must be cleaned up too -- left alone, the agent runtime would pick it up
+    directly and fail at token resolution on every Calendar tool call."""
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table, servers_table, user_servers_table = _calendar_server_setup(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(oauth_table),
+            {"id": 1, "user_id": 100, "provider": "google", "scope": None},
+        )
+        connection.execute(
+            sa.insert(servers_table), {"id": 1, "name": "Google Calendar"}
+        )
+        connection.execute(
+            sa.insert(user_servers_table),
+            {"id": 1, "user_id": 100, "mcpserver_id": 1},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_servers = connection.execute(
+            sa.select(user_servers_table.c.id)
+        ).fetchall()
+
+    assert remaining_servers == []
+
+
+def test_upgrade_keeps_calendar_server_row_for_properly_connected_user(
+    tmp_path,
+) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table, servers_table, user_servers_table = _calendar_server_setup(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(oauth_table),
+            {
+                "id": 1,
+                "user_id": 200,
+                "provider": "google-calendar",
+                "scope": migration.NEW_SCOPE,
+            },
+        )
+        connection.execute(
+            sa.insert(servers_table), {"id": 1, "name": "Google Calendar"}
+        )
+        connection.execute(
+            sa.insert(user_servers_table),
+            {"id": 1, "user_id": 200, "mcpserver_id": 1},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_servers = {
+            row.user_id
+            for row in connection.execute(sa.select(user_servers_table.c.user_id))
+        }
+
+    assert remaining_servers == {200}
+
+
+def test_upgrade_removes_calendar_server_row_for_a_user_revoked_this_run(
+    tmp_path,
+) -> None:
+    """The orphan cleanup runs after the revoke step, against the
+    post-revoke state: a user whose only google-calendar row is revoked in
+    this very migration run must also lose their stale server association,
+    not just the ones who never had one."""
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table, servers_table, user_servers_table = _calendar_server_setup(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(oauth_table),
+            {
+                "id": 1,
+                "user_id": 300,
+                "provider": "google-calendar",
+                "scope": migration.OLD_SCOPE,
+            },
+        )
+        connection.execute(
+            sa.insert(servers_table), {"id": 1, "name": "Google Calendar"}
+        )
+        connection.execute(
+            sa.insert(user_servers_table),
+            {"id": 1, "user_id": 300, "mcpserver_id": 1},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_oauth = connection.execute(sa.select(oauth_table.c.id)).fetchall()
+        remaining_servers = connection.execute(
+            sa.select(user_servers_table.c.id)
+        ).fetchall()
+
+    assert remaining_oauth == []
+    assert remaining_servers == []
+
+
+def test_upgrade_orphan_cleanup_ignores_other_servers_and_users(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table, servers_table, user_servers_table = _calendar_server_setup(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(servers_table),
+            [
+                {"id": 1, "name": "Google Calendar"},
+                {"id": 2, "name": "Gmail"},
+            ],
+        )
+        connection.execute(
+            sa.insert(user_servers_table),
+            [
+                # Bare-google-only Calendar user -- removed.
+                {"id": 1, "user_id": 100, "mcpserver_id": 1},
+                # Same user also has a Gmail server association, unrelated
+                # to Calendar entirely -- must survive.
+                {"id": 2, "user_id": 100, "mcpserver_id": 2},
+            ],
+        )
+        connection.execute(
+            sa.insert(oauth_table),
+            {"id": 1, "user_id": 100, "provider": "google", "scope": None},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_server_ids = {
+            row.mcpserver_id
+            for row in connection.execute(sa.select(user_servers_table.c.mcpserver_id))
+        }
+
+    assert remaining_server_ids == {2}
+
+
+def test_upgrade_skips_orphan_cleanup_when_calendar_server_row_is_absent(
+    tmp_path,
+) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table, servers_table, user_servers_table = _calendar_server_setup(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise with no rows anywhere
+
+
+def test_upgrade_skips_orphan_cleanup_when_user_mcpservers_table_is_absent(
+    tmp_path,
+) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _user_oauth(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {
+                "id": 1,
+                "user_id": 100,
+                "provider": "google-calendar",
+                "scope": migration.OLD_SCOPE,
+            },
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise; only user_oauth exists
 
         remaining = _remaining_ids_and_providers(connection, table)
 
@@ -456,7 +689,7 @@ def test_upgrade_skips_revoke_when_scope_column_is_absent() -> None:
     assert remaining == {1: "google-calendar"}
 
 
-def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
+def test_offline_postgresql_upgrade_emits_literal_update_and_revoke_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()
     context = MigrationContext.configure(
@@ -476,13 +709,19 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
     # The revoke step has no live connection to page through, so it emits
-    # one literal, unbatched DELETE with the equivalent predicate instead of
-    # a Python-side fetch loop (see test_offline_*_upgrade_revokes_matching_*
-    # for proof it round-trips the same set of rows the online path does).
+    # one literal DELETE with the same predicate the online path builds
+    # (_revoke_predicate) -- see test_offline_*_upgrade_revokes_matching_*
+    # for proof it round-trips the same set of rows the online path does.
     assert sql.count("DELETE FROM user_oauth") == 1
     assert "user_oauth.provider = 'google-calendar'" in sql
     assert "user_oauth.scope IS NULL" in sql
     assert "https://www.googleapis.com/auth/calendar" in sql
+    # The orphaned-server cleanup needs a live SELECT (which mcp_servers row
+    # is Calendar's, which users still have a credential) that offline
+    # generation can't do -- it must not emit anything touching either
+    # server table.
+    assert "mcp_servers" not in sql
+    assert "user_mcpservers" not in sql
 
 
 def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
@@ -575,10 +814,11 @@ def test_offline_sqlite_upgrade_round_trips_json_scope_value() -> None:
 
 
 def test_offline_sqlite_upgrade_revokes_matching_user_oauth_rows() -> None:
-    """The offline (--sql) path has no live connection to page through, so
-    it emits one literal, unbatched DELETE instead of skipping the revoke
-    step entirely -- this executes that DELETE and checks it matches exactly
-    the same rows the online, Python-side predicate does."""
+    """The offline (--sql) path emits one literal DELETE built from the same
+    _revoke_predicate the online path uses -- this executes that DELETE
+    against the shared fixture and checks it matches exactly the same rows
+    test_upgrade_revokes_grants_carrying_the_old_calendar_scope's online
+    path does."""
     migration = _load_migration_module()
     output = StringIO()
     context = MigrationContext.configure(
@@ -588,47 +828,31 @@ def test_offline_sqlite_upgrade_revokes_matching_user_oauth_rows() -> None:
     with Operations.context(context):
         migration.upgrade()
 
-    old_scope = migration.OLD_SCOPE
-    new_scope = migration.NEW_SCOPE
-
     connection = sqlite3.connect(":memory:")
     connection.execute(
         "CREATE TABLE public_mcp_apps (app_id TEXT PRIMARY KEY, oauth_scopes JSON)"
     )
     connection.execute(
-        "CREATE TABLE user_oauth (id INTEGER PRIMARY KEY, provider TEXT, scope TEXT)"
+        "CREATE TABLE user_oauth (id INTEGER PRIMARY KEY, user_id INTEGER, "
+        "provider TEXT, scope TEXT)"
     )
     connection.execute(
         "INSERT INTO public_mcp_apps (app_id, oauth_scopes) VALUES (?, ?)",
         ("google-calendar", json.dumps(OLD_SCOPES)),
     )
     connection.executemany(
-        "INSERT INTO user_oauth (id, provider, scope) VALUES (?, ?, ?)",
+        "INSERT INTO user_oauth (id, user_id, provider, scope) VALUES (?, ?, ?, ?)",
         [
-            (1, "google-calendar", old_scope),
-            (2, "google-calendar", f"{new_scope} {old_scope}"),
-            (3, "google-calendar", new_scope),
-            (4, "gmail", "https://www.googleapis.com/auth/gmail.modify"),
-            (5, "google-drive", None),
-            (6, "google", old_scope),
-            (7, "google-calendar", None),
-            (8, "google-calendar", ""),
+            (row["id"], row["user_id"], row["provider"], row["scope"])
+            for row in REVOKE_FIXTURE_ROWS
         ],
     )
     connection.executescript(output.getvalue())
 
-    remaining = {
-        row[0]: row[1]
-        for row in connection.execute("SELECT id, provider FROM user_oauth")
-    }
+    remaining_ids = {row[0] for row in connection.execute("SELECT id FROM user_oauth")}
     connection.close()
 
-    assert remaining == {
-        3: "google-calendar",
-        4: "gmail",
-        5: "google-drive",
-        6: "google",
-    }
+    assert remaining_ids == REVOKE_FIXTURE_SURVIVING_IDS
 
 
 def test_revision_metadata() -> None:
@@ -656,6 +880,14 @@ def _postgres_url() -> str | None:
     )
 
 
+_POSTGRES_TABLES = (
+    "user_mcpservers",
+    "mcp_servers",
+    "user_oauth",
+    "public_mcp_apps",
+)
+
+
 @pytest.fixture
 def postgres_engine():
     url = _postgres_url()
@@ -663,8 +895,8 @@ def postgres_engine():
         pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
     engine = sa.create_engine(url)
     with engine.begin() as conn:
-        conn.execute(text("DROP TABLE IF EXISTS public_mcp_apps CASCADE"))
-        conn.execute(text("DROP TABLE IF EXISTS user_oauth CASCADE"))
+        for table_name in _POSTGRES_TABLES:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table_name} CASCADE"))
         conn.execute(
             text(
                 "CREATE TABLE public_mcp_apps ("
@@ -677,14 +909,30 @@ def postgres_engine():
             text(
                 "CREATE TABLE user_oauth ("
                 "id SERIAL PRIMARY KEY, "
+                "user_id INTEGER, "
                 "provider VARCHAR(50) NOT NULL, "
                 "scope VARCHAR)"
             )
         )
+        conn.execute(
+            text(
+                "CREATE TABLE mcp_servers ("
+                "id SERIAL PRIMARY KEY, "
+                "name VARCHAR(100) NOT NULL UNIQUE)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE user_mcpservers ("
+                "id SERIAL PRIMARY KEY, "
+                "user_id INTEGER NOT NULL, "
+                "mcpserver_id INTEGER NOT NULL)"
+            )
+        )
     yield engine
     with engine.begin() as conn:
-        conn.execute(text("DROP TABLE IF EXISTS public_mcp_apps CASCADE"))
-        conn.execute(text("DROP TABLE IF EXISTS user_oauth CASCADE"))
+        for table_name in _POSTGRES_TABLES:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table_name} CASCADE"))
     engine.dispose()
 
 
@@ -703,6 +951,8 @@ def test_postgresql_online_upgrade_narrows_scope_and_revokes_grants(
     postgres_engine,
 ) -> None:
     migration = _load_migration_module()
+    metadata = sa.MetaData()
+    oauth_table = _user_oauth(metadata)
 
     with postgres_engine.begin() as connection:
         connection.execute(
@@ -712,26 +962,7 @@ def test_postgresql_online_upgrade_narrows_scope_and_revokes_grants(
             ),
             {"scopes": json.dumps(OLD_SCOPES)},
         )
-        connection.execute(
-            text("INSERT INTO user_oauth (id, provider, scope) VALUES (1, :p, :s)"),
-            {"p": "google-calendar", "s": migration.OLD_SCOPE},
-        )
-        connection.execute(
-            text("INSERT INTO user_oauth (id, provider, scope) VALUES (2, :p, :s)"),
-            {"p": "gmail", "s": "https://www.googleapis.com/auth/gmail.modify"},
-        )
-        # No scope recorded (NULL) on a google-calendar row: RFC 6749 5.1
-        # lets a provider omit `scope` when it matches what was requested,
-        # and the only thing ever requested here before this migration was
-        # the old, broad scope -- must be revoked, not skipped.
-        connection.execute(
-            text("INSERT INTO user_oauth (id, provider, scope) VALUES (3, :p, NULL)"),
-            {"p": "google-calendar"},
-        )
-        connection.execute(
-            text("INSERT INTO user_oauth (id, provider, scope) VALUES (4, :p, :s)"),
-            {"p": "google-calendar", "s": ""},
-        )
+        connection.execute(sa.insert(oauth_table), REVOKE_FIXTURE_ROWS)
 
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
@@ -742,13 +973,53 @@ def test_postgresql_online_upgrade_narrows_scope_and_revokes_grants(
                 "WHERE app_id = 'google-calendar'"
             )
         ).scalar_one()
-        remaining_ids = {
-            row.id for row in connection.execute(text("SELECT id FROM user_oauth"))
-        }
+        remaining_ids = set(
+            connection.execute(sa.select(oauth_table.c.id)).scalars().all()
+        )
 
     assert stored_scopes == NEW_SCOPES
-    assert remaining_ids == {2}
+    assert remaining_ids == REVOKE_FIXTURE_SURVIVING_IDS
     assert _oauth_scopes_column_type(postgres_engine) == "json"
+
+
+@pytest.mark.postgresql
+def test_postgresql_online_upgrade_removes_orphaned_calendar_server_row(
+    postgres_engine,
+) -> None:
+    migration = _load_migration_module()
+    metadata = sa.MetaData()
+    oauth_table = _user_oauth(metadata)
+    servers_table = _mcp_servers(metadata)
+    user_servers_table = _user_mcpservers(metadata)
+
+    with postgres_engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, oauth_scopes) "
+                "VALUES ('google-calendar', :scopes)"
+            ),
+            {"scopes": json.dumps(OLD_SCOPES)},
+        )
+        connection.execute(
+            sa.insert(oauth_table),
+            {"id": 1, "user_id": 100, "provider": "google", "scope": None},
+        )
+        connection.execute(
+            sa.insert(servers_table), {"id": 1, "name": "Google Calendar"}
+        )
+        connection.execute(
+            sa.insert(user_servers_table),
+            {"id": 1, "user_id": 100, "mcpserver_id": 1},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_servers = connection.execute(
+            sa.select(user_servers_table.c.id)
+        ).fetchall()
+
+    assert remaining_servers == []
 
 
 @pytest.mark.postgresql
@@ -828,12 +1099,11 @@ def test_postgresql_offline_upgrade_revokes_matching_user_oauth_rows(
     postgres_engine,
 ) -> None:
     """The offline (--sql) DELETE, executed against a real server, must
-    match exactly the same rows the online, Python-side predicate does --
-    including the NULL/empty-scope cases a LIKE-based SQL predicate handles
-    differently from Python's `if row.scope` guard would."""
+    match exactly the same rows the online path's test does -- both built
+    from the same _revoke_predicate and the same fixture."""
     migration = _load_migration_module()
-    old_scope = migration.OLD_SCOPE
-    new_scope = migration.NEW_SCOPE
+    metadata = sa.MetaData()
+    oauth_table = _user_oauth(metadata)
 
     with postgres_engine.begin() as connection:
         connection.execute(
@@ -843,25 +1113,7 @@ def test_postgresql_offline_upgrade_revokes_matching_user_oauth_rows(
             ),
             {"scopes": json.dumps(OLD_SCOPES)},
         )
-        connection.execute(
-            text(
-                "INSERT INTO user_oauth (id, provider, scope) VALUES "
-                "(1, 'google-calendar', :old), "
-                "(2, 'google-calendar', :combined), "
-                "(3, 'google-calendar', :new), "
-                "(4, 'gmail', :gmail_scope), "
-                "(5, 'google-drive', NULL), "
-                "(6, 'google', :old), "
-                "(7, 'google-calendar', NULL), "
-                "(8, 'google-calendar', '')"
-            ),
-            {
-                "old": old_scope,
-                "combined": f"{new_scope} {old_scope}",
-                "new": new_scope,
-                "gmail_scope": "https://www.googleapis.com/auth/gmail.modify",
-            },
-        )
+        connection.execute(sa.insert(oauth_table), REVOKE_FIXTURE_ROWS)
 
     output = StringIO()
     context = MigrationContext.configure(
@@ -873,8 +1125,8 @@ def test_postgresql_offline_upgrade_revokes_matching_user_oauth_rows(
 
     with postgres_engine.begin() as connection:
         connection.execute(text(output.getvalue()))
-        remaining_ids = {
-            row.id for row in connection.execute(text("SELECT id FROM user_oauth"))
-        }
+        remaining_ids = set(
+            connection.execute(sa.select(oauth_table.c.id)).scalars().all()
+        )
 
-    assert remaining_ids == {3, 4, 5, 6}
+    assert remaining_ids == REVOKE_FIXTURE_SURVIVING_IDS

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -15,6 +15,9 @@ MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
     / "src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py"
 )
+REGISTRY_PATH = (
+    Path(__file__).parent.parent.parent / "src/xagent/web/builtin_mcp_registry.py"
+)
 
 OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
 NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
@@ -23,6 +26,19 @@ NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
 def _load_migration_module():
     spec = importlib.util.spec_from_file_location(
         "narrow_google_calendar_scope_migration", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_registry_module():
+    # Loaded from this checkout's file, not `import xagent...`: an editable
+    # install can point at a different checkout (e.g. another git worktree),
+    # which would silently compare the migration against the wrong tree.
+    spec = importlib.util.spec_from_file_location(
+        "builtin_mcp_registry_under_test", REGISTRY_PATH
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -47,6 +63,24 @@ def _public_mcp_apps(metadata: sa.MetaData) -> sa.Table:
 def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
     rows = connection.execute(sa.select(table.c.app_id, table.c.oauth_scopes))
     return {row.app_id: row.oauth_scopes for row in rows}
+
+
+def test_migration_target_scope_matches_the_live_registry() -> None:
+    """Guard against registry/migration drift (the bug this migration fixes).
+
+    Reverting the scope in ``builtin_mcp_registry.py`` without updating this
+    migration's ``NEW_SCOPES`` would otherwise leave every other test in this
+    file green while the app requests a scope the migration never seeded.
+    """
+    migration = _load_migration_module()
+    registry = _load_registry_module()
+    registry_row = next(
+        row
+        for row in registry.get_builtin_public_mcp_app_rows()
+        if row["app_id"] == migration.APP_ID
+    )
+
+    assert registry_row["oauth_scopes"] == migration.NEW_SCOPES
 
 
 def test_upgrade_narrows_google_calendar_scope_without_touching_other_apps(

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -1,0 +1,225 @@
+"""Tests for narrowing the Google Calendar connector's OAuth scope."""
+
+import importlib.util
+import json
+import sqlite3
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py"
+)
+
+OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
+NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "narrow_google_calendar_scope_migration", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection) -> Operations:
+    return Operations(MigrationContext.configure(connection))
+
+
+def _public_mcp_apps(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "public_mcp_apps",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("app_id", sa.String(100), nullable=False, unique=True),
+        sa.Column("oauth_scopes", sa.JSON),
+    )
+
+
+def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
+    rows = connection.execute(sa.select(table.c.app_id, table.c.oauth_scopes))
+    return {row.app_id: row.oauth_scopes for row in rows}
+
+
+def test_upgrade_narrows_google_calendar_scope_without_touching_other_apps(
+    tmp_path,
+) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+                {"app_id": "gmail", "oauth_scopes": ["gmail-scope"]},
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+    assert scopes["gmail"] == ["gmail-scope"]
+
+
+def test_upgrade_is_idempotent(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+
+
+def test_upgrade_skips_when_row_is_absent(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes == {}
+
+
+def test_upgrade_skips_when_catalog_table_is_absent() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+
+def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    table = sa.Table(
+        "public_mcp_apps",
+        metadata,
+        sa.Column("app_id", sa.String(100), primary_key=True),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(sa.insert(table), {"app_id": "google-calendar"})
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        stored = connection.execute(sa.select(table)).mappings().one()
+
+    assert stored["app_id"] == "google-calendar"
+
+
+def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == OLD_SCOPES
+
+
+def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        migration.upgrade()
+
+    sql = output.getvalue()
+    assert sql.count("UPDATE public_mcp_apps SET") == 1
+    assert "oauth_scopes=" in sql
+    assert "public_mcp_apps.app_id = 'google-calendar'" in sql
+    assert "calendar.events" in sql
+    assert "INSERT INTO public_mcp_apps" not in sql
+    assert "DELETE FROM public_mcp_apps" not in sql
+    assert "%(" not in sql
+
+
+def test_offline_sqlite_upgrade_round_trips_json_scope_value() -> None:
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="sqlite",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        migration.upgrade()
+
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE public_mcp_apps (app_id TEXT PRIMARY KEY, oauth_scopes JSON)"
+    )
+    connection.execute(
+        "INSERT INTO public_mcp_apps (app_id, oauth_scopes) VALUES (?, ?)",
+        ("google-calendar", json.dumps(OLD_SCOPES)),
+    )
+    connection.executescript(output.getvalue())
+
+    stored = connection.execute(
+        "SELECT oauth_scopes FROM public_mcp_apps WHERE app_id = 'google-calendar'"
+    ).fetchone()
+    connection.close()
+
+    assert stored is not None
+    assert json.loads(stored[0]) == NEW_SCOPES
+
+
+def test_revision_metadata() -> None:
+    migration = _load_migration_module()
+
+    assert migration.revision == "20260817_narrow_google_calendar_scope"
+    assert migration.down_revision == "20260725_add_uploaded_file_recovery_index"

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -222,4 +222,4 @@ def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
     assert migration.revision == "20260817_narrow_google_calendar_scope"
-    assert migration.down_revision == "20260725_add_uploaded_file_recovery_index"
+    assert migration.down_revision == "20260813_trace_json_columns_to_jsonb"

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -240,11 +240,16 @@ def test_upgrade_revokes_grants_carrying_the_old_calendar_scope(tmp_path) -> Non
                     "provider": "google-calendar",
                     "scope": f"{old_scope} https://www.googleapis.com/auth/userinfo.email",
                 },
-                # A bare provider-level grant that happens to carry the old
-                # scope too -- config.py's app-scoped-grant restriction
-                # doesn't cover google-calendar, so this is also a live
-                # Calendar credential and must be revoked the same way.
-                {"id": 2, "provider": "google", "scope": old_scope},
+                # A combined grant: include_granted_scopes=true can echo
+                # back both the old and the new scope on reconnect. Presence
+                # of the old scope alone must still trigger revocation --
+                # the new scope also being present is not evidence of a
+                # narrowed credential.
+                {
+                    "id": 2,
+                    "provider": "google-calendar",
+                    "scope": f"{new_scope} {old_scope}",
+                },
                 # Already narrowed (e.g. a user who reconnected since this
                 # migration first ran) -- must survive untouched.
                 {"id": 3, "provider": "google-calendar", "scope": new_scope},
@@ -257,6 +262,14 @@ def test_upgrade_revokes_grants_carrying_the_old_calendar_scope(tmp_path) -> Non
                 },
                 # No scope recorded at all -- must not raise on a null scope.
                 {"id": 5, "provider": "google-drive", "scope": None},
+                # A bare provider-level grant that happens to carry the old
+                # scope too -- deliberately left untouched: other Google
+                # connectors may be relying on this exact row as their own
+                # fallback credential (config.py's
+                # _resolve_legacy_oauth_access_token), so revoking it on a
+                # scope-content match alone would risk collateral damage
+                # beyond Calendar.
+                {"id": 6, "provider": "google", "scope": old_scope},
             ],
         )
 
@@ -265,7 +278,91 @@ def test_upgrade_revokes_grants_carrying_the_old_calendar_scope(tmp_path) -> Non
 
         remaining = _remaining_ids_and_providers(connection, table)
 
-    assert remaining == {3: "google-calendar", 4: "gmail", 5: "google-drive"}
+    assert remaining == {
+        3: "google-calendar",
+        4: "gmail",
+        5: "google-drive",
+        6: "google",
+    }
+
+
+def test_upgrade_revoke_does_not_touch_gmail_watch_state(tmp_path) -> None:
+    """Regression for a real collateral-damage bug: gmail_watch_states has
+    ON DELETE CASCADE on user_oauth.id, so revoking a row by scope content
+    alone (rather than by provider) could have silently deleted a user's
+    Gmail push-notification watch state as a side effect of narrowing
+    Calendar's scope."""
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    oauth_table = _user_oauth(metadata)
+    watch_table = sa.Table(
+        "gmail_watch_states",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "user_oauth_id",
+            sa.Integer,
+            sa.ForeignKey("user_oauth.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(oauth_table),
+            {
+                "id": 1,
+                "provider": "gmail",
+                # A Gmail credential that, via include_granted_scopes=true,
+                # also carries the old calendar scope from a prior separate
+                # Calendar connection under the same OAuth client.
+                "scope": (
+                    "https://www.googleapis.com/auth/gmail.modify "
+                    f"{migration.OLD_SCOPE}"
+                ),
+            },
+        )
+        connection.execute(sa.insert(watch_table), {"id": 1, "user_oauth_id": 1})
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining_oauth = _remaining_ids_and_providers(connection, oauth_table)
+        remaining_watch = connection.execute(sa.select(watch_table.c.id)).fetchall()
+
+    assert remaining_oauth == {1: "gmail"}
+    assert len(remaining_watch) == 1
+
+
+def test_upgrade_revoke_pages_through_more_than_one_batch(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _user_oauth(metadata)
+    metadata.create_all(engine)
+
+    row_count = migration.REVOKE_BATCH_SIZE + 5
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                {
+                    "id": i,
+                    "provider": "google-calendar",
+                    "scope": migration.OLD_SCOPE,
+                }
+                for i in range(1, row_count + 1)
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining = _remaining_ids_and_providers(connection, table)
+
+    assert remaining == {}
 
 
 def test_upgrade_revoke_is_idempotent(tmp_path) -> None:
@@ -463,9 +560,11 @@ def test_revision_metadata() -> None:
 # and JSON-vs-JSONB is precisely a distinction sqlite has no concept of. Only
 # a real server can confirm the offline-generated SQL is not merely
 # plausible-looking text but actually executes and stores the right column
-# type, mirroring the pattern in
+# type, mirroring the local-postgres-fixture pattern in
 # tests/migrations/test_20260813_trace_json_columns_to_jsonb.py (the parent
-# revision, which converts these same tables' JSON columns to JSONB).
+# revision -- it converts a different set of tables, trace_events,
+# trace_message_blobs, and trace_checkpoint_blobs, from JSON to JSONB;
+# public_mcp_apps.oauth_scopes stays plain JSON here).
 
 
 def _postgres_url() -> str | None:

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -188,6 +188,58 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert "%(" not in sql
 
 
+def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        migration.downgrade()
+
+    sql = output.getvalue()
+    assert sql.count("UPDATE public_mcp_apps SET") == 1
+    assert "oauth_scopes=" in sql
+    assert "public_mcp_apps.app_id = 'google-calendar'" in sql
+    assert "https://www.googleapis.com/auth/calendar" in sql
+    assert "calendar.events" not in sql
+    assert "INSERT INTO public_mcp_apps" not in sql
+    assert "DELETE FROM public_mcp_apps" not in sql
+    assert "%(" not in sql
+
+
+def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="sqlite",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        migration.downgrade()
+
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE public_mcp_apps (app_id TEXT PRIMARY KEY, oauth_scopes JSON)"
+    )
+    connection.execute(
+        "INSERT INTO public_mcp_apps (app_id, oauth_scopes) VALUES (?, ?)",
+        ("google-calendar", json.dumps(NEW_SCOPES)),
+    )
+    connection.executescript(output.getvalue())
+
+    stored = connection.execute(
+        "SELECT oauth_scopes FROM public_mcp_apps WHERE app_id = 'google-calendar'"
+    ).fetchone()
+    connection.close()
+
+    assert stored is not None
+    assert json.loads(stored[0]) == OLD_SCOPES
+
+
 def test_offline_sqlite_upgrade_round_trips_json_scope_value() -> None:
     migration = _load_migration_module()
     output = StringIO()

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -2,14 +2,17 @@
 
 import importlib.util
 import json
+import os
 import sqlite3
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
+from sqlalchemy import text
 
 MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
@@ -63,6 +66,21 @@ def _public_mcp_apps(metadata: sa.MetaData) -> sa.Table:
 def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
     rows = connection.execute(sa.select(table.c.app_id, table.c.oauth_scopes))
     return {row.app_id: row.oauth_scopes for row in rows}
+
+
+def _user_oauth(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "user_oauth",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("provider", sa.String(50), nullable=False),
+        sa.Column("scope", sa.String, nullable=True),
+    )
+
+
+def _remaining_ids_and_providers(connection, table: sa.Table) -> dict[int, str]:
+    rows = connection.execute(sa.select(table.c.id, table.c.provider))
+    return {row.id: row.provider for row in rows}
 
 
 def test_migration_target_scope_matches_the_live_registry() -> None:
@@ -201,6 +219,131 @@ def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == OLD_SCOPES
 
 
+def test_upgrade_revokes_grants_carrying_the_old_calendar_scope(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _user_oauth(metadata)
+    metadata.create_all(engine)
+
+    old_scope = migration.OLD_SCOPE
+    new_scope = migration.NEW_SCOPE
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                # App-scoped grant carrying the old, broad scope alongside
+                # the identity scopes every Google grant also carries.
+                {
+                    "id": 1,
+                    "provider": "google-calendar",
+                    "scope": f"{old_scope} https://www.googleapis.com/auth/userinfo.email",
+                },
+                # A bare provider-level grant that happens to carry the old
+                # scope too -- config.py's app-scoped-grant restriction
+                # doesn't cover google-calendar, so this is also a live
+                # Calendar credential and must be revoked the same way.
+                {"id": 2, "provider": "google", "scope": old_scope},
+                # Already narrowed (e.g. a user who reconnected since this
+                # migration first ran) -- must survive untouched.
+                {"id": 3, "provider": "google-calendar", "scope": new_scope},
+                # A different connector's grant; must never be touched even
+                # though its provider column also starts with "google".
+                {
+                    "id": 4,
+                    "provider": "gmail",
+                    "scope": "https://www.googleapis.com/auth/gmail.modify",
+                },
+                # No scope recorded at all -- must not raise on a null scope.
+                {"id": 5, "provider": "google-drive", "scope": None},
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining = _remaining_ids_and_providers(connection, table)
+
+    assert remaining == {3: "google-calendar", 4: "gmail", 5: "google-drive"}
+
+
+def test_upgrade_revoke_is_idempotent(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _user_oauth(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"id": 1, "provider": "google-calendar", "scope": migration.OLD_SCOPE},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+
+        remaining = _remaining_ids_and_providers(connection, table)
+
+    assert remaining == {}
+
+
+def test_downgrade_does_not_restore_revoked_grants(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _user_oauth(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"id": 1, "provider": "google-calendar", "scope": migration.OLD_SCOPE},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+
+        remaining = _remaining_ids_and_providers(connection, table)
+
+    assert remaining == {}
+
+
+def test_upgrade_skips_revoke_when_user_oauth_table_is_absent() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+
+def test_upgrade_skips_revoke_when_scope_column_is_absent() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    table = sa.Table(
+        "user_oauth",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("provider", sa.String(50), nullable=False),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(sa.insert(table), {"id": 1, "provider": "google-calendar"})
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        remaining = _remaining_ids_and_providers(connection, table)
+
+    assert remaining == {1: "google-calendar"}
+
+
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()
@@ -220,6 +363,10 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
+    # The revoke step needs a live SELECT to judge each row's granted scope,
+    # which offline (--sql) generation can't do; it must not emit anything
+    # touching user_oauth.
+    assert "user_oauth" not in sql
 
 
 def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
@@ -309,3 +456,174 @@ def test_revision_metadata() -> None:
 
     assert migration.revision == "20260817_narrow_google_calendar_scope"
     assert migration.down_revision == "20260813_trace_json_columns_to_jsonb"
+
+
+# --- PostgreSQL-only: the sqlite tests above never exercise the real
+# postgresql/JSON cast path (`_offline_scopes_literal`'s postgresql branch),
+# and JSON-vs-JSONB is precisely a distinction sqlite has no concept of. Only
+# a real server can confirm the offline-generated SQL is not merely
+# plausible-looking text but actually executes and stores the right column
+# type, mirroring the pattern in
+# tests/migrations/test_20260813_trace_json_columns_to_jsonb.py (the parent
+# revision, which converts these same tables' JSON columns to JSONB).
+
+
+def _postgres_url() -> str | None:
+    return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
+        "POSTGRES_TEST_DATABASE_URL"
+    )
+
+
+@pytest.fixture
+def postgres_engine():
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    engine = sa.create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS public_mcp_apps CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS user_oauth CASCADE"))
+        conn.execute(
+            text(
+                "CREATE TABLE public_mcp_apps ("
+                "id SERIAL PRIMARY KEY, "
+                "app_id VARCHAR(100) NOT NULL UNIQUE, "
+                "oauth_scopes JSON)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE user_oauth ("
+                "id SERIAL PRIMARY KEY, "
+                "provider VARCHAR(50) NOT NULL, "
+                "scope VARCHAR)"
+            )
+        )
+    yield engine
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS public_mcp_apps CASCADE"))
+        conn.execute(text("DROP TABLE IF EXISTS user_oauth CASCADE"))
+    engine.dispose()
+
+
+def _oauth_scopes_column_type(engine: sa.engine.Engine) -> str:
+    with engine.begin() as conn:
+        return conn.execute(
+            text(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_name = 'public_mcp_apps' AND column_name = 'oauth_scopes'"
+            )
+        ).scalar_one()
+
+
+@pytest.mark.postgresql
+def test_postgresql_online_upgrade_narrows_scope_and_revokes_grants(
+    postgres_engine,
+) -> None:
+    migration = _load_migration_module()
+
+    with postgres_engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, oauth_scopes) "
+                "VALUES ('google-calendar', :scopes)"
+            ),
+            {"scopes": json.dumps(OLD_SCOPES)},
+        )
+        connection.execute(
+            text("INSERT INTO user_oauth (id, provider, scope) VALUES (1, :p, :s)"),
+            {"p": "google-calendar", "s": migration.OLD_SCOPE},
+        )
+        connection.execute(
+            text("INSERT INTO user_oauth (id, provider, scope) VALUES (2, :p, :s)"),
+            {"p": "gmail", "s": "https://www.googleapis.com/auth/gmail.modify"},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        stored_scopes = connection.execute(
+            text(
+                "SELECT oauth_scopes FROM public_mcp_apps "
+                "WHERE app_id = 'google-calendar'"
+            )
+        ).scalar_one()
+        remaining_ids = {
+            row.id for row in connection.execute(text("SELECT id FROM user_oauth"))
+        }
+
+    assert stored_scopes == NEW_SCOPES
+    assert remaining_ids == {2}
+    assert _oauth_scopes_column_type(postgres_engine) == "json"
+
+
+@pytest.mark.postgresql
+def test_postgresql_offline_upgrade_sql_executes_and_stores_json_type(
+    postgres_engine,
+) -> None:
+    migration = _load_migration_module()
+
+    with postgres_engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, oauth_scopes) "
+                "VALUES ('google-calendar', :scopes)"
+            ),
+            {"scopes": json.dumps(OLD_SCOPES)},
+        )
+
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    with Operations.context(context):
+        migration.upgrade()
+
+    with postgres_engine.begin() as connection:
+        connection.execute(text(output.getvalue()))
+        stored_scopes = connection.execute(
+            text(
+                "SELECT oauth_scopes FROM public_mcp_apps "
+                "WHERE app_id = 'google-calendar'"
+            )
+        ).scalar_one()
+
+    assert stored_scopes == NEW_SCOPES
+    assert _oauth_scopes_column_type(postgres_engine) == "json"
+
+
+@pytest.mark.postgresql
+def test_postgresql_offline_downgrade_sql_executes_and_restores_old_scope(
+    postgres_engine,
+) -> None:
+    migration = _load_migration_module()
+
+    with postgres_engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, oauth_scopes) "
+                "VALUES ('google-calendar', :scopes)"
+            ),
+            {"scopes": json.dumps(NEW_SCOPES)},
+        )
+
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    with Operations.context(context):
+        migration.downgrade()
+
+    with postgres_engine.begin() as connection:
+        connection.execute(text(output.getvalue()))
+        stored_scopes = connection.execute(
+            text(
+                "SELECT oauth_scopes FROM public_mcp_apps "
+                "WHERE app_id = 'google-calendar'"
+            )
+        ).scalar_one()
+
+    assert stored_scopes == OLD_SCOPES
+    assert _oauth_scopes_column_type(postgres_engine) == "json"

--- a/tests/web/tools/test_legacy_oauth_provider_scoping.py
+++ b/tests/web/tools/test_legacy_oauth_provider_scoping.py
@@ -3,6 +3,15 @@
 Facebook Pages connector, since that flow never requested Facebook's
 app-specific oauth_scopes (e.g. pages_read_user_content). Instagram's shared
 "meta" grant must keep working, since its required scopes haven't changed.
+
+The same policy covers a bare provider-level Google grant
+(UserOAuth.provider == "google") and the Calendar connector: that bare grant
+never requested Calendar's own oauth_scopes either, and Google's
+include_granted_scopes=true means it could otherwise accumulate the old,
+broad calendar scope from a separate authorization and satisfy Calendar
+without ever going through Calendar's own connect flow. See
+20260817_narrow_google_calendar_scope.py's module docstring for why the data
+migration deliberately does not delete that bare row itself.
 """
 
 import asyncio
@@ -63,6 +72,32 @@ def test_restrict_to_app_scoped_oauth_grant_dedupes_and_preserves_order():
     assert restrict_to_app_scoped_oauth_grant(
         "instagram", ["meta", "meta", "instagram", None, ""]
     ) == ["meta", "instagram"]
+
+
+def test_oauth_keys_for_google_calendar_excludes_bare_google_provider():
+    app = {"id": "google-calendar", "provider": "google"}
+    assert _oauth_keys_for_app(app) == ["google-calendar"]
+
+
+def test_oauth_keys_for_gmail_still_includes_bare_google_provider():
+    app = {"id": "gmail", "provider": "google"}
+    keys = _oauth_keys_for_app(app)
+    assert "gmail" in keys
+    assert "google" in keys
+
+
+def test_restrict_to_app_scoped_oauth_grant_narrows_google_calendar():
+    assert restrict_to_app_scoped_oauth_grant(
+        "google-calendar", ["google", "google-calendar"]
+    ) == ["google-calendar"]
+    assert requires_app_scoped_oauth_grant("google-calendar") is True
+
+
+def test_restrict_to_app_scoped_oauth_grant_passes_through_gmail():
+    assert restrict_to_app_scoped_oauth_grant("gmail", ["google", "gmail"]) == [
+        "google",
+        "gmail",
+    ]
 
 
 @pytest.fixture()
@@ -131,3 +166,69 @@ def test_legacy_token_resolution_uses_app_scoped_facebook_grant(db_session):
     )
 
     assert resolution.access_token == "app-scoped-facebook-token"
+
+
+def test_legacy_token_resolution_ignores_bare_google_grant_for_calendar(db_session):
+    """The runtime half of the C1 fix: even if a bare "google" row somehow
+    still carries the old calendar scope (e.g. it predates this migration,
+    or a future reconnect recreates a combined grant), it must never be
+    accepted as a Calendar credential."""
+    db_session.add(
+        UserOAuth(
+            user_id=1,
+            provider="google",
+            access_token="bare-google-token",
+            scope="https://www.googleapis.com/auth/calendar",
+        )
+    )
+    db_session.commit()
+
+    cfg = WebToolConfig(db=None, request=None, db_factory=lambda: db_session, user_id=1)
+
+    resolution = asyncio.run(
+        cfg._resolve_legacy_oauth_access_token(
+            provider_name="google", app_id="google-calendar"
+        )
+    )
+
+    assert resolution.access_token is None
+
+
+def test_legacy_token_resolution_still_uses_bare_google_grant_for_gmail(db_session):
+    db_session.add(
+        UserOAuth(
+            user_id=1,
+            provider="google",
+            access_token="bare-google-token",
+        )
+    )
+    db_session.commit()
+
+    cfg = WebToolConfig(db=None, request=None, db_factory=lambda: db_session, user_id=1)
+
+    resolution = asyncio.run(
+        cfg._resolve_legacy_oauth_access_token(provider_name="google", app_id="gmail")
+    )
+
+    assert resolution.access_token == "bare-google-token"
+
+
+def test_legacy_token_resolution_uses_app_scoped_google_calendar_grant(db_session):
+    db_session.add(
+        UserOAuth(
+            user_id=1,
+            provider="google-calendar",
+            access_token="app-scoped-calendar-token",
+        )
+    )
+    db_session.commit()
+
+    cfg = WebToolConfig(db=None, request=None, db_factory=lambda: db_session, user_id=1)
+
+    resolution = asyncio.run(
+        cfg._resolve_legacy_oauth_access_token(
+            provider_name="google", app_id="google-calendar"
+        )
+    )
+
+    assert resolution.access_token == "app-scoped-calendar-token"


### PR DESCRIPTION
## Summary
- The Google Calendar connector's tools only ever operate on events (search, create, get, update, delete), never on calendar list management, so requesting the full `https://www.googleapis.com/auth/calendar` scope asked for more access than the feature set uses.
- Narrows the scope to `https://www.googleapis.com/auth/calendar.events` in the built-in connector registry.
- Adds a migration to converge already-seeded `public_mcp_apps` rows to the new scope (upgrade + downgrade, online and offline SQL modes, safe no-ops when the table/columns are absent).

## Test plan
- [x] `pytest tests/alembic/test_20260817_narrow_google_calendar_scope.py` (new, 11 cases: upgrade, idempotency, missing row/table/column, downgrade, offline SQL for postgres/sqlite, revision metadata)
- [x] `pytest tests/alembic/test_20260715_normalize_builtin_mcp_launch.py` (existing snapshot migration/tests left untouched — still green)
- [x] `alembic heads` resolves to a single head with this migration on top
- [x] `ruff check`, `ruff format --check`, `mypy`, pre-commit hooks all pass