### PR TITLE
fix(migrations): stop alembic from disabling every existing logger

### DIFF
--- a/src/xagent/migrations/env.py
+++ b/src/xagent/migrations/env.py
@@ -29,8 +29,15 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
+#
+# ``disable_existing_loggers`` defaults to True, which would disable every
+# already-registered logger not explicitly listed in alembic.ini's
+# [loggers] section (root/sqlalchemy/alembic). Migrations run in-process
+# during normal app startup (see xagent.web.models.database), so that
+# default would silently and permanently disable application loggers
+# (e.g. everything under "xagent.*") for the lifetime of the process.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # Use our models' MetaData for autogenerate support
 target_metadata = Base.metadata

--- a/src/xagent/migrations/env.py
+++ b/src/xagent/migrations/env.py
@@ -30,12 +30,17 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 #
+# This branch only runs when alembic is driven from a config *file*: the
+# standalone `alembic upgrade head` CLI and tests/migrations/ (which build
+# their Config from alembic.ini). Normal app startup goes through
+# xagent.db.config.create_alembic_config(), which builds an in-memory Config
+# with no filename, so config.config_file_name is None there and this branch
+# is skipped -- production is not affected either way.
 # ``disable_existing_loggers`` defaults to True, which would disable every
 # already-registered logger not explicitly listed in alembic.ini's
-# [loggers] section (root/sqlalchemy/alembic). Migrations run in-process
-# during normal app startup (see xagent.web.models.database), so that
-# default would silently and permanently disable application loggers
-# (e.g. everything under "xagent.*") for the lifetime of the process.
+# [loggers] section (root/sqlalchemy/alembic) for the rest of the process.
+# That's what was poisoning the test suite: migration tests ran fileConfig
+# and disabled loggers that later tests then asserted against.
 if config.config_file_name is not None:
     fileConfig(config.config_file_name, disable_existing_loggers=False)
 

--- a/tests/migrations/test_env_logging_config.py
+++ b/tests/migrations/test_env_logging_config.py
@@ -1,21 +1,25 @@
 """Regression test for the alembic ``env.py`` logging configuration.
 
-``env.py`` calls ``logging.config.fileConfig(config.config_file_name)`` to
-apply ``alembic.ini``'s ``[loggers]`` section. ``fileConfig`` defaults
-``disable_existing_loggers`` to ``True``, which disables *every* logger
-already registered in ``logging.Logger.manager.loggerDict`` that is not one
-of the names explicitly configured in ``alembic.ini`` (``root``,
-``sqlalchemy``, ``alembic``).
+``env.py`` calls ``logging.config.fileConfig(config.config_file_name)`` when
+Alembic is driven from a config *file* (the standalone ``alembic upgrade
+head`` CLI, and this test suite, which builds its ``Config`` from
+``alembic.ini``). ``fileConfig`` defaults ``disable_existing_loggers`` to
+``True``, which disables *every* logger already registered in
+``logging.Logger.manager.loggerDict`` that is not one of the names
+explicitly configured in ``alembic.ini`` (``root``, ``sqlalchemy``,
+``alembic``).
 
-Because migrations run in-process during normal application startup (see
-``xagent.web.models.database._initialize_database_schema`` ->
-``xagent.db.migration.try_upgrade_db`` -> ``command.upgrade`` -> this
-``env.py``), that default would silently and permanently disable
-application loggers such as everything under ``xagent.*`` for the lifetime
-of the process, contradicting the project's own logging setup
-(``xagent.web.logging_config.setup_logging`` explicitly passes
-``disable_existing_loggers=False``).
+Normal application startup does **not** go through this branch:
+``xagent.db.config.create_alembic_config`` builds an in-memory Alembic
+``Config`` with no filename, so ``config.config_file_name`` is ``None`` and
+``fileConfig`` is never called there. See
+``test_env_logging_config_production.py`` for the test pinning that fact.
 
+What this file's test *is* affected by: when this test suite constructs a
+file-backed ``Config`` and runs a real migration, the old default
+(``disable_existing_loggers=True``) would disable every other already
+registered logger for the rest of the test process, contaminating
+subsequent tests that assert on log output -- 131 of them, historically.
 This test drives a real Alembic upgrade (exercising the actual ``env.py``)
 against a throwaway SQLite database and asserts that a logger which existed
 before the upgrade is not disabled afterward.
@@ -24,8 +28,6 @@ before the upgrade is not disabled afterward.
 from __future__ import annotations
 
 import logging
-import os
-import tempfile
 from collections.abc import Generator
 from pathlib import Path
 
@@ -49,25 +51,15 @@ def preexisting_logger() -> Generator[logging.Logger, None, None]:
 
 
 @pytest.fixture
-def sqlite_alembic_cfg() -> Generator[Config, None, None]:
+def sqlite_alembic_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Config:
     """An Alembic config pointed at a throwaway SQLite database."""
-    old_database_url = os.environ.get("DATABASE_URL")
-    fd, path = tempfile.mkstemp(suffix=".db")
-    os.close(fd)
-    db_url = f"sqlite:///{path}"
-    os.environ["DATABASE_URL"] = db_url
+    db_path = tmp_path / "env_logging_config.db"
+    db_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
 
     cfg = Config(str(project_root / "alembic.ini"))
     cfg.set_main_option("sqlalchemy.url", db_url)
-
-    try:
-        yield cfg
-    finally:
-        if old_database_url is None:
-            os.environ.pop("DATABASE_URL", None)
-        else:
-            os.environ["DATABASE_URL"] = old_database_url
-        os.unlink(path)
+    return cfg
 
 
 @pytest.mark.integration
@@ -77,9 +69,11 @@ def test_alembic_env_does_not_disable_preexisting_loggers(
 ) -> None:
     """Running the real migration env.py must not disable existing loggers.
 
+    This exercises the file-backed ``Config`` path (the same one the
+    standalone ``alembic upgrade head`` CLI and this test suite use).
     ``preexisting_logger`` stands in for any ``xagent.*`` logger created by
-    normal module imports before migrations run during app startup. Alembic
-    only explicitly configures ``root``, ``sqlalchemy``, and ``alembic`` in
+    normal module imports before this migration runs. Alembic only
+    explicitly configures ``root``, ``sqlalchemy``, and ``alembic`` in
     ``alembic.ini``; every other pre-existing logger must be left alone.
     """
     # Base tables are created by SQLAlchemy in production before migrations

--- a/tests/migrations/test_env_logging_config.py
+++ b/tests/migrations/test_env_logging_config.py
@@ -1,0 +1,105 @@
+"""Regression test for the alembic ``env.py`` logging configuration.
+
+``env.py`` calls ``logging.config.fileConfig(config.config_file_name)`` to
+apply ``alembic.ini``'s ``[loggers]`` section. ``fileConfig`` defaults
+``disable_existing_loggers`` to ``True``, which disables *every* logger
+already registered in ``logging.Logger.manager.loggerDict`` that is not one
+of the names explicitly configured in ``alembic.ini`` (``root``,
+``sqlalchemy``, ``alembic``).
+
+Because migrations run in-process during normal application startup (see
+``xagent.web.models.database._initialize_database_schema`` ->
+``xagent.db.migration.try_upgrade_db`` -> ``command.upgrade`` -> this
+``env.py``), that default would silently and permanently disable
+application loggers such as everything under ``xagent.*`` for the lifetime
+of the process, contradicting the project's own logging setup
+(``xagent.web.logging_config.setup_logging`` explicitly passes
+``disable_existing_loggers=False``).
+
+This test drives a real Alembic upgrade (exercising the actual ``env.py``)
+against a throwaway SQLite database and asserts that a logger which existed
+before the upgrade is not disabled afterward.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+project_root = Path(__file__).parent.parent.parent
+
+
+@pytest.fixture
+def preexisting_logger() -> Generator[logging.Logger, None, None]:
+    """A logger that exists before the migration runs, restored afterward."""
+    name = "xagent.test.env_logging_config.preexisting"
+    logger = logging.getLogger(name)
+    original_disabled = logger.disabled
+    try:
+        yield logger
+    finally:
+        logger.disabled = original_disabled
+
+
+@pytest.fixture
+def sqlite_alembic_cfg() -> Generator[Config, None, None]:
+    """An Alembic config pointed at a throwaway SQLite database."""
+    old_database_url = os.environ.get("DATABASE_URL")
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    db_url = f"sqlite:///{path}"
+    os.environ["DATABASE_URL"] = db_url
+
+    cfg = Config(str(project_root / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+
+    try:
+        yield cfg
+    finally:
+        if old_database_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = old_database_url
+        os.unlink(path)
+
+
+@pytest.mark.integration
+def test_alembic_env_does_not_disable_preexisting_loggers(
+    preexisting_logger: logging.Logger,
+    sqlite_alembic_cfg: Config,
+) -> None:
+    """Running the real migration env.py must not disable existing loggers.
+
+    ``preexisting_logger`` stands in for any ``xagent.*`` logger created by
+    normal module imports before migrations run during app startup. Alembic
+    only explicitly configures ``root``, ``sqlalchemy``, and ``alembic`` in
+    ``alembic.ini``; every other pre-existing logger must be left alone.
+    """
+    # Base tables are created by SQLAlchemy in production before migrations
+    # run; mirror that so `command.upgrade` exercises the same path as
+    # `tests/migrations/test_migration_integration.py`.
+    from sqlalchemy import create_engine
+
+    from xagent.web.models.database import Base
+
+    sqlalchemy_url = sqlite_alembic_cfg.get_main_option("sqlalchemy.url")
+    assert sqlalchemy_url is not None
+    engine = create_engine(sqlalchemy_url)
+    Base.metadata.create_all(bind=engine)
+    engine.dispose()
+
+    assert not preexisting_logger.disabled, "sanity check before the upgrade"
+
+    command.upgrade(sqlite_alembic_cfg, "head")
+
+    assert not preexisting_logger.disabled, (
+        "alembic's env.py disabled a pre-existing logger; fileConfig() must "
+        "be called with disable_existing_loggers=False"
+    )

--- a/tests/migrations/test_env_logging_config_production.py
+++ b/tests/migrations/test_env_logging_config_production.py
@@ -1,36 +1,45 @@
 """Pin that the production migration path never runs ``fileConfig``.
 
-This is a companion to ``test_env_logging_config.py``, not a substitute for
-it. That file proves the *fix* is correct for the code path it actually
-changes (a file-backed Alembic ``Config``, used by the standalone ``alembic
-upgrade head`` CLI and by the test suite).
+Companion to ``test_env_logging_config.py``, not a substitute. That file
+proves the *fix* works on the path it actually changes: a file-backed Alembic
+``Config``, used by the standalone ``alembic upgrade head`` CLI and by this
+test suite.
 
-This file proves something different and narrower: that production startup
+This file pins something narrower. Production startup
 (``xagent.web.models.database`` -> ``xagent.db.migration.try_upgrade_db`` ->
 ``xagent.db.config.create_alembic_config``) never reaches the ``fileConfig``
-branch in ``env.py`` at all, because ``create_alembic_config`` builds its
-``Config`` in memory with no filename. Since ``config.config_file_name`` is
-``None`` there, the ``if config.config_file_name is not None:`` guard skips
-``fileConfig`` entirely -- with or without this PR's
-``disable_existing_loggers=False`` fix.
+branch in ``env.py``, because ``create_alembic_config`` builds its ``Config``
+in memory with no filename. ``config.config_file_name`` is ``None`` there, so
+``if config.config_file_name is not None:`` skips ``fileConfig`` entirely --
+with or without this PR's ``disable_existing_loggers=False``.
 
-In other words: this test does NOT demonstrate that the fix changed
-production behavior (it didn't -- production was never affected by the
-bug). It exists so that if ``create_alembic_config`` is ever changed to
-pass a filename, the process-wide logger-disabling regression this PR fixed
-for the test suite cannot silently reappear in production without a test
-failing here first.
+So this does NOT show the fix changed production behavior; production was
+never affected. It guards against ``create_alembic_config`` later being given
+a filename, which would route production through ``fileConfig`` and let the
+process-wide logging mutation reappear.
+
+Asserting on ``logger.disabled`` alone cannot catch that, and this file
+deliberately does not rest on it: the PR sets
+``disable_existing_loggers=False``, so even with ``fileConfig`` running no
+logger would be disabled, and such an assertion would keep passing while the
+guard it claims to provide was gone. The regression would still be real --
+``fileConfig`` also replaces the root handler and resets the root level. The
+checks below therefore assert the *cause* (no filename, no ``fileConfig``
+call) rather than one downstream symptom this PR happens to suppress.
 """
 
 from __future__ import annotations
 
 import logging
+import logging.config
 from collections.abc import Generator
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
 
+from xagent.db.config import create_alembic_config
 from xagent.db.migration import try_upgrade_db
 
 
@@ -46,37 +55,61 @@ def preexisting_logger() -> Generator[logging.Logger, None, None]:
         logger.disabled = original_disabled
 
 
+def test_production_alembic_config_has_no_config_file_name(tmp_path: Path) -> None:
+    """``create_alembic_config`` must not produce a file-backed ``Config``.
+
+    This is the root fact the guard rests on: ``env.py`` gates ``fileConfig``
+    on ``config.config_file_name is not None``, so a config built without a
+    filename can never reach it.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'cfg.db'}")
+    try:
+        cfg = create_alembic_config(engine)
+        assert cfg.config_file_name is None, (
+            "create_alembic_config() returned a file-backed Config; env.py "
+            "would then run fileConfig() during production startup and mutate "
+            "process-wide logging state"
+        )
+    finally:
+        engine.dispose()
+
+
 @pytest.mark.integration
-def test_try_upgrade_db_does_not_disable_preexisting_loggers(
+def test_try_upgrade_db_never_calls_fileconfig(
     preexisting_logger: logging.Logger,
     tmp_path: Path,
 ) -> None:
-    """``try_upgrade_db`` (the production startup path) must not touch loggers.
+    """The production startup path must not invoke ``fileConfig`` at all.
 
-    ``create_alembic_config`` builds its ``Config`` with no filename, so
-    ``env.py``'s ``fileConfig`` branch is skipped for this path regardless of
-    the ``disable_existing_loggers`` argument. This test pins that fact: it
-    is a guard against a future regression (e.g. someone adding a
-    ``config_file_name`` to ``create_alembic_config``), not evidence that
-    this PR's fix altered production behavior -- it did not, because
-    production never executed the buggy line in the first place.
+    ``env.py`` re-imports ``fileConfig`` from ``logging.config`` on every run
+    (Alembic execs the file fresh), so patching it there observes the real
+    call. ``wraps`` keeps the genuine behaviour, so a regression fails on the
+    assertion rather than by breaking the migration.
     """
     # An empty database exercises `command.stamp(alembic_cfg, "head")`,
     # `try_upgrade_db`'s path for a brand-new database. `env.py` runs either
-    # way (stamp and upgrade both trigger it), so this covers the same
-    # fileConfig-skipping guard as a populated database would.
-    db_path = tmp_path / "try_upgrade_db_logging.db"
-    db_url = f"sqlite:///{db_path}"
-    engine = create_engine(db_url)
+    # way -- stamp and upgrade both trigger it -- so this covers the same
+    # branch a populated database would.
+    engine = create_engine(f"sqlite:///{tmp_path / 'try_upgrade_db_logging.db'}")
 
     assert not preexisting_logger.disabled, "sanity check before the upgrade"
 
-    try_upgrade_db(engine)
+    with patch.object(
+        logging.config, "fileConfig", wraps=logging.config.fileConfig
+    ) as spy_file_config:
+        try:
+            try_upgrade_db(engine)
+        finally:
+            engine.dispose()
 
-    assert not preexisting_logger.disabled, (
-        "the production migration path (try_upgrade_db) disabled a "
-        "pre-existing logger; create_alembic_config() must not pass a "
-        "config_file_name that would route env.py through fileConfig()"
+    assert spy_file_config.call_count == 0, (
+        "the production migration path called fileConfig() "
+        f"{spy_file_config.call_count} time(s); create_alembic_config() must "
+        "not pass a config_file_name, or env.py will mutate process-wide "
+        "logging state during application startup"
     )
 
-    engine.dispose()
+    # Secondary, and deliberately not load-bearing: with
+    # disable_existing_loggers=False in place this holds even if fileConfig
+    # had run. Kept only to document the symptom the original bug produced.
+    assert not preexisting_logger.disabled

--- a/tests/migrations/test_env_logging_config_production.py
+++ b/tests/migrations/test_env_logging_config_production.py
@@ -1,0 +1,82 @@
+"""Pin that the production migration path never runs ``fileConfig``.
+
+This is a companion to ``test_env_logging_config.py``, not a substitute for
+it. That file proves the *fix* is correct for the code path it actually
+changes (a file-backed Alembic ``Config``, used by the standalone ``alembic
+upgrade head`` CLI and by the test suite).
+
+This file proves something different and narrower: that production startup
+(``xagent.web.models.database`` -> ``xagent.db.migration.try_upgrade_db`` ->
+``xagent.db.config.create_alembic_config``) never reaches the ``fileConfig``
+branch in ``env.py`` at all, because ``create_alembic_config`` builds its
+``Config`` in memory with no filename. Since ``config.config_file_name`` is
+``None`` there, the ``if config.config_file_name is not None:`` guard skips
+``fileConfig`` entirely -- with or without this PR's
+``disable_existing_loggers=False`` fix.
+
+In other words: this test does NOT demonstrate that the fix changed
+production behavior (it didn't -- production was never affected by the
+bug). It exists so that if ``create_alembic_config`` is ever changed to
+pass a filename, the process-wide logger-disabling regression this PR fixed
+for the test suite cannot silently reappear in production without a test
+failing here first.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+
+from xagent.db.migration import try_upgrade_db
+
+
+@pytest.fixture
+def preexisting_logger() -> Generator[logging.Logger, None, None]:
+    """A logger that exists before the migration runs, restored afterward."""
+    name = "xagent.test.env_logging_config_production.preexisting"
+    logger = logging.getLogger(name)
+    original_disabled = logger.disabled
+    try:
+        yield logger
+    finally:
+        logger.disabled = original_disabled
+
+
+@pytest.mark.integration
+def test_try_upgrade_db_does_not_disable_preexisting_loggers(
+    preexisting_logger: logging.Logger,
+    tmp_path: Path,
+) -> None:
+    """``try_upgrade_db`` (the production startup path) must not touch loggers.
+
+    ``create_alembic_config`` builds its ``Config`` with no filename, so
+    ``env.py``'s ``fileConfig`` branch is skipped for this path regardless of
+    the ``disable_existing_loggers`` argument. This test pins that fact: it
+    is a guard against a future regression (e.g. someone adding a
+    ``config_file_name`` to ``create_alembic_config``), not evidence that
+    this PR's fix altered production behavior -- it did not, because
+    production never executed the buggy line in the first place.
+    """
+    # An empty database exercises `command.stamp(alembic_cfg, "head")`,
+    # `try_upgrade_db`'s path for a brand-new database. `env.py` runs either
+    # way (stamp and upgrade both trigger it), so this covers the same
+    # fileConfig-skipping guard as a populated database would.
+    db_path = tmp_path / "try_upgrade_db_logging.db"
+    db_url = f"sqlite:///{db_path}"
+    engine = create_engine(db_url)
+
+    assert not preexisting_logger.disabled, "sanity check before the upgrade"
+
+    try_upgrade_db(engine)
+
+    assert not preexisting_logger.disabled, (
+        "the production migration path (try_upgrade_db) disabled a "
+        "pre-existing logger; create_alembic_config() must not pass a "
+        "config_file_name that would route env.py through fileConfig()"
+    )
+
+    engine.dispose()


### PR DESCRIPTION
> **Corrected.** The original description of this PR claimed the bug affected production application startup. That was wrong — see [@qinxuye's review](https://github.com/xorbitsai/xagent/pull/1465#discussion_r0) — and the rationale below has been rewritten. The one-line fix and its measured effect on the test suite are unchanged.

## What's wrong

`src/xagent/migrations/env.py` carries alembic's generated line:

```python
fileConfig(config.config_file_name)
```

`disable_existing_loggers` defaults to `True`, and `alembic.ini` only lists `root`, `sqlalchemy` and `alembic`. So every logger already registered when this runs gets `disabled = True` — process-wide, for the rest of that process's life.

## Where it actually bites

This branch only runs when alembic is driven from a config **file**:

| path | config source | branch runs? | impact |
|---|---|---|---|
| app startup | `create_alembic_config()` — `AlembicConfig()`, no filename | **no** — `config_file_name is None` | none |
| `tests/migrations/` | `Config("alembic.ini")` | yes | **poisons the rest of the session** |
| `alembic upgrade head` CLI | `alembic.ini` | yes | harmless — the process only migrates |

Production is **not** affected. `create_alembic_config()` (`src/xagent/db/config.py`) builds an in-memory config and injects logging settings via `set_section_option(...)`, so `config_file_name` is `None` and the branch is skipped for both `command.upgrade` and `command.stamp`. Confirmed empirically: running `try_upgrade_db()` against a temp SQLite database leaves a pre-existing `xagent.*` logger enabled before and after.

The real damage is to the test suite. `tests/migrations/` builds its config from `alembic.ini`, so `fileConfig` runs, disables every application logger registered up to that point, and nothing ever clears the flag. Every later test that asserts on log output then sees nothing — `Logger.isEnabledFor` short-circuits on `disabled`, so the record is never even created.

## The fix

```python
fileConfig(config.config_file_name, disable_existing_loggers=False)
```

**Not** by adding a key to `alembic.ini`: `fileConfig` only reads this from its own signature, never from the ini file (that key belongs to `dictConfig`'s schema). The ini route would silently do nothing.

The `fileConfig` call itself is left in place — it still applies `alembic.ini`'s levels and handlers for the standalone-CLI case.

## Effect on the test suite

| | failures |
|---|---|
| `origin/main` | 152 |
| with this change | **21** |

**131 tests fixed, 0 regressions** — measured by diffing failure *sets*, not by comparing counts. Every one of them asserts on logging: `..._logs_a_warning`, `..._emits_one_structured_warning`, `..._logs_dropped_provider_and_reason`, and so on. They fail on main purely because they happen to run after `tests/migrations/`.

The remaining 21 are unrelated (missing local `libcairo` for SVG rasterisation, etc.).

## Tests

- `tests/migrations/test_env_logging_config.py` — drives a real `command.upgrade(cfg, "head")` from `alembic.ini` against a throwaway SQLite database and asserts a pre-existing `xagent.*` logger is still enabled afterwards. Fails without the fix, passes with it.
- `tests/migrations/test_env_logging_config_production.py` — builds the config the way production does and runs `try_upgrade_db()`, asserting loggers stay enabled. This pins that production is unaffected; it does **not** claim the fix changed production behavior. It guards against someone later giving `create_alembic_config()` a filename and silently reintroducing the contamination. Verified to fail when that regression is simulated.

Both use `tmp_path`/`monkeypatch` so no env var or temp file leaks, and restore any logger flag they touch.

## Notes

- Separate pre-existing gap noticed while tracing this: the `xagent migrate ...` CLI path never calls `setup_logging()`. Not addressed here.
- Thanks to @gemini-code-assist for the fixture-hygiene suggestion, applied in the second commit.