### PR TITLE
fix(monitor): build daily stats windows in UTC instead of naive local time

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -26,6 +26,7 @@ on:
       - 'tests/web/services/test_task_status_storage_postgresql.py'
       - 'src/xagent/web/api/monitor.py'
       - 'tests/web/api/test_monitor_postgresql.py'
+      - 'tests/web/api/monitor_daily_window_shared.py'
       - 'src/xagent/web/services/task_interaction_staging.py'
       - 'tests/web/services/test_interaction_staging_postgresql.py'
       - 'src/xagent/web/services/task_interaction_service.py'
@@ -103,6 +104,7 @@ jobs:
             tests/web/services/test_task_status_storage_postgresql.py
             src/xagent/web/api/monitor.py
             tests/web/api/test_monitor_postgresql.py
+            tests/web/api/monitor_daily_window_shared.py
             src/xagent/web/services/task_interaction_staging.py
             tests/web/services/test_interaction_staging_postgresql.py
             src/xagent/web/services/task_interaction_service.py

--- a/src/xagent/web/api/monitor.py
+++ b/src/xagent/web/api/monitor.py
@@ -1,7 +1,7 @@
 """Monitoring management API route handlers"""
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -300,9 +300,11 @@ async def get_monitoring_stats(
         )
         total_calls = llm_calls_end + tool_executions_end
 
-        # Get today's call count
-        today = datetime.now().date()
-        today_start = datetime.combine(today, datetime.min.time())
+        # Get today's call count. "Today" is the UTC day: the boundary must be
+        # in the same frame as the aware-UTC timestamps the column stores.
+        today_start = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         today_calls = (
             db.query(TraceEvent)
             .filter(
@@ -648,8 +650,9 @@ async def get_dashboard_stats(
         # Get total task count
         total_tasks = db.query(Task).filter(*task_filter).count()
 
-        # Get active agent count (based on tasks with recent activity)
-        recent_active_time = datetime.now().replace(
+        # Get active agent count (based on tasks with recent activity).
+        # UTC-day boundary, matching the aware-UTC ``updated_at`` column.
+        recent_active_time = datetime.now(timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
         active_agents = (
@@ -665,8 +668,11 @@ async def get_dashboard_stats(
         # Get deployed application count (temporarily set to 0, waiting for Deploy feature implementation)
         deployed_apps = 0
 
-        # Get today's call count
-        today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        # Get today's call count. UTC-day boundary, matching the aware-UTC
+        # timestamps stored in ``TraceEvent.timestamp``.
+        today_start = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
 
         # Build TraceEvent filter conditions
         trace_event_filter = []

--- a/src/xagent/web/api/monitor.py
+++ b/src/xagent/web/api/monitor.py
@@ -258,7 +258,12 @@ async def get_monitoring_stats(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> Dict[str, Any]:
-    """Get monitoring statistics"""
+    """Get monitoring statistics.
+
+    The daily fields (``todayCalls``, ``activeModels``) are counted over the
+    current UTC calendar day, so they reset at 00:00 UTC rather than on the
+    server's or the viewer's local day.
+    """
     try:
         from ..models.task import TraceEvent
 
@@ -638,7 +643,12 @@ async def get_dashboard_stats(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> Dict[str, Any]:
-    """Get dashboard statistics"""
+    """Get dashboard statistics.
+
+    The daily fields (``todayCalls``, ``activeAgents``) are counted over the
+    current UTC calendar day, so they reset at 00:00 UTC rather than on the
+    server's or the viewer's local day.
+    """
     try:
         from ..models.task import Task, TaskStatus, TraceEvent, task_status_predicate
 
@@ -650,15 +660,19 @@ async def get_dashboard_stats(
         # Get total task count
         total_tasks = db.query(Task).filter(*task_filter).count()
 
-        # Get active agent count (based on tasks with recent activity).
-        # UTC-day boundary, matching the aware-UTC ``updated_at`` column.
-        recent_active_time = datetime.now(timezone.utc).replace(
+        # Start of the current UTC day, in the same frame as the aware-UTC
+        # ``Task.updated_at`` and ``TraceEvent.timestamp`` columns. Read the
+        # clock once: two reads either side of midnight would leave a single
+        # response reporting one metric for yesterday and the other for today.
+        today_start = datetime.now(timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
+
+        # Get active agent count (based on tasks with recent activity)
         active_agents = (
             db.query(Task)
             .filter(
-                Task.updated_at >= recent_active_time,
+                Task.updated_at >= today_start,
                 task_status_predicate.in_([TaskStatus.RUNNING, TaskStatus.PENDING]),
                 *task_filter,
             )
@@ -667,12 +681,6 @@ async def get_dashboard_stats(
 
         # Get deployed application count (temporarily set to 0, waiting for Deploy feature implementation)
         deployed_apps = 0
-
-        # Get today's call count. UTC-day boundary, matching the aware-UTC
-        # timestamps stored in ``TraceEvent.timestamp``.
-        today_start = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
 
         # Build TraceEvent filter conditions
         trace_event_filter = []
@@ -683,6 +691,7 @@ async def get_dashboard_stats(
                 )
             )
 
+        # Get today's call count
         today_calls = (
             db.query(TraceEvent)
             .filter(

--- a/tests/web/api/monitor_daily_window_shared.py
+++ b/tests/web/api/monitor_daily_window_shared.py
@@ -1,0 +1,49 @@
+"""Frozen clock and boundary-straddling instants for the daily-window tests.
+
+Shared by the SQLite suite (``test_monitor_daily_windows.py``) and the
+PostgreSQL one (``test_monitor_postgresql.py``) so both pin the same
+boundary against the same instants -- the whole point of covering two
+dialects is that they disagree about a naive literal, not about which rows
+were seeded.
+
+Not a ``conftest.py``: these are plain values and a class, imported by name
+where they are used, matching how the rest of ``tests/web/api/`` shares
+helpers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+# 18:00 UTC on a UTC+8 server: the local wall clock reads 02:00 on the *next*
+# calendar day. A "today" boundary built from naive local time is therefore
+# 2026-08-18 00:00 while the correct UTC boundary is 2026-08-17 00:00 -- a
+# full-day gap no seeded row can straddle by accident, so the pre-fix failure
+# is a decisive count of zero rather than an off-by-one.
+NOW_UTC = datetime(2026, 8, 17, 18, 0, tzinfo=timezone.utc)
+NOW_LOCAL_NAIVE = datetime(2026, 8, 18, 2, 0)
+
+# The session timezone the PostgreSQL case sets, chosen to match the +08:00
+# offset the frozen clock models so both halves of that test tell the same
+# story.
+PG_SESSION_TIME_ZONE = "Asia/Shanghai"
+
+UTC_TODAY_EARLY = datetime(2026, 8, 17, 0, 1, tzinfo=timezone.utc)
+UTC_TODAY_LATE = datetime(2026, 8, 17, 17, 0, tzinfo=timezone.utc)
+UTC_YESTERDAY_LATE = datetime(2026, 8, 16, 23, 59, tzinfo=timezone.utc)
+
+
+class FrozenDatetime(datetime):
+    """``datetime`` whose ``now()`` is pinned to :data:`NOW_UTC`.
+
+    The naive branch returns what a UTC+8 server's wall clock would show at
+    that instant, so the pre-fix call sites reproduce the skew
+    deterministically instead of only when the test happens to run between
+    16:00 and 24:00 UTC.
+    """
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        if tz is None:
+            return NOW_LOCAL_NAIVE
+        return NOW_UTC.astimezone(tz)

--- a/tests/web/api/test_monitor_daily_windows.py
+++ b/tests/web/api/test_monitor_daily_windows.py
@@ -1,0 +1,176 @@
+"""Daily-window boundaries in ``/monitor/stats`` and ``/monitor/dashboard-stats``.
+
+``TraceEvent.timestamp`` and ``Task.updated_at`` are timezone-aware columns
+that production writes aware UTC into, but the "today" boundaries in
+``monitor.py`` were built from naive local wall-clock time (#1256). On any
+host east or west of UTC the daily windows shift by the UTC offset: on a
+UTC+8 server "today's calls" covered 08:00 yesterday through 08:00 today,
+and the same skew moved ``activeModels`` and ``activeAgents``.
+
+These tests pin the UTC frame. The server clock is frozen at an instant
+where the local calendar day (UTC+8) has already rolled past the UTC day,
+so a boundary built from naive local time lands a full day ahead of the
+UTC data -- every window then counts zero, which cannot be mistaken for an
+off-by-one at the boundary. Rows are seeded just before and just after UTC
+midnight so the correct window is told apart from both the naive-local one
+and a window that simply counts everything.
+
+The SQLite path is enough here: the sqlite dialect drops the UTC offset at
+bind time on both the stored rows and the query boundary, so the comparison
+happens in UTC wall-clock on both sides exactly when the boundary is built
+in UTC -- and lands a day off when it is built from local time. The
+session-``TimeZone``-dependent coercion PostgreSQL applies to a naive
+literal lives in the sibling ``test_monitor_postgresql.py`` suite's domain.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from xagent.web.api import monitor as monitor_module
+from xagent.web.api.monitor import get_dashboard_stats, get_monitoring_stats
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.models.user import User
+
+from .conftest import _direct_db_session
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+# 18:00 UTC on a UTC+8 server: the local wall clock reads 02:00 on the
+# *next* calendar day. A naive-local "today" boundary is therefore
+# 2026-08-18 00:00 while the correct UTC boundary is 2026-08-17 00:00 --
+# a full-day gap no seeded row can straddle by accident.
+_NOW_UTC = datetime(2026, 8, 17, 18, 0, tzinfo=timezone.utc)
+_NOW_LOCAL_NAIVE = datetime(2026, 8, 18, 2, 0)
+
+_UTC_TODAY_EARLY = datetime(2026, 8, 17, 0, 1, tzinfo=timezone.utc)
+_UTC_TODAY_LATE = datetime(2026, 8, 17, 17, 0, tzinfo=timezone.utc)
+_UTC_YESTERDAY_LATE = datetime(2026, 8, 16, 23, 59, tzinfo=timezone.utc)
+
+
+class _FrozenDatetime(datetime):
+    """``datetime`` whose ``now()`` is pinned to ``_NOW_UTC``.
+
+    The naive branch returns what a UTC+8 server's wall clock would show at
+    that instant, so the pre-fix call sites reproduce the skew
+    deterministically instead of only when the test happens to run between
+    16:00 and 24:00 UTC.
+    """
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        if tz is None:
+            return _NOW_LOCAL_NAIVE
+        return _NOW_UTC.astimezone(tz)
+
+
+@pytest.fixture
+def _utc_plus_8_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(monitor_module, "datetime", _FrozenDatetime)
+
+
+def _seed_admin(db: Session) -> User:
+    admin = User(username="window-admin", password_hash="hash", is_admin=True)
+    db.add(admin)
+    db.commit()
+    db.refresh(admin)
+    return admin
+
+
+def _seed_task(db: Session, admin: User, *, title: str, updated_at: datetime) -> Task:
+    task = Task(
+        user_id=admin.id,
+        title=title,
+        status=TaskStatus.RUNNING,
+        updated_at=updated_at,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def _seed_boundary_straddling_events(db: Session, task: Task) -> None:
+    """Three events: one just before UTC midnight, two after.
+
+    The two "today" events use different event types so both arms of the
+    ``event_type.in_([...])`` filter contribute, and only the LLM call
+    carries a model name so ``activeModels`` counts exactly one distinct
+    model when the window is right and zero when it is a day ahead.
+    """
+    for event_id, event_type, timestamp, data in [
+        (
+            "yesterday-llm",
+            "llm_call_start",
+            _UTC_YESTERDAY_LATE,
+            {"model_name": "stale-model"},
+        ),
+        (
+            "today-llm",
+            "llm_call_start",
+            _UTC_TODAY_EARLY,
+            {"model_name": "fresh-model"},
+        ),
+        ("today-tool", "tool_execution_start", _UTC_TODAY_LATE, None),
+    ]:
+        db.add(
+            TraceEvent(
+                task_id=task.id,
+                event_id=event_id,
+                event_type=event_type,
+                timestamp=timestamp,
+                data=data,
+            )
+        )
+    db.commit()
+
+
+async def test_stats_today_window_is_the_utc_day(_utc_plus_8_server: None) -> None:
+    """``todayCalls``/``activeModels`` count from UTC midnight, not local.
+
+    Expected: the two events after 2026-08-17 00:00 UTC, and the one model
+    they name. The naive-local boundary (2026-08-18 00:00) yields 0 for
+    both; a window ignoring the boundary altogether yields 3 and 2.
+    """
+    db = _direct_db_session()
+    try:
+        admin = _seed_admin(db)
+        task = _seed_task(db, admin, title="stats-task", updated_at=_UTC_TODAY_LATE)
+        _seed_boundary_straddling_events(db, task)
+
+        stats = await get_monitoring_stats(db=db, current_user=admin)
+
+        assert stats["todayCalls"] == 2
+        assert stats["activeModels"] == 1
+    finally:
+        db.close()
+
+
+async def test_dashboard_windows_are_the_utc_day(_utc_plus_8_server: None) -> None:
+    """``todayCalls`` and ``activeAgents`` use the UTC day boundary.
+
+    One RUNNING task last updated late yesterday (UTC) and one updated
+    today: only the latter is active. Both tasks' events straddle the same
+    boundary as the stats test, so ``todayCalls`` again expects 2.
+    """
+    db = _direct_db_session()
+    try:
+        admin = _seed_admin(db)
+        stale_task = _seed_task(
+            db, admin, title="stale-task", updated_at=_UTC_YESTERDAY_LATE
+        )
+        fresh_task = _seed_task(
+            db, admin, title="fresh-task", updated_at=_UTC_TODAY_LATE
+        )
+        del stale_task  # seeded for its updated_at; nothing else to assert on
+        _seed_boundary_straddling_events(db, fresh_task)
+
+        stats = await get_dashboard_stats(db=db, current_user=admin)
+
+        assert stats["todayCalls"] == 2
+        assert stats["activeAgents"] == 1
+    finally:
+        db.close()

--- a/tests/web/api/test_monitor_daily_windows.py
+++ b/tests/web/api/test_monitor_daily_windows.py
@@ -15,17 +15,19 @@ off-by-one at the boundary. Rows are seeded just before and just after UTC
 midnight so the correct window is told apart from both the naive-local one
 and a window that simply counts everything.
 
-The SQLite path is enough here: the sqlite dialect drops the UTC offset at
-bind time on both the stored rows and the query boundary, so the comparison
-happens in UTC wall-clock on both sides exactly when the boundary is built
-in UTC -- and lands a day off when it is built from local time. The
-session-``TimeZone``-dependent coercion PostgreSQL applies to a naive
-literal lives in the sibling ``test_monitor_postgresql.py`` suite's domain.
+This file covers the SQLite path, where the dialect drops the UTC offset at
+bind time on both the stored rows and the query boundary: the comparison
+then happens in UTC wall-clock on both sides exactly when the boundary is
+built in UTC, and lands a day off when it is built from local time. The
+other half of the story -- the session-``TimeZone``-dependent coercion
+PostgreSQL applies to a naive literal -- is pinned by
+``test_monitor_postgresql.py``, which reuses the same frozen clock and
+instants from ``monitor_daily_window_shared``.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 import pytest
 from sqlalchemy.orm import Session
@@ -36,40 +38,19 @@ from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
 
 from .conftest import _direct_db_session
+from .monitor_daily_window_shared import (
+    UTC_TODAY_EARLY,
+    UTC_TODAY_LATE,
+    UTC_YESTERDAY_LATE,
+    FrozenDatetime,
+)
 
 pytestmark = pytest.mark.usefixtures("_test_db")
-
-# 18:00 UTC on a UTC+8 server: the local wall clock reads 02:00 on the
-# *next* calendar day. A naive-local "today" boundary is therefore
-# 2026-08-18 00:00 while the correct UTC boundary is 2026-08-17 00:00 --
-# a full-day gap no seeded row can straddle by accident.
-_NOW_UTC = datetime(2026, 8, 17, 18, 0, tzinfo=timezone.utc)
-_NOW_LOCAL_NAIVE = datetime(2026, 8, 18, 2, 0)
-
-_UTC_TODAY_EARLY = datetime(2026, 8, 17, 0, 1, tzinfo=timezone.utc)
-_UTC_TODAY_LATE = datetime(2026, 8, 17, 17, 0, tzinfo=timezone.utc)
-_UTC_YESTERDAY_LATE = datetime(2026, 8, 16, 23, 59, tzinfo=timezone.utc)
-
-
-class _FrozenDatetime(datetime):
-    """``datetime`` whose ``now()`` is pinned to ``_NOW_UTC``.
-
-    The naive branch returns what a UTC+8 server's wall clock would show at
-    that instant, so the pre-fix call sites reproduce the skew
-    deterministically instead of only when the test happens to run between
-    16:00 and 24:00 UTC.
-    """
-
-    @classmethod
-    def now(cls, tz=None):  # type: ignore[override]
-        if tz is None:
-            return _NOW_LOCAL_NAIVE
-        return _NOW_UTC.astimezone(tz)
 
 
 @pytest.fixture
 def _utc_plus_8_server(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(monitor_module, "datetime", _FrozenDatetime)
+    monkeypatch.setattr(monitor_module, "datetime", FrozenDatetime)
 
 
 def _seed_admin(db: Session) -> User:
@@ -105,16 +86,16 @@ def _seed_boundary_straddling_events(db: Session, task: Task) -> None:
         (
             "yesterday-llm",
             "llm_call_start",
-            _UTC_YESTERDAY_LATE,
+            UTC_YESTERDAY_LATE,
             {"model_name": "stale-model"},
         ),
         (
             "today-llm",
             "llm_call_start",
-            _UTC_TODAY_EARLY,
+            UTC_TODAY_EARLY,
             {"model_name": "fresh-model"},
         ),
-        ("today-tool", "tool_execution_start", _UTC_TODAY_LATE, None),
+        ("today-tool", "tool_execution_start", UTC_TODAY_LATE, None),
     ]:
         db.add(
             TraceEvent(
@@ -138,7 +119,7 @@ async def test_stats_today_window_is_the_utc_day(_utc_plus_8_server: None) -> No
     db = _direct_db_session()
     try:
         admin = _seed_admin(db)
-        task = _seed_task(db, admin, title="stats-task", updated_at=_UTC_TODAY_LATE)
+        task = _seed_task(db, admin, title="stats-task", updated_at=UTC_TODAY_LATE)
         _seed_boundary_straddling_events(db, task)
 
         stats = await get_monitoring_stats(db=db, current_user=admin)
@@ -160,10 +141,10 @@ async def test_dashboard_windows_are_the_utc_day(_utc_plus_8_server: None) -> No
     try:
         admin = _seed_admin(db)
         stale_task = _seed_task(
-            db, admin, title="stale-task", updated_at=_UTC_YESTERDAY_LATE
+            db, admin, title="stale-task", updated_at=UTC_YESTERDAY_LATE
         )
         fresh_task = _seed_task(
-            db, admin, title="fresh-task", updated_at=_UTC_TODAY_LATE
+            db, admin, title="fresh-task", updated_at=UTC_TODAY_LATE
         )
         del stale_task  # seeded for its updated_at; nothing else to assert on
         _seed_boundary_straddling_events(db, fresh_task)

--- a/tests/web/api/test_monitor_postgresql.py
+++ b/tests/web/api/test_monitor_postgresql.py
@@ -33,6 +33,13 @@ what this file can and must pin:
   surrogate pair is not a hazard and must survive, so a non-BMP payload is
   seeded alongside text that merely looks like an escape.
 
+A second, unrelated dialect hazard is pinned at the end of this file: the
+daily "today" windows compare a boundary against ``timestamptz`` columns,
+and PostgreSQL resolves a *naive* boundary using the session's ``TimeZone``
+setting (#1256). That coercion cannot happen on SQLite, so the sibling
+``test_monitor_daily_windows.py`` cannot see it; the case here sets a
+non-UTC session timezone to make it observable.
+
 The read guard in ``get_json_field_expression`` still exists for databases
 whose migration has not run. With ``jsonb`` it can never match, so no test
 over the model's own table can reach its drop path any more --
@@ -59,18 +66,28 @@ from sqlalchemy import text as sa_text
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 
+from xagent.web.api import monitor as monitor_module
 from xagent.web.api.monitor import (
+    get_dashboard_stats,
     get_json_field_expression,
     get_model_stats,
     get_monitoring_stats,
     get_popular_tools,
 )
 from xagent.web.models.database import Base, get_db, get_engine, init_db
-from xagent.web.models.task import Task, TraceEvent
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
 from xagent.web.utils.json_payload_sanitizer import (
     REPLACEMENT_CHARACTER,
     sanitize_json_payload,
+)
+
+from .monitor_daily_window_shared import (
+    PG_SESSION_TIME_ZONE,
+    UTC_TODAY_EARLY,
+    UTC_TODAY_LATE,
+    UTC_YESTERDAY_LATE,
+    FrozenDatetime,
 )
 
 # String values a ``json`` column accepted but ``->>`` then refused to convert
@@ -550,3 +567,132 @@ class TestReadGuardAgainstNativeJson:
             6: f"emoji{NON_BMP_CHAR}",
             7: "literal" + backslash + "u0000",
         }
+
+
+class TestDailyWindowsUnderNonUtcSessionTimeZone:
+    """The "today" boundary must be an instant, not a wall-clock literal.
+
+    ``TraceEvent.timestamp`` and ``Task.updated_at`` are ``timestamptz``
+    here. An *aware* boundary binds as an unambiguous instant, so the
+    session's ``TimeZone`` cannot move it. A *naive* one -- what these call
+    sites used before #1256 -- is resolved by PostgreSQL in the session
+    timezone instead, which silently shifts every daily window by that
+    offset. Only a non-UTC session timezone makes the two tell apart, so
+    these tests set one explicitly rather than trusting the server default.
+
+    The frozen clock reads 2026-08-17 18:00 UTC, which on the ``+08:00``
+    session timezone is already 02:00 on the 18th. A regression to a naive
+    boundary would therefore be resolved to 2026-08-17 16:00 UTC, and each
+    assertion below is chosen so that lands on a different number than the
+    UTC-day answer -- not merely a different row ordering.
+    """
+
+    @staticmethod
+    def _seed(db: Session) -> User:
+        """An admin, three RUNNING tasks, and events straddling UTC midnight.
+
+        The tasks are spread either side of both candidate boundaries: one
+        updated late on the previous UTC day (outside every reading), one at
+        00:01 UTC (inside the UTC day, outside the shifted one) and one at
+        17:00 UTC (inside both). ``activeAgents`` therefore reads 2 under the
+        correct boundary and 1 under the shifted one.
+        """
+        admin = User(
+            username="monitor-pg-window-admin", password_hash="hash", is_admin=True
+        )
+        db.add(admin)
+        db.commit()
+        db.refresh(admin)
+
+        tasks = []
+        for title, updated_at in [
+            ("pg-window-stale", UTC_YESTERDAY_LATE),
+            ("pg-window-early", UTC_TODAY_EARLY),
+            ("pg-window-late", UTC_TODAY_LATE),
+        ]:
+            task = Task(
+                user_id=admin.id,
+                title=title,
+                status=TaskStatus.RUNNING,
+                updated_at=updated_at,
+            )
+            db.add(task)
+            tasks.append(task)
+        db.commit()
+        for task in tasks:
+            db.refresh(task)
+
+        # Hung off the last task; the call counts are over trace events, so
+        # which task owns them does not matter.
+        owner = tasks[-1]
+        for event_id, event_type, timestamp, data in [
+            (
+                "pg-window-yesterday-llm",
+                "llm_call_start",
+                UTC_YESTERDAY_LATE,
+                {"model_name": "stale-model"},
+            ),
+            (
+                "pg-window-today-llm",
+                "llm_call_start",
+                UTC_TODAY_EARLY,
+                {"model_name": "fresh-model"},
+            ),
+            ("pg-window-today-tool", "tool_execution_start", UTC_TODAY_LATE, None),
+        ]:
+            db.add(
+                TraceEvent(
+                    task_id=owner.id,
+                    event_id=event_id,
+                    event_type=event_type,
+                    timestamp=timestamp,
+                    data=data,
+                )
+            )
+        db.commit()
+        return admin
+
+    @staticmethod
+    def _freeze_and_shift_session(db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pin the clock, then move the session off UTC.
+
+        The ``SET`` runs after seeding so no commit intervenes between it and
+        the handler's queries.
+        """
+        monkeypatch.setattr(monitor_module, "datetime", FrozenDatetime)
+        db.execute(sa_text(f"SET TIME ZONE '{PG_SESSION_TIME_ZONE}'"))
+
+    @pytest.mark.postgresql
+    async def test_stats_today_window_ignores_the_session_time_zone(
+        self, pg_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``todayCalls``/``activeModels`` stay on the UTC day.
+
+        Under a naive boundary these would read 1 and 0: the shifted
+        boundary (16:00 UTC) drops the 00:01 UTC call, which is also the
+        only one naming ``fresh-model``.
+        """
+        admin = self._seed(pg_session)
+        self._freeze_and_shift_session(pg_session, monkeypatch)
+
+        stats = await get_monitoring_stats(db=pg_session, current_user=admin)
+
+        assert stats["todayCalls"] == 2
+        assert stats["activeModels"] == 1
+
+    @pytest.mark.postgresql
+    async def test_dashboard_windows_ignore_the_session_time_zone(
+        self, pg_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``todayCalls``/``activeAgents`` stay on the UTC day.
+
+        Under a naive boundary these would read 1 and 1, the shifted
+        boundary having dropped everything before 16:00 UTC.
+        """
+        admin = self._seed(pg_session)
+        self._freeze_and_shift_session(pg_session, monkeypatch)
+
+        stats = await get_dashboard_stats(db=pg_session, current_user=admin)
+
+        assert stats["todayCalls"] == 2
+        assert stats["activeAgents"] == 2


### PR DESCRIPTION
Fixes #1256.

## Problem

The "today" windows in `/monitor/stats` and `/monitor/dashboard-stats` were offset by the server's UTC offset. `TraceEvent.timestamp` and `Task.updated_at` are timezone-aware columns that production writes aware UTC into, but the three comparison boundaries in `monitor.py` were built naive, from local wall-clock time. On a UTC+8 host, "today's calls" actually covered 08:00 yesterday through 08:00 today, and the same skew moved `activeModels` and `activeAgents`. These were the only three naive `datetime.now()` call sites under `src/xagent/web/`.

## Fix

Build all three boundaries with `datetime.now(timezone.utc)` so they sit in the same frame as the columns:

- `get_monitoring_stats`: `today_start` (feeds both `todayCalls` and `activeModels`)
- `get_dashboard_stats`: `recent_active_time` (feeds `activeAgents`) and `today_start` (feeds `todayCalls`)

On PostgreSQL the aware boundary now binds as `timestamptz`, so no session-`TimeZone`-dependent coercion applies. On SQLite the dialect drops the offset on both the stored rows and the boundary, leaving the comparison in UTC wall-clock on both sides — matching the existing repo convention that naive SQLite datetimes mean UTC (`src/xagent/web/utils/db_timezone.py`).

Per the issue's open design question ("UTC-today vs the viewer's local day"): this PR takes the minimal fix — "today" means the UTC day. That removes the silent "whatever timezone the server happens to run in" behavior; a viewer-local day would need a configured or client-supplied timezone and is left as a separate product decision.

## Tests

New `tests/web/api/test_monitor_daily_windows.py`:

- Freezes the server clock (via a `datetime` subclass monkeypatched into the module) at 18:00 UTC as seen from a UTC+8 server, where the local calendar day has already rolled past the UTC day. A naive-local boundary then lands a full day ahead of the data and every window counts zero, so the failure mode is deterministic regardless of when the test runs.
- Seeds `TraceEvent` rows just before and just after UTC midnight (both `llm_call_start` and `tool_execution_start`, one carrying a model name) plus `RUNNING` tasks updated on both sides of the boundary.
- Asserts `todayCalls`/`activeModels` in `/monitor/stats` and `todayCalls`/`activeAgents` in `/monitor/dashboard-stats` count exactly the UTC-today rows.

Both tests fail before the fix (all windows count 0) and pass after.

## Verification

- `pytest tests/web/api` — 2043 passed, 15 skipped (the PostgreSQL suite skips without `XAGENT_TEST_POSTGRES_URL`, pre-existing)
- `ruff format --check` / `ruff check` clean on changed files
- `mypy src/xagent/web/api/monitor.py` clean
