### PR TITLE
fix(tools): scope asset retrieval to what the user asked for

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -26,8 +26,9 @@ from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 class DownloadWebAssetArgs(BaseModel):
     url: str = Field(
         description=(
-            "Exact HTTP or HTTPS image URL discovered on an authoritative page. "
-            "Prefer the official brand domain for logos."
+            "Exact HTTP or HTTPS image URL: one the user supplied directly, or "
+            "one surfaced while carrying out a retrieval the user asked for. "
+            "For a brand asset, prefer the brand's own domain or its CDN."
         )
     )
     filename: str | None = Field(
@@ -74,10 +75,13 @@ class DownloadWebAssetTool(AbstractBaseTool):
     def description(self) -> str:
         return (
             "Download an exact PNG, JPEG, WebP, GIF, BMP, or SVG asset from a "
-            "known URL and register it in the current workspace. Use this after "
-            "fetch_web_content(include_assets=true) discovers an official logo or "
-            "brand image. It returns a trusted FileRef, so do not reproduce the "
-            "asset through api_call plus write_file."
+            "known URL and register it in the current workspace. Use a URL the "
+            "user supplied directly, or one fetch_web_content(include_assets="
+            "true) surfaced while carrying out a retrieval the user asked for; a "
+            "downloaded image is not proof that it is a brand's authentic asset, "
+            "so do not treat one as verified identity material for a retrieval "
+            "nobody requested. It returns a trusted FileRef, so do not reproduce "
+            "the asset through api_call plus write_file."
         )
 
     @property

--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -87,8 +87,9 @@ class DownloadWebAssetTool(AbstractBaseTool):
             "asset counts as verified identity material only when the user "
             "supplied its bytes or confirmed the source. Naming a URL as the "
             "asset is that confirmation; one that merely served as a fetch route "
-            "is not. It returns a trusted FileRef, "
-            "so do not reproduce the asset through api_call plus write_file."
+            "is not. The download returns a workspace FileRef, so do not "
+            "reproduce the asset through api_call plus write_file — the FileRef "
+            "is trustworthy as a file, never as evidence of provenance."
         )
 
     @property

--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -85,7 +85,8 @@ class DownloadWebAssetTool(AbstractBaseTool):
             "enumerate a page does not authorize a download. Downloading also "
             "proves nothing about provenance — however the URL was reached, an "
             "asset counts as verified identity material only when the user "
-            "supplied it or confirmed the source. It returns a trusted FileRef, "
+            "supplied its bytes or confirmed the source; a URL they gave you is "
+            "a route, not a confirmation. It returns a trusted FileRef, "
             "so do not reproduce the asset through api_call plus write_file."
         )
 

--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -26,11 +26,12 @@ from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 class DownloadWebAssetArgs(BaseModel):
     url: str = Field(
         description=(
-            "Exact HTTP or HTTPS image URL: one the user supplied directly, or "
-            "one surfaced while carrying out a download the user asked for — "
-            "enumerating a page's resources is not such a request. For a brand "
-            "asset, prefer the brand's own domain or its CDN, and treat what "
-            "you get as unverified until the user confirms it."
+            "Exact HTTP or HTTPS image URL for an asset the user asked you to "
+            "obtain: one they supplied with that request, or one surfaced while "
+            "carrying it out. A URL pasted to be read or discussed, and a URL "
+            "that page enumeration merely listed, are not such requests. For a "
+            "brand asset, prefer the brand's own domain or its CDN, and treat "
+            "what you get as unverified until the user confirms it."
         )
     )
     filename: str | None = Field(

--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -31,7 +31,7 @@ class DownloadWebAssetArgs(BaseModel):
             "carrying it out. A URL pasted to be read or discussed, and a URL "
             "that page enumeration merely listed, are not such requests. For a "
             "brand asset, prefer the brand's own domain or its CDN, and treat "
-            "what you get as unverified until the user confirms it."
+            "what you get as unverified until the user confirms its source."
         )
     )
     filename: str | None = Field(
@@ -85,8 +85,9 @@ class DownloadWebAssetTool(AbstractBaseTool):
             "enumerate a page does not authorize a download. Downloading also "
             "proves nothing about provenance — however the URL was reached, an "
             "asset counts as verified identity material only when the user "
-            "supplied its bytes or confirmed the source; a URL they gave you is "
-            "a route, not a confirmation. It returns a trusted FileRef, "
+            "supplied its bytes or confirmed the source. Naming a URL as the "
+            "asset is that confirmation; one that merely served as a fetch route "
+            "is not. It returns a trusted FileRef, "
             "so do not reproduce the asset through api_call plus write_file."
         )
 

--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -27,8 +27,10 @@ class DownloadWebAssetArgs(BaseModel):
     url: str = Field(
         description=(
             "Exact HTTP or HTTPS image URL: one the user supplied directly, or "
-            "one surfaced while carrying out a retrieval the user asked for. "
-            "For a brand asset, prefer the brand's own domain or its CDN."
+            "one surfaced while carrying out a download the user asked for — "
+            "enumerating a page's resources is not such a request. For a brand "
+            "asset, prefer the brand's own domain or its CDN, and treat what "
+            "you get as unverified until the user confirms it."
         )
     )
     filename: str | None = Field(
@@ -75,13 +77,15 @@ class DownloadWebAssetTool(AbstractBaseTool):
     def description(self) -> str:
         return (
             "Download an exact PNG, JPEG, WebP, GIF, BMP, or SVG asset from a "
-            "known URL and register it in the current workspace. Use a URL the "
-            "user supplied directly, or one fetch_web_content(include_assets="
-            "true) surfaced while carrying out a retrieval the user asked for; a "
-            "downloaded image is not proof that it is a brand's authentic asset, "
-            "so do not treat one as verified identity material for a retrieval "
-            "nobody requested. It returns a trusted FileRef, so do not reproduce "
-            "the asset through api_call plus write_file."
+            "known URL and register it in the current workspace. The user has to "
+            "have asked you to obtain this asset: use a URL they supplied "
+            "directly, or one fetch_web_content(include_assets=true) surfaced "
+            "while carrying out that request. Being asked to inspect or "
+            "enumerate a page does not authorize a download. Downloading also "
+            "proves nothing about provenance — however the URL was reached, an "
+            "asset counts as verified identity material only when the user "
+            "supplied it or confirmed the source. It returns a trusted FileRef, "
+            "so do not reproduce the asset through api_call plus write_file."
         )
 
     @property

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -28,7 +28,9 @@ class FetchWebContentArgs(BaseModel):
         description=(
             "Optional substring such as 'logo' used to filter assets discovered "
             "in the fetched HTML, matched against each asset's URL, name, and "
-            "alt text. Leave it empty to list everything the page loads. "
+            "alt text. Leave it empty to list every supported static reference "
+            "found in the fetched HTML, subject to the tool's result limit; "
+            "runtime-loaded and CSS-nested resources are never enumerated. "
             "A <link rel=manifest> URL may be included among the "
             "discovered assets, but its contents are not fetched or searched."
         ),
@@ -88,7 +90,8 @@ class FetchWebContentTool(AbstractBaseTool):
             "discover sources. Set include_assets=true when the user asked you "
             "to obtain an exact asset, with asset_query matching it, or when "
             "they asked what a page loads, leaving asset_query empty so nothing "
-            "is filtered out. The page may be one they named or one web_search "
+            "is filtered out of the static references it found. The page may be "
+            "one they named or one web_search "
             "found for that request. What the tool is not for is going after a "
             "brand's identity assets uninstructed. Asset URLs come back with the "
             "official page URL preserved; when the user asked you to obtain one, "

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -28,7 +28,8 @@ class FetchWebContentArgs(BaseModel):
         description=(
             "Optional substring such as 'logo' used to filter assets discovered "
             "in the fetched HTML, matched against each asset's URL, name, and "
-            "alt text. A <link rel=manifest> URL may be included among the "
+            "alt text. Leave it empty to list everything the page loads. "
+            "A <link rel=manifest> URL may be included among the "
             "discovered assets, but its contents are not fetched or searched."
         ),
     )
@@ -84,13 +85,16 @@ class FetchWebContentTool(AbstractBaseTool):
             "to markdown. Use this after web_search finds a promising source, or "
             "when the user provides a URL that needs to be read. This is for "
             "retrieving page content; use web_search first when you need to "
-            "discover sources. When the user asked you to obtain an exact asset, "
-            "or to inspect what a page loads, set include_assets=true and "
-            "asset_query to match it — the page may be one they named or one "
-            "web_search found for that request. What the tool is not for is "
-            "going after a brand's identity assets uninstructed. The returned "
-            "assets preserve official page URLs; pass the chosen URL to "
-            "download_web_asset instead of recreating it with api_call/write_file."
+            "discover sources. Set include_assets=true when the user asked you "
+            "to obtain an exact asset, with asset_query matching it, or when "
+            "they asked what a page loads, leaving asset_query empty so nothing "
+            "is filtered out. The page may be one they named or one web_search "
+            "found for that request. What the tool is not for is going after a "
+            "brand's identity assets uninstructed. Asset URLs come back with the "
+            "official page URL preserved; when the user asked you to obtain one, "
+            "pass the chosen URL to download_web_asset instead of recreating it "
+            "with api_call/write_file — being asked to inspect a page is not "
+            "such a request."
         )
 
     @property

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -18,7 +18,8 @@ class FetchWebContentArgs(BaseModel):
             "Also list image, icon, manifest, script, stylesheet, and other "
             "link-reference URLs found in the page; nothing is downloaded. "
             "Enable it when the user asked "
-            "you to inspect or enumerate what a page loads, or to obtain an "
+            "you to inspect or enumerate the static references a page declares, "
+            "or to obtain an "
             "asset they asked for. Do not enable it to go asset-hunting on your "
             "own, and note that listing a URL here does not authorize "
             "download_web_asset — that needs its own request to obtain the asset."
@@ -31,9 +32,12 @@ class FetchWebContentArgs(BaseModel):
             "in the fetched HTML, matched against each asset's URL, name, and "
             "alt text. Leave it empty to list every supported static reference "
             "found in the fetched HTML, subject to the tool's result limit; "
-            "runtime-loaded and CSS-nested resources are never enumerated. "
-            "A <link rel=manifest> URL is returned regardless of the query, and "
-            "its contents are not fetched or searched."
+            "resources referenced only from CSS or constructed at runtime by "
+            "script are not enumerated, though lazy-loading attributes such as "
+            "data-src are. "
+            "A <link rel=manifest> URL is exempt from the query filter, though "
+            "not from the result limit, and its contents are never fetched or "
+            "searched."
         ),
     )
 

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -15,8 +15,11 @@ class FetchWebContentArgs(BaseModel):
     include_assets: bool = Field(
         default=False,
         description=(
-            "Also discover image, icon, manifest, script, and stylesheet URLs. "
-            "Enable this when looking for logos, brand assets, or images."
+            "Also list image, icon, manifest, script, and stylesheet URLs found "
+            "in the page; nothing is downloaded. Enable it when the user asked "
+            "you to inspect or enumerate what a page loads, or to obtain an "
+            "asset they asked for. Do not enable it to go asset-hunting on your "
+            "own."
         ),
     )
     asset_query: str | None = Field(
@@ -80,9 +83,12 @@ class FetchWebContentTool(AbstractBaseTool):
             "to markdown. Use this after web_search finds a promising source, or "
             "when the user provides a URL that needs to be read. This is for "
             "retrieving page content; use web_search first when you need to "
-            "discover sources. When the task needs a logo or other exact web "
-            "asset, set include_assets=true and usually asset_query='logo'. The "
-            "returned assets preserve official page URLs; pass the chosen URL to "
+            "discover sources. When the user asked you to obtain an exact asset, "
+            "or to inspect what a page loads, set include_assets=true and "
+            "asset_query to match it — the page may be one they named or one "
+            "web_search found for that request. What the tool is not for is "
+            "going after a brand's identity assets uninstructed. The returned "
+            "assets preserve official page URLs; pass the chosen URL to "
             "download_web_asset instead of recreating it with api_call/write_file."
         )
 

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -15,8 +15,9 @@ class FetchWebContentArgs(BaseModel):
     include_assets: bool = Field(
         default=False,
         description=(
-            "Also list image, icon, manifest, script, and stylesheet URLs found "
-            "in the page; nothing is downloaded. Enable it when the user asked "
+            "Also list image, icon, manifest, script, stylesheet, and other "
+            "link-reference URLs found in the page; nothing is downloaded. "
+            "Enable it when the user asked "
             "you to inspect or enumerate what a page loads, or to obtain an "
             "asset they asked for. Do not enable it to go asset-hunting on your "
             "own, and note that listing a URL here does not authorize "
@@ -26,13 +27,13 @@ class FetchWebContentArgs(BaseModel):
     asset_query: str | None = Field(
         default=None,
         description=(
-            "Optional substring such as 'logo' used to filter assets discovered "
+            "Optional substring such as 'hero' used to filter assets discovered "
             "in the fetched HTML, matched against each asset's URL, name, and "
             "alt text. Leave it empty to list every supported static reference "
             "found in the fetched HTML, subject to the tool's result limit; "
             "runtime-loaded and CSS-nested resources are never enumerated. "
-            "A <link rel=manifest> URL may be included among the "
-            "discovered assets, but its contents are not fetched or searched."
+            "A <link rel=manifest> URL is returned regardless of the query, and "
+            "its contents are not fetched or searched."
         ),
     )
 
@@ -61,8 +62,9 @@ class FetchWebContentResult(BaseModel):
         default_factory=list,
         description=(
             "Static asset URLs discovered by parsing the fetched HTML (images, "
-            "icons, stylesheets, scripts, and any linked manifest URL) — the "
-            "manifest itself, if present, is not fetched or searched"
+            "icons, stylesheets, scripts, other link references, and any linked "
+            "manifest URL) — the manifest itself, if present, is not fetched or "
+            "searched"
         ),
     )
 
@@ -89,8 +91,9 @@ class FetchWebContentTool(AbstractBaseTool):
             "retrieving page content; use web_search first when you need to "
             "discover sources. Set include_assets=true when the user asked you "
             "to obtain an exact asset, with asset_query matching it, or when "
-            "they asked what a page loads, leaving asset_query empty so nothing "
-            "is filtered out of the static references it found. The page may be "
+            "they asked what a page loads, leaving asset_query empty so none of "
+            "the static references it found are filtered out (the result limit "
+            "still applies). The page may be "
             "one they named or one web_search "
             "found for that request. What the tool is not for is going after a "
             "brand's identity assets uninstructed. Asset URLs come back with the "

--- a/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
+++ b/src/xagent/core/tools/adapters/vibe/fetch_web_content.py
@@ -19,7 +19,8 @@ class FetchWebContentArgs(BaseModel):
             "in the page; nothing is downloaded. Enable it when the user asked "
             "you to inspect or enumerate what a page loads, or to obtain an "
             "asset they asked for. Do not enable it to go asset-hunting on your "
-            "own."
+            "own, and note that listing a URL here does not authorize "
+            "download_web_asset — that needs its own request to obtain the asset."
         ),
     )
     asset_query: str | None = Field(

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -59,7 +59,9 @@ When given a user request, rewrite and enrich the prompt into a **professional i
      input. A URL is only a retrieval route: asking you to retrieve one
      authorizes the fetch, not the authenticity, and what comes back stays
      unverified identity material until the user confirms its source — an
-     unverified mark cannot serve an identity-critical reference.
+     unverified mark cannot serve an identity-critical reference. A user naming
+     a URL as the asset ("here is our logo: <url>") is that confirmation; a URL
+     that merely served as a fetch route is not.
      When nothing verifiable is available, ask the user how to proceed — and once
      they have chosen to continue without it, act on that choice instead of
      asking again. Pass such a reference by path, URL, or
@@ -154,7 +156,9 @@ an asset is the brand's. Bytes the user already put in this task or its
 workspace are trusted input. A URL is only a retrieval route: asking you to
 retrieve one authorizes the fetch, not the authenticity, and what comes back
 stays unverified identity material until the user confirms its source — an
-unverified mark cannot serve an identity-critical reference. When nothing
+unverified mark cannot serve an identity-critical reference. A user naming a URL
+as the asset ("here is our logo: <url>") is that confirmation; a URL that merely
+served as a fetch route is not. When nothing
 verifiable is available, ask the user
 how to proceed — and once they have chosen to continue without it, act on that
 choice instead of asking again.

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -55,11 +55,12 @@ When given a user request, rewrite and enrich the prompt into a **professional i
      one on your own initiative, not even from a brand's official site, and
      never take one from the user's other tasks. A plausible-looking search
      result is not proof that an asset is the brand's.
-     Bytes the user already put in this task or its workspace are trusted
-     input. A URL is only a retrieval route: asking you to retrieve one
+     Bytes the user themselves put in this task or its workspace are trusted
+     input; bytes you fetched are not, however they got there. A URL is only a
+     retrieval route: asking you to retrieve one
      authorizes the fetch, not the authenticity, and what comes back stays
      unverified identity material until the user confirms its source — an
-     unverified mark cannot serve an identity-critical reference. A user naming
+     unverified mark cannot serve as an identity-critical reference. A user naming
      a URL as the asset ("here is our logo: <url>") is that confirmation; a URL
      that merely served as a fetch route is not.
      When nothing verifiable is available, ask the user how to proceed — and once
@@ -153,10 +154,11 @@ user directed you to retrieve; do not retrieve source or reference material on
 your own initiative, not even from a brand's official site, and never take one
 from the user's other tasks. A plausible-looking search result is not proof that
 an asset is the brand's. Bytes the user already put in this task or its
-workspace are trusted input. A URL is only a retrieval route: asking you to
+workspace are trusted input; bytes you fetched are not, however they got
+there. A URL is only a retrieval route: asking you to
 retrieve one authorizes the fetch, not the authenticity, and what comes back
 stays unverified identity material until the user confirms its source — an
-unverified mark cannot serve an identity-critical reference. A user naming a URL
+unverified mark cannot serve as an identity-critical reference. A user naming a URL
 as the asset ("here is our logo: <url>") is that confirmation; a URL that merely
 served as a fetch route is not. When nothing
 verifiable is available, ask the user

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -54,10 +54,13 @@ When given a user request, rewrite and enrich the prompt into a **professional i
      produced, or an asset the user directed you to retrieve; do not retrieve
      one on your own initiative, not even from a brand's official site, and
      never take one from the user's other tasks. A plausible-looking search
-     result is not proof that an asset is the brand's; when nothing verifiable
-     is available, ask the user how to proceed — and once they have chosen to
-     continue without it, act on that choice instead of asking again. Pass such
-     a reference by path, URL, or
+     result is not proof that an asset is the brand's, and neither is one the
+     user sent you after: their direction permits the retrieval, not the
+     authenticity — a fetched result stays unverified until they confirm its
+     source, and an unverified mark cannot serve an identity-critical reference.
+     When nothing verifiable is available, ask the user how to proceed — and once
+     they have chosen to continue without it, act on that choice instead of
+     asking again. Pass such a reference by path, URL, or
      file_id through the images parameter. Mentioning a reference only in the
      prompt does not attach it to the model request.
   4. Generated depictions are not suitable when a supplied logo, QR code,
@@ -145,8 +148,11 @@ Use only images the user supplied, the task already produced, or an asset the
 user directed you to retrieve; do not retrieve source or reference material on
 your own initiative, not even from a brand's official site, and never take one
 from the user's other tasks. A plausible-looking search result is not proof that
-an asset is the brand's; when nothing verifiable is available, ask the user how
-to proceed — and once they have chosen to continue without it, act on that
+an asset is the brand's, and neither is one the user sent you after: their
+direction permits the retrieval, not the authenticity — a fetched result stays
+unverified until they confirm its source, and an unverified mark cannot serve an
+identity-critical reference. When nothing verifiable is available, ask the user
+how to proceed — and once they have chosen to continue without it, act on that
 choice instead of asking again.
 
 Available models (⭐[DEFAULT] marks the configured default model):

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -54,10 +54,12 @@ When given a user request, rewrite and enrich the prompt into a **professional i
      produced, or an asset the user directed you to retrieve; do not retrieve
      one on your own initiative, not even from a brand's official site, and
      never take one from the user's other tasks. A plausible-looking search
-     result is not proof that an asset is the brand's, and neither is one the
-     user sent you after: their direction permits the retrieval, not the
-     authenticity — a fetched result stays unverified until they confirm its
-     source, and an unverified mark cannot serve an identity-critical reference.
+     result is not proof that an asset is the brand's.
+     Bytes the user already put in this task or its workspace are trusted
+     input. A URL is only a retrieval route: asking you to retrieve one
+     authorizes the fetch, not the authenticity, and what comes back stays
+     unverified identity material until the user confirms its source — an
+     unverified mark cannot serve an identity-critical reference.
      When nothing verifiable is available, ask the user how to proceed — and once
      they have chosen to continue without it, act on that choice instead of
      asking again. Pass such a reference by path, URL, or
@@ -148,10 +150,12 @@ Use only images the user supplied, the task already produced, or an asset the
 user directed you to retrieve; do not retrieve source or reference material on
 your own initiative, not even from a brand's official site, and never take one
 from the user's other tasks. A plausible-looking search result is not proof that
-an asset is the brand's, and neither is one the user sent you after: their
-direction permits the retrieval, not the authenticity — a fetched result stays
-unverified until they confirm its source, and an unverified mark cannot serve an
-identity-critical reference. When nothing verifiable is available, ask the user
+an asset is the brand's. Bytes the user already put in this task or its
+workspace are trusted input. A URL is only a retrieval route: asking you to
+retrieve one authorizes the fetch, not the authenticity, and what comes back
+stays unverified identity material until the user confirms its source — an
+unverified mark cannot serve an identity-critical reference. When nothing
+verifiable is available, ask the user
 how to proceed — and once they have chosen to continue without it, act on that
 choice instead of asking again.
 

--- a/src/xagent/core/tools/core/image_tool.py
+++ b/src/xagent/core/tools/core/image_tool.py
@@ -51,11 +51,13 @@ When given a user request, rewrite and enrich the prompt into a **professional i
   2. Quote required copy clearly and keep unnecessary text out.
   3. Reference images can guide product identity, visual language, palette, and
      composition. Use only references the user supplied, the task already
-     produced, or an asset retrieved from the brand's own official source; do
-     not go looking for reference material from any other origin, and never take
-     one from the user's other tasks. A plausible-looking search result is not
-     proof that an asset is the brand's; when nothing verifiable is available,
-     ask the user for it. Pass such a reference by path, URL, or
+     produced, or an asset the user directed you to retrieve; do not retrieve
+     one on your own initiative, not even from a brand's official site, and
+     never take one from the user's other tasks. A plausible-looking search
+     result is not proof that an asset is the brand's; when nothing verifiable
+     is available, ask the user how to proceed — and once they have chosen to
+     continue without it, act on that choice instead of asking again. Pass such
+     a reference by path, URL, or
      file_id through the images parameter. Mentioning a reference only in the
      prompt does not attach it to the model request.
   4. Generated depictions are not suitable when a supplied logo, QR code,
@@ -139,11 +141,13 @@ Text handling in edited images:
   exact fidelity is required, explain the limitation and ask the user to arrange
   deterministic post-processing — never present a generative edit as exact.
 
-Use only images the user supplied, the task already produced, or an asset
-retrieved from the brand's own official source; do not go looking for source or
-reference material from any other origin, and never take one from the user's
-other tasks. A plausible-looking search result is not proof that an asset is the
-brand's; when nothing verifiable is available, ask the user for it.
+Use only images the user supplied, the task already produced, or an asset the
+user directed you to retrieve; do not retrieve source or reference material on
+your own initiative, not even from a brand's official site, and never take one
+from the user's other tasks. A plausible-looking search result is not proof that
+an asset is the brand's; when nothing verifiable is available, ask the user how
+to proceed — and once they have chosen to continue without it, act on that
+choice instead of asking again.
 
 Available models (⭐[DEFAULT] marks the configured default model):
 {}

--- a/src/xagent/core/tools/core/video_tool.py
+++ b/src/xagent/core/tools/core/video_tool.py
@@ -148,7 +148,7 @@ Parameters:
 - watermark (optional): whether to include provider watermark. Defaults to true when supported.
 - return_last_frame (optional): ask the provider to return the last frame URL when supported.
 - first_frame_image_url / last_frame_image_url (optional): Seedance-style first/last-frame control.
-- reference_image_urls / reference_video_urls / reference_audio_urls (optional): public URLs used as references. Audio references require at least one image or video reference.
+- reference_image_urls / reference_video_urls / reference_audio_urls (optional): public URLs used as references. Audio references require at least one image or video reference. Use only references the user supplied, the task already produced, or an asset the user directed you to retrieve; do not retrieve one on your own initiative, not even from a brand's official site. Bytes the user themselves put in this task or its workspace are trusted input; bytes you fetched are not, however they got there. A URL is only a retrieval route: asking you to retrieve one authorizes the fetch, not the authenticity, and what comes back stays unverified identity material until the user confirms its source — an unverified mark cannot serve as an identity-critical reference. A user naming a URL as the asset ("here is our logo: <url>") is that confirmation; a URL that merely served as a fetch route is not.
 - wait_for_result (optional): wait for task completion and download the result. Defaults to true.
 - poll_interval (optional): polling interval in seconds while waiting. Defaults to 30.
 - timeout (optional): maximum wait time in seconds.

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -181,12 +181,13 @@ useful product, campaign, style, or layout references to image generation or
 editing so the result belongs to the intended visual world.
 
 For work naming a real brand, resolve the brand identity before rendering final
-candidates. Three sources are legitimate: an asset the user gave you in this task
-— including one attached in an earlier turn, whose file_id is no longer in context
-and which you recover by finding it with `list_all_user_files` — the current task
-workspace, and the brand's own official web presence, retrieved with the web
-tools available to you. If none of them yields a verified asset, ask the user for
-it; a visually plausible search result is not proof that a logo is authentic.
+candidates. Two sources need no permission: an asset the user gave you in this
+task — including one attached in an earlier turn, whose file_id is no longer in
+context and which you recover by finding it with `list_all_user_files` — and the
+current task workspace. Going to look for the asset yourself is a third path that
+belongs to the user, not to you: take it only when they tell you to. If no source
+yields a verified asset, ask the user for it; a visually plausible search result
+is not proof that a logo is authentic.
 
 The user's other tasks and earlier outputs are not a source. Do not list them
 looking for brand material, and do not reverse-engineer a brand's identity by

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -82,11 +82,12 @@ locked: each executor receives a distinct proposition, structure, focal device,
 production finish, and explicit exclusions, and must not reinterpret the other
 directions.
 
-Represent this order in the execution plan. Brand/reference acquisition is a
-shared prerequisite, creative direction and design specification depend on that
-grounding, and every render depends on the locked specification. Do not search
-for identity assets in parallel with artifact generation. Inspection depends on
-the render results. Independent renders may run in parallel only after all
+Represent this order in the execution plan. Gathering the brand and reference
+assets you already have — supplied in this task, in the workspace, or retrieved
+at the user's direction, never by searching on your own — is a shared
+prerequisite; creative direction and design specification depend on that
+grounding, and every render depends on the locked specification. Inspection
+depends on the render results. Independent renders may run in parallel only after all
 shared inputs are resolved.
 
 Never bake asset-availability conclusions into planned work before the
@@ -187,9 +188,10 @@ context and which you recover by finding it with `list_all_user_files` — and t
 current task workspace. Going to look for the asset yourself is a third path that
 belongs to the user, not to you: take it only when they tell you to. Bytes
 already in this task or its workspace are trusted input; a URL is only a
-retrieval route, and being asked to retrieve one authorizes the fetch, not the
-authenticity — what comes back stays unverified identity material until the user
-confirms its source. Being told to look at a page is not
+retrieval route: asking you to retrieve one authorizes the fetch, not the
+authenticity, and what comes back stays unverified identity material until the
+user confirms its source. A user naming a URL as the asset ("here is our logo:
+<url>") is that confirmation; a URL that merely served as a fetch route is not. Being told to look at a page is not
 being told to take what it holds — list what is there, then
 ask before acquiring or using it. If no source yields a verified asset, ask the
 user how to proceed — supply it, reserve clean space for it, or build the concept

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -185,9 +185,11 @@ candidates. Two sources need no permission: an asset the user gave you in this
 task — including one attached in an earlier turn, whose file_id is no longer in
 context and which you recover by finding it with `list_all_user_files` — and the
 current task workspace. Going to look for the asset yourself is a third path that
-belongs to the user, not to you: take it only when they tell you to. If no source
-yields a verified asset, ask the user for it; a visually plausible search result
-is not proof that a logo is authentic.
+belongs to the user, not to you: take it only when they tell you to. Being told to
+look at a page is not being told to take what it holds — list what is there, then
+ask before acquiring or using it. If no source yields a verified asset, ask the
+user for it; a visually plausible search result is not proof that a logo is
+authentic.
 
 The user's other tasks and earlier outputs are not a source. Do not list them
 looking for brand material, and do not reverse-engineer a brand's identity by

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -187,7 +187,8 @@ task — including one attached in an earlier turn, whose file_id is no longer i
 context and which you recover by finding it with `list_all_user_files` — and the
 current task workspace. Going to look for the asset yourself is a third path that
 belongs to the user, not to you: take it only when they tell you to. Bytes
-already in this task or its workspace are trusted input; a URL is only a
+the user themselves put in this task or its workspace are trusted input; bytes
+you fetched are not, however they got there; a URL is only a
 retrieval route: asking you to retrieve one authorizes the fetch, not the
 authenticity, and what comes back stays unverified identity material until the
 user confirms its source. A user naming a URL as the asset ("here is our logo:
@@ -228,8 +229,9 @@ Separate stable identity cues from temporary campaign styling. Stable cues may
 include the official logo, recurring color relationships, typography character,
 product imagery, graphic proportions, and tone of voice. Temporary styling may
 include a particular gradient, metallic 3D type, bevel, glow, ribbon, confetti,
-swoosh, or seasonal campaign motif. Use several recent official references when
-available to infer what recurs; do not copy every effect from one old banner.
+swoosh, or seasonal campaign motif. When several recent references are already
+available to you from the sources above, infer what recurs across them; do not
+go collecting more, and do not copy every effect from one old banner.
 
 When official references look dated, familiarity still matters, but datedness
 is not a brand requirement. Preserve recognition through the stable cues and
@@ -423,9 +425,11 @@ layout.
 
 The gate has two halves and the budget touches only one of them.
 
-**Coverage is unconditional.** Do not enter `final_answer` until every required
-asset exists as a successful tool result, including every direction and placement
-the brief or this skill asks for. A spent budget is never a reason an asset is
+**Coverage is unconditional, with one exception.** Do not enter `final_answer`
+until every required asset exists as a successful tool result, including every
+direction and placement the brief or this skill asks for. The exception is a
+branded final the user has already chosen to go without: that one asset stays
+incomplete by their decision, and the rule below governs instead. A spent budget is never a reason an asset is
 absent, because coverage is not budgeted: if one has no candidate, render it. A
 brand-specific final also needs its verified logo — when none was ever obtained
 and the user has not yet chosen, ask rather than shipping a substitute. Once they

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -185,9 +185,11 @@ candidates. Two sources need no permission: an asset the user gave you in this
 task — including one attached in an earlier turn, whose file_id is no longer in
 context and which you recover by finding it with `list_all_user_files` — and the
 current task workspace. Going to look for the asset yourself is a third path that
-belongs to the user, not to you: take it only when they tell you to. Their
-direction permits the retrieval, not the authenticity: what comes back stays
-unverified until they confirm its source. Being told to look at a page is not
+belongs to the user, not to you: take it only when they tell you to. Bytes
+already in this task or its workspace are trusted input; a URL is only a
+retrieval route, and being asked to retrieve one authorizes the fetch, not the
+authenticity — what comes back stays unverified identity material until the user
+confirms its source. Being told to look at a page is not
 being told to take what it holds — list what is there, then
 ask before acquiring or using it. If no source yields a verified asset, ask the
 user how to proceed — supply it, reserve clean space for it, or build the concept

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -185,11 +185,15 @@ candidates. Two sources need no permission: an asset the user gave you in this
 task — including one attached in an earlier turn, whose file_id is no longer in
 context and which you recover by finding it with `list_all_user_files` — and the
 current task workspace. Going to look for the asset yourself is a third path that
-belongs to the user, not to you: take it only when they tell you to. Being told to
-look at a page is not being told to take what it holds — list what is there, then
+belongs to the user, not to you: take it only when they tell you to. Their
+direction permits the retrieval, not the authenticity: what comes back stays
+unverified until they confirm its source. Being told to look at a page is not
+being told to take what it holds — list what is there, then
 ask before acquiring or using it. If no source yields a verified asset, ask the
-user for it; a visually plausible search result is not proof that a logo is
-authentic.
+user how to proceed — supply it, reserve clean space for it, or build the concept
+unbranded — and once they choose, act on that choice instead of asking again; only
+a later change in what they want reopens the question. A visually plausible search
+result is not proof that a logo is authentic.
 
 The user's other tasks and earlier outputs are not a source. Do not list them
 looking for brand material, and do not reverse-engineer a brand's identity by
@@ -211,10 +215,10 @@ Treat identity-critical assets differently:
   placement requires exact reproduction, say so plainly and ask the user to
   arrange deterministic post-processing; never claim a generated candidate is one.
 - Unless the user explicitly requests an unbranded or logo-free concept, a
-  brand-specific final requires a verified logo. If none is available, ask for
-  it and keep any interim output clearly labeled as a concept draft. Do not mark
-  the requested branded asset complete, and never typeset or invent a substitute
-  logo.
+  brand-specific final requires a verified logo. If none is available, ask how to
+  proceed once. After they choose reserved space or an unbranded concept, render
+  and inspect that draft without asking again, label it a concept draft, and leave
+  only the branded final incomplete. Never typeset or invent a substitute logo.
 
 Separate stable identity cues from temporary campaign styling. Stable cues may
 include the official logo, recurring color relationships, typography character,
@@ -419,9 +423,11 @@ The gate has two halves and the budget touches only one of them.
 asset exists as a successful tool result, including every direction and placement
 the brief or this skill asks for. A spent budget is never a reason an asset is
 absent, because coverage is not budgeted: if one has no candidate, render it. A
-brand-specific final also needs its verified logo — when none was ever obtained,
-ask the user rather than shipping a substitute, and keep the interim output
-labeled a concept draft rather than marking the branded asset complete.
+brand-specific final also needs its verified logo — when none was ever obtained
+and the user has not yet chosen, ask rather than shipping a substitute. Once they
+have chosen reserved space or an unbranded concept, that draft is the deliverable
+for this turn: hand it back labeled a concept draft, with only the branded final
+left incomplete, and do not reopen the question.
 
 **Quality is what the budget releases.** Every asset should pass
 `understand_media` inspection with no automatic rejection; a successful

--- a/src/xagent/skills/builtin/static-visual-design/references/static-ad-art-direction.md
+++ b/src/xagent/skills/builtin/static-visual-design/references/static-ad-art-direction.md
@@ -208,8 +208,9 @@ locked direction in a separate generation call.
 
 References must already be resolved before rendering begins. Every generation
 step must depend on the shared brand-and-brief step and receive the locked
-direction, exact copy, and relevant reference assets. Do not search for the logo
-in parallel with generation. Attach acquired references through the image
+direction, exact copy, and relevant reference assets. Identity assets come only
+from the main skill's sanctioned sources — never from a search you started
+yourself. Attach acquired references through the image
 tool's actual image-input parameter; a filename mentioned only inside prose is
 not a model input.
 

--- a/tests/core/agent/test_skill_tool.py
+++ b/tests/core/agent/test_skill_tool.py
@@ -1,9 +1,8 @@
 """Tests for the model-invocable ``load_skill`` tool and skill index."""
 
-from typing import Any
-
 import pytest
 
+from tests.shared.fake_skill_manager import FakeSkillManager
 from xagent.core.agent.context import ExecutionContext
 from xagent.core.agent.context.enrichment import (
     SELECTED_SKILL_METADATA_KEY,
@@ -28,24 +27,6 @@ CODER_SKILL = {
     "when_to_use": "Coding tasks",
     "content": "Prefer small functions.",
 }
-
-
-class FakeSkillManager:
-    def __init__(self, skills: list[dict[str, Any]]) -> None:
-        self.skills = {skill["name"]: skill for skill in skills}
-
-    async def list_skills(self) -> list[dict[str, Any]]:
-        return [
-            {
-                "name": skill["name"],
-                "description": skill.get("description", ""),
-                "when_to_use": skill.get("when_to_use", ""),
-            }
-            for skill in self.skills.values()
-        ]
-
-    async def get_skill(self, name: str) -> dict[str, Any] | None:
-        return self.skills.get(name)
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/core/test_image_tool_core.py
+++ b/tests/core/tools/core/test_image_tool_core.py
@@ -115,7 +115,10 @@ class TestImageGenerationToolCore:
     """Test cases for ImageGenerationToolCore class"""
 
     def test_generate_description_enforces_single_canvas_and_copy_budget(self):
-        description = ImageGenerationToolCore.GENERATE_IMAGE_DESCRIPTION
+        # Normalized: these anchors are sentences and the source wraps them.
+        description = " ".join(
+            ImageGenerationToolCore.GENERATE_IMAGE_DESCRIPTION.split()
+        )
 
         assert "one single final" in description
         assert "one continuous canvas" in description
@@ -125,10 +128,11 @@ class TestImageGenerationToolCore:
         assert "file_id through the images parameter" in description
         assert "Use only references the user supplied" in description
         # The curb this description exists for.
-        assert "not go looking" in description
-        # The official source is the third origin static-visual-design sanctions;
-        # dropping it here would forbid what the skill requires.
-        assert "brand's own official source" in description
+        assert "do not retrieve one on your own initiative" in description
+        # An official site is no longer a standing origin: this description is in
+        # context even when the skill is not, so it cannot offer the wider route.
+        assert "an asset the user directed you to retrieve" in description
+        assert "brand's own official source" not in description
         # Without the authenticity guard the carve-out reads as "go fetch a logo"
         # in every run where the skill is not loaded.
         assert "plausible-looking search result" in description
@@ -137,11 +141,12 @@ class TestImageGenerationToolCore:
     def test_edit_description_restricts_reference_sources(self):
         # generate_image routes reference-based work here, so the restriction has
         # to hold on both descriptions or the model just switches tools.
-        description = ImageGenerationToolCore.EDIT_IMAGE_DESCRIPTION
+        description = " ".join(ImageGenerationToolCore.EDIT_IMAGE_DESCRIPTION.split())
 
         assert "Use only images the user supplied" in description
-        assert "not go looking" in description
-        assert "brand's own official source" in description
+        assert "do not retrieve source or reference material on your own" in description
+        assert "an asset the user directed you to retrieve" in description
+        assert "brand's own official source" not in description
         assert "plausible-looking search result" in description
         assert "never take" in description and "other tasks" in description
         assert "never present a generative edit as exact" in description

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -1,13 +1,8 @@
 """Asset-retrieval tool descriptions must not authorize unprompted retrieval.
 
-These descriptions are injected into the tool schema on every tool-capable step,
-while a skill's policy is only present once it has been loaded. A description
-that offers a wider route than the skill allows therefore wins by default, so the
-authorization wording has to live here too.
-
-The surfaces are read from the tools as they are actually built, and the
-inventory is walked out of the adapter package, so a new retrieval tool fails
-here rather than slipping past a hand-written list.
+A tool description is in the schema on every step; a skill's policy only after
+it loads, so a wider description silently wins. Surfaces are read from the built
+tools and the inventory is walked out of the package, not hand-listed.
 """
 
 import importlib
@@ -20,6 +15,7 @@ import pytest
 from pydantic import BaseModel
 
 import xagent.core.tools.adapters.vibe as vibe_pkg
+from tests.shared.fake_skill_manager import FakeSkillManager
 from xagent.core.model.image.base import BaseImageModel
 from xagent.core.model.video.base import BaseVideoModel
 from xagent.core.tools.adapters.vibe.base import AbstractBaseTool, ToolCategory
@@ -33,16 +29,10 @@ from xagent.core.tools.adapters.vibe.fetch_web_content import (
 )
 from xagent.core.tools.adapters.vibe.image_tool import ImageGenerationTool
 from xagent.core.tools.adapters.vibe.video_tool import VideoGenerationTool
+from xagent.skills.manager import SkillManager
 from xagent.skills.parser import SkillParser
 
-SKILL_DIR = (
-    Path(__file__).resolve().parents[3]
-    / "src"
-    / "xagent"
-    / "skills"
-    / "builtin"
-    / "static-visual-design"
-)
+SKILL_DIR = SkillManager.get_builtin_root() / "static-visual-design"
 
 
 def _normalized(text: str) -> str:
@@ -54,11 +44,7 @@ def _field(model: type[BaseModel], name: str) -> str:
 
 
 def _built_image_descriptions() -> dict[str, str]:
-    """The generate/edit descriptions as `get_tools` emits them to the schema.
-
-    Reading the class constants instead would miss anything the builder prepends
-    or interpolates.
-    """
+    """As `get_tools` emits them: the class constants miss builder interpolation."""
     model = Mock(spec=BaseImageModel)
     workspace = Mock()
     workspace.output_dir = Path("/tmp/asset-authorization-test")
@@ -128,19 +114,14 @@ RETRIEVAL_TOOL_CLASSES = {
 }
 
 # Reach the network or take a URL, but cannot turn one into a reusable asset
-# reference: query-only search returns text and takes no URL; the browser session
-# tools act on an already-open page; the vision and image FunctionTool wrappers
-# carry whichever description their builder hands them, asserted through the built
-# surfaces instead.
+# reference.
 NOT_A_RETRIEVAL_ROUTE = {
-    # Query-only search: returns text, takes no URL.
+    # Query-only: returns text, takes no URL.
     "ExaWebSearchTool",
     "TavilyWebSearchTool",
     "WebSearchTool",
     "ZhipuWebSearchTool",
-    # FunctionTool wrappers whose builders emit no URL-taking parameter. The
-    # image and video wrappers are absent on purpose: their built descriptions
-    # are asserted as surfaces above.
+    # Wrappers whose builders emit no URL-taking parameter.
     "VisionFunctionTool",
     "AudioFunctionTool",
     "MusicFunctionTool",
@@ -156,26 +137,21 @@ NOT_A_RETRIEVAL_ROUTE = {
     "BrowserScreenshotTool",
     "BrowserSelectOptionTool",
     "BrowserWaitForSelectorTool",
-    # Local file, document, and data operations: no remote fetch.
+    # Local file, document, and data operations.
     "FileAnalysisTool",
     "FileTool",
     "PPTXTool",
     "SQLQueryFunctionTool",
     "SkillTool",
-    # Delegating wrappers: the wrapped tool's class carries the classification,
-    # and the wrapper forwards its description verbatim.
+    # Delegating wrappers: the wrapped class carries the classification.
     "OutputFilteredToolWrapper",
     "SandboxedToolWrapper",
 }
 
-# General-purpose remote routes that predate this contract and are not scoped to
-# asset retrieval: constraining them to "only when the user asked for an asset"
-# would break their ordinary use. Listed so they are an explicit carve-out rather
-# than a silent omission; tightening them is its own change.
+# General-purpose remote routes predating this contract. Listed as an explicit
+# carve-out rather than a silent omission; tightening them is its own change.
 GENERIC_REMOTE_ROUTE_OUT_OF_SCOPE = {
-    # Builder-produced wrappers: a concrete instance carries whichever
-    # description its builder supplies, so the governed ones are asserted as
-    # built surfaces rather than by class.
+    # Builder-produced: governed instances are asserted as built surfaces.
     "FunctionTool",
     "ImageGenerationFunctionTool",
     "VideoGenerationFunctionTool",
@@ -185,8 +161,7 @@ GENERIC_REMOTE_ROUTE_OUT_OF_SCOPE = {
     "BrowserNavigateTool",
     "ComputerTool",
     "CreateKnowledgeBaseFromUrlTool",
-    # Code executors can fetch anything by construction; constraining them to
-    # asset requests would break ordinary compute use.
+    # Code executors fetch anything by construction.
     "CommandExecutorFunctionTool",
     "JavaScriptExecutorFunctionTool",
     "PythonExecutorFunctionTool",
@@ -215,11 +190,7 @@ REMOTE_CAPABLE_CATEGORIES = (
 
 
 def _discovered_tool_classes() -> dict[str, type]:
-    """Every tool class that can pull a remote resource into the run.
-
-    Widened past the two categories this PR touches: a tool in any category that
-    accepts a URL is a route the policy has to account for.
-    """
+    """Every tool class that can pull a remote resource into the run."""
     # walk_packages, not iter_modules: subpackages such as sandboxed_tool are
     # only imported lazily by the factory and would otherwise stay invisible.
     for module in pkgutil.walk_packages(vibe_pkg.__path__, f"{vibe_pkg.__name__}."):
@@ -242,10 +213,8 @@ def _discovered_tool_classes() -> dict[str, type]:
             # Unbound on purpose: most args_type implementations ignore self.
             fields = set(cls.args_type(cls).model_fields)  # type: ignore[attr-defined]
         except Exception:
-            # Cannot be introspected statically (args_type reads instance
-            # state, e.g. CustomApiTool, SandboxedToolWrapper). Treat it as
-            # possibly remote so it must be classified explicitly — a swallowed
-            # error must never mean "not remote-capable".
+            # Not statically introspectable; a swallowed error must never read
+            # as "not remote-capable".
             return True
         return bool(URL_BEARING_FIELDS & fields)
 
@@ -361,10 +330,7 @@ def test_authorization_follows_the_request_not_the_url() -> None:
 
 
 def test_a_user_supplied_url_is_a_route_but_not_a_licence() -> None:
-    """A URL supplied with an obtain request is a valid route; one pasted to be
-    read is not. The obtain intent has to qualify both routes, not only the
-    surfaced one.
-    """
+    """The obtain intent qualifies both routes, not only the surfaced one."""
     surfaces = _surfaces()
 
     assert "they supplied with that request" in surfaces["download_web_asset.url"]
@@ -402,11 +368,7 @@ def test_include_assets_is_also_an_enumeration_contract() -> None:
 
 
 def test_page_wide_inspection_leaves_asset_query_empty() -> None:
-    """`_filter_and_deduplicate_assets` only filters on a non-empty query.
-
-    Telling the model to always set asset_query would drop exactly the unrelated
-    assets a page-wide inspection is asking for.
-    """
+    """A non-empty asset_query filters, so page-wide inspection leaves it empty."""
     fetch = _surfaces()["fetch_web_content.description"]
     assert "leaving asset_query empty so none of the static references" in fetch
     assert "the result limit still applies" in fetch
@@ -442,9 +404,8 @@ def test_asking_the_user_stops_once_they_have_chosen() -> None:
         assert "act on that choice instead of asking again" in text, name
 
 
-# The provenance rule as one canonical clause, stated word-for-word on the skill
-# and both image descriptions, so agreement is a comparison rather than per-side
-# spot checks that can drift independently.
+# One canonical clause, word-for-word on every surface, so agreement is a
+# comparison rather than per-side spot checks.
 ROUTE_CLAUSE = (
     "URL is only a retrieval route: asking you to retrieve one authorizes the "
     "fetch, not the authenticity, and what comes back stays unverified identity "
@@ -457,12 +418,7 @@ CONFIRMATION_CLAUSE = (
 
 
 def test_skill_and_tool_descriptions_agree_on_retrieval() -> None:
-    """Both land in the same context once the skill is loaded.
-
-    A skill that sanctions self-directed retrieval overrides the tool schema's
-    prohibition, so the two contracts carry the same canonical clauses — asserted
-    as one string on every surface, not as independent per-side literals.
-    """
+    """Both land in the same context, so both carry the same canonical clauses."""
     body = " ".join(SkillParser.parse(SKILL_DIR)["content"].split())
     surfaces = _surfaces()
 
@@ -499,23 +455,11 @@ def _system_context_after_load_skill() -> str:
     from xagent.core.agent.context.skill_tool import build_load_skill_tool
 
     skill = SkillParser.parse(SKILL_DIR)
-
-    class _Manager:
-        async def list_skills(self) -> list[dict]:
-            return [
-                {
-                    "name": skill["name"],
-                    "description": skill.get("description", ""),
-                    "when_to_use": skill.get("when_to_use", ""),
-                }
-            ]
-
-        async def get_skill(self, name: str) -> dict | None:
-            return skill if name == skill["name"] else None
+    manager = FakeSkillManager([skill])
 
     async def run() -> str:
         context = ExecutionContext(system_prompt="Base prompt.")
-        tool = await build_load_skill_tool(skill_manager=_Manager(), context=context)
+        tool = await build_load_skill_tool(skill_manager=manager, context=context)
         assert tool is not None
         await tool.execute(skill["name"])
         return str(context.get_messages_for_llm()[0]["content"])
@@ -531,11 +475,7 @@ def _section(system: str, heading: str, next_heading: str) -> str:
 
 
 def test_loaded_context_carries_the_policy_without_contradicting_it() -> None:
-    """Reading the file proves the text exists; this proves it reaches the model.
-
-    A transformation between the skill file and the assembled system message would
-    otherwise be invisible to every assertion above.
-    """
+    """Reading the file proves the text exists; this proves it reaches the model."""
     system = _system_context_after_load_skill()
 
     assert "Two sources need no permission" in system
@@ -548,11 +488,7 @@ def test_loaded_context_carries_the_policy_without_contradicting_it() -> None:
 
 
 def test_each_no_logo_gate_settles_the_choice_in_its_own_section() -> None:
-    """Three gates ask for a logo, so each needs its own after-choice rule.
-
-    A single global substring passes on whichever section happens to carry the
-    phrase, leaving the other two free to re-ask.
-    """
+    """Three gates ask for a logo; a global substring passes on any one of them."""
     system = _system_context_after_load_skill()
 
     source = _section(
@@ -574,11 +510,7 @@ def test_each_no_logo_gate_settles_the_choice_in_its_own_section() -> None:
 
 
 def test_provenance_reads_the_same_on_every_surface_that_states_it() -> None:
-    """One distinction, three places: bytes are trusted, a URL is only a route.
-
-    "Supplied" means a URL two sentences earlier in the downloader, so each
-    surface has to keep the two senses apart in its own text.
-    """
+    """Keep the two senses of "supplied" apart on every surface that states it."""
     surfaces = _surfaces()
     system = _system_context_after_load_skill()
 
@@ -598,12 +530,7 @@ def test_provenance_reads_the_same_on_every_surface_that_states_it() -> None:
 
 
 def test_naming_a_url_as_the_asset_confirms_the_source() -> None:
-    """ "Here is our logo: <url>" must not trigger a redundant re-ask.
-
-    The fetch is authorized and the source is confirmed in the same sentence, so
-    every surface that demands confirmation also has to define this as the
-    confirming act.
-    """
+    """Naming a URL as the asset is authorization and confirmation in one."""
     surfaces = _surfaces()
     system = _system_context_after_load_skill()
 
@@ -617,11 +544,7 @@ def test_naming_a_url_as_the_asset_confirms_the_source() -> None:
 
 
 def test_no_surface_frames_self_directed_search_as_a_pipeline_stage() -> None:
-    """The planning text and the always-loaded reference must not re-sanction it.
-
-    "Do not search in parallel" reads as "searching is expected, sequence it
-    right" — the residue this asserts against.
-    """
+    """ "Do not search in parallel" implies searching is expected; assert it is gone."""
     body = " ".join(SkillParser.parse(SKILL_DIR)["content"].split())
     reference = " ".join(
         (SKILL_DIR / "references" / "static-ad-art-direction.md").read_text().split()

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -70,6 +70,11 @@ def _built_image_descriptions() -> dict[str, str]:
     return {t.name: _normalized(t.description) for t in tool.get_tools()}
 
 
+# Emitted by the image builder but carrying no retrieval route: it only lists
+# configured models. Named so a third tool from the same wrapper fails below.
+IMAGE_TOOLS_WITHOUT_A_RETRIEVAL_ROUTE = {"list_image_models"}
+
+
 def _surfaces() -> dict[str, str]:
     """Every description reaching the model alongside an asset-fetch route."""
     image = _built_image_descriptions()
@@ -148,6 +153,20 @@ REQUIRED_WORDING = {
     "generate_image.description": "an asset the user directed you to retrieve",
     "edit_image.description": "an asset the user directed you to retrieve",
 }
+
+
+def test_every_built_image_tool_is_classified() -> None:
+    """A new tool from the same wrapper needs triage, not silent coverage."""
+    built = set(_built_image_descriptions())
+    named = {n.split(".")[0] for n in REQUIRED_WORDING} | (
+        IMAGE_TOOLS_WITHOUT_A_RETRIEVAL_ROUTE
+    )
+
+    assert built <= named, (
+        f"unclassified image tools: {sorted(built - named)}. Add each to "
+        f"REQUIRED_WORDING with its authorization wording, or to "
+        f"IMAGE_TOOLS_WITHOUT_A_RETRIEVAL_ROUTE if it takes no external reference."
+    )
 
 
 def test_every_retrieval_tool_is_classified() -> None:
@@ -251,8 +270,13 @@ def test_page_wide_inspection_leaves_asset_query_empty() -> None:
         "leaving asset_query empty so nothing is filtered out"
         in (_surfaces()["fetch_web_content.description"])
     )
-    assert "Leave it empty to list everything the page loads" in (
-        _field(FetchWebContentArgs, "asset_query")
+    query_field = _field(FetchWebContentArgs, "asset_query")
+    assert "Leave it empty to list every supported static reference" in query_field
+    # The tool parses the initial HTML and caps the result, so promising
+    # "everything the page loads" overstates what comes back.
+    assert "subject to the tool's result limit" in query_field
+    assert "runtime-loaded and CSS-nested resources are never enumerated" in (
+        query_field
     )
 
 
@@ -303,3 +327,53 @@ def test_skill_separates_looking_from_taking() -> None:
         body
     )
     assert "ask before acquiring or using it" in body
+
+
+def _system_context_after_load_skill() -> str:
+    """The system message an LLM call actually receives once the skill is loaded."""
+    import asyncio
+
+    from xagent.core.agent.context.execution import ExecutionContext
+    from xagent.core.agent.context.skill_tool import build_load_skill_tool
+
+    skill = SkillParser.parse(SKILL_DIR)
+
+    class _Manager:
+        async def list_skills(self) -> list[dict]:
+            return [
+                {
+                    "name": skill["name"],
+                    "description": skill.get("description", ""),
+                    "when_to_use": skill.get("when_to_use", ""),
+                }
+            ]
+
+        async def get_skill(self, name: str) -> dict | None:
+            return skill if name == skill["name"] else None
+
+    async def run() -> str:
+        context = ExecutionContext(system_prompt="Base prompt.")
+        tool = await build_load_skill_tool(skill_manager=_Manager(), context=context)
+        assert tool is not None
+        await tool.execute(skill["name"])
+        return str(context.get_messages_for_llm()[0]["content"])
+
+    return " ".join(asyncio.run(run()).split())
+
+
+def test_loaded_context_carries_the_policy_without_contradicting_it() -> None:
+    """Reading the file proves the text exists; this proves it reaches the model.
+
+    A transformation between the skill file and the assembled system message would
+    otherwise be invisible to every assertion above.
+    """
+    system = _system_context_after_load_skill()
+
+    assert "Two sources need no permission" in system
+    assert "take it only when they tell you to" in system
+    assert "their" in system and "direction permits the retrieval" in system
+    assert "act on that choice instead of asking again" in system
+    # The wording this PR exists to remove must not be reachable from the
+    # assembled context either.
+    for phrase in ("official web presence", "retrieved with the web tools"):
+        assert phrase not in system, f"assembled context still sanctions: {phrase!r}"

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 
 import xagent.core.tools.adapters.vibe as vibe_pkg
 from xagent.core.model.image.base import BaseImageModel
+from xagent.core.model.video.base import BaseVideoModel
 from xagent.core.tools.adapters.vibe.base import AbstractBaseTool, ToolCategory
 from xagent.core.tools.adapters.vibe.download_web_asset import (
     DownloadWebAssetArgs,
@@ -31,6 +32,7 @@ from xagent.core.tools.adapters.vibe.fetch_web_content import (
     FetchWebContentTool,
 )
 from xagent.core.tools.adapters.vibe.image_tool import ImageGenerationTool
+from xagent.core.tools.adapters.vibe.video_tool import VideoGenerationTool
 from xagent.skills.parser import SkillParser
 
 SKILL_DIR = (
@@ -70,15 +72,26 @@ def _built_image_descriptions() -> dict[str, str]:
     return {t.name: _normalized(t.description) for t in tool.get_tools()}
 
 
-def _built_image_description(name: str) -> str:
-    built = _built_image_descriptions()
-    assert name in built, f"image builder no longer emits {name!r}: {sorted(built)}"
+def _built_video_descriptions() -> dict[str, str]:
+    """generate_video accepts reference_image_urls, so it is a retrieval surface."""
+    model = Mock(spec=BaseVideoModel)
+    workspace = Mock()
+    workspace.output_dir = Path("/tmp/asset-authorization-test")
+    tool = VideoGenerationTool(
+        {"m": model}, {"m": "test model"}, workspace, default_video_model=model
+    )
+    return {t.name: _normalized(t.description) for t in tool.get_tools()}
+
+
+def _built_description(builder, name: str) -> str:
+    built = builder()
+    assert name in built, f"builder no longer emits {name!r}: {sorted(built)}"
     return built[name]
 
 
 # Emitted by the image builder but carrying no retrieval route: it only lists
 # configured models. Named so a third tool from the same wrapper fails below.
-IMAGE_TOOLS_WITHOUT_A_RETRIEVAL_ROUTE = {"list_image_models"}
+IMAGE_TOOLS_WITHOUT_A_RETRIEVAL_ROUTE = {"list_image_models", "list_video_models"}
 
 
 def _surfaces() -> dict[str, str]:
@@ -88,12 +101,22 @@ def _surfaces() -> dict[str, str]:
         "fetch_web_content.include_assets": _field(
             FetchWebContentArgs, "include_assets"
         ),
+        # Carries the one remaining 'logo' example this PR removed; without it
+        # here, no scan covers the field.
+        "fetch_web_content.asset_query": _field(FetchWebContentArgs, "asset_query"),
         "download_web_asset.description": _normalized(
             DownloadWebAssetTool(None).description  # type: ignore[arg-type]
         ),
         "download_web_asset.url": _field(DownloadWebAssetArgs, "url"),
-        "generate_image.description": _built_image_description("generate_image"),
-        "edit_image.description": _built_image_description("edit_image"),
+        "generate_image.description": _built_description(
+            _built_image_descriptions, "generate_image"
+        ),
+        "edit_image.description": _built_description(
+            _built_image_descriptions, "edit_image"
+        ),
+        "generate_video.description": _built_description(
+            _built_video_descriptions, "generate_video"
+        ),
     }
 
 
@@ -115,16 +138,13 @@ NOT_A_RETRIEVAL_ROUTE = {
     "TavilyWebSearchTool",
     "WebSearchTool",
     "ZhipuWebSearchTool",
-    # FunctionTool wrappers: each carries whichever description its builder
-    # hands it; the retrieval-relevant ones (image) are asserted through the
-    # built surfaces above, the rest generate media from prompts.
-    "FunctionTool",
-    "ImageGenerationFunctionTool",
+    # FunctionTool wrappers whose builders emit no URL-taking parameter. The
+    # image and video wrappers are absent on purpose: their built descriptions
+    # are asserted as surfaces above.
     "VisionFunctionTool",
     "AudioFunctionTool",
     "MusicFunctionTool",
     "SoundEffectFunctionTool",
-    "VideoGenerationFunctionTool",
     # Browser session actions on an already-open page.
     "BrowserClickTool",
     "BrowserCloseTool",
@@ -153,6 +173,12 @@ NOT_A_RETRIEVAL_ROUTE = {
 # would break their ordinary use. Listed so they are an explicit carve-out rather
 # than a silent omission; tightening them is its own change.
 GENERIC_REMOTE_ROUTE_OUT_OF_SCOPE = {
+    # Builder-produced wrappers: a concrete instance carries whichever
+    # description its builder supplies, so the governed ones are asserted as
+    # built surfaces rather than by class.
+    "FunctionTool",
+    "ImageGenerationFunctionTool",
+    "VideoGenerationFunctionTool",
     "APITool",
     "CustomApiTool",
     "MCPToolAdapter",
@@ -205,7 +231,12 @@ def _discovered_tool_classes() -> dict[str, type]:
             yield from descendants(sub)
 
     def remote_capable(cls: type) -> bool:
-        if getattr(cls, "category", None) in REMOTE_CAPABLE_CATEGORIES:
+        category = getattr(cls, "category", None)
+        if isinstance(category, property):
+            # Declared as a property, so its value needs an instance; treat it
+            # as unknown rather than silently not-remote.
+            return True
+        if category in REMOTE_CAPABLE_CATEGORIES:
             return True
         try:
             # Unbound on purpose: most args_type implementations ignore self.
@@ -219,7 +250,10 @@ def _discovered_tool_classes() -> dict[str, type]:
         return bool(URL_BEARING_FIELDS & fields)
 
     return {
-        c.__name__: c for c in set(descendants(AbstractBaseTool)) if remote_capable(c)
+        c.__name__: c
+        for c in set(descendants(AbstractBaseTool))
+        # __subclasses__ is process-global: test fixtures subclass this too.
+        if c.__module__.startswith(vibe_pkg.__name__) and remote_capable(c)
     }
 
 
@@ -239,14 +273,17 @@ REQUIRED_WORDING = {
         "when the user asked you to obtain an exact asset"
     ),
     "fetch_web_content.include_assets": (
-        "Enable it when the user asked you to inspect or enumerate what a page loads"
+        "Enable it when the user asked you to inspect or enumerate the static "
+        "references a page declares"
     ),
+    "fetch_web_content.asset_query": "Leave it empty to list every supported static",
     "download_web_asset.description": (
         "The user has to have asked you to obtain this asset"
     ),
     "download_web_asset.url": "for an asset the user asked you to obtain",
     "generate_image.description": "an asset the user directed you to retrieve",
     "edit_image.description": "an asset the user directed you to retrieve",
+    "generate_video.description": "an asset the user directed you to retrieve",
 }
 
 
@@ -282,6 +319,10 @@ def test_every_retrieval_tool_is_classified() -> None:
     assert set(RETRIEVAL_TOOL_CLASSES) <= discovered, (
         f"renamed or removed: {sorted(set(RETRIEVAL_TOOL_CLASSES) - discovered)}"
     )
+    # Dead entries hide the fact that a carve-out stopped applying.
+    assert classified <= discovered, (
+        f"classified but no longer discovered: {sorted(classified - discovered)}"
+    )
 
 
 def test_every_retrieval_tool_has_a_covered_surface() -> None:
@@ -297,7 +338,7 @@ def test_every_surface_has_required_wording() -> None:
     )
 
 
-@pytest.mark.parametrize("name", sorted(_surfaces()))
+@pytest.mark.parametrize("name", sorted(REQUIRED_WORDING))
 def test_surface_forbids_unprompted_retrieval(name: str) -> None:
     lowered = _surfaces()[name].lower()
     for phrase in BANNED_WORDING:
@@ -374,9 +415,11 @@ def test_page_wide_inspection_leaves_asset_query_empty() -> None:
     # The tool parses the initial HTML and caps the result, so promising
     # "everything the page loads" overstates what comes back.
     assert "subject to the tool's result limit" in query_field
-    assert "runtime-loaded and CSS-nested resources are never enumerated" in (
-        query_field
-    )
+    # Lazy-loading attributes ARE extracted (web_content.py:262,276), so the
+    # caveat has to name what is really excluded.
+    assert "referenced only from CSS or constructed at runtime" in query_field
+    assert "lazy-loading attributes such as data-src are" in query_field
+    assert "not from the result limit" in query_field
 
 
 def test_authenticity_is_independent_of_authorization() -> None:

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -12,7 +12,7 @@ here rather than slipping past a hand-written list.
 
 import importlib
 import pkgutil
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -83,7 +83,7 @@ def _built_video_descriptions() -> dict[str, str]:
     return {t.name: _normalized(t.description) for t in tool.get_tools()}
 
 
-def _built_description(builder, name: str) -> str:
+def _built_description(builder: Callable[[], dict[str, str]], name: str) -> str:
     built = builder()
     assert name in built, f"builder no longer emits {name!r}: {sorted(built)}"
     return built[name]

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -6,6 +6,8 @@ that offers a wider route than the skill allows therefore wins by default, so th
 authorization wording has to live here too.
 """
 
+import pathlib
+
 import pytest
 
 from xagent.core.tools.adapters.vibe.download_web_asset import (
@@ -17,6 +19,16 @@ from xagent.core.tools.adapters.vibe.fetch_web_content import (
     FetchWebContentTool,
 )
 from xagent.core.tools.core.image_tool import ImageGenerationToolCore
+from xagent.skills.parser import SkillParser
+
+SKILL_DIR = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "src"
+    / "xagent"
+    / "skills"
+    / "builtin"
+    / "static-visual-design"
+)
 
 
 def _normalized(text: str) -> str:
@@ -153,3 +165,22 @@ def test_asking_the_user_stops_once_they_have_chosen() -> None:
         text = _surfaces()[name]
         assert "ask the user how to proceed" in text, name
         assert "act on that choice instead of asking again" in text, name
+
+
+def test_skill_and_tool_descriptions_agree_on_retrieval() -> None:
+    """Both land in the same context once the skill is loaded.
+
+    A skill that sanctions self-directed retrieval overrides the tool schema's
+    prohibition, so the two contracts have to move together.
+    """
+    body = " ".join(SkillParser.parse(SKILL_DIR)["content"].split())
+
+    assert "Two sources need no permission" in body
+    assert "official web presence" not in body, (
+        "the skill sanctions retrieval the tool descriptions forbid"
+    )
+    assert "take it only when they tell you to" in body
+
+    surfaces = _surfaces()
+    for name in ("generate_image.description", "edit_image.description"):
+        assert "an asset the user directed you to retrieve" in surfaces[name], name

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -1,0 +1,129 @@
+"""Asset-retrieval tool descriptions must not authorize unprompted retrieval.
+
+These descriptions are injected into the tool schema on every tool-capable step,
+while a skill's policy is only present once it has been loaded. A description
+that offers a wider route than the skill allows therefore wins by default, so the
+authorization wording has to live here too.
+"""
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.download_web_asset import (
+    DownloadWebAssetArgs,
+    DownloadWebAssetTool,
+)
+from xagent.core.tools.adapters.vibe.fetch_web_content import (
+    FetchWebContentArgs,
+    FetchWebContentTool,
+)
+from xagent.core.tools.core.image_tool import ImageGenerationToolCore
+
+
+def _normalized(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _field(model: type, name: str) -> str:
+    return _normalized(model.model_fields[name].description or "")
+
+
+def _surfaces() -> dict[str, str]:
+    """Every description reaching the model alongside an asset-fetch route."""
+    return {
+        "fetch_web_content.description": _normalized(FetchWebContentTool().description),
+        "fetch_web_content.include_assets": _field(
+            FetchWebContentArgs, "include_assets"
+        ),
+        "download_web_asset.description": _normalized(
+            DownloadWebAssetTool.description.fget(  # type: ignore[attr-defined]
+                DownloadWebAssetTool.__new__(DownloadWebAssetTool)
+            )
+        ),
+        "download_web_asset.url": _field(DownloadWebAssetArgs, "url"),
+        "generate_image.description": _normalized(
+            ImageGenerationToolCore.GENERATE_IMAGE_DESCRIPTION
+        ),
+        "edit_image.description": _normalized(
+            ImageGenerationToolCore.EDIT_IMAGE_DESCRIPTION
+        ),
+    }
+
+
+BANNED_WORDING = (
+    "when looking for logos",
+    "usually asset_query='logo'",
+    "prefer the official brand domain",
+    "retrieved from the brand's own official source",
+    "discovers an official logo",
+    "do not go looking",
+)
+
+# One exact phrase per surface. An aggregate count passes on a coincidental
+# "directly" elsewhere in an unrelated sentence.
+REQUIRED_WORDING = {
+    "fetch_web_content.description": "When the user asked you to obtain an exact asset",
+    "fetch_web_content.include_assets": (
+        "Enable it when the user asked you to inspect or enumerate what a page loads"
+    ),
+    "download_web_asset.description": (
+        "surfaced while carrying out a retrieval the user asked for"
+    ),
+    "download_web_asset.url": "one the user supplied directly",
+    "generate_image.description": "an asset the user directed you to retrieve",
+    "edit_image.description": "an asset the user directed you to retrieve",
+}
+
+
+@pytest.mark.parametrize("name", sorted(_surfaces()))
+def test_surface_forbids_unprompted_retrieval(name: str) -> None:
+    lowered = _surfaces()[name].lower()
+    for phrase in BANNED_WORDING:
+        assert phrase not in lowered, f"{name} reintroduced: {phrase!r}"
+
+
+def test_every_surface_is_covered() -> None:
+    assert set(_surfaces()) == set(REQUIRED_WORDING), (
+        "a retrieval surface was added or renamed without its authorization wording"
+    )
+
+
+@pytest.mark.parametrize("name,phrase", sorted(REQUIRED_WORDING.items()))
+def test_surface_requires_user_authorization(name: str, phrase: str) -> None:
+    assert phrase in _surfaces()[name], (
+        f"{name} no longer conditions retrieval on the user asking: {phrase!r}"
+    )
+
+
+def test_authorization_follows_the_request_not_the_url() -> None:
+    """A page web_search found for a retrieval the user asked for is in scope."""
+    fetch = _surfaces()["fetch_web_content.description"]
+
+    assert "one they named or one web_search found for that request" in fetch
+    assert "uninstructed" in fetch
+
+
+def test_direct_user_urls_are_a_described_download_route() -> None:
+    """The user pasting an exact URL is already authorized; describe it as such."""
+    for name in ("download_web_asset.description", "download_web_asset.url"):
+        assert "the user supplied directly" in _surfaces()[name], name
+
+
+def test_include_assets_is_also_an_enumeration_contract() -> None:
+    """The flag lists page resources without downloading them.
+
+    Scoping it to obtaining an asset would block legitimate requests to inspect a
+    page's icons, manifest, scripts, or broken asset references.
+    """
+    flag = _surfaces()["fetch_web_content.include_assets"]
+
+    assert "inspect or enumerate" in flag
+    assert "nothing is downloaded" in flag
+    assert "asset-hunting on your own" in flag
+
+
+def test_asking_the_user_stops_once_they_have_chosen() -> None:
+    """An unscoped "ask the user" reopens a question the user already answered."""
+    for name in ("generate_image.description", "edit_image.description"):
+        text = _surfaces()[name]
+        assert "ask the user how to proceed" in text, name
+        assert "act on that choice instead of asking again" in text, name

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -92,27 +92,75 @@ def _surfaces() -> dict[str, str]:
     }
 
 
-# Tools that can pull remote content into the run and therefore need the
-# authorization wording asserted below.
+# Tools that fetch a remote asset for reuse as a reference, which is what this
+# contract governs.
 RETRIEVAL_TOOL_CLASSES = {
     "FetchWebContentTool": "fetch_web_content",
     "DownloadWebAssetTool": "download_web_asset",
 }
 
-# Tools in the same categories that cannot: query-only search returns text and
-# takes no URL, and the image FunctionTool wrapper carries whichever description
-# the builder hands it, which is asserted through the built surfaces instead.
+# Reach the network or take a URL, but cannot turn one into a reusable asset
+# reference: query-only search returns text and takes no URL; the browser session
+# tools act on an already-open page; the vision and image FunctionTool wrappers
+# carry whichever description their builder hands them, asserted through the built
+# surfaces instead.
 NOT_A_RETRIEVAL_ROUTE = {
     "ExaWebSearchTool",
     "TavilyWebSearchTool",
     "WebSearchTool",
     "ZhipuWebSearchTool",
     "ImageGenerationFunctionTool",
+    "VisionFunctionTool",
+    "BrowserClickTool",
+    "BrowserCloseTool",
+    "BrowserEvaluateTool",
+    "BrowserExtractTextTool",
+    "BrowserFillTool",
+    "BrowserListSessionsTool",
+    "BrowserPdfTool",
+    "BrowserScreenshotTool",
+    "BrowserSelectOptionTool",
+    "BrowserWaitForSelectorTool",
 }
+
+# General-purpose remote routes that predate this contract and are not scoped to
+# asset retrieval: constraining them to "only when the user asked for an asset"
+# would break their ordinary use. Listed so they are an explicit carve-out rather
+# than a silent omission; tightening them is its own change.
+GENERIC_REMOTE_ROUTE_OUT_OF_SCOPE = {
+    "APITool",
+    "BrowserNavigateTool",
+    "ComputerTool",
+    "CreateKnowledgeBaseFromUrlTool",
+}
+
+# Field names that make a tool capable of pulling a caller-named remote resource.
+URL_BEARING_FIELDS = {
+    "url",
+    "urls",
+    "image_url",
+    "image_urls",
+    "images",
+    "src",
+    "source_url",
+}
+
+# Categories whose tools reach outside the run by construction, even when no
+# field is named like a URL.
+REMOTE_CAPABLE_CATEGORIES = (
+    ToolCategory.WEB_SEARCH,
+    ToolCategory.IMAGE,
+    ToolCategory.VISION,
+    ToolCategory.BROWSER,
+)
 
 
 def _discovered_tool_classes() -> dict[str, type]:
-    """Every tool class in the adapter package, imported for its side effect."""
+    """Every tool class that can pull a remote resource into the run.
+
+    Widened past the two categories this PR touches: a tool in any category that
+    accepts a URL is a route the policy has to account for.
+    """
     for module in pkgutil.iter_modules(vibe_pkg.__path__):
         importlib.import_module(f"{vibe_pkg.__name__}.{module.name}")
 
@@ -121,10 +169,17 @@ def _discovered_tool_classes() -> dict[str, type]:
             yield sub
             yield from descendants(sub)
 
+    def remote_capable(cls: type) -> bool:
+        if getattr(cls, "category", None) in REMOTE_CAPABLE_CATEGORIES:
+            return True
+        try:
+            fields = set(cls.args_type(cls).model_fields)  # type: ignore[attr-defined]
+        except Exception:
+            return False
+        return bool(URL_BEARING_FIELDS & fields)
+
     return {
-        c.__name__: c
-        for c in descendants(AbstractBaseTool)
-        if getattr(c, "category", None) in (ToolCategory.WEB_SEARCH, ToolCategory.IMAGE)
+        c.__name__: c for c in set(descendants(AbstractBaseTool)) if remote_capable(c)
     }
 
 
@@ -172,12 +227,17 @@ def test_every_built_image_tool_is_classified() -> None:
 def test_every_retrieval_tool_is_classified() -> None:
     """A new web or image tool has to be triaged, not silently uncovered."""
     discovered = set(_discovered_tool_classes())
-    classified = set(RETRIEVAL_TOOL_CLASSES) | NOT_A_RETRIEVAL_ROUTE
+    classified = (
+        set(RETRIEVAL_TOOL_CLASSES)
+        | NOT_A_RETRIEVAL_ROUTE
+        | GENERIC_REMOTE_ROUTE_OUT_OF_SCOPE
+    )
 
     assert discovered <= classified, (
-        f"unclassified web/image tools: {sorted(discovered - classified)}. Add each "
-        f"to RETRIEVAL_TOOL_CLASSES with its authorization wording, or to "
-        f"NOT_A_RETRIEVAL_ROUTE if it cannot pull remote content in."
+        f"unclassified remote-capable tools: {sorted(discovered - classified)}. "
+        f"Add each to RETRIEVAL_TOOL_CLASSES with its authorization wording, to "
+        f"NOT_A_RETRIEVAL_ROUTE if it cannot produce a reusable asset reference, "
+        f"or to GENERIC_REMOTE_ROUTE_OUT_OF_SCOPE with a reason."
     )
     assert set(RETRIEVAL_TOOL_CLASSES) <= discovered, (
         f"renamed or removed: {sorted(set(RETRIEVAL_TOOL_CLASSES) - discovered)}"
@@ -361,6 +421,13 @@ def _system_context_after_load_skill() -> str:
     return " ".join(asyncio.run(run()).split())
 
 
+def _section(system: str, heading: str, next_heading: str) -> str:
+    """One `## ` section of the loaded skill, as it sits in the system message."""
+    assert heading in system, f"section missing from loaded context: {heading}"
+    body = system.split(heading, 1)[1]
+    return body.split(next_heading, 1)[0] if next_heading in body else body
+
+
 def test_loaded_context_carries_the_policy_without_contradicting_it() -> None:
     """Reading the file proves the text exists; this proves it reaches the model.
 
@@ -371,9 +438,34 @@ def test_loaded_context_carries_the_policy_without_contradicting_it() -> None:
 
     assert "Two sources need no permission" in system
     assert "take it only when they tell you to" in system
-    assert "their" in system and "direction permits the retrieval" in system
-    assert "act on that choice instead of asking again" in system
+    assert "a URL is only a retrieval route" in system
     # The wording this PR exists to remove must not be reachable from the
     # assembled context either.
     for phrase in ("official web presence", "retrieved with the web tools"):
         assert phrase not in system, f"assembled context still sanctions: {phrase!r}"
+
+
+def test_each_no_logo_gate_settles_the_choice_in_its_own_section() -> None:
+    """Three gates ask for a logo, so each needs its own after-choice rule.
+
+    A single global substring passes on whichever section happens to carry the
+    phrase, leaving the other two free to re-ask.
+    """
+    system = _system_context_after_load_skill()
+
+    source = _section(
+        system,
+        "## Use brand and reference assets intentionally",
+        "## Generate the complete creative",
+    )
+    assert "act on that choice instead of asking again" in source
+    assert "only a later change in what they want reopens the question" in source
+    # The identity-asset gate lives in the same section, after the source rules.
+    assert "ask how to proceed once" in source
+    assert "without asking again" in source
+    assert source.index("act on that choice") < source.index("ask how to proceed once")
+
+    gate = _section(system, "## Apply the completion gate", "## Deliver")
+    assert "the user has not yet chosen" in gate
+    assert "do not reopen the question" in gate
+    assert "that draft is the deliverable for this turn" in gate

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -346,7 +346,7 @@ def test_authenticity_is_independent_of_authorization() -> None:
 
     assert "however the URL was reached" in surfaces["download_web_asset.description"]
     assert (
-        "only when the user supplied it or confirmed the source"
+        "only when the user supplied its bytes or confirmed the source"
         in (surfaces["download_web_asset.description"])
     )
     assert "unverified until the user confirms it" in surfaces["download_web_asset.url"]
@@ -438,7 +438,7 @@ def test_loaded_context_carries_the_policy_without_contradicting_it() -> None:
 
     assert "Two sources need no permission" in system
     assert "take it only when they tell you to" in system
-    assert "a URL is only a retrieval route" in system
+    assert "URL is only a retrieval route" in system
     # The wording this PR exists to remove must not be reachable from the
     # assembled context either.
     for phrase in ("official web presence", "retrieved with the web tools"):
@@ -469,3 +469,26 @@ def test_each_no_logo_gate_settles_the_choice_in_its_own_section() -> None:
     assert "the user has not yet chosen" in gate
     assert "do not reopen the question" in gate
     assert "that draft is the deliverable for this turn" in gate
+
+
+def test_provenance_reads_the_same_on_every_surface_that_states_it() -> None:
+    """One distinction, three places: bytes are trusted, a URL is only a route.
+
+    "Supplied" means a URL two sentences earlier in the downloader, so each
+    surface has to keep the two senses apart in its own text.
+    """
+    surfaces = _surfaces()
+    system = _system_context_after_load_skill()
+
+    for name in ("generate_image.description", "edit_image.description"):
+        text = surfaces[name]
+        assert "trusted input" in text, name
+        assert "URL is only a retrieval route" in text, name
+        assert "authorizes the fetch, not the authenticity" in text, name
+
+    download = surfaces["download_web_asset.description"]
+    assert "supplied its bytes or confirmed the source" in download
+    assert "a route, not a confirmation" in download
+
+    assert "trusted input" in system
+    assert "authorizes the fetch, not the" in system

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -4,12 +4,24 @@ These descriptions are injected into the tool schema on every tool-capable step,
 while a skill's policy is only present once it has been loaded. A description
 that offers a wider route than the skill allows therefore wins by default, so the
 authorization wording has to live here too.
+
+The surfaces are read from the tools as they are actually built, and the
+inventory is walked out of the adapter package, so a new retrieval tool fails
+here rather than slipping past a hand-written list.
 """
 
-import pathlib
+import importlib
+import pkgutil
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
+from pydantic import BaseModel
 
+import xagent.core.tools.adapters.vibe as vibe_pkg
+from xagent.core.model.image.base import BaseImageModel
+from xagent.core.tools.adapters.vibe.base import AbstractBaseTool, ToolCategory
 from xagent.core.tools.adapters.vibe.download_web_asset import (
     DownloadWebAssetArgs,
     DownloadWebAssetTool,
@@ -18,11 +30,11 @@ from xagent.core.tools.adapters.vibe.fetch_web_content import (
     FetchWebContentArgs,
     FetchWebContentTool,
 )
-from xagent.core.tools.core.image_tool import ImageGenerationToolCore
+from xagent.core.tools.adapters.vibe.image_tool import ImageGenerationTool
 from xagent.skills.parser import SkillParser
 
 SKILL_DIR = (
-    pathlib.Path(__file__).resolve().parents[3]
+    Path(__file__).resolve().parents[3]
     / "src"
     / "xagent"
     / "skills"
@@ -35,27 +47,79 @@ def _normalized(text: str) -> str:
     return " ".join(text.split())
 
 
-def _field(model: type, name: str) -> str:
+def _field(model: type[BaseModel], name: str) -> str:
     return _normalized(model.model_fields[name].description or "")
+
+
+def _built_image_descriptions() -> dict[str, str]:
+    """The generate/edit descriptions as `get_tools` emits them to the schema.
+
+    Reading the class constants instead would miss anything the builder prepends
+    or interpolates.
+    """
+    model = Mock(spec=BaseImageModel)
+    workspace = Mock()
+    workspace.output_dir = Path("/tmp/asset-authorization-test")
+    tool = ImageGenerationTool(
+        {"m": model},
+        {"m": "test model"},
+        workspace,
+        default_generate_model=model,
+        default_edit_model=model,
+    )
+    return {t.name: _normalized(t.description) for t in tool.get_tools()}
 
 
 def _surfaces() -> dict[str, str]:
     """Every description reaching the model alongside an asset-fetch route."""
+    image = _built_image_descriptions()
     return {
         "fetch_web_content.description": _normalized(FetchWebContentTool().description),
         "fetch_web_content.include_assets": _field(
             FetchWebContentArgs, "include_assets"
         ),
         "download_web_asset.description": _normalized(
-            DownloadWebAssetTool(None).description
+            DownloadWebAssetTool(None).description  # type: ignore[arg-type]
         ),
         "download_web_asset.url": _field(DownloadWebAssetArgs, "url"),
-        "generate_image.description": _normalized(
-            ImageGenerationToolCore.GENERATE_IMAGE_DESCRIPTION
-        ),
-        "edit_image.description": _normalized(
-            ImageGenerationToolCore.EDIT_IMAGE_DESCRIPTION
-        ),
+        "generate_image.description": image["generate_image"],
+        "edit_image.description": image["edit_image"],
+    }
+
+
+# Tools that can pull remote content into the run and therefore need the
+# authorization wording asserted below.
+RETRIEVAL_TOOL_CLASSES = {
+    "FetchWebContentTool": "fetch_web_content",
+    "DownloadWebAssetTool": "download_web_asset",
+}
+
+# Tools in the same categories that cannot: query-only search returns text and
+# takes no URL, and the image FunctionTool wrapper carries whichever description
+# the builder hands it, which is asserted through the built surfaces instead.
+NOT_A_RETRIEVAL_ROUTE = {
+    "ExaWebSearchTool",
+    "TavilyWebSearchTool",
+    "WebSearchTool",
+    "ZhipuWebSearchTool",
+    "ImageGenerationFunctionTool",
+}
+
+
+def _discovered_tool_classes() -> dict[str, type]:
+    """Every tool class in the adapter package, imported for its side effect."""
+    for module in pkgutil.iter_modules(vibe_pkg.__path__):
+        importlib.import_module(f"{vibe_pkg.__name__}.{module.name}")
+
+    def descendants(cls: type) -> Iterator[type]:
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from descendants(sub)
+
+    return {
+        c.__name__: c
+        for c in descendants(AbstractBaseTool)
+        if getattr(c, "category", None) in (ToolCategory.WEB_SEARCH, ToolCategory.IMAGE)
     }
 
 
@@ -86,17 +150,39 @@ REQUIRED_WORDING = {
 }
 
 
+def test_every_retrieval_tool_is_classified() -> None:
+    """A new web or image tool has to be triaged, not silently uncovered."""
+    discovered = set(_discovered_tool_classes())
+    classified = set(RETRIEVAL_TOOL_CLASSES) | NOT_A_RETRIEVAL_ROUTE
+
+    assert discovered <= classified, (
+        f"unclassified web/image tools: {sorted(discovered - classified)}. Add each "
+        f"to RETRIEVAL_TOOL_CLASSES with its authorization wording, or to "
+        f"NOT_A_RETRIEVAL_ROUTE if it cannot pull remote content in."
+    )
+    assert set(RETRIEVAL_TOOL_CLASSES) <= discovered, (
+        f"renamed or removed: {sorted(set(RETRIEVAL_TOOL_CLASSES) - discovered)}"
+    )
+
+
+def test_every_retrieval_tool_has_a_covered_surface() -> None:
+    """Each retrieval tool contributes at least one asserted surface."""
+    covered = {name.split(".")[0] for name in REQUIRED_WORDING}
+    for cls_name, tool_name in RETRIEVAL_TOOL_CLASSES.items():
+        assert tool_name in covered, f"{cls_name} ({tool_name}) has no asserted surface"
+
+
+def test_every_surface_has_required_wording() -> None:
+    assert set(_surfaces()) == set(REQUIRED_WORDING), (
+        "a retrieval surface was added or renamed without its authorization wording"
+    )
+
+
 @pytest.mark.parametrize("name", sorted(_surfaces()))
 def test_surface_forbids_unprompted_retrieval(name: str) -> None:
     lowered = _surfaces()[name].lower()
     for phrase in BANNED_WORDING:
         assert phrase not in lowered, f"{name} reintroduced: {phrase!r}"
-
-
-def test_every_surface_is_covered() -> None:
-    assert set(_surfaces()) == set(REQUIRED_WORDING), (
-        "a retrieval surface was added or renamed without its authorization wording"
-    )
 
 
 @pytest.mark.parametrize("name,phrase", sorted(REQUIRED_WORDING.items()))
@@ -130,11 +216,7 @@ def test_a_user_supplied_url_is_a_route_but_not_a_licence() -> None:
 
 
 def test_enumeration_does_not_authorize_a_download() -> None:
-    """include_assets is inspect-only, so a URL it lists is not yet acquirable.
-
-    Without this boundary the widened enumeration wording would let an
-    inspect-only request satisfy download_web_asset's authorization clause.
-    """
+    """include_assets is inspect-only, so a URL it lists is not yet acquirable."""
     surfaces = _surfaces()
 
     assert (
@@ -150,6 +232,30 @@ def test_enumeration_does_not_authorize_a_download() -> None:
     assert "being asked to inspect a page is not such a request" in fetch
 
 
+def test_include_assets_is_also_an_enumeration_contract() -> None:
+    """The flag lists page resources without downloading them."""
+    flag = _surfaces()["fetch_web_content.include_assets"]
+
+    assert "inspect or enumerate" in flag
+    assert "nothing is downloaded" in flag
+    assert "asset-hunting on your own" in flag
+
+
+def test_page_wide_inspection_leaves_asset_query_empty() -> None:
+    """`_filter_and_deduplicate_assets` only filters on a non-empty query.
+
+    Telling the model to always set asset_query would drop exactly the unrelated
+    assets a page-wide inspection is asking for.
+    """
+    assert (
+        "leaving asset_query empty so nothing is filtered out"
+        in (_surfaces()["fetch_web_content.description"])
+    )
+    assert "Leave it empty to list everything the page loads" in (
+        _field(FetchWebContentArgs, "asset_query")
+    )
+
+
 def test_authenticity_is_independent_of_authorization() -> None:
     """A requested retrieval can still return a counterfeit."""
     surfaces = _surfaces()
@@ -160,19 +266,6 @@ def test_authenticity_is_independent_of_authorization() -> None:
         in (surfaces["download_web_asset.description"])
     )
     assert "unverified until the user confirms it" in surfaces["download_web_asset.url"]
-
-
-def test_include_assets_is_also_an_enumeration_contract() -> None:
-    """The flag lists page resources without downloading them.
-
-    Scoping it to obtaining an asset would block legitimate requests to inspect a
-    page's icons, manifest, scripts, or broken asset references.
-    """
-    flag = _surfaces()["fetch_web_content.include_assets"]
-
-    assert "inspect or enumerate" in flag
-    assert "nothing is downloaded" in flag
-    assert "asset-hunting on your own" in flag
 
 
 def test_asking_the_user_stops_once_they_have_chosen() -> None:
@@ -200,21 +293,6 @@ def test_skill_and_tool_descriptions_agree_on_retrieval() -> None:
     surfaces = _surfaces()
     for name in ("generate_image.description", "edit_image.description"):
         assert "an asset the user directed you to retrieve" in surfaces[name], name
-
-
-def test_page_wide_inspection_leaves_asset_query_empty() -> None:
-    """`_filter_and_deduplicate_assets` only filters on a non-empty query.
-
-    Telling the model to always set asset_query would drop exactly the unrelated
-    assets a page-wide inspection is asking for.
-    """
-    assert (
-        "leaving asset_query empty so nothing is filtered out"
-        in (_surfaces()["fetch_web_content.description"])
-    )
-    assert "Leave it empty to list everything the page loads" in (
-        _field(FetchWebContentArgs, "asset_query")
-    )
 
 
 def test_skill_separates_looking_from_taking() -> None:

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -35,9 +35,7 @@ def _surfaces() -> dict[str, str]:
             FetchWebContentArgs, "include_assets"
         ),
         "download_web_asset.description": _normalized(
-            DownloadWebAssetTool.description.fget(  # type: ignore[attr-defined]
-                DownloadWebAssetTool.__new__(DownloadWebAssetTool)
-            )
+            DownloadWebAssetTool(None).description
         ),
         "download_web_asset.url": _field(DownloadWebAssetArgs, "url"),
         "generate_image.description": _normalized(
@@ -66,7 +64,7 @@ REQUIRED_WORDING = {
         "Enable it when the user asked you to inspect or enumerate what a page loads"
     ),
     "download_web_asset.description": (
-        "surfaced while carrying out a retrieval the user asked for"
+        "The user has to have asked you to obtain this asset"
     ),
     "download_web_asset.url": "one the user supplied directly",
     "generate_image.description": "an asset the user directed you to retrieve",
@@ -105,7 +103,35 @@ def test_authorization_follows_the_request_not_the_url() -> None:
 def test_direct_user_urls_are_a_described_download_route() -> None:
     """The user pasting an exact URL is already authorized; describe it as such."""
     for name in ("download_web_asset.description", "download_web_asset.url"):
-        assert "the user supplied directly" in _surfaces()[name], name
+        assert "supplied directly" in _surfaces()[name], name
+
+
+def test_enumeration_does_not_authorize_a_download() -> None:
+    """include_assets is inspect-only, so a URL it lists is not yet acquirable.
+
+    Without this boundary the widened enumeration wording would let an
+    inspect-only request satisfy download_web_asset's authorization clause.
+    """
+    surfaces = _surfaces()
+
+    assert (
+        "does not authorize download_web_asset"
+        in (surfaces["fetch_web_content.include_assets"])
+    )
+    assert "does not authorize a download" in surfaces["download_web_asset.description"]
+    assert "is not such a request" in surfaces["download_web_asset.url"]
+
+
+def test_authenticity_is_independent_of_authorization() -> None:
+    """A requested retrieval can still return a counterfeit."""
+    surfaces = _surfaces()
+
+    assert "however the URL was reached" in surfaces["download_web_asset.description"]
+    assert (
+        "only when the user supplied it or confirmed the source"
+        in (surfaces["download_web_asset.description"])
+    )
+    assert "unverified until the user confirms it" in surfaces["download_web_asset.url"]
 
 
 def test_include_assets_is_also_an_enumeration_contract() -> None:

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -70,6 +70,12 @@ def _built_image_descriptions() -> dict[str, str]:
     return {t.name: _normalized(t.description) for t in tool.get_tools()}
 
 
+def _built_image_description(name: str) -> str:
+    built = _built_image_descriptions()
+    assert name in built, f"image builder no longer emits {name!r}: {sorted(built)}"
+    return built[name]
+
+
 # Emitted by the image builder but carrying no retrieval route: it only lists
 # configured models. Named so a third tool from the same wrapper fails below.
 IMAGE_TOOLS_WITHOUT_A_RETRIEVAL_ROUTE = {"list_image_models"}
@@ -77,7 +83,6 @@ IMAGE_TOOLS_WITHOUT_A_RETRIEVAL_ROUTE = {"list_image_models"}
 
 def _surfaces() -> dict[str, str]:
     """Every description reaching the model alongside an asset-fetch route."""
-    image = _built_image_descriptions()
     return {
         "fetch_web_content.description": _normalized(FetchWebContentTool().description),
         "fetch_web_content.include_assets": _field(
@@ -87,8 +92,8 @@ def _surfaces() -> dict[str, str]:
             DownloadWebAssetTool(None).description  # type: ignore[arg-type]
         ),
         "download_web_asset.url": _field(DownloadWebAssetArgs, "url"),
-        "generate_image.description": image["generate_image"],
-        "edit_image.description": image["edit_image"],
+        "generate_image.description": _built_image_description("generate_image"),
+        "edit_image.description": _built_image_description("edit_image"),
     }
 
 
@@ -105,12 +110,22 @@ RETRIEVAL_TOOL_CLASSES = {
 # carry whichever description their builder hands them, asserted through the built
 # surfaces instead.
 NOT_A_RETRIEVAL_ROUTE = {
+    # Query-only search: returns text, takes no URL.
     "ExaWebSearchTool",
     "TavilyWebSearchTool",
     "WebSearchTool",
     "ZhipuWebSearchTool",
+    # FunctionTool wrappers: each carries whichever description its builder
+    # hands it; the retrieval-relevant ones (image) are asserted through the
+    # built surfaces above, the rest generate media from prompts.
+    "FunctionTool",
     "ImageGenerationFunctionTool",
     "VisionFunctionTool",
+    "AudioFunctionTool",
+    "MusicFunctionTool",
+    "SoundEffectFunctionTool",
+    "VideoGenerationFunctionTool",
+    # Browser session actions on an already-open page.
     "BrowserClickTool",
     "BrowserCloseTool",
     "BrowserEvaluateTool",
@@ -121,6 +136,16 @@ NOT_A_RETRIEVAL_ROUTE = {
     "BrowserScreenshotTool",
     "BrowserSelectOptionTool",
     "BrowserWaitForSelectorTool",
+    # Local file, document, and data operations: no remote fetch.
+    "FileAnalysisTool",
+    "FileTool",
+    "PPTXTool",
+    "SQLQueryFunctionTool",
+    "SkillTool",
+    # Delegating wrappers: the wrapped tool's class carries the classification,
+    # and the wrapper forwards its description verbatim.
+    "OutputFilteredToolWrapper",
+    "SandboxedToolWrapper",
 }
 
 # General-purpose remote routes that predate this contract and are not scoped to
@@ -129,9 +154,17 @@ NOT_A_RETRIEVAL_ROUTE = {
 # than a silent omission; tightening them is its own change.
 GENERIC_REMOTE_ROUTE_OUT_OF_SCOPE = {
     "APITool",
+    "CustomApiTool",
+    "MCPToolAdapter",
     "BrowserNavigateTool",
     "ComputerTool",
     "CreateKnowledgeBaseFromUrlTool",
+    # Code executors can fetch anything by construction; constraining them to
+    # asset requests would break ordinary compute use.
+    "CommandExecutorFunctionTool",
+    "JavaScriptExecutorFunctionTool",
+    "PythonExecutorFunctionTool",
+    "_SshToolBase",
 }
 
 # Field names that make a tool capable of pulling a caller-named remote resource.
@@ -161,8 +194,10 @@ def _discovered_tool_classes() -> dict[str, type]:
     Widened past the two categories this PR touches: a tool in any category that
     accepts a URL is a route the policy has to account for.
     """
-    for module in pkgutil.iter_modules(vibe_pkg.__path__):
-        importlib.import_module(f"{vibe_pkg.__name__}.{module.name}")
+    # walk_packages, not iter_modules: subpackages such as sandboxed_tool are
+    # only imported lazily by the factory and would otherwise stay invisible.
+    for module in pkgutil.walk_packages(vibe_pkg.__path__, f"{vibe_pkg.__name__}."):
+        importlib.import_module(module.name)
 
     def descendants(cls: type) -> Iterator[type]:
         for sub in cls.__subclasses__():
@@ -173,9 +208,14 @@ def _discovered_tool_classes() -> dict[str, type]:
         if getattr(cls, "category", None) in REMOTE_CAPABLE_CATEGORIES:
             return True
         try:
+            # Unbound on purpose: most args_type implementations ignore self.
             fields = set(cls.args_type(cls).model_fields)  # type: ignore[attr-defined]
         except Exception:
-            return False
+            # Cannot be introspected statically (args_type reads instance
+            # state, e.g. CustomApiTool, SandboxedToolWrapper). Treat it as
+            # possibly remote so it must be classified explicitly — a swallowed
+            # error must never mean "not remote-capable".
+            return True
         return bool(URL_BEARING_FIELDS & fields)
 
     return {
@@ -326,10 +366,9 @@ def test_page_wide_inspection_leaves_asset_query_empty() -> None:
     Telling the model to always set asset_query would drop exactly the unrelated
     assets a page-wide inspection is asking for.
     """
-    assert (
-        "leaving asset_query empty so nothing is filtered out"
-        in (_surfaces()["fetch_web_content.description"])
-    )
+    fetch = _surfaces()["fetch_web_content.description"]
+    assert "leaving asset_query empty so none of the static references" in fetch
+    assert "the result limit still applies" in fetch
     query_field = _field(FetchWebContentArgs, "asset_query")
     assert "Leave it empty to list every supported static reference" in query_field
     # The tool parses the initial HTML and caps the result, so promising
@@ -360,13 +399,29 @@ def test_asking_the_user_stops_once_they_have_chosen() -> None:
         assert "act on that choice instead of asking again" in text, name
 
 
+# The provenance rule as one canonical clause, stated word-for-word on the skill
+# and both image descriptions, so agreement is a comparison rather than per-side
+# spot checks that can drift independently.
+ROUTE_CLAUSE = (
+    "URL is only a retrieval route: asking you to retrieve one authorizes the "
+    "fetch, not the authenticity, and what comes back stays unverified identity "
+    "material until the user confirms its source"
+)
+CONFIRMATION_CLAUSE = (
+    'A user naming a URL as the asset ("here is our logo: <url>") is that '
+    "confirmation; a URL that merely served as a fetch route is not."
+)
+
+
 def test_skill_and_tool_descriptions_agree_on_retrieval() -> None:
     """Both land in the same context once the skill is loaded.
 
     A skill that sanctions self-directed retrieval overrides the tool schema's
-    prohibition, so the two contracts have to move together.
+    prohibition, so the two contracts carry the same canonical clauses — asserted
+    as one string on every surface, not as independent per-side literals.
     """
     body = " ".join(SkillParser.parse(SKILL_DIR)["content"].split())
+    surfaces = _surfaces()
 
     assert "Two sources need no permission" in body
     assert "official web presence" not in body, (
@@ -374,7 +429,11 @@ def test_skill_and_tool_descriptions_agree_on_retrieval() -> None:
     )
     assert "take it only when they tell you to" in body
 
-    surfaces = _surfaces()
+    for clause in (ROUTE_CLAUSE, CONFIRMATION_CLAUSE):
+        assert clause in body, f"skill body dropped: {clause[:50]!r}"
+        for name in ("generate_image.description", "edit_image.description"):
+            assert clause in surfaces[name], f"{name} dropped: {clause[:50]!r}"
+
     for name in ("generate_image.description", "edit_image.description"):
         assert "an asset the user directed you to retrieve" in surfaces[name], name
 
@@ -488,7 +547,46 @@ def test_provenance_reads_the_same_on_every_surface_that_states_it() -> None:
 
     download = surfaces["download_web_asset.description"]
     assert "supplied its bytes or confirmed the source" in download
-    assert "a route, not a confirmation" in download
+    assert "Naming a URL as the asset is that confirmation" in download
+    assert "merely served as a fetch route is not" in download
 
     assert "trusted input" in system
     assert "authorizes the fetch, not the" in system
+
+
+def test_naming_a_url_as_the_asset_confirms_the_source() -> None:
+    """ "Here is our logo: <url>" must not trigger a redundant re-ask.
+
+    The fetch is authorized and the source is confirmed in the same sentence, so
+    every surface that demands confirmation also has to define this as the
+    confirming act.
+    """
+    surfaces = _surfaces()
+    system = _system_context_after_load_skill()
+
+    assert CONFIRMATION_CLAUSE in system
+    for name in ("generate_image.description", "edit_image.description"):
+        assert CONFIRMATION_CLAUSE in surfaces[name], name
+    assert (
+        "Naming a URL as the asset is that confirmation"
+        in (surfaces["download_web_asset.description"])
+    )
+
+
+def test_no_surface_frames_self_directed_search_as_a_pipeline_stage() -> None:
+    """The planning text and the always-loaded reference must not re-sanction it.
+
+    "Do not search in parallel" reads as "searching is expected, sequence it
+    right" — the residue this asserts against.
+    """
+    body = " ".join(SkillParser.parse(SKILL_DIR)["content"].split())
+    reference = " ".join(
+        (SKILL_DIR / "references" / "static-ad-art-direction.md").read_text().split()
+    )
+
+    for text, where in ((body, "SKILL.md"), (reference, "reference")):
+        assert "Do not search for identity assets in parallel" not in text, where
+        assert "Do not search for the logo in parallel" not in text, where
+
+    assert "never by searching on your own" in body
+    assert "never from a search you started yourself" in reference

--- a/tests/core/tools/test_asset_retrieval_authorization.py
+++ b/tests/core/tools/test_asset_retrieval_authorization.py
@@ -71,14 +71,16 @@ BANNED_WORDING = (
 # One exact phrase per surface. An aggregate count passes on a coincidental
 # "directly" elsewhere in an unrelated sentence.
 REQUIRED_WORDING = {
-    "fetch_web_content.description": "When the user asked you to obtain an exact asset",
+    "fetch_web_content.description": (
+        "when the user asked you to obtain an exact asset"
+    ),
     "fetch_web_content.include_assets": (
         "Enable it when the user asked you to inspect or enumerate what a page loads"
     ),
     "download_web_asset.description": (
         "The user has to have asked you to obtain this asset"
     ),
-    "download_web_asset.url": "one the user supplied directly",
+    "download_web_asset.url": "for an asset the user asked you to obtain",
     "generate_image.description": "an asset the user directed you to retrieve",
     "edit_image.description": "an asset the user directed you to retrieve",
 }
@@ -112,10 +114,19 @@ def test_authorization_follows_the_request_not_the_url() -> None:
     assert "uninstructed" in fetch
 
 
-def test_direct_user_urls_are_a_described_download_route() -> None:
-    """The user pasting an exact URL is already authorized; describe it as such."""
-    for name in ("download_web_asset.description", "download_web_asset.url"):
-        assert "supplied directly" in _surfaces()[name], name
+def test_a_user_supplied_url_is_a_route_but_not_a_licence() -> None:
+    """A URL supplied with an obtain request is a valid route; one pasted to be
+    read is not. The obtain intent has to qualify both routes, not only the
+    surfaced one.
+    """
+    surfaces = _surfaces()
+
+    assert "they supplied with that request" in surfaces["download_web_asset.url"]
+    assert "pasted to be read or discussed" in surfaces["download_web_asset.url"]
+    assert (
+        "use a URL they supplied directly"
+        in (surfaces["download_web_asset.description"])
+    )
 
 
 def test_enumeration_does_not_authorize_a_download() -> None:
@@ -131,7 +142,12 @@ def test_enumeration_does_not_authorize_a_download() -> None:
         in (surfaces["fetch_web_content.include_assets"])
     )
     assert "does not authorize a download" in surfaces["download_web_asset.description"]
-    assert "is not such a request" in surfaces["download_web_asset.url"]
+    assert "merely listed, are not such requests" in surfaces["download_web_asset.url"]
+    # The handoff sentence sits right after the inspect-only branch, so it has to
+    # carry the condition rather than apply to every URL that comes back.
+    fetch = surfaces["fetch_web_content.description"]
+    assert "when the user asked you to obtain one, pass the chosen URL" in fetch
+    assert "being asked to inspect a page is not such a request" in fetch
 
 
 def test_authenticity_is_independent_of_authorization() -> None:
@@ -184,3 +200,28 @@ def test_skill_and_tool_descriptions_agree_on_retrieval() -> None:
     surfaces = _surfaces()
     for name in ("generate_image.description", "edit_image.description"):
         assert "an asset the user directed you to retrieve" in surfaces[name], name
+
+
+def test_page_wide_inspection_leaves_asset_query_empty() -> None:
+    """`_filter_and_deduplicate_assets` only filters on a non-empty query.
+
+    Telling the model to always set asset_query would drop exactly the unrelated
+    assets a page-wide inspection is asking for.
+    """
+    assert (
+        "leaving asset_query empty so nothing is filtered out"
+        in (_surfaces()["fetch_web_content.description"])
+    )
+    assert "Leave it empty to list everything the page loads" in (
+        _field(FetchWebContentArgs, "asset_query")
+    )
+
+
+def test_skill_separates_looking_from_taking() -> None:
+    """The skill authorizes an external look; that is not authorization to take."""
+    body = " ".join(SkillParser.parse(SKILL_DIR)["content"].split())
+
+    assert "Being told to look at a page is not being told to take what it holds" in (
+        body
+    )
+    assert "ask before acquiring or using it" in body

--- a/tests/core/tools/test_fetch_web_content.py
+++ b/tests/core/tools/test_fetch_web_content.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
+from bs4 import BeautifulSoup
 
 from xagent.core.tools.adapters.vibe.fetch_web_content import (
     FetchWebContentArgs,
@@ -369,6 +370,67 @@ class TestFetchWebContentTool:
         assert args.url == "https://example.com"
         assert args.include_assets is False
         assert args.asset_query is None
+
+
+class TestExtractionMatchesItsDescription:
+    """The tool description promises "runtime-loaded and CSS-nested resources
+    are never enumerated"; these anchor that claim to the real extraction path,
+    so the description cannot silently become false.
+    """
+
+    def _extract(self, html: str):
+        soup = BeautifulSoup(html, "html.parser")
+        return WebContentFetcher._extract_html_assets(soup, "https://example.com/")
+
+    def test_css_nested_and_runtime_resources_are_not_enumerated(self):
+        assets = self._extract(
+            """
+            <html>
+              <head>
+                <style>.hero { background: url('/assets/css-bg.png'); }</style>
+                <script>
+                  const img = new Image();
+                  img.src = '/assets/runtime-injected.png';
+                </script>
+              </head>
+              <body><img src="/assets/static.png" alt="Static"></body>
+            </html>
+            """
+        )
+        urls = {a.url for a in assets}
+
+        assert "https://example.com/assets/static.png" in urls
+        assert not any("css-bg" in u for u in urls)
+        assert not any("runtime-injected" in u for u in urls)
+
+    def test_manifest_bypasses_the_query_filter(self):
+        assets = self._extract(
+            """
+            <html>
+              <head><link rel="manifest" href="/site.webmanifest"></head>
+              <body><img src="/assets/hero.png" alt="Hero"></body>
+            </html>
+            """
+        )
+        filtered = WebContentFetcher._filter_and_deduplicate_assets(
+            assets, asset_query="hero"
+        )
+        kinds = {a.kind for a in filtered}
+
+        assert "manifest" in kinds, "the manifest entry must survive any query"
+        assert any("hero" in a.url for a in filtered)
+
+    def test_link_kind_is_part_of_the_enumeration(self):
+        assets = self._extract(
+            """
+            <html>
+              <head><link rel="canonical" href="https://example.com/home"></head>
+              <body></body>
+            </html>
+            """
+        )
+
+        assert "link" in {a.kind for a in assets}
 
 
 class TestGetTrustedProxyUrl:

--- a/tests/core/tools/test_fetch_web_content.py
+++ b/tests/core/tools/test_fetch_web_content.py
@@ -373,10 +373,7 @@ class TestFetchWebContentTool:
 
 
 class TestExtractionMatchesItsDescription:
-    """The tool description promises "runtime-loaded and CSS-nested resources
-    are never enumerated"; these anchor that claim to the real extraction path,
-    so the description cannot silently become false.
-    """
+    """Anchor the asset_query description's claims to the real extraction path."""
 
     def _extract(self, html: str):
         soup = BeautifulSoup(html, "html.parser")

--- a/tests/shared/fake_skill_manager.py
+++ b/tests/shared/fake_skill_manager.py
@@ -1,0 +1,21 @@
+"""Skill manager stub for the `build_load_skill_tool` path."""
+
+from typing import Any
+
+
+class FakeSkillManager:
+    def __init__(self, skills: list[dict[str, Any]]) -> None:
+        self.skills = {skill["name"]: skill for skill in skills}
+
+    async def list_skills(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": skill["name"],
+                "description": skill.get("description", ""),
+                "when_to_use": skill.get("when_to_use", ""),
+            }
+            for skill in self.skills.values()
+        ]
+
+    async def get_skill(self, name: str) -> dict[str, Any] | None:
+        return self.skills.get(name)

--- a/tests/skills/test_builtin_static_visual_design.py
+++ b/tests/skills/test_builtin_static_visual_design.py
@@ -67,8 +67,11 @@ def test_static_visual_design_skill_routes_only_commercial_creatives() -> None:
     assert "any `generate_image` or `edit_image` call on an asset that" in content
     assert "any call on an optional asset, including its first" in content
     assert "even at another required placement" in content
-    # The gate's coverage half never yields to the budget.
-    assert "**Coverage is unconditional.**" in content
+    # The gate's coverage half never yields to the budget; its one exception is
+    # a branded final the user chose to go without, not a spent budget.
+    assert "**Coverage is unconditional, with one exception.**" in content
+    assert "branded final the user has already chosen to go without" in content
+    assert "A spent budget is never a reason an asset is" in content
     # Two rejection reasons a rewrite dropped, and the brand rule they serve.
     assert "a render that omits a required brand asset" in content
     assert "labeled a concept draft" in content


### PR DESCRIPTION
Second slice out of the closed #1411. First slice was #1439 (index-entry
truncation).

## Problem

Six descriptions reach the model on every tool-capable step: `fetch_web_content`
(tool + `include_assets` field), `download_web_asset` (tool + `url` field), and
the `generate_image` / `edit_image` prompts. A skill's policy is only present
once that skill has been loaded, so when the two disagree the always-present
description wins.

They disagreed. `include_assets` said "Enable this when looking for logos, brand
assets, or images", `fetch_web_content` said "usually asset_query='logo'",
`download_web_asset.url` said "Prefer the official brand domain for logos", and
both image prompts listed "an asset retrieved from the brand's own official
source" as a sanctioned origin. Read together, that is an instruction to go hunt
for a brand's logo.

## Changes

### 1. Retrieval is authorized by the request, not by who typed the URL

All six descriptions now condition retrieval on the user having asked for it. A
page `web_search` found while carrying out a retrieval the user asked for is in
scope; going after a brand's identity assets uninstructed is not.

Three points where a naive "the user must have named it" phrasing would be wrong:

- **A URL the user pasted directly.** Previously only the
  `fetch_web_content(include_assets=true)` route was described. An exact URL
  supplied by the user is already request-authorized and is now named as a valid
  route on both the tool description and the `url` field.
- **`include_assets` is an enumeration contract, not only a retrieval one.**
  `web_content.py:188-204,232-323` lists page resources — images, icons,
  manifests, scripts, stylesheets — and downloads none of them. Scoping the flag
  to "obtain an asset" would block legitimate requests to inspect what a page
  loads or to find broken asset references, so it now covers inspect/enumerate
  and states that nothing is downloaded.
- **"Ask the user" must stop once they have answered.** Both image prompts said
  to ask when nothing verifiable is available, with no end condition, which
  reopens a settled question after the user has chosen to proceed without a logo.

### 2. Enumeration does not authorize a download

Widening `include_assets` to inspect-only opened a gap: a URL surfaced by a pure
inspection satisfied `download_web_asset`'s "surfaced while carrying out a
retrieval the user asked for". Both download surfaces now require that the user
asked to *obtain* the asset, and both the enumeration and download surfaces say
that listing a URL is not authorization to fetch it.

### 3. Authenticity is unconditional, and separate from authorization

The authenticity warning was scoped to "a retrieval nobody requested", but a
requested search can return a counterfeit just as easily. Authorization now
governs whether the download may happen; provenance is a separate unconditional
rule — an asset counts as verified identity material only when the user supplied
it or confirmed the source, however the URL was reached.

### 4. The skill's source list moves with them

`static-visual-design/SKILL.md:183-189` listed three legitimate sources for brand
identity, the third being "the brand's own official web presence, retrieved with
the web tools available to you" (introduced by #1339). That directly contradicts
the tool descriptions above, and since both land in the same context once the
skill is loaded, shipping only one half would leave the model with incompatible
instructions.

That paragraph now names two sources needing no permission — an asset supplied in
this task, and the current task workspace — and makes going to look for it a
third path that requires the user to ask for it. Nothing else in the skill body
is touched; the rest of the #1411 trim remains a separate PR.

## Tests

`tests/core/tools/test_asset_retrieval_authorization.py` — new, and deliberately
per-surface rather than aggregate. An aggregate substring count over all six
descriptions passes on a coincidental "directly" in an unrelated sentence.

- one banned-phrase assertion per surface, parameterised so failures name the
  surface
- one exact required phrase per surface, in a dict asserted to cover exactly the
  set of surfaces
- targeted cases for request-not-URL scoping, the direct user URL route, the
  enumeration contract, the enumeration/download boundary, and
  authorization-versus-authenticity
- a cross-surface case asserting the skill body and the image descriptions agree,
  so the two halves cannot drift apart again

`test_image_tool_core.py` re-anchored: it asserted `"brand's own official source"
in description`, which is the wording being removed, so the assertion is
inverted. Both description reads are normalized, since these anchors are
sentences that the source wraps.

## Verification

```
.venv/bin/pytest tests/core/tools/test_asset_retrieval_authorization.py \
                 tests/core/tools/core/test_image_tool_core.py tests/skills
139 passed, 1 skipped
```

Guardrail confirmed to bite in both directions: restoring "Enable this when
looking for logos, brand assets, or images" onto `include_assets` fails the
banned assertion (`fetch_web_content.include_assets reintroduced: 'when looking
for logos'`) and the required-wording assertion, both naming the surface.

`tests/core/tools/test_download_web_asset.py` and
`test_workspace_file_tool_consistency.py` fail in this environment on
`psycopg2.OperationalError: connection to localhost:54320 refused` during
workspace file registration. Verified pre-existing: they fail identically on
`main` with these changes stashed.

## Scope

The six descriptions, the one skill paragraph that contradicts them, and their
tests. `_resolve_image_path` still performs no authorization check — the guard
here is prompt-level, as before, just consistent now. A runtime authorization
predicate would be a separate change.
