### PR TITLE
fix(test): pin the Layer-2 widget entity-marker stamp (#1234)

### DIFF
--- a/tests/web/api/test_share_rate_limit_endpoints.py
+++ b/tests/web/api/test_share_rate_limit_endpoints.py
@@ -304,8 +304,12 @@ def test_widget_task_create_ignores_client_injected_entity_markers() -> None:
         task = db.query(Task).filter(Task.id == int(resp.json()["task_id"])).one()
         cfg = task.agent_config
         # Entity markers: server-stamped, workforce cleared to None on the agent
-        # path, agent id is the real one — never the injected values.
-        assert cfg.get("widget_workforce_id") is None
+        # path, agent id is the real one — never the injected values. The
+        # membership check pins the Layer-2 stamp itself: the sanitizer alone
+        # would leave the key absent, and `.get(...) is None` cannot tell
+        # stamped-as-None from stripped (#1234).
+        assert "widget_workforce_id" in cfg
+        assert cfg["widget_workforce_id"] is None
         assert cfg.get("widget_agent_id") != 888888
         assert cfg.get("widget_agent_id") is not None
         # Identity/quota markers: server values win, injected copies stripped.


### PR DESCRIPTION
Closes #1234.

## Problem

`test_widget_task_create_ignores_client_injected_entity_markers` asserted:

```python
assert cfg.get("widget_workforce_id") is None
```

This cannot distinguish "server stamped the key as `None`" from "the sanitizer stripped the key entirely", so deleting the explicit Layer-2 stamp in `create_public_chat_task` (`agent_config["widget_workforce_id"] = access_context.widget_workforce_id`) left the test green — the test did not guard the layer it is named for.

## Fix

Use the membership form, mirroring the share-side fix from #1221:

```python
assert "widget_workforce_id" in cfg
assert cfg["widget_workforce_id"] is None
```

Test-only change; the widget stamp itself (from #1124) is correct and untouched.

## Verification

- Mutation-checked in both directions: the strengthened assertion passes with the stamp present and fails when the Layer-2 stamp line is removed from `create_public_chat_task` (the old assertion stayed green under the same mutation).
- `tests/web/api/test_share_rate_limit_endpoints.py`: 18 passed.
- `ruff format --check` and `ruff check` clean on the changed file.
- Local full-suite run surfaced only pre-existing, unrelated local-environment failures (`test_command_executor` requires a `python` binary on PATH, absent on this machine) and order-dependent flakes that pass in isolation; none touch this change.