### PR TITLE
fix(skills): stop silently truncating builtin skill index entries

### DIFF
--- a/src/xagent/skills/README.md
+++ b/src/xagent/skills/README.md
@@ -42,6 +42,41 @@ Each skill is a directory containing:
 
 See individual skill directories for examples.
 
+### Routing metadata
+
+`description` and `when_to_use` decide whether a skill gets loaded at all: they
+are the only thing the model sees about a skill it has not loaded yet. Two rules
+govern them, and they apply to every skill — built-in, user, external, or
+provider-backed.
+
+**Frontmatter is authoritative; a body section is only a fallback.** A scalar
+`description:` / `when_to_use:` in the YAML frontmatter wins over a `##
+Description` / `## When to Use` section. A whitespace-only frontmatter value
+counts as absent and falls through to the section.
+
+```markdown
+---
+name: my-skill
+description: |
+  What this produces, plus the words a user would say when they want it.
+when_to_use: |
+  When to reach for this, and which skill to prefer instead when not.
+---
+
+## Description
+
+Longer prose for after the skill is loaded. Ignored for routing when the
+frontmatter above defines the field.
+```
+
+**Each field is capped at 200 characters in the index.** Whitespace is
+collapsed to single spaces first, and anything past the cap is dropped
+silently — trigger vocabulary and "use skill X instead" cross-references are
+what usually get lost, since they tend to sit at the end. Keep both fields
+under the cap and put the detail in the body, which is injected in full once
+the skill is loaded. `tests/skills/test_builtin_index_entries.py` enforces this
+for built-in skills.
+
 ## Adding a New Built-in Skill
 
 1. Create a new directory in `src/xagent/skills/builtin/your_skill/`

--- a/src/xagent/skills/builtin/evidence-based-rag/SKILL.md
+++ b/src/xagent/skills/builtin/evidence-based-rag/SKILL.md
@@ -1,5 +1,12 @@
 ---
-description: Evidence-first retrieval-augmented reasoning skill for decision-critical scenarios. Retrieves information from a specified knowledge base, extracts verifiable evidence, detects conflicting claims, and evaluates answer sufficiency with explicit confidence and risk signals. Produces traceable outputs suitable for agent-level decision control and escalation.
+description: |
+  Evidence-first retrieval over a specified knowledge base: cited evidence,
+  conflict detection, and an explicit sufficiency, confidence, and risk verdict
+  on whether the answer is safe to act on.
+when_to_use: |
+  Knowledge base Q&A, fact-checking, evidence verification, due diligence, or
+  compliance review needing source attribution. Not for casual chat, creative
+  writing, or answers that need no citations.
 ---
 
 # Evidence-Based RAG

--- a/src/xagent/skills/builtin/html-deck-editorial/SKILL.md
+++ b/src/xagent/skills/builtin/html-deck-editorial/SKILL.md
@@ -1,21 +1,13 @@
 ---
 name: html-deck-editorial
 description: |
-  Generate a single-file HTML presentation deck with magazine-grade editorial
-  styling. Use only when the user explicitly asks for an "html deck",
-  "editorial slides", "magazine style presentation", "beautiful slides", "美观
-  PPT", or "网页版幻灯片" — i.e. a slide-style visual deliverable AND a
-  beautiful, designer-looking result is expected. Do not use this for generic
-  visual design requests such as ad creatives, posters, banners, social media
-  graphics, or image generation; use `static-visual-design` for designed static
-  graphics and the image-generation tools for standalone image generation.
-  Output is one self-contained .html file (inline CSS + JS, no build, no npm),
-  printable to PDF via the browser, with keyboard navigation. Prefer this over
-  native .pptx when the user wants visual quality over Office compatibility.
+  One self-contained HTML slide deck with magazine-grade editorial styling:
+  "html deck", "editorial slides", "美观 PPT", "网页版幻灯片". Not for posters,
+  ad creatives, or standalone images.
 when_to_use: |
-  Use for the explicit slide-style HTML requests described above when editorial
-  polish matters more than Office compatibility. Prefer over `pptx-editorial`
-  only when HTML output is requested.
+  A slide-style HTML deliverable where editorial polish outweighs Office
+  compatibility. Use pptx-editorial for native .pptx, static-visual-design for
+  designed graphics.
 tags:
   - presentation
   - html

--- a/src/xagent/skills/builtin/pdf-report-editorial/SKILL.md
+++ b/src/xagent/skills/builtin/pdf-report-editorial/SKILL.md
@@ -1,19 +1,12 @@
 ---
 name: pdf-report-editorial
 description: |
-  Generate an editorial-styled PDF report (whitepaper, research brief,
-  executive memo, case study) by first emitting a self-contained HTML
-  document and then rendering it to PDF via the browser. Use when the
-  user asks for a "PDF report", "whitepaper", "executive brief",
-  "research report", "case study PDF", or similar document deliverable
-  where visual quality matters and the format must be portable / printable.
-  Use `pptx-editorial` or `html-deck-editorial` instead if the user
-  actually wants slides; this skill is for read-as-document, not as-slides.
+  An editorial-styled PDF report rendered from HTML via the browser:
+  "PDF report", "whitepaper", "executive brief", "research report",
+  "case study PDF". Read-as-document, not slides.
 when_to_use: |
-  When the user wants a polished read-as-document deliverable (whitepaper,
-  research brief, executive memo, case study) as a PDF where typography and
-  layout matter. Not for slides — use `pptx-editorial` or `html-deck-editorial`
-  for slide-style decks.
+  A polished portable, printable document where typography and layout matter.
+  Use pptx-editorial or html-deck-editorial instead when the user wants slides.
 tags:
   - pdf
   - report

--- a/src/xagent/skills/builtin/pptx-editorial/SKILL.md
+++ b/src/xagent/skills/builtin/pptx-editorial/SKILL.md
@@ -1,25 +1,13 @@
 ---
 name: pptx-editorial
 description: |
-  Generate a native PowerPoint (.pptx) file with magazine-grade editorial
-  styling — pitch decks, investor presentations (路演 PPT), board reviews,
-  executive memos, conference talks, product launches. Output is a single
-  .pptx file generated via pptxgenjs through the JavaScript executor runtime, openable
-  in PowerPoint / Keynote / Google Slides. Uses five named editorial palettes
-  (Monocle, Indigo Porcelain, Forest Ink, Kraft Paper, Dune) with strict
-  typography rules (Georgia display + Calibri body) and 10 numbered layouts
-  (L01 Cover, L02 Act Divider, L03 Big Numbers, ..., L10 Closing).
-  Prefer this skill over the builtin presentation-generator whenever the
-  user wants a polished editorial look, names one of the five palettes,
-  asks for a "美观 PPT" / "投资人路演 PPT" / "pitch deck", or otherwise
-  signals that visual quality matters beyond a generic deck.
-  Use `html-deck-editorial` instead only when the user explicitly wants HTML
-  output (more visual freedom but not Office-compatible).
+  A native .pptx deck with magazine-grade editorial styling: "pitch deck",
+  "投资人路演 PPT", "美观 PPT", board review, product launch. Named palettes,
+  fixed typography, 10 numbered layouts.
 when_to_use: |
-  When the user wants a polished native .pptx deliverable (pitch deck, 路演 PPT,
-  board review, executive memo) where visual quality matters and the file must
-  open in PowerPoint / Keynote / Google Slides. Use `html-deck-editorial`
-  instead when the user explicitly wants HTML output.
+  A polished .pptx that must open in PowerPoint / Keynote / Google Slides.
+  Prefer over presentation-generator when visual quality matters; use
+  html-deck-editorial when the user wants HTML output.
 tags:
   - presentation
   - pptx

--- a/src/xagent/skills/builtin/presentation-generator/SKILL.md
+++ b/src/xagent/skills/builtin/presentation-generator/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: presentation
-description: "Generate and edit PowerPoint presentations (.pptx). Use for: creating slide decks, pitch decks, or presentations from scratch; reading, parsing, or extracting content from .pptx files; editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger only when the user explicitly asks for a deck, slides, presentation, PPT/PPTX, or references a .pptx filename. Do not use for standalone posters, images, banners, illustrations, or social graphics unless the requested deliverable is a presentation file."
+description: |
+  Create, read, or edit PowerPoint .pptx files: slide decks from scratch,
+  content extraction, templates, speaker notes, combining or splitting decks.
+  Not for posters, images, or social graphics.
+when_to_use: |
+  The user asks for a deck, slides, a presentation, PPT/PPTX, or names a .pptx
+  file. Use pptx-editorial instead when magazine-grade editorial styling is
+  wanted.
 ---
 
 # Presentation Generator

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: static-visual-design
 description: |
-  Create polished commercial and brand-facing static visual designs as complete
-  PNG or JPEG assets. Use only for advertising creatives, campaign posters,
-  promotional social posts, event or announcement cards, banners, and placement
-  variants where art direction, typography, hierarchy, brand fidelity, and
-  visual quality matter.
+  Design a finished ad, poster, banner, social post, or invitation as one
+  PNG/JPEG with layout, headline, and brand styling rendered in, or adapt one
+  into another placement size or aspect ratio.
 when_to_use: |
-  Use only for marketing, campaign, event, or brand communication. Do not use
-  for educational infographics, technical diagrams, concept explainers, charts,
-  data visualizations, or standalone illustrations or photos.
+  Any marketing, promotion, campaign, event, or brand-facing image, including
+  ones naming a real brand. Not for explanatory diagrams, charts, infographics,
+  or plain illustrations.
 ---
 
 # Static Visual Design

--- a/src/xagent/skills/builtin/xlsx-financial-report/SKILL.md
+++ b/src/xagent/skills/builtin/xlsx-financial-report/SKILL.md
@@ -1,19 +1,12 @@
 ---
 name: xlsx-financial-report
 description: |
-  Generate a native Excel (.xlsx) file styled as a clean financial /
-  KPI / dashboard report. Use when the user asks for an "Excel report",
-  "financial report", "KPI dashboard", "monthly report", ".xlsx", or
-  similar tabular deliverable where the output must look professional
-  (not just raw data). Output is a single .xlsx file produced via
-  `openpyxl` through the `execute_python_code` tool. Output opens cleanly
-  in Excel / Google Sheets / Numbers.
-  Do NOT use this skill for ad-hoc data exploration or raw CSV dumps —
-  use the regular `excel` tool for those.
+  A native .xlsx styled as a financial, KPI, or dashboard report:
+  "Excel report", "financial report", "KPI dashboard", "monthly report".
+  Opens cleanly in Excel / Google Sheets / Numbers.
 when_to_use: |
-  When the user wants a polished financial / KPI / dashboard Excel deliverable
-  (xlsx) where the file is meant to be opened and skimmed — not raw data dumps.
-  Use the regular `excel` tool instead for ad-hoc exploration / CSV-style output.
+  A polished xlsx meant to be opened and skimmed, not a raw data dump. Use the
+  regular excel tool instead for ad-hoc exploration or CSV-style output.
 tags:
   - xlsx
   - excel

--- a/src/xagent/skills/parser.py
+++ b/src/xagent/skills/parser.py
@@ -79,10 +79,12 @@ class SkillParser:
             "path": path,
             "content": content,  # Complete SKILL.md content
             "template": template_content,  # template.md content (if exists)
-            "description": section_description
-            or SkillParser._frontmatter_string(frontmatter, "description"),
-            "when_to_use": section_when_to_use
-            or SkillParser._frontmatter_string(frontmatter, "when_to_use"),
+            # Frontmatter wins like tags do: it is the bounded routing metadata,
+            # while a body section is prose with no length ceiling.
+            "description": SkillParser._frontmatter_string(frontmatter, "description")
+            or section_description,
+            "when_to_use": SkillParser._frontmatter_string(frontmatter, "when_to_use")
+            or section_when_to_use,
             "execution_flow": SkillParser._extract_section(content, "Execution Flow"),
             "tags": tags,
             "files": sorted(files),

--- a/src/xagent/skills/parser.py
+++ b/src/xagent/skills/parser.py
@@ -73,6 +73,12 @@ class SkillParser:
         section_tags = SkillParser._extract_tags(content)
         frontmatter_tags = SkillParser._frontmatter_string_list(frontmatter, "tags")
         tags = frontmatter_tags or section_tags
+        frontmatter_description = SkillParser._frontmatter_string(
+            frontmatter, "description"
+        )
+        frontmatter_when_to_use = SkillParser._frontmatter_string(
+            frontmatter, "when_to_use"
+        )
 
         return {
             "name": name,
@@ -80,11 +86,14 @@ class SkillParser:
             "content": content,  # Complete SKILL.md content
             "template": template_content,  # template.md content (if exists)
             # Frontmatter wins like tags do: it is the bounded routing metadata,
-            # while a body section is prose with no length ceiling.
-            "description": SkillParser._frontmatter_string(frontmatter, "description")
-            or section_description,
-            "when_to_use": SkillParser._frontmatter_string(frontmatter, "when_to_use")
-            or section_when_to_use,
+            # while a body section is prose with no length ceiling. Whitespace-only
+            # counts as absent, or it wins and then collapses to an empty entry.
+            "description": frontmatter_description
+            if frontmatter_description.strip()
+            else section_description,
+            "when_to_use": frontmatter_when_to_use
+            if frontmatter_when_to_use.strip()
+            else section_when_to_use,
             "execution_flow": SkillParser._extract_section(content, "Execution Flow"),
             "tags": tags,
             "files": sorted(files),

--- a/tests/skills/test_builtin_index_entries.py
+++ b/tests/skills/test_builtin_index_entries.py
@@ -36,9 +36,10 @@ def test_routing_field_is_present_and_untruncated(skill_dir: Path, field: str) -
 
     entry = _index_text(value)
     assert entry == collapsed, (
-        f"{skill_dir.name}: {field} is {len(collapsed)} chars and gets truncated to "
-        f"{INDEX_ENTRY_MAX_CHARS}; {len(collapsed) - INDEX_ENTRY_MAX_CHARS} chars never "
-        f"reach the model"
+        f"{skill_dir.name}: {field} is {len(collapsed)} chars, "
+        f"{len(collapsed) - INDEX_ENTRY_MAX_CHARS} over the "
+        f"{INDEX_ENTRY_MAX_CHARS}-char cap; the index entry keeps only "
+        f"{len(entry) - 1} of them and drops the rest"
     )
 
 
@@ -60,3 +61,24 @@ def test_frontmatter_wins_over_body_section() -> None:
 
     assert skill["description"] == "from frontmatter"
     assert skill["when_to_use"] == "also from frontmatter"
+
+
+def test_whitespace_only_frontmatter_falls_through_to_the_section() -> None:
+    """Otherwise it wins and then collapses to an empty index entry."""
+    skill = SkillParser.parse_bundle(
+        name="fixture",
+        files={
+            "SKILL.md": (
+                "---\n"
+                'description: "   "\n'
+                "when_to_use: |\n"
+                "  \n"
+                "---\n\n"
+                "## Description\n\nfrom section\n\n"
+                "## When to Use\n\nalso from section\n"
+            ).encode()
+        },
+    )
+
+    assert skill["description"] == "from section"
+    assert skill["when_to_use"] == "also from section"

--- a/tests/skills/test_builtin_index_entries.py
+++ b/tests/skills/test_builtin_index_entries.py
@@ -1,0 +1,62 @@
+"""Built-in skill routing fields must survive the index entry cap.
+
+The skill index is the only thing the model sees when deciding whether to load
+a skill, and ``_index_text`` truncates silently, so anything over the cap never
+reaches the routing decision.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from xagent.core.agent.context.skill_tool import INDEX_ENTRY_MAX_CHARS, _index_text
+from xagent.skills.parser import SkillParser
+
+BUILTIN_DIR = (
+    Path(__file__).resolve().parents[2] / "src" / "xagent" / "skills" / "builtin"
+)
+ROUTING_FIELDS = ("description", "when_to_use")
+
+
+def _builtin_skills() -> list[Path]:
+    skills = sorted(p for p in BUILTIN_DIR.iterdir() if (p / "SKILL.md").is_file())
+    assert skills, f"no built-in skills found under {BUILTIN_DIR}"
+    return skills
+
+
+@pytest.mark.parametrize("skill_dir", _builtin_skills(), ids=lambda p: p.name)
+@pytest.mark.parametrize("field", ROUTING_FIELDS)
+def test_routing_field_is_present_and_untruncated(skill_dir: Path, field: str) -> None:
+    value = SkillParser.parse(skill_dir).get(field)
+    collapsed = " ".join(str(value or "").split())
+
+    assert collapsed, (
+        f"{skill_dir.name}: {field} is empty, so the index entry says nothing"
+    )
+
+    entry = _index_text(value)
+    assert entry == collapsed, (
+        f"{skill_dir.name}: {field} is {len(collapsed)} chars and gets truncated to "
+        f"{INDEX_ENTRY_MAX_CHARS}; {len(collapsed) - INDEX_ENTRY_MAX_CHARS} chars never "
+        f"reach the model"
+    )
+
+
+def test_frontmatter_wins_over_body_section() -> None:
+    """A body section is unbounded prose; the bounded frontmatter field routes."""
+    skill = SkillParser.parse_bundle(
+        name="fixture",
+        files={
+            "SKILL.md": (
+                "---\n"
+                "description: from frontmatter\n"
+                "when_to_use: also from frontmatter\n"
+                "---\n\n"
+                "## Description\n\nfrom section\n\n"
+                "## When to Use\n\nalso from section\n"
+            ).encode()
+        },
+    )
+
+    assert skill["description"] == "from frontmatter"
+    assert skill["when_to_use"] == "also from frontmatter"

--- a/tests/skills/test_builtin_static_visual_design.py
+++ b/tests/skills/test_builtin_static_visual_design.py
@@ -19,26 +19,19 @@ def test_static_visual_design_skill_routes_only_commercial_creatives() -> None:
     assert skill["name"] == "static-visual-design"
     description = " ".join(skill["description"].split())
     when_to_use = " ".join(skill["when_to_use"].split())
-    assert "complete PNG or JPEG assets" in description
-    assert "commercial and brand-facing" in description
-    assert "campaign posters" in description
-    assert "advertising creatives" in description
-    assert "placement variants" in description
-    assert "marketing, campaign, event, or brand communication" in when_to_use
-    assert "educational infographics" in when_to_use
-    assert "technical diagrams" in when_to_use
-    assert "concept explainers" in when_to_use
+    assert "one PNG/JPEG" in description
+    assert "brand styling" in description
+    assert "finished ad, poster, banner, social post" in description
+    assert "another placement size or aspect ratio" in description
+    assert "marketing, promotion, campaign, event, or brand-facing image" in when_to_use
+    assert "explanatory diagrams" in when_to_use
+    assert "infographics" in when_to_use
+    assert "plain illustrations" in when_to_use
 
-    # Auto routing sees bounded one-line versions of these fields. Keep the
-    # positive commercial scope and the important exclusions inside that
-    # actual routing surface instead of only in the full skill body.
-    routing_description = _index_text(skill["description"])
-    routing_when_to_use = _index_text(skill["when_to_use"])
-    assert "commercial and brand-facing" in routing_description
-    assert "advertising creatives" in routing_description
-    assert "Use only for marketing" in routing_when_to_use
-    assert "educational infographics" in routing_when_to_use
-    assert "concept explainers" in routing_when_to_use
+    # Auto routing sees bounded one-line versions of these fields, so every
+    # assertion above has to hold on the routing surface, not only in the body.
+    assert _index_text(skill["description"]) == description
+    assert _index_text(skill["when_to_use"]) == when_to_use
 
     content = " ".join(skill["content"].split())
     assert "Stay within the commercial-creative scope" in content


### PR DESCRIPTION
## Background

The skill index is the only thing the model sees when deciding whether to load a
skill at all. `_index_text` (`core/agent/context/skill_tool.py:29`) collapses each
skill's `description` and `when_to_use` to a single line and truncates anything
over `INDEX_ENTRY_MAX_CHARS = 200` — silently, with no warning and no test.

Seven of the eight built-in skills were over that cap. What got cut is precisely
the tail of each field, which is where the trigger vocabulary and the
"use skill X instead when…" cross-references lived. `presentation-generator` had
no `when_to_use` at all, so its index line carried nothing on that axis.

Two skills are affected worse than the character counts suggest:
`SkillParser.parse` resolved `description`/`when_to_use` as
`body_section or frontmatter`, so `evidence-based-rag` was routed on its 885-char
`## When to Use` prose section rather than on any bounded field — 685 characters
of it discarded before the model ever saw it.

## Changes

### 1. Frontmatter wins over body sections (`skills/parser.py`)

Reversed to `frontmatter or body_section`, matching how `tags` has always
resolved (`parser.py:75`). Frontmatter is the declared routing metadata and is
the thing authors can keep under a cap; a body section is prose with no length
ceiling and is meant to be read *after* loading.

Impact on built-ins: only `evidence-based-rag` has such a section, and it now
routes on a new bounded frontmatter field instead of its 885-char body. The body
section is left intact — it is still useful once the skill is loaded. For
external/user skills the change only matters when a skill defines both, and in
that case the explicit frontmatter field is the better answer.

### 2. Every built-in routing field brought under the cap

| skill | description | when_to_use |
| --- | --- | --- |
| `agent-builder` | 156 → 156 | 111 → 111 |
| `evidence-based-rag` | **357 → 192** | **885 → 195** |
| `html-deck-editorial` | **814 → 179** | 189 → 166 |
| `pdf-report-editorial` | **550 → 180** | **247 → 153** |
| `pptx-editorial` | **979 → 180** | **277 → 193** |
| `presentation-generator` | **599 → 192** | **0 → 158** |
| `static-visual-design` | **325 → 192** | **213 → 177** |
| `xlsx-financial-report` | **552 → 184** | **234 → 147** |

Rewriting rule: preserve trigger vocabulary and cross-skill routing, drop
prose. What each skill kept and gave up:

- **`evidence-based-rag`** — kept knowledge-base retrieval, citations, conflict
  detection, sufficiency/confidence/risk. New `when_to_use` names Q&A,
  fact-checking, due diligence, compliance review. Dropped: "agent-level
  decision control and escalation" phrasing.
- **`html-deck-editorial`** — kept `html deck`, `editorial slides`, `美观 PPT`,
  `网页版幻灯片`, and the `pptx-editorial` / `static-visual-design` routing.
  Dropped: `magazine style presentation` and `beautiful slides` as separate
  quoted triggers, and the inline description of the output format (inline
  CSS+JS, no npm, keyboard nav, print-to-PDF) — all of which is in the body.
- **`pdf-report-editorial`** — kept `PDF report`, `whitepaper`,
  `executive brief`, `research report`, `case study PDF`, read-as-document vs
  slides. Dropped: the HTML→browser render pipeline detail.
- **`pptx-editorial`** — kept `pitch deck`, `投资人路演 PPT`, `美观 PPT`, board
  review, product launch, and the preference over `presentation-generator` /
  `html-deck-editorial`. Dropped: the five palette names, the Georgia+Calibri
  typography rule, and the ten layout IDs — 400+ characters of body content that
  cannot influence a load decision.
- **`presentation-generator`** — kept `deck`, `slides`, `presentation`,
  `PPT/PPTX`, `.pptx` filename, plus create/read/edit/combine/split/templates/
  notes. Gained a `when_to_use` that routes styling requests to
  `pptx-editorial`. Dropped: `comments`, `layouts`.
- **`static-visual-design`** — kept the ad/poster/banner/social-post/invitation
  triggers, the placement-adaptation trigger, and the diagram/chart/infographic
  exclusions.
- **`xlsx-financial-report`** — kept `Excel report`, `financial report`,
  `KPI dashboard`, `monthly report`, and the fallback to the plain `excel` tool.
  Dropped: the `openpyxl` / `execute_python_code` implementation note.

No routing boundary between skills was changed. The cross-references that
previously existed only past the truncation point now actually reach the model.

### 3. A test that fails instead of truncating silently

`tests/skills/test_builtin_index_entries.py` parameterises over every
`builtin/*/SKILL.md` × both routing fields and asserts the field is non-empty and
that `_index_text(value) == value`. It imports `INDEX_ENTRY_MAX_CHARS` and
`_index_text` from the production module rather than recomputing a length, so a
future cap change carries automatically. Failure output names the skill, the
field, and how many characters are being lost.

`test_builtin_static_visual_design.py` was re-anchored to the new wording; its
two separate "full value" and "routing value" assertion blocks collapsed into an
equality check, since the field is now provably under the cap.

## Verification

```
.venv/bin/pytest tests/skills tests/core/agent/test_skill_tool.py
118 passed, 1 skipped
```

Guardrail confirmed to bite: padding `agent-builder`'s description to 377 chars
fails with `description is 377 chars and gets truncated to 200; 177 chars never
reach the model`.

Behavioural evidence for the fix comes from the closed #1411, where three
Chinese-language brand prompts run through real ReAct executions moved
`skill_loaded` from 0.67 to 1.00 once `static-visual-design`'s truncated index
entries were repaired — that was the decisive change of that PR, isolated here.

## Scope

Frontmatter and index-entry mechanics only. No skill body, tool description, or
runtime behaviour is touched. The prompt-semantics work from #1411 (logo
authorization, repair-budget hand-back, planner-visible ordering) will follow in
separate PRs.
