### PR TITLE
fix: bound durable upload concurrency

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,7 +79,7 @@ Marked tasks do not remain isolated when executed by an older worker. Keep publi
 
 ### Deployment impact
 
-Chat attachments now enter a process-local durable-upload admission gate before object storage registration. The frontend also limits one browser composer to three active attachment requests. This reduces connection bursts from multi-file selections while retaining the existing retryable HTTP 503 contract.
+Chat attachments now enter a process-local durable-upload admission gate before object storage registration. The frontend also limits one browser composer to three active attachment requests. This reduces connection bursts from multi-file selections while retaining the existing retryable HTTP 503 contract. The browser limit is demand reduction, not a server security or capacity boundary.
 
 S3 clients now default to standard retry mode with three total attempts when `XAGENT_FILE_STORAGE_OPTIONS` does not provide an explicit retry configuration. There is no database migration, backfill, new dependency, or infrastructure requirement.
 
@@ -93,6 +93,8 @@ XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS=30
 ```
 
 Both variables are optional. The deployment-wide maximum is approximately the configured concurrency multiplied by the number of backend processes. Tune the value against the object-storage connection pool and the number of backend processes; it is not a cluster-wide limit.
+
+`XAGENT_FILE_UPLOAD_MAX_CONCURRENCY` bounds active durable registrations only. It does not bound waiting requests, parsed multipart bodies, previews, local staged files, or aggregate staged bytes. Estimate staging capacity from peak accepted upload traffic over `XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS`, including the backend per-file limit and proxy request limits. Configure an upstream upload request-rate or concurrency ceiling when the calculated exposure can exceed available staging resources.
 
 Existing `XAGENT_FILE_STORAGE_OPTIONS` retry settings remain authoritative. When retries are not explicitly configured, the backend uses standard mode with three total attempts.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,3 +74,46 @@ If one task must recover before its policy inconsistency can be repaired, quiesc
 Gate new widget and shared-link task creation before rolling back any worker. Roll back all API and task-execution workers together. Do not re-enable public task creation while versions are mixed.
 
 Marked tasks do not remain isolated when executed by an older worker. Keep public execution gated during rollback, or complete the forward rollout before those tasks resume.
+
+## 2026-08-18 — Bounded durable attachment uploads
+
+### Deployment impact
+
+Chat attachments now enter a process-local durable-upload admission gate before object storage registration. The frontend also limits one browser composer to three active attachment requests. This reduces connection bursts from multi-file selections while retaining the existing retryable HTTP 503 contract.
+
+S3 clients now default to standard retry mode with three total attempts when `XAGENT_FILE_STORAGE_OPTIONS` does not provide an explicit retry configuration. There is no database migration, backfill, new dependency, or infrastructure requirement.
+
+### Prerequisites and configuration
+
+The defaults permit four active durable upload registrations per backend process and let a staged request wait 30 seconds for capacity:
+
+```text
+XAGENT_FILE_UPLOAD_MAX_CONCURRENCY=4
+XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS=30
+```
+
+Both variables are optional. The deployment-wide maximum is approximately the configured concurrency multiplied by the number of backend processes. Tune the value against the object-storage connection pool and the number of backend processes; it is not a cluster-wide limit.
+
+Existing `XAGENT_FILE_STORAGE_OPTIONS` retry settings remain authoritative. When retries are not explicitly configured, the backend uses standard mode with three total attempts.
+
+### Deployment and migration steps
+
+1. Deploy the backend first so every new upload is protected by admission control.
+2. Verify backend health and one single-file upload.
+3. Upload more than three files from one composer and verify that the requests complete without an unrestricted burst.
+4. Deploy the matching frontend.
+
+No maintenance window or data migration is required. Mixed frontend versions are compatible with the new backend because the upload API request and response shapes are unchanged.
+
+### Verification and monitoring
+
+Monitor backend logs for these messages:
+
+- `Durable storage unavailable during upload` indicates a provider or filesystem failure and now includes the chained exception.
+- `Timed out waiting for durable upload capacity` indicates that the process-local admission queue exceeded its configured wait.
+
+Verify that persistent provider failures still return `503` with `Durable storage is temporarily unavailable`, and that successful attachments remain available when another selected file fails.
+
+### Rollback
+
+The frontend and backend can be rolled back independently because no persisted schema or API shape changed. Rolling back the backend removes admission control and restores the previous default retry configuration. As an operational mitigation before rollback, increase `XAGENT_FILE_UPLOAD_MAX_CONCURRENCY` or supply the previous retry policy through `XAGENT_FILE_STORAGE_OPTIONS`; monitor storage pressure while doing so.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,7 +79,7 @@ Marked tasks do not remain isolated when executed by an older worker. Keep publi
 
 ### Deployment impact
 
-Chat attachments now enter a process-local durable-upload admission gate before object storage registration. The frontend also limits one browser composer to three active attachment requests. This reduces connection bursts from multi-file selections while retaining the existing retryable HTTP 503 contract. The browser limit is demand reduction, not a server security or capacity boundary.
+Chat attachments now always enter a process-local durable-upload admission gate before object storage registration. The frontend also limits one browser composer to three active attachment requests. This reduces connection bursts from multi-file selections while retaining the existing retryable HTTP 503 contract. The browser limit is demand reduction, not a server security or capacity boundary.
 
 S3 clients now default to standard retry mode with three total attempts when `XAGENT_FILE_STORAGE_OPTIONS` does not provide an explicit retry configuration. There is no database migration, backfill, new dependency, or infrastructure requirement.
 
@@ -92,22 +92,22 @@ XAGENT_FILE_UPLOAD_MAX_CONCURRENCY=4
 XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS=30
 ```
 
-Both variables are optional. The deployment-wide maximum is approximately the configured concurrency multiplied by the number of backend processes. Tune the value against the object-storage connection pool and the number of backend processes; it is not a cluster-wide limit.
+Both variables are optional. The admission gate cannot be disabled; these variables only tune its concurrency and wait time. The deployment-wide maximum is approximately the configured concurrency multiplied by the number of backend processes. Tune the value against the object-storage connection pool and the number of backend processes; it is not a cluster-wide limit.
 
 `XAGENT_FILE_UPLOAD_MAX_CONCURRENCY` bounds active durable registrations only. It does not bound waiting requests, parsed multipart bodies, previews, local staged files, or aggregate staged bytes. Estimate staging capacity from peak accepted upload traffic over `XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS`, including the backend per-file limit and proxy request limits. Configure an upstream upload request-rate or concurrency ceiling when the calculated exposure can exceed available staging resources.
 
-Existing `XAGENT_FILE_STORAGE_OPTIONS` retry settings remain authoritative. When retries are not explicitly configured, the backend uses standard mode with three total attempts.
+Existing `XAGENT_FILE_STORAGE_OPTIONS` retry settings remain authoritative. When retries are not explicitly configured, the backend uses standard mode with three total attempts. To preserve the current retry behavior while classifying failures, set an explicit `config_kwargs.retries` value under `XAGENT_FILE_STORAGE_OPTIONS` before the rollout.
 
 ### Deployment and migration steps
 
-Roll out the change in these stages:
+Exception-chain logging, always-on admission control, and the default standard retry policy arrive in one backend artifact; they cannot be deployed as separate stages.
 
-1. Deploy exception-chain logging before changing admission or retry behavior.
-2. Reproduce or observe the storage failure. Use the logged `operation`, `backend`, and exception chain to classify it as transient/throttling, pool pressure, configuration/permission failure, or local capacity failure.
-3. Repair configuration, permissions, or local capacity before continuing when the failure is not transient. Do not enable additional retries for those failures.
-4. Deploy backend admission control, verify backend health, and complete one single-file upload. Start with four active registrations and a 30-second queue timeout per process.
-5. Only when Stage 2 confirms transient or throttling failures, enable the standard S3 retry default of three total attempts. Operators deploying one combined backend build must keep their existing explicit retry policy in `XAGENT_FILE_STORAGE_OPTIONS` until this gate is satisfied.
-6. Upload more than three files from one composer and verify that requests complete without an unrestricted burst, then deploy the matching frontend.
+1. Before deploying the backend, tune the admission limits for each process and, if needed, set an explicit `config_kwargs.retries` value matching the current retry behavior.
+2. Deploy the combined backend artifact to all backend processes.
+3. Reproduce or observe the storage failure. Use the logged `operation`, `backend`, and exception chain to classify it as transient/throttling, pool pressure, configuration/permission failure, or local capacity failure.
+4. Repair configuration, permissions, or local capacity when the failure is not transient; do not increase retries for those failures.
+5. Verify backend health, complete one single-file upload, and exercise a concurrent upload burst. Confirm that registrations respect the per-process limit and that excess requests either acquire capacity or return the documented retryable `503` after the configured wait.
+6. Deploy the matching frontend, then upload more than three files from one composer and verify that requests complete without an unrestricted browser burst.
 
 No maintenance window or data migration is required. Mixed frontend versions are compatible with the new backend because the upload API request and response shapes are unchanged.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -98,10 +98,14 @@ Existing `XAGENT_FILE_STORAGE_OPTIONS` retry settings remain authoritative. When
 
 ### Deployment and migration steps
 
-1. Deploy the backend first so every new upload is protected by admission control.
-2. Verify backend health and one single-file upload.
-3. Upload more than three files from one composer and verify that the requests complete without an unrestricted burst.
-4. Deploy the matching frontend.
+Roll out the change in these stages:
+
+1. Deploy exception-chain logging before changing admission or retry behavior.
+2. Reproduce or observe the storage failure. Use the logged `operation`, `backend`, and exception chain to classify it as transient/throttling, pool pressure, configuration/permission failure, or local capacity failure.
+3. Repair configuration, permissions, or local capacity before continuing when the failure is not transient. Do not enable additional retries for those failures.
+4. Deploy backend admission control, verify backend health, and complete one single-file upload. Start with four active registrations and a 30-second queue timeout per process.
+5. Only when Stage 2 confirms transient or throttling failures, enable the standard S3 retry default of three total attempts. Operators deploying one combined backend build must keep their existing explicit retry policy in `XAGENT_FILE_STORAGE_OPTIONS` until this gate is satisfied.
+6. Upload more than three files from one composer and verify that requests complete without an unrestricted burst, then deploy the matching frontend.
 
 No maintenance window or data migration is required. Mixed frontend versions are compatible with the new backend because the upload API request and response shapes are unchanged.
 
@@ -109,7 +113,7 @@ No maintenance window or data migration is required. Mixed frontend versions are
 
 Monitor backend logs for these messages:
 
-- `Durable storage unavailable during upload` indicates a provider or filesystem failure and now includes the chained exception.
+- `Durable storage unavailable during upload` identifies `operation=register_local_uploads`, the configured storage `backend`, and the chained provider or filesystem exception.
 - `Timed out waiting for durable upload capacity` indicates that the process-local admission queue exceeded its configured wait.
 
 Verify that persistent provider failures still return `503` with `Durable storage is temporarily unavailable`, and that successful attachments remain available when another selected file fails.

--- a/example.env
+++ b/example.env
@@ -699,10 +699,14 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 # longer waits.
 # XAGENT_FILE_STORAGE_OPTIONS='{"endpoint_url":"https://s3.example.com","region_name":"us-east-1"}'
 
-# Bound durable upload registration per backend process. Requests stage locally,
-# then wait up to the queue timeout before returning the standard retryable 503.
-# Deployment-wide maximum concurrency is approximately this value multiplied by
-# the number of backend processes.
+# Bound active durable upload registrations per backend process. This does not
+# bound waiting requests, parsed multipart bodies, previews, local staged files,
+# or aggregate staged bytes. Requests stage locally, then wait up to the queue
+# timeout before returning the standard retryable 503. Size staging for peak
+# accepted traffic over that timeout, including per-file and proxy limits. Set
+# an upstream upload request-rate or concurrency ceiling if calculated exposure
+# can exceed available staging resources. Deployment-wide active registration
+# concurrency is approximately this value multiplied by the backend processes.
 # XAGENT_FILE_UPLOAD_MAX_CONCURRENCY="4"
 # XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS="30"
 

--- a/example.env
+++ b/example.env
@@ -699,6 +699,13 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 # longer waits.
 # XAGENT_FILE_STORAGE_OPTIONS='{"endpoint_url":"https://s3.example.com","region_name":"us-east-1"}'
 
+# Bound durable upload registration per backend process. Requests stage locally,
+# then wait up to the queue timeout before returning the standard retryable 503.
+# Deployment-wide maximum concurrency is approximately this value multiplied by
+# the number of backend processes.
+# XAGENT_FILE_UPLOAD_MAX_CONCURRENCY="4"
+# XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS="30"
+
 # Local temp/cache directory for materializing durable files when libraries need paths.
 # XAGENT_FILE_MATERIALIZE_DIR="/tmp/xagent-materialized"
 

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -192,7 +192,7 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
           const uploadResponse = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
             method: 'POST',
             body: formData,
-          });
+          }, { retryTransport: false });
           const parsed = await parseApiResponse(uploadResponse);
           if (!uploadResponse.ok) {
             throw new Error(getUploadErrorMessage(uploadResponse, parsed, {

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1358,10 +1358,21 @@ describe("ChatInput", () => {
   })
 
   it("caps attachment uploads across repeated selections", async () => {
-    const pending: Array<(value: { file_id: string }) => void> = []
-    const uploadFile = vi.fn(() => new Promise<{ file_id: string }>((resolve) => {
-      pending.push(resolve)
-    }))
+    const controlledUploads: Array<{
+      file: File
+      resolve: (value: { file_id: string }) => void
+    }> = []
+    let activeUploads = 0
+    let maxActiveUploads = 0
+    const uploadFile = vi.fn((file: File) => {
+      activeUploads += 1
+      maxActiveUploads = Math.max(maxActiveUploads, activeUploads)
+      return new Promise<{ file_id: string }>((resolve) => {
+        controlledUploads.push({ file, resolve })
+      }).finally(() => {
+        activeUploads -= 1
+      })
+    })
 
     function Harness() {
       const [files, setFiles] = React.useState<File[]>([])
@@ -1384,26 +1395,53 @@ describe("ChatInput", () => {
     const secondBatch = Array.from({ length: 2 }, (_, index) => (
       new File([String(index)], `second-${index}.txt`, { type: "text/plain" })
     ))
+    const expectedUploadOrder = [...firstBatch, ...secondBatch].map(file => file.name)
 
     fireEvent.change(fileInput, { target: { files: firstBatch } })
-    await waitFor(() => expect(uploadFile).toHaveBeenCalled())
-    expect(uploadFile).toHaveBeenCalledTimes(3)
+    await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(3))
+    expect(activeUploads).toBe(3)
+    expect(maxActiveUploads).toBe(3)
 
     fireEvent.change(fileInput, { target: { files: secondBatch } })
     await act(async () => Promise.resolve())
     expect(uploadFile).toHaveBeenCalledTimes(3)
 
-    while (uploadFile.mock.calls.length < 7) {
-      const next = pending.shift()
-      expect(next).toBeDefined()
-      await act(async () => next?.({ file_id: `file-${uploadFile.mock.calls.length}` }))
-    }
-    await act(async () => {
-      pending.splice(0).forEach((resolve, index) => {
-        resolve({ file_id: `remaining-${index}` })
+    let resolvedUploads = 0
+    while (uploadFile.mock.calls.length < expectedUploadOrder.length) {
+      const uploadsStarted = uploadFile.mock.calls.length
+      const controlledUpload = controlledUploads[resolvedUploads]
+      expect(controlledUpload).toBeDefined()
+
+      await act(async () => {
+        controlledUpload.resolve({ file_id: `id-${controlledUpload.file.name}` })
       })
-      await Promise.resolve()
-    })
+      resolvedUploads += 1
+
+      await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(uploadsStarted + 1))
+      expect(activeUploads).toBe(3)
+      expect(maxActiveUploads).toBeLessThanOrEqual(3)
+    }
+
+    expect(uploadFile.mock.calls.map(([file]) => file.name)).toEqual(
+      expectedUploadOrder
+    )
+
+    while (resolvedUploads < controlledUploads.length) {
+      const controlledUpload = controlledUploads[resolvedUploads]
+      await act(async () => {
+        controlledUpload.resolve({ file_id: `id-${controlledUpload.file.name}` })
+      })
+      resolvedUploads += 1
+
+      await waitFor(() => {
+        expect(activeUploads).toBe(expectedUploadOrder.length - resolvedUploads)
+      })
+      expect(uploadFile).toHaveBeenCalledTimes(expectedUploadOrder.length)
+      expect(maxActiveUploads).toBeLessThanOrEqual(3)
+    }
+
+    expect(activeUploads).toBe(0)
+    expect(maxActiveUploads).toBe(3)
     await waitFor(() => {
       expect(container.querySelector('button[type="submit"]')).not.toBeDisabled()
     })
@@ -1446,12 +1484,17 @@ describe("ChatInput", () => {
     expect(signals[1].aborted).toBe(false)
   })
 
-  it("keeps successful attachments when another upload fails", async () => {
+  it("keeps successful attachments when other uploads fail", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
-    const uploadFile = vi.fn(async (file: File) => {
-      if (file.name === "failed.txt") throw new Error("storage unavailable")
-      return { file_id: `id-${file.name}` }
-    })
+    const controlledUploads = new Map<string, {
+      resolve: (value: { file_id: string }) => void
+      reject: (reason: unknown) => void
+    }>()
+    const uploadFile = vi.fn((file: File) => new Promise<{ file_id: string }>(
+      (resolve, reject) => {
+        controlledUploads.set(file.name, { resolve, reject })
+      }
+    ))
 
     function Harness() {
       const [files, setFiles] = React.useState<File[]>([])
@@ -1469,19 +1512,37 @@ describe("ChatInput", () => {
     const { container } = render(<Harness />)
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
     const successful = new File(["ok"], "successful.txt")
-    const failed = new File(["bad"], "failed.txt")
+    const firstFailure = new File(["bad-1"], "failed-one.txt")
+    const secondFailure = new File(["bad-2"], "failed-two.txt")
 
-    fireEvent.change(fileInput, { target: { files: [successful, failed] } })
+    fireEvent.change(fileInput, {
+      target: { files: [successful, firstFailure, secondFailure] },
+    })
+    await waitFor(() => expect(controlledUploads.size).toBe(3))
+
+    await act(async () => {
+      controlledUploads.get(successful.name)?.resolve({
+        file_id: `id-${successful.name}`,
+      })
+      controlledUploads.get(firstFailure.name)?.reject(
+        new Error("storage unavailable")
+      )
+      controlledUploads.get(secondFailure.name)?.reject(
+        new Error("storage unavailable")
+      )
+    })
 
     await waitFor(() => {
-      expect(screen.getByText("successful.txt")).toBeInTheDocument()
-      expect(screen.queryByText("failed.txt")).not.toBeInTheDocument()
+      expect(screen.getByText(successful.name)).toBeInTheDocument()
+      expect(screen.queryByText(firstFailure.name)).not.toBeInTheDocument()
+      expect(screen.queryByText(secondFailure.name)).not.toBeInTheDocument()
     })
     expect((successful as File & { file_id?: string }).file_id).toBe(
       "id-successful.txt"
     )
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
     expect(toastErrorMock).toHaveBeenCalledWith(
-      "storage unavailable (1): failed.txt",
+      "storage unavailable (2): failed-one.txt, failed-two.txt",
       expect.anything(),
     )
     consoleError.mockRestore()

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1357,6 +1357,136 @@ describe("ChatInput", () => {
     expect(container.querySelector('button[type="submit"]')).toBeDisabled()
   })
 
+  it("caps attachment uploads across repeated selections", async () => {
+    const pending: Array<(value: { file_id: string }) => void> = []
+    const uploadFile = vi.fn(() => new Promise<{ file_id: string }>((resolve) => {
+      pending.push(resolve)
+    }))
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          hideConfig
+          files={files}
+          onFilesChange={setFiles}
+          onSend={vi.fn()}
+          uploadFile={uploadFile}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const firstBatch = Array.from({ length: 5 }, (_, index) => (
+      new File([String(index)], `first-${index}.txt`, { type: "text/plain" })
+    ))
+    const secondBatch = Array.from({ length: 2 }, (_, index) => (
+      new File([String(index)], `second-${index}.txt`, { type: "text/plain" })
+    ))
+
+    fireEvent.change(fileInput, { target: { files: firstBatch } })
+    await waitFor(() => expect(uploadFile).toHaveBeenCalled())
+    expect(uploadFile).toHaveBeenCalledTimes(3)
+
+    fireEvent.change(fileInput, { target: { files: secondBatch } })
+    await act(async () => Promise.resolve())
+    expect(uploadFile).toHaveBeenCalledTimes(3)
+
+    while (uploadFile.mock.calls.length < 7) {
+      const next = pending.shift()
+      expect(next).toBeDefined()
+      await act(async () => next?.({ file_id: `file-${uploadFile.mock.calls.length}` }))
+    }
+    await act(async () => {
+      pending.splice(0).forEach((resolve, index) => {
+        resolve({ file_id: `remaining-${index}` })
+      })
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(container.querySelector('button[type="submit"]')).not.toBeDisabled()
+    })
+  })
+
+  it("cancels duplicate-metadata files by object identity", async () => {
+    const signals: AbortSignal[] = []
+    apiRequestMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "http://upload.local/api/files/upload") {
+        signals.push(init?.signal as AbortSignal)
+        return new Promise<Response>(() => {})
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          hideConfig
+          files={files}
+          onFilesChange={setFiles}
+          onSend={vi.fn()}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const lastModified = Date.now()
+    const first = new File(["first"], "duplicate.txt", { lastModified })
+    const second = new File(["second"], "duplicate.txt", { lastModified })
+
+    fireEvent.change(fileInput, { target: { files: [first, second] } })
+    await waitFor(() => expect(signals).toHaveLength(2))
+
+    fireEvent.click(screen.getAllByTitle("common.cancel")[0])
+
+    expect(signals[0].aborted).toBe(true)
+    expect(signals[1].aborted).toBe(false)
+  })
+
+  it("keeps successful attachments when another upload fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    const uploadFile = vi.fn(async (file: File) => {
+      if (file.name === "failed.txt") throw new Error("storage unavailable")
+      return { file_id: `id-${file.name}` }
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          hideConfig
+          files={files}
+          onFilesChange={setFiles}
+          onSend={vi.fn()}
+          uploadFile={uploadFile}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const successful = new File(["ok"], "successful.txt")
+    const failed = new File(["bad"], "failed.txt")
+
+    fireEvent.change(fileInput, { target: { files: [successful, failed] } })
+
+    await waitFor(() => {
+      expect(screen.getByText("successful.txt")).toBeInTheDocument()
+      expect(screen.queryByText("failed.txt")).not.toBeInTheDocument()
+    })
+    expect((successful as File & { file_id?: string }).file_id).toBe(
+      "id-successful.txt"
+    )
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "storage unavailable: failed.txt",
+      expect.anything(),
+    )
+    consoleError.mockRestore()
+  })
+
   it("keeps pause hidden while running draft files are still uploading", async () => {
     const onPause = vi.fn()
     const uploadFile = vi.fn(() => new Promise<{ file_id: string }>(() => {}))

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1481,7 +1481,7 @@ describe("ChatInput", () => {
       "id-successful.txt"
     )
     expect(toastErrorMock).toHaveBeenCalledWith(
-      "storage unavailable: failed.txt",
+      "storage unavailable (1): failed.txt",
       expect.anything(),
     )
     consoleError.mockRestore()

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -491,7 +491,7 @@ export function ChatInput({
             method: 'POST',
             body: formData,
             signal: controller.signal
-          });
+          }, { retryTransport: false });
           const parsed = await parseApiResponse(response);
 
           if (response.ok && isJsonRecord(parsed.data)) {

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -134,6 +134,48 @@ interface DefaultModelRecord {
   model?: ModelRecord | null;
 }
 
+const MAX_CONCURRENT_ATTACHMENT_UPLOADS = 3;
+
+type ScheduledUploadTask = {
+  execute: () => Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+};
+
+/** A component-local FIFO shared by every attachment selection. */
+class AttachmentUploadScheduler {
+  private readonly pending: ScheduledUploadTask[] = [];
+  private active = 0;
+
+  constructor(private readonly concurrency: number) {}
+
+  schedule(execute: () => Promise<void>): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.pending.push({ execute, resolve, reject });
+      this.drain();
+    });
+  }
+
+  cancelPending(reason: unknown): void {
+    this.pending.splice(0).forEach(task => task.reject(reason));
+  }
+
+  private drain(): void {
+    while (this.active < this.concurrency && this.pending.length > 0) {
+      const task = this.pending.shift();
+      if (!task) return;
+      this.active += 1;
+      void Promise.resolve()
+        .then(task.execute)
+        .then(task.resolve, task.reject)
+        .finally(() => {
+          this.active -= 1;
+          this.drain();
+        });
+    }
+  }
+}
+
 export function ChatInput({
   onSend,
   isLoading,
@@ -280,9 +322,19 @@ export function ChatInput({
     [files, filesDisabled],
   );
 
-  // Track files for async operations
+  // File object identity remains stable while an attachment is in the composer,
+  // unlike name/mtime pairs which can collide for files from different folders.
   const filesRef = useRef(enabledFiles);
-  const uploadAbortControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const uploadAbortControllersRef = useRef<Map<File, AbortController>>(new Map());
+  const uploadSchedulerRef = useRef<AttachmentUploadScheduler | null>(null);
+  const uploadsMountedRef = useRef(true);
+  const uploadsEnabledRef = useRef(!filesDisabled);
+  if (!uploadSchedulerRef.current) {
+    uploadSchedulerRef.current = new AttachmentUploadScheduler(
+      MAX_CONCURRENT_ATTACHMENT_UPLOADS
+    );
+  }
+  uploadsEnabledRef.current = !filesDisabled;
 
   useEffect(() => {
     filesRef.current = enabledFiles;
@@ -351,8 +403,14 @@ export function ChatInput({
   }>({ model: "" });
   const [models, setModels] = useState<ModelRecord[]>([]);
 
-  // State to track files currently being uploaded
-  const [uploadingFiles, setUploadingFiles] = useState<Set<string>>(new Set());
+  // Queued and running files share one identity-based set so submission stays
+  // blocked until every selected attachment has settled.
+  const [uploadingFiles, setUploadingFiles] = useState<Set<File>>(new Set());
+
+  const publishFiles = (nextFiles: File[]) => {
+    filesRef.current = nextFiles;
+    onFilesChange?.(nextFiles);
+  };
 
   const extractDroppedFiles = (dataTransfer: DataTransfer) => {
     const itemFiles = Array.from(dataTransfer.items || [])
@@ -374,101 +432,121 @@ export function ChatInput({
   useEffect(() => {
     if (!filesDisabled) return;
 
-    uploadAbortControllersRef.current.forEach((controller) => {
-      controller.abort();
-    });
+    uploadAbortControllersRef.current.forEach(controller => controller.abort());
     uploadAbortControllersRef.current.clear();
+    uploadSchedulerRef.current?.cancelPending(
+      new DOMException("File uploads disabled", "AbortError")
+    );
     setUploadingFiles(new Set());
     dragDepthRef.current = 0;
     setIsDraggingFiles(false);
   }, [filesDisabled]);
 
-  // Helper to upload files immediately
+  useEffect(() => {
+    uploadsMountedRef.current = true;
+    const abortControllers = uploadAbortControllersRef.current;
+    const uploadScheduler = uploadSchedulerRef.current;
+    return () => {
+      uploadsMountedRef.current = false;
+      abortControllers.forEach(controller => controller.abort());
+      abortControllers.clear();
+      uploadScheduler?.cancelPending(
+        new DOMException("File uploader unmounted", "AbortError")
+      );
+    };
+  }, []);
+
   const uploadFiles = async (newFiles: File[]) => {
     if (filesDisabled || newFiles.length === 0) return;
 
-    // Mark as uploading (use name + lastModified as rough unique ID)
-    const fileIds = newFiles.map(f => `${f.name}-${f.lastModified}`);
-    setUploadingFiles(prev => {
-      const next = new Set(prev);
-      fileIds.forEach(id => next.add(id));
-      return next;
-    });
-
+    setUploadingFiles(previous => new Set([...previous, ...newFiles]));
     const failedFiles = new Set<File>();
-    let uploadErrorMessage: string | null = null;
+    const failureMessages = new Map<File, string>();
+    const scheduler = uploadSchedulerRef.current;
+    if (!scheduler) return;
 
-    // Upload files individually to ensure better reliability and progress tracking
-    await Promise.all(newFiles.map(async (file) => {
-      const fileId = `${file.name}-${file.lastModified}`;
+    const scheduled = newFiles.map(file => {
       const controller = new AbortController();
-      uploadAbortControllersRef.current.set(fileId, controller);
+      uploadAbortControllersRef.current.set(file, controller);
 
-      try {
-        const currentTaskType = mode || 'task';
+      return scheduler.schedule(async () => {
+        try {
+          if (controller.signal.aborted) return;
+          const currentTaskType = mode || 'task';
 
-        if (uploadFile) {
-          const result = await uploadFile(file, { taskType: currentTaskType });
-          if (result && typeof result.file_id === 'string') {
-            (file as File & { file_id?: string }).file_id = result.file_id;
-          } else {
-            failedFiles.add(file);
+          if (uploadFile) {
+            const result = await uploadFile(file, { taskType: currentTaskType });
+            if (result && typeof result.file_id === 'string') {
+              (file as File & { file_id?: string }).file_id = result.file_id;
+            } else {
+              failedFiles.add(file);
+            }
+            return;
           }
-        } else {
+
           const formData = new FormData();
           formData.append('file', file);
-          // Default to task mode if not specified
           formData.append('task_type', currentTaskType);
-
           const response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
             method: 'POST',
             body: formData,
             signal: controller.signal
           });
-
           const parsed = await parseApiResponse(response);
 
           if (response.ok && isJsonRecord(parsed.data)) {
-            const data = parsed.data;
-            if (data.success && typeof data.file_id === 'string') {
-              // Attach file_id to the File object
-              (file as File & { file_id?: string }).file_id = data.file_id;
+            if (parsed.data.success && typeof parsed.data.file_id === 'string') {
+              (file as File & { file_id?: string }).file_id = parsed.data.file_id;
             } else {
               failedFiles.add(file);
             }
-          } else {
-            failedFiles.add(file);
-            uploadErrorMessage = uploadErrorMessage || getUploadErrorMessage(response, parsed, {
-              generic: t("files.uploadFailed") || "Failed to upload some files",
-              ...UPLOAD_ERROR_MESSAGES,
+            return;
+          }
+
+          failedFiles.add(file);
+          failureMessages.set(file, getUploadErrorMessage(response, parsed, {
+            generic: t("files.uploadFailed") || "Failed to upload some files",
+            ...UPLOAD_ERROR_MESSAGES,
+          }));
+        } catch (error) {
+          if (
+            controller.signal.aborted
+            || (error instanceof DOMException && error.name === 'AbortError')
+          ) return;
+
+          console.error("Error uploading file:", error);
+          failedFiles.add(file);
+          if (error instanceof Error && error.message) {
+            failureMessages.set(file, error.message);
+          }
+        } finally {
+          uploadAbortControllersRef.current.delete(file);
+          if (uploadsMountedRef.current && uploadsEnabledRef.current) {
+            setUploadingFiles(previous => {
+              const next = new Set(previous);
+              next.delete(file);
+              return next;
             });
           }
         }
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          // Upload cancelled, do nothing
-        } else {
-          console.error("Error uploading file:", error);
-          failedFiles.add(file);
-          uploadErrorMessage = uploadErrorMessage || (error instanceof Error ? error.message : null);
-        }
-      } finally {
-        uploadAbortControllersRef.current.delete(fileId);
-        setUploadingFiles(prev => {
-          const next = new Set(prev);
-          next.delete(fileId);
-          return next;
-        });
-      }
-    }));
+      });
+    });
 
-    // Handle failed files
-    if (failedFiles.size > 0) {
-      toast.error(uploadErrorMessage || t("files.uploadFailed") || "Failed to upload some files");
-      if (onFilesChange) {
-        onFilesChange(filesRef.current.filter(f => !failedFiles.has(f)));
-      }
-    }
+    await Promise.allSettled(scheduled);
+    if (
+      !uploadsMountedRef.current
+      || !uploadsEnabledRef.current
+      || failedFiles.size === 0
+    ) return;
+
+    const failedNames = newFiles
+      .filter(file => failedFiles.has(file))
+      .map(file => file.name);
+    publishFiles(filesRef.current.filter(file => !failedFiles.has(file)));
+    const failureMessage = failureMessages.values().next().value
+      || t("files.uploadFailed")
+      || "Failed to upload some files";
+    toast.error(`${failureMessage}: ${failedNames.join(', ')}`);
   };
 
   const appendFiles = (newFiles: File[]) => {
@@ -478,9 +556,9 @@ export function ChatInput({
       || !onFilesChange
       || isInputBusy
     ) return;
-    onFilesChange([...filesRef.current, ...newFiles]);
+    publishFiles([...filesRef.current, ...newFiles]);
     if (!deferFileUpload) {
-      uploadFiles(newFiles);
+      void uploadFiles(newFiles);
     }
   };
 
@@ -863,16 +941,18 @@ export function ChatInput({
   };
 
   const removeFile = (index: number) => {
-    const fileToRemove = enabledFiles[index];
-    if (fileToRemove) {
-      const fileId = `${fileToRemove.name}-${fileToRemove.lastModified}`;
-      const controller = uploadAbortControllersRef.current.get(fileId);
-      if (controller) {
-        controller.abort();
-        uploadAbortControllersRef.current.delete(fileId);
-      }
-    }
-    onFilesChange?.(enabledFiles.filter((_, i) => i !== index));
+    const fileToRemove = filesRef.current[index];
+    if (!fileToRemove) return;
+
+    const controller = uploadAbortControllersRef.current.get(fileToRemove);
+    controller?.abort();
+    uploadAbortControllersRef.current.delete(fileToRemove);
+    setUploadingFiles(previous => {
+      const next = new Set(previous);
+      next.delete(fileToRemove);
+      return next;
+    });
+    publishFiles(filesRef.current.filter(file => file !== fileToRemove));
   };
 
   useEffect(() => {
@@ -993,7 +1073,7 @@ export function ChatInput({
           {enabledFiles.length > 0 && (
             <div className="flex flex-wrap gap-2 px-4 pt-3">
               {enabledFiles.map((file, index) => {
-                const isUploading = uploadingFiles.has(`${file.name}-${file.lastModified}`);
+                const isUploading = uploadingFiles.has(file);
                 return (
                   <div
                     key={index}

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -546,7 +546,7 @@ export function ChatInput({
     const failureMessage = failureMessages.values().next().value
       || t("files.uploadFailed")
       || "Failed to upload some files";
-    toast.error(`${failureMessage}: ${failedNames.join(', ')}`);
+    toast.error(`${failureMessage} (${failedNames.length}): ${failedNames.join(', ')}`);
   };
 
   const appendFiles = (newFiles: File[]) => {

--- a/frontend/src/components/pages/files.tsx
+++ b/frontend/src/components/pages/files.tsx
@@ -175,7 +175,7 @@ export function FilesPage() {
       const response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
         method: 'POST',
         body: formData
-      })
+      }, { retryTransport: false })
 
       const parsed = await parseApiResponse(response)
 

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -20,11 +20,17 @@ const app = vi.hoisted(() => ({
     transport?: AppProviderTransportConfig
   },
   startScreenProps: null as null | {
+    onSend: (
+      message: string,
+      files: File[],
+      config?: Record<string, string>,
+    ) => Promise<void>
     voiceInputEnabled?: boolean
   },
 }))
 
 const i18n = vi.hoisted(() => ({ t: (key: string) => key }))
+const uploads = vi.hoisted(() => ({ deferred: vi.fn() }))
 
 vi.mock("@/contexts/app-context-chat", () => ({
   AppProvider: ({
@@ -56,6 +62,10 @@ vi.mock("@/contexts/app-context-chat", () => ({
 
 vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => i18n,
+}))
+
+vi.mock("@/lib/public-chat-file-upload", () => ({
+  uploadDeferredPublicChatFiles: uploads.deferred,
 }))
 
 vi.mock("@/components/chat/ChatStartScreen", () => ({
@@ -236,6 +246,14 @@ describe("PublicAgentChatPage", () => {
     app.startScreenProps = null
     sessionStorage.clear()
     fetchMock.mockReset()
+    uploads.deferred.mockReset()
+    uploads.deferred.mockImplementation(async (files: File[]) =>
+      files.map((file, index) => ({
+        file_id: `uploaded-${index}`,
+        name: file.name,
+        size: file.size,
+        type: file.type,
+      })))
     vi.stubGlobal("fetch", fetchMock)
   })
 
@@ -289,6 +307,26 @@ describe("PublicAgentChatPage", () => {
       },
     )
     expectPublicProviderToken()
+  })
+
+  it("uses the shared deferred uploader for existing-task transport uploads", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+    const file = new File(["existing"], "existing.txt", { type: "text/plain" })
+
+    renderWidgetPage({ widgetKey: "widget-secret" })
+    await screen.findByRole("button", { name: "start:Support Agent" })
+    await app.provider?.transport?.uploadFiles?.([file], {
+      taskId: 71,
+      taskType: "task",
+    })
+
+    expect(uploads.deferred).toHaveBeenCalledWith([file], {
+      url: "https://api.example/api/widget/files/upload",
+      accessToken: "public-access-token",
+      taskType: "task",
+      taskId: 71,
+      fallbackError: "files.uploadFailed",
+    })
   })
 
   it("fails closed for an invalid direct widget key", async () => {
@@ -504,17 +542,25 @@ describe("PublicAgentChatPage", () => {
     expect(app.setTaskId).toHaveBeenCalledWith(42, { navigate: false })
   })
 
-  it("lets workforce task creation start the opening turn without sending it again", async () => {
+  it("uses the shared deferred uploader when workforce task creation starts the opening turn", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
       .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(43, "running")))
+    const file = new File(["opening"], "opening.txt", { type: "text/plain" })
 
     renderWidgetPage({ searchAgentId: null, widgetKey: "widget-secret" })
 
-    fireEvent.click(await screen.findByRole("button", { name: "start:Support Workforce" }))
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+    await app.startScreenProps?.onSend("first message", [file], { mode: "balanced" })
 
     await waitFor(() => {
       expect(app.setTaskId).toHaveBeenCalledWith(43, { navigate: false })
+    })
+    expect(uploads.deferred).toHaveBeenCalledWith([file], {
+      url: "https://api.example/api/widget/files/upload",
+      accessToken: "public-access-token",
+      taskType: "task",
+      fallbackError: "files.uploadFailed",
     })
     expect(app.sendMessage).not.toHaveBeenCalled()
     expect(fetchMock).toHaveBeenCalledTimes(2)
@@ -543,6 +589,7 @@ describe("PublicAgentChatPage", () => {
         body: JSON.stringify({
           title: "first message",
           description: "first message",
+          files: ["uploaded-0"],
         }),
       },
     )

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { AppProviderTransportConfig } from "@/contexts/app-context-chat"
 
@@ -25,6 +25,8 @@ const app = vi.hoisted(() => ({
       files: File[],
       config?: Record<string, string>,
     ) => Promise<void>
+    inputValue: string
+    onInputChange: (value: string) => void
     voiceInputEnabled?: boolean
   },
 }))
@@ -72,12 +74,15 @@ vi.mock("@/components/chat/ChatStartScreen", () => ({
   ChatStartScreen: (props: {
     onSend: (message: string, files: File[], config?: Record<string, string>) => Promise<void>
     title: string
+    inputValue: string
+    onInputChange: (value: string) => void
     voiceInputEnabled?: boolean
   }) => {
     app.startScreenProps = props
     return (
       <button
         type="button"
+        data-input-value={props.inputValue}
         onClick={() => {
           void props.onSend("first message", [], { mode: "balanced" }).catch(() => undefined)
         }}
@@ -131,6 +136,14 @@ function jsonResponse(payload: unknown, status = 200) {
     status,
     headers: { "Content-Type": "application/json" },
   })
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
 }
 
 function renderWidgetPage(overrides: Partial<React.ComponentProps<typeof PublicAgentChatPage>> = {}) {
@@ -545,6 +558,89 @@ describe("PublicAgentChatPage", () => {
 
     expect(await screen.findByTestId("conversation-panel")).toBeInTheDocument()
     expect(app.setTaskId).toHaveBeenCalledWith(42, { navigate: false })
+  })
+
+  it("ignores a replaced bootstrap after successful task JSON resolves", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+    renderWidgetPage({ widgetKey: "widget-secret" })
+
+    const startButton = await screen.findByRole("button", { name: "start:Support Agent" })
+    app.setTaskId.mockClear()
+    // Keep the start screen mounted even if stale code attempts publication so
+    // draft clearing is independently observable rather than hidden by the
+    // mocked provider switching to the conversation panel.
+    app.setTaskId.mockImplementation(() => undefined)
+    app.dispatch.mockClear()
+    const staleJson = deferred<ReturnType<typeof widgetTaskResponse>>()
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => staleJson.promise,
+    } as Response)
+    fetchMock.mockReturnValueOnce(new Promise(() => undefined))
+
+    act(() => app.startScreenProps?.onInputChange("keep active draft"))
+    const staleSend = app.startScreenProps!.onSend("stale message", [])
+      .catch(error => error)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    const activeSend = app.startScreenProps!.onSend("active message", [])
+      .catch(error => error)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+
+    await act(async () => {
+      staleJson.resolve(widgetTaskResponse(42, "pending"))
+      await staleSend
+    })
+
+    expect(app.setTaskId).not.toHaveBeenCalled()
+    expect(app.dispatch).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: "SET_CURRENT_TASK",
+    }))
+    expect(app.sendMessage).not.toHaveBeenCalled()
+    expect(startButton).toHaveAttribute("data-input-value", "keep active draft")
+    expect(screen.queryByText("widgetChat.messages.error_init")).toBeNull()
+    void activeSend
+  })
+
+  it("ignores a replaced bootstrap after non-ok task JSON resolves", async () => {
+    localStorage.clear()
+    localStorage.setItem(SHARE_AUTH_KEY, JSON.stringify(successfulAgentAuth))
+    renderSharePage()
+
+    const startButton = await screen.findByRole("button", { name: "start:Support Agent" })
+    app.setTaskId.mockClear()
+    app.dispatch.mockClear()
+    const staleJson = deferred<{ detail: string }>()
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: () => staleJson.promise,
+    } as Response)
+    fetchMock.mockReturnValueOnce(new Promise(() => undefined))
+
+    act(() => app.startScreenProps?.onInputChange("keep active draft"))
+    const staleSend = app.startScreenProps!.onSend("stale message", [])
+      .catch(error => error)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+    const activeSend = app.startScreenProps!.onSend("active message", [])
+      .catch(error => error)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      staleJson.resolve({ detail: "stale task error" })
+      await staleSend
+    })
+
+    expect(localStorage.getItem(SHARE_AUTH_KEY)).not.toBeNull()
+    expect(app.setTaskId).not.toHaveBeenCalled()
+    expect(app.dispatch).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: "SET_CURRENT_TASK",
+    }))
+    expect(app.sendMessage).not.toHaveBeenCalled()
+    expect(startButton).toHaveAttribute("data-input-value", "keep active draft")
+    expect(screen.queryByText("stale task error")).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    void activeSend
   })
 
   it("uses the shared deferred uploader when workforce task creation starts the opening turn", async () => {

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -315,18 +315,22 @@ describe("PublicAgentChatPage", () => {
 
     renderWidgetPage({ widgetKey: "widget-secret" })
     await screen.findByRole("button", { name: "start:Support Agent" })
+    const signal = new AbortController().signal
     await app.provider?.transport?.uploadFiles?.([file], {
       taskId: 71,
       taskType: "task",
+      signal,
     })
 
-    expect(uploads.deferred).toHaveBeenCalledWith([file], {
+    expect(uploads.deferred).toHaveBeenCalledWith([file], expect.objectContaining({
       url: "https://api.example/api/widget/files/upload",
       accessToken: "public-access-token",
       taskType: "task",
       taskId: 71,
       fallbackError: "files.uploadFailed",
-    })
+      signal,
+      uploadContext: expect.any(Object),
+    }))
   })
 
   it("fails closed for an invalid direct widget key", async () => {
@@ -509,6 +513,7 @@ describe("PublicAgentChatPage", () => {
       "https://api.example/api/widget/chat/task/create",
       {
         method: "POST",
+        signal: expect.any(AbortSignal),
         headers: {
           "Content-Type": "application/json",
           Authorization: "Bearer public-access-token",
@@ -556,12 +561,14 @@ describe("PublicAgentChatPage", () => {
     await waitFor(() => {
       expect(app.setTaskId).toHaveBeenCalledWith(43, { navigate: false })
     })
-    expect(uploads.deferred).toHaveBeenCalledWith([file], {
+    expect(uploads.deferred).toHaveBeenCalledWith([file], expect.objectContaining({
       url: "https://api.example/api/widget/files/upload",
       accessToken: "public-access-token",
       taskType: "task",
       fallbackError: "files.uploadFailed",
-    })
+      signal: expect.any(AbortSignal),
+      uploadContext: expect.any(Object),
+    }))
     expect(app.sendMessage).not.toHaveBeenCalled()
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -582,6 +589,7 @@ describe("PublicAgentChatPage", () => {
       "https://api.example/api/widget/chat/task/create",
       {
         method: "POST",
+        signal: expect.any(AbortSignal),
         headers: {
           "Content-Type": "application/json",
           Authorization: "Bearer public-access-token",
@@ -596,6 +604,37 @@ describe("PublicAgentChatPage", () => {
     await waitFor(() => {
       expect(localStorage.getItem("widget_task_wf8_guest-1")).toBe("43")
     })
+  })
+
+  it("aborts workforce opening uploads on unmount before task creation", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
+    uploads.deferred.mockImplementation((_files: File[], options: { signal: AbortSignal }) => (
+      new Promise((_resolve, reject) => {
+        options.signal.addEventListener(
+          "abort",
+          () => reject(options.signal.reason),
+          { once: true },
+        )
+      })
+    ))
+    const file = new File(["opening"], "opening.txt", { type: "text/plain" })
+    const { unmount } = renderWidgetPage({
+      searchAgentId: null,
+      widgetKey: "widget-secret",
+    })
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+    const sendOutcome = app.startScreenProps!.onSend("first message", [file])
+      .then(() => "resolved", error => `rejected:${(error as Error).name}`)
+
+    await waitFor(() => expect(uploads.deferred).toHaveBeenCalledOnce())
+    unmount()
+
+    await expect(sendOutcome).resolves.toBe("rejected:AbortError")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/chat/task/create"),
+      expect.anything(),
+    )
   })
 
   it("authenticates a share link and persists the guest token for reuse", async () => {

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { AppProviderTransportConfig } from "@/contexts/app-context-chat"
 
@@ -560,87 +560,66 @@ describe("PublicAgentChatPage", () => {
     expect(app.setTaskId).toHaveBeenCalledWith(42, { navigate: false })
   })
 
-  it("ignores a replaced bootstrap after successful task JSON resolves", async () => {
+  it("serializes reentrant opening sends into one task creation", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+    const taskCreation = deferred<Response>()
+    fetchMock.mockReturnValueOnce(taskCreation.promise)
+    app.sendMessage.mockResolvedValue(undefined)
     renderWidgetPage({ widgetKey: "widget-secret" })
 
-    const startButton = await screen.findByRole("button", { name: "start:Support Agent" })
-    app.setTaskId.mockClear()
-    // Keep the start screen mounted even if stale code attempts publication so
-    // draft clearing is independently observable rather than hidden by the
-    // mocked provider switching to the conversation panel.
-    app.setTaskId.mockImplementation(() => undefined)
-    app.dispatch.mockClear()
-    const staleJson = deferred<ReturnType<typeof widgetTaskResponse>>()
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: () => staleJson.promise,
-    } as Response)
-    fetchMock.mockReturnValueOnce(new Promise(() => undefined))
+    await screen.findByRole("button", { name: "start:Support Agent" })
+    const firstSend = app.startScreenProps!.onSend("first message", [])
+    const secondSend = app.startScreenProps!.onSend("second message", [])
 
-    act(() => app.startScreenProps?.onInputChange("keep active draft"))
-    const staleSend = app.startScreenProps!.onSend("stale message", [])
-      .catch(error => error)
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
-    const activeSend = app.startScreenProps!.onSend("active message", [])
-      .catch(error => error)
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(fetchMock.mock.calls.filter(([url]) =>
+      url === "https://api.example/api/widget/chat/task/create")).toHaveLength(1)
+    const taskCreateSignal = (fetchMock.mock.calls[1][1] as RequestInit).signal
+    expect(taskCreateSignal?.aborted).toBe(false)
 
-    await act(async () => {
-      staleJson.resolve(widgetTaskResponse(42, "pending"))
-      await staleSend
-    })
+    taskCreation.resolve(jsonResponse(widgetTaskResponse(42, "pending")))
+    await Promise.all([firstSend, secondSend])
 
-    expect(app.setTaskId).not.toHaveBeenCalled()
-    expect(app.dispatch).not.toHaveBeenCalledWith(expect.objectContaining({
-      type: "SET_CURRENT_TASK",
-    }))
-    expect(app.sendMessage).not.toHaveBeenCalled()
-    expect(startButton).toHaveAttribute("data-input-value", "keep active draft")
-    expect(screen.queryByText("widgetChat.messages.error_init")).toBeNull()
-    void activeSend
+    expect(app.sendMessage).toHaveBeenCalledOnce()
+    expect(app.sendMessage).toHaveBeenCalledWith(
+      "first message",
+      { targetTaskId: 42 },
+      [],
+    )
   })
 
-  it("ignores a replaced bootstrap after non-ok task JSON resolves", async () => {
-    localStorage.clear()
-    localStorage.setItem(SHARE_AUTH_KEY, JSON.stringify(successfulAgentAuth))
-    renderSharePage()
+  it("gates New Conversation until the opening send has a definite outcome", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(42, "pending")))
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(43, "pending")))
+    const openingSend = deferred<void>()
+    app.sendMessage.mockReturnValueOnce(openingSend.promise)
+    renderWidgetPage({ widgetKey: "widget-secret" })
 
-    const startButton = await screen.findByRole("button", { name: "start:Support Agent" })
+    await screen.findByRole("button", { name: "start:Support Agent" })
     app.setTaskId.mockClear()
-    app.dispatch.mockClear()
-    const staleJson = deferred<{ detail: string }>()
-    fetchMock.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-      json: () => staleJson.promise,
-    } as Response)
-    fetchMock.mockReturnValueOnce(new Promise(() => undefined))
+    const send = app.startScreenProps!.onSend("first message", [])
 
-    act(() => app.startScreenProps?.onInputChange("keep active draft"))
-    const staleSend = app.startScreenProps!.onSend("stale message", [])
-      .catch(error => error)
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
-    const activeSend = app.startScreenProps!.onSend("active message", [])
-      .catch(error => error)
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
-
-    await act(async () => {
-      staleJson.resolve({ detail: "stale task error" })
-      await staleSend
+    const newConversation = await screen.findByRole("button", {
+      name: "widgetChat.newConversation",
     })
+    expect(newConversation).toBeDisabled()
+    fireEvent.click(newConversation)
+    expect(app.setTaskId).not.toHaveBeenCalledWith(null, { navigate: false })
 
-    expect(localStorage.getItem(SHARE_AUTH_KEY)).not.toBeNull()
-    expect(app.setTaskId).not.toHaveBeenCalled()
-    expect(app.dispatch).not.toHaveBeenCalledWith(expect.objectContaining({
-      type: "SET_CURRENT_TASK",
-    }))
-    expect(app.sendMessage).not.toHaveBeenCalled()
-    expect(startButton).toHaveAttribute("data-input-value", "keep active draft")
-    expect(screen.queryByText("stale task error")).toBeNull()
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    void activeSend
+    openingSend.resolve()
+    await send
+    await waitFor(() => expect(newConversation).toBeEnabled())
+    fireEvent.click(newConversation)
+
+    expect(app.setTaskId).toHaveBeenCalledWith(null, { navigate: false })
+    expect(await screen.findByRole("button", { name: "start:Support Agent" })).toBeInTheDocument()
+
+    await app.startScreenProps!.onSend("next conversation", [])
+    expect(fetchMock.mock.calls.filter(([url]) =>
+      url === "https://api.example/api/widget/chat/task/create")).toHaveLength(2)
+    expect(app.setTaskId).toHaveBeenCalledWith(43, { navigate: false })
   })
 
   it("uses the shared deferred uploader when workforce task creation starts the opening turn", async () => {
@@ -700,6 +679,60 @@ describe("PublicAgentChatPage", () => {
     await waitFor(() => {
       expect(localStorage.getItem("widget_task_wf8_guest-1")).toBe("43")
     })
+  })
+
+  it("keeps the workforce taskless upload context across a partial retry", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(43, "running")))
+    uploads.deferred
+      .mockRejectedValueOnce(new Error("retry upload"))
+      .mockResolvedValueOnce([{ file_id: "uploaded-retry" }])
+    const file = new File(["opening"], "opening.txt", { type: "text/plain" })
+
+    renderWidgetPage({ searchAgentId: null, widgetKey: "widget-secret" })
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+
+    await expect(app.startScreenProps!.onSend("first message", [file]))
+      .rejects.toThrow("retry upload")
+    await expect(app.startScreenProps!.onSend("first message", [file]))
+      .resolves.toBeUndefined()
+
+    const firstContext = uploads.deferred.mock.calls[0][1].uploadContext
+    const retryContext = uploads.deferred.mock.calls[1][1].uploadContext
+    expect(retryContext).toBe(firstContext)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("rotates the workforce taskless upload context for a new conversation", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(43, "running")))
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(44, "running")))
+    uploads.deferred
+      .mockResolvedValueOnce([{ file_id: "conversation-a-file" }])
+      .mockResolvedValueOnce([{ file_id: "conversation-b-file" }])
+    const file = new File(["same"], "same.txt", { type: "text/plain" })
+
+    renderWidgetPage({ searchAgentId: null, widgetKey: "widget-secret" })
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+    await app.startScreenProps!.onSend("conversation A", [file])
+
+    fireEvent.click(await screen.findByRole("button", {
+      name: "widgetChat.newConversation",
+    }))
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+    await app.startScreenProps!.onSend("conversation B", [file])
+
+    expect(uploads.deferred).toHaveBeenCalledTimes(2)
+    expect(uploads.deferred.mock.calls[1][0][0]).toBe(file)
+    expect(uploads.deferred.mock.calls[1][1].uploadContext).not.toBe(
+      uploads.deferred.mock.calls[0][1].uploadContext,
+    )
+    expect(JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string))
+      .toMatchObject({ files: ["conversation-a-file"] })
+    expect(JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string))
+      .toMatchObject({ files: ["conversation-b-file"] })
   })
 
   it("aborts workforce opening uploads on unmount before task creation", async () => {

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Loader2, MessageSquarePlus } from "lucide-react"
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
@@ -127,6 +127,15 @@ const shareGuestIdFromToken = (token: string): string => {
 
 type PublicMessageConfig = Record<string, unknown>
 
+// Consume generation inputs only to trigger a new opaque identity. The cache
+// receives the returned object and never retains those inputs (including tokens).
+const createPublicUploadContext = (...generationInputs: unknown[]): object => {
+  // Reading the count prevents the generation inputs from becoming retained
+  // properties while still making their deliberate consumption explicit.
+  void generationInputs.length
+  return {}
+}
+
 function PublicConversationContent({
   authMode,
   routeToken,
@@ -154,6 +163,13 @@ function PublicConversationContent({
   const [draftFiles, setDraftFiles] = useState<File[]>([])
   const [isBootstrappingTask, setIsBootstrappingTask] = useState(false)
   const [hasResolvedStoredTask, setHasResolvedStoredTask] = useState(false)
+  const bootstrapControllerRef = useRef<AbortController | null>(null)
+  // Object identity scopes taskless retry ids to this public auth generation
+  // without retaining the raw credential in the upload cache.
+  const workforceUploadContext = useMemo(
+    () => createPublicUploadContext(accessToken, authMode, routeToken),
+    [accessToken, authMode, routeToken],
+  )
   const storageKey = authMode === "share"
     // Scope the persisted task-id by guest_id (decoded from the guest JWT) so a
     // task minted under one guest is never read back under another's token — a
@@ -224,6 +240,8 @@ function PublicConversationContent({
   // active taskId, and the visitor is back on the start screen; the next
   // message creates a fresh task through handleSend. #1039
   const handleNewConversation = useCallback(() => {
+    bootstrapControllerRef.current?.abort()
+    bootstrapControllerRef.current = null
     safeRemoveItem(storageKey)
     setTaskId(null, { navigate: false })
     // Nulling taskId closes the socket, so no terminal WS event will ever
@@ -238,6 +256,11 @@ function PublicConversationContent({
     setDraftFiles([])
     setCreateTaskError(null)
   }, [dispatch, storageKey, setTaskId])
+
+  useEffect(() => () => {
+    bootstrapControllerRef.current?.abort()
+    bootstrapControllerRef.current = null
+  }, [])
 
   const handleSend = useCallback(async (
     message: string,
@@ -257,6 +280,9 @@ function PublicConversationContent({
       return
     }
 
+    bootstrapControllerRef.current?.abort()
+    const bootstrapController = new AbortController()
+    bootstrapControllerRef.current = bootstrapController
     setIsBootstrappingTask(true)
     try {
       const taskPayload: Record<string, string | number | string[]> = {
@@ -279,12 +305,18 @@ function PublicConversationContent({
           accessToken,
           taskType: "task",
           fallbackError: t("files.uploadFailed"),
+          signal: bootstrapController.signal,
+          uploadContext: workforceUploadContext,
         })
+        if (bootstrapController.signal.aborted) {
+          throw bootstrapController.signal.reason
+        }
         taskPayload.files = uploaded.map((item) => item.file_id)
       }
 
       const response = await fetch(`${getApiUrl()}${publicApiPrefix}/chat/task/create`, {
         method: "POST",
+        signal: bootstrapController.signal,
         headers: {
           "Content-Type": "application/json",
           "Authorization": `Bearer ${accessToken}`,
@@ -344,8 +376,12 @@ function PublicConversationContent({
     } catch (error) {
       setIsBootstrappingTask(false)
       throw error
+    } finally {
+      if (bootstrapControllerRef.current === bootstrapController) {
+        bootstrapControllerRef.current = null
+      }
     }
-  }, [accessToken, agentId, agentLogo, agentName, authMode, dispatch, onAuthInvalidated, publicApiPrefix, sendMessage, setTaskId, state.taskId, storageKey, t, workforceId])
+  }, [accessToken, agentId, agentLogo, agentName, authMode, dispatch, onAuthInvalidated, publicApiPrefix, sendMessage, setTaskId, state.taskId, storageKey, t, workforceId, workforceUploadContext])
 
   useEffect(() => {
     if (state.taskId || createTaskError) {
@@ -586,6 +622,12 @@ export function PublicAgentChatPage({
   const publicAccessToken = authResult?.access_token ?? ""
   const fileAccess = usePublicFileAccessPolicy(publicAccessToken)
 
+  // A new auth result creates a new cache owner without storing its token.
+  const transportUploadContext = useMemo(
+    () => createPublicUploadContext(authMode, publicAccessToken),
+    [authMode, publicAccessToken],
+  )
+
   const transport = useMemo<AppProviderTransportConfig>(() => ({
     capabilities: {
       agentCards: "disabled",
@@ -606,8 +648,10 @@ export function PublicAgentChatPage({
         taskType: params.taskType,
         taskId: params.taskId,
         fallbackError: t("files.uploadFailed"),
+        signal: params.signal,
+        uploadContext: transportUploadContext,
       }),
-  }), [authMode, fileAccess, publicAccessToken, t])
+  }), [authMode, fileAccess, publicAccessToken, t, transportUploadContext])
 
   if (isInitializing) {
     return (

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -283,6 +283,15 @@ function PublicConversationContent({
     bootstrapControllerRef.current?.abort()
     const bootstrapController = new AbortController()
     bootstrapControllerRef.current = bootstrapController
+    const ensureActiveBootstrap = () => {
+      if (
+        bootstrapControllerRef.current !== bootstrapController
+        || bootstrapController.signal.aborted
+      ) {
+        throw bootstrapController.signal.reason
+          ?? new DOMException("Task bootstrap was cancelled", "AbortError")
+      }
+    }
     setIsBootstrappingTask(true)
     try {
       const taskPayload: Record<string, string | number | string[]> = {
@@ -308,9 +317,7 @@ function PublicConversationContent({
           signal: bootstrapController.signal,
           uploadContext: workforceUploadContext,
         })
-        if (bootstrapController.signal.aborted) {
-          throw bootstrapController.signal.reason
-        }
+        ensureActiveBootstrap()
         taskPayload.files = uploaded.map((item) => item.file_id)
       }
 
@@ -323,8 +330,14 @@ function PublicConversationContent({
         },
         body: JSON.stringify(taskPayload),
       })
+      // Aborting fetch does not prevent an already-resolved Response body from
+      // settling later. Fence both the controller generation and its signal at
+      // every boundary so a replaced bootstrap cannot publish stale results.
+      ensureActiveBootstrap()
 
       if (!response.ok) {
+        const errorData = await response.json().catch(() => null)
+        ensureActiveBootstrap()
         // A share task-create carries no task id, so 401/403 here means the
         // guest token itself is no longer valid (rotated/disabled link, or a
         // legacy token rejected post-#973). Drop the persisted token and force
@@ -333,13 +346,13 @@ function PublicConversationContent({
           safeRemoveItem(storageKey)
           onAuthInvalidated?.()
         }
-        const errorData = await response.json().catch(() => null)
         const errorMessage = errorData?.detail || t("widgetChat.messages.error_init")
         setCreateTaskError(errorMessage)
         throw new Error(errorMessage)
       }
 
       const taskData = await response.json()
+      ensureActiveBootstrap()
       const newTaskId = taskData.task_id
       if (typeof newTaskId !== "number") {
         throw new Error("Task creation failed")
@@ -366,6 +379,7 @@ function PublicConversationContent({
 
       if (!workforceId) {
         await sendMessage(message, { ...config, targetTaskId: newTaskId }, files)
+        ensureActiveBootstrap()
       }
       // Workforce share sessions already started their first turn (with the
       // files threaded in above) inside task creation — the connection
@@ -374,7 +388,9 @@ function PublicConversationContent({
       setDraftMessage("")
       setDraftFiles([])
     } catch (error) {
-      setIsBootstrappingTask(false)
+      if (bootstrapControllerRef.current === bootstrapController) {
+        setIsBootstrappingTask(false)
+      }
       throw error
     } finally {
       if (bootstrapControllerRef.current === bootstrapController) {

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -342,9 +342,9 @@ function PublicConversationContent({
         },
         body: JSON.stringify(taskPayload),
       })
-      // Aborting fetch does not prevent an already-resolved Response body from
-      // settling later. Fence both the controller generation and its signal at
-      // every boundary so a replaced bootstrap cannot publish stale results.
+      // Owner cancellation can race with an already-resolved response or
+      // delayed body parsing. Fence every boundary so an unmounted bootstrap
+      // cannot publish stale results.
       ensureActiveBootstrap()
 
       if (!response.ok) {
@@ -404,8 +404,6 @@ function PublicConversationContent({
       // duplicate the turn.
       setDraftMessage("")
       setDraftFiles([])
-    } catch (error) {
-      throw error
     } finally {
       if (bootstrapControllerRef.current === bootstrapController) {
         bootstrapControllerRef.current = null

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -163,12 +163,18 @@ function PublicConversationContent({
   const [draftFiles, setDraftFiles] = useState<File[]>([])
   const [isBootstrappingTask, setIsBootstrappingTask] = useState(false)
   const [hasResolvedStoredTask, setHasResolvedStoredTask] = useState(false)
+  const [workforceUploadGeneration, setWorkforceUploadGeneration] = useState(0)
   const bootstrapControllerRef = useRef<AbortController | null>(null)
-  // Object identity scopes taskless retry ids to this public auth generation
-  // without retaining the raw credential in the upload cache.
+  // Object identity retains taskless upload successes across retries for one
+  // pending conversation, then rotates when that conversation is acknowledged.
   const workforceUploadContext = useMemo(
-    () => createPublicUploadContext(accessToken, authMode, routeToken),
-    [accessToken, authMode, routeToken],
+    () => createPublicUploadContext(
+      accessToken,
+      authMode,
+      routeToken,
+      workforceUploadGeneration,
+    ),
+    [accessToken, authMode, routeToken, workforceUploadGeneration],
   )
   const storageKey = authMode === "share"
     // Scope the persisted task-id by guest_id (decoded from the guest JWT) so a
@@ -240,8 +246,11 @@ function PublicConversationContent({
   // active taskId, and the visitor is back on the start screen; the next
   // message creates a fresh task through handleSend. #1039
   const handleNewConversation = useCallback(() => {
-    bootstrapControllerRef.current?.abort()
-    bootstrapControllerRef.current = null
+    // Task creation and the agent opening send form one bootstrap operation.
+    // Do not let a reset cancel it after the server may have created the task.
+    if (bootstrapControllerRef.current) return
+
+    setWorkforceUploadGeneration((generation) => generation + 1)
     safeRemoveItem(storageKey)
     setTaskId(null, { navigate: false })
     // Nulling taskId closes the socket, so no terminal WS event will ever
@@ -267,6 +276,10 @@ function PublicConversationContent({
     config?: PublicMessageConfig,
     files?: File[],
   ) => {
+    // This ref is set before any React state update or await. Reentrant sends
+    // are ignored without replacing or duplicating the active bootstrap.
+    if (bootstrapControllerRef.current) return
+
     if (state.taskId) {
       await sendMessage(message, config, files)
       return
@@ -280,7 +293,6 @@ function PublicConversationContent({
       return
     }
 
-    bootstrapControllerRef.current?.abort()
     const bootstrapController = new AbortController()
     bootstrapControllerRef.current = bootstrapController
     const ensureActiveBootstrap = () => {
@@ -358,6 +370,11 @@ function PublicConversationContent({
         throw new Error("Task creation failed")
       }
 
+      // A valid task id acknowledges the taskless upload generation. Future
+      // conversations must POST even when the visitor selects the same File.
+      if (workforceId) {
+        setWorkforceUploadGeneration((generation) => generation + 1)
+      }
       setTaskId(newTaskId, { navigate: false })
       dispatch({
         type: "SET_CURRENT_TASK",
@@ -388,22 +405,14 @@ function PublicConversationContent({
       setDraftMessage("")
       setDraftFiles([])
     } catch (error) {
-      if (bootstrapControllerRef.current === bootstrapController) {
-        setIsBootstrappingTask(false)
-      }
       throw error
     } finally {
       if (bootstrapControllerRef.current === bootstrapController) {
         bootstrapControllerRef.current = null
+        setIsBootstrappingTask(false)
       }
     }
   }, [accessToken, agentId, agentLogo, agentName, authMode, dispatch, onAuthInvalidated, publicApiPrefix, sendMessage, setTaskId, state.taskId, storageKey, t, workforceId, workforceUploadContext])
-
-  useEffect(() => {
-    if (state.taskId || createTaskError) {
-      setIsBootstrappingTask(false)
-    }
-  }, [createTaskError, state.taskId])
 
   const resolvedAgentName = state.currentTask?.agentName || agentName || t("widgetChat.title")
   const resolvedAgentLogo = state.currentTask?.agentLogoUrl || agentLogo || null
@@ -442,9 +451,10 @@ function PublicConversationContent({
             <button
               type="button"
               onClick={handleNewConversation}
+              disabled={isBootstrappingTask}
               title={t("widgetChat.newConversation")}
               aria-label={t("widgetChat.newConversation")}
-              className="ml-auto p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              className="ml-auto p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
             >
               <MessageSquarePlus className="w-4 h-4" />
             </button>

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -7,7 +7,7 @@ import { TaskConversationPanel } from "@/components/task/task-conversation-panel
 import { AppProvider, useApp, type AppProviderTransportConfig } from "@/contexts/app-context-chat"
 import { usePublicFileAccessPolicy } from "@/contexts/file-access-context"
 import { useI18n } from "@/contexts/i18n-context"
-import { uploadPublicChatFile } from "@/lib/public-chat-file-upload"
+import { uploadDeferredPublicChatFiles } from "@/lib/public-chat-file-upload"
 import { normalizeTaskStatus } from "@/lib/task-status"
 import {
   getApiUrl,
@@ -274,13 +274,12 @@ function PublicConversationContent({
       // exists yet) and threaded in as file ids BEFORE the run begins;
       // otherwise the first turn never sees them.
       if (workforceId && files?.length) {
-        const uploaded = await Promise.all(files.map((file) => uploadPublicChatFile({
+        const uploaded = await uploadDeferredPublicChatFiles(files, {
           url: `${getApiUrl()}${publicApiPrefix}/files/upload`,
           accessToken,
-          file,
           taskType: "task",
           fallbackError: t("files.uploadFailed"),
-        })))
+        })
         taskPayload.files = uploaded.map((item) => item.file_id)
       }
 
@@ -601,16 +600,13 @@ export function PublicAgentChatPage({
       `${baseUrl}/${authMode === "share" ? "api/share" : "api/widget"}/chat/ws/${taskId}${token ? `?token=${token}` : ""}`,
     fileAccess,
     uploadFiles: (files, params) =>
-      Promise.all(files.map((file) =>
-        uploadPublicChatFile({
-          url: `${getApiUrl()}/${authMode === "share" ? "api/share" : "api/widget"}/files/upload`,
-          accessToken: publicAccessToken,
-          file,
-          taskType: params.taskType,
-          taskId: params.taskId,
-          fallbackError: t("files.uploadFailed"),
-        }),
-      )),
+      uploadDeferredPublicChatFiles(files, {
+        url: `${getApiUrl()}/${authMode === "share" ? "api/share" : "api/widget"}/files/upload`,
+        accessToken: publicAccessToken,
+        taskType: params.taskType,
+        taskId: params.taskId,
+        fallbackError: t("files.uploadFailed"),
+      }),
   }), [authMode, fileAccess, publicAccessToken, t])
 
   if (isInitializing) {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -1653,6 +1653,28 @@ describe("AppProvider websocket message routing", () => {
     })
   })
 
+  it("passes caller-owned upload cancellation through the provider transport seam", async () => {
+    const uploadFiles = vi.fn().mockResolvedValue([])
+    render(
+      <AppProvider token="token" transport={{ uploadFiles }}>
+        <StateProbe />
+      </AppProvider>,
+    )
+    const signal = new AbortController().signal
+    const wiredUpload = webSocketOptions.current?.uploadFiles as (
+      files: File[],
+      params: { taskType: string; taskId?: number | null; signal: AbortSignal },
+    ) => Promise<unknown>
+
+    await wiredUpload([], { taskType: "task", taskId: 7, signal })
+
+    expect(uploadFiles).toHaveBeenCalledWith([], {
+      taskType: "task",
+      taskId: 7,
+      signal,
+    })
+  })
+
   it("passes the persistent Session transport contract and sends the first taskless turn only through the socket", async () => {
     const transport = makeSessionTransport()
     const acknowledgement = deferred<{

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1555,7 +1555,11 @@ export interface AppProviderTransportConfig {
    * transports use this to keep guest credentials instance-scoped.
    */
   fileAccess?: FileAccessPolicy
-  uploadFiles?: (files: File[], params: { taskId?: number | null; taskType: string }) => Promise<Array<{ file_id: string; name?: string; size?: number; type?: string }>>
+  uploadFiles?: (files: File[], params: {
+    taskId?: number | null
+    taskType: string
+    signal: AbortSignal
+  }) => Promise<Array<{ file_id: string; name?: string; size?: number; type?: string }>>
   capabilities?: AppProviderTransportCapabilities
   session?: {
     connection: WebSocketConnection | null

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -5623,7 +5623,7 @@ export function AppProvider({
               const uploadResponse = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
                 method: 'POST',
                 body: formData
-              })
+              }, { retryTransport: false })
 
               const parsed = await parseApiResponse(uploadResponse)
 

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -2499,6 +2499,9 @@ describe("useWebSocket normalized connections", () => {
       await Promise.resolve()
     })
     const oldSettledBeforeUploadCompleted = oldSettled
+    expect(uploadFiles.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+    expect(uploadFiles.mock.calls[0][1].signal.aborted).toBe(true)
+    expect(uploadFiles.mock.calls[1][1].signal.aborted).toBe(false)
 
     await act(async () => {
       oldUpload.resolve([{ file_id: "stale-file" }])

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -1208,7 +1208,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
                 'Authorization': `Bearer ${tokenRef.current ?? localStorage.getItem('token') ?? ''}`,
               },
               body: formData,
-            })
+            }, { retryTransport: false })
             const parsed = await parseApiResponse(response)
             if (!response.ok || !isJsonRecord(parsed.data)) {
               throw deliveryError(getUploadErrorMessage(response, parsed, {

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -124,6 +124,7 @@ interface MessagePreparationClaim {
   cancellation: Promise<never>
   cancel: (error: Error) => void
   cancelled: boolean
+  uploadController: AbortController
   connectionIdentity: string
   descriptorKey: ConnectionDescriptorIdentity
   lifecycleEpoch: number
@@ -208,7 +209,11 @@ export interface UseWebSocketOptions {
   taskId?: number
   token?: string
   buildWebSocketUrl?: (params: { baseUrl: string; taskId: number; token?: string }) => string
-  uploadFiles?: (files: File[], params: { taskId?: number | null; taskType: string }) => Promise<Array<{ file_id: string; name?: string; size?: number; type?: string }>>
+  uploadFiles?: (files: File[], params: {
+    taskId?: number | null
+    taskType: string
+    signal: AbortSignal
+  }) => Promise<Array<{ file_id: string; name?: string; size?: number; type?: string }>>
   connection?: WebSocketConnection | null
   deliveryGeneration?: number
   onConnectionClose?: (event: CloseEvent) => "handled" | "default"
@@ -1146,14 +1151,17 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     const cancellation = new Promise<never>((_resolve, reject) => {
       rejectCancellation = reject
     })
+    const uploadController = new AbortController()
     const claim: MessagePreparationClaim = {
       cancellation,
       cancel: (error) => {
         if (claim.cancelled) return
         claim.cancelled = true
+        uploadController.abort(error)
         rejectCancellation(error)
       },
       cancelled: false,
+      uploadController,
       connectionIdentity: connection.identity,
       descriptorKey: currentDescriptorKey,
       lifecycleEpoch: currentLifecycleEpoch,
@@ -1193,6 +1201,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
             uploadFiles(filesToUpload, {
               taskId: currentTaskId,
               taskType: 'task',
+              signal: claim.uploadController.signal,
             }),
             claim.cancellation,
           ])
@@ -1204,6 +1213,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
             formData.append('task_id', currentTaskId.toString())
             const response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
               method: 'POST',
+              signal: claim.uploadController.signal,
               headers: {
                 'Authorization': `Bearer ${tokenRef.current ?? localStorage.getItem('token') ?? ''}`,
               },

--- a/frontend/src/lib/api-wrapper.test.ts
+++ b/frontend/src/lib/api-wrapper.test.ts
@@ -238,6 +238,61 @@ describe("api-wrapper auth refresh", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it("does not generically retry a failed upload replay after refreshing auth", async () => {
+    writeAuthCache(user, "old-access", "old-refresh", 120, 240)
+    const uploadUrl = "http://api.local/api/files/upload"
+    const replayError = new TypeError("replay connection lost")
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (input, options) => {
+        const url = String(input)
+        const authorization = new Headers(options?.headers).get("Authorization")
+
+        if (url.endsWith("/api/auth/refresh")) {
+          return new Response(JSON.stringify({
+            success: true,
+            access_token: "new-access",
+            refresh_token: "new-refresh",
+            expires_in: 120,
+            refresh_expires_in: 240,
+          }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+        if (url === uploadUrl && authorization === "Bearer old-access") {
+          return new Response(null, {
+            status: 401,
+            headers: { "Error-Type": "TokenExpired" },
+          })
+        }
+        if (url === uploadUrl && authorization === "Bearer new-access") {
+          throw replayError
+        }
+        throw new Error(`Unexpected request: ${url}`)
+      },
+    )
+
+    await expect(apiRequest(
+      uploadUrl,
+      { method: "POST", body: new FormData() },
+      { retryTransport: false },
+    )).rejects.toBe(replayError)
+
+    expect(readAuthCache()).toMatchObject({
+      token: "new-access",
+      refreshToken: "new-refresh",
+    })
+    expect(fetchMock.mock.calls.map(([input, options]) => ({
+      url: String(input),
+      authorization: new Headers(options?.headers).get("Authorization"),
+    }))).toEqual([
+      { url: uploadUrl, authorization: "Bearer old-access" },
+      { url: expect.stringMatching(/\/api\/auth\/refresh$/), authorization: null },
+      { url: uploadUrl, authorization: "Bearer new-access" },
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
   it("replays once when the profile advances after the refreshed credential is committed", async () => {
     writeAuthCache(user, "old-access", "old-refresh", 120, 240)
     const updateProfileAfterRefresh = () => {

--- a/frontend/src/lib/api-wrapper.test.ts
+++ b/frontend/src/lib/api-wrapper.test.ts
@@ -224,6 +224,20 @@ describe("api-wrapper auth refresh", () => {
     mockNavigatorLocks()
   })
 
+  it("does not replay an upload after an ambiguous transport failure", async () => {
+    writeAuthCache(user, "access-token", "refresh-token", 120, 240)
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValue(new TypeError("network connection lost"))
+
+    await expect(apiRequest(
+      "http://api.local/api/files/upload",
+      { method: "POST", body: new FormData() },
+      { retryTransport: false },
+    )).rejects.toThrow("network connection lost")
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it("replays once when the profile advances after the refreshed credential is committed", async () => {
     writeAuthCache(user, "old-access", "old-refresh", 120, 240)
     const updateProfileAfterRefresh = () => {

--- a/frontend/src/lib/api-wrapper.ts
+++ b/frontend/src/lib/api-wrapper.ts
@@ -142,11 +142,19 @@ export function refreshStoredAccessToken(expectedSession: AuthSessionSnapshot): 
 function withBearer(options: RequestInit, token: string): RequestInit {
   return { ...options, headers: { ...options.headers, Authorization: `Bearer ${token}` } }
 }
+export interface ApiRequestPolicy { retryTransport?: boolean }
 /** A request has at most one post-401 replay, bound to an exact immutable credential snapshot. */
-export async function apiRequest(url: string, options: RequestInit = {}): Promise<Response> {
+export async function apiRequest(
+  url: string,
+  options: RequestInit = {},
+  policy: ApiRequestPolicy = {},
+): Promise<Response> {
   const session = readAuthSessionSnapshot()
   if (!session.accessToken) return fetch(url, options)
-  const response = await fetchWithRetry(url, withBearer(options, session.accessToken))
+  const authenticatedOptions = withBearer(options, session.accessToken)
+  const response = await (policy.retryTransport === false
+    ? fetch(url, authenticatedOptions)
+    : fetchWithRetry(url, authenticatedOptions))
   if (response.status !== 401 || shouldSkipRefresh(url)) return response
   const afterResponse = compareAuthSession(session)
   if (afterResponse.status === "credentials_advanced" || afterResponse.status === "credentials_and_profile_advanced") {

--- a/frontend/src/lib/public-chat-file-upload.test.ts
+++ b/frontend/src/lib/public-chat-file-upload.test.ts
@@ -1,6 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { uploadPublicChatFile } from "./public-chat-file-upload"
+import {
+  uploadDeferredPublicChatFiles,
+  uploadPublicChatFile,
+} from "./public-chat-file-upload"
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
 
 describe("uploadPublicChatFile", () => {
   afterEach(() => {
@@ -37,10 +57,7 @@ describe("uploadPublicChatFile", () => {
 
   it("returns normalized file metadata for successful uploads", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ success: true, file_id: "file-1" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+      jsonResponse({ success: true, file_id: "file-1" }),
     )
     const file = new File(["trip"], "trip.txt", { type: "text/plain" })
 
@@ -56,5 +73,122 @@ describe("uploadPublicChatFile", () => {
       size: 4,
       type: "text/plain",
     })
+  })
+})
+
+describe("uploadDeferredPublicChatFiles", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const options = {
+    url: "http://api.local/api/share/files/upload",
+    accessToken: "guest-token",
+    taskType: "task",
+    fallbackError: "Upload failed",
+  }
+
+  it("admits uploads FIFO with at most three active requests through drainage", async () => {
+    const requests = Array.from({ length: 7 }, () => deferred<Response>())
+    const admitted: string[] = []
+    let active = 0
+    let maxActive = 0
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const file = (init?.body as FormData).get("file") as File
+      const request = requests[admitted.length]
+      admitted.push(file.name)
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      try {
+        return await request.promise
+      } finally {
+        active -= 1
+      }
+    })
+    const files = Array.from(
+      { length: 7 },
+      (_, index) => new File([`${index}`], `file-${index}.txt`),
+    )
+
+    const upload = uploadDeferredPublicChatFiles(files, options)
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(admitted).toEqual(["file-0.txt", "file-1.txt", "file-2.txt"])
+    for (let index = 0; index < requests.length; index += 1) {
+      requests[index].resolve(jsonResponse({
+        success: true,
+        file_id: `id-${index}`,
+      }))
+      if (index < requests.length - 3) {
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(index + 4))
+      }
+      expect(active).toBeLessThanOrEqual(3)
+    }
+
+    await expect(upload).resolves.toEqual(files.map((file, index) => ({
+      file_id: `id-${index}`,
+      name: file.name,
+      size: file.size,
+      type: file.type,
+    })))
+    expect(admitted).toEqual(files.map((file) => file.name))
+    expect(maxActive).toBe(3)
+  })
+
+  it("settles every scheduled upload and preserves successful ids after partial failure", async () => {
+    const requests = Array.from({ length: 4 }, () => deferred<Response>())
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => requests[fetchMock.mock.calls.length - 1].promise,
+    )
+    const files = Array.from(
+      { length: 4 },
+      (_, index) => new File([`${index}`], `file-${index}.txt`),
+    )
+    let settled = false
+
+    const upload = uploadDeferredPublicChatFiles(files, options).finally(() => {
+      settled = true
+    })
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    requests[0].resolve(jsonResponse({ success: true, file_id: "id-0" }))
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4))
+    requests[1].resolve(jsonResponse({ detail: "storage unavailable" }, 503))
+    requests[2].resolve(jsonResponse({ success: true, file_id: "id-2" }))
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    requests[3].resolve(jsonResponse({ success: true, file_id: "id-3" }))
+
+    await expect(upload).rejects.toThrow("storage unavailable")
+    expect((files[0] as File & { file_id?: string }).file_id).toBe("id-0")
+    expect((files[1] as File & { file_id?: string }).file_id).toBeUndefined()
+    expect((files[2] as File & { file_id?: string }).file_id).toBe("id-2")
+    expect((files[3] as File & { file_id?: string }).file_id).toBe("id-3")
+  })
+
+  it("skips files that succeeded when the same selection is retried", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "id-success" }))
+      .mockResolvedValueOnce(jsonResponse({ detail: "retry me" }, 503))
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "id-retry" }))
+    const successful = new File(["ok"], "successful.txt")
+    const retry = new File(["retry"], "retry.txt")
+
+    await expect(
+      uploadDeferredPublicChatFiles([successful, retry], options),
+    ).rejects.toThrow("retry me")
+    await expect(
+      uploadDeferredPublicChatFiles([successful, retry], options),
+    ).resolves.toEqual([
+      expect.objectContaining({ file_id: "id-success", name: "successful.txt" }),
+      expect.objectContaining({ file_id: "id-retry", name: "retry.txt" }),
+    ])
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls.map(([, init]) =>
+      ((init?.body as FormData).get("file") as File).name)).toEqual([
+      "successful.txt",
+      "retry.txt",
+      "retry.txt",
+    ])
   })
 })

--- a/frontend/src/lib/public-chat-file-upload.test.ts
+++ b/frontend/src/lib/public-chat-file-upload.test.ts
@@ -78,14 +78,17 @@ describe("uploadPublicChatFile", () => {
 
 describe("uploadDeferredPublicChatFiles", () => {
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
+  const uploadContext = {}
   const options = {
     url: "http://api.local/api/share/files/upload",
     accessToken: "guest-token",
     taskType: "task",
     fallbackError: "Upload failed",
+    uploadContext,
   }
 
   it("admits uploads FIFO with at most three active requests through drainage", async () => {
@@ -159,10 +162,8 @@ describe("uploadDeferredPublicChatFiles", () => {
     requests[3].resolve(jsonResponse({ success: true, file_id: "id-3" }))
 
     await expect(upload).rejects.toThrow("storage unavailable")
-    expect((files[0] as File & { file_id?: string }).file_id).toBe("id-0")
-    expect((files[1] as File & { file_id?: string }).file_id).toBeUndefined()
-    expect((files[2] as File & { file_id?: string }).file_id).toBe("id-2")
-    expect((files[3] as File & { file_id?: string }).file_id).toBe("id-3")
+    // Cache state is context-scoped rather than published as a bare File id.
+    expect(files.every(file => !("file_id" in file))).toBe(true)
   })
 
   it("skips files that succeeded when the same selection is retried", async () => {
@@ -190,5 +191,170 @@ describe("uploadDeferredPublicChatFiles", () => {
       "retry.txt",
       "retry.txt",
     ])
+  })
+
+  it("does not reuse ids across task or taskless upload scopes", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "task-a" }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "task-b" }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "taskless" }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "task-bound" }))
+    const taskFile = new File(["same"], "task.txt")
+    const bindingFile = new File(["same"], "binding.txt")
+
+    await expect(uploadDeferredPublicChatFiles([taskFile], {
+      ...options,
+      taskId: 1,
+    })).resolves.toEqual([expect.objectContaining({ file_id: "task-a" })])
+    await expect(uploadDeferredPublicChatFiles([taskFile], {
+      ...options,
+      taskId: 2,
+    })).resolves.toEqual([expect.objectContaining({ file_id: "task-b" })])
+    await expect(uploadDeferredPublicChatFiles([bindingFile], options))
+      .resolves.toEqual([expect.objectContaining({ file_id: "taskless" })])
+    await expect(uploadDeferredPublicChatFiles([bindingFile], {
+      ...options,
+      taskId: 3,
+    })).resolves.toEqual([expect.objectContaining({ file_id: "task-bound" })])
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it("does not let a late obsolete attempt publish over the current attempt", async () => {
+    const first = deferred<Response>()
+    const second = deferred<Response>()
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    const file = new File(["same"], "late.txt")
+
+    const staleUpload = uploadDeferredPublicChatFiles([file], options)
+    const currentUpload = uploadDeferredPublicChatFiles([file], options)
+    second.resolve(jsonResponse({ success: true, file_id: "current" }))
+    await expect(currentUpload).resolves.toEqual([
+      expect.objectContaining({ file_id: "current" }),
+    ])
+    first.resolve(jsonResponse({ success: true, file_id: "stale" }))
+    await expect(staleUpload).resolves.toEqual([
+      expect.objectContaining({ file_id: "stale" }),
+    ])
+
+    await expect(uploadDeferredPublicChatFiles([file], options)).resolves.toEqual([
+      expect.objectContaining({ file_id: "current" }),
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("removes an aborted queued upload without fetching it", async () => {
+    const active = Array.from({ length: 3 }, () => deferred<Response>())
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => active[fetchMock.mock.calls.length - 1].promise,
+    )
+    const occupied = uploadDeferredPublicChatFiles(
+      Array.from({ length: 3 }, (_, index) => new File(["x"], `active-${index}.txt`)),
+      options,
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    const controller = new AbortController()
+    const queued = uploadDeferredPublicChatFiles(
+      [new File(["queued"], "queued.txt")],
+      { ...options, signal: controller.signal },
+    )
+
+    controller.abort()
+    await expect(queued).rejects.toMatchObject({ name: "AbortError" })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    active.forEach((request, index) => request.resolve(
+      jsonResponse({ success: true, file_id: `active-${index}` }),
+    ))
+    await occupied
+  })
+
+  it("aborts an active upload and drains its slot", async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => (
+      new Promise<Response>((resolve, reject) => {
+        const file = (init?.body as FormData).get("file") as File
+        if (file.name === "replacement.txt") {
+          resolve(jsonResponse({ success: true, file_id: "replacement" }))
+          return
+        }
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
+      })
+    ))
+    const occupied = uploadDeferredPublicChatFiles(
+      [
+        new File(["x"], "cancel.txt"),
+        new File(["x"], "stall-1.txt"),
+        new File(["x"], "stall-2.txt"),
+      ],
+      { ...options, signal: controller.signal },
+    )
+    const replacement = uploadDeferredPublicChatFiles(
+      [new File(["x"], "replacement.txt")],
+      options,
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+
+    controller.abort()
+    await expect(occupied).rejects.toMatchObject({ name: "AbortError" })
+    await expect(replacement).resolves.toEqual([
+      expect.objectContaining({ file_id: "replacement" }),
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it("applies the admitted timeout to response parsing", async () => {
+    vi.useFakeTimers()
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => new Promise<unknown>(() => undefined),
+    } as Response)
+    const upload = uploadDeferredPublicChatFiles(
+      [new File(["x"], "parsing.txt")],
+      { ...options, timeoutMs: 1_000 },
+    )
+    const expectation = expect(upload).rejects.toMatchObject({
+      name: "TimeoutError",
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await expectation
+    vi.useRealTimers()
+  })
+
+  it("times out admitted uploads and cannot wedge later work", async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => (
+      new Promise<Response>((resolve, reject) => {
+        const file = (init?.body as FormData).get("file") as File
+        if (file.name === "later.txt") {
+          resolve(jsonResponse({ success: true, file_id: "later" }))
+          return
+        }
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
+      })
+    ))
+    const stalled = uploadDeferredPublicChatFiles(
+      Array.from({ length: 3 }, (_, index) => new File(["x"], `stall-${index}.txt`)),
+      { ...options, timeoutMs: 1_000 },
+    )
+    const later = uploadDeferredPublicChatFiles(
+      [new File(["x"], "later.txt")],
+      options,
+    )
+    const stalledExpectation = expect(stalled).rejects.toMatchObject({
+      name: "TimeoutError",
+    })
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await stalledExpectation
+    await expect(later).resolves.toEqual([
+      expect.objectContaining({ file_id: "later" }),
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    vi.useRealTimers()
   })
 })

--- a/frontend/src/lib/public-chat-file-upload.test.ts
+++ b/frontend/src/lib/public-chat-file-upload.test.ts
@@ -78,7 +78,6 @@ describe("uploadPublicChatFile", () => {
 
 describe("uploadDeferredPublicChatFiles", () => {
   afterEach(() => {
-    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -220,6 +219,30 @@ describe("uploadDeferredPublicChatFiles", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4)
   })
 
+  it("posts the same taskless File again for a new conversation context", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "conversation-a" }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "conversation-b" }))
+    const file = new File(["same"], "same.txt")
+    const conversationA = {}
+    const conversationB = {}
+
+    await expect(uploadDeferredPublicChatFiles([file], {
+      ...options,
+      uploadContext: conversationA,
+    })).resolves.toEqual([expect.objectContaining({ file_id: "conversation-a" })])
+    await expect(uploadDeferredPublicChatFiles([file], {
+      ...options,
+      uploadContext: conversationA,
+    })).resolves.toEqual([expect.objectContaining({ file_id: "conversation-a" })])
+    await expect(uploadDeferredPublicChatFiles([file], {
+      ...options,
+      uploadContext: conversationB,
+    })).resolves.toEqual([expect.objectContaining({ file_id: "conversation-b" })])
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it("does not let a late obsolete attempt publish over the current attempt", async () => {
     const first = deferred<Response>()
     const second = deferred<Response>()
@@ -305,56 +328,4 @@ describe("uploadDeferredPublicChatFiles", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4)
   })
 
-  it("applies the admitted timeout to response parsing", async () => {
-    vi.useFakeTimers()
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      json: () => new Promise<unknown>(() => undefined),
-    } as Response)
-    const upload = uploadDeferredPublicChatFiles(
-      [new File(["x"], "parsing.txt")],
-      { ...options, timeoutMs: 1_000 },
-    )
-    const expectation = expect(upload).rejects.toMatchObject({
-      name: "TimeoutError",
-    })
-
-    await vi.advanceTimersByTimeAsync(1_000)
-
-    await expectation
-    vi.useRealTimers()
-  })
-
-  it("times out admitted uploads and cannot wedge later work", async () => {
-    vi.useFakeTimers()
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => (
-      new Promise<Response>((resolve, reject) => {
-        const file = (init?.body as FormData).get("file") as File
-        if (file.name === "later.txt") {
-          resolve(jsonResponse({ success: true, file_id: "later" }))
-          return
-        }
-        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
-      })
-    ))
-    const stalled = uploadDeferredPublicChatFiles(
-      Array.from({ length: 3 }, (_, index) => new File(["x"], `stall-${index}.txt`)),
-      { ...options, timeoutMs: 1_000 },
-    )
-    const later = uploadDeferredPublicChatFiles(
-      [new File(["x"], "later.txt")],
-      options,
-    )
-    const stalledExpectation = expect(stalled).rejects.toMatchObject({
-      name: "TimeoutError",
-    })
-    await vi.advanceTimersByTimeAsync(1_000)
-
-    await stalledExpectation
-    await expect(later).resolves.toEqual([
-      expect.objectContaining({ file_id: "later" }),
-    ])
-    expect(fetchMock).toHaveBeenCalledTimes(4)
-    vi.useRealTimers()
-  })
 })

--- a/frontend/src/lib/public-chat-file-upload.ts
+++ b/frontend/src/lib/public-chat-file-upload.ts
@@ -14,6 +14,54 @@ interface UploadPublicChatFileOptions {
   fallbackError: string
 }
 
+type UploadDeferredPublicChatFilesOptions = Omit<UploadPublicChatFileOptions, "file">
+type PublicChatFileWithUploadId = File & { file_id?: string }
+
+type ScheduledUpload = {
+  run: () => Promise<PublicChatUploadedFile>
+  resolve: (file: PublicChatUploadedFile) => void
+  reject: (reason: unknown) => void
+}
+
+const MAX_ACTIVE_DEFERRED_UPLOADS = 3
+const deferredUploadQueue: ScheduledUpload[] = []
+let activeDeferredUploads = 0
+
+/**
+ * Drain the process-wide browser queue in admission order. A single queue keeps
+ * separate public-chat send paths from collectively exceeding the three-upload
+ * ceiling when their lifetimes overlap.
+ */
+function drainDeferredUploadQueue() {
+  while (
+    activeDeferredUploads < MAX_ACTIVE_DEFERRED_UPLOADS
+    && deferredUploadQueue.length > 0
+  ) {
+    const scheduled = deferredUploadQueue.shift()
+    if (!scheduled) {
+      return
+    }
+
+    activeDeferredUploads += 1
+    void scheduled.run()
+      .then(scheduled.resolve, scheduled.reject)
+      .finally(() => {
+        activeDeferredUploads -= 1
+        drainDeferredUploadQueue()
+      })
+  }
+}
+
+function scheduleDeferredUpload(
+  run: () => Promise<PublicChatUploadedFile>,
+): Promise<PublicChatUploadedFile> {
+  const scheduled = new Promise<PublicChatUploadedFile>((resolve, reject) => {
+    deferredUploadQueue.push({ run, resolve, reject })
+  })
+  drainDeferredUploadQueue()
+  return scheduled
+}
+
 interface PublicChatUploadResponse {
   success?: boolean
   file_id?: unknown
@@ -21,6 +69,7 @@ interface PublicChatUploadResponse {
   message?: unknown
 }
 
+/** Upload one public-chat file without changing the existing request contract. */
 export async function uploadPublicChatFile({
   url,
   accessToken,
@@ -59,4 +108,45 @@ export async function uploadPublicChatFile({
     size: file.size,
     type: file.type,
   }
+}
+
+/**
+ * Upload a deferred selection with bounded FIFO admission.
+ *
+ * Every selected file is allowed to settle even when another upload fails.
+ * Successful ids are written back to their source File, matching the chat
+ * transport's pre-uploaded-file convention so a user retry reuses completed
+ * work instead of issuing another POST.
+ */
+export async function uploadDeferredPublicChatFiles(
+  files: File[],
+  options: UploadDeferredPublicChatFilesOptions,
+): Promise<PublicChatUploadedFile[]> {
+  const uploads = files.map((file) => {
+    const sourceFile = file as PublicChatFileWithUploadId
+    if (sourceFile.file_id) {
+      return Promise.resolve({
+        file_id: sourceFile.file_id,
+        name: file.name,
+        size: file.size,
+        type: file.type,
+      })
+    }
+
+    return scheduleDeferredUpload(async () => {
+      const uploaded = await uploadPublicChatFile({ ...options, file })
+      sourceFile.file_id = uploaded.file_id
+      return uploaded
+    })
+  })
+  const settled = await Promise.allSettled(uploads)
+  const failed = settled.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  )
+
+  if (failed) {
+    throw failed.reason
+  }
+
+  return settled.map((result) => (result as PromiseFulfilledResult<PublicChatUploadedFile>).value)
 }

--- a/frontend/src/lib/public-chat-file-upload.ts
+++ b/frontend/src/lib/public-chat-file-upload.ts
@@ -12,25 +12,72 @@ interface UploadPublicChatFileOptions {
   taskType: string
   taskId?: number | string | null
   fallbackError: string
+  signal?: AbortSignal
 }
 
-type UploadDeferredPublicChatFilesOptions = Omit<UploadPublicChatFileOptions, "file">
-type PublicChatFileWithUploadId = File & { file_id?: string }
+interface UploadDeferredPublicChatFilesOptions extends Omit<UploadPublicChatFileOptions, "file"> {
+  /**
+   * Stable identity for the credential/session generation that owns this
+   * upload. Object identity scopes cached ids without retaining raw tokens.
+   */
+  uploadContext: object
+  /** Timeout after scheduler admission. It covers fetch and body parsing. */
+  timeoutMs?: number
+}
 
 type ScheduledUpload = {
-  run: () => Promise<PublicChatUploadedFile>
+  run: (signal: AbortSignal) => Promise<PublicChatUploadedFile>
   resolve: (file: PublicChatUploadedFile) => void
   reject: (reason: unknown) => void
+  signal?: AbortSignal
+  timeoutMs: number
+  abortQueued: () => void
+}
+
+interface CachedUploadState {
+  currentAttempt?: symbol
+  uploaded?: PublicChatUploadedFile
 }
 
 const MAX_ACTIVE_DEFERRED_UPLOADS = 3
+const DEFAULT_DEFERRED_UPLOAD_TIMEOUT_MS = 30_000
 const deferredUploadQueue: ScheduledUpload[] = []
+const deferredUploadCache = new WeakMap<
+  File,
+  WeakMap<object, Map<string, CachedUploadState>>
+>()
 let activeDeferredUploads = 0
 
+const abortReason = (signal: AbortSignal): unknown =>
+  signal.reason ?? new DOMException("The operation was aborted.", "AbortError")
+
+const timeoutError = () =>
+  new DOMException("File upload timed out.", "TimeoutError")
+
+/** Reject an async transport or parsing operation as soon as its signal fires. */
+function raceWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return operation
+  if (signal.aborted) return Promise.reject(abortReason(signal))
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortReason(signal))
+    signal.addEventListener("abort", onAbort, { once: true })
+    operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort)
+        reject(error)
+      },
+    )
+  })
+}
+
 /**
- * Drain the process-wide browser queue in admission order. A single queue keeps
- * separate public-chat send paths from collectively exceeding the three-upload
- * ceiling when their lifetimes overlap.
+ * Drain the module-wide browser queue in admission order. The timeout begins
+ * here—not while queued—and every settled/aborted job releases its global slot.
  */
 function drainDeferredUploadQueue() {
   while (
@@ -38,14 +85,27 @@ function drainDeferredUploadQueue() {
     && deferredUploadQueue.length > 0
   ) {
     const scheduled = deferredUploadQueue.shift()
-    if (!scheduled) {
-      return
+    if (!scheduled) return
+
+    scheduled.signal?.removeEventListener("abort", scheduled.abortQueued)
+    if (scheduled.signal?.aborted) {
+      scheduled.reject(abortReason(scheduled.signal))
+      continue
     }
 
     activeDeferredUploads += 1
-    void scheduled.run()
+    const controller = new AbortController()
+    const abortActive = () => controller.abort(abortReason(scheduled.signal as AbortSignal))
+    scheduled.signal?.addEventListener("abort", abortActive, { once: true })
+    const timeout = setTimeout(() => {
+      controller.abort(timeoutError())
+    }, scheduled.timeoutMs)
+
+    void scheduled.run(controller.signal)
       .then(scheduled.resolve, scheduled.reject)
       .finally(() => {
+        clearTimeout(timeout)
+        scheduled.signal?.removeEventListener("abort", abortActive)
         activeDeferredUploads -= 1
         drainDeferredUploadQueue()
       })
@@ -53,10 +113,29 @@ function drainDeferredUploadQueue() {
 }
 
 function scheduleDeferredUpload(
-  run: () => Promise<PublicChatUploadedFile>,
+  run: (signal: AbortSignal) => Promise<PublicChatUploadedFile>,
+  signal: AbortSignal | undefined,
+  timeoutMs: number,
 ): Promise<PublicChatUploadedFile> {
+  if (signal?.aborted) return Promise.reject(abortReason(signal))
+
   const scheduled = new Promise<PublicChatUploadedFile>((resolve, reject) => {
-    deferredUploadQueue.push({ run, resolve, reject })
+    const job: ScheduledUpload = {
+      run,
+      resolve,
+      reject,
+      signal,
+      timeoutMs,
+      abortQueued: () => {
+        const index = deferredUploadQueue.indexOf(job)
+        if (index < 0) return
+        deferredUploadQueue.splice(index, 1)
+        signal?.removeEventListener("abort", job.abortQueued)
+        reject(abortReason(signal as AbortSignal))
+      },
+    }
+    signal?.addEventListener("abort", job.abortQueued, { once: true })
+    deferredUploadQueue.push(job)
   })
   drainDeferredUploadQueue()
   return scheduled
@@ -77,6 +156,7 @@ export async function uploadPublicChatFile({
   taskType,
   taskId,
   fallbackError,
+  signal,
 }: UploadPublicChatFileOptions): Promise<PublicChatUploadedFile> {
   const formData = new FormData()
   formData.append("file", file)
@@ -85,12 +165,16 @@ export async function uploadPublicChatFile({
     formData.append("task_id", taskId.toString())
   }
 
-  const response = await fetch(url, {
+  const response = await raceWithAbort(fetch(url, {
     method: "POST",
     headers: { "Authorization": `Bearer ${accessToken}` },
     body: formData,
-  })
-  const data = await response.json().catch(() => null) as PublicChatUploadResponse | null
+    signal,
+  }), signal)
+  const data = await raceWithAbort(
+    response.json().catch(() => null) as Promise<PublicChatUploadResponse | null>,
+    signal,
+  )
   const fileId = typeof data?.file_id === "string" ? data.file_id : null
 
   if (!response.ok || data?.success !== true || !fileId) {
@@ -110,43 +194,81 @@ export async function uploadPublicChatFile({
   }
 }
 
+const uploadScopeKey = ({
+  url,
+  taskType,
+  taskId,
+}: UploadDeferredPublicChatFilesOptions): string =>
+  `${url}\u0000${taskType}\u0000${taskId == null ? "taskless" : `${typeof taskId}:${taskId}`}`
+
+function getCachedUploadState(
+  file: File,
+  uploadContext: object,
+  scopeKey: string,
+): CachedUploadState {
+  let contexts = deferredUploadCache.get(file)
+  if (!contexts) {
+    contexts = new WeakMap()
+    deferredUploadCache.set(file, contexts)
+  }
+  let scopes = contexts.get(uploadContext)
+  if (!scopes) {
+    scopes = new Map()
+    contexts.set(uploadContext, scopes)
+  }
+  let state = scopes.get(scopeKey)
+  if (!state) {
+    state = {}
+    scopes.set(scopeKey, state)
+  }
+  return state
+}
+
 /**
  * Upload a deferred selection with bounded FIFO admission.
  *
- * Every selected file is allowed to settle even when another upload fails.
- * Successful ids are written back to their source File, matching the chat
- * transport's pre-uploaded-file convention so a user retry reuses completed
- * work instead of issuing another POST.
+ * Successful ids are retained only for the same caller-owned credential,
+ * endpoint, task binding, and task type. Each invocation supersedes older
+ * in-flight attempts in that scope, preventing late results from publishing
+ * over the current attempt while preserving successful partial retries.
  */
 export async function uploadDeferredPublicChatFiles(
   files: File[],
   options: UploadDeferredPublicChatFilesOptions,
 ): Promise<PublicChatUploadedFile[]> {
+  const attempt = Symbol("deferred-public-upload-attempt")
+  const scopeKey = uploadScopeKey(options)
+  const timeoutMs = options.timeoutMs !== undefined
+    && Number.isFinite(options.timeoutMs)
+    && options.timeoutMs > 0
+    ? options.timeoutMs
+    : DEFAULT_DEFERRED_UPLOAD_TIMEOUT_MS
   const uploads = files.map((file) => {
-    const sourceFile = file as PublicChatFileWithUploadId
-    if (sourceFile.file_id) {
-      return Promise.resolve({
-        file_id: sourceFile.file_id,
-        name: file.name,
-        size: file.size,
-        type: file.type,
-      })
-    }
+    const state = getCachedUploadState(file, options.uploadContext, scopeKey)
+    if (state.uploaded) return Promise.resolve(state.uploaded)
 
-    return scheduleDeferredUpload(async () => {
-      const uploaded = await uploadPublicChatFile({ ...options, file })
-      sourceFile.file_id = uploaded.file_id
-      return uploaded
-    })
+    state.currentAttempt = attempt
+    return scheduleDeferredUpload(async (signal) => {
+      try {
+        const uploaded = await uploadPublicChatFile({ ...options, file, signal })
+        if (state.currentAttempt === attempt) {
+          state.uploaded = uploaded
+          state.currentAttempt = undefined
+        }
+        return uploaded
+      } catch (error) {
+        if (state.currentAttempt === attempt) state.currentAttempt = undefined
+        throw error
+      }
+    }, options.signal, timeoutMs)
   })
   const settled = await Promise.allSettled(uploads)
   const failed = settled.find(
     (result): result is PromiseRejectedResult => result.status === "rejected",
   )
 
-  if (failed) {
-    throw failed.reason
-  }
-
-  return settled.map((result) => (result as PromiseFulfilledResult<PublicChatUploadedFile>).value)
+  if (failed) throw failed.reason
+  return settled.map(
+    (result) => (result as PromiseFulfilledResult<PublicChatUploadedFile>).value,
+  )
 }

--- a/frontend/src/lib/public-chat-file-upload.ts
+++ b/frontend/src/lib/public-chat-file-upload.ts
@@ -21,8 +21,6 @@ interface UploadDeferredPublicChatFilesOptions extends Omit<UploadPublicChatFile
    * upload. Object identity scopes cached ids without retaining raw tokens.
    */
   uploadContext: object
-  /** Timeout after scheduler admission. It covers fetch and body parsing. */
-  timeoutMs?: number
 }
 
 type ScheduledUpload = {
@@ -30,7 +28,6 @@ type ScheduledUpload = {
   resolve: (file: PublicChatUploadedFile) => void
   reject: (reason: unknown) => void
   signal?: AbortSignal
-  timeoutMs: number
   abortQueued: () => void
 }
 
@@ -40,7 +37,6 @@ interface CachedUploadState {
 }
 
 const MAX_ACTIVE_DEFERRED_UPLOADS = 3
-const DEFAULT_DEFERRED_UPLOAD_TIMEOUT_MS = 30_000
 const deferredUploadQueue: ScheduledUpload[] = []
 const deferredUploadCache = new WeakMap<
   File,
@@ -50,9 +46,6 @@ let activeDeferredUploads = 0
 
 const abortReason = (signal: AbortSignal): unknown =>
   signal.reason ?? new DOMException("The operation was aborted.", "AbortError")
-
-const timeoutError = () =>
-  new DOMException("File upload timed out.", "TimeoutError")
 
 /** Reject an async transport or parsing operation as soon as its signal fires. */
 function raceWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
@@ -76,8 +69,8 @@ function raceWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<
 }
 
 /**
- * Drain the module-wide browser queue in admission order. The timeout begins
- * here—not while queued—and every settled/aborted job releases its global slot.
+ * Drain the module-wide browser queue in admission order. Every settled or
+ * owner-aborted job releases its global slot for the next queued upload.
  */
 function drainDeferredUploadQueue() {
   while (
@@ -97,14 +90,10 @@ function drainDeferredUploadQueue() {
     const controller = new AbortController()
     const abortActive = () => controller.abort(abortReason(scheduled.signal as AbortSignal))
     scheduled.signal?.addEventListener("abort", abortActive, { once: true })
-    const timeout = setTimeout(() => {
-      controller.abort(timeoutError())
-    }, scheduled.timeoutMs)
 
     void scheduled.run(controller.signal)
       .then(scheduled.resolve, scheduled.reject)
       .finally(() => {
-        clearTimeout(timeout)
         scheduled.signal?.removeEventListener("abort", abortActive)
         activeDeferredUploads -= 1
         drainDeferredUploadQueue()
@@ -115,7 +104,6 @@ function drainDeferredUploadQueue() {
 function scheduleDeferredUpload(
   run: (signal: AbortSignal) => Promise<PublicChatUploadedFile>,
   signal: AbortSignal | undefined,
-  timeoutMs: number,
 ): Promise<PublicChatUploadedFile> {
   if (signal?.aborted) return Promise.reject(abortReason(signal))
 
@@ -125,7 +113,6 @@ function scheduleDeferredUpload(
       resolve,
       reject,
       signal,
-      timeoutMs,
       abortQueued: () => {
         const index = deferredUploadQueue.indexOf(job)
         if (index < 0) return
@@ -238,11 +225,6 @@ export async function uploadDeferredPublicChatFiles(
 ): Promise<PublicChatUploadedFile[]> {
   const attempt = Symbol("deferred-public-upload-attempt")
   const scopeKey = uploadScopeKey(options)
-  const timeoutMs = options.timeoutMs !== undefined
-    && Number.isFinite(options.timeoutMs)
-    && options.timeoutMs > 0
-    ? options.timeoutMs
-    : DEFAULT_DEFERRED_UPLOAD_TIMEOUT_MS
   const uploads = files.map((file) => {
     const state = getCachedUploadState(file, options.uploadContext, scopeKey)
     if (state.uploaded) return Promise.resolve(state.uploaded)
@@ -260,7 +242,7 @@ export async function uploadDeferredPublicChatFiles(
         if (state.currentAttempt === attempt) state.currentAttempt = undefined
         throw error
       }
-    }, options.signal, timeoutMs)
+    }, options.signal)
   })
   const settled = await Promise.allSettled(uploads)
   const failed = settled.find(

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -74,6 +74,8 @@ _NATIVE_BROWSER_APP_NAMES_BY_CASEFOLD = {
 MAX_UPLOAD_SIZE = "XAGENT_MAX_UPLOAD_SIZE"
 FILE_STORAGE_URI = "XAGENT_FILE_STORAGE_URI"
 FILE_STORAGE_OPTIONS = "XAGENT_FILE_STORAGE_OPTIONS"
+FILE_UPLOAD_MAX_CONCURRENCY = "XAGENT_FILE_UPLOAD_MAX_CONCURRENCY"
+FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS = "XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS"
 FILE_MATERIALIZE_DIR = "XAGENT_FILE_MATERIALIZE_DIR"
 PREVIEW_TMP_DIR = "XAGENT_PREVIEW_TMP_DIR"
 FILE_STORAGE_STARTUP_SYNC_ENABLED = "XAGENT_FILE_STORAGE_STARTUP_SYNC_ENABLED"
@@ -1819,6 +1821,24 @@ def get_file_storage_options() -> dict[str, Any]:
         raise ValueError(f"Invalid {FILE_STORAGE_OPTIONS} value: must be a JSON object")
 
     return parsed
+
+
+def get_file_upload_max_concurrency() -> int:
+    """Return the maximum active durable upload registrations per process.
+
+    The admission gate applies at the asynchronous HTTP boundary immediately
+    before durable registration. Keeping the value process-local protects each
+    backend worker's object-storage connection pool without implying a
+    deployment-wide distributed limit.
+    """
+
+    return _get_positive_int_env(FILE_UPLOAD_MAX_CONCURRENCY, 4)
+
+
+def get_file_upload_queue_timeout_seconds() -> int:
+    """Return how long an upload may wait for durable-registration capacity."""
+
+    return _get_positive_int_env(FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS, 30)
 
 
 def get_file_materialize_dir() -> Path:

--- a/src/xagent/core/file_storage/factory.py
+++ b/src/xagent/core/file_storage/factory.py
@@ -18,7 +18,10 @@ from .storage import FsspecFileStorage
 _DEFAULT_S3_CONFIG_KWARGS = {
     "connect_timeout": 3,
     "read_timeout": 10,
-    "retries": {"max_attempts": 1},
+    "retries": {
+        "mode": "standard",
+        "total_max_attempts": 3,
+    },
 }
 
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -588,7 +588,13 @@ async def store_uploaded_files(
             )
         completed = True
     except DurableStorageOperationError as exc:
-        logger.warning("Durable storage unavailable during upload: %s", exc)
+        logger.exception(
+            "Durable storage unavailable during upload: user_id=%s task_id=%s "
+            "file_count=%s",
+            user_id,
+            parsed_task_id,
+            len(upload_items),
+        )
         raise _durable_storage_unavailable() from exc
     finally:
         if not completed:

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -37,7 +37,7 @@ from ...config import (
     get_uploads_dir,
 )
 from ...core.execution_scope import resolve_execution_scope
-from ...core.file_storage import get_user_file_storage
+from ...core.file_storage import get_file_storage_backend, get_user_file_storage
 from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
 from ...core.utils.svg import rasterize_svg_bytes
@@ -604,8 +604,10 @@ async def store_uploaded_files(
         completed = True
     except DurableStorageOperationError as exc:
         logger.exception(
-            "Durable storage unavailable during upload: user_id=%s task_id=%s "
+            "Durable storage unavailable during upload: "
+            "operation=register_local_uploads backend=%s user_id=%s task_id=%s "
             "file_count=%s",
+            get_file_storage_backend(),
             user_id,
             parsed_task_id,
             len(upload_items),

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -76,6 +76,10 @@ from ..services.managed_file_ref import (
     ManagedFileRef,
     guess_media_type,
 )
+from ..services.upload_storage_gate import (
+    UploadStorageCapacityError,
+    get_upload_storage_gate,
+)
 from ..services.uploaded_file_store import (
     LocalUploadRegistration,
     UploadedFileStore,
@@ -573,9 +577,20 @@ async def store_uploaded_files(
                 )
             )
 
-        registered = await run_db_io_cancellation_safe(
-            lambda: register_local_uploads_sync(registrations)
-        )
+        try:
+            async with get_upload_storage_gate().lease():
+                registered = await run_db_io_cancellation_safe(
+                    lambda: register_local_uploads_sync(registrations)
+                )
+        except UploadStorageCapacityError as exc:
+            logger.warning(
+                "Timed out waiting for durable upload capacity: "
+                "user_id=%s task_id=%s file_count=%s",
+                user_id,
+                parsed_task_id,
+                len(upload_items),
+            )
+            raise _durable_storage_unavailable() from exc
         for file_record in registered:
             uploaded_files.append(
                 {

--- a/src/xagent/web/services/upload_storage_gate.py
+++ b/src/xagent/web/services/upload_storage_gate.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from functools import lru_cache
+from threading import Lock
 
 from ...config import (
     get_file_upload_max_concurrency,
@@ -36,9 +36,13 @@ class UploadStorageGate:
             raise ValueError("max_concurrency must be positive")
         if queue_timeout_seconds <= 0:
             raise ValueError("queue_timeout_seconds must be positive")
+        self._max_concurrency = max_concurrency
         self._semaphore = asyncio.Semaphore(max_concurrency)
         self._queue_timeout_seconds = queue_timeout_seconds
         self._active = 0
+        self._waiting = 0
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._lifecycle_lock = Lock()
 
     @property
     def active(self) -> int:
@@ -46,33 +50,87 @@ class UploadStorageGate:
 
         return self._active
 
+    def _prepare_for_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Bind to one live loop, resetting only after its work is drained."""
+
+        with self._lifecycle_lock:
+            if self._loop is loop:
+                return
+            if self._loop is None:
+                self._loop = loop
+                return
+            if not self._loop.is_closed():
+                raise RuntimeError(
+                    "Upload storage gate does not support concurrent event loops"
+                )
+            if self._active or self._waiting:
+                raise RuntimeError(
+                    "Upload storage gate cannot leave a closed event loop until "
+                    "all leases and waiters are drained"
+                )
+
+            # Contention binds asyncio.Semaphore to its event loop. Recreate
+            # only that loop-bound primitive while retaining the one process
+            # gate and its configured capacity.
+            self._semaphore = asyncio.Semaphore(self._max_concurrency)
+            self._loop = loop
+
     @asynccontextmanager
     async def lease(self) -> AsyncIterator[None]:
         """Acquire registration capacity and release it on every scope exit."""
 
+        self._prepare_for_loop(asyncio.get_running_loop())
+        with self._lifecycle_lock:
+            self._waiting += 1
         try:
-            await asyncio.wait_for(
-                self._semaphore.acquire(),
-                timeout=self._queue_timeout_seconds,
-            )
-        except TimeoutError as exc:
-            raise UploadStorageCapacityError(
-                "Timed out waiting for durable upload capacity"
-            ) from exc
+            try:
+                await asyncio.wait_for(
+                    self._semaphore.acquire(),
+                    timeout=self._queue_timeout_seconds,
+                )
+            except TimeoutError as exc:
+                raise UploadStorageCapacityError(
+                    "Timed out waiting for durable upload capacity"
+                ) from exc
+        finally:
+            with self._lifecycle_lock:
+                self._waiting -= 1
 
-        self._active += 1
+        with self._lifecycle_lock:
+            self._active += 1
         try:
             yield
         finally:
-            self._active -= 1
+            with self._lifecycle_lock:
+                self._active -= 1
             self._semaphore.release()
 
 
-@lru_cache(maxsize=1)
-def get_upload_storage_gate() -> UploadStorageGate:
-    """Return the configured gate shared by upload requests in this process."""
+_gate: UploadStorageGate | None = None
+_gate_lock = Lock()
 
-    return UploadStorageGate(
-        max_concurrency=get_file_upload_max_concurrency(),
-        queue_timeout_seconds=get_file_upload_queue_timeout_seconds(),
-    )
+
+def get_upload_storage_gate() -> UploadStorageGate:
+    """Return the sole process gate, prepared for the current event loop.
+
+    Sequential event-loop lifecycles reuse the same gate after the prior loop
+    is closed and all of its leases and waiters have drained. Access from a
+    second live loop is unsupported and raises ``RuntimeError`` rather than
+    creating another independently usable capacity pool.
+    """
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    global _gate
+    with _gate_lock:
+        if _gate is None:
+            _gate = UploadStorageGate(
+                max_concurrency=get_file_upload_max_concurrency(),
+                queue_timeout_seconds=get_file_upload_queue_timeout_seconds(),
+            )
+        if loop is not None:
+            _gate._prepare_for_loop(loop)
+        return _gate

--- a/src/xagent/web/services/upload_storage_gate.py
+++ b/src/xagent/web/services/upload_storage_gate.py
@@ -9,14 +9,18 @@ released only after the worker has settled and can no longer write storage.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from threading import Lock
+from time import monotonic
 
 from ...config import (
     get_file_upload_max_concurrency,
     get_file_upload_queue_timeout_seconds,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class UploadStorageCapacityError(TimeoutError):
@@ -80,6 +84,7 @@ class UploadStorageGate:
         """Acquire registration capacity and release it on every scope exit."""
 
         self._prepare_for_loop(asyncio.get_running_loop())
+        wait_started_at = monotonic()
         with self._lifecycle_lock:
             self._waiting += 1
         try:
@@ -96,14 +101,40 @@ class UploadStorageGate:
             with self._lifecycle_lock:
                 self._waiting -= 1
 
+        lease_started_at = monotonic()
         with self._lifecycle_lock:
             self._active += 1
+            active = self._active
+            waiting = self._waiting
+        logger.debug(
+            "Acquired durable upload capacity after %.3f seconds "
+            "(active=%s, waiting=%s, max_concurrency=%s, "
+            "queue_timeout_seconds=%s)",
+            lease_started_at - wait_started_at,
+            active,
+            waiting,
+            self._max_concurrency,
+            self._queue_timeout_seconds,
+        )
         try:
             yield
         finally:
+            lease_seconds = monotonic() - lease_started_at
             with self._lifecycle_lock:
                 self._active -= 1
+                active = self._active
+                waiting = self._waiting
             self._semaphore.release()
+            logger.debug(
+                "Released durable upload capacity after %.3f seconds "
+                "(active=%s, waiting=%s, max_concurrency=%s, "
+                "queue_timeout_seconds=%s)",
+                lease_seconds,
+                active,
+                waiting,
+                self._max_concurrency,
+                self._queue_timeout_seconds,
+            )
 
 
 _gate: UploadStorageGate | None = None

--- a/src/xagent/web/services/upload_storage_gate.py
+++ b/src/xagent/web/services/upload_storage_gate.py
@@ -1,0 +1,78 @@
+"""Process-local admission control for durable upload registration.
+
+The gate lives at the asynchronous HTTP boundary so requests wait without
+occupying the shared ``asyncio.to_thread`` executor. A lease covers the full
+cancellation-safe registration call: if the client disconnects, capacity is
+released only after the worker has settled and can no longer write storage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from functools import lru_cache
+
+from ...config import (
+    get_file_upload_max_concurrency,
+    get_file_upload_queue_timeout_seconds,
+)
+
+
+class UploadStorageCapacityError(TimeoutError):
+    """Raised when an upload cannot enter durable registration in time."""
+
+
+class UploadStorageGate:
+    """Bound active durable upload registrations within one backend process."""
+
+    def __init__(
+        self,
+        *,
+        max_concurrency: int,
+        queue_timeout_seconds: float,
+    ) -> None:
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be positive")
+        if queue_timeout_seconds <= 0:
+            raise ValueError("queue_timeout_seconds must be positive")
+        self._semaphore = asyncio.Semaphore(max_concurrency)
+        self._queue_timeout_seconds = queue_timeout_seconds
+        self._active = 0
+
+    @property
+    def active(self) -> int:
+        """Return the number of leases currently performing registration."""
+
+        return self._active
+
+    @asynccontextmanager
+    async def lease(self) -> AsyncIterator[None]:
+        """Acquire registration capacity and release it on every scope exit."""
+
+        try:
+            await asyncio.wait_for(
+                self._semaphore.acquire(),
+                timeout=self._queue_timeout_seconds,
+            )
+        except TimeoutError as exc:
+            raise UploadStorageCapacityError(
+                "Timed out waiting for durable upload capacity"
+            ) from exc
+
+        self._active += 1
+        try:
+            yield
+        finally:
+            self._active -= 1
+            self._semaphore.release()
+
+
+@lru_cache(maxsize=1)
+def get_upload_storage_gate() -> UploadStorageGate:
+    """Return the configured gate shared by upload requests in this process."""
+
+    return UploadStorageGate(
+        max_concurrency=get_file_upload_max_concurrency(),
+        queue_timeout_seconds=get_file_upload_queue_timeout_seconds(),
+    )

--- a/src/xagent/web/services/upload_storage_gate.py
+++ b/src/xagent/web/services/upload_storage_gate.py
@@ -60,7 +60,9 @@ class UploadStorageGate:
                 self._loop = loop
                 return
             if not self._loop.is_closed():
-                raise RuntimeError("Upload storage gate does not support concurrent event loops")
+                raise RuntimeError(
+                    "Upload storage gate does not support concurrent event loops"
+                )
             if self._active or self._waiting:
                 raise RuntimeError(
                     "Upload storage gate cannot leave a closed event loop until "

--- a/src/xagent/web/services/upload_storage_gate.py
+++ b/src/xagent/web/services/upload_storage_gate.py
@@ -9,18 +9,14 @@ released only after the worker has settled and can no longer write storage.
 from __future__ import annotations
 
 import asyncio
-import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from threading import Lock
-from time import monotonic
 
 from ...config import (
     get_file_upload_max_concurrency,
     get_file_upload_queue_timeout_seconds,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class UploadStorageCapacityError(TimeoutError):
@@ -64,9 +60,7 @@ class UploadStorageGate:
                 self._loop = loop
                 return
             if not self._loop.is_closed():
-                raise RuntimeError(
-                    "Upload storage gate does not support concurrent event loops"
-                )
+                raise RuntimeError("Upload storage gate does not support concurrent event loops")
             if self._active or self._waiting:
                 raise RuntimeError(
                     "Upload storage gate cannot leave a closed event loop until "
@@ -84,7 +78,6 @@ class UploadStorageGate:
         """Acquire registration capacity and release it on every scope exit."""
 
         self._prepare_for_loop(asyncio.get_running_loop())
-        wait_started_at = monotonic()
         with self._lifecycle_lock:
             self._waiting += 1
         try:
@@ -101,40 +94,14 @@ class UploadStorageGate:
             with self._lifecycle_lock:
                 self._waiting -= 1
 
-        lease_started_at = monotonic()
         with self._lifecycle_lock:
             self._active += 1
-            active = self._active
-            waiting = self._waiting
-        logger.debug(
-            "Acquired durable upload capacity after %.3f seconds "
-            "(active=%s, waiting=%s, max_concurrency=%s, "
-            "queue_timeout_seconds=%s)",
-            lease_started_at - wait_started_at,
-            active,
-            waiting,
-            self._max_concurrency,
-            self._queue_timeout_seconds,
-        )
         try:
             yield
         finally:
-            lease_seconds = monotonic() - lease_started_at
             with self._lifecycle_lock:
                 self._active -= 1
-                active = self._active
-                waiting = self._waiting
             self._semaphore.release()
-            logger.debug(
-                "Released durable upload capacity after %.3f seconds "
-                "(active=%s, waiting=%s, max_concurrency=%s, "
-                "queue_timeout_seconds=%s)",
-                lease_seconds,
-                active,
-                waiting,
-                self._max_concurrency,
-                self._queue_timeout_seconds,
-            )
 
 
 _gate: UploadStorageGate | None = None

--- a/src/xagent/web/services/upload_storage_gate.py
+++ b/src/xagent/web/services/upload_storage_gate.py
@@ -60,9 +60,7 @@ class UploadStorageGate:
                 self._loop = loop
                 return
             if not self._loop.is_closed():
-                raise RuntimeError(
-                    "Upload storage gate does not support concurrent event loops"
-                )
+                raise RuntimeError("Upload storage gate does not support concurrent event loops")
             if self._active or self._waiting:
                 raise RuntimeError(
                     "Upload storage gate cannot leave a closed event loop until "

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -823,6 +823,32 @@ class TestFileStorageConfig:
         with pytest.raises(ValueError, match="XAGENT_FILE_STORAGE_OPTIONS"):
             get_file_storage_options()
 
+    def test_file_upload_admission_defaults(self, monkeypatch):
+        monkeypatch.delenv("XAGENT_FILE_UPLOAD_MAX_CONCURRENCY", raising=False)
+        monkeypatch.delenv(
+            "XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS", raising=False
+        )
+
+        assert config.get_file_upload_max_concurrency() == 4
+        assert config.get_file_upload_queue_timeout_seconds() == 30
+
+    def test_file_upload_admission_uses_positive_overrides(self, monkeypatch):
+        monkeypatch.setenv("XAGENT_FILE_UPLOAD_MAX_CONCURRENCY", "7")
+        monkeypatch.setenv("XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS", "45")
+
+        assert config.get_file_upload_max_concurrency() == 7
+        assert config.get_file_upload_queue_timeout_seconds() == 45
+
+    @pytest.mark.parametrize("value", ["0", "-1", "invalid"])
+    def test_file_upload_admission_rejects_invalid_overrides(
+        self, monkeypatch, value
+    ):
+        monkeypatch.setenv("XAGENT_FILE_UPLOAD_MAX_CONCURRENCY", value)
+        monkeypatch.setenv("XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS", value)
+
+        assert config.get_file_upload_max_concurrency() == 4
+        assert config.get_file_upload_queue_timeout_seconds() == 30
+
     def test_file_materialize_dir_default(self, monkeypatch):
         monkeypatch.delenv(FILE_MATERIALIZE_DIR, raising=False)
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -825,9 +825,7 @@ class TestFileStorageConfig:
 
     def test_file_upload_admission_defaults(self, monkeypatch):
         monkeypatch.delenv("XAGENT_FILE_UPLOAD_MAX_CONCURRENCY", raising=False)
-        monkeypatch.delenv(
-            "XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS", raising=False
-        )
+        monkeypatch.delenv("XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS", raising=False)
 
         assert config.get_file_upload_max_concurrency() == 4
         assert config.get_file_upload_queue_timeout_seconds() == 30
@@ -840,9 +838,7 @@ class TestFileStorageConfig:
         assert config.get_file_upload_queue_timeout_seconds() == 45
 
     @pytest.mark.parametrize("value", ["0", "-1", "invalid"])
-    def test_file_upload_admission_rejects_invalid_overrides(
-        self, monkeypatch, value
-    ):
+    def test_file_upload_admission_rejects_invalid_overrides(self, monkeypatch, value):
         monkeypatch.setenv("XAGENT_FILE_UPLOAD_MAX_CONCURRENCY", value)
         monkeypatch.setenv("XAGENT_FILE_UPLOAD_QUEUE_TIMEOUT_SECONDS", value)
 

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -176,7 +176,10 @@ def test_s3_file_storage_uses_bounded_client_timeouts(monkeypatch, tmp_path):
         "config_kwargs": {
             "connect_timeout": 3,
             "read_timeout": 10,
-            "retries": {"max_attempts": 1},
+            "retries": {
+                "mode": "standard",
+                "total_max_attempts": 3,
+            },
         }
     }
 
@@ -218,6 +221,48 @@ def test_s3_file_storage_keeps_explicit_client_timeout_overrides(monkeypatch, tm
             "read_timeout": 2,
             "retries": {"max_attempts": 3},
         },
+    }
+
+
+def test_s3_file_storage_keeps_explicit_retry_mode_override(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    class DummyStorage:
+        pass
+
+    def fake_url_to_fs(uri: str, **options: object):
+        captured["options"] = options
+        return DummyStorage(), "bucket/root"
+
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", "s3://bucket/root")
+    monkeypatch.setenv("XAGENT_FILE_MATERIALIZE_DIR", str(tmp_path))
+    monkeypatch.setenv(
+        "XAGENT_FILE_STORAGE_OPTIONS",
+        json.dumps(
+            {
+                "config_kwargs": {
+                    "retries": {
+                        "mode": "adaptive",
+                        "total_max_attempts": 5,
+                    }
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr(file_storage_factory.fsspec.core, "url_to_fs", fake_url_to_fs)
+    get_unscoped_file_storage.cache_clear()
+
+    get_unscoped_file_storage()
+
+    assert captured["options"] == {
+        "config_kwargs": {
+            "connect_timeout": 3,
+            "read_timeout": 10,
+            "retries": {
+                "mode": "adaptive",
+                "total_max_attempts": 5,
+            },
+        }
     }
 
 

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -31,6 +31,10 @@ from xagent.web.services.managed_file_ref import (
     DurableStorageOperationError,
     ManagedFileRef,
 )
+from xagent.web.services.upload_storage_gate import (
+    UploadStorageCapacityError,
+    UploadStorageGate,
+)
 
 from .conftest import (
     _admin_headers,
@@ -592,6 +596,58 @@ async def test_cancelled_store_cleans_its_exact_late_result_once(
 
     assert unlink_calls.count(target) == 1
     assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_registration_holds_capacity_until_worker_settles(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cancellation cannot admit a replacement while durable I/O still runs."""
+
+    user_id = 7
+    gate = UploadStorageGate(max_concurrency=1, queue_timeout_seconds=0.01)
+    registration_started = threading.Event()
+    release_registration = threading.Event()
+    monkeypatch.setattr(files_api, "get_upload_path", _stage_path_in(tmp_path, user_id))
+    monkeypatch.setattr(files_api, "get_upload_storage_gate", lambda: gate)
+
+    def blocked_registration(_registrations):  # type: ignore[no-untyped-def]
+        registration_started.set()
+        assert release_registration.wait(2)
+        return ()
+
+    monkeypatch.setattr(
+        files_api,
+        "register_local_uploads_sync",
+        blocked_registration,
+    )
+    task = asyncio.create_task(
+        files_api.store_uploaded_files(
+            upload_items=[
+                UploadFile(
+                    filename="cancelled-registration.txt",
+                    file=io.BytesIO(b"payload"),
+                )
+            ],
+            task_type="general",
+            task_id=None,
+            folder=None,
+            user_id=user_id,
+            single_file_mode=True,
+        )
+    )
+    assert await asyncio.to_thread(registration_started.wait, 2)
+
+    task.cancel()
+    with pytest.raises(UploadStorageCapacityError):
+        async with gate.lease():
+            raise AssertionError("replacement must not overlap the draining worker")
+
+    release_registration.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert gate.active == 0
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_upload_storage_gate.py
+++ b/tests/web/services/test_upload_storage_gate.py
@@ -1,10 +1,12 @@
 """Concurrency and cancellation contracts for durable-upload admission."""
 
 import asyncio
+import logging
 
 import pytest
 
 from xagent.config import get_file_upload_max_concurrency
+from xagent.web.services import upload_storage_gate
 from xagent.web.services.upload_storage_gate import (
     UploadStorageCapacityError,
     UploadStorageGate,
@@ -97,6 +99,38 @@ async def test_gate_bounds_concurrent_leases() -> None:
     release.set()
     await asyncio.gather(*tasks)
     assert gate.active == 0
+
+
+@pytest.mark.asyncio
+async def test_gate_logs_lease_lifecycle_at_debug_level(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = UploadStorageGate(max_concurrency=2, queue_timeout_seconds=4)
+    moments = iter((10.0, 11.25, 13.75))
+    monkeypatch.setattr(
+        upload_storage_gate,
+        "monotonic",
+        moments.__next__,
+        raising=False,
+    )
+    caplog.set_level(logging.DEBUG, logger=upload_storage_gate.__name__)
+
+    async with gate.lease():
+        pass
+
+    records = [
+        record
+        for record in caplog.records
+        if record.name == upload_storage_gate.__name__
+    ]
+    assert [record.levelno for record in records] == [logging.DEBUG, logging.DEBUG]
+    assert [record.getMessage() for record in records] == [
+        "Acquired durable upload capacity after 1.250 seconds "
+        "(active=1, waiting=0, max_concurrency=2, queue_timeout_seconds=4)",
+        "Released durable upload capacity after 2.500 seconds "
+        "(active=0, waiting=0, max_concurrency=2, queue_timeout_seconds=4)",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_upload_storage_gate.py
+++ b/tests/web/services/test_upload_storage_gate.py
@@ -4,10 +4,70 @@ import asyncio
 
 import pytest
 
+from xagent.config import get_file_upload_max_concurrency
 from xagent.web.services.upload_storage_gate import (
     UploadStorageCapacityError,
     UploadStorageGate,
+    get_upload_storage_gate,
 )
+
+
+def test_accessor_survives_sequential_contended_event_loops() -> None:
+    capacity = get_file_upload_max_concurrency()
+    gates: list[UploadStorageGate] = []
+
+    async def contend_for_gate() -> None:
+        gate = get_upload_storage_gate()
+        gates.append(gate)
+        release = asyncio.Event()
+        capacity_reached = asyncio.Event()
+        active = 0
+
+        async def hold_capacity() -> None:
+            nonlocal active
+            async with gate.lease():
+                active += 1
+                if active == capacity:
+                    capacity_reached.set()
+                await release.wait()
+                active -= 1
+
+        holders = [asyncio.create_task(hold_capacity()) for _ in range(capacity)]
+        await asyncio.wait_for(capacity_reached.wait(), timeout=1)
+
+        async def wait_for_capacity() -> None:
+            async with gate.lease():
+                pass
+
+        waiter = asyncio.create_task(wait_for_capacity())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert gate.active == capacity
+        assert not waiter.done()
+        release.set()
+        await asyncio.gather(*holders, waiter)
+        assert gate.active == 0
+
+    asyncio.run(contend_for_gate())
+    asyncio.run(contend_for_gate())
+
+    assert gates[0] is gates[1]
+
+
+@pytest.mark.asyncio
+async def test_accessor_rejects_a_second_live_event_loop() -> None:
+    gate = get_upload_storage_gate()
+
+    async def access_from_another_loop() -> None:
+        with pytest.raises(
+            RuntimeError,
+            match="does not support concurrent event loops",
+        ):
+            get_upload_storage_gate()
+
+    await asyncio.to_thread(asyncio.run, access_from_another_loop())
+
+    assert get_upload_storage_gate() is gate
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_upload_storage_gate.py
+++ b/tests/web/services/test_upload_storage_gate.py
@@ -3,6 +3,7 @@
 import asyncio
 
 import pytest
+
 from xagent.web.services.upload_storage_gate import (
     UploadStorageCapacityError,
     UploadStorageGate,

--- a/tests/web/services/test_upload_storage_gate.py
+++ b/tests/web/services/test_upload_storage_gate.py
@@ -1,0 +1,74 @@
+"""Concurrency and cancellation contracts for durable-upload admission."""
+
+import asyncio
+
+import pytest
+from xagent.web.services.upload_storage_gate import (
+    UploadStorageCapacityError,
+    UploadStorageGate,
+)
+
+
+@pytest.mark.asyncio
+async def test_gate_bounds_concurrent_leases() -> None:
+    gate = UploadStorageGate(max_concurrency=2, queue_timeout_seconds=1)
+    active = 0
+    maximum_active = 0
+    release = asyncio.Event()
+    first_pair_active = asyncio.Event()
+
+    async def use_gate() -> None:
+        nonlocal active, maximum_active
+        async with gate.lease():
+            active += 1
+            maximum_active = max(maximum_active, active)
+            if active == 2:
+                first_pair_active.set()
+            await release.wait()
+            active -= 1
+
+    tasks = [asyncio.create_task(use_gate()) for _ in range(8)]
+    await asyncio.wait_for(first_pair_active.wait(), timeout=1)
+
+    assert maximum_active == 2
+    assert gate.active == 2
+
+    release.set()
+    await asyncio.gather(*tasks)
+    assert gate.active == 0
+
+
+@pytest.mark.asyncio
+async def test_gate_times_out_without_consuming_capacity() -> None:
+    gate = UploadStorageGate(max_concurrency=1, queue_timeout_seconds=0.01)
+
+    async with gate.lease():
+        with pytest.raises(UploadStorageCapacityError):
+            async with gate.lease():
+                raise AssertionError("timed-out lease must not enter")
+        assert gate.active == 1
+
+    async with gate.lease():
+        assert gate.active == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_releases_capacity_when_lease_owner_is_cancelled() -> None:
+    gate = UploadStorageGate(max_concurrency=1, queue_timeout_seconds=1)
+    acquired = asyncio.Event()
+    block = asyncio.Event()
+
+    async def hold_lease() -> None:
+        async with gate.lease():
+            acquired.set()
+            await block.wait()
+
+    task = asyncio.create_task(hold_lease())
+    await asyncio.wait_for(acquired.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert gate.active == 0
+    async with gate.lease():
+        assert gate.active == 1

--- a/tests/web/services/test_upload_storage_gate.py
+++ b/tests/web/services/test_upload_storage_gate.py
@@ -1,12 +1,10 @@
 """Concurrency and cancellation contracts for durable-upload admission."""
 
 import asyncio
-import logging
 
 import pytest
 
 from xagent.config import get_file_upload_max_concurrency
-from xagent.web.services import upload_storage_gate
 from xagent.web.services.upload_storage_gate import (
     UploadStorageCapacityError,
     UploadStorageGate,
@@ -99,38 +97,6 @@ async def test_gate_bounds_concurrent_leases() -> None:
     release.set()
     await asyncio.gather(*tasks)
     assert gate.active == 0
-
-
-@pytest.mark.asyncio
-async def test_gate_logs_lease_lifecycle_at_debug_level(
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    gate = UploadStorageGate(max_concurrency=2, queue_timeout_seconds=4)
-    moments = iter((10.0, 11.25, 13.75))
-    monkeypatch.setattr(
-        upload_storage_gate,
-        "monotonic",
-        moments.__next__,
-        raising=False,
-    )
-    caplog.set_level(logging.DEBUG, logger=upload_storage_gate.__name__)
-
-    async with gate.lease():
-        pass
-
-    records = [
-        record
-        for record in caplog.records
-        if record.name == upload_storage_gate.__name__
-    ]
-    assert [record.levelno for record in records] == [logging.DEBUG, logging.DEBUG]
-    assert [record.getMessage() for record in records] == [
-        "Acquired durable upload capacity after 1.250 seconds "
-        "(active=1, waiting=0, max_concurrency=2, queue_timeout_seconds=4)",
-        "Released durable upload capacity after 2.500 seconds "
-        "(active=0, waiting=0, max_concurrency=2, queue_timeout_seconds=4)",
-    ]
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -522,8 +522,14 @@ class TestFileUpload:
         assert "x-accel-redirect" not in preview.headers
         assert preview.content == b"<h1>preview</h1>"
 
-    def test_upload_remote_storage_outage_returns_503_and_rolls_back(
-        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch
+    def test_upload_remote_storage_outage_returns_503_and_logs_cause(
+        self,
+        client,
+        test_db,
+        temp_uploads_dir,
+        auth_headers,
+        monkeypatch,
+        caplog,
     ):
         from xagent.core.file_storage.storage import FsspecFileStorage
 
@@ -542,7 +548,16 @@ class TestFileUpload:
         )
 
         assert response.status_code == 503
-        assert "durable storage" in response.json()["detail"].lower()
+        assert response.json() == {
+            "detail": "Durable storage is temporarily unavailable"
+        }
+        assert "simulated remote write outage" in caplog.text
+        assert any(
+            record.exc_info is not None
+            for record in caplog.records
+            if record.name == "xagent.web.api.files"
+            and "Durable storage unavailable during upload" in record.getMessage()
+        )
         assert not list(temp_uploads_dir.rglob("outage.txt"))
 
         db = next(test_app.dependency_overrides[get_db]())

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -574,6 +574,68 @@ class TestFileUpload:
         finally:
             db.close()
 
+    def test_upload_capacity_timeout_returns_503_and_cleans_staging(
+        self,
+        client,
+        test_db,
+        temp_uploads_dir,
+        auth_headers,
+        monkeypatch,
+        caplog,
+    ):
+        import xagent.web.api.files as files_api
+        from xagent.web.services.upload_storage_gate import (
+            UploadStorageCapacityError,
+        )
+
+        admin_user, test_app = test_db
+
+        class RejectedLease:
+            async def __aenter__(self):
+                raise UploadStorageCapacityError("capacity exhausted")
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return False
+
+        class RejectingGate:
+            def lease(self):
+                return RejectedLease()
+
+        monkeypatch.setattr(
+            files_api,
+            "get_upload_storage_gate",
+            lambda: RejectingGate(),
+            raising=False,
+        )
+
+        response = client.post(
+            "/api/files/upload",
+            files={"file": ("queued.txt", b"queued content", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 503
+        assert response.json() == {
+            "detail": "Durable storage is temporarily unavailable"
+        }
+        assert "Timed out waiting for durable upload capacity" in caplog.text
+        assert not list(temp_uploads_dir.rglob("queued.txt"))
+
+        db = next(test_app.dependency_overrides[get_db]())
+        try:
+            assert (
+                db.query(UploadedFile)
+                .filter(
+                    UploadedFile.user_id == admin_user.id,
+                    UploadedFile.filename == "queued.txt",
+                )
+                .first()
+                is None
+            )
+        finally:
+            db.close()
+
     def test_download_serves_existing_local_file_during_remote_outage(
         self, client, temp_uploads_dir, auth_headers, monkeypatch
     ):

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -552,12 +552,16 @@ class TestFileUpload:
             "detail": "Durable storage is temporarily unavailable"
         }
         assert "simulated remote write outage" in caplog.text
-        assert any(
-            record.exc_info is not None
+        failure_records = [
+            record
             for record in caplog.records
             if record.name == "xagent.web.api.files"
             and "Durable storage unavailable during upload" in record.getMessage()
-        )
+        ]
+        assert len(failure_records) == 1
+        assert failure_records[0].exc_info is not None
+        assert "operation=register_local_uploads" in failure_records[0].getMessage()
+        assert "backend=file" in failure_records[0].getMessage()
         assert not list(temp_uploads_dir.rglob("outage.txt"))
 
         db = next(test_app.dependency_overrides[get_db]())


### PR DESCRIPTION
## Summary

- add a process-local admission gate for durable upload registration, with configurable concurrency and queue timeout
- use explicit Botocore standard retries while preserving operator-provided retry settings
- limit one browser composer to three active attachment uploads and preserve successful attachments when peers fail
- suppress ambiguous frontend transport replay for upload POSTs while retaining authentication refresh behavior
- improve durable upload diagnostics and document the staged rollout, monitoring, and rollback procedure

## Behavior

- durable registration defaults to four active requests per backend process
- staged requests wait up to 30 seconds before returning the existing generic `503`
- cancellation retains capacity until the cancellation-safe registration worker settles
- attachment uploads share one FIFO scheduler across repeated selections
- failed attachments are removed while successful attachments remain, and the toast includes failed count and filenames
- upload request and response shapes remain unchanged

## Verification

- `uv run pytest tests/web/services/test_upload_storage_gate.py tests/web/api/test_upload_connection_boundary.py::test_cancelled_registration_holds_capacity_until_worker_settles tests/web/test_file_upload.py::TestFileUpload::test_upload_capacity_timeout_returns_503_and_cleans_staging tests/web/test_file_upload.py::TestFileUpload::test_upload_remote_storage_outage_returns_503_and_logs_cause -q`
- `uv run pytest tests/core/test_config.py -k file_upload_admission -q`
- `npm run --prefix frontend test:run -- src/components/chat/ChatInput.test.tsx src/lib/api-wrapper.test.ts`
- `npm run --prefix frontend type-check`
- frontend file-scoped pre-commit hooks

Repository-wide Ruff remains blocked by pre-existing violations in touched legacy backend files. The targeted backend checks, mypy, codespell, isort, EOF, and whitespace hooks passed.

## Rollout

Follow `docs/deployment.md`: deploy diagnostic logging first, classify the storage failure, add admission control, enable the standard retry default only for transient or throttling failures, and then deploy the frontend scheduler.
