### PR TITLE
feat: add Stripe connector (Restricted API Key + custom MCP tools)

### DIFF
--- a/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
+++ b/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
@@ -1,0 +1,81 @@
+"""seed built-in Stripe (key-based) MCP connector
+
+Revision ID: 20260818_seed_stripe_mcp_app
+Revises: 20260819_merge_jira_and_linear_heads
+Create Date: 2026-08-18 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260818_seed_stripe_mcp_app"
+down_revision: Union[str, None] = "20260819_merge_jira_and_linear_heads"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "stripe"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "Stripe",
+    "description": "Connect to Stripe to look up customers, charges, invoices, and subscriptions, and issue refunds.",
+    "icon": "https://www.google.com/s2/favicons?domain=stripe.com&sz=128",
+    "transport": "stdio",
+    "provider_name": None,
+    "category": "Finance",
+    "oauth_scopes": None,
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.stripe"],
+        "required_env": ["STRIPE_API_KEY"],
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. Stripe has no oauth_providers row
+    # (it is key-based). Any MCPServer/UserMCPServer rows created by users who
+    # already connected are intentionally left in place -- connect-driven
+    # rows are not owned by this migration and are cleaned up through the
+    # normal disconnect path.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
+++ b/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
@@ -36,7 +36,7 @@ APP_ID = "stripe"
 ROW = {
     "app_id": APP_ID,
     "name": "Stripe",
-    "description": "Connect to Stripe to look up customers, charges, invoices, and subscriptions, and issue refunds.",
+    "description": "Connect to Stripe with a Restricted API Key (not your full secret key) to look up customers, charges, invoices, and subscriptions, and issue refunds.",
     "icon": "https://www.google.com/s2/favicons?domain=stripe.com&sz=128",
     "transport": "stdio",
     "provider_name": None,

--- a/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
+++ b/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
@@ -6,10 +6,13 @@ Create Date: 2026-08-18 00:00:00.000000
 
 """
 
+import logging
 from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+
+logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision: str = "20260818_seed_stripe_mcp_app"
@@ -62,6 +65,20 @@ def upgrade() -> None:
     if APP_ID in existing:
         return
 
+    # Silently degrades rather than failing outright (this table is never
+    # expected to be missing a column that predates this migration by
+    # months), but the app_id-exists guard above means a row seeded here
+    # while a column was missing can never self-heal on a later re-run --
+    # so at least surface which keys were dropped instead of leaving no
+    # trace at all.
+    dropped_keys = sorted(set(ROW) - columns)
+    if dropped_keys:
+        logger.warning(
+            "public_mcp_apps is missing columns %s; seeding %r without "
+            "them -- this row will not self-heal on a later re-run",
+            dropped_keys,
+            APP_ID,
+        )
     row = {k: v for k, v in ROW.items() if k in columns}
     bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
 

--- a/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
+++ b/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Stripe (key-based) MCP connector
 
 Revision ID: 20260818_seed_stripe_mcp_app
-Revises: 20260820_merge_jira_posthog_heads
+Revises: b1efe0dbe0af
 Create Date: 2026-08-18 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260818_seed_stripe_mcp_app"
-down_revision: Union[str, None] = "20260820_merge_jira_posthog_heads"
+down_revision: Union[str, None] = "b1efe0dbe0af"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
+++ b/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in Stripe (key-based) MCP connector
 
 Revision ID: 20260818_seed_stripe_mcp_app
-Revises: 20260819_merge_jira_and_linear_heads
+Revises: 20260820_merge_jira_posthog_heads
 Create Date: 2026-08-18 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "20260818_seed_stripe_mcp_app"
-down_revision: Union[str, None] = "20260819_merge_jira_and_linear_heads"
+down_revision: Union[str, None] = "20260820_merge_jira_posthog_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
+++ b/src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py
@@ -40,7 +40,7 @@ ROW = {
     "icon": "https://www.google.com/s2/favicons?domain=stripe.com&sz=128",
     "transport": "stdio",
     "provider_name": None,
-    "category": "Finance",
+    "category": "Payments",
     "oauth_scopes": None,
     "is_visible_in_connector": True,
     "launch_config": {

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -954,6 +954,35 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "env_mapping": {"JIRA_ACCESS_TOKEN": "access_token"},
             },
         },
+        {
+            "app_id": "stripe",
+            "name": "Stripe",
+            "description": "Connect to Stripe to look up customers, charges, invoices, and subscriptions, and issue refunds.",
+            "icon": "https://www.google.com/s2/favicons?domain=stripe.com&sz=128",
+            "transport": "stdio",
+            "provider_name": None,
+            "category": "Finance",
+            "oauth_scopes": None,
+            "is_visible_in_connector": True,
+            # Key-based (non-oauth), like aws/google-maps/posthog: Stripe's
+            # own OAuth flow (Connect "Standard accounts") is for a platform
+            # aggregating many *other* merchants' accounts, not for a single
+            # user granting a tool access to their own account -- Stripe's
+            # docs explicitly discourage it for new integrations, and since
+            # June 2021 a read_write OAuth connection fails outright if the
+            # account is already connected to another platform. A
+            # Restricted API Key (rk_live_.../rk_test_...) sidesteps both
+            # problems entirely and is what Stripe's own agent-toolkit/MCP
+            # server recommends for exactly this use case (see
+            # github.com/stripe/agent-toolkit tools/README.md) -- same
+            # no-review self-serve bar as an OAuth App, scoped to only the
+            # permissions the user grants it.
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.stripe"],
+                "required_env": ["STRIPE_API_KEY"],
+            },
+        },
     ]
 
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -957,7 +957,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
         {
             "app_id": "stripe",
             "name": "Stripe",
-            "description": "Connect to Stripe to look up customers, charges, invoices, and subscriptions, and issue refunds.",
+            "description": "Connect to Stripe with a Restricted API Key (not your full secret key) to look up customers, charges, invoices, and subscriptions, and issue refunds.",
             "icon": "https://www.google.com/s2/favicons?domain=stripe.com&sz=128",
             "transport": "stdio",
             "provider_name": None,

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -961,7 +961,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "icon": "https://www.google.com/s2/favicons?domain=stripe.com&sz=128",
             "transport": "stdio",
             "provider_name": None,
-            "category": "Finance",
+            "category": "Payments",
             "oauth_scopes": None,
             "is_visible_in_connector": True,
             # Key-based (non-oauth), like aws/google-maps/posthog: Stripe's

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 import requests
 from mcp.server.fastmcp import FastMCP
 
+from ....core.utils.security import redact_sensitive_text
 from ...utils.graphql_errors import truncate_error_text
 from .utils import setup_proxy_env
 
@@ -168,13 +169,29 @@ def _request(
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
         except requests.RequestException as exc:
-            # Bounded the same way an HTTP-level error body is below: a
-            # ConnectionError/Timeout's str(exc) is unstructured and can be
-            # arbitrarily long (e.g. embed a proxy's effective URL), so it
-            # must not reach the LLM/logs raw and unbounded either.
-            raise RuntimeError(
-                f"Stripe request failed: {truncate_error_text(str(exc))}"
-            ) from exc
+            # A connection/timeout/proxy failure's message can itself embed
+            # sensitive data -- e.g. a ProxyError echoing the ambient
+            # HTTPS_PROXY URL, which may carry embedded user:pass@
+            # credentials (setup_proxy_env() exports whatever the OS has
+            # configured) -- matches posthog.py's identical fix for the
+            # same shared proxy-env exposure surface. Also bounded in
+            # length the same way an HTTP-level error body is below, since
+            # the redacted text is still unstructured and can be long.
+            exc_detail = truncate_error_text(redact_sensitive_text(str(exc)))
+            # For a POST, this is the one failure mode where whether the
+            # operation actually reached Stripe is genuinely unknown (unlike
+            # a >=400 response, which means Stripe received and rejected
+            # it) -- so this is exactly the moment a caller deciding whether
+            # to retry needs the key that would make that retry safe.
+            hint = (
+                f" If you intend to retry this exact operation, pass "
+                f'idempotency_key="{resolved_idempotency_key}" so a retry is '
+                f"deduped by Stripe instead of creating a duplicate in case "
+                f"this request actually went through before failing."
+                if resolved_idempotency_key is not None
+                else ""
+            )
+            raise RuntimeError(f"Stripe request failed: {exc_detail}{hint}") from exc
         if response.status_code == 429 and attempt == 0:
             try:
                 retry_after = int(response.headers.get("Retry-After", "0"))
@@ -206,7 +223,7 @@ def _request(
             f"Stripe API error (status {response.status_code}): {detail}"
         )
 
-    if response_meta is not None and resolved_idempotency_key is not None:
+    if response_meta is not None:
         response_meta["idempotent_replayed"] = idempotent_replayed
 
     if response.status_code == 204 or not response.content:
@@ -320,7 +337,10 @@ def stripe_create_customer(
     that may have already succeeded (e.g. it errored or timed out and you
     don't know if it went through): Stripe will then return the original
     customer instead of creating a second one, and the response's
-    idempotent_replayed flag will be true.
+    idempotent_replayed flag will be true. If this tool errors with a
+    request-failed message rather than returning a result, that message
+    includes the idempotency_key that was used -- pass that same value back
+    in if you decide to retry, rather than retrying with no key at all.
     """
     try:
         form_data: dict[str, Any] = {}
@@ -422,7 +442,10 @@ def stripe_create_refund(
     that may have already succeeded (e.g. it errored or timed out and you
     don't know if it went through): Stripe will then return the original
     refund instead of issuing a second one, and the response's
-    idempotent_replayed flag will be true.
+    idempotent_replayed flag will be true. If this tool errors with a
+    request-failed message rather than returning a result, that message
+    includes the idempotency_key that was used -- pass that same value back
+    in if you decide to retry, rather than retrying with no key at all.
     """
     try:
         if not charge_id and not payment_intent_id:

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -76,6 +76,24 @@ def _bool_str(value: bool) -> str:
     return "true" if value else "false"
 
 
+def _prefix_mismatch(value: str, prefix: str, field_name: str) -> str | None:
+    """Return a clear local error message if `value` doesn't look like the
+    right kind of Stripe id, else None.
+
+    An LLM passing e.g. a payment-intent id ("pi_...", exactly what
+    stripe_list_payment_intents returns) into a tool's charge_id parameter
+    is a plausible mistake -- Stripe would eventually reject it, but only
+    after a round trip and with a less specific error than this connector
+    can give locally.
+    """
+    if not value.startswith(prefix):
+        return (
+            f"{field_name} should start with {prefix!r} (got {value!r}); "
+            "double check you're passing the right kind of Stripe id"
+        )
+    return None
+
+
 def _path_segment(value: str) -> str:
     """Percent-encode a value for safe interpolation into a URL path segment
     (e.g. a customer/charge/invoice id), matching jira.py's _path_segment /
@@ -141,9 +159,11 @@ def _extract_error_detail(response: requests.Response) -> str | None:
     """Pull the human-readable message out of a Stripe error body.
 
     Stripe error responses are {"error": {"type", "code", "message",
-    "param"}} -- the "message" field alone is more useful to the LLM than
-    the raw envelope. Returns None if the body isn't in the expected shape,
-    so the caller can fall back to the raw response text.
+    "param"}} -- "message" plus "param" (when present) is more useful to an
+    LLM trying to self-correct than the raw envelope: "param" names exactly
+    which argument was wrong for a parameter_invalid_* class error. Returns
+    None if the body isn't in the expected shape, so the caller can fall
+    back to the raw response text.
     """
     try:
         payload = response.json()
@@ -155,7 +175,12 @@ def _extract_error_detail(response: requests.Response) -> str | None:
     if not isinstance(error, dict):
         return None
     message = error.get("message")
-    return message if isinstance(message, str) and message else None
+    if not isinstance(message, str) or not message:
+        return None
+    param = error.get("param")
+    if isinstance(param, str) and param:
+        return f"{message} (param: {param})"
+    return message
 
 
 def _request(
@@ -170,11 +195,13 @@ def _request(
     """`idempotency_key`, for a POST, is sent as Stripe's Idempotency-Key
     header; if omitted, a fresh one is generated per call (see
     `_generate_idempotency_key`'s docstring for why). `response_meta`, when
-    passed, is populated with `idempotent_replayed` so a caller that creates
-    a resource can tell a dedup replay apart from a fresh create -- for both
-    a successful response and a >=400 one, since Stripe replays a cached
-    *failed* response verbatim too, and a caller retrying that with the same
-    key would just get the same failure again.
+    passed, is populated with `idempotent_replayed` on a successful response,
+    so a caller that creates a resource can tell a dedup replay apart from a
+    fresh create. A >=400 response never reaches this assignment (the
+    RuntimeError below is raised first), but it isn't left unexplained: a
+    replayed *failed* response gets the same signal folded into the raised
+    message instead, since a caller retrying that with the same key would
+    just get the same failure again.
     """
     resolved_idempotency_key = (
         (idempotency_key or _generate_idempotency_key()) if method == "POST" else None
@@ -242,7 +269,9 @@ def _request(
         # context, matching posthog.py's identical treatment. Applied to
         # both sources uniformly, not just the raw-text fallback, since
         # either one is equally capable of embedding an echoed header.
-        detail = truncate_error_text(redact_sensitive_text(detail))
+        detail = truncate_error_text(redact_sensitive_text(detail)) or (
+            "<empty response body>"
+        )
         if idempotent_replayed:
             detail = (
                 f"{detail} (this is a replay of a previous failed attempt with "
@@ -260,11 +289,21 @@ def _request(
     if response.status_code == 204 or not response.content:
         return {}
     try:
-        return response.json()
+        parsed = response.json()
     except ValueError as exc:
         raise RuntimeError(
             f"Stripe returned a 2xx response with a non-JSON body: {exc}"
         ) from exc
+    # Checked once here, at the single choke point every caller goes
+    # through, rather than in each of the 7 _paginated_results callers:
+    # every caller assumes a dict (via .get(...)), so a bare JSON array or
+    # string body would otherwise surface as an unclear AttributeError deep
+    # in a specific tool instead of a clear error at the source.
+    if not isinstance(parsed, dict):
+        raise RuntimeError(
+            f"Stripe returned a non-dict 2xx body ({type(parsed).__name__})"
+        )
+    return parsed
 
 
 def _paginated_results(payload: dict[str, Any], limit: int) -> tuple[list[Any], bool]:
@@ -356,6 +395,9 @@ def stripe_get_customer(customer_id: str) -> str:
     try:
         if not customer_id:
             return _error("customer_id is required")
+        prefix_error = _prefix_mismatch(customer_id, "cus_", "customer_id")
+        if prefix_error:
+            return _error(prefix_error)
         result = _request("GET", f"/customers/{_path_segment(customer_id)}")
         return _success(customer=result)
     except Exception as e:
@@ -449,6 +491,9 @@ def stripe_get_charge(charge_id: str) -> str:
     try:
         if not charge_id:
             return _error("charge_id is required")
+        prefix_error = _prefix_mismatch(charge_id, "ch_", "charge_id")
+        if prefix_error:
+            return _error(prefix_error)
         result = _request("GET", f"/charges/{_path_segment(charge_id)}")
         return _success(charge=result)
     except Exception as e:
@@ -472,8 +517,8 @@ def stripe_create_refund(
     payment_intent_id: a Stripe payment intent id, e.g. "pi_ABC123", as an
     alternative way to identify the payment to refund. Provide this or
     charge_id, not both.
-    amount: optional amount to refund in the currency's smallest unit (e.g.
-    cents for USD); omit to refund the full remaining amount.
+    amount: optional positive amount to refund in the currency's smallest
+    unit (e.g. cents for USD); omit to refund the full remaining amount.
     reason: optional one of "duplicate", "fraudulent", or
     "requested_by_customer". "fraudulent" is not just a label: for
     applicable card payments it reports the charge to Stripe Radar as fraud
@@ -501,6 +546,18 @@ def stripe_create_refund(
             return _error(
                 "Provide only one of charge_id or payment_intent_id, not both"
             )
+        if charge_id:
+            prefix_error = _prefix_mismatch(charge_id, "ch_", "charge_id")
+            if prefix_error:
+                return _error(prefix_error)
+        if payment_intent_id:
+            prefix_error = _prefix_mismatch(
+                payment_intent_id, "pi_", "payment_intent_id"
+            )
+            if prefix_error:
+                return _error(prefix_error)
+        if amount is not None and amount <= 0:
+            return _error("amount must be a positive integer")
         form_data: dict[str, Any] = {}
         if charge_id:
             form_data["charge"] = charge_id
@@ -596,6 +653,9 @@ def stripe_get_invoice(invoice_id: str) -> str:
     try:
         if not invoice_id:
             return _error("invoice_id is required")
+        prefix_error = _prefix_mismatch(invoice_id, "in_", "invoice_id")
+        if prefix_error:
+            return _error(prefix_error)
         result = _request("GET", f"/invoices/{_path_segment(invoice_id)}")
         return _success(invoice=result)
     except Exception as e:

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -63,6 +63,8 @@ def _flatten_form_params(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
     elif isinstance(value, list):
         for index, sub_value in enumerate(value):
             items.extend(_flatten_form_params(sub_value, f"{prefix}[{index}]"))
+    elif isinstance(value, bool):
+        items.append((prefix, "true" if value else "false"))
     elif value is not None:
         items.append((prefix, value))
     return items

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -51,6 +51,14 @@ def _clamp_limit(limit: int) -> int:
     return max(1, min(int(limit), MAX_LIMIT))
 
 
+def _bool_str(value: bool) -> str:
+    """`requests` serializes a bare Python bool as "True"/"False" in both
+    query strings and (via _flatten_form_params) form bodies, but Stripe's
+    API only accepts lowercase "true"/"false" for boolean filters/fields.
+    """
+    return "true" if value else "false"
+
+
 def _path_segment(value: str) -> str:
     """Percent-encode a value for safe interpolation into a URL path segment
     (e.g. a customer/charge/invoice id), matching jira.py's _path_segment /
@@ -65,8 +73,15 @@ def _idempotency_key(method: str, path: str, form_data: dict[str, Any] | None) -
     """Derive a stable Idempotency-Key for a mutating request from its exact
     arguments, so an agent retry of the identical tool call (e.g. after a
     timeout or dropped connection) is deduped by Stripe instead of creating a
-    second real refund/customer, while a call with genuinely different
-    arguments still gets a different key.
+    second real refund/customer.
+
+    Tradeoff: two genuinely distinct calls that happen to share identical
+    arguments (e.g. two separate real customers both created with just
+    name="Acme") are content-indistinguishable from a retry and will also be
+    deduped -- Stripe caches a key's result for ~24h and replays it verbatim.
+    Callers MUST pass `response_meta` to `_request` and surface its
+    `idempotent_replayed` flag in the tool's response so this is visible
+    rather than a silent duplicate customer/refund object.
     """
     canonical = json.dumps(
         {"method": method, "path": path, "form_data": form_data or {}},
@@ -96,7 +111,7 @@ def _flatten_form_params(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
         for index, sub_value in enumerate(value):
             items.extend(_flatten_form_params(sub_value, f"{prefix}[{index}]"))
     elif isinstance(value, bool):
-        items.append((prefix, "true" if value else "false"))
+        items.append((prefix, _bool_str(value)))
     elif value is not None:
         items.append((prefix, value))
     return items
@@ -129,7 +144,13 @@ def _request(
     *,
     params: dict[str, Any] | None = None,
     form_data: dict[str, Any] | None = None,
+    response_meta: dict[str, Any] | None = None,
 ) -> Any:
+    """`response_meta`, when passed, is populated with `idempotent_replayed`
+    for POST requests -- see `_idempotency_key`'s docstring for why a caller
+    that creates a resource needs to know when a call was a dedup replay
+    rather than a fresh create.
+    """
     idempotency_key = (
         _idempotency_key(method, path, form_data) if method == "POST" else None
     )
@@ -158,6 +179,11 @@ def _request(
             detail = truncate_error_text(response.text.strip())
         raise RuntimeError(
             f"Stripe API error (status {response.status_code}): {detail}"
+        )
+
+    if response_meta is not None and idempotency_key is not None:
+        response_meta["idempotent_replayed"] = (
+            response.headers.get("Idempotent-Replayed") == "true"
         )
 
     if response.status_code == 204 or not response.content:
@@ -242,6 +268,8 @@ def stripe_get_customer(customer_id: str) -> str:
     customer_id: a Stripe customer id, e.g. "cus_ABC123".
     """
     try:
+        if not customer_id:
+            return _error("customer_id is required")
         result = _request("GET", f"/customers/{_path_segment(customer_id)}")
         return _success(customer=result)
     except Exception as e:
@@ -261,6 +289,12 @@ def stripe_create_customer(
     name/email/description: optional customer profile fields.
     metadata: optional string key/value pairs to attach for your own
     bookkeeping, e.g. {"internal_id": "6735"}.
+
+    A retry of this exact call (same arguments) is deduped by Stripe and
+    returns the original customer instead of creating a second one; the
+    response's idempotent_replayed flag is true when that happened. Vary at
+    least one argument (e.g. add a distinguishing metadata value) to
+    intentionally create another customer with otherwise-identical details.
     """
     try:
         form_data: dict[str, Any] = {}
@@ -272,8 +306,14 @@ def stripe_create_customer(
             form_data["description"] = description
         if metadata:
             form_data["metadata"] = metadata
-        result = _request("POST", "/customers", form_data=form_data)
-        return _success(customer=result)
+        response_meta: dict[str, Any] = {}
+        result = _request(
+            "POST", "/customers", form_data=form_data, response_meta=response_meta
+        )
+        return _success(
+            customer=result,
+            idempotent_replayed=response_meta.get("idempotent_replayed", False),
+        )
     except Exception as e:
         logger.error(f"Error creating Stripe customer: {e}")
         return _error(str(e))
@@ -311,6 +351,8 @@ def stripe_get_charge(charge_id: str) -> str:
     charge_id: a Stripe charge id, e.g. "ch_ABC123".
     """
     try:
+        if not charge_id:
+            return _error("charge_id is required")
         result = _request("GET", f"/charges/{_path_segment(charge_id)}")
         return _success(charge=result)
     except Exception as e:
@@ -335,6 +377,10 @@ def stripe_create_refund(
     cents for USD); omit to refund the full remaining amount.
     reason: optional one of "duplicate", "fraudulent", or
     "requested_by_customer".
+
+    A retry of this exact call (same arguments) is deduped by Stripe and
+    returns the original refund instead of creating a second one; the
+    response's idempotent_replayed flag is true when that happened.
     """
     try:
         if not charge_id and not payment_intent_id:
@@ -348,8 +394,14 @@ def stripe_create_refund(
             form_data["amount"] = amount
         if reason:
             form_data["reason"] = reason
-        result = _request("POST", "/refunds", form_data=form_data)
-        return _success(refund=result)
+        response_meta: dict[str, Any] = {}
+        result = _request(
+            "POST", "/refunds", form_data=form_data, response_meta=response_meta
+        )
+        return _success(
+            refund=result,
+            idempotent_replayed=response_meta.get("idempotent_replayed", False),
+        )
     except Exception as e:
         logger.error(f"Error creating Stripe refund: {e}")
         return _error(str(e))
@@ -420,6 +472,8 @@ def stripe_get_invoice(invoice_id: str) -> str:
     invoice_id: a Stripe invoice id, e.g. "in_ABC123".
     """
     try:
+        if not invoice_id:
+            return _error("invoice_id is required")
         result = _request("GET", f"/invoices/{_path_segment(invoice_id)}")
         return _success(invoice=result)
     except Exception as e:
@@ -475,9 +529,7 @@ def stripe_list_products(
         max_results = _clamp_limit(limit)
         params: dict[str, Any] = {"limit": max_results}
         if active is not None:
-            # `requests` serializes a bare bool as "True"/"False" in query
-            # strings, but Stripe's API only accepts lowercase "true"/"false".
-            params["active"] = "true" if active else "false"
+            params["active"] = _bool_str(active)
         if starting_after:
             params["starting_after"] = starting_after
         result = _request("GET", "/products", params=params)
@@ -509,9 +561,7 @@ def stripe_list_prices(
         if product_id:
             params["product"] = product_id
         if active is not None:
-            # `requests` serializes a bare bool as "True"/"False" in query
-            # strings, but Stripe's API only accepts lowercase "true"/"false".
-            params["active"] = "true" if active else "false"
+            params["active"] = _bool_str(active)
         if starting_after:
             params["starting_after"] = starting_after
         result = _request("GET", "/prices", params=params)

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -1,11 +1,15 @@
+import hashlib
 import json
 import logging
 import os
+import time
 from typing import Any
+from urllib.parse import quote
 
 import requests
 from mcp.server.fastmcp import FastMCP
 
+from ...utils.graphql_errors import truncate_error_text
 from .utils import setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)
@@ -19,10 +23,10 @@ mcp = FastMCP("stripe-mcp")
 BASE_URL = "https://api.stripe.com/v1"
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_LIMIT = 100
-# Matches zoom.py's/linear.py's convention: an error body that isn't the
-# expected {"error": {...}} shape (e.g. an HTML gateway error page) must not
-# be forwarded to the LLM/logs verbatim and unbounded.
-MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
+# Stripe is rate-limited; on a 429 with a small Retry-After we wait once and
+# retry rather than failing outright, mirroring jira.py's/intercom.py's/
+# slack.py's bounded-retry policy for the same REST-shaped 429 signal.
+MAX_RETRY_AFTER_SECONDS = 30
 
 
 def _success(**payload: Any) -> str:
@@ -33,15 +37,43 @@ def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
 
 
-def _headers() -> dict[str, str]:
+def _headers(idempotency_key: str | None = None) -> dict[str, str]:
     api_key = os.environ.get("STRIPE_API_KEY")
     if not api_key:
         raise ValueError("STRIPE_API_KEY environment variable is missing")
-    return {"Authorization": f"Bearer {api_key}"}
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+    return headers
 
 
 def _clamp_limit(limit: int) -> int:
     return max(1, min(int(limit), MAX_LIMIT))
+
+
+def _path_segment(value: str) -> str:
+    """Percent-encode a value for safe interpolation into a URL path segment
+    (e.g. a customer/charge/invoice id), matching jira.py's _path_segment /
+    zoom.py's _encode_meeting_id. Percent-encoding - not a blocklist of "/",
+    "?", "#" - is what actually prevents a value like "cus_1/../account"
+    from escaping its intended path segment.
+    """
+    return quote(str(value), safe="")
+
+
+def _idempotency_key(method: str, path: str, form_data: dict[str, Any] | None) -> str:
+    """Derive a stable Idempotency-Key for a mutating request from its exact
+    arguments, so an agent retry of the identical tool call (e.g. after a
+    timeout or dropped connection) is deduped by Stripe instead of creating a
+    second real refund/customer, while a call with genuinely different
+    arguments still gets a different key.
+    """
+    canonical = json.dumps(
+        {"method": method, "path": path, "form_data": form_data or {}},
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def _flatten_form_params(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
@@ -98,20 +130,32 @@ def _request(
     params: dict[str, Any] | None = None,
     form_data: dict[str, Any] | None = None,
 ) -> Any:
-    response = requests.request(
-        method=method,
-        url=f"{BASE_URL}{path}",
-        headers=_headers(),
-        params=params,
-        data=_flatten_form_params(form_data) if form_data else None,
-        timeout=DEFAULT_TIMEOUT_SECONDS,
+    idempotency_key = (
+        _idempotency_key(method, path, form_data) if method == "POST" else None
     )
+    for attempt in (0, 1):
+        response = requests.request(
+            method=method,
+            url=f"{BASE_URL}{path}",
+            headers=_headers(idempotency_key),
+            params=params,
+            data=_flatten_form_params(form_data) if form_data else None,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+        if response.status_code == 429 and attempt == 0:
+            try:
+                retry_after = int(response.headers.get("Retry-After", "0"))
+            except ValueError:
+                retry_after = 0
+            if 0 < retry_after <= MAX_RETRY_AFTER_SECONDS:
+                time.sleep(retry_after)
+                continue
+        break
+
     if response.status_code >= 400:
         detail = _extract_error_detail(response)
         if detail is None:
-            detail = response.text.strip()
-            if len(detail) > MAX_ERROR_RESPONSE_TEXT_CHARS:
-                detail = detail[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+            detail = truncate_error_text(response.text.strip())
         raise RuntimeError(
             f"Stripe API error (status {response.status_code}): {detail}"
         )
@@ -198,7 +242,7 @@ def stripe_get_customer(customer_id: str) -> str:
     customer_id: a Stripe customer id, e.g. "cus_ABC123".
     """
     try:
-        result = _request("GET", f"/customers/{customer_id}")
+        result = _request("GET", f"/customers/{_path_segment(customer_id)}")
         return _success(customer=result)
     except Exception as e:
         logger.error(f"Error fetching Stripe customer {customer_id}: {e}")
@@ -267,7 +311,7 @@ def stripe_get_charge(charge_id: str) -> str:
     charge_id: a Stripe charge id, e.g. "ch_ABC123".
     """
     try:
-        result = _request("GET", f"/charges/{charge_id}")
+        result = _request("GET", f"/charges/{_path_segment(charge_id)}")
         return _success(charge=result)
     except Exception as e:
         logger.error(f"Error fetching Stripe charge {charge_id}: {e}")
@@ -376,7 +420,7 @@ def stripe_get_invoice(invoice_id: str) -> str:
     invoice_id: a Stripe invoice id, e.g. "in_ABC123".
     """
     try:
-        result = _request("GET", f"/invoices/{invoice_id}")
+        result = _request("GET", f"/invoices/{_path_segment(invoice_id)}")
         return _success(invoice=result)
     except Exception as e:
         logger.error(f"Error fetching Stripe invoice {invoice_id}: {e}")
@@ -396,7 +440,8 @@ def stripe_list_subscriptions(
     subscriptions.
     status: optional one of "active", "past_due", "unpaid", "canceled",
     "incomplete", "incomplete_expired", "trialing", "paused", or "all"
-    (Stripe defaults to "active" only if omitted).
+    (if omitted, Stripe returns every non-canceled status, not just
+    "active" -- pass "active" explicitly to filter to active-only).
     starting_after: a subscription id from a previous page, to page forward.
     """
     try:

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -468,6 +468,10 @@ def stripe_list_charges(
     starting_after: a charge id from a previous page, to page forward.
     """
     try:
+        if customer_id:
+            prefix_error = _prefix_mismatch(customer_id, "cus_", "customer_id")
+            if prefix_error:
+                return _error(prefix_error)
         max_results = _clamp_limit(limit)
         params: dict[str, Any] = {"limit": max_results}
         if customer_id:
@@ -598,6 +602,10 @@ def stripe_list_payment_intents(
     forward.
     """
     try:
+        if customer_id:
+            prefix_error = _prefix_mismatch(customer_id, "cus_", "customer_id")
+            if prefix_error:
+                return _error(prefix_error)
         max_results = _clamp_limit(limit)
         params: dict[str, Any] = {"limit": max_results}
         if customer_id:
@@ -628,6 +636,10 @@ def stripe_list_invoices(
     starting_after: an invoice id from a previous page, to page forward.
     """
     try:
+        if customer_id:
+            prefix_error = _prefix_mismatch(customer_id, "cus_", "customer_id")
+            if prefix_error:
+                return _error(prefix_error)
         max_results = _clamp_limit(limit)
         params: dict[str, Any] = {"limit": max_results}
         if customer_id:
@@ -681,6 +693,10 @@ def stripe_list_subscriptions(
     starting_after: a subscription id from a previous page, to page forward.
     """
     try:
+        if customer_id:
+            prefix_error = _prefix_mismatch(customer_id, "cus_", "customer_id")
+            if prefix_error:
+                return _error(prefix_error)
         max_results = _clamp_limit(limit)
         params: dict[str, Any] = {"limit": max_results}
         if customer_id:
@@ -738,6 +754,10 @@ def stripe_list_prices(
     starting_after: a price id from a previous page, to page forward.
     """
     try:
+        if product_id:
+            prefix_error = _prefix_mismatch(product_id, "prod_", "product_id")
+            if prefix_error:
+                return _error(prefix_error)
         max_results = _clamp_limit(limit)
         params: dict[str, Any] = {"limit": max_results}
         if product_id:

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -268,8 +268,14 @@ def _request(
 
 
 def _paginated_results(payload: dict[str, Any], limit: int) -> tuple[list[Any], bool]:
-    data = payload.get("data") or []
-    if not isinstance(data, list):
+    data = payload.get("data")
+    if data is None:
+        data = []
+    elif not isinstance(data, list):
+        # Checked before any `or []`-style fallback: that would silently
+        # coerce a falsy-but-invalid value (0, "", False) to an empty list
+        # instead of catching it here, defeating the point of this check
+        # for exactly the malformed-response shapes it's meant to catch.
         raise RuntimeError(
             f"Stripe returned a non-list 'data' field ({type(data).__name__})"
         )

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -42,6 +42,22 @@ def _headers(idempotency_key: str | None = None) -> dict[str, str]:
     api_key = os.environ.get("STRIPE_API_KEY")
     if not api_key:
         raise ValueError("STRIPE_API_KEY environment variable is missing")
+    # Enforced here, not just recommended in the connector's description:
+    # a full sk_live_/sk_test_ secret key works against Stripe's API just
+    # as well as a Restricted Key, so nothing else in this connector (or
+    # the generic MCP connect flow, which has no per-connector validation
+    # hook) stops one from being pasted in and silently granted full
+    # account access instead of the curated, minimal permissions a
+    # Restricted Key guarantees. Matches aws.py's precedent of enforcing
+    # its own security claim server-side rather than relying on user
+    # diligence.
+    if not api_key.startswith(("rk_live_", "rk_test_")):
+        raise ValueError(
+            "STRIPE_API_KEY must be a Restricted API Key (rk_live_... or "
+            "rk_test_...), not a full secret key. Create one in the Stripe "
+            "Dashboard under Developers > API keys > Create restricted key, "
+            "scoped to only the permissions this connector needs."
+        )
     headers = {"Authorization": f"Bearer {api_key}"}
     if idempotency_key:
         headers["Idempotency-Key"] = idempotency_key
@@ -102,7 +118,14 @@ def _flatten_form_params(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
     items: list[tuple[str, Any]] = []
     if isinstance(value, dict):
         for key, sub_value in value.items():
-            new_prefix = f"{prefix}[{key}]" if prefix else str(key)
+            key_str = str(key)
+            if not key_str or "[" in key_str or "]" in key_str:
+                raise ValueError(
+                    f"Invalid form field name {key_str!r}: must be non-empty "
+                    "and must not contain '[' or ']', which are reserved for "
+                    "Stripe's own bracket-notation nesting"
+                )
+            new_prefix = f"{prefix}[{key_str}]" if prefix else key_str
             items.extend(_flatten_form_params(sub_value, new_prefix))
     elif isinstance(value, list):
         for index, sub_value in enumerate(value):
@@ -211,7 +234,15 @@ def _request(
     if response.status_code >= 400:
         detail = _extract_error_detail(response)
         if detail is None:
-            detail = truncate_error_text(response.text.strip())
+            detail = response.text.strip()
+        # The response body is attacker/host-controlled content, not
+        # something this module wrote -- if it happens to echo request
+        # headers (e.g. a misconfigured proxy/WAF/gateway's error page),
+        # redact the Bearer token before it reaches logs or the LLM's
+        # context, matching posthog.py's identical treatment. Applied to
+        # both sources uniformly, not just the raw-text fallback, since
+        # either one is equally capable of embedding an echoed header.
+        detail = truncate_error_text(redact_sensitive_text(detail))
         if idempotent_replayed:
             detail = (
                 f"{detail} (this is a replay of a previous failed attempt with "
@@ -228,11 +259,20 @@ def _request(
 
     if response.status_code == 204 or not response.content:
         return {}
-    return response.json()
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Stripe returned a 2xx response with a non-JSON body: {exc}"
+        ) from exc
 
 
 def _paginated_results(payload: dict[str, Any], limit: int) -> tuple[list[Any], bool]:
     data = payload.get("data") or []
+    if not isinstance(data, list):
+        raise RuntimeError(
+            f"Stripe returned a non-list 'data' field ({type(data).__name__})"
+        )
     truncated = bool(payload.get("has_more")) or len(data) > limit
     return data[:limit], truncated
 
@@ -422,9 +462,10 @@ def stripe_create_refund(
     """
     Refund a charge, in full or in part.
     charge_id: a Stripe charge id, e.g. "ch_ABC123". Provide this or
-    payment_intent_id (at least one is required).
+    payment_intent_id, not both.
     payment_intent_id: a Stripe payment intent id, e.g. "pi_ABC123", as an
-    alternative way to identify the payment to refund.
+    alternative way to identify the payment to refund. Provide this or
+    charge_id, not both.
     amount: optional amount to refund in the currency's smallest unit (e.g.
     cents for USD); omit to refund the full remaining amount.
     reason: optional one of "duplicate", "fraudulent", or
@@ -450,6 +491,10 @@ def stripe_create_refund(
     try:
         if not charge_id and not payment_intent_id:
             return _error("Either charge_id or payment_intent_id is required")
+        if charge_id and payment_intent_id:
+            return _error(
+                "Provide only one of charge_id or payment_intent_id, not both"
+            )
         form_data: dict[str, Any] = {}
         if charge_id:
             form_data["charge"] = charge_id

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -154,13 +154,15 @@ def _request(
     idempotency_key = (
         _idempotency_key(method, path, form_data) if method == "POST" else None
     )
+    headers = _headers(idempotency_key)
+    data = _flatten_form_params(form_data) if form_data else None
     for attempt in (0, 1):
         response = requests.request(
             method=method,
             url=f"{BASE_URL}{path}",
-            headers=_headers(idempotency_key),
+            headers=headers,
             params=params,
-            data=_flatten_form_params(form_data) if form_data else None,
+            data=data,
             timeout=DEFAULT_TIMEOUT_SECONDS,
         )
         if response.status_code == 429 and attempt == 0:
@@ -181,10 +183,12 @@ def _request(
             f"Stripe API error (status {response.status_code}): {detail}"
         )
 
-    if response_meta is not None and idempotency_key is not None:
-        response_meta["idempotent_replayed"] = (
-            response.headers.get("Idempotent-Replayed") == "true"
-        )
+    if idempotency_key is not None:
+        idempotent_replayed = response.headers.get("Idempotent-Replayed") == "true"
+        if idempotent_replayed:
+            logger.warning(f"Stripe idempotent replay detected for POST {path}")
+        if response_meta is not None:
+            response_meta["idempotent_replayed"] = idempotent_replayed
 
     if response.status_code == 204 or not response.content:
         return {}
@@ -366,6 +370,7 @@ def stripe_create_refund(
     payment_intent_id: str = "",
     amount: int | None = None,
     reason: str = "",
+    metadata: dict[str, str] | None = None,
 ) -> str:
     """
     Refund a charge, in full or in part.
@@ -377,10 +382,14 @@ def stripe_create_refund(
     cents for USD); omit to refund the full remaining amount.
     reason: optional one of "duplicate", "fraudulent", or
     "requested_by_customer".
+    metadata: optional string key/value pairs to attach for your own
+    bookkeeping, e.g. {"internal_id": "6735"}.
 
     A retry of this exact call (same arguments) is deduped by Stripe and
     returns the original refund instead of creating a second one; the
-    response's idempotent_replayed flag is true when that happened.
+    response's idempotent_replayed flag is true when that happened. Vary at
+    least one argument (e.g. add a distinguishing metadata value) to
+    intentionally issue another refund with otherwise-identical details.
     """
     try:
         if not charge_id and not payment_intent_id:
@@ -394,6 +403,8 @@ def stripe_create_refund(
             form_data["amount"] = amount
         if reason:
             form_data["reason"] = reason
+        if metadata:
+            form_data["metadata"] = metadata
         response_meta: dict[str, Any] = {}
         result = _request(
             "POST", "/refunds", form_data=form_data, response_meta=response_meta

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -1,0 +1,479 @@
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("stripe-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("stripe-mcp")
+
+BASE_URL = "https://api.stripe.com/v1"
+DEFAULT_TIMEOUT_SECONDS = 30
+MAX_LIMIT = 100
+# Matches zoom.py's/linear.py's convention: an error body that isn't the
+# expected {"error": {...}} shape (e.g. an HTML gateway error page) must not
+# be forwarded to the LLM/logs verbatim and unbounded.
+MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _headers() -> dict[str, str]:
+    api_key = os.environ.get("STRIPE_API_KEY")
+    if not api_key:
+        raise ValueError("STRIPE_API_KEY environment variable is missing")
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _clamp_limit(limit: int) -> int:
+    return max(1, min(int(limit), MAX_LIMIT))
+
+
+def _flatten_form_params(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
+    """Flatten nested dict/list params into Stripe's bracket-notation form
+    encoding, e.g. {"metadata": {"order_id": "6735"}} ->
+    [("metadata[order_id]", "6735")].
+
+    Stripe's API takes application/x-www-form-urlencoded bodies, not JSON --
+    `requests` does not flatten nested dict/list values on its own, so
+    passing a dict straight through as `data=` would serialize it as an
+    unusable Python repr string instead of the bracket-keyed pairs Stripe
+    expects.
+    """
+    items: list[tuple[str, Any]] = []
+    if isinstance(value, dict):
+        for key, sub_value in value.items():
+            new_prefix = f"{prefix}[{key}]" if prefix else str(key)
+            items.extend(_flatten_form_params(sub_value, new_prefix))
+    elif isinstance(value, list):
+        for index, sub_value in enumerate(value):
+            items.extend(_flatten_form_params(sub_value, f"{prefix}[{index}]"))
+    elif value is not None:
+        items.append((prefix, value))
+    return items
+
+
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull the human-readable message out of a Stripe error body.
+
+    Stripe error responses are {"error": {"type", "code", "message",
+    "param"}} -- the "message" field alone is more useful to the LLM than
+    the raw envelope. Returns None if the body isn't in the expected shape,
+    so the caller can fall back to the raw response text.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    message = error.get("message")
+    return message if isinstance(message, str) and message else None
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    form_data: dict[str, Any] | None = None,
+) -> Any:
+    response = requests.request(
+        method=method,
+        url=f"{BASE_URL}{path}",
+        headers=_headers(),
+        params=params,
+        data=_flatten_form_params(form_data) if form_data else None,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    if response.status_code >= 400:
+        detail = _extract_error_detail(response)
+        if detail is None:
+            detail = response.text.strip()
+            if len(detail) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+                detail = detail[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+        raise RuntimeError(
+            f"Stripe API error (status {response.status_code}): {detail}"
+        )
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _paginated_results(payload: dict[str, Any], limit: int) -> tuple[list[Any], bool]:
+    data = payload.get("data") or []
+    truncated = bool(payload.get("has_more")) or len(data) > limit
+    return data[:limit], truncated
+
+
+@mcp.tool()
+def stripe_get_account_info() -> str:
+    """
+    Get the Stripe account this connector's API key belongs to (id,
+    business name, email, country, default currency). Use this for "my
+    account" / "who am I" requests instead of asking the user for their
+    Stripe account id.
+    """
+    try:
+        result = _request("GET", "/account")
+        return _success(
+            account={
+                "id": result.get("id"),
+                "business_name": (result.get("business_profile") or {}).get("name"),
+                "email": result.get("email"),
+                "country": result.get("country"),
+                "default_currency": result.get("default_currency"),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error fetching authenticated Stripe account: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_get_balance() -> str:
+    """
+    Get the current Stripe balance (available and pending amounts per
+    currency) for the connected account.
+    """
+    try:
+        result = _request("GET", "/balance")
+        return _success(
+            available=result.get("available"), pending=result.get("pending")
+        )
+    except Exception as e:
+        logger.error(f"Error fetching Stripe balance: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_list_customers(
+    email: str = "", limit: int = 10, starting_after: str = ""
+) -> str:
+    """
+    List customers, most recently created first.
+    email: optional exact-match filter on the customer's email.
+    starting_after: a customer id from a previous page, to page forward.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        params: dict[str, Any] = {"limit": max_results}
+        if email:
+            params["email"] = email
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = _request("GET", "/customers", params=params)
+        customers, truncated = _paginated_results(result, max_results)
+        return _success(customers=customers, truncated=truncated)
+    except Exception as e:
+        logger.error(f"Error listing Stripe customers: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_get_customer(customer_id: str) -> str:
+    """
+    Get one customer's full details by id.
+    customer_id: a Stripe customer id, e.g. "cus_ABC123".
+    """
+    try:
+        result = _request("GET", f"/customers/{customer_id}")
+        return _success(customer=result)
+    except Exception as e:
+        logger.error(f"Error fetching Stripe customer {customer_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_create_customer(
+    name: str = "",
+    email: str = "",
+    description: str = "",
+    metadata: dict[str, str] | None = None,
+) -> str:
+    """
+    Create a new customer.
+    name/email/description: optional customer profile fields.
+    metadata: optional string key/value pairs to attach for your own
+    bookkeeping, e.g. {"internal_id": "6735"}.
+    """
+    try:
+        form_data: dict[str, Any] = {}
+        if name:
+            form_data["name"] = name
+        if email:
+            form_data["email"] = email
+        if description:
+            form_data["description"] = description
+        if metadata:
+            form_data["metadata"] = metadata
+        result = _request("POST", "/customers", form_data=form_data)
+        return _success(customer=result)
+    except Exception as e:
+        logger.error(f"Error creating Stripe customer: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_list_charges(
+    customer_id: str = "", limit: int = 10, starting_after: str = ""
+) -> str:
+    """
+    List charges, most recently created first.
+    customer_id: optional Stripe customer id to filter to one customer's
+    charges.
+    starting_after: a charge id from a previous page, to page forward.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        params: dict[str, Any] = {"limit": max_results}
+        if customer_id:
+            params["customer"] = customer_id
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = _request("GET", "/charges", params=params)
+        charges, truncated = _paginated_results(result, max_results)
+        return _success(charges=charges, truncated=truncated)
+    except Exception as e:
+        logger.error(f"Error listing Stripe charges: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_get_charge(charge_id: str) -> str:
+    """
+    Get one charge's full details by id.
+    charge_id: a Stripe charge id, e.g. "ch_ABC123".
+    """
+    try:
+        result = _request("GET", f"/charges/{charge_id}")
+        return _success(charge=result)
+    except Exception as e:
+        logger.error(f"Error fetching Stripe charge {charge_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_create_refund(
+    charge_id: str = "",
+    payment_intent_id: str = "",
+    amount: int | None = None,
+    reason: str = "",
+) -> str:
+    """
+    Refund a charge, in full or in part.
+    charge_id: a Stripe charge id, e.g. "ch_ABC123". Provide this or
+    payment_intent_id (at least one is required).
+    payment_intent_id: a Stripe payment intent id, e.g. "pi_ABC123", as an
+    alternative way to identify the payment to refund.
+    amount: optional amount to refund in the currency's smallest unit (e.g.
+    cents for USD); omit to refund the full remaining amount.
+    reason: optional one of "duplicate", "fraudulent", or
+    "requested_by_customer".
+    """
+    try:
+        if not charge_id and not payment_intent_id:
+            return _error("Either charge_id or payment_intent_id is required")
+        form_data: dict[str, Any] = {}
+        if charge_id:
+            form_data["charge"] = charge_id
+        if payment_intent_id:
+            form_data["payment_intent"] = payment_intent_id
+        if amount is not None:
+            form_data["amount"] = amount
+        if reason:
+            form_data["reason"] = reason
+        result = _request("POST", "/refunds", form_data=form_data)
+        return _success(refund=result)
+    except Exception as e:
+        logger.error(f"Error creating Stripe refund: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_list_payment_intents(
+    customer_id: str = "", limit: int = 10, starting_after: str = ""
+) -> str:
+    """
+    List payment intents, most recently created first.
+    customer_id: optional Stripe customer id to filter to one customer's
+    payment intents.
+    starting_after: a payment intent id from a previous page, to page
+    forward.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        params: dict[str, Any] = {"limit": max_results}
+        if customer_id:
+            params["customer"] = customer_id
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = _request("GET", "/payment_intents", params=params)
+        payment_intents, truncated = _paginated_results(result, max_results)
+        return _success(payment_intents=payment_intents, truncated=truncated)
+    except Exception as e:
+        logger.error(f"Error listing Stripe payment intents: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_list_invoices(
+    customer_id: str = "",
+    status: str = "",
+    limit: int = 10,
+    starting_after: str = "",
+) -> str:
+    """
+    List invoices, most recently created first.
+    customer_id: optional Stripe customer id to filter to one customer's
+    invoices.
+    status: optional one of "draft", "open", "paid", "uncollectible", or
+    "void".
+    starting_after: an invoice id from a previous page, to page forward.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        params: dict[str, Any] = {"limit": max_results}
+        if customer_id:
+            params["customer"] = customer_id
+        if status:
+            params["status"] = status
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = _request("GET", "/invoices", params=params)
+        invoices, truncated = _paginated_results(result, max_results)
+        return _success(invoices=invoices, truncated=truncated)
+    except Exception as e:
+        logger.error(f"Error listing Stripe invoices: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_get_invoice(invoice_id: str) -> str:
+    """
+    Get one invoice's full details by id.
+    invoice_id: a Stripe invoice id, e.g. "in_ABC123".
+    """
+    try:
+        result = _request("GET", f"/invoices/{invoice_id}")
+        return _success(invoice=result)
+    except Exception as e:
+        logger.error(f"Error fetching Stripe invoice {invoice_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_list_subscriptions(
+    customer_id: str = "",
+    status: str = "",
+    limit: int = 10,
+    starting_after: str = "",
+) -> str:
+    """
+    List subscriptions, most recently created first.
+    customer_id: optional Stripe customer id to filter to one customer's
+    subscriptions.
+    status: optional one of "active", "past_due", "unpaid", "canceled",
+    "incomplete", "incomplete_expired", "trialing", "paused", or "all"
+    (Stripe defaults to "active" only if omitted).
+    starting_after: a subscription id from a previous page, to page forward.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        params: dict[str, Any] = {"limit": max_results}
+        if customer_id:
+            params["customer"] = customer_id
+        if status:
+            params["status"] = status
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = _request("GET", "/subscriptions", params=params)
+        subscriptions, truncated = _paginated_results(result, max_results)
+        return _success(subscriptions=subscriptions, truncated=truncated)
+    except Exception as e:
+        logger.error(f"Error listing Stripe subscriptions: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_list_products(
+    active: bool | None = None, limit: int = 10, starting_after: str = ""
+) -> str:
+    """
+    List products, most recently created first.
+    active: optional filter to only active (true) or inactive (false)
+    products; omit to return both.
+    starting_after: a product id from a previous page, to page forward.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        params: dict[str, Any] = {"limit": max_results}
+        if active is not None:
+            # `requests` serializes a bare bool as "True"/"False" in query
+            # strings, but Stripe's API only accepts lowercase "true"/"false".
+            params["active"] = "true" if active else "false"
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = _request("GET", "/products", params=params)
+        products, truncated = _paginated_results(result, max_results)
+        return _success(products=products, truncated=truncated)
+    except Exception as e:
+        logger.error(f"Error listing Stripe products: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def stripe_list_prices(
+    product_id: str = "",
+    active: bool | None = None,
+    limit: int = 10,
+    starting_after: str = "",
+) -> str:
+    """
+    List prices, most recently created first.
+    product_id: optional Stripe product id to filter to one product's
+    prices.
+    active: optional filter to only active (true) or inactive (false)
+    prices; omit to return both.
+    starting_after: a price id from a previous page, to page forward.
+    """
+    try:
+        max_results = _clamp_limit(limit)
+        params: dict[str, Any] = {"limit": max_results}
+        if product_id:
+            params["product"] = product_id
+        if active is not None:
+            # `requests` serializes a bare bool as "True"/"False" in query
+            # strings, but Stripe's API only accepts lowercase "true"/"false".
+            params["active"] = "true" if active else "false"
+        if starting_after:
+            params["starting_after"] = starting_after
+        result = _request("GET", "/prices", params=params)
+        prices, truncated = _paginated_results(result, max_results)
+        return _success(prices=prices, truncated=truncated)
+    except Exception as e:
+        logger.error(f"Error listing Stripe prices: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/stripe.py
+++ b/src/xagent/web/tools/mcp/stripe.py
@@ -1,8 +1,8 @@
-import hashlib
 import json
 import logging
 import os
 import time
+import uuid
 from typing import Any
 from urllib.parse import quote
 
@@ -69,26 +69,22 @@ def _path_segment(value: str) -> str:
     return quote(str(value), safe="")
 
 
-def _idempotency_key(method: str, path: str, form_data: dict[str, Any] | None) -> str:
-    """Derive a stable Idempotency-Key for a mutating request from its exact
-    arguments, so an agent retry of the identical tool call (e.g. after a
-    timeout or dropped connection) is deduped by Stripe instead of creating a
-    second real refund/customer.
+def _generate_idempotency_key() -> str:
+    """A fresh, content-independent Idempotency-Key for a POST call that
+    didn't get an explicit one from its caller.
 
-    Tradeoff: two genuinely distinct calls that happen to share identical
-    arguments (e.g. two separate real customers both created with just
-    name="Acme") are content-indistinguishable from a retry and will also be
-    deduped -- Stripe caches a key's result for ~24h and replays it verbatim.
-    Callers MUST pass `response_meta` to `_request` and surface its
-    `idempotent_replayed` flag in the tool's response so this is visible
-    rather than a silent duplicate customer/refund object.
+    A key derived from the request's own arguments (an earlier version of
+    this function) seemed appealing for deduping an agent's accidental retry
+    without any extra plumbing, but it silently merges two *genuinely
+    distinct* calls that happen to share identical arguments (e.g. two real
+    customers both created with just name="Acme") into one -- Stripe caches
+    a key's result for ~24h and replays it verbatim, indistinguishable from
+    a fresh success. A random key makes every call independent by default;
+    real retry-safety is opt-in via the tool's own `idempotency_key`
+    parameter, which a caller passes explicitly (and reuses verbatim) only
+    when it is deliberately retrying a specific prior call.
     """
-    canonical = json.dumps(
-        {"method": method, "path": path, "form_data": form_data or {}},
-        sort_keys=True,
-        default=str,
-    )
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return uuid.uuid4().hex
 
 
 def _flatten_form_params(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
@@ -144,27 +140,41 @@ def _request(
     *,
     params: dict[str, Any] | None = None,
     form_data: dict[str, Any] | None = None,
+    idempotency_key: str | None = None,
     response_meta: dict[str, Any] | None = None,
 ) -> Any:
-    """`response_meta`, when passed, is populated with `idempotent_replayed`
-    for POST requests -- see `_idempotency_key`'s docstring for why a caller
-    that creates a resource needs to know when a call was a dedup replay
-    rather than a fresh create.
+    """`idempotency_key`, for a POST, is sent as Stripe's Idempotency-Key
+    header; if omitted, a fresh one is generated per call (see
+    `_generate_idempotency_key`'s docstring for why). `response_meta`, when
+    passed, is populated with `idempotent_replayed` so a caller that creates
+    a resource can tell a dedup replay apart from a fresh create -- for both
+    a successful response and a >=400 one, since Stripe replays a cached
+    *failed* response verbatim too, and a caller retrying that with the same
+    key would just get the same failure again.
     """
-    idempotency_key = (
-        _idempotency_key(method, path, form_data) if method == "POST" else None
+    resolved_idempotency_key = (
+        (idempotency_key or _generate_idempotency_key()) if method == "POST" else None
     )
-    headers = _headers(idempotency_key)
+    headers = _headers(resolved_idempotency_key)
     data = _flatten_form_params(form_data) if form_data else None
     for attempt in (0, 1):
-        response = requests.request(
-            method=method,
-            url=f"{BASE_URL}{path}",
-            headers=headers,
-            params=params,
-            data=data,
-            timeout=DEFAULT_TIMEOUT_SECONDS,
-        )
+        try:
+            response = requests.request(
+                method=method,
+                url=f"{BASE_URL}{path}",
+                headers=headers,
+                params=params,
+                data=data,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            # Bounded the same way an HTTP-level error body is below: a
+            # ConnectionError/Timeout's str(exc) is unstructured and can be
+            # arbitrarily long (e.g. embed a proxy's effective URL), so it
+            # must not reach the LLM/logs raw and unbounded either.
+            raise RuntimeError(
+                f"Stripe request failed: {truncate_error_text(str(exc))}"
+            ) from exc
         if response.status_code == 429 and attempt == 0:
             try:
                 retry_after = int(response.headers.get("Retry-After", "0"))
@@ -175,20 +185,29 @@ def _request(
                 continue
         break
 
+    idempotent_replayed = False
+    if resolved_idempotency_key is not None:
+        idempotent_replayed = response.headers.get("Idempotent-Replayed") == "true"
+        if idempotent_replayed:
+            logger.warning(f"Stripe idempotent replay detected for POST {path}")
+
     if response.status_code >= 400:
         detail = _extract_error_detail(response)
         if detail is None:
             detail = truncate_error_text(response.text.strip())
+        if idempotent_replayed:
+            detail = (
+                f"{detail} (this is a replay of a previous failed attempt with "
+                "the same idempotency_key -- retrying with that same key will "
+                "reproduce the same failure; use a different idempotency_key "
+                "for a genuinely new attempt)"
+            )
         raise RuntimeError(
             f"Stripe API error (status {response.status_code}): {detail}"
         )
 
-    if idempotency_key is not None:
-        idempotent_replayed = response.headers.get("Idempotent-Replayed") == "true"
-        if idempotent_replayed:
-            logger.warning(f"Stripe idempotent replay detected for POST {path}")
-        if response_meta is not None:
-            response_meta["idempotent_replayed"] = idempotent_replayed
+    if response_meta is not None and resolved_idempotency_key is not None:
+        response_meta["idempotent_replayed"] = idempotent_replayed
 
     if response.status_code == 204 or not response.content:
         return {}
@@ -287,18 +306,21 @@ def stripe_create_customer(
     email: str = "",
     description: str = "",
     metadata: dict[str, str] | None = None,
+    idempotency_key: str = "",
 ) -> str:
     """
     Create a new customer.
     name/email/description: optional customer profile fields.
     metadata: optional string key/value pairs to attach for your own
     bookkeeping, e.g. {"internal_id": "6735"}.
-
-    A retry of this exact call (same arguments) is deduped by Stripe and
-    returns the original customer instead of creating a second one; the
-    response's idempotent_replayed flag is true when that happened. Vary at
-    least one argument (e.g. add a distinguishing metadata value) to
-    intentionally create another customer with otherwise-identical details.
+    idempotency_key: optional. Omit it for a normal call -- each call then
+    gets its own fresh key, so two distinct customers created with identical
+    arguments are never silently merged into one. Only pass the SAME value
+    here when you are deliberately retrying a previous call to this tool
+    that may have already succeeded (e.g. it errored or timed out and you
+    don't know if it went through): Stripe will then return the original
+    customer instead of creating a second one, and the response's
+    idempotent_replayed flag will be true.
     """
     try:
         form_data: dict[str, Any] = {}
@@ -312,7 +334,11 @@ def stripe_create_customer(
             form_data["metadata"] = metadata
         response_meta: dict[str, Any] = {}
         result = _request(
-            "POST", "/customers", form_data=form_data, response_meta=response_meta
+            "POST",
+            "/customers",
+            form_data=form_data,
+            idempotency_key=idempotency_key or None,
+            response_meta=response_meta,
         )
         return _success(
             customer=result,
@@ -371,6 +397,7 @@ def stripe_create_refund(
     amount: int | None = None,
     reason: str = "",
     metadata: dict[str, str] | None = None,
+    idempotency_key: str = "",
 ) -> str:
     """
     Refund a charge, in full or in part.
@@ -381,15 +408,21 @@ def stripe_create_refund(
     amount: optional amount to refund in the currency's smallest unit (e.g.
     cents for USD); omit to refund the full remaining amount.
     reason: optional one of "duplicate", "fraudulent", or
-    "requested_by_customer".
+    "requested_by_customer". "fraudulent" is not just a label: for
+    applicable card payments it reports the charge to Stripe Radar as fraud
+    and can add the card's fingerprint and the customer's email(s) to the
+    account's default block lists -- only use it when that fraud-reporting
+    side effect is actually intended.
     metadata: optional string key/value pairs to attach for your own
     bookkeeping, e.g. {"internal_id": "6735"}.
-
-    A retry of this exact call (same arguments) is deduped by Stripe and
-    returns the original refund instead of creating a second one; the
-    response's idempotent_replayed flag is true when that happened. Vary at
-    least one argument (e.g. add a distinguishing metadata value) to
-    intentionally issue another refund with otherwise-identical details.
+    idempotency_key: optional. Omit it for a normal call -- each call then
+    gets its own fresh key, so two distinct refunds issued with identical
+    arguments are never silently merged into one. Only pass the SAME value
+    here when you are deliberately retrying a previous call to this tool
+    that may have already succeeded (e.g. it errored or timed out and you
+    don't know if it went through): Stripe will then return the original
+    refund instead of issuing a second one, and the response's
+    idempotent_replayed flag will be true.
     """
     try:
         if not charge_id and not payment_intent_id:
@@ -407,7 +440,11 @@ def stripe_create_refund(
             form_data["metadata"] = metadata
         response_meta: dict[str, Any] = {}
         result = _request(
-            "POST", "/refunds", form_data=form_data, response_meta=response_meta
+            "POST",
+            "/refunds",
+            form_data=form_data,
+            idempotency_key=idempotency_key or None,
+            response_meta=response_meta,
         )
         return _success(
             refund=result,

--- a/src/xagent/web/utils/graphql_errors.py
+++ b/src/xagent/web/utils/graphql_errors.py
@@ -1,10 +1,15 @@
 """Turn a Linear GraphQL API error response into a human-readable message.
 
-Shared by `tools/mcp/linear.py`'s `_graphql()` (used by every Linear MCP tool
-call) and `api/auth.py`'s `_fetch_linear_viewer_identity()` (used once, at
-OAuth-connect time) -- both parse the same GraphQL endpoint's error shape,
-and had drifted into two independently-maintained copies (the `auth.py` copy
-lost the "message is present but empty" fallback) before this module existed.
+`graphql_errors_message` is shared by `tools/mcp/linear.py`'s `_graphql()`
+(used by every Linear MCP tool call) and `api/auth.py`'s
+`_fetch_linear_viewer_identity()` (used once, at OAuth-connect time) -- both
+parse the same GraphQL endpoint's error shape, and had drifted into two
+independently-maintained copies (the `auth.py` copy lost the "message is
+present but empty" fallback) before this module existed.
+
+`truncate_error_text`, despite living in this GraphQL-named module, is
+generic (any text, any source) and is reused by non-GraphQL REST connectors
+too, e.g. `tools/mcp/stripe.py`.
 """
 
 from __future__ import annotations

--- a/tests/alembic/test_20260818_seed_stripe_mcp_app.py
+++ b/tests/alembic/test_20260818_seed_stripe_mcp_app.py
@@ -73,6 +73,44 @@ def test_upgrade_inserts_stripe(tmp_path):
         assert "STRIPE_API_KEY" in str(row[2])
 
 
+def test_upgrade_warns_and_still_inserts_when_column_missing(tmp_path, caplog):
+    """If a table predates one of ROW's keys (shouldn't happen here, but the
+    column-filter exists defensively), the row must still be inserted, and
+    the drop must be logged rather than silent -- app_id then already
+    exists, so a later run can never self-heal the missing column."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE public_mcp_apps (
+                    id INTEGER PRIMARY KEY,
+                    app_id VARCHAR(100) NOT NULL UNIQUE,
+                    name VARCHAR(200) NOT NULL,
+                    icon VARCHAR(1000),
+                    transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                    provider_name VARCHAR(50),
+                    category VARCHAR(100),
+                    oauth_scopes JSON,
+                    is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                    launch_config JSON
+                )
+                """
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            with caplog.at_level("WARNING"):
+                migration.upgrade()
+        assert "stripe" in _app_ids(connection)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "description" in message and "missing columns" in message
+        for message in messages
+    )
+
+
 def test_upgrade_is_idempotent(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()

--- a/tests/alembic/test_20260818_seed_stripe_mcp_app.py
+++ b/tests/alembic/test_20260818_seed_stripe_mcp_app.py
@@ -1,0 +1,125 @@
+"""Tests for the Stripe MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260818_seed_stripe_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_stripe_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_stripe(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "stripe" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='stripe'"
+            )
+        ).first()
+        assert row[0] == "stdio"
+        assert row[1] is None
+        assert "xagent.web.tools.mcp.stripe" in str(row[2])
+        assert "STRIPE_API_KEY" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='stripe'")
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry():
+    """The migration snapshot and the runtime registry must define the same
+    stripe row (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "stripe"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_downgrade_removes_stripe(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "stripe" not in _app_ids(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "public_mcp_apps" not in table_names

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -981,6 +981,21 @@ def test_paginated_results_rejects_non_list_data():
         stripe._paginated_results({"data": "not-a-list"}, limit=3)
 
 
+@pytest.mark.parametrize("falsy_invalid_data", [0, "", False])
+def test_paginated_results_rejects_falsy_non_list_data(falsy_invalid_data):
+    """A falsy-but-wrong-type value (0/""/False) must still be rejected, not
+    silently coerced to an empty list by an `or []`-style fallback."""
+    with pytest.raises(RuntimeError, match="non-list"):
+        stripe._paginated_results({"data": falsy_invalid_data}, limit=3)
+
+
+def test_paginated_results_defaults_missing_data_to_empty_list():
+    data, truncated = stripe._paginated_results({}, limit=3)
+
+    assert data == []
+    assert truncated is False
+
+
 def test_request_raises_on_non_json_success_body(monkeypatch):
     response = Mock()
     response.status_code = 200

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -692,6 +692,19 @@ def test_list_charges_uses_customer_filter(monkeypatch):
     assert mock_request.call_args.kwargs["params"]["customer"] == "cus_1"
 
 
+def test_list_charges_rejects_wrong_customer_prefix(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_charges(customer_id="pi_1"))
+
+    assert result["status"] == "error"
+    assert "cus_" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_list_charges_clamps_limit(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(json_data={"data": [], "has_more": False})
@@ -938,6 +951,19 @@ def test_list_payment_intents_returns_results(monkeypatch):
     assert result["payment_intents"] == [{"id": "pi_1"}]
 
 
+def test_list_payment_intents_rejects_wrong_customer_prefix(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_payment_intents(customer_id="ch_1"))
+
+    assert result["status"] == "error"
+    assert "cus_" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_list_invoices_uses_status_filter(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -983,6 +1009,19 @@ def test_get_invoice_rejects_wrong_prefix(monkeypatch):
     mock_request.assert_not_called()
 
 
+def test_list_invoices_rejects_wrong_customer_prefix(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_invoices(customer_id="ch_1"))
+
+    assert result["status"] == "error"
+    assert "cus_" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_list_subscriptions_uses_status_filter(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -995,6 +1034,19 @@ def test_list_subscriptions_uses_status_filter(monkeypatch):
 
     assert result["status"] == "success"
     assert mock_request.call_args.kwargs["params"]["status"] == "past_due"
+
+
+def test_list_subscriptions_rejects_wrong_customer_prefix(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_subscriptions(customer_id="ch_1"))
+
+    assert result["status"] == "error"
+    assert "cus_" in result["message"]
+    mock_request.assert_not_called()
 
 
 def test_list_products_uses_active_filter(monkeypatch):
@@ -1036,6 +1088,19 @@ def test_list_prices_uses_product_filter(monkeypatch):
 
     assert result["status"] == "success"
     assert mock_request.call_args.kwargs["params"]["product"] == "prod_1"
+
+
+def test_list_prices_rejects_wrong_product_prefix(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_prices(product_id="cus_1"))
+
+    assert result["status"] == "error"
+    assert "prod_" in result["message"]
+    mock_request.assert_not_called()
 
 
 def test_list_prices_uses_active_filter(monkeypatch):

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -324,6 +324,54 @@ def test_request_wraps_network_exception(monkeypatch):
         stripe._request("GET", "/account")
 
 
+def test_request_redacts_credentials_from_network_exception(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            side_effect=stripe.requests.ConnectionError(
+                "ProxyError connecting via http://user:secret@proxyhost:8080"
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stripe._request("GET", "/account")
+
+    assert "secret" not in str(excinfo.value)
+
+
+def test_request_network_exception_suggests_idempotency_key_for_post(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(side_effect=stripe.requests.ConnectionError("timed out")),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stripe._request(
+            "POST",
+            "/refunds",
+            form_data={"charge": "ch_1"},
+            idempotency_key="retry-me",
+        )
+
+    assert 'idempotency_key="retry-me"' in str(excinfo.value)
+
+
+def test_request_network_exception_omits_idempotency_hint_for_get(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(side_effect=stripe.requests.ConnectionError("timed out")),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stripe._request("GET", "/account")
+
+    assert "idempotency_key" not in str(excinfo.value)
+
+
 def test_request_truncates_long_network_exception_text(monkeypatch):
     monkeypatch.setattr(
         stripe.requests,

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -128,6 +128,30 @@ def test_request_form_encodes_nested_form_data(monkeypatch):
     ]
 
 
+def test_request_logs_warning_on_idempotent_replay(monkeypatch, caplog):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"id": "cus_1"}, headers={"Idempotent-Replayed": "true"}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    with caplog.at_level("WARNING", logger=stripe.logger.name):
+        stripe._request("POST", "/customers", form_data={"name": "Acme"})
+
+    assert "idempotent replay" in caplog.text.lower()
+
+
+def test_request_does_not_log_warning_on_fresh_create(monkeypatch, caplog):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    with caplog.at_level("WARNING", logger=stripe.logger.name):
+        stripe._request("POST", "/customers", form_data={"name": "Acme"})
+
+    assert "idempotent replay" not in caplog.text.lower()
+
+
 def test_request_sends_idempotency_key_only_for_post(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_123"}))
     monkeypatch.setattr(stripe.requests, "request", mock_request)
@@ -174,6 +198,23 @@ def test_request_retries_once_on_429_with_retry_after(monkeypatch):
     assert result == {"id": "acct_123"}
     assert mock_request.call_count == 2
     mock_sleep.assert_called_once_with(1)
+
+
+def test_request_reuses_same_headers_and_data_across_429_retry(monkeypatch):
+    responses = [
+        MockResponse(status_code=429, text="rate limited"),
+        MockResponse(json_data={"id": "cus_1"}),
+    ]
+    responses[0].headers = {"Retry-After": "1"}
+    mock_request = Mock(side_effect=responses)
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+    monkeypatch.setattr(stripe.time, "sleep", Mock())
+
+    stripe._request("POST", "/customers", form_data={"name": "Acme"})
+
+    first_call, second_call = mock_request.call_args_list
+    assert first_call.kwargs["headers"] == second_call.kwargs["headers"]
+    assert first_call.kwargs["data"] == second_call.kwargs["data"]
 
 
 def test_request_does_not_retry_past_max_retry_after(monkeypatch):
@@ -471,6 +512,18 @@ def test_create_refund_sends_payment_intent(monkeypatch):
     assert mock_request.call_args.kwargs["data"] == [
         ("payment_intent", "pi_1"),
         ("reason", "requested_by_customer"),
+    ]
+
+
+def test_create_refund_sends_metadata(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_create_refund(charge_id="ch_1", metadata={"internal_id": "6735"})
+
+    assert mock_request.call_args.kwargs["data"] == [
+        ("charge", "ch_1"),
+        ("metadata[internal_id]", "6735"),
     ]
 
 

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -54,6 +54,17 @@ def test_flatten_form_params_omits_none_values():
     assert result == [("name", "Acme")]
 
 
+def test_flatten_form_params_serializes_booleans_lowercase():
+    result = stripe._flatten_form_params(
+        {"metadata": {"is_active": True, "is_pending": False}}
+    )
+
+    assert result == [
+        ("metadata[is_active]", "true"),
+        ("metadata[is_pending]", "false"),
+    ]
+
+
 def test_request_uses_base_url_and_headers(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"id": "acct_123"}))
     monkeypatch.setattr(stripe.requests, "request", mock_request)

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -1,0 +1,430 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import stripe
+
+
+class MockResponse:
+    def __init__(
+        self, json_data=None, status_code: int = 200, text: str = "", url: str = ""
+    ):
+        self._json_data = json_data if json_data is not None else {}
+        self.status_code = status_code
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.content = self.text.encode()
+        self.url = url
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("STRIPE_API_KEY", "rk_test_123")
+
+
+def test_headers_require_api_key(monkeypatch):
+    monkeypatch.delenv("STRIPE_API_KEY")
+
+    with pytest.raises(ValueError, match="STRIPE_API_KEY"):
+        stripe._headers()
+
+
+def test_headers_include_bearer_token_only():
+    assert stripe._headers() == {"Authorization": "Bearer rk_test_123"}
+
+
+def test_flatten_form_params_flattens_nested_dict():
+    result = stripe._flatten_form_params({"metadata": {"order_id": "6735"}})
+
+    assert result == [("metadata[order_id]", "6735")]
+
+
+def test_flatten_form_params_flattens_list():
+    result = stripe._flatten_form_params({"expand": ["customer", "invoice"]})
+
+    assert result == [("expand[0]", "customer"), ("expand[1]", "invoice")]
+
+
+def test_flatten_form_params_omits_none_values():
+    result = stripe._flatten_form_params({"name": "Acme", "description": None})
+
+    assert result == [("name", "Acme")]
+
+
+def test_request_uses_base_url_and_headers(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "acct_123"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = stripe._request("GET", "/account")
+
+    assert result == {"id": "acct_123"}
+    assert mock_request.call_args.kwargs["url"] == "https://api.stripe.com/v1/account"
+    assert (
+        mock_request.call_args.kwargs["headers"]["Authorization"]
+        == "Bearer rk_test_123"
+    )
+
+
+def test_request_form_encodes_nested_form_data(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_123"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe._request(
+        "POST",
+        "/customers",
+        form_data={"name": "Acme", "metadata": {"order_id": "6735"}},
+    )
+
+    assert mock_request.call_args.kwargs["data"] == [
+        ("name", "Acme"),
+        ("metadata[order_id]", "6735"),
+    ]
+
+
+def test_request_raises_with_structured_error_detail(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=402,
+                json_data={
+                    "error": {
+                        "type": "card_error",
+                        "code": "card_declined",
+                        "message": "Your card was declined.",
+                    }
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Your card was declined"):
+        stripe._request("GET", "/charges/ch_123")
+
+
+def test_request_truncates_unstructured_error_body(monkeypatch):
+    long_body = "x" * 5000
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text=long_body)),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stripe._request("GET", "/charges/ch_123")
+
+    assert "[truncated]" in str(excinfo.value)
+    assert len(str(excinfo.value)) < len(long_body)
+
+
+def test_get_account_info_returns_profile(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "id": "acct_123",
+                    "business_profile": {"name": "Acme Corp"},
+                    "email": "billing@acme.com",
+                    "country": "US",
+                    "default_currency": "usd",
+                }
+            )
+        ),
+    )
+
+    result = json.loads(stripe.stripe_get_account_info())
+
+    assert result["status"] == "success"
+    assert result["account"]["business_name"] == "Acme Corp"
+    assert result["account"]["id"] == "acct_123"
+
+
+def test_get_account_info_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=401,
+                json_data={
+                    "error": {
+                        "type": "authentication_error",
+                        "message": "Invalid API key",
+                    }
+                },
+            )
+        ),
+    )
+
+    result = json.loads(stripe.stripe_get_account_info())
+
+    assert result["status"] == "error"
+    assert "Invalid API key" in result["message"]
+
+
+def test_get_balance_returns_available_and_pending(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "available": [{"amount": 1000, "currency": "usd"}],
+                    "pending": [{"amount": 500, "currency": "usd"}],
+                }
+            )
+        ),
+    )
+
+    result = json.loads(stripe.stripe_get_balance())
+
+    assert result["status"] == "success"
+    assert result["available"] == [{"amount": 1000, "currency": "usd"}]
+    assert result["pending"] == [{"amount": 500, "currency": "usd"}]
+
+
+def test_list_customers_includes_email_filter_and_truncated_flag(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "data": [{"id": "cus_1", "email": "ada@example.com"}],
+                "has_more": True,
+            }
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_customers(email="ada@example.com"))
+
+    assert result["status"] == "success"
+    assert result["customers"] == [{"id": "cus_1", "email": "ada@example.com"}]
+    assert result["truncated"] is True
+    assert mock_request.call_args.kwargs["params"]["email"] == "ada@example.com"
+
+
+def test_list_customers_not_truncated_when_no_more(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"data": [], "has_more": False})),
+    )
+
+    result = json.loads(stripe.stripe_list_customers())
+
+    assert result["status"] == "success"
+    assert result["truncated"] is False
+
+
+def test_get_customer_returns_customer(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_get_customer("cus_1"))
+
+    assert result["status"] == "success"
+    assert result["customer"]["id"] == "cus_1"
+    assert mock_request.call_args.kwargs["url"].endswith("/customers/cus_1")
+
+
+def test_create_customer_sends_form_data_with_metadata(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(
+        stripe.stripe_create_customer(
+            name="Acme", email="billing@acme.com", metadata={"order_id": "6735"}
+        )
+    )
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["data"] == [
+        ("name", "Acme"),
+        ("email", "billing@acme.com"),
+        ("metadata[order_id]", "6735"),
+    ]
+
+
+def test_create_customer_omits_optional_fields_when_not_provided(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_create_customer()
+
+    assert mock_request.call_args.kwargs["data"] is None
+
+
+def test_list_charges_uses_customer_filter(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"data": [{"id": "ch_1"}], "has_more": False}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_charges(customer_id="cus_1"))
+
+    assert result["status"] == "success"
+    assert result["charges"] == [{"id": "ch_1"}]
+    assert mock_request.call_args.kwargs["params"]["customer"] == "cus_1"
+
+
+def test_get_charge_returns_charge(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"id": "ch_1", "amount": 500})),
+    )
+
+    result = json.loads(stripe.stripe_get_charge("ch_1"))
+
+    assert result["status"] == "success"
+    assert result["charge"]["amount"] == 500
+
+
+def test_create_refund_requires_charge_or_payment_intent():
+    result = json.loads(stripe.stripe_create_refund())
+
+    assert result["status"] == "error"
+    assert "charge_id or payment_intent_id" in result["message"]
+
+
+def test_create_refund_sends_charge_and_amount(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_create_refund(charge_id="ch_1", amount=500))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["data"] == [
+        ("charge", "ch_1"),
+        ("amount", 500),
+    ]
+
+
+def test_create_refund_sends_payment_intent(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_create_refund(
+        payment_intent_id="pi_1", reason="requested_by_customer"
+    )
+
+    assert mock_request.call_args.kwargs["data"] == [
+        ("payment_intent", "pi_1"),
+        ("reason", "requested_by_customer"),
+    ]
+
+
+def test_list_payment_intents_returns_results(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={"data": [{"id": "pi_1"}], "has_more": False}
+            )
+        ),
+    )
+
+    result = json.loads(stripe.stripe_list_payment_intents())
+
+    assert result["status"] == "success"
+    assert result["payment_intents"] == [{"id": "pi_1"}]
+
+
+def test_list_invoices_uses_status_filter(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"data": [{"id": "in_1"}], "has_more": False}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_invoices(status="open"))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["params"]["status"] == "open"
+
+
+def test_get_invoice_returns_invoice(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"id": "in_1", "total": 1000})),
+    )
+
+    result = json.loads(stripe.stripe_get_invoice("in_1"))
+
+    assert result["status"] == "success"
+    assert result["invoice"]["total"] == 1000
+
+
+def test_list_subscriptions_uses_status_filter(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"data": [{"id": "sub_1"}], "has_more": False}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_subscriptions(status="past_due"))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["params"]["status"] == "past_due"
+
+
+def test_list_products_uses_active_filter(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"data": [{"id": "prod_1"}], "has_more": False}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_products(active=True))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["params"]["active"] == "true"
+
+
+def test_list_products_serializes_active_false_as_lowercase_string(monkeypatch):
+    """requests would otherwise serialize a bare Python bool as "True"/"False"
+    in the query string, which Stripe's API does not accept."""
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_list_products(active=False)
+
+    assert mock_request.call_args.kwargs["params"]["active"] == "false"
+
+
+def test_list_prices_uses_product_filter(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"data": [{"id": "price_1"}], "has_more": False}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_prices(product_id="prod_1"))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["params"]["product"] == "prod_1"
+
+
+def test_stripe_app_registry_requires_api_key():
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    stripe_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "stripe"
+    )
+    assert stripe_app["provider_name"] is None
+    assert stripe_app["launch_config"]["required_env"] == ["STRIPE_API_KEY"]

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -55,16 +55,9 @@ def test_path_segment_percent_encodes_path_traversal_characters():
     assert stripe._path_segment("cus_1/../account") == "cus_1%2F..%2Faccount"
 
 
-def test_idempotency_key_is_stable_for_identical_arguments():
-    first = stripe._idempotency_key("POST", "/refunds", {"charge": "ch_1"})
-    second = stripe._idempotency_key("POST", "/refunds", {"charge": "ch_1"})
-
-    assert first == second
-
-
-def test_idempotency_key_differs_for_different_arguments():
-    first = stripe._idempotency_key("POST", "/refunds", {"charge": "ch_1"})
-    second = stripe._idempotency_key("POST", "/refunds", {"charge": "ch_2"})
+def test_generate_idempotency_key_is_not_stable_across_calls():
+    first = stripe._generate_idempotency_key()
+    second = stripe._generate_idempotency_key()
 
     assert first != second
 
@@ -170,7 +163,10 @@ def test_request_omits_idempotency_key_for_get(monkeypatch):
     assert "Idempotency-Key" not in mock_request.call_args.kwargs["headers"]
 
 
-def test_request_reuses_idempotency_key_for_identical_retry_arguments(monkeypatch):
+def test_request_generates_different_key_for_identical_default_calls(monkeypatch):
+    """Two independent calls with the same arguments and no explicit
+    idempotency_key must NOT collide -- see _generate_idempotency_key's
+    docstring for why a content-derived key was wrong."""
     mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
     monkeypatch.setattr(stripe.requests, "request", mock_request)
 
@@ -179,7 +175,23 @@ def test_request_reuses_idempotency_key_for_identical_retry_arguments(monkeypatc
 
     first_key = mock_request.call_args_list[0].kwargs["headers"]["Idempotency-Key"]
     second_key = mock_request.call_args_list[1].kwargs["headers"]["Idempotency-Key"]
-    assert first_key == second_key
+    assert first_key != second_key
+
+
+def test_request_reuses_caller_supplied_idempotency_key(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe._request(
+        "POST", "/refunds", form_data={"charge": "ch_1"}, idempotency_key="retry-1"
+    )
+    stripe._request(
+        "POST", "/refunds", form_data={"charge": "ch_2"}, idempotency_key="retry-1"
+    )
+
+    first_key = mock_request.call_args_list[0].kwargs["headers"]["Idempotency-Key"]
+    second_key = mock_request.call_args_list[1].kwargs["headers"]["Idempotency-Key"]
+    assert first_key == second_key == "retry-1"
 
 
 def test_request_retries_once_on_429_with_retry_after(monkeypatch):
@@ -264,6 +276,66 @@ def test_request_truncates_unstructured_error_body(monkeypatch):
 
     assert "[truncated]" in str(excinfo.value)
     assert len(str(excinfo.value)) < len(long_body)
+
+
+def test_request_flags_replay_on_error_response(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=402,
+                json_data={"error": {"message": "Your card was declined."}},
+                headers={"Idempotent-Replayed": "true"},
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="replay of a previous failed attempt"):
+        stripe._request("POST", "/refunds", form_data={"charge": "ch_1"})
+
+
+def test_request_does_not_mention_replay_on_fresh_error(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=402,
+                json_data={"error": {"message": "Your card was declined."}},
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stripe._request("POST", "/refunds", form_data={"charge": "ch_1"})
+
+    assert "replay" not in str(excinfo.value).lower()
+
+
+def test_request_wraps_network_exception(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(side_effect=stripe.requests.ConnectionError("boom at http://x:y@host")),
+    )
+
+    with pytest.raises(RuntimeError, match="Stripe request failed"):
+        stripe._request("GET", "/account")
+
+
+def test_request_truncates_long_network_exception_text(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(side_effect=stripe.requests.ConnectionError("x" * 5000)),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stripe._request("GET", "/account")
+
+    assert "[truncated]" in str(excinfo.value)
+    assert len(str(excinfo.value)) < 5000
 
 
 def test_get_account_info_returns_profile(monkeypatch):
@@ -439,6 +511,15 @@ def test_create_customer_reports_idempotent_replayed_false_on_fresh_create(
     assert result["idempotent_replayed"] is False
 
 
+def test_create_customer_passes_through_caller_supplied_idempotency_key(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_create_customer(name="Acme", idempotency_key="my-retry-key")
+
+    assert mock_request.call_args.kwargs["headers"]["Idempotency-Key"] == "my-retry-key"
+
+
 def test_get_customer_requires_non_empty_id():
     result = json.loads(stripe.stripe_get_customer(""))
 
@@ -547,6 +628,15 @@ def test_create_refund_reports_idempotent_replayed_false_on_fresh_create(monkeyp
     result = json.loads(stripe.stripe_create_refund(charge_id="ch_1"))
 
     assert result["idempotent_replayed"] is False
+
+
+def test_create_refund_passes_through_caller_supplied_idempotency_key(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_create_refund(charge_id="ch_1", idempotency_key="my-retry-key")
+
+    assert mock_request.call_args.kwargs["headers"]["Idempotency-Key"] == "my-retry-key"
 
 
 def test_list_payment_intents_returns_results(monkeypatch):
@@ -699,3 +789,50 @@ def test_stripe_app_registry_requires_api_key():
     )
     assert stripe_app["provider_name"] is None
     assert stripe_app["launch_config"]["required_env"] == ["STRIPE_API_KEY"]
+
+
+async def test_mcp_registers_all_fourteen_tools():
+    """Direct-call unit tests above exercise each tool's Python body, but
+    none of them go through FastMCP's own registration/schema layer -- a
+    tool whose @mcp.tool() decorator was dropped, or whose name was typo'd,
+    would still pass every test above while being unreachable to an agent."""
+    tools = await stripe.mcp.list_tools()
+
+    assert {tool.name for tool in tools} == {
+        "stripe_get_account_info",
+        "stripe_get_balance",
+        "stripe_list_customers",
+        "stripe_get_customer",
+        "stripe_create_customer",
+        "stripe_list_charges",
+        "stripe_get_charge",
+        "stripe_create_refund",
+        "stripe_list_payment_intents",
+        "stripe_list_invoices",
+        "stripe_get_invoice",
+        "stripe_list_subscriptions",
+        "stripe_list_products",
+        "stripe_list_prices",
+    }
+
+
+async def test_create_customer_via_mcp_layer_parses_json_string_metadata(monkeypatch):
+    """MCP tool arguments arrive as JSON over the wire; some callers send a
+    dict-typed argument as a JSON-encoded string rather than a native JSON
+    object (a real, observed LLM tool-calling behavior). FastMCP's schema
+    validation pre-parses this before the tool body runs -- a direct Python
+    call bypasses that layer entirely, so metadata's dict[str, str] contract
+    is only actually exercised through mcp.call_tool, not stripe_create_
+    customer(...) called directly."""
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    await stripe.mcp.call_tool(
+        "stripe_create_customer",
+        {"name": "Acme", "metadata": '{"internal_id": "6735"}'},
+    )
+
+    assert mock_request.call_args.kwargs["data"] == [
+        ("name", "Acme"),
+        ("metadata[internal_id]", "6735"),
+    ]

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -8,13 +8,19 @@ from xagent.web.tools.mcp import stripe
 
 class MockResponse:
     def __init__(
-        self, json_data=None, status_code: int = 200, text: str = "", url: str = ""
+        self,
+        json_data=None,
+        status_code: int = 200,
+        text: str = "",
+        url: str = "",
+        headers=None,
     ):
         self._json_data = json_data if json_data is not None else {}
         self.status_code = status_code
         self.text = text or (json.dumps(self._json_data) if json_data else "")
         self.content = self.text.encode()
         self.url = url
+        self.headers = headers or {}
 
     def json(self):
         return self._json_data
@@ -368,6 +374,37 @@ def test_create_customer_omits_optional_fields_when_not_provided(monkeypatch):
     assert mock_request.call_args.kwargs["data"] is None
 
 
+def test_create_customer_reports_idempotent_replayed_true_on_dedup(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"id": "cus_1"}, headers={"Idempotent-Replayed": "true"}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_create_customer(name="Acme"))
+
+    assert result["idempotent_replayed"] is True
+
+
+def test_create_customer_reports_idempotent_replayed_false_on_fresh_create(
+    monkeypatch,
+):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_create_customer(name="Acme"))
+
+    assert result["idempotent_replayed"] is False
+
+
+def test_get_customer_requires_non_empty_id():
+    result = json.loads(stripe.stripe_get_customer(""))
+
+    assert result["status"] == "error"
+    assert "customer_id is required" in result["message"]
+
+
 def test_list_charges_uses_customer_filter(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -394,6 +431,13 @@ def test_get_charge_returns_charge(monkeypatch):
 
     assert result["status"] == "success"
     assert result["charge"]["amount"] == 500
+
+
+def test_get_charge_requires_non_empty_id():
+    result = json.loads(stripe.stripe_get_charge(""))
+
+    assert result["status"] == "error"
+    assert "charge_id is required" in result["message"]
 
 
 def test_create_refund_requires_charge_or_payment_intent():
@@ -428,6 +472,28 @@ def test_create_refund_sends_payment_intent(monkeypatch):
         ("payment_intent", "pi_1"),
         ("reason", "requested_by_customer"),
     ]
+
+
+def test_create_refund_reports_idempotent_replayed_true_on_dedup(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"id": "re_1"}, headers={"Idempotent-Replayed": "true"}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_create_refund(charge_id="ch_1"))
+
+    assert result["idempotent_replayed"] is True
+
+
+def test_create_refund_reports_idempotent_replayed_false_on_fresh_create(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_create_refund(charge_id="ch_1"))
+
+    assert result["idempotent_replayed"] is False
 
 
 def test_list_payment_intents_returns_results(monkeypatch):
@@ -472,6 +538,13 @@ def test_get_invoice_returns_invoice(monkeypatch):
 
     assert result["status"] == "success"
     assert result["invoice"]["total"] == 1000
+
+
+def test_get_invoice_requires_non_empty_id():
+    result = json.loads(stripe.stripe_get_invoice(""))
+
+    assert result["status"] == "error"
+    assert "invoice_id is required" in result["message"]
 
 
 def test_list_subscriptions_uses_status_filter(monkeypatch):
@@ -527,6 +600,42 @@ def test_list_prices_uses_product_filter(monkeypatch):
 
     assert result["status"] == "success"
     assert mock_request.call_args.kwargs["params"]["product"] == "prod_1"
+
+
+def test_list_prices_uses_active_filter(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"data": [{"id": "price_1"}], "has_more": False}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_prices(active=True))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["params"]["active"] == "true"
+
+
+def test_list_prices_serializes_active_false_as_lowercase_string(monkeypatch):
+    """requests would otherwise serialize a bare Python bool as "True"/"False"
+    in the query string, which Stripe's API does not accept."""
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_list_prices(active=False)
+
+    assert mock_request.call_args.kwargs["params"]["active"] == "false"
+
+
+def test_paginated_results_truncates_when_data_exceeds_limit():
+    data, truncated = stripe._paginated_results(
+        {"data": [{"id": f"cus_{i}"} for i in range(5)], "has_more": False}, limit=3
+    )
+
+    assert data == [{"id": "cus_0"}, {"id": "cus_1"}, {"id": "cus_2"}]
+    assert truncated is True
 
 
 def test_stripe_app_registry_requires_api_key():

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -36,6 +36,33 @@ def test_headers_include_bearer_token_only():
     assert stripe._headers() == {"Authorization": "Bearer rk_test_123"}
 
 
+def test_headers_include_idempotency_key_when_given():
+    headers = stripe._headers(idempotency_key="abc123")
+
+    assert headers == {
+        "Authorization": "Bearer rk_test_123",
+        "Idempotency-Key": "abc123",
+    }
+
+
+def test_path_segment_percent_encodes_path_traversal_characters():
+    assert stripe._path_segment("cus_1/../account") == "cus_1%2F..%2Faccount"
+
+
+def test_idempotency_key_is_stable_for_identical_arguments():
+    first = stripe._idempotency_key("POST", "/refunds", {"charge": "ch_1"})
+    second = stripe._idempotency_key("POST", "/refunds", {"charge": "ch_1"})
+
+    assert first == second
+
+
+def test_idempotency_key_differs_for_different_arguments():
+    first = stripe._idempotency_key("POST", "/refunds", {"charge": "ch_1"})
+    second = stripe._idempotency_key("POST", "/refunds", {"charge": "ch_2"})
+
+    assert first != second
+
+
 def test_flatten_form_params_flattens_nested_dict():
     result = stripe._flatten_form_params({"metadata": {"order_id": "6735"}})
 
@@ -93,6 +120,66 @@ def test_request_form_encodes_nested_form_data(monkeypatch):
         ("name", "Acme"),
         ("metadata[order_id]", "6735"),
     ]
+
+
+def test_request_sends_idempotency_key_only_for_post(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_123"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe._request("POST", "/customers", form_data={"name": "Acme"})
+
+    assert "Idempotency-Key" in mock_request.call_args.kwargs["headers"]
+
+
+def test_request_omits_idempotency_key_for_get(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "acct_123"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe._request("GET", "/account")
+
+    assert "Idempotency-Key" not in mock_request.call_args.kwargs["headers"]
+
+
+def test_request_reuses_idempotency_key_for_identical_retry_arguments(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe._request("POST", "/refunds", form_data={"charge": "ch_1"})
+    stripe._request("POST", "/refunds", form_data={"charge": "ch_1"})
+
+    first_key = mock_request.call_args_list[0].kwargs["headers"]["Idempotency-Key"]
+    second_key = mock_request.call_args_list[1].kwargs["headers"]["Idempotency-Key"]
+    assert first_key == second_key
+
+
+def test_request_retries_once_on_429_with_retry_after(monkeypatch):
+    responses = [
+        MockResponse(status_code=429, text="rate limited"),
+        MockResponse(json_data={"id": "acct_123"}),
+    ]
+    responses[0].headers = {"Retry-After": "1"}
+    mock_request = Mock(side_effect=responses)
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+    mock_sleep = Mock()
+    monkeypatch.setattr(stripe.time, "sleep", mock_sleep)
+
+    result = stripe._request("GET", "/account")
+
+    assert result == {"id": "acct_123"}
+    assert mock_request.call_count == 2
+    mock_sleep.assert_called_once_with(1)
+
+
+def test_request_does_not_retry_past_max_retry_after(monkeypatch):
+    response = MockResponse(status_code=429, text="rate limited")
+    response.headers = {"Retry-After": str(stripe.MAX_RETRY_AFTER_SECONDS + 1)}
+    mock_request = Mock(return_value=response)
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    with pytest.raises(RuntimeError, match="429"):
+        stripe._request("GET", "/account")
+
+    assert mock_request.call_count == 1
 
 
 def test_request_raises_with_structured_error_detail(monkeypatch):
@@ -241,6 +328,17 @@ def test_get_customer_returns_customer(monkeypatch):
     assert result["status"] == "success"
     assert result["customer"]["id"] == "cus_1"
     assert mock_request.call_args.kwargs["url"].endswith("/customers/cus_1")
+
+
+def test_get_customer_percent_encodes_customer_id(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_get_customer("cus_1/../account")
+
+    assert mock_request.call_args.kwargs["url"].endswith(
+        "/customers/cus_1%2F..%2Faccount"
+    )
 
 
 def test_create_customer_sends_form_data_with_metadata(monkeypatch):

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -271,6 +271,27 @@ def test_request_does_not_retry_past_max_retry_after(monkeypatch):
     assert mock_request.call_count == 1
 
 
+def test_request_appends_param_when_present(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={
+                    "error": {
+                        "message": "Invalid string: must be shorter than 5000 characters",
+                        "param": "metadata[note]",
+                    }
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match=r"\(param: metadata\[note\]\)"):
+        stripe._request("GET", "/charges/ch_123")
+
+
 def test_request_raises_with_structured_error_detail(monkeypatch):
     monkeypatch.setattr(
         stripe.requests,
@@ -645,6 +666,17 @@ def test_get_customer_requires_non_empty_id():
     assert "customer_id is required" in result["message"]
 
 
+def test_get_customer_rejects_wrong_prefix(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "cus_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_get_customer("pi_1"))
+
+    assert result["status"] == "error"
+    assert "cus_" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_list_charges_uses_customer_filter(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -669,6 +701,17 @@ def test_list_charges_clamps_limit(monkeypatch):
     stripe.stripe_list_charges(limit=500)
 
     assert mock_request.call_args.kwargs["params"]["limit"] == stripe.MAX_LIMIT
+
+
+def test_list_charges_clamps_limit_lower_bound(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_list_charges(limit=0)
+
+    assert mock_request.call_args.kwargs["params"]["limit"] == 1
 
 
 def test_list_charges_forwards_starting_after(monkeypatch):
@@ -744,6 +787,17 @@ def test_get_charge_requires_non_empty_id():
     assert "charge_id is required" in result["message"]
 
 
+def test_get_charge_rejects_wrong_prefix(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "ch_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_get_charge("pi_1"))
+
+    assert result["status"] == "error"
+    assert "ch_" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_create_refund_requires_charge_or_payment_intent():
     result = json.loads(stripe.stripe_create_refund())
 
@@ -761,6 +815,39 @@ def test_create_refund_rejects_both_charge_and_payment_intent(monkeypatch):
 
     assert result["status"] == "error"
     assert "not both" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_create_refund_rejects_wrong_charge_prefix(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_create_refund(charge_id="pi_1"))
+
+    assert result["status"] == "error"
+    assert "ch_" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_create_refund_rejects_wrong_payment_intent_prefix(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_create_refund(payment_intent_id="ch_1"))
+
+    assert result["status"] == "error"
+    assert "pi_" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_create_refund_rejects_non_positive_amount(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_create_refund(charge_id="ch_1", amount=0))
+
+    assert result["status"] == "error"
+    assert "positive" in result["message"]
     mock_request.assert_not_called()
 
 
@@ -885,6 +972,17 @@ def test_get_invoice_requires_non_empty_id():
     assert "invoice_id is required" in result["message"]
 
 
+def test_get_invoice_rejects_wrong_prefix(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "in_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_get_invoice("ch_1"))
+
+    assert result["status"] == "error"
+    assert "in_" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_list_subscriptions_uses_status_filter(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -1005,6 +1103,29 @@ def test_request_raises_on_non_json_success_body(monkeypatch):
     monkeypatch.setattr(stripe.requests, "request", Mock(return_value=response))
 
     with pytest.raises(RuntimeError, match="non-JSON body"):
+        stripe._request("GET", "/account")
+
+
+def test_request_raises_on_non_dict_success_body(monkeypatch):
+    response = Mock()
+    response.status_code = 200
+    response.content = b"[1, 2, 3]"
+    response.headers = {}
+    response.json.return_value = [1, 2, 3]
+    monkeypatch.setattr(stripe.requests, "request", Mock(return_value=response))
+
+    with pytest.raises(RuntimeError, match="non-dict"):
+        stripe._request("GET", "/account")
+
+
+def test_request_uses_empty_body_placeholder_on_empty_error(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=502, text="")),
+    )
+
+    with pytest.raises(RuntimeError, match=r"<empty response body>"):
         stripe._request("GET", "/account")
 
 

--- a/tests/web/tools/test_stripe_mcp.py
+++ b/tests/web/tools/test_stripe_mcp.py
@@ -42,6 +42,26 @@ def test_headers_include_bearer_token_only():
     assert stripe._headers() == {"Authorization": "Bearer rk_test_123"}
 
 
+def test_headers_accept_live_restricted_key(monkeypatch):
+    monkeypatch.setenv("STRIPE_API_KEY", "rk_live_abc")
+
+    assert stripe._headers() == {"Authorization": "Bearer rk_live_abc"}
+
+
+def test_headers_reject_full_secret_key(monkeypatch):
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_live_abc")
+
+    with pytest.raises(ValueError, match="Restricted API Key"):
+        stripe._headers()
+
+
+def test_headers_reject_test_mode_full_secret_key(monkeypatch):
+    monkeypatch.setenv("STRIPE_API_KEY", "sk_test_abc")
+
+    with pytest.raises(ValueError, match="Restricted API Key"):
+        stripe._headers()
+
+
 def test_headers_include_idempotency_key_when_given():
     headers = stripe._headers(idempotency_key="abc123")
 
@@ -89,6 +109,16 @@ def test_flatten_form_params_serializes_booleans_lowercase():
         ("metadata[is_active]", "true"),
         ("metadata[is_pending]", "false"),
     ]
+
+
+def test_flatten_form_params_rejects_bracket_in_key():
+    with pytest.raises(ValueError, match="Invalid form field name"):
+        stripe._flatten_form_params({"metadata": {"foo]bar": "1"}})
+
+
+def test_flatten_form_params_rejects_empty_key():
+    with pytest.raises(ValueError, match="must be non-empty"):
+        stripe._flatten_form_params({"": "1"})
 
 
 def test_request_uses_base_url_and_headers(monkeypatch):
@@ -261,6 +291,46 @@ def test_request_raises_with_structured_error_detail(monkeypatch):
 
     with pytest.raises(RuntimeError, match="Your card was declined"):
         stripe._request("GET", "/charges/ch_123")
+
+
+def test_request_redacts_structured_error_message(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=402,
+                json_data={
+                    "error": {
+                        "message": "Gateway error, Authorization: Bearer sk_live_leaked"
+                    }
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stripe._request("GET", "/charges/ch_123")
+
+    assert "sk_live_leaked" not in str(excinfo.value)
+
+
+def test_request_redacts_raw_error_body(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=500,
+                text="<html>Authorization: Bearer sk_live_leaked</html>",
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        stripe._request("GET", "/charges/ch_123")
+
+    assert "sk_live_leaked" not in str(excinfo.value)
 
 
 def test_request_truncates_unstructured_error_body(monkeypatch):
@@ -590,6 +660,70 @@ def test_list_charges_uses_customer_filter(monkeypatch):
     assert mock_request.call_args.kwargs["params"]["customer"] == "cus_1"
 
 
+def test_list_charges_clamps_limit(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_list_charges(limit=500)
+
+    assert mock_request.call_args.kwargs["params"]["limit"] == stripe.MAX_LIMIT
+
+
+def test_list_charges_forwards_starting_after(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"data": [], "has_more": False})
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    stripe.stripe_list_charges(starting_after="ch_1")
+
+    assert mock_request.call_args.kwargs["params"]["starting_after"] == "ch_1"
+
+
+def test_list_charges_reports_truncated_flag(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"data": [{"id": "ch_1"}], "has_more": True}
+        )
+    )
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(stripe.stripe_list_charges())
+
+    assert result["truncated"] is True
+
+
+def test_list_charges_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="boom")),
+    )
+
+    result = json.loads(stripe.stripe_list_charges())
+
+    assert result["status"] == "error"
+
+
+def test_create_refund_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        stripe.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=402, json_data={"error": {"message": "card declined"}}
+            )
+        ),
+    )
+
+    result = json.loads(stripe.stripe_create_refund(charge_id="ch_1"))
+
+    assert result["status"] == "error"
+    assert "card declined" in result["message"]
+
+
 def test_get_charge_returns_charge(monkeypatch):
     monkeypatch.setattr(
         stripe.requests,
@@ -615,6 +749,19 @@ def test_create_refund_requires_charge_or_payment_intent():
 
     assert result["status"] == "error"
     assert "charge_id or payment_intent_id" in result["message"]
+
+
+def test_create_refund_rejects_both_charge_and_payment_intent(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"id": "re_1"}))
+    monkeypatch.setattr(stripe.requests, "request", mock_request)
+
+    result = json.loads(
+        stripe.stripe_create_refund(charge_id="ch_1", payment_intent_id="pi_1")
+    )
+
+    assert result["status"] == "error"
+    assert "not both" in result["message"]
+    mock_request.assert_not_called()
 
 
 def test_create_refund_sends_charge_and_amount(monkeypatch):
@@ -827,6 +974,23 @@ def test_paginated_results_truncates_when_data_exceeds_limit():
 
     assert data == [{"id": "cus_0"}, {"id": "cus_1"}, {"id": "cus_2"}]
     assert truncated is True
+
+
+def test_paginated_results_rejects_non_list_data():
+    with pytest.raises(RuntimeError, match="non-list"):
+        stripe._paginated_results({"data": "not-a-list"}, limit=3)
+
+
+def test_request_raises_on_non_json_success_body(monkeypatch):
+    response = Mock()
+    response.status_code = 200
+    response.content = b"not json"
+    response.headers = {}
+    response.json.side_effect = ValueError("Expecting value")
+    monkeypatch.setattr(stripe.requests, "request", Mock(return_value=response))
+
+    with pytest.raises(RuntimeError, match="non-JSON body"):
+        stripe._request("GET", "/account")
 
 
 def test_stripe_app_registry_requires_api_key():


### PR DESCRIPTION
## Summary

Adds a Stripe MCP connector (key-based, not OAuth) covering accounts, balance, customers, charges, refunds, payment intents, invoices, subscriptions, products, and prices.

### Why not OAuth

Stripe's own OAuth flow (Connect "Standard accounts") is built for platforms that aggregate many *other* merchants' accounts (a marketplace/SaaS model), not for a single user granting a tool access to their own account:

- Stripe's docs explicitly discourage this OAuth flow for new integrations.
- Since June 2021, a `read_write`-scope OAuth connection fails outright if the account is already connected to another platform.
- The token exchange authenticates with your *own* platform secret key via HTTP Basic Auth rather than a client_id/client_secret pair — a materially different shape than every other OAuth connector in this codebase.

Instead this uses a **Restricted API Key** (`rk_live_.../rk_test_...`), which the user generates themselves in the Stripe Dashboard scoped to only the permissions they grant. This is also what Stripe's own [agent-toolkit/MCP server](https://github.com/stripe/agent-toolkit) recommends for third-party agent integrations — same no-review self-serve bar as an OAuth App, without the marketplace-shaped restrictions above. Follows the same key-based pattern already used for AWS/Google Maps/PostHog (`required_env`, connected via `POST /api/mcp/apps/{id}/connect`).

### Implementation notes

- Stripe's API takes `application/x-www-form-urlencoded` bodies (not JSON), including nested params via bracket notation (e.g. `metadata[order_id]=6735`). Added a `_flatten_form_params` helper since `requests` does not flatten nested dict/list values on its own.
- Caught during self-review before committing: `requests` serializes a bare Python `bool` as `True`/`False` in query strings, but Stripe's API only accepts lowercase `true`/`false` for boolean filters (`active` on products/prices) — fixed by explicitly lowercasing, with a regression test locking it in.
- Error responses are `{"error": {"type", "code", "message", "param"}}`; the `message` field is surfaced to the LLM instead of the raw envelope.

## Test plan

- [x] `tests/web/tools/test_stripe_mcp.py` — 35 tests covering headers, form-param flattening, error handling, and all 14 tools
- [x] `tests/alembic/test_20260818_seed_stripe_mcp_app.py` — seed migration upgrade/idempotency/downgrade + registry-drift check
- [x] Full alembic chain (`alembic upgrade head`) verified against a scratch sqlite db — single head, applies cleanly
- [x] `ruff check` / `ruff format` / `mypy` / `codespell` / pre-commit all clean