### PR TITLE
feat: add Jira connector (OAuth App + custom MCP tools)

### DIFF
--- a/src/xagent/migrations/versions/20260818_seed_jira_mcp_app.py
+++ b/src/xagent/migrations/versions/20260818_seed_jira_mcp_app.py
@@ -1,0 +1,177 @@
+"""seed built-in Jira (OAuth) MCP connector
+
+Revision ID: 20260818_seed_jira_mcp_app
+Revises: 20260813_trace_json_columns_to_jsonb
+Create Date: 2026-08-18 00:00:00.000000
+
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260818_seed_jira_mcp_app"
+down_revision: Union[str, None] = "20260813_trace_json_columns_to_jsonb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FULL_OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+    sa.column("name", sa.String),
+    sa.column("client_id", sa.String),
+    sa.column("client_secret", sa.String),
+    sa.column("auth_url", sa.String),
+    sa.column("token_url", sa.String),
+    sa.column("redirect_uri", sa.String),
+    sa.column("userinfo_url", sa.String),
+    sa.column("user_id_path", sa.String),
+    sa.column("email_path", sa.String),
+    sa.column("default_scopes", sa.JSON),
+)
+
+OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+)
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "jira"
+
+JIRA_SCOPES = [
+    "offline_access",
+    "read:jira-work",
+    "write:jira-work",
+    "read:jira-user",
+    "read:me",
+]
+
+
+def _filter_row(row: dict[str, object], allowed_columns: set[str]) -> dict[str, object]:
+    return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+def _jira_provider_row() -> dict[str, object]:
+    return {
+        "provider_name": "jira",
+        "name": "Jira",
+        "client_id": os.environ.get("JIRA_CLIENT_ID", ""),
+        "client_secret": os.environ.get("JIRA_CLIENT_SECRET", ""),
+        "auth_url": "https://auth.atlassian.com/authorize",
+        "token_url": "https://auth.atlassian.com/oauth/token",
+        "redirect_uri": os.environ.get("JIRA_REDIRECT_URI", ""),
+        "userinfo_url": "https://api.atlassian.com/me",
+        "user_id_path": "account_id",
+        "email_path": "email",
+        "default_scopes": JIRA_SCOPES,
+    }
+
+
+def _jira_app_row() -> dict[str, object]:
+    return {
+        "app_id": APP_ID,
+        "name": "Jira",
+        "description": "Connect to Jira to search issues with JQL, read and create issues and comments, transition issues through their workflow, and browse projects and users.",
+        "icon": "https://www.google.com/s2/favicons?domain=atlassian.com&sz=128",
+        "transport": "oauth",
+        "provider_name": "jira",
+        "category": "Productivity",
+        "oauth_scopes": JIRA_SCOPES,
+        "is_visible_in_connector": True,
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.jira"],
+            "env_mapping": {"JIRA_ACCESS_TOKEN": "access_token"},
+        },
+    }
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "oauth_providers" in existing_tables:
+        oauth_columns = {
+            column["name"] for column in inspector.get_columns("oauth_providers")
+        }
+        existing_provider_names = set(
+            bind.execute(sa.select(OAUTH_PROVIDERS_TABLE.c.provider_name)).scalars()
+        )
+        if "jira" not in existing_provider_names:
+            bind.execute(
+                sa.insert(FULL_OAUTH_PROVIDERS_TABLE),
+                [_filter_row(_jira_provider_row(), oauth_columns)],
+            )
+
+    if "public_mcp_apps" in existing_tables:
+        app_columns = {
+            column["name"] for column in inspector.get_columns("public_mcp_apps")
+        }
+        existing_app_ids = set(
+            bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars()
+        )
+        if APP_ID not in existing_app_ids:
+            bind.execute(
+                sa.insert(PUBLIC_MCP_APPS_TABLE),
+                [_filter_row(_jira_app_row(), app_columns)],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "public_mcp_apps" in existing_tables:
+        # Only the catalog entry is removed. Any user OAuth connections created
+        # against this app are not owned by this migration and are cleaned up
+        # through the normal disconnect path.
+        bind.execute(
+            sa.delete(PUBLIC_MCP_APPS_TABLE).where(
+                PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID
+            )
+        )
+
+    if "oauth_providers" not in existing_tables:
+        return
+
+    if "public_mcp_apps" in existing_tables:
+        remaining_jira_apps = bind.execute(
+            sa.select(sa.func.count())
+            .select_from(PUBLIC_MCP_APPS_TABLE)
+            .where(PUBLIC_MCP_APPS_TABLE.c.provider_name == "jira")
+        ).scalar()
+        if remaining_jira_apps:
+            return
+
+    # Only delete the provider row when it still matches the static shape this
+    # migration seeded, so an admin-created "jira" provider (via
+    # POST /admin/mcp/providers) is preserved. client_id/client_secret are
+    # env-dependent and intentionally not part of the guard. name/auth_url/
+    # token_url are NOT NULL core columns present since the table's creation,
+    # so they can be matched unconditionally.
+    seeded_provider = _jira_provider_row()
+    bind.execute(
+        sa.delete(FULL_OAUTH_PROVIDERS_TABLE)
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "jira")
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.name == seeded_provider["name"])
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.auth_url == seeded_provider["auth_url"])
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.token_url == seeded_provider["token_url"])
+    )

--- a/src/xagent/migrations/versions/20260818_seed_jira_mcp_app.py
+++ b/src/xagent/migrations/versions/20260818_seed_jira_mcp_app.py
@@ -33,11 +33,6 @@ FULL_OAUTH_PROVIDERS_TABLE = sa.table(
     sa.column("default_scopes", sa.JSON),
 )
 
-OAUTH_PROVIDERS_TABLE = sa.table(
-    "oauth_providers",
-    sa.column("provider_name", sa.String),
-)
-
 PUBLIC_MCP_APPS_TABLE = sa.table(
     "public_mcp_apps",
     sa.column("app_id", sa.String),
@@ -112,7 +107,9 @@ def upgrade() -> None:
             column["name"] for column in inspector.get_columns("oauth_providers")
         }
         existing_provider_names = set(
-            bind.execute(sa.select(OAUTH_PROVIDERS_TABLE.c.provider_name)).scalars()
+            bind.execute(
+                sa.select(FULL_OAUTH_PROVIDERS_TABLE.c.provider_name)
+            ).scalars()
         )
         if "jira" not in existing_provider_names:
             bind.execute(

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1295,6 +1295,17 @@ def generic_oauth_login(
         params["prompt"] = "consent"
     if provider.lower() == "zoom":
         params["prompt"] = "login"
+    if provider.lower() == "jira":
+        # Required by Atlassian's authorize endpoint for every 3LO app,
+        # regardless of scopes requested -- identifies the resource server
+        # the requested token is meant for (api.atlassian.com), not an
+        # actual audience restriction on this connector's own behalf.
+        params["audience"] = "api.atlassian.com"
+        # Atlassian does not silently re-prompt on a scope change like most
+        # providers here -- without forcing the consent screen, a user who
+        # previously granted a narrower scope set can be silently handed a
+        # token still limited to that earlier grant.
+        params["prompt"] = "consent"
     meta_config_id = _meta_login_config_id() if provider.lower() == "meta" else ""
     if meta_config_id:
         params["config_id"] = meta_config_id
@@ -1528,8 +1539,16 @@ def generic_oauth_callback(
             data["client_id"] = client_id
             data["client_secret"] = client_secret
 
+        # Atlassian's token endpoint requires a JSON body -- unlike every
+        # other provider here, it does not accept form-urlencoded and
+        # answers a form-encoded POST with a 400.
+        post_kwargs: dict[str, Any] = {"data": data}
+        if provider.lower() == "jira":
+            headers = {"Content-Type": "application/json"}
+            post_kwargs = {"json": data}
+
         token_response = requests.post(
-            token_url, data=data, headers=headers, timeout=10.0, auth=auth
+            token_url, headers=headers, timeout=10.0, auth=auth, **post_kwargs
         )
         token_data = token_response.json()
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -206,6 +206,29 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             # ignores.
             "default_scopes": [],
         },
+        {
+            "provider_name": "jira",
+            "name": "Jira",
+            "client_id": os.environ.get("JIRA_CLIENT_ID", ""),
+            "client_secret": os.environ.get("JIRA_CLIENT_SECRET", ""),
+            "auth_url": "https://auth.atlassian.com/authorize",
+            "token_url": "https://auth.atlassian.com/oauth/token",
+            "redirect_uri": os.environ.get("JIRA_REDIRECT_URI", ""),
+            "userinfo_url": "https://api.atlassian.com/me",
+            "user_id_path": "account_id",
+            "email_path": "email",
+            # offline_access is required to get a refresh_token back at all
+            # (Atlassian omits it from the token response otherwise); read/
+            # write:jira-work cover issue and comment access, read:jira-user
+            # covers the user-search tool, and read:me backs jira_get_current_user.
+            "default_scopes": [
+                "offline_access",
+                "read:jira-work",
+                "write:jira-work",
+                "read:jira-user",
+                "read:me",
+            ],
+        },
     ]
 
 
@@ -767,6 +790,28 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "command": "python",
                 "args": ["-m", "xagent.web.tools.mcp.intercom"],
                 "env_mapping": {"INTERCOM_ACCESS_TOKEN": "access_token"},
+            },
+        },
+        {
+            "app_id": "jira",
+            "name": "Jira",
+            "description": "Connect to Jira to search issues with JQL, read and create issues and comments, transition issues through their workflow, and browse projects and users.",
+            "icon": "https://www.google.com/s2/favicons?domain=atlassian.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "jira",
+            "category": "Productivity",
+            "oauth_scopes": [
+                "offline_access",
+                "read:jira-work",
+                "write:jira-work",
+                "read:jira-user",
+                "read:me",
+            ],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.jira"],
+                "env_mapping": {"JIRA_ACCESS_TOKEN": "access_token"},
             },
         },
     ]

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -659,12 +659,19 @@ async def refresh_oauth_token_if_needed(
         if normalized_provider == "linkedin":
             headers["Content-Type"] = "application/x-www-form-urlencoded"
 
+        # Matches the code-exchange branch in api/auth.py: Atlassian's token
+        # endpoint requires a JSON body on refresh too, not form-urlencoded.
+        body_kwarg: dict[str, Any] = {"data": data}
+        if normalized_provider == "jira":
+            headers["Content-Type"] = "application/json"
+            body_kwarg = {"json": data}
+
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 provider_config.token_url,
-                data=data,
                 headers=headers,
                 timeout=10.0,
+                **body_kwarg,
                 **post_kwargs,
             )
 

--- a/src/xagent/web/tools/mcp/jira.py
+++ b/src/xagent/web/tools/mcp/jira.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import os
+import time
 from typing import Any
+from urllib.parse import quote
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -21,10 +23,14 @@ ME_URL = "https://api.atlassian.com/me"
 JIRA_API_BASE = "https://api.atlassian.com/ex/jira"
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_LIMIT = 100
-# Matches zoom.py's/linear.py's convention: an error body that isn't the
-# expected {"errorMessages": [...]} shape (e.g. an HTML gateway error page)
-# must not be forwarded to the LLM/logs verbatim and unbounded.
+# Matches zoom.py's convention: an error body that isn't the expected
+# {"errorMessages": [...]} shape (e.g. an HTML gateway error page) must not
+# be forwarded to the LLM/logs verbatim and unbounded.
 MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
+# Jira endpoints are rate-limited; on a 429 with a small Retry-After we wait
+# once and retry rather than failing outright, mirroring the same bounded-
+# retry policy as the Slack/Intercom sibling modules.
+MAX_RETRY_AFTER_SECONDS = 30
 
 
 def _success(**payload: Any) -> str:
@@ -48,6 +54,26 @@ def _headers() -> dict[str, str]:
 
 def _clamp_limit(limit: int) -> int:
     return max(1, min(int(limit), MAX_LIMIT))
+
+
+def _path_segment(value: str) -> str:
+    """Percent-encode a value for safe interpolation into a URL path
+    segment (e.g. an issue key or cloud id), matching hubspot.py's
+    _url_path_id / intercom.py's inline quote() calls. Percent-encoding -
+    not a blocklist of "/", "?", "#" - is what actually prevents a value
+    like "ENG-1/../other" from escaping its intended path segment.
+    """
+    return quote(str(value), safe="")
+
+
+def _issue_path(issue_key: str, suffix: str = "") -> str:
+    """Build an issue-scoped REST path with the issue key percent-encoded.
+
+    Single choke point for every /rest/api/2/issue/{key}... path so a new
+    issue-scoped tool can't forget _path_segment and reopen the
+    path-escape the encoding exists to prevent.
+    """
+    return f"/rest/api/2/issue/{_path_segment(issue_key)}{suffix}"
 
 
 def _extract_error_detail(response: requests.Response) -> str | None:
@@ -84,14 +110,25 @@ def _request_absolute(
     params: dict[str, Any] | None = None,
     json_data: dict[str, Any] | None = None,
 ) -> Any:
-    response = requests.request(
-        method=method,
-        url=url,
-        headers=_headers(),
-        params=params,
-        json=json_data,
-        timeout=DEFAULT_TIMEOUT_SECONDS,
-    )
+    for attempt in (0, 1):
+        response = requests.request(
+            method=method,
+            url=url,
+            headers=_headers(),
+            params=params,
+            json=json_data,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+        if response.status_code == 429 and attempt == 0:
+            try:
+                retry_after = int(response.headers.get("Retry-After", "0"))
+            except ValueError:
+                retry_after = 0
+            if 0 < retry_after <= MAX_RETRY_AFTER_SECONDS:
+                time.sleep(retry_after)
+                continue
+        break
+
     try:
         response.raise_for_status()
     except requests.HTTPError as exc:
@@ -153,7 +190,7 @@ def _request(
     resolved_cloud_id = _resolve_cloud_id(cloud_id)
     return _request_absolute(
         method,
-        f"{JIRA_API_BASE}/{resolved_cloud_id}{path}",
+        f"{JIRA_API_BASE}/{_path_segment(resolved_cloud_id)}{path}",
         params=params,
         json_data=json_data,
     )
@@ -201,53 +238,85 @@ def jira_get_current_user() -> str:
 
 
 @mcp.tool()
-def jira_list_projects(cloud_id: str = "", limit: int = 50) -> str:
+def jira_list_projects(cloud_id: str = "", limit: int = 50, start_at: int = 0) -> str:
     """
     List projects on a Jira site -- id, key (e.g. "ENG"), and name. Use the
     returned key with jira_create_issue and jira_search_issues.
     cloud_id: optional site id from jira_list_accessible_sites; omit when
     the account has only one accessible site.
+    start_at: offset into the full project list -- pass the previous
+    response's next_start_at to fetch the next page (0 to start over).
     """
     try:
         max_results = _clamp_limit(limit)
+        offset = max(0, int(start_at))
         result = _request(
             "GET",
             cloud_id,
             "/rest/api/2/project/search",
-            params={"maxResults": max_results},
+            params={"maxResults": max_results, "startAt": offset},
         )
+        if not isinstance(result, dict):
+            return _error("Unexpected response format from Jira projects API")
         projects = result.get("values") or []
-        truncated = not result.get("isLast", True)
-        return _success(projects=projects, truncated=truncated)
+        # bool(projects) guards against a server that signals more pages
+        # while returning an empty page: without it next_start_at would
+        # equal start_at and a caller following it would loop forever.
+        truncated = bool(projects) and not result.get("isLast", True)
+        return _success(
+            projects=projects,
+            truncated=truncated,
+            next_start_at=(offset + len(projects)) if truncated else None,
+        )
     except Exception as e:
         logger.error(f"Error listing Jira projects: {e}")
         return _error(str(e))
 
 
 @mcp.tool()
-def jira_search_issues(jql: str, cloud_id: str = "", limit: int = 20) -> str:
+def jira_search_issues(
+    jql: str, cloud_id: str = "", limit: int = 20, next_page_token: str = ""
+) -> str:
     """
     Search issues with JQL (Jira Query Language) -- the recommended way to
     find issues by project, assignee, status, text, etc.
     jql: a JQL query, e.g. 'project = ENG AND status = "In Progress"
     ORDER BY updated DESC' or 'text ~ "login bug"'.
     limit: max issues to return (default 20, capped at 100).
+    next_page_token: pass the previous response's next_page_token to fetch
+    the next page.
     """
     try:
         max_results = _clamp_limit(limit)
+        # /rest/api/2/search and /rest/api/3/search are deprecated (removed
+        # by Atlassian on Jira Cloud); /rest/api/3/search/jql is the
+        # replacement and pages via nextPageToken instead of startAt/total.
+        params: dict[str, Any] = {
+            "jql": jql,
+            "maxResults": max_results,
+            "fields": "summary,status,assignee,priority,issuetype,project,updated",
+        }
+        if next_page_token:
+            params["nextPageToken"] = next_page_token
         result = _request(
             "GET",
             cloud_id,
-            "/rest/api/2/search",
-            params={
-                "jql": jql,
-                "maxResults": max_results,
-                "fields": "summary,status,assignee,priority,issuetype,project,updated",
-            },
+            "/rest/api/3/search/jql",
+            params=params,
         )
+        if not isinstance(result, dict):
+            return _error("Unexpected response format from Jira search API")
         issues = result.get("issues") or []
-        total = result.get("total", len(issues))
-        return _success(issues=issues, total=total, truncated=total > len(issues))
+        # The enhanced-search endpoint signals "more pages" by including
+        # nextPageToken; isLast is not guaranteed to be present, so the
+        # token's presence is the reliable pagination signal in both
+        # directions (no token => last page, token => more pages).
+        next_token = result.get("nextPageToken")
+        return _success(
+            issues=issues,
+            truncated=bool(next_token),
+            next_page_token=next_token or None,
+        )
     except Exception as e:
         logger.error(f"Error searching Jira issues with JQL '{jql}': {e}")
         return _error(str(e))
@@ -261,7 +330,7 @@ def jira_get_issue(issue_key: str, cloud_id: str = "") -> str:
     issue_key: an issue key (e.g. "ENG-123") or its numeric id.
     """
     try:
-        result = _request("GET", cloud_id, f"/rest/api/2/issue/{issue_key}")
+        result = _request("GET", cloud_id, _issue_path(issue_key))
         return _success(issue=result)
     except Exception as e:
         logger.error(f"Error fetching Jira issue {issue_key}: {e}")
@@ -347,7 +416,7 @@ def jira_update_issue(
         _request(
             "PUT",
             cloud_id,
-            f"/rest/api/2/issue/{issue_key}",
+            _issue_path(issue_key),
             json_data={"fields": fields},
         )
         return _success(issue_key=issue_key)
@@ -365,10 +434,17 @@ def jira_list_transitions(issue_key: str, cloud_id: str = "") -> str:
     jira_transition_issue resolves it internally too.
     """
     try:
-        result = _request("GET", cloud_id, f"/rest/api/2/issue/{issue_key}/transitions")
+        result = _request(
+            "GET",
+            cloud_id,
+            _issue_path(issue_key, "/transitions"),
+        )
+        if not isinstance(result, dict):
+            return _error("Unexpected response format from Jira transitions API")
         transitions = [
             {"id": t.get("id"), "name": t.get("name")}
             for t in result.get("transitions") or []
+            if isinstance(t, dict)
         ]
         return _success(transitions=transitions)
     except Exception as e:
@@ -391,20 +467,24 @@ def jira_transition_issue(
         result = _request(
             "GET",
             resolved_cloud_id,
-            f"/rest/api/2/issue/{issue_key}/transitions",
+            _issue_path(issue_key, "/transitions"),
         )
+        if not isinstance(result, dict):
+            return _error("Unexpected response format from Jira transitions API")
         needle = transition_name.strip().lower()
         match = next(
             (
                 t
                 for t in result.get("transitions") or []
-                if str(t.get("name") or "").lower() == needle
+                if isinstance(t, dict) and str(t.get("name") or "").lower() == needle
             ),
             None,
         )
         if not match:
             available = ", ".join(
-                str(t.get("name")) for t in result.get("transitions") or []
+                str(t.get("name"))
+                for t in result.get("transitions") or []
+                if isinstance(t, dict)
             )
             return _error(
                 f"Transition '{transition_name}' is not available for {issue_key}. "
@@ -419,7 +499,7 @@ def jira_transition_issue(
         _request(
             "POST",
             resolved_cloud_id,
-            f"/rest/api/2/issue/{issue_key}/transitions",
+            _issue_path(issue_key, "/transitions"),
             json_data={"transition": {"id": transition_id}},
         )
         return _success(issue_key=issue_key, transitioned_to=match.get("name"))
@@ -431,21 +511,34 @@ def jira_transition_issue(
 
 
 @mcp.tool()
-def jira_list_comments(issue_key: str, cloud_id: str = "", limit: int = 50) -> str:
+def jira_list_comments(
+    issue_key: str, cloud_id: str = "", limit: int = 50, start_at: int = 0
+) -> str:
     """
     List comments on an issue (body, author, timestamp).
+    start_at: offset into the full comment list -- pass the previous
+    response's next_start_at to fetch the next page (0 to start over).
     """
     try:
         max_results = _clamp_limit(limit)
+        offset = max(0, int(start_at))
         result = _request(
             "GET",
             cloud_id,
-            f"/rest/api/2/issue/{issue_key}/comment",
-            params={"maxResults": max_results},
+            _issue_path(issue_key, "/comment"),
+            params={"maxResults": max_results, "startAt": offset},
         )
+        if not isinstance(result, dict):
+            return _error("Unexpected response format from Jira comments API")
         comments = result.get("comments") or []
+        total = result.get("total", offset + len(comments))
+        # bool(comments) guards the no-progress case (empty page while total
+        # still exceeds offset): next_start_at must never equal start_at.
+        truncated = bool(comments) and offset + len(comments) < total
         return _success(
-            comments=comments, truncated=result.get("total", 0) > len(comments)
+            comments=comments,
+            truncated=truncated,
+            next_start_at=(offset + len(comments)) if truncated else None,
         )
     except Exception as e:
         logger.error(f"Error listing comments for Jira issue {issue_key}: {e}")
@@ -462,7 +555,7 @@ def jira_add_comment(issue_key: str, body: str, cloud_id: str = "") -> str:
         result = _request(
             "POST",
             cloud_id,
-            f"/rest/api/2/issue/{issue_key}/comment",
+            _issue_path(issue_key, "/comment"),
             json_data={"body": body},
         )
         return _success(comment=result)
@@ -472,29 +565,46 @@ def jira_add_comment(issue_key: str, body: str, cloud_id: str = "") -> str:
 
 
 @mcp.tool()
-def jira_search_users(query: str, cloud_id: str = "", limit: int = 20) -> str:
+def jira_search_users(
+    query: str, cloud_id: str = "", limit: int = 20, start_at: int = 0
+) -> str:
     """
     Search site users by name or email -- accountId, displayName, email.
     Resolve a person to an accountId here before passing
     assignee_account_id to jira_create_issue or jira_update_issue.
+    start_at: offset into the full user list -- pass the previous
+    response's next_start_at to fetch the next page (0 to start over).
     """
     try:
         max_results = _clamp_limit(limit)
+        offset = max(0, int(start_at))
         result = _request(
             "GET",
             cloud_id,
             "/rest/api/2/user/search",
-            params={"query": query, "maxResults": max_results},
+            params={"query": query, "maxResults": max_results, "startAt": offset},
         )
+        if not isinstance(result, list):
+            return _error("Unexpected response format from Jira user search API")
         users = [
             {
                 "account_id": u.get("accountId"),
                 "display_name": u.get("displayName"),
                 "email": u.get("emailAddress"),
             }
-            for u in (result if isinstance(result, list) else [])
+            for u in result
+            if isinstance(u, dict)
         ]
-        return _success(users=users)
+        # This endpoint returns a plain array with no total/isLast -- a full
+        # page is the only signal a caller has that more results may exist.
+        # Count the raw page (not the filtered rows) so a malformed element
+        # can't stall pagination or skew the next offset.
+        truncated = len(result) == max_results
+        return _success(
+            users=users,
+            truncated=truncated,
+            next_start_at=(offset + len(result)) if truncated else None,
+        )
     except Exception as e:
         logger.error(f"Error searching Jira users for '{query}': {e}")
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/jira.py
+++ b/src/xagent/web/tools/mcp/jira.py
@@ -64,7 +64,13 @@ def _extract_error_detail(response: requests.Response) -> str | None:
         return None
     if not isinstance(payload, dict):
         return None
-    messages = list(payload.get("errorMessages") or [])
+    raw_messages = payload.get("errorMessages")
+    if isinstance(raw_messages, list):
+        messages = [str(m) for m in raw_messages]
+    elif isinstance(raw_messages, str):
+        messages = [raw_messages]
+    else:
+        messages = []
     field_errors = payload.get("errors")
     if isinstance(field_errors, dict):
         messages.extend(f"{field}: {msg}" for field, msg in field_errors.items())
@@ -121,8 +127,15 @@ def _resolve_cloud_id(cloud_id: str) -> str:
     if not sites:
         raise ValueError("No accessible Jira sites found for this account")
     if len(sites) == 1:
-        return str(sites[0]["id"])
-    site_list = ", ".join(f"{s.get('name')} ({s.get('id')})" for s in sites)
+        site_id = sites[0].get("id") if isinstance(sites[0], dict) else None
+        if not site_id:
+            raise ValueError("The single accessible Jira site is missing a valid 'id'")
+        return str(site_id)
+    site_list = ", ".join(
+        f"{s.get('name') or 'Unknown'} ({s.get('id') or 'No ID'})"
+        for s in sites
+        if isinstance(s, dict)
+    )
     raise ValueError(
         f"Multiple Jira sites are accessible ({site_list}) -- call "
         "jira_list_accessible_sites and pass cloud_id explicitly"
@@ -172,6 +185,8 @@ def jira_get_current_user() -> str:
     """
     try:
         result = _request_absolute("GET", ME_URL)
+        if not isinstance(result, dict):
+            return _error("Unexpected response format from Atlassian profile API")
         return _success(
             user={
                 "account_id": result.get("account_id"),
@@ -395,12 +410,17 @@ def jira_transition_issue(
                 f"Transition '{transition_name}' is not available for {issue_key}. "
                 f"Available transitions: {available}"
             )
+        transition_id = match.get("id")
+        if not transition_id:
+            return _error(
+                f"Matched transition '{transition_name}' is missing a valid 'id'"
+            )
 
         _request(
             "POST",
             resolved_cloud_id,
             f"/rest/api/2/issue/{issue_key}/transitions",
-            json_data={"transition": {"id": match["id"]}},
+            json_data={"transition": {"id": transition_id}},
         )
         return _success(issue_key=issue_key, transitioned_to=match.get("name"))
     except Exception as e:

--- a/src/xagent/web/tools/mcp/jira.py
+++ b/src/xagent/web/tools/mcp/jira.py
@@ -56,6 +56,13 @@ def _clamp_limit(limit: int) -> int:
     return max(1, min(int(limit), MAX_LIMIT))
 
 
+def _truncate(text: str) -> str:
+    """Bound error text to MAX_ERROR_RESPONSE_TEXT_CHARS, marking the cut."""
+    if len(text) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+        return text[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+    return text
+
+
 def _path_segment(value: str) -> str:
     """Percent-encode a value for safe interpolation into a URL path
     segment (e.g. an issue key or cloud id), matching hubspot.py's
@@ -100,7 +107,9 @@ def _extract_error_detail(response: requests.Response) -> str | None:
     field_errors = payload.get("errors")
     if isinstance(field_errors, dict):
         messages.extend(f"{field}: {msg}" for field, msg in field_errors.items())
-    return "; ".join(messages) if messages else None
+    if not messages:
+        return None
+    return _truncate("; ".join(messages))
 
 
 def _request_absolute(
@@ -135,9 +144,7 @@ def _request_absolute(
         message = str(exc)
         detail = _extract_error_detail(response)
         if detail is None:
-            detail = response.text.strip()
-            if len(detail) > MAX_ERROR_RESPONSE_TEXT_CHARS:
-                detail = detail[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+            detail = _truncate(response.text.strip())
         if detail:
             message = f"{message} - {detail}"
         raise RuntimeError(message) from exc
@@ -149,14 +156,17 @@ def _request_absolute(
 
 def _accessible_resources() -> list[dict[str, Any]]:
     result = _request_absolute("GET", ACCESSIBLE_RESOURCES_URL)
-    return result if isinstance(result, list) else []
+    if not isinstance(result, list):
+        raise ValueError(
+            "Unexpected response format from Jira accessible-resources API"
+        )
+    return result
 
 
 def _resolve_cloud_id(cloud_id: str) -> str:
     """Resolve cloud_id, auto-detecting it when there's exactly one
-    accessible Jira site (the common case) -- Jira has no "@current" shortcut
-    like PostHog/Linear, so this is done by actually listing sites rather
-    than a magic path segment.
+    accessible Jira site (the common case) -- Jira has no magic "current
+    site" path segment, so this is done by actually listing sites.
     """
     if cloud_id:
         return cloud_id
@@ -168,10 +178,13 @@ def _resolve_cloud_id(cloud_id: str) -> str:
         if not site_id:
             raise ValueError("The single accessible Jira site is missing a valid 'id'")
         return str(site_id)
-    site_list = ", ".join(
-        f"{s.get('name') or 'Unknown'} ({s.get('id') or 'No ID'})"
-        for s in sites
-        if isinstance(s, dict)
+    site_list = (
+        ", ".join(
+            f"{s.get('name') or 'Unknown'} ({s.get('id') or 'No ID'})"
+            for s in sites
+            if isinstance(s, dict)
+        )
+        or "details unavailable -- response entries were not in the expected shape"
     )
     raise ValueError(
         f"Multiple Jira sites are accessible ({site_list}) -- call "
@@ -359,6 +372,8 @@ def jira_create_issue(
     be one of the site's configured priorities.
     """
     try:
+        if not summary:
+            return _error("summary cannot be empty")
         fields: dict[str, Any] = {
             "project": {"key": project_key},
             "summary": summary,
@@ -401,6 +416,8 @@ def jira_update_issue(
     try:
         fields: dict[str, Any] = {}
         if summary is not None:
+            if not summary:
+                return _error("summary cannot be empty")
             fields["summary"] = summary
         if description is not None:
             fields["description"] = description
@@ -409,6 +426,11 @@ def jira_update_issue(
                 {"accountId": assignee_account_id} if assignee_account_id else None
             )
         if priority is not None:
+            if not priority:
+                return _error(
+                    "priority cannot be empty -- Jira has no way to clear "
+                    "priority through this field; omit the parameter instead"
+                )
             fields["priority"] = {"name": priority}
         if not fields:
             return _error("No fields provided to update")
@@ -531,7 +553,8 @@ def jira_list_comments(
         if not isinstance(result, dict):
             return _error("Unexpected response format from Jira comments API")
         comments = result.get("comments") or []
-        total = result.get("total", offset + len(comments))
+        raw_total = result.get("total")
+        total = raw_total if isinstance(raw_total, int) else offset + len(comments)
         # bool(comments) guards the no-progress case (empty page while total
         # still exceeds offset): next_start_at must never equal start_at.
         truncated = bool(comments) and offset + len(comments) < total

--- a/src/xagent/web/tools/mcp/jira.py
+++ b/src/xagent/web/tools/mcp/jira.py
@@ -1,0 +1,484 @@
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("jira-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("jira-mcp")
+
+ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
+ME_URL = "https://api.atlassian.com/me"
+JIRA_API_BASE = "https://api.atlassian.com/ex/jira"
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_LIMIT = 100
+# Matches zoom.py's/linear.py's convention: an error body that isn't the
+# expected {"errorMessages": [...]} shape (e.g. an HTML gateway error page)
+# must not be forwarded to the LLM/logs verbatim and unbounded.
+MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _headers() -> dict[str, str]:
+    access_token = os.environ.get("JIRA_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("JIRA_ACCESS_TOKEN environment variable is missing")
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _clamp_limit(limit: int) -> int:
+    return max(1, min(int(limit), MAX_LIMIT))
+
+
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull the human-readable message out of a Jira error body.
+
+    Jira error responses are typically {"errorMessages": [...], "errors":
+    {field: message}}; joining both is more useful to the LLM than the raw
+    envelope. Returns None if the body isn't in the expected shape, so the
+    caller can fall back to the raw response text.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    messages = list(payload.get("errorMessages") or [])
+    field_errors = payload.get("errors")
+    if isinstance(field_errors, dict):
+        messages.extend(f"{field}: {msg}" for field, msg in field_errors.items())
+    return "; ".join(messages) if messages else None
+
+
+def _request_absolute(
+    method: str,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+) -> Any:
+    response = requests.request(
+        method=method,
+        url=url,
+        headers=_headers(),
+        params=params,
+        json=json_data,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        message = str(exc)
+        detail = _extract_error_detail(response)
+        if detail is None:
+            detail = response.text.strip()
+            if len(detail) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+                detail = detail[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+        if detail:
+            message = f"{message} - {detail}"
+        raise RuntimeError(message) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _accessible_resources() -> list[dict[str, Any]]:
+    result = _request_absolute("GET", ACCESSIBLE_RESOURCES_URL)
+    return result if isinstance(result, list) else []
+
+
+def _resolve_cloud_id(cloud_id: str) -> str:
+    """Resolve cloud_id, auto-detecting it when there's exactly one
+    accessible Jira site (the common case) -- Jira has no "@current" shortcut
+    like PostHog/Linear, so this is done by actually listing sites rather
+    than a magic path segment.
+    """
+    if cloud_id:
+        return cloud_id
+    sites = _accessible_resources()
+    if not sites:
+        raise ValueError("No accessible Jira sites found for this account")
+    if len(sites) == 1:
+        return str(sites[0]["id"])
+    site_list = ", ".join(f"{s.get('name')} ({s.get('id')})" for s in sites)
+    raise ValueError(
+        f"Multiple Jira sites are accessible ({site_list}) -- call "
+        "jira_list_accessible_sites and pass cloud_id explicitly"
+    )
+
+
+def _request(
+    method: str,
+    cloud_id: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+) -> Any:
+    resolved_cloud_id = _resolve_cloud_id(cloud_id)
+    return _request_absolute(
+        method,
+        f"{JIRA_API_BASE}/{resolved_cloud_id}{path}",
+        params=params,
+        json_data=json_data,
+    )
+
+
+@mcp.tool()
+def jira_list_accessible_sites() -> str:
+    """
+    List the Atlassian sites (Jira Cloud instances) this account's OAuth
+    grant can access -- id (cloud_id), name, url, and granted scopes.
+    Every other tool here takes an optional cloud_id; pass one from here
+    when the account has more than one accessible site (auto-resolved
+    without asking when there's only one).
+    """
+    try:
+        sites = _accessible_resources()
+        return _success(sites=sites)
+    except Exception as e:
+        logger.error(f"Error listing accessible Jira sites: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_get_current_user() -> str:
+    """
+    Get the profile of the Atlassian account this connector is
+    authenticated as (account_id, email, name). Use this for "my account" /
+    "who am I" requests instead of asking the user for their Jira account id.
+    """
+    try:
+        result = _request_absolute("GET", ME_URL)
+        return _success(
+            user={
+                "account_id": result.get("account_id"),
+                "email": result.get("email"),
+                "name": result.get("name"),
+                "picture": result.get("picture"),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error fetching authenticated Jira user: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_list_projects(cloud_id: str = "", limit: int = 50) -> str:
+    """
+    List projects on a Jira site -- id, key (e.g. "ENG"), and name. Use the
+    returned key with jira_create_issue and jira_search_issues.
+    cloud_id: optional site id from jira_list_accessible_sites; omit when
+    the account has only one accessible site.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        result = _request(
+            "GET",
+            cloud_id,
+            "/rest/api/2/project/search",
+            params={"maxResults": max_results},
+        )
+        projects = result.get("values") or []
+        truncated = not result.get("isLast", True)
+        return _success(projects=projects, truncated=truncated)
+    except Exception as e:
+        logger.error(f"Error listing Jira projects: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_search_issues(jql: str, cloud_id: str = "", limit: int = 20) -> str:
+    """
+    Search issues with JQL (Jira Query Language) -- the recommended way to
+    find issues by project, assignee, status, text, etc.
+    jql: a JQL query, e.g. 'project = ENG AND status = "In Progress"
+    ORDER BY updated DESC' or 'text ~ "login bug"'.
+    limit: max issues to return (default 20, capped at 100).
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        result = _request(
+            "GET",
+            cloud_id,
+            "/rest/api/2/search",
+            params={
+                "jql": jql,
+                "maxResults": max_results,
+                "fields": "summary,status,assignee,priority,issuetype,project,updated",
+            },
+        )
+        issues = result.get("issues") or []
+        total = result.get("total", len(issues))
+        return _success(issues=issues, total=total, truncated=total > len(issues))
+    except Exception as e:
+        logger.error(f"Error searching Jira issues with JQL '{jql}': {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_get_issue(issue_key: str, cloud_id: str = "") -> str:
+    """
+    Get one issue's full details, including description, status, assignee,
+    and priority.
+    issue_key: an issue key (e.g. "ENG-123") or its numeric id.
+    """
+    try:
+        result = _request("GET", cloud_id, f"/rest/api/2/issue/{issue_key}")
+        return _success(issue=result)
+    except Exception as e:
+        logger.error(f"Error fetching Jira issue {issue_key}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_create_issue(
+    project_key: str,
+    summary: str,
+    cloud_id: str = "",
+    description: str = "",
+    issue_type: str = "Task",
+    assignee_account_id: str = "",
+    priority: str = "",
+) -> str:
+    """
+    Create a new issue.
+    project_key: the target project's key (e.g. "ENG"), from jira_list_projects.
+    summary: the issue title.
+    description: optional body (plain text).
+    issue_type: the issue type's name (e.g. "Task", "Bug", "Story") --
+    must be one of the target project's configured issue types.
+    assignee_account_id: optional account id from jira_search_users.
+    priority: optional priority name (e.g. "High", "Medium", "Low") -- must
+    be one of the site's configured priorities.
+    """
+    try:
+        fields: dict[str, Any] = {
+            "project": {"key": project_key},
+            "summary": summary,
+            "issuetype": {"name": issue_type},
+        }
+        if description:
+            fields["description"] = description
+        if assignee_account_id:
+            fields["assignee"] = {"accountId": assignee_account_id}
+        if priority:
+            fields["priority"] = {"name": priority}
+
+        result = _request(
+            "POST", cloud_id, "/rest/api/2/issue", json_data={"fields": fields}
+        )
+        return _success(issue=result)
+    except Exception as e:
+        logger.error(f"Error creating Jira issue in project {project_key}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_update_issue(
+    issue_key: str,
+    cloud_id: str = "",
+    summary: str | None = None,
+    description: str | None = None,
+    assignee_account_id: str | None = None,
+    priority: str | None = None,
+) -> str:
+    """
+    Update an existing issue. Only the fields explicitly provided are
+    changed; leave a parameter unset (None) to leave that field untouched.
+    issue_key: an issue key (e.g. "ENG-123") or its numeric id.
+    assignee_account_id: an account id from jira_search_users, to reassign
+    the issue -- pass an empty string to unassign it.
+    priority: a priority name (e.g. "High") -- must be one of the site's
+    configured priorities.
+    """
+    try:
+        fields: dict[str, Any] = {}
+        if summary is not None:
+            fields["summary"] = summary
+        if description is not None:
+            fields["description"] = description
+        if assignee_account_id is not None:
+            fields["assignee"] = (
+                {"accountId": assignee_account_id} if assignee_account_id else None
+            )
+        if priority is not None:
+            fields["priority"] = {"name": priority}
+        if not fields:
+            return _error("No fields provided to update")
+
+        _request(
+            "PUT",
+            cloud_id,
+            f"/rest/api/2/issue/{issue_key}",
+            json_data={"fields": fields},
+        )
+        return _success(issue_key=issue_key)
+    except Exception as e:
+        logger.error(f"Error updating Jira issue {issue_key}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_list_transitions(issue_key: str, cloud_id: str = "") -> str:
+    """
+    List an issue's available workflow transitions (e.g. "Start Progress",
+    "Done") -- id and name. Resolve a transition name here before passing
+    it to jira_transition_issue, or pass the name directly since
+    jira_transition_issue resolves it internally too.
+    """
+    try:
+        result = _request("GET", cloud_id, f"/rest/api/2/issue/{issue_key}/transitions")
+        transitions = [
+            {"id": t.get("id"), "name": t.get("name")}
+            for t in result.get("transitions") or []
+        ]
+        return _success(transitions=transitions)
+    except Exception as e:
+        logger.error(f"Error listing transitions for Jira issue {issue_key}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_transition_issue(
+    issue_key: str, transition_name: str, cloud_id: str = ""
+) -> str:
+    """
+    Move an issue through its workflow (e.g. to "Done", "In Progress").
+    transition_name: a transition's name, case-insensitive (see
+    jira_list_transitions for the exact set available on this issue --
+    available transitions depend on the issue's current status).
+    """
+    try:
+        resolved_cloud_id = _resolve_cloud_id(cloud_id)
+        result = _request(
+            "GET",
+            resolved_cloud_id,
+            f"/rest/api/2/issue/{issue_key}/transitions",
+        )
+        needle = transition_name.strip().lower()
+        match = next(
+            (
+                t
+                for t in result.get("transitions") or []
+                if str(t.get("name") or "").lower() == needle
+            ),
+            None,
+        )
+        if not match:
+            available = ", ".join(
+                str(t.get("name")) for t in result.get("transitions") or []
+            )
+            return _error(
+                f"Transition '{transition_name}' is not available for {issue_key}. "
+                f"Available transitions: {available}"
+            )
+
+        _request(
+            "POST",
+            resolved_cloud_id,
+            f"/rest/api/2/issue/{issue_key}/transitions",
+            json_data={"transition": {"id": match["id"]}},
+        )
+        return _success(issue_key=issue_key, transitioned_to=match.get("name"))
+    except Exception as e:
+        logger.error(
+            f"Error transitioning Jira issue {issue_key} to '{transition_name}': {e}"
+        )
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_list_comments(issue_key: str, cloud_id: str = "", limit: int = 50) -> str:
+    """
+    List comments on an issue (body, author, timestamp).
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        result = _request(
+            "GET",
+            cloud_id,
+            f"/rest/api/2/issue/{issue_key}/comment",
+            params={"maxResults": max_results},
+        )
+        comments = result.get("comments") or []
+        return _success(
+            comments=comments, truncated=result.get("total", 0) > len(comments)
+        )
+    except Exception as e:
+        logger.error(f"Error listing comments for Jira issue {issue_key}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_add_comment(issue_key: str, body: str, cloud_id: str = "") -> str:
+    """
+    Add a comment to an issue.
+    body: the comment text (plain text).
+    """
+    try:
+        result = _request(
+            "POST",
+            cloud_id,
+            f"/rest/api/2/issue/{issue_key}/comment",
+            json_data={"body": body},
+        )
+        return _success(comment=result)
+    except Exception as e:
+        logger.error(f"Error adding comment to Jira issue {issue_key}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def jira_search_users(query: str, cloud_id: str = "", limit: int = 20) -> str:
+    """
+    Search site users by name or email -- accountId, displayName, email.
+    Resolve a person to an accountId here before passing
+    assignee_account_id to jira_create_issue or jira_update_issue.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        result = _request(
+            "GET",
+            cloud_id,
+            "/rest/api/2/user/search",
+            params={"query": query, "maxResults": max_results},
+        )
+        users = [
+            {
+                "account_id": u.get("accountId"),
+                "display_name": u.get("displayName"),
+                "email": u.get("emailAddress"),
+            }
+            for u in (result if isinstance(result, list) else [])
+        ]
+        return _success(users=users)
+    except Exception as e:
+        logger.error(f"Error searching Jira users for '{query}': {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/alembic/test_20260818_seed_jira_mcp_app.py
+++ b/tests/alembic/test_20260818_seed_jira_mcp_app.py
@@ -1,0 +1,208 @@
+"""Tests for the Jira MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260818_seed_jira_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location("seed_jira_migration", migration_file)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_tables(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE oauth_providers (
+                id INTEGER PRIMARY KEY,
+                provider_name VARCHAR(50) NOT NULL UNIQUE,
+                name VARCHAR(100) NOT NULL,
+                client_id VARCHAR(500) NOT NULL,
+                client_secret VARCHAR(500) NOT NULL,
+                auth_url VARCHAR(500) NOT NULL,
+                token_url VARCHAR(500) NOT NULL,
+                redirect_uri VARCHAR(500),
+                userinfo_url VARCHAR(500),
+                user_id_path VARCHAR(100),
+                email_path VARCHAR(100),
+                default_scopes JSON
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def _provider_names(connection):
+    return set(
+        connection.execute(text("SELECT provider_name FROM oauth_providers")).scalars()
+    )
+
+
+def test_upgrade_inserts_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "jira" in _provider_names(connection)
+        assert "jira" in _app_ids(connection)
+
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='jira'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "jira"
+        assert "xagent.web.tools.mcp.jira" in str(row[2])
+        assert "JIRA_ACCESS_TOKEN" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        app_count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='jira'")
+        ).scalar()
+        assert app_count == 1
+        provider_count = connection.execute(
+            text("SELECT COUNT(*) FROM oauth_providers WHERE provider_name='jira'")
+        ).scalar()
+        assert provider_count == 1
+
+
+def test_seed_rows_match_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    jira rows (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_oauth_provider_rows,
+        get_builtin_public_mcp_app_rows,
+    )
+
+    migration = _load_migration_module()
+
+    registry_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "jira"
+    )
+    assert migration._jira_app_row() == registry_app
+
+    registry_provider = next(
+        row
+        for row in get_builtin_oauth_provider_rows()
+        if row["provider_name"] == "jira"
+    )
+    assert migration._jira_provider_row() == registry_provider
+
+
+def test_downgrade_removes_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "jira" not in _app_ids(connection)
+        assert "jira" not in _provider_names(connection)
+
+
+def test_downgrade_keeps_provider_when_custom_jira_app_exists(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "INSERT INTO public_mcp_apps (app_id, name, transport, provider_name)"
+                    " VALUES ('custom-jira', 'Custom Jira', 'oauth', 'jira')"
+                )
+            )
+            migration.downgrade()
+        assert "jira" in _provider_names(connection)
+
+
+def test_downgrade_preserves_admin_created_jira_provider(tmp_path):
+    """A pre-existing admin-created "jira" provider (different shape than the
+    seeded row) must survive downgrade even when no jira apps remain."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO oauth_providers"
+                " (provider_name, name, client_id, client_secret, auth_url, token_url)"
+                " VALUES ('jira', 'Custom Jira', 'cid', 'secret',"
+                " 'https://custom.example.com/authorize',"
+                " 'https://custom.example.com/token')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "jira" not in _app_ids(connection)
+        assert "jira" in _provider_names(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_tables(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "oauth_providers" not in table_names
+        assert "public_mcp_apps" not in table_names

--- a/tests/web/test_jira_oauth.py
+++ b/tests/web/test_jira_oauth.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api import auth as auth_api
+from xagent.web.api.auth import create_access_token, generic_oauth_callback
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.oauth_provider import OAuthProvider
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.tools import config as tool_config
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        PublicMCPApp(
+            app_id="jira",
+            name="Jira",
+            description="Jira connector",
+            transport="oauth",
+            provider_name="jira",
+            category="Productivity",
+            oauth_scopes=["read:jira-work", "write:jira-work", "offline_access"],
+            is_visible_in_connector=True,
+            launch_config={
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.jira"],
+                "env_mapping": {"JIRA_ACCESS_TOKEN": "access_token"},
+            },
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _jira_provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider_name="jira",
+        client_id=encrypt_value("jira-client-id"),
+        client_secret=encrypt_value("jira-client-secret"),
+        auth_url="https://auth.atlassian.com/authorize",
+        token_url="https://auth.atlassian.com/oauth/token",
+        redirect_uri="https://app.example.com/api/auth/jira/callback",
+        userinfo_url="https://api.atlassian.com/me",
+        user_id_path="account_id",
+        email_path="email",
+        default_scopes=["read:jira-work", "write:jira-work", "offline_access"],
+    )
+
+
+def test_login_sends_audience_and_prompt_consent(db_session):
+    db, user = db_session
+    token = create_access_token(
+        data={"sub": user.username, "type": "access"},
+        expires_delta=timedelta(minutes=5),
+    )
+
+    response = auth_api.generic_oauth_login(
+        "jira", token=token, app_id="jira", db=db, db_provider=_jira_provider()
+    )
+
+    assert response.status_code == 307
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    assert query["audience"] == ["api.atlassian.com"]
+    assert query["prompt"] == ["consent"]
+
+
+def test_jira_callback_exchanges_code_with_json_body(db_session, monkeypatch):
+    """Atlassian's token endpoint requires a JSON body -- a form-urlencoded
+    POST (every other provider here) gets rejected."""
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "jira",
+            "app_id": "jira",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "jira-code", "state": state})
+
+    post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "jira-token",
+                "refresh_token": "jira-refresh",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "scope": "read:jira-work write:jira-work offline_access",
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", post)
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"account_id": "jira-user-1", "email": "alice@example.com"}
+            )
+        ),
+    )
+
+    response = generic_oauth_callback("jira", request, db, _jira_provider())
+
+    assert response.status_code == 200
+    assert post.call_args.kwargs["headers"]["Content-Type"] == "application/json"
+    assert post.call_args.kwargs["json"] == {
+        "grant_type": "authorization_code",
+        "code": "jira-code",
+        "redirect_uri": "https://app.example.com/api/auth/jira/callback",
+        "client_id": "jira-client-id",
+        "client_secret": "jira-client-secret",
+    }
+    assert "data" not in post.call_args.kwargs
+
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "jira")
+        .one()
+    )
+    assert oauth_account.access_token == "jira-token"
+    assert oauth_account.refresh_token == "jira-refresh"
+    assert oauth_account.provider_user_id == "jira-user-1"
+    assert oauth_account.email == "alice@example.com"
+
+    server = db.query(MCPServer).filter(MCPServer.name == "Jira").one()
+    assert server.transport == "oauth"
+    user_mcp = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    assert user_mcp.is_active is True
+
+
+def test_non_jira_callback_still_sends_form_urlencoded_body(db_session, monkeypatch):
+    """Guard the branch condition: a non-jira provider must be unaffected by
+    the Atlassian-specific JSON-body carve-out."""
+    db, user = db_session
+    db.add(
+        PublicMCPApp(
+            app_id="gmail",
+            name="Gmail",
+            transport="oauth",
+            provider_name="google",
+        )
+    )
+    db.commit()
+
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "google",
+            "app_id": "gmail",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "code", "state": state})
+    post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "tok",
+                "token_type": "Bearer",
+                "scope": "",
+                "expires_in": 3600,
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", post)
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(return_value=MockResponse({"sub": "u1", "email": "alice@gmail.com"})),
+    )
+
+    google_provider = SimpleNamespace(
+        provider_name="google",
+        client_id=encrypt_value("google-client-id"),
+        client_secret=encrypt_value("google-client-secret"),
+        token_url="https://oauth2.googleapis.com/token",
+        redirect_uri="https://app.example.com/api/auth/google/callback",
+        userinfo_url="https://openidconnect.googleapis.com/v1/userinfo",
+        user_id_path="sub",
+        email_path="email",
+        default_scopes=["https://www.googleapis.com/auth/gmail.modify"],
+    )
+
+    response = generic_oauth_callback("google", request, db, google_provider)
+
+    assert response.status_code == 200
+    assert post.call_args.kwargs["headers"]["Content-Type"] == (
+        "application/x-www-form-urlencoded"
+    )
+    assert post.call_args.kwargs["data"]["client_id"] == "google-client-id"
+    assert "json" not in post.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_jira_expired_token_refresh_uses_json_body(db_session, monkeypatch):
+    db, user = db_session
+    db.add(
+        OAuthProvider(
+            provider_name="jira",
+            name="Jira",
+            client_id=encrypt_value("jira-client-id"),
+            client_secret=encrypt_value("jira-client-secret"),
+            auth_url="https://auth.atlassian.com/authorize",
+            token_url="https://auth.atlassian.com/oauth/token",
+            redirect_uri="https://app.example.com/api/auth/jira/callback",
+            userinfo_url="https://api.atlassian.com/me",
+            user_id_path="account_id",
+            email_path="email",
+            default_scopes=["read:jira-work", "offline_access"],
+        )
+    )
+    oauth_account = UserOAuth(
+        user_id=user.id,
+        provider="jira",
+        access_token="old-token",
+        refresh_token="old-refresh",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="jira-user-1",
+    )
+    db.add(oauth_account)
+    db.commit()
+
+    captured_requests = []
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured_requests.append((url, kwargs))
+            return MockResponse(
+                {
+                    "access_token": "new-token",
+                    # Atlassian rotates refresh tokens on every use.
+                    "refresh_token": "new-refresh",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                },
+                status_code=200,
+            )
+
+    monkeypatch.setattr(tool_config.httpx, "AsyncClient", FakeAsyncClient)
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "jira")
+        is True
+    )
+
+    assert oauth_account.access_token == "new-token"
+    assert oauth_account.refresh_token == "new-refresh"
+    assert len(captured_requests) == 1
+    url, kwargs = captured_requests[0]
+    assert url == "https://auth.atlassian.com/oauth/token"
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert kwargs["json"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "old-refresh",
+        "client_id": "jira-client-id",
+        "client_secret": "jira-client-secret",
+    }
+    assert "data" not in kwargs

--- a/tests/web/tools/test_jira_mcp.py
+++ b/tests/web/tools/test_jira_mcp.py
@@ -1,0 +1,461 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.web.tools.mcp import jira
+
+
+class MockResponse:
+    def __init__(
+        self, json_data=None, status_code: int = 200, text: str = "", url: str = ""
+    ):
+        self._json_data = json_data if json_data is not None else {}
+        self.status_code = status_code
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.content = self.text.encode()
+        self.url = url
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                f"{self.status_code} Client Error for url: {self.url}", response=self
+            )
+
+
+_SITE_A = {"id": "site-a", "name": "Acme", "url": "https://acme.atlassian.net"}
+_SITE_B = {"id": "site-b", "name": "Beta", "url": "https://beta.atlassian.net"}
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("JIRA_ACCESS_TOKEN", "access-token")
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("JIRA_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="JIRA_ACCESS_TOKEN"):
+        jira._headers()
+
+
+def test_headers_include_bearer_token():
+    headers = jira._headers()
+    assert headers["Authorization"] == "Bearer access-token"
+    assert headers["Accept"] == "application/json"
+
+
+def test_request_absolute_raises_with_structured_error_messages(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={
+                    "errorMessages": ["The issue no longer exists."],
+                    "errors": {"assignee": "User does not exist"},
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        jira._request_absolute("GET", "https://api.atlassian.com/me")
+
+    assert "no longer exists" in str(excinfo.value)
+    assert "assignee: User does not exist" in str(excinfo.value)
+
+
+def test_request_absolute_truncates_unstructured_error_body(monkeypatch):
+    long_body = "x" * 5000
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text=long_body)),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        jira._request_absolute("GET", "https://api.atlassian.com/me")
+
+    assert "[truncated]" in str(excinfo.value)
+    assert len(str(excinfo.value)) < len(long_body)
+
+
+def test_resolve_cloud_id_passes_through_explicit_value(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    assert jira._resolve_cloud_id("explicit-id") == "explicit-id"
+    mock_request.assert_not_called()
+
+
+def test_resolve_cloud_id_auto_resolves_single_site(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=[_SITE_A])),
+    )
+
+    assert jira._resolve_cloud_id("") == "site-a"
+
+
+def test_resolve_cloud_id_raises_when_multiple_sites(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=[_SITE_A, _SITE_B])),
+    )
+
+    with pytest.raises(ValueError, match="Multiple Jira sites"):
+        jira._resolve_cloud_id("")
+
+
+def test_resolve_cloud_id_raises_when_no_sites(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests, "request", Mock(return_value=MockResponse(json_data=[]))
+    )
+
+    with pytest.raises(ValueError, match="No accessible Jira sites"):
+        jira._resolve_cloud_id("")
+
+
+def test_request_builds_url_with_resolved_cloud_id(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"id": "10001", "key": "ENG-1"})
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    jira._request("GET", "site-a", "/rest/api/2/issue/ENG-1")
+
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.atlassian.com/ex/jira/site-a/rest/api/2/issue/ENG-1"
+    )
+
+
+def test_list_accessible_sites_returns_sites(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=[_SITE_A, _SITE_B])),
+    )
+
+    result = json.loads(jira.jira_list_accessible_sites())
+
+    assert result["status"] == "success"
+    assert result["sites"] == [_SITE_A, _SITE_B]
+
+
+def test_get_current_user_returns_profile(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "account_id": "u1",
+                "email": "ada@example.com",
+                "name": "Ada",
+                "picture": "https://example.com/ada.png",
+            }
+        )
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_get_current_user())
+
+    assert result["status"] == "success"
+    assert result["user"]["email"] == "ada@example.com"
+    assert mock_request.call_args.kwargs["url"] == "https://api.atlassian.com/me"
+
+
+def test_get_current_user_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=401, json_data={"errorMessages": ["Unauthorized"]}
+            )
+        ),
+    )
+
+    result = json.loads(jira.jira_get_current_user())
+
+    assert result["status"] == "error"
+    assert "Unauthorized" in result["message"]
+
+
+def test_list_projects_uses_resolved_cloud_id(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data={
+                    "values": [{"id": "1", "key": "ENG", "name": "Engineering"}],
+                    "isLast": True,
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_list_projects())
+
+    assert result["status"] == "success"
+    assert result["projects"] == [{"id": "1", "key": "ENG", "name": "Engineering"}]
+    assert result["truncated"] is False
+    project_call = mock_request.call_args_list[1]
+    assert project_call.kwargs["url"] == (
+        "https://api.atlassian.com/ex/jira/site-a/rest/api/2/project/search"
+    )
+
+
+def test_search_issues_sends_jql_and_reports_total(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data={
+                    "issues": [{"key": "ENG-1", "fields": {"summary": "Bug"}}],
+                    "total": 5,
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_search_issues("project = ENG"))
+
+    assert result["status"] == "success"
+    assert result["issues"][0]["key"] == "ENG-1"
+    assert result["total"] == 5
+    assert result["truncated"] is True
+    search_call = mock_request.call_args_list[1]
+    assert search_call.kwargs["params"]["jql"] == "project = ENG"
+
+
+def test_get_issue_returns_issue(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse(json_data=[_SITE_A]),
+                MockResponse(json_data={"key": "ENG-1", "fields": {"summary": "Bug"}}),
+            ]
+        ),
+    )
+
+    result = json.loads(jira.jira_get_issue("ENG-1"))
+
+    assert result["status"] == "success"
+    assert result["issue"]["key"] == "ENG-1"
+
+
+def test_create_issue_sends_expected_fields(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(json_data={"key": "ENG-2", "id": "10002"}),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(
+        jira.jira_create_issue(
+            project_key="ENG",
+            summary="New bug",
+            description="Steps to reproduce",
+            assignee_account_id="u1",
+            priority="High",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["issue"]["key"] == "ENG-2"
+    create_call = mock_request.call_args_list[1]
+    assert create_call.kwargs["json"] == {
+        "fields": {
+            "project": {"key": "ENG"},
+            "summary": "New bug",
+            "issuetype": {"name": "Task"},
+            "description": "Steps to reproduce",
+            "assignee": {"accountId": "u1"},
+            "priority": {"name": "High"},
+        }
+    }
+
+
+def test_update_issue_requires_at_least_one_field(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_update_issue("ENG-1"))
+
+    assert result["status"] == "error"
+    assert "No fields" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_update_issue_unassigns_on_explicit_empty_assignee_id(monkeypatch):
+    mock_request = Mock(
+        side_effect=[MockResponse(json_data=[_SITE_A]), MockResponse(json_data={})]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_update_issue("ENG-1", assignee_account_id=""))
+
+    assert result["status"] == "success"
+    update_call = mock_request.call_args_list[1]
+    assert update_call.kwargs["json"] == {"fields": {"assignee": None}}
+
+
+def test_list_transitions_returns_id_and_name(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse(json_data=[_SITE_A]),
+                MockResponse(
+                    json_data={
+                        "transitions": [
+                            {"id": "11", "name": "In Progress", "extra": "dropped"},
+                            {"id": "21", "name": "Done"},
+                        ]
+                    }
+                ),
+            ]
+        ),
+    )
+
+    result = json.loads(jira.jira_list_transitions("ENG-1"))
+
+    assert result["status"] == "success"
+    assert result["transitions"] == [
+        {"id": "11", "name": "In Progress"},
+        {"id": "21", "name": "Done"},
+    ]
+
+
+def test_transition_issue_matches_name_case_insensitively(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data={
+                    "transitions": [
+                        {"id": "11", "name": "In Progress"},
+                        {"id": "21", "name": "Done"},
+                    ]
+                }
+            ),
+            MockResponse(json_data={}),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_transition_issue("ENG-1", "done"))
+
+    assert result["status"] == "success"
+    assert result["transitioned_to"] == "Done"
+    transition_call = mock_request.call_args_list[2]
+    assert transition_call.kwargs["json"] == {"transition": {"id": "21"}}
+
+
+def test_transition_issue_reports_available_transitions_when_not_found(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse(json_data=[_SITE_A]),
+                MockResponse(
+                    json_data={"transitions": [{"id": "11", "name": "In Progress"}]}
+                ),
+            ]
+        ),
+    )
+
+    result = json.loads(jira.jira_transition_issue("ENG-1", "Nonexistent"))
+
+    assert result["status"] == "error"
+    assert "In Progress" in result["message"]
+
+
+def test_list_comments_reports_truncated(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse(json_data=[_SITE_A]),
+                MockResponse(
+                    json_data={
+                        "comments": [{"id": "1", "body": "First"}],
+                        "total": 3,
+                    }
+                ),
+            ]
+        ),
+    )
+
+    result = json.loads(jira.jira_list_comments("ENG-1"))
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+
+
+def test_add_comment_sends_body(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(json_data={"id": "1", "body": "Looks good"}),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_add_comment("ENG-1", "Looks good"))
+
+    assert result["status"] == "success"
+    comment_call = mock_request.call_args_list[1]
+    assert comment_call.kwargs["json"] == {"body": "Looks good"}
+
+
+def test_search_users_maps_fields(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse(json_data=[_SITE_A]),
+                MockResponse(
+                    json_data=[
+                        {
+                            "accountId": "u1",
+                            "displayName": "Ada Lovelace",
+                            "emailAddress": "ada@example.com",
+                        }
+                    ]
+                ),
+            ]
+        ),
+    )
+
+    result = json.loads(jira.jira_search_users("ada"))
+
+    assert result["status"] == "success"
+    assert result["users"] == [
+        {"account_id": "u1", "display_name": "Ada Lovelace", "email": "ada@example.com"}
+    ]
+
+
+def test_jira_app_registry_includes_offline_access_scope():
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    jira_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "jira"
+    )
+    assert "offline_access" in jira_app["oauth_scopes"]

--- a/tests/web/tools/test_jira_mcp.py
+++ b/tests/web/tools/test_jira_mcp.py
@@ -9,13 +9,19 @@ from xagent.web.tools.mcp import jira
 
 class MockResponse:
     def __init__(
-        self, json_data=None, status_code: int = 200, text: str = "", url: str = ""
+        self,
+        json_data=None,
+        status_code: int = 200,
+        text: str = "",
+        url: str = "",
+        headers: dict | None = None,
     ):
         self._json_data = json_data if json_data is not None else {}
         self.status_code = status_code
         self.text = text or (json.dumps(self._json_data) if json_data else "")
         self.content = self.text.encode()
         self.url = url
+        self.headers = headers or {}
 
     def json(self):
         return self._json_data
@@ -86,6 +92,37 @@ def test_request_absolute_truncates_unstructured_error_body(monkeypatch):
     assert len(str(excinfo.value)) < len(long_body)
 
 
+def test_request_absolute_retries_once_on_429_with_retry_after(monkeypatch):
+    sleep_calls = []
+    monkeypatch.setattr(jira.time, "sleep", lambda s: sleep_calls.append(s))
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(status_code=429, headers={"Retry-After": "2"}),
+            MockResponse(json_data={"ok": True}),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = jira._request_absolute("GET", "https://api.atlassian.com/me")
+
+    assert result == {"ok": True}
+    assert sleep_calls == [2]
+    assert mock_request.call_count == 2
+
+
+def test_request_absolute_does_not_retry_429_twice(monkeypatch):
+    monkeypatch.setattr(jira.time, "sleep", lambda s: None)
+    mock_request = Mock(
+        return_value=MockResponse(status_code=429, headers={"Retry-After": "1"})
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    with pytest.raises(RuntimeError):
+        jira._request_absolute("GET", "https://api.atlassian.com/me")
+
+    assert mock_request.call_count == 2
+
+
 def test_resolve_cloud_id_passes_through_explicit_value(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(jira.requests, "request", mock_request)
@@ -134,6 +171,35 @@ def test_request_builds_url_with_resolved_cloud_id(monkeypatch):
 
     assert mock_request.call_args.kwargs["url"] == (
         "https://api.atlassian.com/ex/jira/site-a/rest/api/2/issue/ENG-1"
+    )
+
+
+def test_request_percent_encodes_cloud_id_in_url(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    jira._request("GET", "site/../a", "/rest/api/2/issue/ENG-1")
+
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.atlassian.com/ex/jira/site%2F..%2Fa/rest/api/2/issue/ENG-1"
+    )
+
+
+def test_get_issue_percent_encodes_issue_key_in_path(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(json_data={"key": "ENG-1"}),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    jira.jira_get_issue("ENG-1/../secrets?x=1")
+
+    issue_call = mock_request.call_args_list[1]
+    assert issue_call.kwargs["url"] == (
+        "https://api.atlassian.com/ex/jira/site-a/rest/api/2/issue/"
+        "ENG-1%2F..%2Fsecrets%3Fx%3D1"
     )
 
 
@@ -206,20 +272,62 @@ def test_list_projects_uses_resolved_cloud_id(monkeypatch):
     assert result["status"] == "success"
     assert result["projects"] == [{"id": "1", "key": "ENG", "name": "Engineering"}]
     assert result["truncated"] is False
+    assert result["next_start_at"] is None
     project_call = mock_request.call_args_list[1]
     assert project_call.kwargs["url"] == (
         "https://api.atlassian.com/ex/jira/site-a/rest/api/2/project/search"
     )
+    assert project_call.kwargs["params"]["startAt"] == 0
 
 
-def test_search_issues_sends_jql_and_reports_total(monkeypatch):
+def test_list_projects_reports_next_start_at_when_truncated(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data={
+                    "values": [{"id": "1", "key": "ENG", "name": "Engineering"}],
+                    "isLast": False,
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_list_projects(start_at=5))
+
+    assert result["truncated"] is True
+    assert result["next_start_at"] == 6
+    project_call = mock_request.call_args_list[1]
+    assert project_call.kwargs["params"]["startAt"] == 5
+
+
+def test_list_projects_empty_page_never_repeats_offset(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(json_data={"values": [], "isLast": False}),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_list_projects(start_at=5))
+
+    assert result["truncated"] is False
+    assert result["next_start_at"] is None
+
+
+def test_search_issues_sends_jql_and_reports_next_page_token(monkeypatch):
+    # No isLast in the mock on purpose: the enhanced-search endpoint's
+    # pagination signal is nextPageToken presence, and isLast is not
+    # guaranteed to appear in the response.
     mock_request = Mock(
         side_effect=[
             MockResponse(json_data=[_SITE_A]),
             MockResponse(
                 json_data={
                     "issues": [{"key": "ENG-1", "fields": {"summary": "Bug"}}],
-                    "total": 5,
+                    "nextPageToken": "token-2",
                 }
             ),
         ]
@@ -230,10 +338,38 @@ def test_search_issues_sends_jql_and_reports_total(monkeypatch):
 
     assert result["status"] == "success"
     assert result["issues"][0]["key"] == "ENG-1"
-    assert result["total"] == 5
     assert result["truncated"] is True
+    assert result["next_page_token"] == "token-2"
     search_call = mock_request.call_args_list[1]
+    assert search_call.kwargs["url"] == (
+        "https://api.atlassian.com/ex/jira/site-a/rest/api/3/search/jql"
+    )
     assert search_call.kwargs["params"]["jql"] == "project = ENG"
+
+
+def test_search_issues_passes_next_page_token_when_provided(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data={
+                    "issues": [{"key": "ENG-2", "fields": {"summary": "Bug 2"}}],
+                    "isLast": True,
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(
+        jira.jira_search_issues("project = ENG", next_page_token="token-2")
+    )
+
+    assert result["status"] == "success"
+    assert result["truncated"] is False
+    assert result["next_page_token"] is None
+    search_call = mock_request.call_args_list[1]
+    assert search_call.kwargs["params"]["nextPageToken"] == "token-2"
 
 
 def test_get_issue_returns_issue(monkeypatch):
@@ -406,6 +542,44 @@ def test_list_comments_reports_truncated(monkeypatch):
 
     assert result["status"] == "success"
     assert result["truncated"] is True
+    assert result["next_start_at"] == 1
+
+
+def test_list_comments_paginates_with_start_at(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data={
+                    "comments": [{"id": "2", "body": "Second"}],
+                    "total": 2,
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_list_comments("ENG-1", start_at=1))
+
+    assert result["truncated"] is False
+    assert result["next_start_at"] is None
+    comment_call = mock_request.call_args_list[1]
+    assert comment_call.kwargs["params"]["startAt"] == 1
+
+
+def test_list_comments_empty_page_never_repeats_offset(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(json_data={"comments": [], "total": 10}),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_list_comments("ENG-1", start_at=5))
+
+    assert result["truncated"] is False
+    assert result["next_start_at"] is None
 
 
 def test_add_comment_sends_body(monkeypatch):
@@ -425,24 +599,21 @@ def test_add_comment_sends_body(monkeypatch):
 
 
 def test_search_users_maps_fields(monkeypatch):
-    monkeypatch.setattr(
-        jira.requests,
-        "request",
-        Mock(
-            side_effect=[
-                MockResponse(json_data=[_SITE_A]),
-                MockResponse(
-                    json_data=[
-                        {
-                            "accountId": "u1",
-                            "displayName": "Ada Lovelace",
-                            "emailAddress": "ada@example.com",
-                        }
-                    ]
-                ),
-            ]
-        ),
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data=[
+                    {
+                        "accountId": "u1",
+                        "displayName": "Ada Lovelace",
+                        "emailAddress": "ada@example.com",
+                    }
+                ]
+            ),
+        ]
     )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
 
     result = json.loads(jira.jira_search_users("ada"))
 
@@ -450,6 +621,74 @@ def test_search_users_maps_fields(monkeypatch):
     assert result["users"] == [
         {"account_id": "u1", "display_name": "Ada Lovelace", "email": "ada@example.com"}
     ]
+    assert result["truncated"] is False
+    user_call = mock_request.call_args_list[1]
+    assert user_call.kwargs["params"]["startAt"] == 0
+
+
+def test_search_users_reports_truncated_on_full_page(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data=[
+                    {
+                        "accountId": f"u{i}",
+                        "displayName": f"User {i}",
+                        "emailAddress": f"u{i}@example.com",
+                    }
+                    for i in range(2)
+                ]
+            ),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_search_users("a", limit=2, start_at=2))
+
+    assert result["truncated"] is True
+    assert result["next_start_at"] == 4
+    user_call = mock_request.call_args_list[1]
+    assert user_call.kwargs["params"]["startAt"] == 2
+
+
+def test_search_users_returns_error_on_non_list_response(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(json_data={"unexpected": "shape"}),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_search_users("ada"))
+
+    assert result["status"] == "error"
+    assert "Unexpected response format" in result["message"]
+
+
+def test_search_users_counts_raw_page_for_pagination(monkeypatch):
+    # A malformed (non-dict) element is dropped from users but must still
+    # count toward the page size, or pagination would stall or re-read rows.
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data=[
+                    {"accountId": "u1", "displayName": "Ada", "emailAddress": "a@x.io"},
+                    "malformed-entry",
+                ]
+            ),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_search_users("a", limit=2))
+
+    assert result["status"] == "success"
+    assert len(result["users"]) == 1
+    assert result["truncated"] is True
+    assert result["next_start_at"] == 2
 
 
 def test_jira_app_registry_includes_offline_access_scope():

--- a/tests/web/tools/test_jira_mcp.py
+++ b/tests/web/tools/test_jira_mcp.py
@@ -18,7 +18,9 @@ class MockResponse:
     ):
         self._json_data = json_data if json_data is not None else {}
         self.status_code = status_code
-        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.text = text or (
+            json.dumps(self._json_data) if json_data is not None else ""
+        )
         self.content = self.text.encode()
         self.url = url
         self.headers = headers or {}
@@ -92,6 +94,25 @@ def test_request_absolute_truncates_unstructured_error_body(monkeypatch):
     assert len(str(excinfo.value)) < len(long_body)
 
 
+def test_request_absolute_truncates_large_structured_error_body(monkeypatch):
+    long_messages = [f"error {i}" for i in range(500)]
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400, json_data={"errorMessages": long_messages}
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        jira._request_absolute("GET", "https://api.atlassian.com/me")
+
+    assert "[truncated]" in str(excinfo.value)
+    assert len(str(excinfo.value)) < len("; ".join(long_messages))
+
+
 def test_request_absolute_retries_once_on_429_with_retry_after(monkeypatch):
     sleep_calls = []
     monkeypatch.setattr(jira.time, "sleep", lambda s: sleep_calls.append(s))
@@ -158,6 +179,28 @@ def test_resolve_cloud_id_raises_when_no_sites(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="No accessible Jira sites"):
+        jira._resolve_cloud_id("")
+
+
+def test_accessible_resources_raises_on_non_list_response(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"unexpected": "shape"})),
+    )
+
+    with pytest.raises(ValueError, match="Unexpected response format"):
+        jira._accessible_resources()
+
+
+def test_resolve_cloud_id_multiple_sites_message_handles_non_dict_entries(monkeypatch):
+    monkeypatch.setattr(
+        jira.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=["not-a-dict", "also-not-a-dict"])),
+    )
+
+    with pytest.raises(ValueError, match="details unavailable"):
         jira._resolve_cloud_id("")
 
 
@@ -448,6 +491,39 @@ def test_update_issue_unassigns_on_explicit_empty_assignee_id(monkeypatch):
     assert update_call.kwargs["json"] == {"fields": {"assignee": None}}
 
 
+def test_create_issue_rejects_empty_summary(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_create_issue(project_key="ENG", summary=""))
+
+    assert result["status"] == "error"
+    assert "summary cannot be empty" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_update_issue_rejects_empty_summary(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_update_issue("ENG-1", summary=""))
+
+    assert result["status"] == "error"
+    assert "summary cannot be empty" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_update_issue_rejects_empty_priority(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_update_issue("ENG-1", priority=""))
+
+    assert result["status"] == "error"
+    assert "priority cannot be empty" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_list_transitions_returns_id_and_name(monkeypatch):
     monkeypatch.setattr(
         jira.requests,
@@ -578,6 +654,24 @@ def test_list_comments_empty_page_never_repeats_offset(monkeypatch):
 
     result = json.loads(jira.jira_list_comments("ENG-1", start_at=5))
 
+    assert result["truncated"] is False
+    assert result["next_start_at"] is None
+
+
+def test_list_comments_ignores_non_int_total(monkeypatch):
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=[_SITE_A]),
+            MockResponse(
+                json_data={"comments": [{"id": "1", "body": "First"}], "total": None}
+            ),
+        ]
+    )
+    monkeypatch.setattr(jira.requests, "request", mock_request)
+
+    result = json.loads(jira.jira_list_comments("ENG-1"))
+
+    assert result["status"] == "success"
     assert result["truncated"] is False
     assert result["next_start_at"] is None
 


### PR DESCRIPTION
## Summary
- Adds a Jira connector using the same static-client OAuth + custom FastMCP pattern already used for GitHub/Linear/Slack/Zoom/HubSpot: a seeded `oauth_providers` + `public_mcp_apps` row pair, and a new `tools/mcp/jira.py` module wrapping the Jira Cloud REST API (projects, issues, comments, workflow transitions, user search, a JQL search tool, and an authenticated-user profile lookup).
- Jira/Atlassian OAuth 2.0 (3LO) apps require no platform-level review to function — registering a Developer Console app and sharing the client_id/secret is immediately usable by any Atlassian account. (Each customer's own site admin can independently gate third-party app installs on their instance, but that's the customer's own security policy, not an Atlassian review queue blocking the connector itself.)
- Three Atlassian-specific quirks handled in the shared generic OAuth flow:
  - Every authorize request must carry `audience=api.atlassian.com` and `prompt=consent` — added to `generic_oauth_login`.
  - The token endpoint (both the initial code exchange **and** refresh) requires a **JSON body** — every other provider here uses form-urlencoded. Added to `generic_oauth_callback` and `refresh_oauth_token_if_needed`.
  - `offline_access` must be explicitly requested to get a `refresh_token` back at all — included in this connector's default scopes.
- API calls are routed through `https://api.atlassian.com/ex/jira/{cloudId}/...`, not the customer's own domain. `cloud_id` is resolved via the `accessible-resources` endpoint and auto-picked when an account has exactly one accessible site (mirrors the `@current` convenience used in the Linear/PostHog connectors, implemented via an actual site lookup since Jira has no such shortcut) — otherwise the tool reports the available sites and asks the caller to pick one.

## Test plan
- [x] `tests/alembic/test_20260818_seed_jira_mcp_app.py` — seed migration insert/idempotency/downgrade, and drift check against `builtin_mcp_registry.py`
- [x] `tests/web/tools/test_jira_mcp.py` — cloud_id resolution (single/multiple/zero sites, explicit override), error-body handling, and all 12 Jira tools
- [x] `tests/web/test_jira_oauth.py` — `audience`/`prompt` params on login, JSON-body token exchange and refresh, and non-jira providers unaffected
- [x] `ruff check` / `ruff format` / mypy / pre-commit hooks all pass
- [x] Regression: existing Zoom/Slack/Intercom OAuth tests still pass after the shared `generic_oauth_callback`/`refresh_oauth_token_if_needed` changes