### PR TITLE
ci(migrations): install from uv.lock instead of resolving from PyPI

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -167,14 +167,21 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: "pip"
 
       - name: Install dependencies
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[all]"
-          pip install pytest pytest-mock
+          # Install from uv.lock, the same resolution every other job uses.
+          # A plain "pip install -e .[all]" re-resolves the whole graph from
+          # PyPI on every run, so an upper bound added anywhere in pyproject
+          # -- or any upstream release -- can make the resolver backtrack
+          # until it gives up, turning this workflow red on changes that have
+          # nothing to do with it. Putting the environment on PATH keeps the
+          # test steps below unchanged and leaves no call site able to fall
+          # back to the system interpreter.
+          python -m pip install --upgrade uv
+          uv sync --all-extras --group dev
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Test migration upgrade
         if: needs.detect-migration-changes.outputs.should-test == 'true'
@@ -230,14 +237,21 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-          cache: "pip"
 
       - name: Install dependencies
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[all]"
-          pip install pytest pytest-mock
+          # Install from uv.lock, the same resolution every other job uses.
+          # A plain "pip install -e .[all]" re-resolves the whole graph from
+          # PyPI on every run, so an upper bound added anywhere in pyproject
+          # -- or any upstream release -- can make the resolver backtrack
+          # until it gives up, turning this workflow red on changes that have
+          # nothing to do with it. Putting the environment on PATH keeps the
+          # test steps below unchanged and leaves no call site able to fall
+          # back to the system interpreter.
+          python -m pip install --upgrade uv
+          uv sync --all-extras --group dev
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Test migration upgrade
         if: needs.detect-migration-changes.outputs.should-test == 'true'
@@ -274,7 +288,6 @@ jobs:
       - name: Test Gmail provisioning Postgres-only behavior
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
-          pip install pytest-asyncio
           pytest tests/web/services/test_gmail_provisioning.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
@@ -317,7 +330,6 @@ jobs:
       - name: Test monitoring JSON extraction (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
-          pip install pytest-asyncio
           pytest tests/web/api/test_monitor_postgresql.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -53,6 +53,11 @@ on:
   # stalls. Harmless before a queue exists -- merge_group simply never fires.
   merge_group:
 
+env:
+  # Same version docker/Dockerfile.backend and docker/Dockerfile.sandbox pin.
+  # Declared once here so the two install steps below cannot drift apart.
+  UV_VERSION: "0.11.10"
+
 jobs:
   detect-migration-changes:
     name: Detect migration changes
@@ -179,8 +184,23 @@ jobs:
           # nothing to do with it. Putting the environment on PATH keeps the
           # test steps below unchanged and leaves no call site able to fall
           # back to the system interpreter.
-          python -m pip install --upgrade uv
-          uv sync --all-extras --group dev
+          #
+          # --locked is what turns that into a guarantee. A bare "uv sync"
+          # rewrites uv.lock as soon as project metadata has drifted from it,
+          # which puts the independent resolution straight back; --locked
+          # fails the job instead and names the stale lock.
+          #
+          # Pinning uv is the other half of that guarantee: a floating uv can
+          # ship a lock-format change that makes --locked fail on uv's release
+          # schedule rather than on anything in this repository.
+          #
+          # Only the test group is installed. The dev group adds pre-commit,
+          # ruff, flake8, mypy and the type stubs, and no step in either
+          # migration job runs any of them. alembic comes from the project
+          # dependencies and pytest from the test group, so both jobs still
+          # have everything they invoke.
+          python -m pip install "uv==${UV_VERSION}"
+          uv sync --locked --all-extras --no-default-groups --group test
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Test migration upgrade
@@ -249,8 +269,23 @@ jobs:
           # nothing to do with it. Putting the environment on PATH keeps the
           # test steps below unchanged and leaves no call site able to fall
           # back to the system interpreter.
-          python -m pip install --upgrade uv
-          uv sync --all-extras --group dev
+          #
+          # --locked is what turns that into a guarantee. A bare "uv sync"
+          # rewrites uv.lock as soon as project metadata has drifted from it,
+          # which puts the independent resolution straight back; --locked
+          # fails the job instead and names the stale lock.
+          #
+          # Pinning uv is the other half of that guarantee: a floating uv can
+          # ship a lock-format change that makes --locked fail on uv's release
+          # schedule rather than on anything in this repository.
+          #
+          # Only the test group is installed. The dev group adds pre-commit,
+          # ruff, flake8, mypy and the type stubs, and no step in either
+          # migration job runs any of them. alembic comes from the project
+          # dependencies and pytest from the test group, so both jobs still
+          # have everything they invoke.
+          python -m pip install "uv==${UV_VERSION}"
+          uv sync --locked --all-extras --no-default-groups --group test
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Test migration upgrade


### PR DESCRIPTION
## What broke

Both migration jobs installed their dependencies with `pip install -e ".[all]"`, which re-resolves the whole graph from PyPI on every run. Every other job in the repository installs from `uv.lock`.

Capping `mcp` at `<2` (#1414) is correct for the codebase, and the lockfile absorbed it without trouble — every uv-based job stayed green. Plain pip could not: `mcp` publishes 2.0.0 as its newest release, so before the cap the resolver took it and finished; after the cap it has to search 58 1.x releases, re-checking the rest of the graph against each one. The backtracking cascaded — 25 `transformers` versions, 40 `zhipuai`, 30 `aiobotocore`, plus `google-api-core` and `grpcio-status` — and gave up after 33 minutes with `resolution-too-deep`.

Timeline on 2026-08-17: installs succeeded at 09:51 and 09:52; the cap landed on main at 10:38; every run since that actually installs has failed, on this repository's pull requests generally, not one branch. Runs that appear green in between are ones where `detect-migration-changes` skipped the install step.

## What this changes

Both jobs now install with `uv sync --all-extras --group dev` and put the environment on `PATH`. The sixteen test steps below are untouched: prefixing each with `uv run` would work too, but a missed call site would silently fall back to the system interpreter, whereas `PATH` covers them uniformly.

Two `pip install pytest-asyncio` lines are removed — it is in the dev group, along with pytest and pytest-mock. The `cache: "pip"` on `setup-python` goes with them, since it cached wheels for an installer this workflow no longer uses for its dependency set.

## Same mechanism as #1046

That issue describes the mypy pre-commit hook maintaining a second dependency resolution alongside the lockfile, where any upstream release can turn CI red on unrelated pull requests. It records three occurrences, each closed by pinning the one package involved. This workflow was a fourth instance of the same mechanism, and the fix here is the structural one that issue asks for: no second resolution, so nothing can change the outcome without a lockfile change. The hook half of #1046 is not touched here.

## Verification

Locally, `uv sync --all-extras --group dev` produces alembic 1.18.4, pytest, pytest-mock and pytest-asyncio in `.venv`, and `python tests/migrations/test_migration_integration.py --db sqlite upgrade` passes when run through that environment. The workflow's own jobs on this PR exercise the rest.
