### PR TITLE
feat(encryption): add strict decrypt helpers that report an unreadable token

### DIFF
--- a/src/xagent/core/utils/encryption.py
+++ b/src/xagent/core/utils/encryption.py
@@ -1,5 +1,6 @@
 """Encryption utilities for sensitive data."""
 
+import base64
 import logging
 import os
 from functools import lru_cache
@@ -79,3 +80,83 @@ def decrypt_env_dict(env: dict | None) -> dict | None:
     if not env:
         return env
     return {k: (decrypt_value(v) if isinstance(v, str) else v) for k, v in env.items()}
+
+
+class EncryptionDecodeError(ValueError):
+    """A Fernet-shaped value could not be decrypted with the configured key.
+
+    Raised only by the strict decryption helpers. It never carries the value
+    or any part of it: these are credentials.
+    """
+
+
+# A Fernet token is url-safe base64 over: 1 version byte (0x80) + 8 timestamp
+# bytes + 16 IV bytes + at least one 16-byte AES-CBC block + 32 HMAC bytes,
+# so the shortest possible token decodes to 73 bytes.
+_FERNET_VERSION_BYTE = 0x80
+_FERNET_MIN_TOKEN_BYTES = 73
+
+
+def _looks_like_fernet_token(value: str) -> bool:
+    """True if value has the structure of a Fernet token, ignoring the key.
+
+    Deliberately not `_is_encrypted`: that one answers "does the configured
+    key open this", which is exactly the question the strict helpers must
+    not conflate with "is this a token at all". A token produced under a
+    different key fails `_is_encrypted` while still being a token.
+
+    The check is the structural half of what Fernet itself does before it
+    touches the key: url-safe base64, a leading version byte of 0x80, and
+    enough bytes to hold version, timestamp, IV, one ciphertext block and
+    the HMAC. A value that fails any of these cannot be opened by any key,
+    so treating it as plaintext loses nothing.
+    """
+    try:
+        data = base64.urlsafe_b64decode(value)
+    except (ValueError, TypeError):
+        return False
+    return len(data) >= _FERNET_MIN_TOKEN_BYTES and data[0] == _FERNET_VERSION_BYTE
+
+
+def decrypt_value_strict(encrypted_value: str) -> str:
+    """Decrypt a value, raising when a token cannot be opened.
+
+    Same result as `decrypt_value` for every input that one handles
+    successfully, and the same pass-through for values that are not tokens
+    (empty, None, plaintext). The one difference is the case `decrypt_value`
+    cannot report: a value that is structurally a Fernet token but does not
+    decrypt under the configured key raises `EncryptionDecodeError` instead
+    of being returned unchanged.
+
+    Use this where returning ciphertext to the caller would be worse than
+    failing -- for example before handing a value to a subprocess
+    environment, or when deciding whether stored data is still readable.
+    """
+    if not encrypted_value:
+        return encrypted_value
+    try:
+        return get_cipher().decrypt(encrypted_value.encode()).decode()
+    except Exception as exc:
+        if _looks_like_fernet_token(encrypted_value):
+            raise EncryptionDecodeError(
+                "Value is a Fernet token but could not be decrypted with the "
+                "configured encryption key"
+            ) from exc
+        logger.debug("Value is not a Fernet token; returning it unchanged")
+        return encrypted_value
+
+
+def decrypt_env_dict_strict(env: dict | None) -> dict | None:
+    """Decrypt env var values, raising on the first undecryptable token.
+
+    All-or-nothing on purpose: it does not drop or replace bad entries.
+    Deciding what a partially readable env map means -- skip the server,
+    surface an error, fall back to another layer -- belongs to the caller,
+    so this only reports that the map is not fully readable.
+    """
+    if not env:
+        return env
+    return {
+        k: (decrypt_value_strict(v) if isinstance(v, str) else v)
+        for k, v in env.items()
+    }

--- a/src/xagent/core/utils/encryption.py
+++ b/src/xagent/core/utils/encryption.py
@@ -134,9 +134,13 @@ def decrypt_value_strict(encrypted_value: str) -> str:
     """
     if not encrypted_value:
         return encrypted_value
+    # Outside the try on purpose: a missing or malformed ENCRYPTION_KEY is a
+    # configuration fault, not a property of the value, and must not be
+    # reported as "this value is not a token".
+    cipher = get_cipher()
     try:
-        return get_cipher().decrypt(encrypted_value.encode()).decode()
-    except Exception as exc:
+        return cipher.decrypt(encrypted_value.encode()).decode()
+    except InvalidToken as exc:
         if _looks_like_fernet_token(encrypted_value):
             raise EncryptionDecodeError(
                 "Value is a Fernet token but could not be decrypted with the "

--- a/src/xagent/core/utils/encryption.py
+++ b/src/xagent/core/utils/encryption.py
@@ -134,20 +134,38 @@ def decrypt_value_strict(encrypted_value: str) -> str:
     """
     if not encrypted_value:
         return encrypted_value
-    # Outside the try on purpose: a missing or malformed ENCRYPTION_KEY is a
-    # configuration fault, not a property of the value, and must not be
-    # reported as "this value is not a token".
-    cipher = get_cipher()
-    try:
-        return cipher.decrypt(encrypted_value.encode()).decode()
-    except InvalidToken as exc:
-        if _looks_like_fernet_token(encrypted_value):
-            raise EncryptionDecodeError(
-                "Value is a Fernet token but could not be decrypted with the "
-                "configured encryption key"
-            ) from exc
+    # Shape first, key second. A value that is not token-shaped is passed
+    # through without ever asking for a key, so a missing or malformed
+    # ENCRYPTION_KEY cannot turn plaintext into an error; and because the
+    # shape check never encodes the value itself, a string that cannot be
+    # UTF-8 encoded is simply "not a token" here rather than a raw
+    # UnicodeEncodeError. Only a token-shaped value needs the cipher, and for
+    # it a key configuration fault is exactly what should surface.
+    if not _looks_like_fernet_token(encrypted_value):
         logger.debug("Value is not a Fernet token; returning it unchanged")
         return encrypted_value
+    cipher = get_cipher()
+    try:
+        plaintext = cipher.decrypt(encrypted_value.encode())
+    except InvalidToken as exc:
+        raise EncryptionDecodeError(
+            "Value is a Fernet token but could not be decrypted with the "
+            "configured encryption key"
+        ) from exc
+    # Decode outside any except block so the error carries no reference to
+    # the decrypted bytes: UnicodeDecodeError keeps them in .object/.args, and
+    # `raise ... from None` would still leave it reachable via __context__.
+    text: str | None
+    try:
+        text = plaintext.decode()
+    except UnicodeDecodeError:
+        text = None
+    if text is None:
+        raise EncryptionDecodeError(
+            "Value is a Fernet token that decrypted, but its content is not "
+            "valid UTF-8 text"
+        )
+    return text
 
 
 def decrypt_env_dict_strict(env: dict | None) -> dict | None:

--- a/tests/core/utils/test_encryption.py
+++ b/tests/core/utils/test_encryption.py
@@ -190,19 +190,74 @@ def test_decrypt_env_dict_strict_raises_on_foreign_token(use_key):
         decrypt_env_dict_strict(env)
 
 
-def test_decrypt_value_strict_reports_missing_key_not_plaintext(monkeypatch):
-    """A key configuration fault must surface, not read as "not a token".
+def test_decrypt_value_strict_reports_missing_key_for_a_token(monkeypatch):
+    """A key configuration fault must surface for a token-shaped value.
 
     With no usable key at all, the lenient helper quietly returns the input;
     the strict helper must instead let get_cipher()'s ValueError out, because
-    "this deployment has no key" and "this value is plaintext" call for
+    "this deployment has no key" and "this token cannot be opened" call for
     entirely different responses.
     """
+    token = Fernet(STRICT_KEY_A.encode()).encrypt(b"secret").decode()
     monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
     monkeypatch.setenv("ENVIRONMENT", "production")
     get_cipher.cache_clear()
     try:
         with pytest.raises(ValueError, match="ENCRYPTION_KEY"):
-            decrypt_value_strict("sk-abc123")
+            decrypt_value_strict(token)
     finally:
         get_cipher.cache_clear()
+
+
+def test_decrypt_value_strict_passes_plaintext_through_without_a_key(monkeypatch):
+    """Plaintext never needs a key, so a missing key must not turn it into an error."""
+    monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    get_cipher.cache_clear()
+    try:
+        assert decrypt_value_strict("sk-abc123") == "sk-abc123"
+    finally:
+        get_cipher.cache_clear()
+
+
+def test_decrypt_value_strict_passes_unencodable_plaintext_through(use_key):
+    """A lone surrogate cannot be UTF-8 encoded; it is plaintext, not a token."""
+    use_key(STRICT_KEY_A)
+    value = "sk-\ud800-key"
+    assert decrypt_value_strict(value) == value
+
+
+def test_decrypt_value_strict_binary_plaintext_raises_without_the_bytes(use_key):
+    """A token whose plaintext is not UTF-8 raises the typed error and keeps
+    the decrypted bytes out of the exception entirely -- not in the message,
+    not in args, and not reachable through __cause__ or __context__."""
+    use_key(STRICT_KEY_A)
+    secret = b"\xff\xfe\x00secret-bytes"
+    token = get_cipher().encrypt(secret).decode()
+    with pytest.raises(EncryptionDecodeError) as excinfo:
+        decrypt_value_strict(token)
+    exc = excinfo.value
+    assert exc.__cause__ is None
+    assert exc.__context__ is None
+    assert b"secret-bytes" not in repr(exc.args).encode()
+    assert "secret-bytes" not in str(exc)
+
+
+@pytest.mark.parametrize("cut", [4, 8, 12, 16, 20])
+def test_decrypt_value_strict_truncated_token_still_raises(use_key, cut):
+    """A token that lost a few base64 characters in transit is still reported.
+
+    Its decoded length is no longer a whole number of AES blocks, so no key
+    could open it -- but it is ciphertext, and handing it back as if it were
+    plaintext is exactly the outcome the strict helper exists to prevent.
+    The shape floor is a minimum, not an alignment rule, on purpose: a
+    two-block token (89 raw bytes) cut by 4..20 base64 characters decodes to
+    87/84/81/78/75 bytes, all still above the floor and all still reported.
+    (A one-block token is already at the floor, so a truncated one falls
+    below it under any rule; this test uses the two-block case.)
+    """
+    use_key(STRICT_KEY_A)
+    token = get_cipher().encrypt(b"a-secret-of-20-bytes").decode()
+    truncated = token[:-cut]
+    with pytest.raises(EncryptionDecodeError):
+        decrypt_value_strict(truncated)

--- a/tests/core/utils/test_encryption.py
+++ b/tests/core/utils/test_encryption.py
@@ -1,9 +1,16 @@
 import pytest
+from cryptography.fernet import Fernet
 
 from xagent.core.utils.encryption import (
+    EncryptionDecodeError,
     _get_encryption_key,
+    decrypt_env_dict,
+    decrypt_env_dict_strict,
     decrypt_value,
+    decrypt_value_strict,
+    encrypt_env_dict,
     encrypt_value,
+    get_cipher,
 )
 
 
@@ -75,3 +82,109 @@ def test_get_encryption_key_with_env(monkeypatch):
     monkeypatch.setenv("ENCRYPTION_KEY", test_key)
     key = _get_encryption_key()
     assert key == test_key
+
+
+STRICT_KEY_A = "RQMpe38gK3m0szjpSmTNw_sP3Y54r6hDc6JewBoPKXc="
+STRICT_KEY_B = Fernet.generate_key().decode()
+
+
+@pytest.fixture
+def use_key(monkeypatch):
+    """Switch the module to a given encryption key for one test.
+
+    Setting ENCRYPTION_KEY alone has no effect once get_cipher() has run:
+    it is lru_cached. Clear on every switch, and again on teardown so no
+    test key survives into another test in the same process.
+    """
+
+    def _use(key):
+        monkeypatch.setenv("ENCRYPTION_KEY", key)
+        get_cipher.cache_clear()
+
+    yield _use
+    get_cipher.cache_clear()
+
+
+def test_decrypt_value_strict_raises_on_foreign_token(use_key):
+    """A token from another key raises, where the lenient helper stays silent."""
+    use_key(STRICT_KEY_A)
+    token = encrypt_value("secret")
+
+    use_key(STRICT_KEY_B)
+    assert decrypt_value(token) == token
+    with pytest.raises(EncryptionDecodeError):
+        decrypt_value_strict(token)
+
+
+def test_decrypt_value_strict_roundtrip(use_key):
+    use_key(STRICT_KEY_A)
+    assert decrypt_value_strict(encrypt_value("secret")) == "secret"
+
+
+@pytest.mark.parametrize(
+    "plaintext",
+    ["invalid_token_value", "gAAAAABnot-a-real-token", "sk-abc123", "plain text"],
+)
+def test_decrypt_value_strict_passes_plaintext_through(use_key, plaintext):
+    """Values that are not token-shaped are returned unchanged, as before.
+
+    No key can open them, so classifying them as plaintext loses nothing.
+    """
+    use_key(STRICT_KEY_A)
+    assert decrypt_value_strict(plaintext) == plaintext
+
+
+def test_decrypt_value_strict_empty_value(use_key):
+    use_key(STRICT_KEY_A)
+    assert decrypt_value_strict("") == ""
+    assert decrypt_value_strict(None) is None
+
+
+def test_decrypt_value_strict_error_is_value_error(use_key):
+    """Callers already catching ValueError keep working."""
+    use_key(STRICT_KEY_A)
+    token = encrypt_value("secret")
+
+    use_key(STRICT_KEY_B)
+    with pytest.raises(ValueError):
+        decrypt_value_strict(token)
+
+
+def test_decrypt_value_strict_error_omits_the_value(use_key):
+    use_key(STRICT_KEY_A)
+    token = encrypt_value("secret")
+
+    use_key(STRICT_KEY_B)
+    with pytest.raises(EncryptionDecodeError) as excinfo:
+        decrypt_value_strict(token)
+    assert token not in str(excinfo.value)
+
+
+def test_decrypt_env_dict_strict(use_key):
+    use_key(STRICT_KEY_A)
+    assert decrypt_env_dict_strict(encrypt_env_dict({"A": "1", "B": "2"})) == {
+        "A": "1",
+        "B": "2",
+    }
+    assert decrypt_env_dict_strict(None) is None
+    assert decrypt_env_dict_strict({}) == {}
+
+    mixed = {"A": encrypt_value("1"), "B": "plain", "C": 5, "D": None}
+    assert decrypt_env_dict_strict(mixed) == {
+        "A": "1",
+        "B": "plain",
+        "C": 5,
+        "D": None,
+    }
+
+
+def test_decrypt_env_dict_strict_raises_on_foreign_token(use_key):
+    """One unreadable entry fails the whole map, instead of leaking ciphertext."""
+    use_key(STRICT_KEY_A)
+    foreign = encrypt_value("1")
+
+    use_key(STRICT_KEY_B)
+    env = {"A": encrypt_value("ok"), "B": foreign}
+    assert decrypt_env_dict(env)["B"] == foreign
+    with pytest.raises(EncryptionDecodeError):
+        decrypt_env_dict_strict(env)

--- a/tests/core/utils/test_encryption.py
+++ b/tests/core/utils/test_encryption.py
@@ -188,3 +188,21 @@ def test_decrypt_env_dict_strict_raises_on_foreign_token(use_key):
     assert decrypt_env_dict(env)["B"] == foreign
     with pytest.raises(EncryptionDecodeError):
         decrypt_env_dict_strict(env)
+
+
+def test_decrypt_value_strict_reports_missing_key_not_plaintext(monkeypatch):
+    """A key configuration fault must surface, not read as "not a token".
+
+    With no usable key at all, the lenient helper quietly returns the input;
+    the strict helper must instead let get_cipher()'s ValueError out, because
+    "this deployment has no key" and "this value is plaintext" call for
+    entirely different responses.
+    """
+    monkeypatch.delenv("ENCRYPTION_KEY", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    get_cipher.cache_clear()
+    try:
+        with pytest.raises(ValueError, match="ENCRYPTION_KEY"):
+            decrypt_value_strict("sk-abc123")
+    finally:
+        get_cipher.cache_clear()


### PR DESCRIPTION
## What

Adds three things to `src/xagent/core/utils/encryption.py`:

- `EncryptionDecodeError(ValueError)` — raised when a Fernet-shaped value
  cannot be decrypted with the configured key.
- `decrypt_value_strict(value)` — behaves exactly like `decrypt_value()`
  except that it raises `EncryptionDecodeError` for a token the configured
  key cannot open, instead of returning the ciphertext unchanged.
- `decrypt_env_dict_strict(env)` — the mapping form, raising on the first
  entry that cannot be read.

`decrypt_value()`, `decrypt_env_dict()`, `encrypt_value()`,
`encrypt_env_dict()` and `_is_encrypted()` are untouched.

## Why

`decrypt_value()` returns its input unchanged whenever `Fernet.decrypt()`
raises, which makes "this was never encrypted" and "this is a token from a
different key" indistinguishable to the caller. In the second case the caller
receives ciphertext and has no signal that anything went wrong. Callers that
would rather fail than propagate an unreadable value currently have no way to
express that.

The decision cannot be made with `_is_encrypted()`: it answers "does the
configured key open this", and returns `False` for a wrong-key token and for
plaintext alike. The strict path therefore uses a key-independent structural
check (`_looks_like_fernet_token`): url-safe base64, a leading `0x80` version
byte, and at least 73 bytes — version + timestamp + IV + one AES-CBC block +
HMAC, the floor below which no key could open the value. Anything failing that
check is passed through unchanged, exactly as the lenient path does.

## Compatibility

- Default behaviour is unchanged. No existing function was modified, so every
  current call site produces byte-identical results.
- The new behaviour is opt-in through a separate function name rather than a
  `strict=` flag, so tests that patch `decrypt_value` do not silently disable
  the strict contract at call sites that rely on it.
- `EncryptionDecodeError` subclasses `ValueError`, which this module already
  raises for a missing key, so callers with an existing `except ValueError`
  keep working without changes.
- The error message never contains the value or any part of it.

## Tests

Added to `tests/core/utils/test_encryption.py`, driven by a `use_key` fixture
that switches `ENCRYPTION_KEY` and clears the `get_cipher` lru_cache on both
switch and teardown:

- a token encrypted under key A raises `EncryptionDecodeError` under key B,
  while `decrypt_value` returns it unchanged in the same situation;
- a token round-trips under its own key;
- non-token values (`invalid_token_value`, `gAAAAABnot-a-real-token`,
  `sk-abc123`, `plain text`) are returned unchanged;
- `""` and `None` are returned unchanged;
- the raised error is catchable as `ValueError`;
- the error message does not contain the token;
- `decrypt_env_dict_strict` handles `None`, `{}`, mixed str/non-str values,
  and raises when any single entry is unreadable.

Closes #1420
