### PR TITLE
feat(migrations): backfill auth.app_id onto legacy builtin-OAuth server rows

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -409,6 +409,20 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      # Placed after every step above that needs the real, fully-migrated shape
+      # of mcp_servers/public_mcp_apps: this test stubs them in a throwaway
+      # schema of its own (search_path), so it cannot touch the shared ones --
+      # but ordering it last keeps that independent of the fixture's details.
+      # Without this step the file's postgres-marked test runs nowhere: the
+      # fast job deselects the marker and provisions no database, so the
+      # backfill's data path would have no PostgreSQL coverage at all.
+      - name: Test legacy OAuth app-identity backfill (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/migrations/test_20260818_backfill_oauth_server_app_identity.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
       - name: Test legacy resume interaction close rowcount grid (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -140,7 +140,7 @@ to every pre-migration reader (they all prefer ``app_id`` and only fall
 back to names when it is absent).
 
 Revision ID: 20260818_backfill_oauth_server_app_identity
-Revises: 20260819_merge_jira_and_linear_heads
+Revises: 20260820_merge_jira_posthog_heads
 Create Date: 2026-08-18
 """
 
@@ -157,7 +157,7 @@ logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision: str = "20260818_backfill_oauth_server_app_identity"
-down_revision: str | None = "20260819_merge_jira_and_linear_heads"
+down_revision: str | None = "20260820_merge_jira_posthog_heads"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -52,8 +52,11 @@ can be derived safely:
   whitespace/case variants are producible — they simply do not match here,
   and under-matching leaves the name-fallback shim in charge.
 - Each is matched against ``public_mcp_apps`` (builtin apps are seeded
-  into that table too) by exact display name, the same value
-  ``_ensure_user_mcp_server`` named the row after. If the name resolves
+  into that table too) by exact display name -- the stored column, which is
+  the value ``_ensure_user_mcp_server`` named the row after *unless* a
+  builtin's stored name has drifted from the code registry
+  ``_app_to_dict`` serves it from, in which case this simply does not match
+  and the row is left alone. If the name resolves
   nothing -- including when it is *ambiguous*, i.e. shared by two OAuth
   apps -- and the row's ``auth.provider`` names exactly one OAuth app,
   that app is used instead. Providers are non-unique across apps (the
@@ -129,6 +132,8 @@ Create Date: 2026-08-18
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
+from typing import NamedTuple
 
 import sqlalchemy as sa
 from alembic import op
@@ -138,8 +143,23 @@ logger = logging.getLogger(__name__)
 # revision identifiers, used by Alembic.
 revision: str = "20260818_backfill_oauth_server_app_identity"
 down_revision: str | None = "20260818_seed_jira_mcp_app"
-branch_labels = None
-depends_on = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+class _CatalogApp(NamedTuple):
+    """The identity fields the backfill reads off a catalog app row."""
+
+    app_id: str
+    provider: str | None
+
+
+class _Candidate(NamedTuple):
+    """An oauth row still needing a stamp, with its usable stored provider."""
+
+    row: sa.RowMapping
+    auth: dict
+    provider: str | None
 
 
 def _nonblank_str(value: object) -> str | None:
@@ -205,8 +225,10 @@ def upgrade() -> None:
     # the identity paths compare them exactly. Only ``transport`` is folded,
     # because it is a shape enum rather than an identity -- and a little more
     # tolerantly than classify_app_auth, which lowercases without stripping.
-    apps_by_name: dict[str, tuple[str, str | None] | None] = {}
-    apps_by_provider: dict[str, tuple[str, str | None] | None] = {}
+    apps_by_name: dict[str, _CatalogApp] = {}
+    apps_by_provider: dict[str, _CatalogApp] = {}
+    ambiguous_names: set[str] = set()
+    ambiguous_providers: set[str] = set()
     names_of_other_shapes: set[str] = set()
     for app_row in bind.execute(sa.select(public_mcp_apps)).mappings():
         if str(app_row["transport"] or "").strip().lower() != "oauth":
@@ -223,12 +245,16 @@ def upgrade() -> None:
         if not app_id:
             continue
         provider = _nonblank_str(app_row["provider_name"])
-        entry = (app_id, provider)
+        entry = _CatalogApp(app_id, provider)
         name = _nonblank_str(app_row["name"])
         if name:
-            apps_by_name[name] = None if name in apps_by_name else entry
+            if name in apps_by_name:
+                ambiguous_names.add(name)
+            apps_by_name[name] = entry
         if provider:
-            apps_by_provider[provider] = None if provider in apps_by_provider else entry
+            if provider in apps_by_provider:
+                ambiguous_providers.add(provider)
+            apps_by_provider[provider] = entry
 
     # Materialized before the loop: the loop UPDATEs the same table, and
     # stepping a live pysqlite cursor across a mutating table has formally
@@ -239,7 +265,7 @@ def upgrade() -> None:
     candidates = (
         bind.execute(
             sa.select(mcp_servers)
-            .where(mcp_servers.c.transport == "oauth")
+            .where(sa.func.lower(sa.func.trim(mcp_servers.c.transport)) == "oauth")
             .order_by(mcp_servers.c.id)
         )
         .mappings()
@@ -256,7 +282,7 @@ def upgrade() -> None:
     # name fallback, this migration is irreversible (downgrade is a no-op),
     # and destroying a value we do not have to is the wrong default for a
     # data migration. NULL auth is the primary target and is not that case.
-    pending: list[tuple[sa.RowMapping, dict, str | None]] = []
+    pending: list[_Candidate] = []
     already_stamped: set[str] = set()
     for row in candidates:
         raw_auth = row["auth"]
@@ -283,7 +309,7 @@ def upgrade() -> None:
                 row["id"],
             )
             continue
-        pending.append((row, auth, _nonblank_str(raw_provider)))
+        pending.append(_Candidate(row, auth, _nonblank_str(raw_provider)))
 
     # Two passes so one app is never stamped onto two rows, and so which row
     # wins is decided by evidence rather than by row order. Name evidence is
@@ -305,22 +331,36 @@ def upgrade() -> None:
     # the same identity to the next-best row.
     resolutions: dict[int, str] = {}
     claimed: set[str] = set(already_stamped)
-    deferred: list[tuple[sa.RowMapping, dict, str]] = []
+    deferred: list[_Candidate] = []
 
-    for row, auth, provider in pending:
-        row_name = str(row["name"]) if row["name"] else ""
+    def claim(candidate: _Candidate, app: _CatalogApp) -> None:
+        """Record the stamp, or refuse it because the identity is taken."""
+        if app.app_id in claimed:
+            logger.warning(
+                "%s: app_id %r is already carried by another row; leaving "
+                "mcp_servers row %s to its pre-migration name fallback",
+                revision,
+                app.app_id,
+                candidate.row["id"],
+            )
+            return
+        claimed.add(app.app_id)
+        resolutions[int(candidate.row["id"])] = app.app_id
+
+    for candidate in pending:
+        row_name = str(candidate.row["name"]) if candidate.row["name"] else ""
         if row_name in names_of_other_shapes:
             # The name belongs to an app of another transport. That is
             # evidence about *this* row, not an absence of evidence, so it
             # refuses outright instead of falling through to the provider
             # fallback -- which would stamp it with an unrelated app's id.
             continue
-        resolved = apps_by_name.get(row_name)
-        if resolved is None:
-            if provider:
-                deferred.append((row, auth, provider))
+        app = None if row_name in ambiguous_names else apps_by_name.get(row_name)
+        if app is None:
+            if candidate.provider:
+                deferred.append(candidate)
             continue
-        if provider and resolved[1] and provider != resolved[1]:
+        if candidate.provider and app.provider and candidate.provider != app.provider:
             # The row's own provider contradicts the name-resolved app -- the
             # same conflict _ensure_server_matches_oauth_app refuses with a
             # ValueError. Stamping the name's app_id would create a row *no*
@@ -331,36 +371,20 @@ def upgrade() -> None:
             # contradiction is information: two signals disagree, and picking
             # either one would be a guess.
             continue
-        if resolved[0] in claimed:
-            logger.warning(
-                "%s: app_id %r is already carried by another row; leaving "
-                "mcp_servers row %s to its pre-migration name fallback",
-                revision,
-                resolved[0],
-                row["id"],
-            )
-            continue
-        claimed.add(resolved[0])
-        resolutions[int(row["id"])] = resolved[0]
+        claim(candidate, app)
 
-    for row, auth, provider in deferred:
-        resolved = apps_by_provider.get(provider)
-        if resolved is None:
+    for candidate in deferred:
+        provider = candidate.provider
+        assert provider is not None  # only providers reach the deferred list
+        if provider in ambiguous_providers:
             continue
-        if resolved[0] in claimed:
-            logger.warning(
-                "%s: app_id %r is already carried by another row; leaving "
-                "mcp_servers row %s to its pre-migration name fallback",
-                revision,
-                resolved[0],
-                row["id"],
-            )
-            continue
-        claimed.add(resolved[0])
-        resolutions[int(row["id"])] = resolved[0]
+        app = apps_by_provider.get(provider)
+        if app is not None:
+            claim(candidate, app)
 
     stamped = 0
-    for row, auth, _provider in pending:
+    for candidate in pending:
+        row, auth = candidate.row, candidate.auth
         app_id = resolutions.get(int(row["id"]))
         if app_id is None:
             continue

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -140,7 +140,7 @@ to every pre-migration reader (they all prefer ``app_id`` and only fall
 back to names when it is absent).
 
 Revision ID: 20260818_backfill_oauth_server_app_identity
-Revises: 20260818_seed_jira_mcp_app
+Revises: 20260819_merge_jira_and_linear_heads
 Create Date: 2026-08-18
 """
 
@@ -157,7 +157,7 @@ logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision: str = "20260818_backfill_oauth_server_app_identity"
-down_revision: str | None = "20260818_seed_jira_mcp_app"
+down_revision: str | None = "20260819_merge_jira_and_linear_heads"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -182,6 +182,21 @@ class _Candidate(NamedTuple):
     provider: str | None
 
 
+def _same_provider(left: str, right: str) -> bool:
+    """Whether two provider strings name the same provider.
+
+    Normalized the way the runtime compares them (``_normalize_app_key``:
+    casefold, strip, whitespace-to-hyphen), not exactly. Providers are not
+    identities here -- they are only ever used to detect a *contradiction* --
+    so comparing them more strictly than the runtime does would refuse a row
+    over a difference the runtime already treats as no difference, and this
+    migration runs once and cannot be undone.
+    """
+    return "-".join(left.strip().lower().split()) == "-".join(
+        right.strip().lower().split()
+    )
+
+
 def _nonblank_str(value: object) -> str | None:
     """The value itself when it is a str with non-whitespace content, else None.
 
@@ -216,8 +231,18 @@ def upgrade() -> None:
     inspector = sa.inspect(bind)
     tables = set(inspector.get_table_names())
     # A bare database has neither table until create_all runs; there is
-    # nothing to backfill there.
+    # nothing to backfill there. Logged rather than returned silently: Alembic
+    # still commits the version bump, so a skip here is permanent, and that is
+    # exactly the "advance the version without backfilling" shape the offline
+    # branch above raises over. It is benign only because a database with no
+    # mcp_servers has no rows to stamp -- an operator seeing this line on a
+    # populated deployment is looking at a search_path problem.
     if "mcp_servers" not in tables or "public_mcp_apps" not in tables:
+        logger.warning(
+            "%s: mcp_servers/public_mcp_apps not visible on this connection's "
+            "search_path; nothing backfilled and the revision is marked applied",
+            revision,
+        )
         return
 
     mcp_servers = sa.table(
@@ -296,9 +321,29 @@ def upgrade() -> None:
         .all()
     )
 
-    # Split the candidates: rows already carrying a usable identity, and rows
-    # still needing one. A nonblank *string* app_id is the only shape the read
-    # path accepts (get_app_for_mcp_server rejects a non-string app_id
+    # Every identity any row already carries, read *without* a transport
+    # filter. Deliberately wider than the candidate query above, because the
+    # reader that matters here is wider too: get_app_for_mcp_server resolves
+    # from auth.app_id with no transport check at all, and the OAuth-disconnect
+    # cleanup path walks a user's whole server list through it. So a row whose
+    # transport is "OAuth" -- or anything else -- still makes its app_id taken,
+    # even though that row could never serve the connector itself. Filtering
+    # this by transport left such an id invisible to the claim guard, which
+    # could then hand it to a second row: the one thing this migration promises
+    # it will not do.
+    already_stamped: set[str] = set()
+    for row in bind.execute(
+        sa.select(mcp_servers.c.auth).where(mcp_servers.c.auth.is_not(None))
+    ).mappings():
+        raw = row["auth"]
+        if isinstance(raw, dict):
+            existing_any = _nonblank_str(raw.get("app_id"))
+            if existing_any:
+                already_stamped.add(existing_any)
+
+    # Split the candidates into rows already carrying a usable identity and
+    # rows still needing one. A nonblank *string* app_id is the only shape the
+    # read path accepts (get_app_for_mcp_server rejects a non-string app_id
     # outright), so that is what counts as "already stamped".
     #
     # A non-dict auth payload is garbage on an oauth row, but it is left
@@ -307,15 +352,12 @@ def upgrade() -> None:
     # and destroying a value we do not have to is the wrong default for a
     # data migration. NULL auth is the primary target and is not that case.
     pending: list[_Candidate] = []
-    already_stamped: set[str] = set()
     for row in candidates:
         raw_auth = row["auth"]
         if raw_auth is not None and not isinstance(raw_auth, dict):
             continue
         auth: dict = raw_auth if isinstance(raw_auth, dict) else {}
-        existing = _nonblank_str(auth.get("app_id"))
-        if existing:
-            already_stamped.add(existing)
+        if _nonblank_str(auth.get("app_id")):
             continue
         raw_provider = auth.get("provider")
         if raw_provider is not None and not isinstance(raw_provider, str):
@@ -349,11 +391,15 @@ def upgrade() -> None:
     # colliding partner is the row the writer stamped when a rename left the
     # old one orphaned, and it never enters `pending`. Seeding it is also what
     # makes idempotence hold across a downgrade-then-upgrade rerun.
-    resolutions: dict[int, str] = {}
     claimed: set[str] = set(already_stamped)
 
-    def claim(candidate: _Candidate, app: _CatalogApp) -> None:
-        """Record the stamp, or refuse it because the identity is taken."""
+    def claim(candidate: _Candidate, app: _CatalogApp) -> str | None:
+        """Reserve the identity for this row, or refuse it as already taken.
+
+        Reserving as we go is what lets resolution and the write share one
+        pass: a candidate's decision only ever depends on the candidates
+        already processed, never on later ones.
+        """
         if app.app_id in claimed:
             logger.warning(
                 "%s: app_id %r is already carried by another row; leaving "
@@ -362,10 +408,11 @@ def upgrade() -> None:
                 app.app_id,
                 candidate.row["id"],
             )
-            return
+            return None
         claimed.add(app.app_id)
-        resolutions[int(candidate.row["id"])] = app.app_id
+        return app.app_id
 
+    stamped = 0
     for candidate in pending:
         row_name = str(candidate.row["name"]) if candidate.row["name"] else ""
         if row_name in names_of_other_shapes:
@@ -379,7 +426,11 @@ def upgrade() -> None:
         app = apps_by_name.get(row_name)
         if app is None:
             continue
-        if candidate.provider and app.provider and candidate.provider != app.provider:
+        if (
+            candidate.provider
+            and app.provider
+            and not _same_provider(candidate.provider, app.provider)
+        ):
             # The row's own provider contradicts the name-resolved app -- the
             # same conflict _ensure_server_matches_oauth_app refuses with a
             # ValueError. This is a guard on the name path, not a leftover of
@@ -388,39 +439,54 @@ def upgrade() -> None:
             # row that matches no app at all, where today it still matches by
             # name.
             continue
-        claim(candidate, app)
-
-    stamped = 0
-    for candidate in pending:
-        row, auth = candidate.row, candidate.auth
-        app_id = resolutions.get(int(row["id"]))
+        app_id = claim(candidate, app)
         if app_id is None:
+            continue
+
+        row_id = candidate.row["id"]
+        # Re-read immediately before writing: candidates were materialized up
+        # front, and this migration deliberately targets rows a live
+        # provisioning flow can still be writing to. Without this, a blind
+        # UPDATE of the whole auth column would silently discard whatever was
+        # committed in between -- most plausibly a provider the writer added.
+        current = bind.execute(
+            sa.select(mcp_servers.c.auth).where(mcp_servers.c.id == row_id)
+        ).scalar()
+        if current != candidate.auth and not (current is None and candidate.auth == {}):
+            logger.warning(
+                "%s: mcp_servers row %s changed under us; leaving it unstamped",
+                revision,
+                row_id,
+            )
             continue
         # Only app_id is written. The row's own provider (when it has one) is
         # left as-is and none is added: app_id alone resolves the app, while
         # _is_oauth_server_for_app checks a stored provider *even when the
         # app_id matches*, so writing one sourced from a possibly-drifted
         # public_mcp_apps.provider_name could break a match that works today.
-        new_auth = dict(auth)
+        new_auth = dict(candidate.auth)
         new_auth["app_id"] = app_id
         bind.execute(
             sa.update(mcp_servers)
-            .where(mcp_servers.c.id == row["id"])
+            .where(mcp_servers.c.id == row_id)
             .values(auth=new_auth)
         )
-        # Per-row audit: stamping is irreversible (downgrade is a no-op), so
-        # an operator reconstructing or reversing a bad backfill needs the
-        # individual rows, not just the totals below.
-        logger.info(
+        # Audit at WARNING, not INFO, on purpose: Alembic loads version files
+        # by bare filename, so this logger is not the configured `alembic`
+        # qualname logger and alembic.ini's root=WARN drops INFO from it
+        # entirely. Stamping is irreversible (downgrade is a no-op), so an
+        # operator reconstructing or reversing a bad backfill needs these lines
+        # to actually appear.
+        logger.warning(
             "%s: stamped mcp_servers row %s (name %r) with app_id %r",
             revision,
-            row["id"],
-            row["name"],
+            row_id,
+            candidate.row["name"],
             app_id,
         )
         stamped += 1
 
-    logger.info(
+    logger.warning(
         "%s: stamped %s of %s unstamped oauth row(s); %s left unstamped",
         revision,
         stamped,

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -1,8 +1,7 @@
 """backfill auth.app_id onto unstamped OAuth-transport server rows
 
 Rows provisioned before ``_ensure_user_mcp_server`` wrote OAuth metadata
-carry no ``auth`` payload at all (and a small malformed population can
-carry a blank or provider-only ``auth``). Every read path that resolves a
+carry no ``auth`` payload at all. Every read path that resolves a
 server row back to its catalog app prefers the stable ``auth.app_id`` and
 falls back to the row's *exact current display name*
 (``get_app_for_mcp_server``) -- so an unstamped row's identity lives and
@@ -56,31 +55,35 @@ can be derived safely:
   whitespace/case variants are producible — they simply do not match here,
   and under-matching leaves the name-fallback shim in charge.
 - Each is matched against ``public_mcp_apps`` (builtin apps are seeded
-  into that table too) by exact display name -- the stored column, which is
-  the value ``_ensure_user_mcp_server`` named the row after *unless* a
-  builtin's stored name has drifted from the code registry
-  ``_app_to_dict`` serves it from, in which case this simply does not match
-  and the row is left alone. If the name resolves
-  nothing -- including when it is *ambiguous*, i.e. shared by two OAuth
-  apps -- and the row's ``auth.provider`` names exactly one OAuth app,
-  that app is used instead. Providers are non-unique across apps (the
-  meta/Instagram siblings), so an ambiguous provider is never resolved.
-  Names are resolved for *every* candidate before any provider fallback
-  runs, and an app already claimed by a name match is never handed to a
-  second row: ``_ensure_user_mcp_server`` creates a *new* row when a
-  rename makes the old one unfindable, so orphan pairs for one app are
-  this migration's own target population, and stamping both would give
-  two rows the same identity -- which ``_lookup_oauth_server_for_app``
-  resolves from an unordered query, making configure/disconnect pick
-  nondeterministically between them. Name evidence wins; the loser keeps
-  the behavior it had before this migration.
+  into that table too) by its exact stored display name -- the value
+  ``_ensure_user_mcp_server`` named the row after, *unless* a builtin's
+  stored name has drifted from the code registry ``_app_to_dict`` serves
+  it from, in which case this simply does not match and the row is left
+  alone. A name shared by two OAuth apps resolves nothing: picking either
+  would be a guess.
+- The stored name is the **only** signal used to resolve an app. There is
+  deliberately no provider fallback: no writer this codebase has ever
+  shipped produces a row carrying a provider but no ``app_id``
+  (``_oauth_auth_metadata`` writes ``app_id`` first and unconditionally,
+  and the generic servers API cannot author ``transport="oauth"`` at all --
+  ``MCPServerConfig`` rejects it), so that population has never existed,
+  while the population that *does* exist -- rows written with no ``auth``
+  at all before ``cb724dbb`` -- carries no provider to fall back to. A
+  provider-keyed pass would defend nothing real, and it was the only place
+  where two rows could compete for one identity.
+- An app already carried by another row is never handed to a second one.
+  ``_ensure_user_mcp_server`` creates a *new* row when a rename makes the
+  old one unfindable, so orphan pairs for one app are this migration's own
+  target population, and two rows sharing an identity would make
+  ``_lookup_oauth_server_for_app`` -- which reads an unordered query --
+  pick nondeterministically between them for configure/disconnect. The
+  refused row keeps the behavior it had before this migration.
 - Only apps whose own ``transport`` is ``oauth`` are eligible: a
   same-named non-OAuth app is a different connector shape, and stamping
   its id onto an oauth-transport row would manufacture exactly the
   cross-shape identity confusion this migration exists to remove. Such a
-  name is *refused*, not merely unmatched -- it is evidence about the row,
-  so letting it fall through to the provider fallback would stamp the row
-  with some unrelated app's id.
+  name is *refused*, not merely treated as unmatched -- it is evidence
+  about the row rather than an absence of evidence.
 - Rows that resolve to nothing are left untouched, keeping the exact-name
   fallback in ``get_app_for_mcp_server`` as their compatibility shim. That
   is a deliberate trade rather than a free win: ``get_app_for_mcp_server``
@@ -94,15 +97,17 @@ can be derived safely:
   the code registry (``_app_to_dict``) and only warn about drift. The two
   can therefore disagree about a drifted row; the blast radius is one
   unambiguous stamp on a row whose stored shape says ``oauth``.
-- Only rows whose stored name still matches can be stamped by name. In a
-  deployment where the drift already happened, only the provider fallback
-  can rescue the row -- and not when the provider is shared or absent. So
-  this hardens the population that is still resolvable today; it cannot
-  retroactively repair a row whose every identity signal is already gone.
+- Only rows whose stored name still matches can be stamped. In a
+  deployment where the drift already happened, nothing here can rescue the
+  row: this hardens the population still resolvable today, and cannot
+  retroactively repair one whose identity signal is already gone.
 - A row whose own ``auth.provider`` contradicts the name-resolved app's
   provider is refused — the same conflict the provisioning writer
-  (``_ensure_server_matches_oauth_app``) refuses with a ValueError.
-  Stamping the name's id would produce a row *no* app claims.
+  (``_ensure_server_matches_oauth_app``) refuses with a ValueError. This is
+  a guard on the name path, not a remnant of any fallback:
+  ``_is_oauth_server_for_app`` checks a stored provider *even when the
+  app_id matches*, so stamping here would leave a row that matches no app
+  at all, where today it still matches by name.
 - Only ``app_id`` is written, into a *copy* of the existing auth dict;
   nothing else is added or touched. A ``provider`` is deliberately not
   written: ``app_id`` alone resolves the app, while
@@ -152,7 +157,12 @@ depends_on: str | Sequence[str] | None = None
 
 
 class _CatalogApp(NamedTuple):
-    """The identity fields the backfill reads off a catalog app row."""
+    """A catalog app's ``app_id``, plus its provider.
+
+    ``app_id`` is the identity that gets stamped. ``provider`` is *not* an
+    identity signal -- nothing resolves an app by it -- and is carried only so
+    the name path can refuse a row whose own stored provider contradicts it.
+    """
 
     app_id: str
     provider: str | None
@@ -219,28 +229,25 @@ def upgrade() -> None:
         sa.column("provider_name", sa.String),
     )
 
-    # Exact display name -> app, and provider -> apps, for OAuth apps only.
-    # A key shared by two OAuth apps is poisoned to None: that *key* then
+    # Exact display name -> app, for OAuth apps only.
+    # A name shared by two OAuth apps is recorded as ambiguous: it then
     # resolves nothing rather than picking whichever app was seeded first.
-    # Poisoning is per key, not per row -- a row whose name is ambiguous
-    # still gets the provider fallback below, which is the point (the name
-    # carries no information there, while an unambiguous provider does).
     # Keys and stored values are the raw strings — identities are opaque, and
     # the identity paths compare them exactly. Only ``transport`` is folded,
     # because it is a shape enum rather than an identity -- and a little more
     # tolerantly than classify_app_auth, which lowercases without stripping.
     apps_by_name: dict[str, _CatalogApp] = {}
-    apps_by_provider: dict[str, _CatalogApp] = {}
     ambiguous_names: set[str] = set()
-    ambiguous_providers: set[str] = set()
     names_of_other_shapes: set[str] = set()
     for app_row in bind.execute(sa.select(public_mcp_apps)).mappings():
         if str(app_row["transport"] or "").strip().lower() != "oauth":
             # Recorded, not ignored: a row whose name belongs to a non-oauth
             # app must be told apart from a row whose name belongs to nothing.
             # Both miss apps_by_name, but the first is positive evidence of a
-            # *different-shape* app, and letting it fall through to the
-            # provider fallback would stamp it with an unrelated app's id.
+            # *different-shape* app. It only changes the outcome when one name
+            # is carried by both an oauth and a non-oauth app -- then this is
+            # what stops the oauth app from claiming the row on a name whose
+            # ownership is genuinely contested.
             other_name = _nonblank_str(app_row["name"])
             if other_name:
                 names_of_other_shapes.add(other_name)
@@ -248,24 +255,21 @@ def upgrade() -> None:
         app_id = _nonblank_str(app_row["app_id"])
         if not app_id:
             continue
-        provider = _nonblank_str(app_row["provider_name"])
-        entry = _CatalogApp(app_id, provider)
+        entry = _CatalogApp(app_id, _nonblank_str(app_row["provider_name"]))
         name = _nonblank_str(app_row["name"])
         if name:
             if name in apps_by_name:
                 ambiguous_names.add(name)
             apps_by_name[name] = entry
-        if provider:
-            if provider in apps_by_provider:
-                ambiguous_providers.add(provider)
-            apps_by_provider[provider] = entry
 
     # Materialized before the loop: the loop UPDATEs the same table, and
     # stepping a live pysqlite cursor across a mutating table has formally
     # unspecified row visibility. The table is small (one row per connector).
-    # Ordered by id so a tie the evidence cannot break -- two unstamped rows
-    # whose only signal is the same provider -- resolves to the same row on
-    # every run and every backend, instead of following an unordered scan.
+    # Ordered by id. No longer load-bearing for correctness -- with the
+    # provider pass gone, mcp_servers.name is unique and each name maps to one
+    # app, so two candidates can never contest one identity -- but it keeps the
+    # UPDATE order and the per-row audit log reproducible across runs and
+    # backends, which matters for a migration with no downgrade.
     candidates = (
         bind.execute(
             sa.select(mcp_servers)
@@ -325,27 +329,22 @@ def upgrade() -> None:
             continue
         pending.append(_Candidate(row, auth, _nonblank_str(raw_provider)))
 
-    # Two passes so one app is never stamped onto two rows, and so which row
-    # wins is decided by evidence rather than by row order. Name evidence is
-    # strictly stronger than a provider (it names one app; a provider can be
-    # shared), so every name match is resolved first and claims its app; the
-    # provider fallback then only fills apps nobody claimed by name.
+    # One pass: a row is resolved by its exact stored name and nothing else.
+    # There is deliberately no provider fallback -- no writer this codebase has
+    # ever shipped produces a row with a provider but no app_id
+    # (_oauth_auth_metadata writes app_id first and unconditionally; the
+    # generic servers API cannot author transport="oauth" at all), so such a
+    # population has never existed, and the population that *does* exist --
+    # rows written with no auth at all before cb724dbb -- carries no provider
+    # to fall back to. A provider-keyed pass would defend nothing real while
+    # being the only place two rows could compete for one identity.
     #
-    # This is not hypothetical: _ensure_user_mcp_server creates a *new* row
-    # when a rename makes the old one unfindable, so two rows for one app are
-    # exactly this migration's target population. Stamping both would make
-    # _lookup_oauth_server_for_app -- which reads an unordered query -- pick
-    # nondeterministically between them for configure/disconnect.
-    #
-    # `claimed` starts from the identities rows *already* carry, not empty:
-    # the colliding partner is usually the row the writer stamped on rename,
-    # which never enters `pending` at all. Seeding it is also what makes the
-    # idempotence claim true across a downgrade-then-upgrade rerun -- the
-    # no-op downgrade leaves run 1's stamps in place, and run 2 must not hand
-    # the same identity to the next-best row.
+    # `claimed` still starts from the identities rows already carry: the
+    # colliding partner is the row the writer stamped when a rename left the
+    # old one orphaned, and it never enters `pending`. Seeding it is also what
+    # makes idempotence hold across a downgrade-then-upgrade rerun.
     resolutions: dict[int, str] = {}
     claimed: set[str] = set(already_stamped)
-    deferred: list[_Candidate] = []
 
     def claim(candidate: _Candidate, app: _CatalogApp) -> None:
         """Record the stamp, or refuse it because the identity is taken."""
@@ -364,37 +363,26 @@ def upgrade() -> None:
     for candidate in pending:
         row_name = str(candidate.row["name"]) if candidate.row["name"] else ""
         if row_name in names_of_other_shapes:
-            # The name belongs to an app of another transport. That is
-            # evidence about *this* row, not an absence of evidence, so it
-            # refuses outright instead of falling through to the provider
-            # fallback -- which would stamp it with an unrelated app's id.
+            # The name belongs to an app of another transport -- evidence about
+            # this row, so it refuses rather than resolving to nothing.
             continue
-        app = None if row_name in ambiguous_names else apps_by_name.get(row_name)
+        if row_name in ambiguous_names:
+            # Two OAuth apps share this exact name; picking either would be a
+            # guess, so the row keeps its read-time name fallback.
+            continue
+        app = apps_by_name.get(row_name)
         if app is None:
-            if candidate.provider:
-                deferred.append(candidate)
             continue
         if candidate.provider and app.provider and candidate.provider != app.provider:
             # The row's own provider contradicts the name-resolved app -- the
             # same conflict _ensure_server_matches_oauth_app refuses with a
-            # ValueError. Stamping the name's app_id would create a row *no*
-            # app claims (it fails this app's provider gate and the provider's
-            # app_id gate), so refuse and leave the read-time name fallback
-            # exactly as it was. Unlike an *ambiguous* name, which carries no
-            # information and so still gets the provider fallback above, a
-            # contradiction is information: two signals disagree, and picking
-            # either one would be a guess.
+            # ValueError. This is a guard on the name path, not a leftover of
+            # any fallback: _is_oauth_server_for_app checks a stored provider
+            # *even when the app_id matches*, so stamping here would leave a
+            # row that matches no app at all, where today it still matches by
+            # name.
             continue
         claim(candidate, app)
-
-    for candidate in deferred:
-        provider = candidate.provider
-        assert provider is not None  # only providers reach the deferred list
-        if provider in ambiguous_providers:
-            continue
-        app = apps_by_provider.get(provider)
-        if app is not None:
-            claim(candidate, app)
 
     stamped = 0
     for candidate in pending:

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -1,0 +1,176 @@
+"""backfill auth.app_id onto legacy builtin-OAuth server rows
+
+Rows provisioned before ``_ensure_user_mcp_server`` wrote OAuth metadata
+carry no ``auth`` payload at all (and a small malformed population can
+carry a blank or provider-only ``auth``). Every read path that resolves a
+server row back to its catalog app prefers the stable ``auth.app_id`` and
+falls back to the row's *exact current display name*
+(``get_app_for_mcp_server``) -- so the moment an admin renames the app,
+an unstamped row loses its identity: ``/api/mcp/servers`` enrichment
+reports no ``app_id``, the connector picker persists the app's new
+display name, and the runtime -- which knows the row only under its old
+name -- resolves the selection to zero tools, silently (#1429, surfaced
+reviewing #1403).
+
+This migration stamps the identity while the name still matches, which
+is the only moment it can be derived safely:
+
+- Candidates are ``mcp_servers`` rows with ``transport = 'oauth'`` whose
+  ``auth`` is missing, not a dict, or lacks a nonblank ``app_id``.
+- Each is matched against ``public_mcp_apps`` (builtin apps are seeded
+  into that table too) by exact display name, the same value
+  ``_ensure_user_mcp_server`` named the row after. If the name resolves
+  nothing and the row's ``auth.provider`` names exactly one OAuth app,
+  that app is used instead -- providers are non-unique across apps (the
+  meta/Instagram siblings), so an ambiguous provider is never resolved.
+- Only apps whose own ``transport`` is ``oauth`` are eligible: a
+  same-named non-OAuth app is a different connector shape, and stamping
+  its id onto an oauth-transport row would manufacture exactly the
+  cross-shape identity confusion this migration exists to remove.
+- Rows that resolve to nothing are left untouched. The exact-name
+  fallback in ``get_app_for_mcp_server`` remains as the compatibility
+  shim for them, unchanged in behavior: stamping nothing loses nothing.
+- A row whose own ``auth.provider`` contradicts the name-resolved app's
+  provider is refused — the same conflict the provisioning writer
+  (``_ensure_server_matches_oauth_app``) refuses with a ValueError.
+  Stamping the name's id would produce a row *no* app claims.
+- ``app_id`` is written into a *copy* of the existing auth dict;
+  ``provider`` is added only when absent. Nothing else in ``auth`` is
+  touched — except a non-dict ``auth`` payload (garbage on an
+  oauth-transport row), which is replaced wholesale, matching the
+  provisioning writer, which discards non-dict auth the same way. Rows
+  already carrying a nonblank ``app_id`` are not candidates at all, so
+  re-running the migration is a no-op (idempotent).
+
+Offline (``--sql``) mode emits nothing: a data migration must read rows,
+which a MockConnection cannot. Run it online; the schema is untouched
+either way.
+
+The downgrade is a deliberate no-op. Removing ``auth.app_id`` would need
+to distinguish stamped rows from rows the post-metadata writer created,
+which the data cannot express -- and an extra stable identity is harmless
+to every pre-migration reader (they all prefer ``app_id`` and only fall
+back to names when it is absent).
+
+Revision ID: 20260818_backfill_oauth_server_app_identity
+Revises: 20260813_trace_json_columns_to_jsonb
+Create Date: 2026-08-18
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260818_backfill_oauth_server_app_identity"
+down_revision: str | None = "20260813_trace_json_columns_to_jsonb"
+branch_labels = None
+depends_on = None
+
+
+def _normalized(value: object) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def upgrade() -> None:
+    if op.get_context().as_sql:
+        # Data-only migration: offline (--sql) generation runs against a
+        # MockConnection that cannot read rows, and there is no schema change
+        # to emit. Documented in the module docstring.
+        return
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+    # A bare database has neither table until create_all runs; there is
+    # nothing to backfill there.
+    if "mcp_servers" not in tables or "public_mcp_apps" not in tables:
+        return
+
+    mcp_servers = sa.table(
+        "mcp_servers",
+        sa.column("id", sa.Integer),
+        sa.column("name", sa.String),
+        sa.column("transport", sa.String),
+        sa.column("auth", sa.JSON),
+    )
+    public_mcp_apps = sa.table(
+        "public_mcp_apps",
+        sa.column("app_id", sa.String),
+        sa.column("name", sa.String),
+        sa.column("transport", sa.String),
+        sa.column("provider_name", sa.String),
+    )
+
+    # Exact display name -> app, and provider -> apps, for OAuth apps only.
+    # Both maps refuse ambiguity rather than guessing: two same-named OAuth
+    # apps drop the name key entirely, and a provider shared by more than one
+    # app resolves nothing (the meta/Instagram case).
+    apps_by_name: dict[str, tuple[str, str | None] | None] = {}
+    apps_by_provider: dict[str, tuple[str, str | None] | None] = {}
+    for app_row in bind.execute(sa.select(public_mcp_apps)).mappings():
+        if _normalized(app_row["transport"]).lower() != "oauth":
+            continue
+        app_id = _normalized(app_row["app_id"])
+        if not app_id:
+            continue
+        provider = _normalized(app_row["provider_name"]) or None
+        entry = (app_id, provider)
+        name = _normalized(app_row["name"])
+        if name:
+            apps_by_name[name] = None if name in apps_by_name else entry
+        if provider:
+            apps_by_provider[provider] = None if provider in apps_by_provider else entry
+
+    # Materialized before the loop: the loop UPDATEs the same table, and
+    # stepping a live pysqlite cursor across a mutating table has formally
+    # unspecified row visibility. The table is small (one row per connector).
+    candidates = (
+        bind.execute(sa.select(mcp_servers).where(mcp_servers.c.transport == "oauth"))
+        .mappings()
+        .all()
+    )
+
+    for row in candidates:
+        auth = row["auth"] if isinstance(row["auth"], dict) else None
+        if auth is not None and _normalized(auth.get("app_id")):
+            continue
+        row_provider = _normalized(auth.get("provider")) if auth is not None else ""
+
+        resolved = apps_by_name.get(_normalized(row["name"]))
+        if (
+            resolved is not None
+            and row_provider
+            and resolved[1]
+            and row_provider != resolved[1]
+        ):
+            # The row's own provider contradicts the name-resolved app — the
+            # same conflict _ensure_server_matches_oauth_app refuses with a
+            # ValueError. Stamping the name's app_id would create a row *no*
+            # app claims (it fails this app's provider gate and the provider's
+            # app_id gate), so refuse and leave the read-time provider
+            # fallback exactly as it was.
+            continue
+        if resolved is None and row_provider:
+            resolved = apps_by_provider.get(row_provider)
+        if resolved is None:
+            continue
+
+        app_id, provider = resolved
+        new_auth = dict(auth or {})
+        new_auth["app_id"] = app_id
+        if provider and not _normalized(new_auth.get("provider")):
+            new_auth["provider"] = provider
+        bind.execute(
+            sa.update(mcp_servers)
+            .where(mcp_servers.c.id == row["id"])
+            .values(auth=new_auth)
+        )
+
+
+def downgrade() -> None:
+    # Deliberate no-op: stamped rows are indistinguishable from rows the
+    # post-metadata writer created, and the extra stable identity is harmless
+    # to every pre-migration reader (see module docstring).
+    pass

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -35,16 +35,22 @@ The stamp is derived while the name still matches, the only moment it
 can be derived safely:
 
 - Candidates are ``mcp_servers`` rows with ``transport = 'oauth'`` whose
-  ``auth`` is missing, not a dict, or lacks a nonblank *string* ``app_id``
-  — a non-string value (e.g. an integer) is malformed metadata the read
-  path rejects outright, so such a row stays a candidate and a successful
-  match overwrites the malformed value.
+  ``auth`` is missing or lacks a nonblank *string* ``app_id`` — a
+  non-string value (e.g. an integer) is malformed metadata the read path
+  rejects outright, so such a row stays a candidate and a successful match
+  overwrites the malformed value. A row whose whole ``auth`` payload is a
+  non-dict, or whose stored ``provider`` is present but not a usable
+  string, is left alone instead: both resolve fine today through the name
+  fallback, and this migration is irreversible.
 - Identities are opaque and matched/stored as **raw strings**, never
-  trimmed or coerced: every read path compares them exactly, and stamping
-  a trimmed variant of a padded catalog id would write a value the exact
-  lookup can never resolve. Whitespace-variant names therefore do not
-  match — under-matching leaves the name-fallback shim in charge, which
-  loses nothing.
+  trimmed or coerced: the identity paths this migration feeds compare them
+  exactly (``get_app_by_id``, ``get_app_by_name``, and through them
+  ``get_app_for_mcp_server``), so stamping a trimmed variant of a padded
+  catalog id would write a value the exact lookup can never resolve.
+  Elsewhere in the connector listing, names *are* matched normalized, and
+  ``public_mcp_apps.name`` carries no uniqueness constraint, so
+  whitespace/case variants are producible — they simply do not match here,
+  and under-matching leaves the name-fallback shim in charge.
 - Each is matched against ``public_mcp_apps`` (builtin apps are seeded
   into that table too) by exact display name, the same value
   ``_ensure_user_mcp_server`` named the row after. If the name resolves
@@ -64,7 +70,10 @@ can be derived safely:
 - Only apps whose own ``transport`` is ``oauth`` are eligible: a
   same-named non-OAuth app is a different connector shape, and stamping
   its id onto an oauth-transport row would manufacture exactly the
-  cross-shape identity confusion this migration exists to remove.
+  cross-shape identity confusion this migration exists to remove. Such a
+  name is *refused*, not merely unmatched -- it is evidence about the row,
+  so letting it fall through to the provider fallback would stamp the row
+  with some unrelated app's id.
 - Rows that resolve to nothing are left untouched, keeping the exact-name
   fallback in ``get_app_for_mcp_server`` as their compatibility shim. That
   is a deliberate trade rather than a free win: ``get_app_for_mcp_server``
@@ -87,13 +96,17 @@ can be derived safely:
   provider is refused — the same conflict the provisioning writer
   (``_ensure_server_matches_oauth_app``) refuses with a ValueError.
   Stamping the name's id would produce a row *no* app claims.
-- ``app_id`` is written into a *copy* of the existing auth dict;
-  ``provider`` is added only when absent. Nothing else in ``auth`` is
-  touched — except a non-dict ``auth`` payload (garbage on an
-  oauth-transport row), which is replaced wholesale, matching the
-  provisioning writer, which discards non-dict auth the same way. Rows
-  already carrying a nonblank ``app_id`` are not candidates at all, so
-  re-running the migration is a no-op (idempotent).
+- Only ``app_id`` is written, into a *copy* of the existing auth dict;
+  nothing else is added or touched. A ``provider`` is deliberately not
+  written: ``app_id`` alone resolves the app, while
+  ``_is_oauth_server_for_app`` checks a stored provider *even when the
+  app_id matches*, so writing one sourced from a possibly-drifted
+  ``public_mcp_apps.provider_name`` could break a match that works today.
+- Rows already carrying a nonblank ``app_id`` are not candidates, and the
+  identities they already carry seed the claim set, so a rerun -- including
+  after the no-op downgrade -- neither re-stamps them nor hands their
+  identity to the next-best row. That is what makes the idempotence claim
+  hold across runs, not only within one.
 
 Offline (``--sql``) mode **raises** instead of no-opping: Alembic emits
 the ``alembic_version`` bookkeeping even for an empty migration body, so
@@ -189,13 +202,22 @@ def upgrade() -> None:
     # still gets the provider fallback below, which is the point (the name
     # carries no information there, while an unambiguous provider does).
     # Keys and stored values are the raw strings — identities are opaque, and
-    # every read path compares them exactly. Only ``transport`` is folded,
-    # because it is a shape enum, not an identity (mirroring
-    # classify_app_auth).
+    # the identity paths compare them exactly. Only ``transport`` is folded,
+    # because it is a shape enum rather than an identity -- and a little more
+    # tolerantly than classify_app_auth, which lowercases without stripping.
     apps_by_name: dict[str, tuple[str, str | None] | None] = {}
     apps_by_provider: dict[str, tuple[str, str | None] | None] = {}
+    names_of_other_shapes: set[str] = set()
     for app_row in bind.execute(sa.select(public_mcp_apps)).mappings():
         if str(app_row["transport"] or "").strip().lower() != "oauth":
+            # Recorded, not ignored: a row whose name belongs to a non-oauth
+            # app must be told apart from a row whose name belongs to nothing.
+            # Both miss apps_by_name, but the first is positive evidence of a
+            # *different-shape* app, and letting it fall through to the
+            # provider fallback would stamp it with an unrelated app's id.
+            other_name = _nonblank_str(app_row["name"])
+            if other_name:
+                names_of_other_shapes.add(other_name)
             continue
         app_id = _nonblank_str(app_row["app_id"])
         if not app_id:
@@ -211,25 +233,57 @@ def upgrade() -> None:
     # Materialized before the loop: the loop UPDATEs the same table, and
     # stepping a live pysqlite cursor across a mutating table has formally
     # unspecified row visibility. The table is small (one row per connector).
+    # Ordered by id so a tie the evidence cannot break -- two unstamped rows
+    # whose only signal is the same provider -- resolves to the same row on
+    # every run and every backend, instead of following an unordered scan.
     candidates = (
-        bind.execute(sa.select(mcp_servers).where(mcp_servers.c.transport == "oauth"))
+        bind.execute(
+            sa.select(mcp_servers)
+            .where(mcp_servers.c.transport == "oauth")
+            .order_by(mcp_servers.c.id)
+        )
         .mappings()
         .all()
     )
 
-    # (row, auth-or-None, row provider) for every row still needing a stamp.
-    pending: list[tuple[sa.RowMapping, dict | None, str | None]] = []
+    # Split the candidates: rows already carrying a usable identity, and rows
+    # still needing one. A nonblank *string* app_id is the only shape the read
+    # path accepts (get_app_for_mcp_server rejects a non-string app_id
+    # outright), so that is what counts as "already stamped".
+    #
+    # A non-dict auth payload is garbage on an oauth row, but it is left
+    # alone rather than replaced: such a row resolves fine today through the
+    # name fallback, this migration is irreversible (downgrade is a no-op),
+    # and destroying a value we do not have to is the wrong default for a
+    # data migration. NULL auth is the primary target and is not that case.
+    pending: list[tuple[sa.RowMapping, dict, str | None]] = []
+    already_stamped: set[str] = set()
     for row in candidates:
-        auth = row["auth"] if isinstance(row["auth"], dict) else None
-        # Already-stamped means a nonblank *string* app_id — the only shape
-        # the read path accepts (get_app_for_mcp_server rejects a non-string
-        # app_id outright). A non-string or blank value is malformed metadata
-        # that leaves the row permanently unresolvable, so such a row stays a
-        # candidate and a successful match overwrites the malformed value.
-        if auth is not None and _nonblank_str(auth.get("app_id")):
+        raw_auth = row["auth"]
+        if raw_auth is not None and not isinstance(raw_auth, dict):
             continue
-        provider = _nonblank_str(auth.get("provider")) if auth is not None else None
-        pending.append((row, auth, provider))
+        auth: dict = raw_auth if isinstance(raw_auth, dict) else {}
+        existing = _nonblank_str(auth.get("app_id"))
+        if existing:
+            already_stamped.add(existing)
+            continue
+        raw_provider = auth.get("provider")
+        if raw_provider is not None and not isinstance(raw_provider, str):
+            # Present but not a string at all (a list, a number). The
+            # provider-conflict gate below cannot compare it, and
+            # _is_oauth_server_for_app would reject the row against any app
+            # once stamped, so a stamp would buy nothing. Refuse, matching
+            # _ensure_server_matches_oauth_app's strictness about
+            # contradictory stored metadata. A *blank* string is different:
+            # it carries no claim, so it counts as absent, like a missing key.
+            logger.warning(
+                "%s: mcp_servers row %s has a malformed auth.provider; "
+                "leaving it unstamped",
+                revision,
+                row["id"],
+            )
+            continue
+        pending.append((row, auth, _nonblank_str(raw_provider)))
 
     # Two passes so one app is never stamped onto two rows, and so which row
     # wins is decided by evidence rather than by row order. Name evidence is
@@ -242,45 +296,44 @@ def upgrade() -> None:
     # exactly this migration's target population. Stamping both would make
     # _lookup_oauth_server_for_app -- which reads an unordered query -- pick
     # nondeterministically between them for configure/disconnect.
-    resolutions: dict[int, tuple[str, str | None]] = {}
-    claimed: set[str] = set()
-    deferred: list[tuple[sa.RowMapping, dict | None, str]] = []
+    #
+    # `claimed` starts from the identities rows *already* carry, not empty:
+    # the colliding partner is usually the row the writer stamped on rename,
+    # which never enters `pending` at all. Seeding it is also what makes the
+    # idempotence claim true across a downgrade-then-upgrade rerun -- the
+    # no-op downgrade leaves run 1's stamps in place, and run 2 must not hand
+    # the same identity to the next-best row.
+    resolutions: dict[int, str] = {}
+    claimed: set[str] = set(already_stamped)
+    deferred: list[tuple[sa.RowMapping, dict, str]] = []
 
     for row, auth, provider in pending:
-        resolved = apps_by_name.get(str(row["name"]) if row["name"] else "")
+        row_name = str(row["name"]) if row["name"] else ""
+        if row_name in names_of_other_shapes:
+            # The name belongs to an app of another transport. That is
+            # evidence about *this* row, not an absence of evidence, so it
+            # refuses outright instead of falling through to the provider
+            # fallback -- which would stamp it with an unrelated app's id.
+            continue
+        resolved = apps_by_name.get(row_name)
         if resolved is None:
             if provider:
                 deferred.append((row, auth, provider))
             continue
         if provider and resolved[1] and provider != resolved[1]:
-            # The row's own provider contradicts the name-resolved app — the
+            # The row's own provider contradicts the name-resolved app -- the
             # same conflict _ensure_server_matches_oauth_app refuses with a
             # ValueError. Stamping the name's app_id would create a row *no*
             # app claims (it fails this app's provider gate and the provider's
-            # app_id gate), so refuse and leave the read-time provider
-            # fallback exactly as it was.
-            continue
-        if resolved[0] in claimed:
-            # Two rows named after one app: only the unique-name namespace on
-            # mcp_servers.name makes this impossible in practice, so refuse
-            # rather than assume it.
-            logger.warning(
-                "%s: app_id %r already claimed; leaving mcp_servers row %s unstamped",
-                revision,
-                resolved[0],
-                row["id"],
-            )
-            continue
-        claimed.add(resolved[0])
-        resolutions[int(row["id"])] = resolved
-
-    for row, auth, provider in deferred:
-        resolved = apps_by_provider.get(provider)
-        if resolved is None:
+            # app_id gate), so refuse and leave the read-time name fallback
+            # exactly as it was. Unlike an *ambiguous* name, which carries no
+            # information and so still gets the provider fallback above, a
+            # contradiction is information: two signals disagree, and picking
+            # either one would be a guess.
             continue
         if resolved[0] in claimed:
             logger.warning(
-                "%s: app_id %r already claimed by a name match; leaving "
+                "%s: app_id %r is already carried by another row; leaving "
                 "mcp_servers row %s to its pre-migration name fallback",
                 revision,
                 resolved[0],
@@ -288,27 +341,55 @@ def upgrade() -> None:
             )
             continue
         claimed.add(resolved[0])
-        resolutions[int(row["id"])] = resolved
+        resolutions[int(row["id"])] = resolved[0]
+
+    for row, auth, provider in deferred:
+        resolved = apps_by_provider.get(provider)
+        if resolved is None:
+            continue
+        if resolved[0] in claimed:
+            logger.warning(
+                "%s: app_id %r is already carried by another row; leaving "
+                "mcp_servers row %s to its pre-migration name fallback",
+                revision,
+                resolved[0],
+                row["id"],
+            )
+            continue
+        claimed.add(resolved[0])
+        resolutions[int(row["id"])] = resolved[0]
 
     stamped = 0
     for row, auth, _provider in pending:
-        resolved = resolutions.get(int(row["id"]))
-        if resolved is None:
+        app_id = resolutions.get(int(row["id"]))
+        if app_id is None:
             continue
-        app_id, provider = resolved
-        new_auth = dict(auth or {})
+        # Only app_id is written. The row's own provider (when it has one) is
+        # left as-is and none is added: app_id alone resolves the app, while
+        # _is_oauth_server_for_app checks a stored provider *even when the
+        # app_id matches*, so writing one sourced from a possibly-drifted
+        # public_mcp_apps.provider_name could break a match that works today.
+        new_auth = dict(auth)
         new_auth["app_id"] = app_id
-        if provider and not _nonblank_str(new_auth.get("provider")):
-            new_auth["provider"] = provider
         bind.execute(
             sa.update(mcp_servers)
             .where(mcp_servers.c.id == row["id"])
             .values(auth=new_auth)
         )
+        # Per-row audit: stamping is irreversible (downgrade is a no-op), so
+        # an operator reconstructing or reversing a bad backfill needs the
+        # individual rows, not just the totals below.
+        logger.info(
+            "%s: stamped mcp_servers row %s (name %r) with app_id %r",
+            revision,
+            row["id"],
+            row["name"],
+            app_id,
+        )
         stamped += 1
 
     logger.info(
-        "%s: stamped %s of %s unstamped oauth row(s); %s left to the name fallback",
+        "%s: stamped %s of %s unstamped oauth row(s); %s left unstamped",
         revision,
         stamped,
         len(pending),

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -1,19 +1,38 @@
-"""backfill auth.app_id onto legacy builtin-OAuth server rows
+"""backfill auth.app_id onto unstamped OAuth-transport server rows
 
 Rows provisioned before ``_ensure_user_mcp_server`` wrote OAuth metadata
 carry no ``auth`` payload at all (and a small malformed population can
 carry a blank or provider-only ``auth``). Every read path that resolves a
 server row back to its catalog app prefers the stable ``auth.app_id`` and
 falls back to the row's *exact current display name*
-(``get_app_for_mcp_server``) -- so the moment an admin renames the app,
-an unstamped row loses its identity: ``/api/mcp/servers`` enrichment
-reports no ``app_id``, the connector picker persists the app's new
-display name, and the runtime -- which knows the row only under its old
-name -- resolves the selection to zero tools, silently (#1429, surfaced
-reviewing #1403).
+(``get_app_for_mcp_server``) -- so an unstamped row's identity lives and
+dies by that name: once it stops matching, ``/api/mcp/servers``
+enrichment reports no ``app_id``, the connector picker persists the app's
+current display name, and the runtime -- which knows the row only under
+its stored name -- resolves the selection to zero tools, silently (#1429,
+surfaced reviewing #1403).
 
-This migration stamps the identity while the name still matches, which
-is the only moment it can be derived safely:
+Which apps can drift that way is narrower than "any OAuth app", and
+worth stating precisely, because it is the whole reason this is a
+hardening pass rather than a repair of a known-broken population:
+
+- Genuine **builtin** apps cannot be renamed at all: ``name``,
+  ``transport`` and ``provider_name`` are in
+  ``_BUILTIN_PROTECTED_FIELDS`` (``admin_mcp.py``) and a PATCH touching
+  them 409s, while ``_app_to_dict`` serves the registry's name
+  regardless of what the row stores.
+- **Admin-created** OAuth catalog apps *are* freely renameable, and
+  ``classify_app_auth`` labels them ``builtin_oauth`` too (purely on
+  ``transport == "oauth"``). But admin app CRUD and the unconditional
+  ``app_id`` writer arrived in the same commit, so every row provisioned
+  for such an app already carries the stamp.
+- What is left unstamped-and-renameable is therefore reachable only
+  outside the API surface: direct database edits, or a code-level
+  registry rename across versions. This migration exists to make that
+  residue resolvable rather than to fix a live API-reachable break.
+
+The stamp is derived while the name still matches, the only moment it
+can be derived safely:
 
 - Candidates are ``mcp_servers`` rows with ``transport = 'oauth'`` whose
   ``auth`` is missing, not a dict, or lacks a nonblank *string* ``app_id``
@@ -29,16 +48,41 @@ is the only moment it can be derived safely:
 - Each is matched against ``public_mcp_apps`` (builtin apps are seeded
   into that table too) by exact display name, the same value
   ``_ensure_user_mcp_server`` named the row after. If the name resolves
-  nothing and the row's ``auth.provider`` names exactly one OAuth app,
-  that app is used instead -- providers are non-unique across apps (the
+  nothing -- including when it is *ambiguous*, i.e. shared by two OAuth
+  apps -- and the row's ``auth.provider`` names exactly one OAuth app,
+  that app is used instead. Providers are non-unique across apps (the
   meta/Instagram siblings), so an ambiguous provider is never resolved.
+  Names are resolved for *every* candidate before any provider fallback
+  runs, and an app already claimed by a name match is never handed to a
+  second row: ``_ensure_user_mcp_server`` creates a *new* row when a
+  rename makes the old one unfindable, so orphan pairs for one app are
+  this migration's own target population, and stamping both would give
+  two rows the same identity -- which ``_lookup_oauth_server_for_app``
+  resolves from an unordered query, making configure/disconnect pick
+  nondeterministically between them. Name evidence wins; the loser keeps
+  the behavior it had before this migration.
 - Only apps whose own ``transport`` is ``oauth`` are eligible: a
   same-named non-OAuth app is a different connector shape, and stamping
   its id onto an oauth-transport row would manufacture exactly the
   cross-shape identity confusion this migration exists to remove.
-- Rows that resolve to nothing are left untouched. The exact-name
-  fallback in ``get_app_for_mcp_server`` remains as the compatibility
-  shim for them, unchanged in behavior: stamping nothing loses nothing.
+- Rows that resolve to nothing are left untouched, keeping the exact-name
+  fallback in ``get_app_for_mcp_server`` as their compatibility shim. That
+  is a deliberate trade rather than a free win: ``get_app_for_mcp_server``
+  never falls back to the name once ``app_id`` is present, so a stamp that
+  later goes dangling (an admin deletes a custom OAuth app and recreates
+  it under the same name with a new id) resolves to nothing where an
+  unstamped row would still have matched by name. Stamping only
+  unambiguous matches is what keeps that trade narrow.
+- A drifted builtin row is classified here from its *stored* columns,
+  while runtime reads take ``transport``/``provider_name``/``name`` from
+  the code registry (``_app_to_dict``) and only warn about drift. The two
+  can therefore disagree about a drifted row; the blast radius is one
+  unambiguous stamp on a row whose stored shape says ``oauth``.
+- Only rows whose stored name still matches can be stamped by name. In a
+  deployment where the drift already happened, only the provider fallback
+  can rescue the row -- and not when the provider is shared or absent. So
+  this hardens the population that is still resolvable today; it cannot
+  retroactively repair a row whose every identity signal is already gone.
 - A row whose own ``auth.provider`` contradicts the name-resolved app's
   provider is refused — the same conflict the provisioning writer
   (``_ensure_server_matches_oauth_app``) refuses with a ValueError.
@@ -71,8 +115,12 @@ Create Date: 2026-08-18
 
 from __future__ import annotations
 
+import logging
+
 import sqlalchemy as sa
 from alembic import op
+
+logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision: str = "20260818_backfill_oauth_server_app_identity"
@@ -135,12 +183,15 @@ def upgrade() -> None:
     )
 
     # Exact display name -> app, and provider -> apps, for OAuth apps only.
-    # Both maps refuse ambiguity rather than guessing: two same-named OAuth
-    # apps drop the name key entirely, and a provider shared by more than one
-    # app resolves nothing (the meta/Instagram case). Keys and stored values
-    # are the raw strings — identities are opaque, and every read path
-    # compares them exactly. Only ``transport`` is folded, because it is a
-    # shape enum, not an identity (mirroring classify_app_auth).
+    # A key shared by two OAuth apps is poisoned to None: that *key* then
+    # resolves nothing rather than picking whichever app was seeded first.
+    # Poisoning is per key, not per row -- a row whose name is ambiguous
+    # still gets the provider fallback below, which is the point (the name
+    # carries no information there, while an unambiguous provider does).
+    # Keys and stored values are the raw strings — identities are opaque, and
+    # every read path compares them exactly. Only ``transport`` is folded,
+    # because it is a shape enum, not an identity (mirroring
+    # classify_app_auth).
     apps_by_name: dict[str, tuple[str, str | None] | None] = {}
     apps_by_provider: dict[str, tuple[str, str | None] | None] = {}
     for app_row in bind.execute(sa.select(public_mcp_apps)).mappings():
@@ -166,6 +217,8 @@ def upgrade() -> None:
         .all()
     )
 
+    # (row, auth-or-None, row provider) for every row still needing a stamp.
+    pending: list[tuple[sa.RowMapping, dict | None, str | None]] = []
     for row in candidates:
         auth = row["auth"] if isinstance(row["auth"], dict) else None
         # Already-stamped means a nonblank *string* app_id — the only shape
@@ -175,15 +228,31 @@ def upgrade() -> None:
         # candidate and a successful match overwrites the malformed value.
         if auth is not None and _nonblank_str(auth.get("app_id")):
             continue
-        row_provider = _nonblank_str(auth.get("provider")) if auth is not None else None
+        provider = _nonblank_str(auth.get("provider")) if auth is not None else None
+        pending.append((row, auth, provider))
 
+    # Two passes so one app is never stamped onto two rows, and so which row
+    # wins is decided by evidence rather than by row order. Name evidence is
+    # strictly stronger than a provider (it names one app; a provider can be
+    # shared), so every name match is resolved first and claims its app; the
+    # provider fallback then only fills apps nobody claimed by name.
+    #
+    # This is not hypothetical: _ensure_user_mcp_server creates a *new* row
+    # when a rename makes the old one unfindable, so two rows for one app are
+    # exactly this migration's target population. Stamping both would make
+    # _lookup_oauth_server_for_app -- which reads an unordered query -- pick
+    # nondeterministically between them for configure/disconnect.
+    resolutions: dict[int, tuple[str, str | None]] = {}
+    claimed: set[str] = set()
+    deferred: list[tuple[sa.RowMapping, dict | None, str]] = []
+
+    for row, auth, provider in pending:
         resolved = apps_by_name.get(str(row["name"]) if row["name"] else "")
-        if (
-            resolved is not None
-            and row_provider
-            and resolved[1]
-            and row_provider != resolved[1]
-        ):
+        if resolved is None:
+            if provider:
+                deferred.append((row, auth, provider))
+            continue
+        if provider and resolved[1] and provider != resolved[1]:
             # The row's own provider contradicts the name-resolved app — the
             # same conflict _ensure_server_matches_oauth_app refuses with a
             # ValueError. Stamping the name's app_id would create a row *no*
@@ -191,11 +260,41 @@ def upgrade() -> None:
             # app_id gate), so refuse and leave the read-time provider
             # fallback exactly as it was.
             continue
-        if resolved is None and row_provider:
-            resolved = apps_by_provider.get(row_provider)
+        if resolved[0] in claimed:
+            # Two rows named after one app: only the unique-name namespace on
+            # mcp_servers.name makes this impossible in practice, so refuse
+            # rather than assume it.
+            logger.warning(
+                "%s: app_id %r already claimed; leaving mcp_servers row %s unstamped",
+                revision,
+                resolved[0],
+                row["id"],
+            )
+            continue
+        claimed.add(resolved[0])
+        resolutions[int(row["id"])] = resolved
+
+    for row, auth, provider in deferred:
+        resolved = apps_by_provider.get(provider)
         if resolved is None:
             continue
+        if resolved[0] in claimed:
+            logger.warning(
+                "%s: app_id %r already claimed by a name match; leaving "
+                "mcp_servers row %s to its pre-migration name fallback",
+                revision,
+                resolved[0],
+                row["id"],
+            )
+            continue
+        claimed.add(resolved[0])
+        resolutions[int(row["id"])] = resolved
 
+    stamped = 0
+    for row, auth, _provider in pending:
+        resolved = resolutions.get(int(row["id"]))
+        if resolved is None:
+            continue
         app_id, provider = resolved
         new_auth = dict(auth or {})
         new_auth["app_id"] = app_id
@@ -206,6 +305,15 @@ def upgrade() -> None:
             .where(mcp_servers.c.id == row["id"])
             .values(auth=new_auth)
         )
+        stamped += 1
+
+    logger.info(
+        "%s: stamped %s of %s unstamped oauth row(s); %s left to the name fallback",
+        revision,
+        stamped,
+        len(pending),
+        len(pending) - stamped,
+    )
 
 
 def downgrade() -> None:

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -109,7 +109,7 @@ to every pre-migration reader (they all prefer ``app_id`` and only fall
 back to names when it is absent).
 
 Revision ID: 20260818_backfill_oauth_server_app_identity
-Revises: 20260813_trace_json_columns_to_jsonb
+Revises: 20260818_seed_jira_mcp_app
 Create Date: 2026-08-18
 """
 
@@ -124,7 +124,7 @@ logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision: str = "20260818_backfill_oauth_server_app_identity"
-down_revision: str | None = "20260813_trace_json_columns_to_jsonb"
+down_revision: str | None = "20260818_seed_jira_mcp_app"
 branch_labels = None
 depends_on = None
 

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -16,7 +16,16 @@ This migration stamps the identity while the name still matches, which
 is the only moment it can be derived safely:
 
 - Candidates are ``mcp_servers`` rows with ``transport = 'oauth'`` whose
-  ``auth`` is missing, not a dict, or lacks a nonblank ``app_id``.
+  ``auth`` is missing, not a dict, or lacks a nonblank *string* ``app_id``
+  — a non-string value (e.g. an integer) is malformed metadata the read
+  path rejects outright, so such a row stays a candidate and a successful
+  match overwrites the malformed value.
+- Identities are opaque and matched/stored as **raw strings**, never
+  trimmed or coerced: every read path compares them exactly, and stamping
+  a trimmed variant of a padded catalog id would write a value the exact
+  lookup can never resolve. Whitespace-variant names therefore do not
+  match — under-matching leaves the name-fallback shim in charge, which
+  loses nothing.
 - Each is matched against ``public_mcp_apps`` (builtin apps are seeded
   into that table too) by exact display name, the same value
   ``_ensure_user_mcp_server`` named the row after. If the name resolves
@@ -42,9 +51,12 @@ is the only moment it can be derived safely:
   already carrying a nonblank ``app_id`` are not candidates at all, so
   re-running the migration is a no-op (idempotent).
 
-Offline (``--sql``) mode emits nothing: a data migration must read rows,
-which a MockConnection cannot. Run it online; the schema is untouched
-either way.
+Offline (``--sql``) mode **raises** instead of no-opping: Alembic emits
+the ``alembic_version`` bookkeeping even for an empty migration body, so
+a silently-skipped offline run would advance the version while touching
+no row — and a later online upgrade would then skip this revision
+forever. Failing loudly forces the one correct path: run this revision
+online. The schema is untouched either way.
 
 The downgrade is a deliberate no-op. Removing ``auth.app_id`` would need
 to distinguish stamped rows from rows the post-metadata writer created,
@@ -69,16 +81,35 @@ branch_labels = None
 depends_on = None
 
 
-def _normalized(value: object) -> str:
-    return str(value).strip() if value is not None else ""
+def _nonblank_str(value: object) -> str | None:
+    """The value itself when it is a str with non-whitespace content, else None.
+
+    Raw, never trimmed or coerced: identities are opaque and every downstream
+    comparison is exact (``get_app_by_id`` compares ``PublicMCPApp.app_id``
+    directly; ``get_app_for_mcp_server`` rejects a non-string ``auth.app_id``).
+    Stamping a trimmed variant of a padded catalog id would write a value the
+    exact lookup can never resolve — strictly worse than not stamping. This
+    helper decides only *whether* a usable string exists; the string used for
+    matching and for storage is always the raw one.
+    """
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
 
 
 def upgrade() -> None:
     if op.get_context().as_sql:
-        # Data-only migration: offline (--sql) generation runs against a
-        # MockConnection that cannot read rows, and there is no schema change
-        # to emit. Documented in the module docstring.
-        return
+        # Fail loudly rather than no-op: returning here would still let
+        # Alembic emit the alembic_version bookkeeping, so an operator who
+        # applies the generated --sql script advances the version while no
+        # row was read or updated — and a later online upgrade then skips
+        # this revision forever, leaving the legacy rows unstamped.
+        raise RuntimeError(
+            "20260818_backfill_oauth_server_app_identity is a data migration "
+            "and cannot run in offline (--sql) mode: applying generated SQL "
+            "would advance alembic_version without performing the backfill. "
+            "Run `alembic upgrade` online for this revision."
+        )
 
     bind = op.get_bind()
     inspector = sa.inspect(bind)
@@ -106,18 +137,21 @@ def upgrade() -> None:
     # Exact display name -> app, and provider -> apps, for OAuth apps only.
     # Both maps refuse ambiguity rather than guessing: two same-named OAuth
     # apps drop the name key entirely, and a provider shared by more than one
-    # app resolves nothing (the meta/Instagram case).
+    # app resolves nothing (the meta/Instagram case). Keys and stored values
+    # are the raw strings — identities are opaque, and every read path
+    # compares them exactly. Only ``transport`` is folded, because it is a
+    # shape enum, not an identity (mirroring classify_app_auth).
     apps_by_name: dict[str, tuple[str, str | None] | None] = {}
     apps_by_provider: dict[str, tuple[str, str | None] | None] = {}
     for app_row in bind.execute(sa.select(public_mcp_apps)).mappings():
-        if _normalized(app_row["transport"]).lower() != "oauth":
+        if str(app_row["transport"] or "").strip().lower() != "oauth":
             continue
-        app_id = _normalized(app_row["app_id"])
+        app_id = _nonblank_str(app_row["app_id"])
         if not app_id:
             continue
-        provider = _normalized(app_row["provider_name"]) or None
+        provider = _nonblank_str(app_row["provider_name"])
         entry = (app_id, provider)
-        name = _normalized(app_row["name"])
+        name = _nonblank_str(app_row["name"])
         if name:
             apps_by_name[name] = None if name in apps_by_name else entry
         if provider:
@@ -134,11 +168,16 @@ def upgrade() -> None:
 
     for row in candidates:
         auth = row["auth"] if isinstance(row["auth"], dict) else None
-        if auth is not None and _normalized(auth.get("app_id")):
+        # Already-stamped means a nonblank *string* app_id — the only shape
+        # the read path accepts (get_app_for_mcp_server rejects a non-string
+        # app_id outright). A non-string or blank value is malformed metadata
+        # that leaves the row permanently unresolvable, so such a row stays a
+        # candidate and a successful match overwrites the malformed value.
+        if auth is not None and _nonblank_str(auth.get("app_id")):
             continue
-        row_provider = _normalized(auth.get("provider")) if auth is not None else ""
+        row_provider = _nonblank_str(auth.get("provider")) if auth is not None else None
 
-        resolved = apps_by_name.get(_normalized(row["name"]))
+        resolved = apps_by_name.get(str(row["name"]) if row["name"] else "")
         if (
             resolved is not None
             and row_provider
@@ -160,7 +199,7 @@ def upgrade() -> None:
         app_id, provider = resolved
         new_auth = dict(auth or {})
         new_auth["app_id"] = app_id
-        if provider and not _normalized(new_auth.get("provider")):
+        if provider and not _nonblank_str(new_auth.get("provider")):
             new_auth["provider"] = provider
         bind.execute(
             sa.update(mcp_servers)

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -12,9 +12,9 @@ current display name, and the runtime -- which knows the row only under
 its stored name -- resolves the selection to zero tools, silently (#1429,
 surfaced reviewing #1403).
 
-Which apps can drift that way is narrower than "any OAuth app", and
-worth stating precisely, because it is the whole reason this is a
-hardening pass rather than a repair of a known-broken population:
+Which apps can drift that way is worth stating precisely, because the
+at-risk population is real and was produced by the normal API, not by
+out-of-band edits:
 
 - Genuine **builtin** apps cannot be renamed at all: ``name``,
   ``transport`` and ``provider_name`` are in
@@ -23,13 +23,17 @@ hardening pass rather than a repair of a known-broken population:
   regardless of what the row stores.
 - **Admin-created** OAuth catalog apps *are* freely renameable, and
   ``classify_app_auth`` labels them ``builtin_oauth`` too (purely on
-  ``transport == "oauth"``). But admin app CRUD and the unconditional
-  ``app_id`` writer arrived in the same commit, so every row provisioned
-  for such an app already carries the stamp.
-- What is left unstamped-and-renameable is therefore reachable only
-  outside the API surface: direct database edits, or a code-level
-  registry rename across versions. This migration exists to make that
-  residue resolvable rather than to fix a live API-reachable break.
+  ``transport == "oauth"``). Admin app CRUD shipped in ``c8642b8c``
+  (2026-04-24); ``_ensure_user_mcp_server`` did not write ``auth`` at
+  all until ``cb724dbb`` (2026-06-26). For those ~63 days the ordinary
+  OAuth-connect flow, on an app an admin could rename the next day,
+  produced exactly the unstamped row this migration exists for. Any
+  deployment that connected such an app in that window still carries
+  those rows.
+- After ``cb724dbb`` every provisioned row carries the stamp, so nothing
+  new joins the population; what remains is that historical residue plus
+  whatever direct database edits or a code-level registry rename leave
+  behind.
 
 The stamp is derived while the name still matches, the only moment it
 can be derived safely:
@@ -265,7 +269,17 @@ def upgrade() -> None:
     candidates = (
         bind.execute(
             sa.select(mcp_servers)
-            .where(sa.func.lower(sa.func.trim(mcp_servers.c.transport)) == "oauth")
+            # Exact, matching the writer and every runtime reader: the five
+            # gates that make an oauth row *work* (tools/config.py's credential
+            # injection, _is_oauth_server_for_app, _enrich_oauth_server_info,
+            # _ensure_server_matches_oauth_app) all compare `transport ==
+            # "oauth"` unfolded. A row stored "OAuth" passes none of them, so
+            # it is a dead row: stamping it would be worthless to it and, worse,
+            # could burn the app's one identity -- the `claimed` guard would
+            # then refuse the genuine row, irreversibly (downgrade is a no-op).
+            # Folding here would make this migration the only place with a
+            # wider notion of "oauth" than everything consuming its output.
+            .where(mcp_servers.c.transport == "oauth")
             .order_by(mcp_servers.c.id)
         )
         .mappings()

--- a/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
+++ b/src/xagent/migrations/versions/20260818_backfill_oauth_server_app_identity.py
@@ -71,6 +71,12 @@ can be derived safely:
   at all before ``cb724dbb`` -- carries no provider to fall back to. A
   provider-keyed pass would defend nothing real, and it was the only place
   where two rows could compete for one identity.
+- This migration cannot stop a *future* rename from recreating the
+  condition: ``_ensure_user_mcp_server`` still looks its row up by display
+  name, so the next connect after a rename creates a second row that the
+  unconditional writer stamps with the same ``app_id``. That write-path
+  root cause is tracked in #1569; what follows is only about not creating
+  the condition here.
 - An app already carried by another row is never handed to a second one.
   ``_ensure_user_mcp_server`` creates a *new* row when a rename makes the
   old one unfindable, so orphan pairs for one app are this migration's own

--- a/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
+++ b/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
@@ -9,9 +9,9 @@ What must hold:
 
 - an auth-less oauth row named exactly after an OAuth app is stamped with
   that app's ``app_id`` -- and only that: no ``provider`` is written;
-- a provider-only row (blank/absent ``app_id``) is stamped through its
-  provider when exactly one OAuth app uses that provider, and left alone
-  when the provider is ambiguous — providers are non-unique across apps;
+- a provider-only row is never stamped: the stored name is the only signal,
+  because no writer this codebase shipped produces a provider-without-app_id
+  row and the population that does exist carries no auth at all;
 - rows already carrying a nonblank ``app_id`` are untouched (idempotence);
 - rows resolving to nothing (orphans, non-oauth-app name matches) are left
   exactly as they were, preserving the name-fallback shim's behavior;
@@ -132,9 +132,14 @@ def test_an_auth_less_row_is_stamped_by_exact_display_name(seeded_engine):
     assert auth == {"app_id": "acme-drive"}
 
 
-def test_a_provider_only_row_is_stamped_when_the_provider_is_unambiguous(
-    seeded_engine,
-):
+def test_a_provider_only_row_is_never_stamped(seeded_engine):
+    """There is no provider fallback: the stored name is the only signal. No
+    writer this codebase shipped produces a provider-without-app_id row
+    (_oauth_auth_metadata writes app_id first and unconditionally; the generic
+    servers API cannot author transport="oauth" -- MCPServerConfig rejects it),
+    and the population that does exist carries no auth at all, so a
+    provider-keyed pass would defend nothing while being the only place two
+    rows could compete for one identity."""
     engine, metadata = seeded_engine
     _seed(
         engine,
@@ -148,56 +153,26 @@ def test_a_provider_only_row_is_stamped_when_the_provider_is_unambiguous(
             }
         ],
         servers=[
+            # Blank app_id plus a provider that would have resolved uniquely.
             {
                 "name": "Old Acme Name",
                 "transport": "oauth",
                 "auth": {"app_id": "   ", "provider": "acme"},
-            }
-        ],
-    )
-
-    _run_upgrade(engine)
-
-    auth = _auth_by_name(engine, metadata)["Old Acme Name"]
-    assert auth["app_id"] == "acme-drive"
-    # The row's own provider spelling is kept, not overwritten.
-    assert auth["provider"] == "acme"
-
-
-def test_an_ambiguous_provider_resolves_nothing(seeded_engine):
-    """The meta/Instagram case: two apps on one provider. Guessing would
-    attribute another connector's identity, so the row stays unstamped and
-    keeps the name-fallback shim's behavior."""
-    engine, metadata = seeded_engine
-    _seed(
-        engine,
-        metadata,
-        apps=[
-            {
-                "app_id": "acme-drive",
-                "name": "Acme Drive",
-                "transport": "oauth",
-                "provider_name": "acme",
             },
+            # No app_id at all, provider only.
             {
-                "app_id": "acme-mail",
-                "name": "Acme Mail",
-                "transport": "oauth",
-                "provider_name": "acme",
-            },
-        ],
-        servers=[
-            {
-                "name": "Old Acme Name",
+                "name": "Older Acme Name",
                 "transport": "oauth",
                 "auth": {"provider": "acme"},
-            }
+            },
         ],
     )
 
     _run_upgrade(engine)
 
-    assert _auth_by_name(engine, metadata)["Old Acme Name"] == {"provider": "acme"}
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Old Acme Name"] == {"app_id": "   ", "provider": "acme"}
+    assert auth["Older Acme Name"] == {"provider": "acme"}
 
 
 def test_rows_already_stamped_and_orphans_are_untouched(seeded_engine):
@@ -266,9 +241,7 @@ def test_a_provider_conflict_refuses_the_name_match(seeded_engine):
     _run_upgrade(engine)
 
     # Untouched: the conflicting evidence is left for a human (or the
-    # provisioning writer's own refusal path) to resolve. NOTE the provider
-    # fallback did not fire either — the name match short-circuits before it,
-    # and resurrecting it here would guess between two contradictory signals.
+    # provisioning writer's own refusal path) to resolve.
     assert _auth_by_name(engine, metadata)["Acme Drive"] == {"provider": "other"}
 
 
@@ -393,11 +366,21 @@ def test_identities_are_matched_raw_never_trimmed(seeded_engine):
                 "name": "Acme Drive",
                 "transport": "oauth",
                 "provider_name": "acme",
-            }
+            },
+            # A second app so the variant-name row below has an identity
+            # available to it: were the lookup to trim, it would resolve this
+            # app rather than being refused by the claim guard, which would
+            # otherwise mask the bug.
+            {
+                "app_id": "acme-mail",
+                "name": "Acme Mail",
+                "transport": "oauth",
+                "provider_name": "mail",
+            },
         ],
         servers=[
             {"name": "Acme Drive", "transport": "oauth", "auth": None},
-            {"name": "Acme Drive ", "transport": "oauth", "auth": None},
+            {"name": "Acme Mail ", "transport": "oauth", "auth": None},
         ],
     )
 
@@ -405,17 +388,21 @@ def test_identities_are_matched_raw_never_trimmed(seeded_engine):
 
     auth = _auth_by_name(engine, metadata)
     assert auth["Acme Drive"] == {"app_id": " acme-drive "}
-    assert auth["Acme Drive "] is None
+    # Trailing space: no match, and "acme-mail" is claimed by nobody, so only a
+    # trimming lookup could have stamped this row.
+    assert auth["Acme Mail "] is None
 
 
-def test_one_app_is_never_stamped_onto_two_rows(seeded_engine):
-    """_ensure_user_mcp_server creates a *new* row when a rename makes the old
-    one unfindable, so two rows for one app are this migration's own target
-    population. Stamping both would give them one identity, and
-    _lookup_oauth_server_for_app reads an unordered query — configure and
-    disconnect would then pick between them nondeterministically. Name
-    evidence wins; the provider-matched row keeps its pre-migration
-    behavior."""
+def test_an_identity_another_row_already_carries_is_refused(seeded_engine):
+    """`claimed` seeds from the identities rows already carry, so an app whose
+    app_id is already on one row is never stamped onto a second -- two rows
+    sharing an identity would make _lookup_oauth_server_for_app, which reads an
+    unordered query, pick nondeterministically between them.
+
+    Reachable through the API, not only by out-of-band edits: rename the app
+    away (the writer, finding no row under the new name, creates and stamps a
+    fresh one), then rename it back, and a legacy unstamped row's name once
+    again resolves an app another row already carries."""
     engine, metadata = seeded_engine
     _seed(
         engine,
@@ -429,46 +416,13 @@ def test_one_app_is_never_stamped_onto_two_rows(seeded_engine):
             }
         ],
         servers=[
-            # Matches by name.
-            {"name": "Acme Drive", "transport": "oauth", "auth": None},
-            # Would match the same app by provider — the orphan left behind by
-            # a rename.
+            # Carries the identity already, and is not a candidate.
             {
-                "name": "Acme Drive (old)",
+                "name": "Acme Drive (renamed away)",
                 "transport": "oauth",
-                "auth": {"provider": "acme"},
+                "auth": {"app_id": "acme-drive"},
             },
-        ],
-    )
-
-    _run_upgrade(engine)
-
-    auth = _auth_by_name(engine, metadata)
-    assert auth["Acme Drive"] == {"app_id": "acme-drive"}
-    assert auth["Acme Drive (old)"] == {"provider": "acme"}
-
-
-def test_name_evidence_wins_regardless_of_row_order(seeded_engine):
-    """The same collision with the provider-matched row seeded *first*: which
-    row wins must follow the evidence, not insertion order."""
-    engine, metadata = seeded_engine
-    _seed(
-        engine,
-        metadata,
-        apps=[
-            {
-                "app_id": "acme-drive",
-                "name": "Acme Drive",
-                "transport": "oauth",
-                "provider_name": "acme",
-            }
-        ],
-        servers=[
-            {
-                "name": "Acme Drive (old)",
-                "transport": "oauth",
-                "auth": {"provider": "acme"},
-            },
+            # Would resolve to the same app by exact name.
             {"name": "Acme Drive", "transport": "oauth", "auth": None},
         ],
     )
@@ -476,55 +430,15 @@ def test_name_evidence_wins_regardless_of_row_order(seeded_engine):
     _run_upgrade(engine)
 
     auth = _auth_by_name(engine, metadata)
-    assert auth["Acme Drive"] == {"app_id": "acme-drive"}
-    assert auth["Acme Drive (old)"] == {"provider": "acme"}
+    assert auth["Acme Drive (renamed away)"] == {"app_id": "acme-drive"}
+    assert auth["Acme Drive"] is None
 
 
-def test_an_ambiguous_name_still_gets_the_provider_fallback(seeded_engine):
-    """Poisoning is per *key*, not per row: an ambiguous name carries no
-    information, so a row under it still resolves through an unambiguous
-    provider. The two same-named apps differ in provider, so only one is
-    reachable that way."""
-    engine, metadata = seeded_engine
-    _seed(
-        engine,
-        metadata,
-        apps=[
-            {
-                "app_id": "acme-drive",
-                "name": "Acme Drive",
-                "transport": "oauth",
-                "provider_name": "acme",
-            },
-            {
-                "app_id": "other-drive",
-                "name": "Acme Drive",
-                "transport": "oauth",
-                "provider_name": "other",
-            },
-        ],
-        servers=[
-            {
-                "name": "Acme Drive",
-                "transport": "oauth",
-                "auth": {"provider": "other"},
-            }
-        ],
-    )
-
-    _run_upgrade(engine)
-
-    assert _auth_by_name(engine, metadata)["Acme Drive"] == {
-        "app_id": "other-drive",
-        "provider": "other",
-    }
-
-
-def test_lookup_map_construction_skips_and_folds_the_right_fields(seeded_engine):
-    """Three map-building branches at once: an app with a blank app_id is
-    skipped entirely, an app with a blank name contributes to the provider map
-    only, and app-side `transport` is case-folded (it is a shape enum, not an
-    identity)."""
+def test_lookup_map_construction_skips_the_right_apps(seeded_engine):
+    """Two map-building branches: an app whose app_id is blank is unusable as
+    an identity and contributes nothing, and app-side ``transport`` is
+    case-folded (it is a shape enum, not an identity). A name-keyed map means a
+    blank-named app is simply unreachable."""
     engine, metadata = seeded_engine
     _seed(
         engine,
@@ -537,14 +451,7 @@ def test_lookup_map_construction_skips_and_folds_the_right_fields(seeded_engine)
                 "transport": "oauth",
                 "provider_name": "blank",
             },
-            # Blank name: reachable by provider only.
-            {
-                "app_id": "nameless-app",
-                "name": "   ",
-                "transport": "oauth",
-                "provider_name": "nameless",
-            },
-            # Mixed-case transport still counts as oauth.
+            # Mixed-case transport still counts as oauth on the app side.
             {
                 "app_id": "cased-app",
                 "name": "Cased App",
@@ -554,11 +461,6 @@ def test_lookup_map_construction_skips_and_folds_the_right_fields(seeded_engine)
         ],
         servers=[
             {"name": "Blank Id App", "transport": "oauth", "auth": None},
-            {
-                "name": "Whatever",
-                "transport": "oauth",
-                "auth": {"provider": "nameless"},
-            },
             {"name": "Cased App", "transport": "oauth", "auth": None},
         ],
     )
@@ -567,8 +469,6 @@ def test_lookup_map_construction_skips_and_folds_the_right_fields(seeded_engine)
 
     auth = _auth_by_name(engine, metadata)
     assert auth["Blank Id App"] is None
-    assert auth["Whatever"] == {"provider": "nameless", "app_id": "nameless-app"}
-    # No provider on the app, so only app_id is written.
     assert auth["Cased App"] == {"app_id": "cased-app"}
 
 
@@ -606,53 +506,10 @@ def test_unrelated_auth_keys_survive_the_stamp(seeded_engine):
     }
 
 
-def test_a_pre_stamped_row_blocks_a_second_row_claiming_its_app(seeded_engine):
-    """The collision the two-pass fix alone did not close: the partner row was
-    stamped *before* this run (by the writer, or by an earlier run), so it
-    never enters the candidate set. Its identity must still be claimed, or the
-    orphan gets the same app_id and _lookup_oauth_server_for_app picks between
-    them nondeterministically."""
-    engine, metadata = seeded_engine
-    _seed(
-        engine,
-        metadata,
-        apps=[
-            {
-                "app_id": "acme-drive",
-                "name": "Acme Drive v2",
-                "transport": "oauth",
-                "provider_name": "acme",
-            }
-        ],
-        servers=[
-            # Already carries the identity — the row the writer created on
-            # rename, and not a candidate.
-            {
-                "name": "Acme Drive v2",
-                "transport": "oauth",
-                "auth": {"app_id": "acme-drive", "provider": "acme"},
-            },
-            # The orphan left under the old name; only its provider resolves.
-            {
-                "name": "Acme Drive",
-                "transport": "oauth",
-                "auth": {"provider": "acme"},
-            },
-        ],
-    )
-
-    _run_upgrade(engine)
-
-    auth = _auth_by_name(engine, metadata)
-    assert auth["Acme Drive v2"] == {"app_id": "acme-drive", "provider": "acme"}
-    assert auth["Acme Drive"] == {"provider": "acme"}
-
-
 def test_a_stamp_survives_a_rerun_unchanged(seeded_engine):
-    """Idempotence across runs, not just within one: run 1 stamps the name
-    match, and run 2 -- which is what a downgrade (a no-op) plus upgrade
-    produces -- must neither restamp it nor hand its identity to the orphan
-    that lost the first time."""
+    """Idempotence across runs, not just within one: run 2 -- what a downgrade
+    (a no-op) plus upgrade produces -- must neither restamp the row nor let the
+    identity it now carries be handed to anything else."""
     engine, metadata = seeded_engine
     _seed(
         engine,
@@ -665,34 +522,24 @@ def test_a_stamp_survives_a_rerun_unchanged(seeded_engine):
                 "provider_name": "acme",
             }
         ],
-        servers=[
-            {"name": "Acme Drive", "transport": "oauth", "auth": None},
-            {
-                "name": "Acme Drive (old)",
-                "transport": "oauth",
-                "auth": {"provider": "acme"},
-            },
-        ],
+        servers=[{"name": "Acme Drive", "transport": "oauth", "auth": None}],
     )
 
     _run_upgrade(engine)
     after_first = _auth_by_name(engine, metadata)
+    assert after_first["Acme Drive"] == {"app_id": "acme-drive"}
 
     module = _migration_module()
     module.downgrade()
     _run_upgrade(engine)
 
     assert _auth_by_name(engine, metadata) == after_first
-    assert after_first["Acme Drive"] == {"app_id": "acme-drive"}
-    assert after_first["Acme Drive (old)"] == {"provider": "acme"}
 
 
-def test_a_name_owned_by_a_non_oauth_app_refuses_the_provider_fallback(
-    seeded_engine,
-):
+def test_a_name_owned_by_a_non_oauth_app_is_refused(seeded_engine):
     """A name matching a *non-OAuth* app is evidence about this row, not an
-    absence of evidence. Treating the two alike would let the row fall through
-    to the provider fallback and be stamped with an unrelated app's id."""
+    absence of evidence: the row is refused rather than treated as unmatched,
+    so no later rule can claim it for an app of the wrong shape."""
     engine, metadata = seeded_engine
     _seed(
         engine,
@@ -725,6 +572,37 @@ def test_a_name_owned_by_a_non_oauth_app_refuses_the_provider_fallback(
     assert _auth_by_name(engine, metadata)["Acme Notes"] == {"provider": "acme"}
 
 
+def test_a_name_carried_by_both_shapes_refuses_the_oauth_app(seeded_engine):
+    """The one case where the cross-shape gate changes the outcome: a single
+    display name carried by an OAuth app *and* a non-OAuth app. Without the
+    gate the OAuth app would simply win the name; with it the ownership is
+    contested, so the row keeps its read-time name fallback."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            },
+            {
+                "app_id": "acme-drive-stdio",
+                "name": "Acme Drive",
+                "transport": "stdio",
+                "provider_name": None,
+            },
+        ],
+        servers=[{"name": "Acme Drive", "transport": "oauth", "auth": None}],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] is None
+
+
 def test_a_malformed_non_string_provider_refuses_the_row(seeded_engine):
     """A provider that is not a string at all cannot be compared by the
     conflict gate, and _is_oauth_server_for_app would reject the row against
@@ -754,35 +632,6 @@ def test_a_malformed_non_string_provider_refuses_the_row(seeded_engine):
     _run_upgrade(engine)
 
     assert _auth_by_name(engine, metadata)["Acme Drive"] == {"provider": ["acme"]}
-
-
-def test_two_provider_only_rows_resolve_deterministically(seeded_engine):
-    """A tie the evidence cannot break: two unstamped rows whose only signal
-    is the same provider. Exactly one may be stamped, and candidates are read
-    ordered by id so it is the same one on every run and every backend."""
-    engine, metadata = seeded_engine
-    _seed(
-        engine,
-        metadata,
-        apps=[
-            {
-                "app_id": "acme-drive",
-                "name": "Acme Drive",
-                "transport": "oauth",
-                "provider_name": "acme",
-            }
-        ],
-        servers=[
-            {"name": "orphan-a", "transport": "oauth", "auth": {"provider": "acme"}},
-            {"name": "orphan-b", "transport": "oauth", "auth": {"provider": "acme"}},
-        ],
-    )
-
-    _run_upgrade(engine)
-
-    auth = _auth_by_name(engine, metadata)
-    assert auth["orphan-a"] == {"app_id": "acme-drive", "provider": "acme"}
-    assert auth["orphan-b"] == {"provider": "acme"}
 
 
 def test_a_mixed_case_transport_row_is_not_a_candidate(seeded_engine):
@@ -918,7 +767,9 @@ def postgres_seeded_engine():
 @pytest.mark.postgresql
 def test_the_backfill_runs_on_postgresql(postgres_seeded_engine):
     """Stamp, refusal and collision behavior on the real backend: the JSON
-    write round-trips, and the pre-stamped partner still blocks the orphan."""
+    write round-trips; a name match is stamped; a row whose name resolves an
+    app another row already carries is refused; a provider-only row and an
+    orphan are both left alone."""
     engine, metadata = postgres_seeded_engine
     _seed(
         engine,
@@ -958,6 +809,7 @@ def test_the_backfill_runs_on_postgresql(postgres_seeded_engine):
     auth = _auth_by_name(engine, metadata)
     assert auth["Acme Mail"] == {"app_id": "acme-mail"}
     assert auth["Acme Drive v2"] == {"app_id": "acme-drive", "provider": "acme"}
-    # Its app_id is already carried by the row above.
+    # Its name resolves acme-drive, but the row above already carries that
+    # identity, so it is refused and keeps its pre-migration state.
     assert auth["Acme Drive"] == {"provider": "acme"}
     assert auth["orphan"] is None

--- a/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
+++ b/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
@@ -48,11 +48,15 @@ def _migration_module() -> ModuleType:
 def _pre_migration_metadata() -> sa.MetaData:
     """The two tables reduced to the columns the migration reads/writes."""
     metadata = sa.MetaData()
+    # Uniqueness mirrors production (mcp_servers.name, public_mcp_apps.app_id)
+    # so a fixture cannot seed a state the real schema would reject -- which
+    # is also what makes the same-name-server cases below honest: they must use
+    # distinct names, exactly like production data.
     sa.Table(
         "mcp_servers",
         metadata,
         sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False, unique=True),
         sa.Column("transport", sa.String(50), nullable=False),
         sa.Column("auth", sa.JSON, nullable=True),
     )
@@ -60,7 +64,7 @@ def _pre_migration_metadata() -> sa.MetaData:
         "public_mcp_apps",
         metadata,
         sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("app_id", sa.String(100), nullable=False),
+        sa.Column("app_id", sa.String(100), nullable=False, unique=True),
         sa.Column("name", sa.String(100), nullable=False),
         sa.Column("transport", sa.String(50), nullable=False),
         sa.Column("provider_name", sa.String(50), nullable=True),
@@ -290,26 +294,27 @@ def test_a_non_dict_auth_payload_is_replaced_wholesale(seeded_engine):
     assert auth == {"app_id": "acme-drive", "provider": "acme"}
 
 
-def test_offline_sql_mode_raises_instead_of_stamping(seeded_engine):
+def test_offline_sql_mode_raises_instead_of_stamping():
     """Alembic emits alembic_version bookkeeping even for an empty migration
     body, so a silent offline no-op would advance the version while touching
     no row — permanently skipping the backfill on the next online upgrade.
-    The offline branch must fail loudly instead, for both dialects."""
-    from io import StringIO
+    The offline branch must fail loudly instead, for both dialects.
 
+    Scope: this pins the raise, which is the whole guard. The bookkeeping
+    hazard itself lives in Alembic's env.py/CLI path, which this harness does
+    not drive — an end-to-end `alembic upgrade --sql` test would need a real
+    config and script directory, and the raise here is what makes that path
+    unreachable in the first place."""
     module = _migration_module()
     for dialect in ("sqlite", "postgresql"):
-        output = StringIO()
         migration_context = MigrationContext.configure(
-            dialect_name=dialect,
-            opts={"as_sql": True, "output_buffer": output},
+            dialect_name=dialect, opts={"as_sql": True}
         )
         with (
             Operations.context(migration_context),
             pytest.raises(RuntimeError, match="offline"),
         ):
             module.upgrade()
-        assert output.getvalue() == ""
 
 
 def test_duplicate_exact_names_are_ambiguous_and_resolve_nothing(seeded_engine):
@@ -398,6 +403,203 @@ def test_identities_are_matched_raw_never_trimmed(seeded_engine):
     assert auth["Acme Drive "] is None
 
 
+def test_one_app_is_never_stamped_onto_two_rows(seeded_engine):
+    """_ensure_user_mcp_server creates a *new* row when a rename makes the old
+    one unfindable, so two rows for one app are this migration's own target
+    population. Stamping both would give them one identity, and
+    _lookup_oauth_server_for_app reads an unordered query — configure and
+    disconnect would then pick between them nondeterministically. Name
+    evidence wins; the provider-matched row keeps its pre-migration
+    behavior."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            # Matches by name.
+            {"name": "Acme Drive", "transport": "oauth", "auth": None},
+            # Would match the same app by provider — the orphan left behind by
+            # a rename.
+            {
+                "name": "Acme Drive (old)",
+                "transport": "oauth",
+                "auth": {"provider": "acme"},
+            },
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Acme Drive"] == {"app_id": "acme-drive", "provider": "acme"}
+    assert auth["Acme Drive (old)"] == {"provider": "acme"}
+
+
+def test_name_evidence_wins_regardless_of_row_order(seeded_engine):
+    """The same collision with the provider-matched row seeded *first*: which
+    row wins must follow the evidence, not insertion order."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {
+                "name": "Acme Drive (old)",
+                "transport": "oauth",
+                "auth": {"provider": "acme"},
+            },
+            {"name": "Acme Drive", "transport": "oauth", "auth": None},
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Acme Drive"] == {"app_id": "acme-drive", "provider": "acme"}
+    assert auth["Acme Drive (old)"] == {"provider": "acme"}
+
+
+def test_an_ambiguous_name_still_gets_the_provider_fallback(seeded_engine):
+    """Poisoning is per *key*, not per row: an ambiguous name carries no
+    information, so a row under it still resolves through an unambiguous
+    provider. The two same-named apps differ in provider, so only one is
+    reachable that way."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            },
+            {
+                "app_id": "other-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "other",
+            },
+        ],
+        servers=[
+            {
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "auth": {"provider": "other"},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == {
+        "app_id": "other-drive",
+        "provider": "other",
+    }
+
+
+def test_lookup_map_construction_skips_and_folds_the_right_fields(seeded_engine):
+    """Three map-building branches at once: an app with a blank app_id is
+    skipped entirely, an app with a blank name contributes to the provider map
+    only, and app-side `transport` is case-folded (it is a shape enum, not an
+    identity)."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            # Blank app_id: unusable as an identity, contributes nothing.
+            {
+                "app_id": "   ",
+                "name": "Blank Id App",
+                "transport": "oauth",
+                "provider_name": "blank",
+            },
+            # Blank name: reachable by provider only.
+            {
+                "app_id": "nameless-app",
+                "name": "   ",
+                "transport": "oauth",
+                "provider_name": "nameless",
+            },
+            # Mixed-case transport still counts as oauth.
+            {
+                "app_id": "cased-app",
+                "name": "Cased App",
+                "transport": "OAuth",
+                "provider_name": None,
+            },
+        ],
+        servers=[
+            {"name": "Blank Id App", "transport": "oauth", "auth": None},
+            {
+                "name": "Whatever",
+                "transport": "oauth",
+                "auth": {"provider": "nameless"},
+            },
+            {"name": "Cased App", "transport": "oauth", "auth": None},
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Blank Id App"] is None
+    assert auth["Whatever"] == {"provider": "nameless", "app_id": "nameless-app"}
+    # No provider on the app, so only app_id is written.
+    assert auth["Cased App"] == {"app_id": "cased-app"}
+
+
+def test_a_blank_provider_is_filled_while_unrelated_keys_survive(seeded_engine):
+    """A whitespace-only provider counts as absent and is replaced, and
+    everything else in the auth dict is carried through untouched."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "auth": {"provider": "  ", "access_token": "encrypted-blob"},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == {
+        "app_id": "acme-drive",
+        "provider": "acme",
+        "access_token": "encrypted-blob",
+    }
+
+
 def test_non_oauth_shapes_are_never_candidates(seeded_engine):
     """A stdio server row named like an app, and an oauth row named after a
     *non-oauth* app, are both left alone: the first is a different transport,
@@ -415,7 +617,11 @@ def test_non_oauth_shapes_are_never_candidates(seeded_engine):
             }
         ],
         servers=[
-            {"name": "Acme Notes", "transport": "stdio", "auth": None},
+            # mcp_servers.name is unique in production, so the two shapes must
+            # be seeded under distinct names; the stdio row is a candidate by
+            # neither transport nor name, and the oauth row's name resolves
+            # only a stdio app, which is the cross-shape refusal.
+            {"name": "Acme Notes Local", "transport": "stdio", "auth": None},
             {"name": "Acme Notes", "transport": "oauth", "auth": None},
         ],
     )

--- a/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
+++ b/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
@@ -25,6 +25,7 @@ What must hold:
 from __future__ import annotations
 
 import importlib.util
+import os
 from pathlib import Path
 from types import ModuleType
 
@@ -784,6 +785,31 @@ def test_two_provider_only_rows_resolve_deterministically(seeded_engine):
     assert auth["orphan-b"] == {"provider": "acme"}
 
 
+def test_a_mixed_case_transport_row_is_still_a_candidate(seeded_engine):
+    """Transport is a shape enum, not an identity, and every reader folds its
+    case (classify_app_auth, _normalize_app_key). A row stored "OAuth" is
+    builtin_oauth to all of them, so the candidate filter must see it too --
+    otherwise the one shape the backfill exists for is invisible to it."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[{"name": "Acme Drive", "transport": "OAuth", "auth": None}],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == {"app_id": "acme-drive"}
+
+
 def test_downgrade_is_a_no_op(seeded_engine):
     """Documented as irreversible: the downgrade must not attempt to strip
     stamps it cannot tell apart from the writer's own."""
@@ -844,9 +870,11 @@ def test_non_oauth_shapes_are_never_candidates(seeded_engine):
 
 
 def _postgres_url() -> str | None:
-    import os
-
-    return os.environ.get("XAGENT_TEST_POSTGRES_URL")
+    # Both spellings, matching the sibling migration suites: CI sets the first,
+    # while a local run may already export the second.
+    return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
+        "POSTGRES_TEST_DATABASE_URL"
+    )
 
 
 @pytest.fixture

--- a/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
+++ b/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
@@ -8,14 +8,18 @@ so no full alembic history replay is needed).
 What must hold:
 
 - an auth-less oauth row named exactly after an OAuth app is stamped with
-  that app's ``app_id`` (and ``provider`` when the app has one);
+  that app's ``app_id`` -- and only that: no ``provider`` is written;
 - a provider-only row (blank/absent ``app_id``) is stamped through its
   provider when exactly one OAuth app uses that provider, and left alone
   when the provider is ambiguous — providers are non-unique across apps;
 - rows already carrying a nonblank ``app_id`` are untouched (idempotence);
 - rows resolving to nothing (orphans, non-oauth-app name matches) are left
   exactly as they were, preserving the name-fallback shim's behavior;
-- non-oauth-transport server rows are never candidates.
+- non-oauth-transport server rows are never candidates, and neither are
+  rows whose whole ``auth`` payload is a non-dict or whose stored
+  ``provider`` is present but unusable;
+- one ``app_id`` never lands on two rows -- including when the colliding
+  partner was stamped before the run, or by an earlier run.
 """
 
 from __future__ import annotations
@@ -28,7 +32,7 @@ import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 TARGET_REVISION = "20260818_backfill_oauth_server_app_identity"
 
@@ -124,7 +128,7 @@ def test_an_auth_less_row_is_stamped_by_exact_display_name(seeded_engine):
     _run_upgrade(engine)
 
     auth = _auth_by_name(engine, metadata)["Acme Drive"]
-    assert auth == {"app_id": "acme-drive", "provider": "acme"}
+    assert auth == {"app_id": "acme-drive"}
 
 
 def test_a_provider_only_row_is_stamped_when_the_provider_is_unambiguous(
@@ -267,10 +271,11 @@ def test_a_provider_conflict_refuses_the_name_match(seeded_engine):
     assert _auth_by_name(engine, metadata)["Acme Drive"] == {"provider": "other"}
 
 
-def test_a_non_dict_auth_payload_is_replaced_wholesale(seeded_engine):
-    """Garbage (a scalar/list auth on an oauth row) is replaced by the stamped
-    identity, matching the provisioning writer, which discards non-dict auth
-    the same way."""
+def test_a_non_dict_auth_payload_is_left_alone(seeded_engine):
+    """Garbage (a scalar/list auth on an oauth row) is not a candidate: such a
+    row resolves fine today through the name fallback, and this migration is
+    irreversible, so destroying a value it does not have to touch is the wrong
+    default."""
     engine, metadata = seeded_engine
     _seed(
         engine,
@@ -290,8 +295,7 @@ def test_a_non_dict_auth_payload_is_replaced_wholesale(seeded_engine):
 
     _run_upgrade(engine)
 
-    auth = _auth_by_name(engine, metadata)["Acme Drive"]
-    assert auth == {"app_id": "acme-drive", "provider": "acme"}
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == "garbage-string"
 
 
 def test_offline_sql_mode_raises_instead_of_stamping():
@@ -369,7 +373,7 @@ def test_a_non_string_app_id_is_malformed_and_restamped(seeded_engine):
     _run_upgrade(engine)
 
     auth = _auth_by_name(engine, metadata)["Acme Drive"]
-    assert auth == {"app_id": "acme-drive", "provider": "acme"}
+    assert auth == {"app_id": "acme-drive"}
 
 
 def test_identities_are_matched_raw_never_trimmed(seeded_engine):
@@ -399,7 +403,7 @@ def test_identities_are_matched_raw_never_trimmed(seeded_engine):
     _run_upgrade(engine)
 
     auth = _auth_by_name(engine, metadata)
-    assert auth["Acme Drive"] == {"app_id": " acme-drive ", "provider": "acme"}
+    assert auth["Acme Drive"] == {"app_id": " acme-drive "}
     assert auth["Acme Drive "] is None
 
 
@@ -439,7 +443,7 @@ def test_one_app_is_never_stamped_onto_two_rows(seeded_engine):
     _run_upgrade(engine)
 
     auth = _auth_by_name(engine, metadata)
-    assert auth["Acme Drive"] == {"app_id": "acme-drive", "provider": "acme"}
+    assert auth["Acme Drive"] == {"app_id": "acme-drive"}
     assert auth["Acme Drive (old)"] == {"provider": "acme"}
 
 
@@ -471,7 +475,7 @@ def test_name_evidence_wins_regardless_of_row_order(seeded_engine):
     _run_upgrade(engine)
 
     auth = _auth_by_name(engine, metadata)
-    assert auth["Acme Drive"] == {"app_id": "acme-drive", "provider": "acme"}
+    assert auth["Acme Drive"] == {"app_id": "acme-drive"}
     assert auth["Acme Drive (old)"] == {"provider": "acme"}
 
 
@@ -567,9 +571,10 @@ def test_lookup_map_construction_skips_and_folds_the_right_fields(seeded_engine)
     assert auth["Cased App"] == {"app_id": "cased-app"}
 
 
-def test_a_blank_provider_is_filled_while_unrelated_keys_survive(seeded_engine):
-    """A whitespace-only provider counts as absent and is replaced, and
-    everything else in the auth dict is carried through untouched."""
+def test_unrelated_auth_keys_survive_the_stamp(seeded_engine):
+    """Only app_id is added: everything already in the auth dict -- including
+    a blank provider and an encrypted secret -- is carried through
+    untouched."""
     engine, metadata = seeded_engine
     _seed(
         engine,
@@ -595,9 +600,213 @@ def test_a_blank_provider_is_filled_while_unrelated_keys_survive(seeded_engine):
 
     assert _auth_by_name(engine, metadata)["Acme Drive"] == {
         "app_id": "acme-drive",
-        "provider": "acme",
+        "provider": "  ",
         "access_token": "encrypted-blob",
     }
+
+
+def test_a_pre_stamped_row_blocks_a_second_row_claiming_its_app(seeded_engine):
+    """The collision the two-pass fix alone did not close: the partner row was
+    stamped *before* this run (by the writer, or by an earlier run), so it
+    never enters the candidate set. Its identity must still be claimed, or the
+    orphan gets the same app_id and _lookup_oauth_server_for_app picks between
+    them nondeterministically."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive v2",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            # Already carries the identity — the row the writer created on
+            # rename, and not a candidate.
+            {
+                "name": "Acme Drive v2",
+                "transport": "oauth",
+                "auth": {"app_id": "acme-drive", "provider": "acme"},
+            },
+            # The orphan left under the old name; only its provider resolves.
+            {
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "auth": {"provider": "acme"},
+            },
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Acme Drive v2"] == {"app_id": "acme-drive", "provider": "acme"}
+    assert auth["Acme Drive"] == {"provider": "acme"}
+
+
+def test_a_stamp_survives_a_rerun_unchanged(seeded_engine):
+    """Idempotence across runs, not just within one: run 1 stamps the name
+    match, and run 2 -- which is what a downgrade (a no-op) plus upgrade
+    produces -- must neither restamp it nor hand its identity to the orphan
+    that lost the first time."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {"name": "Acme Drive", "transport": "oauth", "auth": None},
+            {
+                "name": "Acme Drive (old)",
+                "transport": "oauth",
+                "auth": {"provider": "acme"},
+            },
+        ],
+    )
+
+    _run_upgrade(engine)
+    after_first = _auth_by_name(engine, metadata)
+
+    module = _migration_module()
+    module.downgrade()
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata) == after_first
+    assert after_first["Acme Drive"] == {"app_id": "acme-drive"}
+    assert after_first["Acme Drive (old)"] == {"provider": "acme"}
+
+
+def test_a_name_owned_by_a_non_oauth_app_refuses_the_provider_fallback(
+    seeded_engine,
+):
+    """A name matching a *non-OAuth* app is evidence about this row, not an
+    absence of evidence. Treating the two alike would let the row fall through
+    to the provider fallback and be stamped with an unrelated app's id."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-notes",
+                "name": "Acme Notes",
+                "transport": "stdio",
+                "provider_name": "acme",
+            },
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            },
+        ],
+        servers=[
+            {
+                "name": "Acme Notes",
+                "transport": "oauth",
+                "auth": {"provider": "acme"},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Notes"] == {"provider": "acme"}
+
+
+def test_a_malformed_non_string_provider_refuses_the_row(seeded_engine):
+    """A provider that is not a string at all cannot be compared by the
+    conflict gate, and _is_oauth_server_for_app would reject the row against
+    any app once stamped — so a stamp buys nothing and the row is left
+    alone."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "auth": {"provider": ["acme"]},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == {"provider": ["acme"]}
+
+
+def test_two_provider_only_rows_resolve_deterministically(seeded_engine):
+    """A tie the evidence cannot break: two unstamped rows whose only signal
+    is the same provider. Exactly one may be stamped, and candidates are read
+    ordered by id so it is the same one on every run and every backend."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {"name": "orphan-a", "transport": "oauth", "auth": {"provider": "acme"}},
+            {"name": "orphan-b", "transport": "oauth", "auth": {"provider": "acme"}},
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["orphan-a"] == {"app_id": "acme-drive", "provider": "acme"}
+    assert auth["orphan-b"] == {"provider": "acme"}
+
+
+def test_downgrade_is_a_no_op(seeded_engine):
+    """Documented as irreversible: the downgrade must not attempt to strip
+    stamps it cannot tell apart from the writer's own."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[{"name": "Acme Drive", "transport": "oauth", "auth": None}],
+    )
+    _run_upgrade(engine)
+    before = _auth_by_name(engine, metadata)
+
+    _migration_module().downgrade()
+
+    assert _auth_by_name(engine, metadata) == before
 
 
 def test_non_oauth_shapes_are_never_candidates(seeded_engine):
@@ -632,3 +841,84 @@ def test_non_oauth_shapes_are_never_candidates(seeded_engine):
     with engine.connect() as conn:
         rows = conn.execute(sa.select(servers)).all()
     assert all(row.auth is None for row in rows)
+
+
+def _postgres_url() -> str | None:
+    import os
+
+    return os.environ.get("XAGENT_TEST_POSTGRES_URL")
+
+
+@pytest.fixture
+def postgres_seeded_engine():
+    """The same two tables on a real PostgreSQL server.
+
+    The chain-level CI job upgrades an *empty* database, so without this the
+    backfill's data path would never run on PostgreSQL at all -- and JSON
+    round-tripping and the ordered read are exactly the parts that could
+    differ from SQLite.
+    """
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    engine = create_engine(url)
+    metadata = _pre_migration_metadata()
+    with engine.begin() as conn:
+        for table in ("mcp_servers", "public_mcp_apps"):
+            conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+    metadata.create_all(bind=engine)
+    try:
+        yield engine, metadata
+    finally:
+        with engine.begin() as conn:
+            for table in ("mcp_servers", "public_mcp_apps"):
+                conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+        engine.dispose()
+
+
+@pytest.mark.postgresql
+def test_the_backfill_runs_on_postgresql(postgres_seeded_engine):
+    """Stamp, refusal and collision behavior on the real backend: the JSON
+    write round-trips, and the pre-stamped partner still blocks the orphan."""
+    engine, metadata = postgres_seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            },
+            {
+                "app_id": "acme-mail",
+                "name": "Acme Mail",
+                "transport": "oauth",
+                "provider_name": "mail",
+            },
+        ],
+        servers=[
+            {"name": "Acme Mail", "transport": "oauth", "auth": None},
+            {
+                "name": "Acme Drive v2",
+                "transport": "oauth",
+                "auth": {"app_id": "acme-drive", "provider": "acme"},
+            },
+            {
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "auth": {"provider": "acme"},
+            },
+            {"name": "orphan", "transport": "oauth", "auth": None},
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Acme Mail"] == {"app_id": "acme-mail"}
+    assert auth["Acme Drive v2"] == {"app_id": "acme-drive", "provider": "acme"}
+    # Its app_id is already carried by the row above.
+    assert auth["Acme Drive"] == {"provider": "acme"}
+    assert auth["orphan"] is None

--- a/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
+++ b/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
@@ -785,11 +785,15 @@ def test_two_provider_only_rows_resolve_deterministically(seeded_engine):
     assert auth["orphan-b"] == {"provider": "acme"}
 
 
-def test_a_mixed_case_transport_row_is_still_a_candidate(seeded_engine):
-    """Transport is a shape enum, not an identity, and every reader folds its
-    case (classify_app_auth, _normalize_app_key). A row stored "OAuth" is
-    builtin_oauth to all of them, so the candidate filter must see it too --
-    otherwise the one shape the backfill exists for is invisible to it."""
+def test_a_mixed_case_transport_row_is_not_a_candidate(seeded_engine):
+    """The five gates that make an oauth row work compare `transport ==
+    "oauth"` unfolded (tools/config.py's credential injection,
+    _is_oauth_server_for_app, _enrich_oauth_server_info,
+    _ensure_server_matches_oauth_app), so a row stored "OAuth" is dead to all
+    of them. Stamping it would be worthless to that row and could burn the
+    app's one identity: the `claimed` guard would then refuse the genuine row,
+    with no downgrade to undo it. The candidate filter therefore matches
+    exactly, like the writer and the readers."""
     engine, metadata = seeded_engine
     _seed(
         engine,
@@ -802,12 +806,19 @@ def test_a_mixed_case_transport_row_is_still_a_candidate(seeded_engine):
                 "provider_name": "acme",
             }
         ],
-        servers=[{"name": "Acme Drive", "transport": "OAuth", "auth": None}],
+        servers=[
+            {"name": "Acme Drive", "transport": "OAuth", "auth": None},
+            {"name": "Acme Drive (real)", "transport": "oauth", "auth": None},
+        ],
     )
 
     _run_upgrade(engine)
 
-    assert _auth_by_name(engine, metadata)["Acme Drive"] == {"app_id": "acme-drive"}
+    auth = _auth_by_name(engine, metadata)
+    # The dead row is untouched, and its presence did not deny the identity to
+    # a working row (this one loses only because its name does not match).
+    assert auth["Acme Drive"] is None
+    assert auth["Acme Drive (real)"] is None
 
 
 def test_downgrade_is_a_no_op(seeded_engine):

--- a/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
+++ b/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
@@ -89,11 +89,22 @@ def seeded_engine():
 
 
 def _run_upgrade(engine) -> None:
+    _run(engine, "upgrade")
+
+
+def _run_downgrade(engine) -> None:
+    _run(engine, "downgrade")
+
+
+def _run(engine, direction: str) -> None:
+    """Both directions go through the same Operations context Alembic gives a
+    version module, so a downgrade that started using `op` would be exercised
+    the same way an upgrade is rather than only appearing to work."""
     module = _migration_module()
     with engine.begin() as conn:
         migration_context = MigrationContext.configure(conn)
         with Operations.context(migration_context):
-            module.upgrade()
+            getattr(module, direction)()
 
 
 def _auth_by_name(engine, metadata) -> dict[str, object]:
@@ -529,8 +540,7 @@ def test_a_stamp_survives_a_rerun_unchanged(seeded_engine):
     after_first = _auth_by_name(engine, metadata)
     assert after_first["Acme Drive"] == {"app_id": "acme-drive"}
 
-    module = _migration_module()
-    module.downgrade()
+    _run_downgrade(engine)
     _run_upgrade(engine)
 
     assert _auth_by_name(engine, metadata) == after_first
@@ -670,6 +680,150 @@ def test_a_mixed_case_transport_row_is_not_a_candidate(seeded_engine):
     assert auth["Acme Drive (real)"] is None
 
 
+def test_an_identity_on_a_non_oauth_transport_row_is_still_claimed(seeded_engine):
+    """The claim set is read *without* a transport filter, deliberately wider
+    than the candidate query. get_app_for_mcp_server resolves from auth.app_id
+    with no transport check at all, and the OAuth-disconnect cleanup path walks
+    a user's whole server list through it -- so a row stored "OAuth" (or any
+    other transport) still makes its app_id taken, even though that row could
+    never serve the connector itself. Filtering the claim set by transport left
+    such an id invisible and let a second row be stamped with it."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            # Not a candidate (transport is not exactly "oauth"), but it does
+            # carry the identity, and the transport-blind reader sees it.
+            {
+                "name": "Acme Drive (mixed case)",
+                "transport": "OAuth",
+                "auth": {"app_id": "acme-drive"},
+            },
+            # Would resolve to the same app by exact name.
+            {"name": "Acme Drive", "transport": "oauth", "auth": None},
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Acme Drive (mixed case)"] == {"app_id": "acme-drive"}
+    assert auth["Acme Drive"] is None
+
+
+def test_a_provider_differing_only_in_case_is_not_a_conflict(seeded_engine):
+    """The conflict gate compares providers the way the runtime does
+    (_normalize_app_key: casefold, strip, whitespace-to-hyphen). Comparing
+    them exactly would permanently refuse a stamp over a difference
+    _is_oauth_server_for_app already treats as none -- and this migration runs
+    once."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "auth": {"provider": "  Acme "},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == {
+        "provider": "  Acme ",
+        "app_id": "acme-drive",
+    }
+
+
+def test_a_missing_table_is_a_logged_no_op(seeded_engine, caplog):
+    """Alembic commits the version bump either way, so a skip here is
+    permanent: it must at least say so."""
+    import logging
+
+    engine, _metadata = seeded_engine
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE public_mcp_apps"))
+
+    with caplog.at_level(logging.WARNING):
+        _run_upgrade(engine)
+
+    assert any("search_path" in r.getMessage() for r in caplog.records)
+
+
+def test_an_auth_list_payload_is_left_alone(seeded_engine):
+    """The non-dict branch covers a JSON list too, not just a scalar."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[{"name": "Acme Drive", "transport": "oauth", "auth": ["junk"]}],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == ["junk"]
+
+
+def test_a_blank_app_side_provider_is_not_a_conflict(seeded_engine):
+    """An app with no provider cannot contradict anything, so a row that has
+    one is still stamped."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "   ",
+            }
+        ],
+        servers=[
+            {
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "auth": {"provider": "acme"},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == {
+        "provider": "acme",
+        "app_id": "acme-drive",
+    }
+
+
 def test_downgrade_is_a_no_op(seeded_engine):
     """Documented as irreversible: the downgrade must not attempt to strip
     stamps it cannot tell apart from the writer's own."""
@@ -690,7 +844,7 @@ def test_downgrade_is_a_no_op(seeded_engine):
     _run_upgrade(engine)
     before = _auth_by_name(engine, metadata)
 
-    _migration_module().downgrade()
+    _run_downgrade(engine)
 
     assert _auth_by_name(engine, metadata) == before
 
@@ -729,6 +883,16 @@ def test_non_oauth_shapes_are_never_candidates(seeded_engine):
     assert all(row.auth is None for row in rows)
 
 
+# Its own schema, not the shared public one. The CI Postgres job runs every
+# step against a single database, and later steps depend on the real,
+# fully-migrated shape of mcp_servers/public_mcp_apps -- dropping and stubbing
+# those in `public` would corrupt them. The migration reads through
+# `inspector.get_table_names()` and unqualified table literals, both of which
+# follow search_path, so pointing search_path at a private schema isolates the
+# whole run without the migration needing to know.
+_PG_SCHEMA = "backfill_app_identity_test"
+
+
 def _postgres_url() -> str | None:
     # Both spellings, matching the sibling migration suites: CI sets the first,
     # while a local run may already export the second.
@@ -739,28 +903,30 @@ def _postgres_url() -> str | None:
 
 @pytest.fixture
 def postgres_seeded_engine():
-    """The same two tables on a real PostgreSQL server.
+    """The two tables on a real PostgreSQL server, in a throwaway schema.
 
     The chain-level CI job upgrades an *empty* database, so without this the
     backfill's data path would never run on PostgreSQL at all -- and JSON
-    round-tripping and the ordered read are exactly the parts that could
-    differ from SQLite.
+    round-tripping, the ordered read and the re-read guard are exactly the
+    parts that could differ from SQLite.
     """
     url = _postgres_url()
     if not url:
         pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
-    engine = create_engine(url)
-    metadata = _pre_migration_metadata()
+    engine = create_engine(
+        url,
+        connect_args={"options": f"-csearch_path={_PG_SCHEMA}"},
+    )
     with engine.begin() as conn:
-        for table in ("mcp_servers", "public_mcp_apps"):
-            conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {_PG_SCHEMA} CASCADE"))
+        conn.execute(text(f"CREATE SCHEMA {_PG_SCHEMA}"))
+    metadata = _pre_migration_metadata()
     metadata.create_all(bind=engine)
     try:
         yield engine, metadata
     finally:
         with engine.begin() as conn:
-            for table in ("mcp_servers", "public_mcp_apps"):
-                conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+            conn.execute(text(f"DROP SCHEMA IF EXISTS {_PG_SCHEMA} CASCADE"))
         engine.dispose()
 
 

--- a/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
+++ b/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
@@ -1,0 +1,337 @@
+"""Tests for migration 20260818_backfill_oauth_server_app_identity (#1429).
+
+Following this repo's migration-test convention: the two tables are built
+in their pre-migration shape with SQLAlchemy Core, seeded, and only the
+migration under test is run against them (via MigrationContext/Operations,
+so no full alembic history replay is needed).
+
+What must hold:
+
+- an auth-less oauth row named exactly after an OAuth app is stamped with
+  that app's ``app_id`` (and ``provider`` when the app has one);
+- a provider-only row (blank/absent ``app_id``) is stamped through its
+  provider when exactly one OAuth app uses that provider, and left alone
+  when the provider is ambiguous — providers are non-unique across apps;
+- rows already carrying a nonblank ``app_id`` are untouched (idempotence);
+- rows resolving to nothing (orphans, non-oauth-app name matches) are left
+  exactly as they were, preserving the name-fallback shim's behavior;
+- non-oauth-transport server rows are never candidates.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+TARGET_REVISION = "20260818_backfill_oauth_server_app_identity"
+
+
+def _migration_module() -> ModuleType:
+    import xagent.migrations as migrations_pkg
+
+    migrations_dir = Path(next(iter(migrations_pkg.__path__)))
+    path = migrations_dir / "versions" / f"{TARGET_REVISION}.py"
+    spec = importlib.util.spec_from_file_location(TARGET_REVISION, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _pre_migration_metadata() -> sa.MetaData:
+    """The two tables reduced to the columns the migration reads/writes."""
+    metadata = sa.MetaData()
+    sa.Table(
+        "mcp_servers",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("transport", sa.String(50), nullable=False),
+        sa.Column("auth", sa.JSON, nullable=True),
+    )
+    sa.Table(
+        "public_mcp_apps",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("app_id", sa.String(100), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("transport", sa.String(50), nullable=False),
+        sa.Column("provider_name", sa.String(50), nullable=True),
+    )
+    return metadata
+
+
+@pytest.fixture()
+def seeded_engine():
+    engine = create_engine("sqlite:///:memory:")
+    metadata = _pre_migration_metadata()
+    metadata.create_all(engine)
+    try:
+        yield engine, metadata
+    finally:
+        engine.dispose()
+
+
+def _run_upgrade(engine) -> None:
+    module = _migration_module()
+    with engine.begin() as conn:
+        migration_context = MigrationContext.configure(conn)
+        with Operations.context(migration_context):
+            module.upgrade()
+
+
+def _auth_by_name(engine, metadata) -> dict[str, object]:
+    servers = metadata.tables["mcp_servers"]
+    with engine.connect() as conn:
+        return {row.name: row.auth for row in conn.execute(sa.select(servers)).all()}
+
+
+def _seed(engine, metadata, apps: list[dict], servers: list[dict]) -> None:
+    with engine.begin() as conn:
+        if apps:
+            conn.execute(metadata.tables["public_mcp_apps"].insert(), apps)
+        if servers:
+            conn.execute(metadata.tables["mcp_servers"].insert(), servers)
+
+
+def test_an_auth_less_row_is_stamped_by_exact_display_name(seeded_engine):
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[{"name": "Acme Drive", "transport": "oauth", "auth": None}],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)["Acme Drive"]
+    assert auth == {"app_id": "acme-drive", "provider": "acme"}
+
+
+def test_a_provider_only_row_is_stamped_when_the_provider_is_unambiguous(
+    seeded_engine,
+):
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {
+                "name": "Old Acme Name",
+                "transport": "oauth",
+                "auth": {"app_id": "   ", "provider": "acme"},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)["Old Acme Name"]
+    assert auth["app_id"] == "acme-drive"
+    # The row's own provider spelling is kept, not overwritten.
+    assert auth["provider"] == "acme"
+
+
+def test_an_ambiguous_provider_resolves_nothing(seeded_engine):
+    """The meta/Instagram case: two apps on one provider. Guessing would
+    attribute another connector's identity, so the row stays unstamped and
+    keeps the name-fallback shim's behavior."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            },
+            {
+                "app_id": "acme-mail",
+                "name": "Acme Mail",
+                "transport": "oauth",
+                "provider_name": "acme",
+            },
+        ],
+        servers=[
+            {
+                "name": "Old Acme Name",
+                "transport": "oauth",
+                "auth": {"provider": "acme"},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Old Acme Name"] == {"provider": "acme"}
+
+
+def test_rows_already_stamped_and_orphans_are_untouched(seeded_engine):
+    engine, metadata = seeded_engine
+    stamped = {"app_id": "acme-drive", "provider": "acme", "extra": "kept"}
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {"name": "Acme Drive", "transport": "oauth", "auth": dict(stamped)},
+            {"name": "no-such-app", "transport": "oauth", "auth": None},
+        ],
+    )
+
+    _run_upgrade(engine)
+    # Idempotence: a second run changes nothing either.
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Acme Drive"] == stamped
+    assert auth["no-such-app"] is None
+
+
+def test_a_provider_conflict_refuses_the_name_match(seeded_engine):
+    """A row named after app A whose own auth.provider names a different
+    provider is the conflict _ensure_server_matches_oauth_app refuses with a
+    ValueError. Stamping A's app_id would create a row *no* app claims — it
+    fails A's provider gate and the other provider's app_id gate — so the
+    migration refuses too, leaving the read-time provider fallback exactly as
+    it was."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            },
+            {
+                "app_id": "other-app",
+                "name": "Other App",
+                "transport": "oauth",
+                "provider_name": "other",
+            },
+        ],
+        servers=[
+            {
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "auth": {"provider": "other"},
+            }
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    # Untouched: the conflicting evidence is left for a human (or the
+    # provisioning writer's own refusal path) to resolve. NOTE the provider
+    # fallback did not fire either — the name match short-circuits before it,
+    # and resurrecting it here would guess between two contradictory signals.
+    assert _auth_by_name(engine, metadata)["Acme Drive"] == {"provider": "other"}
+
+
+def test_a_non_dict_auth_payload_is_replaced_wholesale(seeded_engine):
+    """Garbage (a scalar/list auth on an oauth row) is replaced by the stamped
+    identity, matching the provisioning writer, which discards non-dict auth
+    the same way."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {"name": "Acme Drive", "transport": "oauth", "auth": "garbage-string"}
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)["Acme Drive"]
+    assert auth == {"app_id": "acme-drive", "provider": "acme"}
+
+
+def test_offline_sql_mode_emits_nothing(seeded_engine):
+    """A data migration cannot read rows through a MockConnection; the offline
+    branch is a documented no-op for both dialects."""
+    from io import StringIO
+
+    module = _migration_module()
+    for dialect in ("sqlite", "postgresql"):
+        output = StringIO()
+        migration_context = MigrationContext.configure(
+            dialect_name=dialect,
+            opts={"as_sql": True, "output_buffer": output},
+        )
+        with Operations.context(migration_context):
+            module.upgrade()
+        assert output.getvalue() == ""
+
+
+def test_non_oauth_shapes_are_never_candidates(seeded_engine):
+    """A stdio server row named like an app, and an oauth row named after a
+    *non-oauth* app, are both left alone: the first is a different transport,
+    the second would stamp a cross-shape identity."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-notes",
+                "name": "Acme Notes",
+                "transport": "stdio",
+                "provider_name": None,
+            }
+        ],
+        servers=[
+            {"name": "Acme Notes", "transport": "stdio", "auth": None},
+            {"name": "Acme Notes", "transport": "oauth", "auth": None},
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    servers = metadata.tables["mcp_servers"]
+    with engine.connect() as conn:
+        rows = conn.execute(sa.select(servers)).all()
+    assert all(row.auth is None for row in rows)

--- a/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
+++ b/tests/migrations/test_20260818_backfill_oauth_server_app_identity.py
@@ -290,9 +290,11 @@ def test_a_non_dict_auth_payload_is_replaced_wholesale(seeded_engine):
     assert auth == {"app_id": "acme-drive", "provider": "acme"}
 
 
-def test_offline_sql_mode_emits_nothing(seeded_engine):
-    """A data migration cannot read rows through a MockConnection; the offline
-    branch is a documented no-op for both dialects."""
+def test_offline_sql_mode_raises_instead_of_stamping(seeded_engine):
+    """Alembic emits alembic_version bookkeeping even for an empty migration
+    body, so a silent offline no-op would advance the version while touching
+    no row — permanently skipping the backfill on the next online upgrade.
+    The offline branch must fail loudly instead, for both dialects."""
     from io import StringIO
 
     module = _migration_module()
@@ -302,9 +304,98 @@ def test_offline_sql_mode_emits_nothing(seeded_engine):
             dialect_name=dialect,
             opts={"as_sql": True, "output_buffer": output},
         )
-        with Operations.context(migration_context):
+        with (
+            Operations.context(migration_context),
+            pytest.raises(RuntimeError, match="offline"),
+        ):
             module.upgrade()
         assert output.getvalue() == ""
+
+
+def test_duplicate_exact_names_are_ambiguous_and_resolve_nothing(seeded_engine):
+    """Two OAuth apps sharing one exact display name poison that name key: an
+    auth-less row under it stays untouched rather than being stamped with
+    whichever app happened to be seeded first."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": None,
+            },
+            {
+                "app_id": "acme-drive-eu",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": None,
+            },
+        ],
+        servers=[{"name": "Acme Drive", "transport": "oauth", "auth": None}],
+    )
+
+    _run_upgrade(engine)
+
+    assert _auth_by_name(engine, metadata)["Acme Drive"] is None
+
+
+def test_a_non_string_app_id_is_malformed_and_restamped(seeded_engine):
+    """get_app_for_mcp_server rejects a non-string auth.app_id outright, so a
+    row carrying one is permanently unresolvable — it must stay a candidate
+    and a successful name match overwrites the malformed value."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": "acme-drive",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[{"name": "Acme Drive", "transport": "oauth", "auth": {"app_id": 123}}],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)["Acme Drive"]
+    assert auth == {"app_id": "acme-drive", "provider": "acme"}
+
+
+def test_identities_are_matched_raw_never_trimmed(seeded_engine):
+    """Identities are opaque and every read path compares them exactly, so the
+    migration must not trim: a padded catalog app_id is stamped verbatim
+    (that raw value is what get_app_by_id can resolve), and a
+    whitespace-variant row name does not match at all — under-matching leaves
+    the name-fallback shim in charge."""
+    engine, metadata = seeded_engine
+    _seed(
+        engine,
+        metadata,
+        apps=[
+            {
+                "app_id": " acme-drive ",
+                "name": "Acme Drive",
+                "transport": "oauth",
+                "provider_name": "acme",
+            }
+        ],
+        servers=[
+            {"name": "Acme Drive", "transport": "oauth", "auth": None},
+            {"name": "Acme Drive ", "transport": "oauth", "auth": None},
+        ],
+    )
+
+    _run_upgrade(engine)
+
+    auth = _auth_by_name(engine, metadata)
+    assert auth["Acme Drive"] == {"app_id": " acme-drive ", "provider": "acme"}
+    assert auth["Acme Drive "] is None
 
 
 def test_non_oauth_shapes_are_never_candidates(seeded_engine):


### PR DESCRIPTION
## Problem

Rows provisioned before `_ensure_user_mcp_server` wrote OAuth metadata carry no `auth` payload (and a small malformed population can carry a blank or provider-only `auth`). Every read path that resolves a server row back to its catalog app prefers the stable `auth.app_id` and falls back to the row's *exact current display name* (`get_app_for_mcp_server`) — so the moment an admin renames the app, an unstamped row loses its identity: `/api/mcp/servers` enrichment reports no `app_id`, the connector picker persists the app's new display name, and the runtime — which knows the row only under its old name — resolves the selection to zero tools, silently.

## Fix

One data migration, `20260818_backfill_oauth_server_app_identity`, stamping the identity while the name still matches — the only moment it can be derived safely:

- Candidates: `mcp_servers` rows with `transport = 'oauth'` whose `auth` is missing, not a dict, or lacks a nonblank `app_id`.
- Matched against `public_mcp_apps` (builtin apps are seeded there too) by exact display name — the value `_ensure_user_mcp_server` named the row after — with an **unambiguous** `auth.provider` as the fallback. Providers are non-unique across apps (the meta/Instagram siblings), so an ambiguous provider resolves nothing, and a row whose own provider **contradicts** the name-resolved app is refused outright — the same conflict the provisioning writer refuses with a ValueError; stamping through it would create a row no app claims.
- Only OAuth-transport apps are eligible: stamping a non-OAuth app's id onto an oauth row would manufacture a cross-shape identity.
- Unresolvable rows are left untouched; the exact-name fallback in `get_app_for_mcp_server` remains as the compatibility shim for them, unchanged in behavior.
- Idempotent across runs, not just within one: rows already carrying an identity seed the claim set, so a rerun (including after the no-op downgrade) neither re-stamps them nor hands their identity to the next-best row.
- A non-dict `auth` payload and a non-string stored `provider` are left alone rather than overwritten — both resolve fine today through the name fallback, and this migration is irreversible.
- Offline `--sql` mode **raises** rather than emitting nothing. Note the project-wide consequence, since this is the first migration here to do it: `alembic upgrade head --sql` hard-stops at this revision, so any deployment that generates offline scripts must run *this* revision online. The alternative was worse: Alembic writes the `alembic_version` bookkeeping even for an empty body, so a silent skip would advance the version without backfilling and the next online upgrade would skip the revision forever. Run this revision online. The downgrade is a documented no-op.
- Candidate rows are materialized before the update loop — stepping a live pysqlite cursor across a mutating table has unspecified visibility.

## Testing

24 tests against the pre-migration table shapes (which mirror production's unique constraints), run through the same `MigrationContext`/`Operations` surface alembic uses: stamp-by-name, unambiguous-provider stamp, ambiguous-provider and ambiguous-name refusals, provider-conflict refusal, cross-shape-name refusal, malformed-provider refusal, non-dict-auth preservation, raw-identity matching, pre-stamped collision, rerun survival, provider-vs-provider determinism, mixed-case transport, lookup-map construction branches, downgrade no-op, offline-mode raise, and a PostgreSQL-marked run of the actual backfill, now wired into the migrations workflow's postgres job (it previously existed but was never selected, since that job runs pytest files by name — so the data path had no PG coverage at all). Its fixture creates and drops a schema of its own rather than the shared tables, and the step is ordered after every integration step that needs their real shape. `tests/migrations` passes in full (141 cases), the alembic chain keeps a single head, and a fresh SQLite database upgrades end-to-end.

## Scope

- Addresses #1429 item 1 (the backfill). **It does not close the issue on its own**: the issue's headline symptom is `/api/mcp/servers` enrichment returning no `app_id`, and that enrichment still resolves by name on `main` — the `app_id`-first version lives in #1403 (commit 245e340), which is not merged. #1429 closes when both land. This PR supplies the data half, which is what #1403's review is blocked on; item 2 is the spec's alternative to item 1 and is deliberately not taken.
- Out of scope, pre-existing and tracked: runtime selection is still keyed by normalized display name rather than a stable identity — #1404. The user-vs-governing-agent visibility basis is #1409/#1366.
- Sequencing: #1403's review is blocked on exactly this backfill; landing this first lets that PR stay a pure picker change.


