### PR TITLE
fix(tools): refresh the governing team id on cache-reused tool configs

### DIFF
--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -34,6 +34,11 @@ logger = logging.getLogger(__name__)
 _UNSET = object()
 
 
+# Bounded rebuild budget: each retry means an invalidation landed inside the
+# creator awaits, so exhausting it points at churn rather than a race.
+_TOOL_BUILD_ATTEMPTS = 3
+
+
 class AgentService:
     """Service facade that executes tasks through agent only."""
 
@@ -113,6 +118,7 @@ class AgentService:
         # cheap; the signature naturally invalidates when policy
         # changes later, restoring upstream's rebuild semantics.
         self._tool_policy_signature: Any | None = None
+        self._tool_invalidation_epoch = 0
         if self._tools_initialized and self.tool_config:
             try:
                 has_async_policy_refresh = callable(
@@ -218,6 +224,9 @@ class AgentService:
 
         self._tools_initialized = False
         self._tool_policy_signature = None
+        # A build already awaiting its creators cannot be cancelled, so it is
+        # retired by epoch instead: publishing it would overwrite this call.
+        self._tool_invalidation_epoch += 1
 
     def _refresh_task_runtime_context(self) -> None:
         """Refresh prompt and model preferences from the current tool contribution."""
@@ -731,29 +740,42 @@ class AgentService:
                     return
 
                 # Rebuild the tool list so disabled tools disappear from reused agents.
-                new_tools = await ToolFactory.create_all_tools(self.tool_config)
-                self.tools = list(new_tools)
-                self._refresh_task_runtime_context()
+                built: list[Any] = []
+                for _attempt in range(_TOOL_BUILD_ATTEMPTS):
+                    epoch = self._tool_invalidation_epoch
+                    built = list(await ToolFactory.create_all_tools(self.tool_config))
 
-                if hasattr(self.tool_config, "get_allowed_tools"):
-                    allowed_tools = self.tool_config.get_allowed_tools()
-                    if allowed_tools is not None:
-                        allowed_set = set(allowed_tools)
-                        self.tools = [
-                            tool
-                            for tool in self.tools
-                            if hasattr(tool, "name") and tool.name in allowed_set
-                        ]
+                    if hasattr(self.tool_config, "get_allowed_tools"):
+                        allowed_tools = self.tool_config.get_allowed_tools()
+                        if allowed_tools is not None:
+                            allowed_set = set(allowed_tools)
+                            built = [
+                                tool
+                                for tool in built
+                                if hasattr(tool, "name") and tool.name in allowed_set
+                            ]
 
-                self.agent.tools = self.tools
-                if self._execution_adapter is not None:
-                    self._execution_adapter.config.tools = self.tools
-                    self._execution_adapter.config.system_prompt = self.system_prompt
-                    self._execution_adapter.config.preferred_input_modalities = (
-                        self.preferred_input_modalities
-                    )
-                self._tools_initialized = True
-                self._tool_policy_signature = policy_signature
+                    # Nothing is published until the whole build is known to
+                    # belong to the current epoch: an invalidation that landed
+                    # in any creator await above (MCP handshakes included)
+                    # makes this set the previous config's, and installing it
+                    # would undo that invalidation.
+                    if epoch == self._tool_invalidation_epoch:
+                        self._publish_tools(built)
+                        self._tools_initialized = True
+                        self._tool_policy_signature = policy_signature
+                        return
+
+                # Budget exhausted: install the freshest build (never the
+                # pre-invalidation one) but leave it unmarked, so the next call
+                # rebuilds instead of accepting it.
+                self._publish_tools(built)
+                logger.warning(
+                    "Tool build for AgentService '%s' was retired %s times by "
+                    "concurrent invalidation; leaving the set unmarked",
+                    self.name,
+                    _TOOL_BUILD_ATTEMPTS,
+                )
             except ConnectorRuntimeError:
                 raise
             except RequiredMCPUnavailableError:
@@ -765,6 +787,18 @@ class AgentService:
                 raise RuntimeError(
                     f"Tool initialization failed for AgentService '{self.name}': {exc}"
                 ) from exc
+
+    def _publish_tools(self, tools: list[Any]) -> None:
+        """Install a built tool set on the agent and the execution adapter."""
+        self.tools = tools
+        self._refresh_task_runtime_context()
+        self.agent.tools = self.tools
+        if self._execution_adapter is not None:
+            self._execution_adapter.config.tools = self.tools
+            self._execution_adapter.config.system_prompt = self.system_prompt
+            self._execution_adapter.config.preferred_input_modalities = (
+                self.preferred_input_modalities
+            )
 
     def _current_tool_policy_signature(
         self,

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -454,11 +454,21 @@ async def _resume_input_required_a2a_task(
     try:
 
         async def inject_user_message() -> tuple[Any, bool]:
+            from ..services.task_setup_snapshot import (
+                load_task_setup_snapshot_sync,
+            )
             from .chat import get_agent_manager
 
+            # An authoritative agent read, not just message metadata: a
+            # cache hit reuses a tool config whose governing team was captured
+            # on an earlier turn, and only a snapshot can revalidate it.
+            snapshot = await run_db_io_cancellation_safe(
+                lambda: load_task_setup_snapshot_sync(task_id, task_owner_user_id)
+            )
             agent_service = await get_agent_manager().get_agent_for_task(
                 task_id,
                 None,
+                task_setup_snapshot=snapshot,
                 task_owner_user_id=task_owner_user_id,
             )
             posted = await agent_service.post_user_message(

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -454,22 +454,22 @@ async def _resume_input_required_a2a_task(
     try:
 
         async def inject_user_message() -> tuple[Any, bool]:
-            from ..services.task_setup_snapshot import (
-                load_task_setup_snapshot_sync,
-            )
+            from ..services.task_setup_snapshot import load_governing_team_sync
             from .chat import get_agent_manager
 
-            # An authoritative agent read, not just message metadata: a
-            # cache hit reuses a tool config whose governing team was captured
-            # on an earlier turn, and only a snapshot can revalidate it.
-            snapshot = await run_db_io_cancellation_safe(
-                lambda: load_task_setup_snapshot_sync(task_id, task_owner_user_id)
+            # An authoritative agent read, not the reply's own turn id, is what
+            # lets a reused tool config revalidate its governing team. Only the
+            # team projection: a cache miss loads its own full snapshot, so the
+            # transcript/recovery reads a bootstrap snapshot performs would be
+            # spent for one scalar on every reply.
+            governing_team_id = await run_db_io_cancellation_safe(
+                lambda: load_governing_team_sync(task_id, task_owner_user_id)
             )
             agent_service = await get_agent_manager().get_agent_for_task(
                 task_id,
                 None,
-                task_setup_snapshot=snapshot,
                 task_owner_user_id=task_owner_user_id,
+                governing_team_id=governing_team_id,
             )
             posted = await agent_service.post_user_message(
                 str(task_id),

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -131,6 +131,8 @@ from ..services.task_runtime import (
     validate_task_extension_requests,
 )
 from ..services.task_setup_snapshot import (
+    GOVERNING_TEAM_NOT_READ,
+    GoverningTeamNotRead,
     RuntimeUserFields,
     TaskOwnerMismatchError,
     TaskSetupSnapshot,
@@ -2105,6 +2107,9 @@ class AgentServiceManager:
         resolved_execution_scope: Union[
             ExecutionScope, None, ExecutionScopeNotProvided
         ] = EXECUTION_SCOPE_NOT_PROVIDED,
+        governing_team_id: Union[int, None, GoverningTeamNotRead] = (
+            GOVERNING_TEAM_NOT_READ
+        ),
     ) -> AgentService:
         lock = self._agent_build_locks.get(task_id)
         if lock is None:
@@ -2119,6 +2124,7 @@ class AgentServiceManager:
                 task_owner_user_id=task_owner_user_id,
                 connector_runtime_turn_id=connector_runtime_turn_id,
                 resolved_execution_scope=resolved_execution_scope,
+                governing_team_id=governing_team_id,
             )
 
     async def _get_agent_for_task_unlocked(
@@ -2132,6 +2138,9 @@ class AgentServiceManager:
         resolved_execution_scope: Union[
             ExecutionScope, None, ExecutionScopeNotProvided
         ] = EXECUTION_SCOPE_NOT_PROVIDED,
+        governing_team_id: Union[int, None, GoverningTeamNotRead] = (
+            GOVERNING_TEAM_NOT_READ
+        ),
     ) -> AgentService:
         """Get or create AgentService instance for specific task.
 
@@ -2415,7 +2424,9 @@ class AgentServiceManager:
                             self._sync_connector_runtime_turn(
                                 task_id, connector_runtime_turn_id
                             )
-                            self._sync_connector_team_id(task_id, task_setup_snapshot)
+                            self._sync_connector_team_id(
+                                task_id, task_setup_snapshot, governing_team_id
+                            )
                             self._sync_execution_scope(task_id, scope)
                             return self._agents[task_id]
                     except (
@@ -2870,7 +2881,7 @@ class AgentServiceManager:
         self._agent_owner_ids[task_id] = runtime_user_id
         self._agent_scope_fingerprints[task_id] = fingerprint
         self._sync_connector_runtime_turn(task_id, connector_runtime_turn_id)
-        self._sync_connector_team_id(task_id, task_setup_snapshot)
+        self._sync_connector_team_id(task_id, task_setup_snapshot, governing_team_id)
         self._sync_execution_scope(task_id, scope)
         return self._agents[task_id]
 
@@ -2918,17 +2929,28 @@ class AgentServiceManager:
             )
 
     def _sync_connector_team_id(
-        self, task_id: int, task_setup_snapshot: Optional[TaskSetupSnapshot]
+        self,
+        task_id: int,
+        task_setup_snapshot: Optional[TaskSetupSnapshot],
+        governing_team_id: Union[int, None, GoverningTeamNotRead],
     ) -> None:
         """Re-derive the governing agent's team on a reused tool config.
 
-        Only a wholly absent snapshot skips the sync. A present snapshot whose
+        Either input is an authoritative read and the scalar wins when both
+        arrive: build callers already hold a full snapshot, while cache-hit
+        refresh callers pass only the team projection. A snapshot whose
         ``agent`` is ``None`` is an authoritative negative -- the governing
         agent is gone or no longer resolvable -- and must clear the team the
         same way fresh construction derives ``None`` from it, never leave the
-        previous team's grants in place.
+        previous team's grants in place. Only the absence of both reads skips
+        the sync.
         """
-        if task_setup_snapshot is None:
+        if not isinstance(governing_team_id, GoverningTeamNotRead):
+            team_id = governing_team_id
+        elif task_setup_snapshot is not None:
+            snapshot_agent = task_setup_snapshot.agent
+            team_id = snapshot_agent.team_id if snapshot_agent is not None else None
+        else:
             return
         agent = self._agents.get(task_id)
         if agent is None:
@@ -2937,8 +2959,6 @@ class AgentServiceManager:
         tool_config = getattr(agent, "tool_config", None)
         if tool_config is None or not hasattr(tool_config, "set_connector_team_id"):
             return
-        snapshot_agent = task_setup_snapshot.agent
-        team_id = snapshot_agent.team_id if snapshot_agent is not None else None
         if tool_config.set_connector_team_id(team_id):
             logger.info(
                 "Refreshing connector tools for task %s: governing team is now %s",

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2922,12 +2922,13 @@ class AgentServiceManager:
     ) -> None:
         """Re-derive the governing agent's team on a reused tool config.
 
-        Without a snapshot there is no authoritative read of the agent row:
-        the cache-hit path loads one only when the caller supplies it, and the
-        callers that omit it (a2a / v1 message posting) also omit the turn id,
-        so neither sync runs for them.
+        Only a wholly absent snapshot skips the sync. A present snapshot whose
+        ``agent`` is ``None`` is an authoritative negative -- the governing
+        agent is gone or no longer resolvable -- and must clear the team the
+        same way fresh construction derives ``None`` from it, never leave the
+        previous team's grants in place.
         """
-        if task_setup_snapshot is None or task_setup_snapshot.agent is None:
+        if task_setup_snapshot is None:
             return
         agent = self._agents.get(task_id)
         if agent is None:
@@ -2936,7 +2937,8 @@ class AgentServiceManager:
         tool_config = getattr(agent, "tool_config", None)
         if tool_config is None or not hasattr(tool_config, "set_connector_team_id"):
             return
-        team_id = task_setup_snapshot.agent.team_id
+        snapshot_agent = task_setup_snapshot.agent
+        team_id = snapshot_agent.team_id if snapshot_agent is not None else None
         if tool_config.set_connector_team_id(team_id):
             logger.info(
                 "Refreshing connector tools for task %s: governing team is now %s",

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2415,6 +2415,7 @@ class AgentServiceManager:
                             self._sync_connector_runtime_turn(
                                 task_id, connector_runtime_turn_id
                             )
+                            self._sync_connector_team_id(task_id, task_setup_snapshot)
                             self._sync_execution_scope(task_id, scope)
                             return self._agents[task_id]
                     except (
@@ -2869,6 +2870,7 @@ class AgentServiceManager:
         self._agent_owner_ids[task_id] = runtime_user_id
         self._agent_scope_fingerprints[task_id] = fingerprint
         self._sync_connector_runtime_turn(task_id, connector_runtime_turn_id)
+        self._sync_connector_team_id(task_id, task_setup_snapshot)
         self._sync_execution_scope(task_id, scope)
         return self._agents[task_id]
 
@@ -2914,6 +2916,34 @@ class AgentServiceManager:
                 task_id,
                 connector_runtime_turn_id,
             )
+
+    def _sync_connector_team_id(
+        self, task_id: int, task_setup_snapshot: Optional[TaskSetupSnapshot]
+    ) -> None:
+        """Re-derive the governing agent's team on a reused tool config.
+
+        Without a snapshot there is no authoritative read of the agent row:
+        the cache-hit path loads one only when the caller supplies it, and the
+        callers that omit it (a2a / v1 message posting) also omit the turn id,
+        so neither sync runs for them.
+        """
+        if task_setup_snapshot is None or task_setup_snapshot.agent is None:
+            return
+        agent = self._agents.get(task_id)
+        if agent is None:
+            return
+        # getattr/hasattr for the same reason as _sync_execution_scope below.
+        tool_config = getattr(agent, "tool_config", None)
+        if tool_config is None or not hasattr(tool_config, "set_connector_team_id"):
+            return
+        team_id = task_setup_snapshot.agent.team_id
+        if tool_config.set_connector_team_id(team_id):
+            logger.info(
+                "Refreshing connector tools for task %s: governing team is now %s",
+                task_id,
+                team_id,
+            )
+            agent.invalidate_tools()
 
     def _sync_execution_scope(
         self, task_id: int, scope: Optional[ExecutionScope]

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -502,11 +502,21 @@ async def reply_to_task(
     try:
 
         async def inject_user_message() -> tuple[Any, bool]:
+            from ...services.task_setup_snapshot import (
+                load_task_setup_snapshot_sync,
+            )
             from .. import chat
 
+            # See the a2a twin: the reply turn id is message metadata, so a
+            # snapshot is the only authoritative read that can revalidate a
+            # reused tool config's governing team.
+            snapshot = await run_db_io_cancellation_safe(
+                lambda: load_task_setup_snapshot_sync(task_id, ctx.task_owner_user_id)
+            )
             agent_service = await chat.get_agent_manager().get_agent_for_task(
                 task_id,
                 None,
+                task_setup_snapshot=snapshot,
                 task_owner_user_id=ctx.task_owner_user_id,
             )
             posted = await agent_service.post_user_message(

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -502,22 +502,20 @@ async def reply_to_task(
     try:
 
         async def inject_user_message() -> tuple[Any, bool]:
-            from ...services.task_setup_snapshot import (
-                load_task_setup_snapshot_sync,
-            )
+            from ...services.task_setup_snapshot import load_governing_team_sync
             from .. import chat
 
-            # See the a2a twin: the reply turn id is message metadata, so a
-            # snapshot is the only authoritative read that can revalidate a
-            # reused tool config's governing team.
-            snapshot = await run_db_io_cancellation_safe(
-                lambda: load_task_setup_snapshot_sync(task_id, ctx.task_owner_user_id)
+            # See the a2a twin: the reply turn id is message metadata, so this
+            # projection is the authoritative read that revalidates a reused
+            # tool config's governing team.
+            governing_team_id = await run_db_io_cancellation_safe(
+                lambda: load_governing_team_sync(task_id, ctx.task_owner_user_id)
             )
             agent_service = await chat.get_agent_manager().get_agent_for_task(
                 task_id,
                 None,
-                task_setup_snapshot=snapshot,
                 task_owner_user_id=ctx.task_owner_user_id,
+                governing_team_id=governing_team_id,
             )
             posted = await agent_service.post_user_message(
                 str(task_id),

--- a/src/xagent/web/services/task_setup_snapshot.py
+++ b/src/xagent/web/services/task_setup_snapshot.py
@@ -229,6 +229,51 @@ def _resolve_inline_preview_excluded_agent_id(
     return int(preview_agent.id)
 
 
+class GoverningTeamNotRead:
+    """Marker distinguishing an unread governing team from a resolved ``None``."""
+
+    __slots__ = ()
+
+
+GOVERNING_TEAM_NOT_READ = GoverningTeamNotRead()
+
+
+def load_governing_team_sync(
+    task_id: int,
+    task_owner_user_id: Optional[int],
+) -> int | None | GoverningTeamNotRead:
+    """Read only the governing agent's team, for refreshing a cached config.
+
+    The cache-hit refresh consumes one scalar, so this skips everything
+    ``load_task_setup_snapshot_sync`` loads for a build: LLM resolution, agent
+    builder config, transcript, recovery and reconstruction state. The agent
+    itself is resolved through the same ``_load_agent_for_task_runtime`` that
+    the full snapshot uses, so the two can never disagree about which agent
+    governs the task.
+    """
+    from .llm_utils import _load_agent_for_task_runtime
+    from .workforce_runtime import resolve_workforce_task_runtime
+
+    session_factory = get_session_local()
+    session: Session = session_factory()
+    try:
+        task_row = session.query(Task).filter(Task.id == task_id).first()
+        if task_row is None:
+            return GOVERNING_TEAM_NOT_READ
+
+        owner_user_id = int(task_row.user_id)
+        if task_owner_user_id is not None and owner_user_id != task_owner_user_id:
+            raise TaskOwnerMismatchError(task_id, task_owner_user_id, owner_user_id)
+
+        workforce = resolve_workforce_task_runtime(session, task_row)
+        agent_row = _load_agent_for_task_runtime(session, task_row, workforce)
+        if agent_row is None or agent_row.team_id is None:
+            return None
+        return int(agent_row.team_id)
+    finally:
+        session.close()
+
+
 def load_task_setup_snapshot_sync(
     task_id: int,
     task_owner_user_id: Optional[int],

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1345,6 +1345,9 @@ class WebToolConfig(BaseToolConfig):
         self._cached_embedding_model: Optional[str] = None
         self._cached_rerank_model: Optional[str] = None
         self._factory_runtime_snapshot: _ToolFactoryRuntimeSnapshot | None = None
+        # Bumped by every discard so a detached factory load already in flight
+        # cannot install its pre-discard result over the current turn's inputs.
+        self._factory_runtime_generation = 0
         self._retained_factory_model_state: _RetainedFactoryModelState | None = None
         self._factory_runtime_handed_off = False
         self._pending_runtime_policy: _ToolRuntimePolicySnapshot | None = None
@@ -1643,8 +1646,7 @@ class WebToolConfig(BaseToolConfig):
         self._connector_runtime_turn_id = normalized_turn_id
         self._connector_runtime_view = None
         self._cached_mcp_configs = None
-        self._factory_runtime_snapshot = None
-        self._pending_runtime_policy = None
+        self.discard_prepared_factory_runtime()
         return True
 
     def set_connector_team_id(self, team_id: Optional[int]) -> bool:
@@ -1664,8 +1666,7 @@ class WebToolConfig(BaseToolConfig):
         self._connector_team_id = normalized_team_id
         self._connector_runtime_view = None
         self._cached_mcp_configs = None
-        self._factory_runtime_snapshot = None
-        self._pending_runtime_policy = None
+        self.discard_prepared_factory_runtime()
         return True
 
     def set_execution_scope(self, scope: Optional[Any]) -> bool:
@@ -1701,8 +1702,7 @@ class WebToolConfig(BaseToolConfig):
             return False
         self._execution_scope = scope
         self._cached_mcp_configs = None
-        self._factory_runtime_snapshot = None
-        self._pending_runtime_policy = None
+        self.discard_prepared_factory_runtime()
         return True
 
     def _parse_numeric_task_id(self) -> Optional[int]:
@@ -2161,6 +2161,7 @@ class WebToolConfig(BaseToolConfig):
         from ..services.db_runtime import run_db_io_cancellation_safe
 
         plan = self._build_factory_runtime_load_plan()
+        generation = self._factory_runtime_generation
         policy_snapshot = self._pending_runtime_policy
         self._pending_runtime_policy = None
         session_factory = self.get_session_factory()
@@ -2175,12 +2176,18 @@ class WebToolConfig(BaseToolConfig):
                 policy_snapshot,
             )
         )
+        # The plan was built before this await: a discard that landed while the
+        # worker ran makes its result the previous turn's, and applying it would
+        # republish inputs the invalidation just retired.
+        if generation != self._factory_runtime_generation:
+            return
         self._apply_factory_runtime_snapshot(snapshot)
 
     def discard_prepared_factory_runtime(self) -> None:
         """Discard construction-only snapshots without changing DB ownership."""
         self._factory_runtime_snapshot = None
         self._pending_runtime_policy = None
+        self._factory_runtime_generation += 1
 
     def release_prepared_factory_runtime(self) -> None:
         """Compatibility alias for configs that only discard snapshots."""

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1172,6 +1172,12 @@ def _load_tool_runtime_policy_snapshot(
 _APP_LOCALE_TO_BROWSER_LOCALE = {"en": "en-US", "zh": "zh-CN"}
 
 
+# Bounded reload budget for prepare_factory_runtime: each retry means a
+# per-turn invalidation landed mid-load, so exhausting it is a sign of a
+# resolver churning rather than a race worth chasing further.
+_FACTORY_RUNTIME_PREPARE_ATTEMPTS = 3
+
+
 class WebToolConfig(BaseToolConfig):
     """Web-specific tool configuration that loads from database."""
 
@@ -2160,28 +2166,40 @@ class WebToolConfig(BaseToolConfig):
 
         from ..services.db_runtime import run_db_io_cancellation_safe
 
-        plan = self._build_factory_runtime_load_plan()
-        generation = self._factory_runtime_generation
-        policy_snapshot = self._pending_runtime_policy
-        self._pending_runtime_policy = None
-        session_factory = self.get_session_factory()
-        # The worker mints its own Session from the same engine. A live request
-        # Session may already hold the pool's only connection after a SELECT,
-        # so release clean read transactions before the worker checks out.
-        self.release_db_connection()
-        snapshot = await run_db_io_cancellation_safe(
-            lambda: _load_tool_factory_runtime_snapshot(
-                session_factory,
-                plan,
-                policy_snapshot,
+        for _attempt in range(_FACTORY_RUNTIME_PREPARE_ATTEMPTS):
+            plan = self._build_factory_runtime_load_plan()
+            generation = self._factory_runtime_generation
+            policy_snapshot = self._pending_runtime_policy
+            self._pending_runtime_policy = None
+            session_factory = self.get_session_factory()
+            # The worker mints its own Session from the same engine. A live
+            # request Session may already hold the pool's only connection after
+            # a SELECT, so release clean read transactions before the worker
+            # checks out.
+            self.release_db_connection()
+            snapshot = await run_db_io_cancellation_safe(
+                lambda: _load_tool_factory_runtime_snapshot(
+                    session_factory,
+                    plan,
+                    policy_snapshot,
+                )
             )
+            # The plan was built before this await: a discard that landed while
+            # the worker ran makes its result the previous turn's. Reload
+            # against the current generation rather than returning without
+            # prepared inputs -- the factory treats a bare return as a
+            # successful preparation and its getters would then reopen the
+            # request Session synchronously on the event loop.
+            if generation == self._factory_runtime_generation:
+                self._apply_factory_runtime_snapshot(snapshot)
+                return
+        logger.warning(
+            "Factory runtime preparation retired %s times for task %s; leaving "
+            "inputs unprepared so the getters re-read under the current "
+            "generation",
+            _FACTORY_RUNTIME_PREPARE_ATTEMPTS,
+            self._task_id,
         )
-        # The plan was built before this await: a discard that landed while the
-        # worker ran makes its result the previous turn's, and applying it would
-        # republish inputs the invalidation just retired.
-        if generation != self._factory_runtime_generation:
-            return
-        self._apply_factory_runtime_snapshot(snapshot)
 
     def discard_prepared_factory_runtime(self) -> None:
         """Discard construction-only snapshots without changing DB ownership."""

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1647,6 +1647,27 @@ class WebToolConfig(BaseToolConfig):
         self._pending_runtime_policy = None
         return True
 
+    def set_connector_team_id(self, team_id: Optional[int]) -> bool:
+        """Refresh the governing agent's owning team for a reused config.
+
+        Cached with ``AgentService`` by task, so a mid-session change to the
+        governing agent's team (shared to a team, made personal, re-homed)
+        must not keep resolving connector visibility against the team
+        captured at construction time. Clears the same caches the turn-id
+        setter does: all three connector reads (runtime view, MCP configs,
+        custom APIs) are keyed on this value.
+        """
+
+        normalized_team_id = int(team_id) if team_id is not None else None
+        if self._connector_team_id == normalized_team_id:
+            return False
+        self._connector_team_id = normalized_team_id
+        self._connector_runtime_view = None
+        self._cached_mcp_configs = None
+        self._factory_runtime_snapshot = None
+        self._pending_runtime_policy = None
+        return True
+
     def set_execution_scope(self, scope: Optional[Any]) -> bool:
         """Switch the per-turn execution scope for a reused tool config.
 

--- a/tests/core/agent/test_agent_service_tool_refresh.py
+++ b/tests/core/agent/test_agent_service_tool_refresh.py
@@ -188,8 +188,8 @@ async def test_agent_service_refreshes_runtime_prompt_and_modalities_with_tools(
     }
     tool_config = ToolConfig({})
     tool_config.get_task_runtime_contribution = lambda: contribution_holder["value"]
-    tool_config.set_task_runtime_contribution = (
-        lambda value: contribution_holder.update(value=value)
+    tool_config.set_task_runtime_contribution = lambda value: (
+        contribution_holder.update(value=value)
     )
 
     async def create_all_tools(config: Any) -> list[Any]:
@@ -748,3 +748,79 @@ async def test_agent_service_preserves_required_mcp_initialization_errors(
         await service._ensure_tools_initialized()
 
     assert exc_info.value is required_error
+
+
+@pytest.mark.asyncio
+async def test_invalidation_inside_a_creator_await_is_not_published(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A build overtaken by ``invalidate_tools`` never reaches ``self.tools``.
+
+    ``create_all_tools`` awaits its creators (MCP handshakes among them), and an
+    invalidation landing in that window cannot cancel it. Publishing the result
+    would reinstate the tool set the invalidation just retired and mark it
+    initialized, so the next call would accept the stale build.
+    """
+    tool_config = AllowedToolsConfig()
+    service = AgentService(
+        name="epoch-test",
+        id="epoch-test",
+        tool_config=tool_config,
+        enable_workspace=False,
+    )
+    stale = NamedTool("stale")
+    fresh = NamedTool("fresh")
+    builds: list[list[Any]] = [[stale], [fresh]]
+
+    async def create_all_tools(config: Any) -> list[Any]:
+        assert config is tool_config
+        built = builds.pop(0)
+        if built[0] is stale:
+            # The team change lands while this build owns the creators.
+            service.invalidate_tools()
+        return built
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        create_all_tools,
+    )
+
+    await service._ensure_tools_initialized()
+
+    assert [tool.name for tool in service.tools] == ["fresh"]
+    assert service._tools_initialized is True
+    assert not builds
+
+
+@pytest.mark.asyncio
+async def test_exhausted_rebuild_budget_installs_the_freshest_set_unmarked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under continuous invalidation the newest build is still installed -- the
+    alternative is executing with the previous turn's tools -- but it stays
+    unmarked so the next call rebuilds rather than accepting it."""
+    tool_config = AllowedToolsConfig()
+    service = AgentService(
+        name="epoch-churn-test",
+        id="epoch-churn-test",
+        tool_config=tool_config,
+        enable_workspace=False,
+    )
+    attempts = 0
+
+    async def create_all_tools(config: Any) -> list[Any]:
+        nonlocal attempts
+        attempts += 1
+        service.invalidate_tools()
+        return [NamedTool(f"build-{attempts}")]
+
+    monkeypatch.setattr(
+        "xagent.core.tools.adapters.vibe.factory.ToolFactory.create_all_tools",
+        create_all_tools,
+    )
+
+    await service._ensure_tools_initialized()
+
+    assert attempts == 3
+    assert [tool.name for tool in service.tools] == ["build-3"]
+    assert service._tools_initialized is False

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -697,6 +697,13 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
         request_interrupt=False,
         reason="A2A input-required response",
     )
+    # The reply carries an authoritative agent read, so a cached tool config
+    # can have its governing team revalidated rather than frozen (#1281).
+    resume_snapshot = agent_manager.get_agent_for_task.await_args.kwargs[
+        "task_setup_snapshot"
+    ]
+    assert resume_snapshot is not None
+    assert resume_snapshot.task.id == int(task_id)
     begin_turn.assert_not_awaited()
     schedule_resume.assert_called_once()
     scheduled_lease = schedule_resume.call_args.kwargs["task_lease"]

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -656,12 +656,29 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
             lease_db.close()
         return True
 
+    # A governing team to actually resolve, so the projection is proven to read
+    # the agent row rather than merely being threaded through as None.
+    team_db = _direct_db_session()
+    try:
+        governed = team_db.query(Agent).filter(Agent.id == agent_id).one()
+        governed.team_id = 77
+        team_db.commit()
+    finally:
+        team_db.close()
+
     agent_service = MagicMock()
     agent_service.post_user_message = AsyncMock(side_effect=post_user_message)
     agent_manager = MagicMock()
     agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
     begin_turn = AsyncMock()
+    bootstrap_load = MagicMock(
+        side_effect=AssertionError("reply loaded a full bootstrap snapshot")
+    )
     with (
+        patch(
+            "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+            new=bootstrap_load,
+        ),
         patch(
             "xagent.web.api.chat.get_agent_manager",
             return_value=agent_manager,
@@ -697,13 +714,14 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
         request_interrupt=False,
         reason="A2A input-required response",
     )
-    # The reply carries an authoritative agent read, so a cached tool config
-    # can have its governing team revalidated rather than frozen (#1281).
-    resume_snapshot = agent_manager.get_agent_for_task.await_args.kwargs[
-        "task_setup_snapshot"
-    ]
-    assert resume_snapshot is not None
-    assert resume_snapshot.task.id == int(task_id)
+    # The reply carries an authoritative governing-team read, so a cached tool
+    # config can have its team revalidated rather than frozen (#1281) -- as the
+    # team projection, not a bootstrap snapshot whose transcript and recovery
+    # reads the cache-hit refresh never consumes.
+    resume_kwargs = agent_manager.get_agent_for_task.await_args.kwargs
+    assert resume_kwargs["governing_team_id"] == 77
+    assert "task_setup_snapshot" not in resume_kwargs
+    bootstrap_load.assert_not_called()
     begin_turn.assert_not_awaited()
     schedule_resume.assert_called_once()
     scheduled_lease = schedule_resume.call_args.kwargs["task_lease"]

--- a/tests/web/api/test_agent_cache_connector_team_refresh.py
+++ b/tests/web/api/test_agent_cache_connector_team_refresh.py
@@ -83,7 +83,7 @@ def _cached_manager(built_team_id: Optional[int]) -> tuple[Any, Any, Any]:
     return manager, agent, tool_config
 
 
-async def _reuse(manager: AgentServiceManager, snapshot: Any) -> Any:
+async def _reuse(manager: AgentServiceManager, snapshot: Any, **extra: Any) -> Any:
     return await manager.get_agent_for_task(
         task_id=TASK_ID,
         db=None,
@@ -91,6 +91,7 @@ async def _reuse(manager: AgentServiceManager, snapshot: Any) -> Any:
         task_setup_snapshot=snapshot,
         task_owner_user_id=OWNER_ID,
         resolved_execution_scope=None,
+        **extra,
     )
 
 
@@ -123,13 +124,42 @@ async def test_unchanged_team_does_not_rebuild_tools() -> None:
 
 @pytest.mark.asyncio
 async def test_absent_snapshot_leaves_the_team_alone() -> None:
-    """No snapshot is no read at all -- the sync may not guess a value."""
+    """Neither read supplied is no read at all -- the sync may not guess."""
     manager, agent, tool_config = _cached_manager(101)
 
     await _reuse(manager, None)
 
     assert tool_config._connector_team_id == 101
     agent.invalidate_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("built_team_id", "read_team_id"),
+    [(None, 101), (101, 202), (101, None)],
+)
+async def test_governing_team_projection_alone_refreshes(
+    built_team_id, read_team_id
+) -> None:
+    """The reply paths pass only the team projection -- no snapshot -- so the
+    scalar has to be sufficient on its own."""
+    manager, agent, tool_config = _cached_manager(built_team_id)
+
+    await _reuse(manager, None, governing_team_id=read_team_id)
+
+    assert tool_config._connector_team_id == read_team_id
+    agent.invalidate_tools.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unread_projection_does_not_override_a_snapshot() -> None:
+    """Build callers pass a snapshot and no projection; the default sentinel
+    must not be mistaken for an authoritative ``None``."""
+    manager, agent, tool_config = _cached_manager(None)
+
+    await _reuse(manager, _snapshot(101))
+
+    assert tool_config._connector_team_id == 101
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_agent_cache_connector_team_refresh.py
+++ b/tests/web/api/test_agent_cache_connector_team_refresh.py
@@ -122,13 +122,24 @@ async def test_unchanged_team_does_not_rebuild_tools() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("snapshot", [None, _snapshot(None, with_agent=False)])
-async def test_no_authoritative_agent_read_leaves_the_team_alone(snapshot) -> None:
-    """Callers that post into a live agent (a2a, v1 reply) pass no snapshot,
-    exactly as they pass no turn id -- neither sync may guess a value."""
+async def test_absent_snapshot_leaves_the_team_alone() -> None:
+    """No snapshot is no read at all -- the sync may not guess a value."""
     manager, agent, tool_config = _cached_manager(101)
 
-    await _reuse(manager, snapshot)
+    await _reuse(manager, None)
 
     assert tool_config._connector_team_id == 101
     agent.invalidate_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_negative_agent_result_clears_the_team() -> None:
+    """A present snapshot resolving no agent is an authoritative negative, not
+    an absent read: fresh construction derives None from it, so a reused config
+    must stop resolving the previous team's grants."""
+    manager, agent, tool_config = _cached_manager(101)
+
+    await _reuse(manager, _snapshot(None, with_agent=False))
+
+    assert tool_config._connector_team_id is None
+    agent.invalidate_tools.assert_called_once()

--- a/tests/web/api/test_agent_cache_connector_team_refresh.py
+++ b/tests/web/api/test_agent_cache_connector_team_refresh.py
@@ -1,0 +1,134 @@
+"""Cache-reused tool configs re-derive the governing agent's team (#1281).
+
+``WebToolConfig._connector_team_id`` was written once at construction while
+the instance is cached with its ``AgentService`` by task, so a governing
+agent re-homed mid-session kept resolving connector visibility against the
+team captured on the first turn. These tests drive the real cache-hit return
+path of ``get_agent_for_task``; the visibility consequence of the refresh
+itself is pinned in ``tests/web/tools/test_mcp_team_visibility.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from xagent.web.api.chat import AgentServiceManager
+from xagent.web.models.agent import AgentStatus
+from xagent.web.models.task import TaskStatus
+from xagent.web.services.llm_utils import AgentRuntimeFields
+from xagent.web.services.task_setup_snapshot import (
+    RuntimeUserFields,
+    TaskSetupSnapshot,
+    _TaskFields,
+)
+from xagent.web.tools.config import WebToolConfig
+
+TASK_ID = 42
+OWNER_ID = 1
+
+
+def _snapshot(team_id: Optional[int], *, with_agent: bool = True) -> TaskSetupSnapshot:
+    return TaskSetupSnapshot(
+        task=_TaskFields(
+            id=TASK_ID,
+            user_id=OWNER_ID,
+            status=TaskStatus.PENDING,
+            agent_id=7,
+            agent_config=None,
+            model_name=None,
+            compact_model_name=None,
+            execution_mode="flash",
+            agent_type="standard",
+        ),
+        runtime_user=RuntimeUserFields(id=OWNER_ID, is_admin=False),
+        has_reconstructable_history=False,
+        task_pattern="single_call",
+        task_llm=None,
+        task_fast_llm=None,
+        task_vision_llm=None,
+        task_compact_llm=None,
+        agent=AgentRuntimeFields(
+            id=7,
+            name="governed-agent",
+            status=AgentStatus.PUBLISHED,
+            instructions=None,
+            team_id=team_id,
+        )
+        if with_agent
+        else None,
+        agent_config=None,
+        excluded_agent_id=7,
+    )
+
+
+def _cached_manager(built_team_id: Optional[int]) -> tuple[Any, Any, Any]:
+    """A manager whose cache already holds an agent built for ``built_team_id``."""
+    manager = AgentServiceManager()
+    # A real config, not a mock: the sync is guarded by hasattr, and a
+    # MagicMock would satisfy that guard whether or not the setter exists.
+    tool_config = WebToolConfig(
+        db=None,
+        request=None,
+        user_id=OWNER_ID,
+        connector_team_id=built_team_id,
+    )
+    agent = MagicMock()
+    agent.tool_config = tool_config
+    manager._agents[TASK_ID] = agent
+    manager._agent_owner_ids[TASK_ID] = OWNER_ID
+    manager._agent_scope_fingerprints[TASK_ID] = None
+    return manager, agent, tool_config
+
+
+async def _reuse(manager: AgentServiceManager, snapshot: Any) -> Any:
+    return await manager.get_agent_for_task(
+        task_id=TASK_ID,
+        db=None,
+        user=None,
+        task_setup_snapshot=snapshot,
+        task_owner_user_id=OWNER_ID,
+        resolved_execution_scope=None,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("built_team_id", "next_team_id"),
+    [(None, 101), (101, 202), (101, None)],
+)
+async def test_reused_config_adopts_the_new_governing_team(
+    built_team_id, next_team_id
+) -> None:
+    manager, agent, tool_config = _cached_manager(built_team_id)
+
+    reused = await _reuse(manager, _snapshot(next_team_id))
+
+    assert reused is agent
+    assert tool_config._connector_team_id == next_team_id
+    agent.invalidate_tools.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unchanged_team_does_not_rebuild_tools() -> None:
+    manager, agent, tool_config = _cached_manager(101)
+
+    await _reuse(manager, _snapshot(101))
+
+    assert tool_config._connector_team_id == 101
+    agent.invalidate_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("snapshot", [None, _snapshot(None, with_agent=False)])
+async def test_no_authoritative_agent_read_leaves_the_team_alone(snapshot) -> None:
+    """Callers that post into a live agent (a2a, v1 reply) pass no snapshot,
+    exactly as they pass no turn id -- neither sync may guess a value."""
+    manager, agent, tool_config = _cached_manager(101)
+
+    await _reuse(manager, snapshot)
+
+    assert tool_config._connector_team_id == 101
+    agent.invalidate_tools.assert_not_called()

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -206,10 +206,27 @@ def test_reply_happy_path_resumes_the_same_run(mock_start_task):
     task_id = _create_waiting_task(full_key, agent_id, run_id="run-original")
     _insert_question_message(task_id)
 
+    # A governing team to actually resolve, so the projection is proven to read
+    # the agent row rather than merely being threaded through as None.
+    team_db = _direct_db_session()
+    try:
+        governed = team_db.query(Agent).filter(Agent.id == agent_id).one()
+        governed.team_id = 77
+        team_db.commit()
+    finally:
+        team_db.close()
+
     post_user_message = AsyncMock(return_value=True)
     agent_patch, agent_service = _patch_agent_service(post_user_message)
+    bootstrap_load = MagicMock(
+        side_effect=AssertionError("reply loaded a full bootstrap snapshot")
+    )
     with (
         agent_patch,
+        patch(
+            "xagent.web.services.task_setup_snapshot.load_task_setup_snapshot_sync",
+            new=bootstrap_load,
+        ),
         patch(
             "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
             new=AsyncMock(),
@@ -234,13 +251,13 @@ def test_reply_happy_path_resumes_the_same_run(mock_start_task):
     assert call_kwargs["display_message"] == "yes, continue"
     assert call_kwargs["request_interrupt"] is False
     assert call_kwargs["turn_id"].startswith(f"v1:reply:{task_id}:")
-    # The turn id is message metadata; the snapshot is the authoritative agent
-    # read that lets a cached tool config revalidate its team (#1281).
-    resume_snapshot = agent_service.agent_manager.get_agent_for_task.await_args.kwargs[
-        "task_setup_snapshot"
-    ]
-    assert resume_snapshot is not None
-    assert resume_snapshot.task.id == task_id
+    # The turn id is message metadata; the governing-team projection is the
+    # authoritative read that lets a cached tool config revalidate its team
+    # (#1281), without the bootstrap snapshot's transcript/recovery loads.
+    resume_kwargs = agent_service.agent_manager.get_agent_for_task.await_args.kwargs
+    assert resume_kwargs["governing_team_id"] == 77
+    assert "task_setup_snapshot" not in resume_kwargs
+    bootstrap_load.assert_not_called()
     schedule_resume.assert_called_once()
     scheduled_lease = schedule_resume.call_args.kwargs["task_lease"]
     assert scheduled_lease.run_id == "run-original"

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -141,6 +141,9 @@ def _patch_agent_service(post_user_message: AsyncMock):
     agent_service.post_user_message = post_user_message
     agent_manager = MagicMock()
     agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    # Exposed on the service so the nine existing two-tuple call sites keep
+    # unpacking unchanged.
+    agent_service.agent_manager = agent_manager
     return patch(
         "xagent.web.api.chat.get_agent_manager",
         return_value=agent_manager,
@@ -231,6 +234,13 @@ def test_reply_happy_path_resumes_the_same_run(mock_start_task):
     assert call_kwargs["display_message"] == "yes, continue"
     assert call_kwargs["request_interrupt"] is False
     assert call_kwargs["turn_id"].startswith(f"v1:reply:{task_id}:")
+    # The turn id is message metadata; the snapshot is the authoritative agent
+    # read that lets a cached tool config revalidate its team (#1281).
+    resume_snapshot = agent_service.agent_manager.get_agent_for_task.await_args.kwargs[
+        "task_setup_snapshot"
+    ]
+    assert resume_snapshot is not None
+    assert resume_snapshot.task.id == task_id
     schedule_resume.assert_called_once()
     scheduled_lease = schedule_resume.call_args.kwargs["task_lease"]
     assert scheduled_lease.run_id == "run-original"

--- a/tests/web/tools/test_mcp_team_visibility.py
+++ b/tests/web/tools/test_mcp_team_visibility.py
@@ -446,3 +446,56 @@ async def test_direct_private_loader_call_resolves_nothing_without_identity(db_s
         assert configs == []
     finally:
         connector_team_scope.set_connector_team_hooks()
+
+
+# ---------------------------------------------------------------------------
+# A cache-reused config re-resolves visibility after the governing agent's
+# team changes mid-session. Driven through the public entry point, which
+# serves ``_cached_mcp_configs`` -- the private loader below rebuilds
+# unconditionally, so it cannot tell a cleared cache from a stale one.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("next_team_id", "expected_extra"),
+    [(T2, "team_x"), (None, None)],
+)
+async def test_team_change_between_turns_reresolves(
+    db_session, seed, next_team_id, expected_extra
+):
+    _install_env_t(seed)
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+    first = await cfg.get_mcp_server_configs()
+    assert {c["name"] for c in first} == {seed.active_own.name, seed.team_s.name}
+    assert cfg._cached_mcp_configs is not None  # the cache the refresh must clear
+
+    assert cfg.set_connector_team_id(next_team_id) is True
+
+    second = await cfg.get_mcp_server_configs()
+    expected = {seed.active_own.name}
+    if expected_extra is not None:
+        expected.add(getattr(seed, expected_extra).name)
+    assert {c["name"] for c in second} == expected
+
+
+def test_team_change_clears_every_sibling_cache(db_session, seed):
+    """The runtime view and factory snapshot are keyed on the same value but
+    have no cheap end-to-end probe here; assert the reset directly."""
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+    cfg._connector_runtime_view = {"mcp:1": {}}
+    cfg._factory_runtime_snapshot = object()
+    cfg._pending_runtime_policy = object()
+
+    assert cfg.set_connector_team_id(T2) is True
+
+    assert cfg._connector_runtime_view is None
+    assert cfg._factory_runtime_snapshot is None
+    assert cfg._pending_runtime_policy is None
+
+
+def test_unchanged_team_is_a_noop(db_session, seed):
+    cfg = _cfg(db_session, seed, connector_team_id=T1)
+    cfg._cached_mcp_configs = ["sentinel"]
+    assert cfg.set_connector_team_id(T1) is False
+    assert cfg._cached_mcp_configs == ["sentinel"]

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -2973,8 +2973,10 @@ async def test_in_flight_factory_load_does_not_republish_retired_inputs(monkeypa
 
     ``prepare_factory_runtime`` builds its load plan before awaiting the
     worker. A turn-id / team / scope change arriving in that window discards
-    the prepared state, but cannot cancel the worker -- so the result must be
-    dropped on return instead of installed over the current turn's inputs.
+    the prepared state but cannot cancel the worker, so its result must not be
+    installed. Preparation then reloads under the new generation instead of
+    returning unprepared, which the factory would read as success and answer
+    from the request Session on the event loop.
     """
     loads: list[object] = []
 
@@ -3012,8 +3014,10 @@ async def test_in_flight_factory_load_does_not_republish_retired_inputs(monkeypa
 
     def load_then_change_team(*args, **kwargs):
         snapshot = real_loader(*args, **kwargs)
-        # The team change lands while this worker still owns the load.
-        assert cfg.set_connector_team_id(202) is True
+        # Only the first worker is overtaken; the reload must be allowed to
+        # finish under the new generation.
+        if len(loads) == 1:
+            assert cfg.set_connector_team_id(202) is True
         return snapshot
 
     monkeypatch.setattr(
@@ -3025,10 +3029,12 @@ async def test_in_flight_factory_load_does_not_republish_retired_inputs(monkeypa
     try:
         await cfg.prepare_factory_runtime()
 
-        assert cfg._factory_runtime_snapshot is None
-        # The retired result is not installed, so the getter re-reads under the
-        # new team instead of serving the worker's pre-change model.
-        assert cfg.get_image_models()["image"] is loads[-1]
+        # Two worker loads: the retired one, then the reload that observes the
+        # new team. The installed snapshot is the second one, and the getter is
+        # served from it rather than from a synchronous re-read.
         assert len(loads) == 2
+        assert cfg._factory_runtime_snapshot is not None
+        assert cfg.get_image_models()["image"] is loads[-1]
+        assert cfg._connector_team_id == 202
     finally:
         cfg.close()

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -36,6 +36,7 @@ from xagent.web.services.tool_credentials import (
     set_user_tool_allowlist_hook,
     set_user_tool_overrides_hook,
 )
+from xagent.web.tools import config as config_module
 from xagent.web.tools.config import WebToolConfig
 
 
@@ -2964,3 +2965,70 @@ def test_custom_api_config_loader_propagates_runtime_view_resolution_error(monke
 
     assert exc_info.value.code == ERROR_CONNECTOR_RUNTIME_UNAVAILABLE
     assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_in_flight_factory_load_does_not_republish_retired_inputs(monkeypatch):
+    """A per-turn invalidation landing during the detached load retires it.
+
+    ``prepare_factory_runtime`` builds its load plan before awaiting the
+    worker. A turn-id / team / scope change arriving in that window discards
+    the prepared state, but cannot cancel the worker -- so the result must be
+    dropped on return instead of installed over the current turn's inputs.
+    """
+    loads: list[object] = []
+
+    def session_factory() -> _TrackingSession:
+        return _TrackingSession()
+
+    def load_image_models(*_args, **_kwargs):
+        model = object()
+        loads.append(model)
+        return {"image": model}
+
+    monkeypatch.setattr(
+        "xagent.web.services.model_service.get_image_models",
+        load_image_models,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.model_service.get_default_image_generate_model",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.model_service.get_default_image_edit_model",
+        lambda *_args, **_kwargs: None,
+    )
+    cfg = WebToolConfig(
+        db=None,
+        request=None,
+        db_factory=session_factory,
+        user_id=1,
+        include_mcp_tools=False,
+        connector_team_id=101,
+        tool_selection_spec=ToolSelectionSpec.from_raw(tool_categories=["image"]),
+    )
+
+    real_loader = config_module._load_tool_factory_runtime_snapshot
+
+    def load_then_change_team(*args, **kwargs):
+        snapshot = real_loader(*args, **kwargs)
+        # The team change lands while this worker still owns the load.
+        assert cfg.set_connector_team_id(202) is True
+        return snapshot
+
+    monkeypatch.setattr(
+        config_module,
+        "_load_tool_factory_runtime_snapshot",
+        load_then_change_team,
+    )
+
+    try:
+        await cfg.prepare_factory_runtime()
+
+        assert cfg._factory_runtime_snapshot is None
+        # The retired result is not installed, so the getter re-reads under the
+        # new team instead of serving the worker's pre-change model.
+        assert cfg.get_image_models()["image"] is loads[-1]
+        assert len(loads) == 2
+    finally:
+        cfg.close()


### PR DESCRIPTION
Closes #1281.

### Problem

`WebToolConfig._connector_team_id` is assigned once in `__init__` and has no setter, while `WebToolConfig` instances are cache-reused with their `AgentService` across turns within a task. The cache-hit return path re-syncs the connector-runtime turn id and the execution scope, but not the governing team id.

If the governing agent's owning team changes mid-session (shared to a team, made personal again, re-homed), a reused config keeps resolving connector visibility against the team captured at construction time until the cache entry expires.

All four consumers read the field:

- `_load_mcp_server_configs` — MCP server visibility
- `get_custom_api_configs` — custom API visibility
- `_load_connector_runtime_view` — connector runtime view
- the delegated MCP refresh callback — team for per-tool-call refreshes

The window is bounded by the config cache lifetime and the value drifts toward whatever the next fresh construction derives, so the exposure is transient rather than persistent — but it was undocumented and untested.

### Change

Symmetric with the existing `set_connector_runtime_turn_id`:

- `WebToolConfig.set_connector_team_id()` — swaps only on a real change, clears the same caches the turn-id setter does (runtime view, MCP configs, factory snapshot, pending policy), and reports whether it changed.
- `AgentServiceManager._sync_connector_team_id()` — sits next to `_sync_connector_runtime_turn`, derives the team from `task_setup_snapshot.agent.team_id` (the same place the construction path reads it), and calls `invalidate_tools()` on a change. Wired into both return points: the reconstruct path and the normal one.

Only a wholly absent snapshot skips the sync. A present snapshot whose `agent` is `None` is an authoritative negative result and clears the team, exactly as fresh construction derives `None` from the same snapshot.

The two callers that previously passed no snapshot — `a2a.py::inject_user_message` and `v1/task_reply.py::inject_user_message` — now load an authoritative detached snapshot themselves. Their generated reply turn id is message metadata and cannot stand in for an agent read. Loaded per caller rather than by relaxing the manager's cache-hit load condition, which would add a snapshot load to every cache hit including the callers that already supply one.

Per-turn invalidation now also retires an in-flight factory load: `prepare_factory_runtime` builds its load plan before awaiting its worker, so a team/turn/scope change landing in that window would otherwise let the worker install its pre-change snapshot after the invalidation. `discard_prepared_factory_runtime` bumps a generation counter, all three per-turn setters route their factory reset through it, and the prepare path drops a result whose generation no longer matches. This closes the same pre-existing window on `set_connector_runtime_turn_id` and `set_execution_scope`, which clear the same field.

Scope deliberately kept minimal: `_agent_creator_user_id` and `_declared_knowledge_bases` are also assigned once in `__init__`, but the former is the agent's creator (it does not change with the team) and the latter comes from the task configuration — a different staleness class, not addressed here.

### Tests

`tests/web/tools/test_mcp_team_visibility.py`

- Visibility re-resolves after the governing team changes between turns, parametrized over T1→T2 and T1→personal. Asserted through the public `get_mcp_server_configs()` rather than the private loader — the latter rebuilds unconditionally and cannot tell a cleared cache from a stale one.
- Every sibling cache is cleared on a team change.
- An unchanged value is a no-op.

`tests/web/api/test_agent_cache_connector_team_refresh.py` (new)

- Drives the real `get_agent_for_task` cache-hit return path across personal→team, team→other team, and team→personal. Uses a real `WebToolConfig` rather than a mock: the sync is `hasattr`-guarded, and a MagicMock satisfies that guard whether or not the setter exists.
- An unchanged team does not rebuild tools.
- An absent snapshot leaves the existing value alone; a present snapshot resolving no agent clears it.

`tests/web/api/test_a2a_api.py`, `tests/web/api/v1/test_task_reply.py`

- Both reply-driven resume paths assert `get_agent_for_task` received a non-`None` snapshot for the task.

`tests/web/tools/test_web_tool_config_session_factory.py`

- A team change landing inside the worker load is not installed on return, and the getter re-reads instead of serving the worker's pre-change model.

### Verification

Mutation rounds, one per guard:

1. Drop the two sync calls in `chat.py` → 3 manager-level tests fail
2. Drop the cache clearing in the setter → 3 visibility tests fail
3. Restore the `agent is None` skip → the negative-result test fails
4. Drop either `task_setup_snapshot=` argument → the a2a / v1 reply tests fail
5. Remove the generation comparison → the in-flight-load test fails

Regression: `tests/web/tools/`, `tests/web/api/`, connector team scope, and factory runtime suites — clean.
