### PR TITLE
refactor(ws): extract the trace data serializer to module level

### DIFF
--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -161,7 +161,7 @@ def _marker_clean(value: str) -> str:
     cannot share code with -- ``src/xagent/web/api/trace_handlers.py``'s
     ``DatabaseTraceHandler._serialize_data_for_json`` (``clean_string``),
     ``src/xagent/web/api/ws_trace_handlers.py``'s
-    ``WebSocketTraceHandler._serialize_data`` (``clean_string``), and
+    ``serialize_trace_data`` (``clean_string``), and
     ``src/xagent/web/api/websocket.py``'s
     ``SharedWebSocketTracer._serialize_data`` (``clean_string``) -- and
     ``src/xagent/web/services/task_clarification_draft.py``'s

--- a/src/xagent/web/api/ws_trace_handlers.py
+++ b/src/xagent/web/api/ws_trace_handlers.py
@@ -223,6 +223,78 @@ def is_agent_checkpoint_data(data: Any) -> bool:
     )
 
 
+def serialize_trace_data(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively serialize trace event data to ensure JSON compatibility.
+
+    Module-level so the v1 SSE content-projection layer
+    (``v1/_events_stream.py``) can reuse the exact same pass on live
+    broadcast frames that the WebSocket handler applies before
+    persisting/broadcasting -- this function never reads ``self``, so
+    lifting it out of ``WebSocketTraceHandler`` changes nothing about
+    its behavior for the existing caller below.
+    """
+    import json
+    from datetime import datetime
+
+    def clean_string(value: str) -> str:
+        """Clean string data to remove problematic characters for JSON."""
+        if not isinstance(value, str):
+            return value
+
+        # Remove NULL characters and other problematic control characters
+        cleaned = value.replace("\x00", "")  # Remove NULL character
+        cleaned = cleaned.replace("\u0000", "")  # Remove Unicode NULL
+        # Remove other control characters that might cause issues
+        cleaned = "".join(
+            char for char in cleaned if ord(char) >= 32 or char in "\n\r\t"
+        )
+        return cleaned
+
+    def serialize_value(value: Any) -> Any:
+        # Handle Pydantic models (BaseModel)
+        if hasattr(value, "model_dump"):
+            return serialize_value(value.model_dump())
+        elif callable(getattr(value, "to_dict", None)):
+            return serialize_value(value.to_dict())
+        elif hasattr(value, "dict"):  # Fallback for older Pydantic
+            return serialize_value(value.dict())
+        elif isinstance(value, datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return value.timestamp()
+        elif isinstance(value, str):
+            return clean_string(value)
+        elif isinstance(value, dict):
+            return {k: serialize_value(v) for k, v in value.items()}
+        elif isinstance(value, (list, tuple)):
+            return [serialize_value(item) for item in value]
+        elif isinstance(value, bytes):
+            try:
+                return clean_string(value.decode("utf-8"))
+            except UnicodeDecodeError:
+                return f"<bytes: {len(value)}>"
+        else:
+            return value
+
+    try:
+        # First clean and serialize the data
+        cleaned_data = serialize_value(data)
+
+        # Test if cleaned data is JSON serializable
+        json.dumps(cleaned_data)
+        return cleaned_data  # type: ignore[no-any-return]
+    except (TypeError, ValueError) as e:
+        # If still not serializable, return a safe fallback
+        logger.warning(
+            f"Failed to serialize data for JSON: {e}, data type: {type(data)}"
+        )
+        return {
+            "_serialization_error": f"Failed to serialize {type(data).__name__}",
+            "_original_type": type(data).__name__,
+            "_error": str(e),
+        }
+
+
 def _convert_timestamp_to_utc_timestamp(timestamp: Any) -> float:
     """Convert timestamp to Unix timestamp for WebSocket compatibility."""
     if timestamp is None:
@@ -419,64 +491,11 @@ class WebSocketTraceHandler(TraceHandler):
             return False
 
     def _serialize_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Recursively serialize data to ensure JSON compatibility."""
-        import json
-        from datetime import datetime
+        """Recursively serialize data to ensure JSON compatibility.
 
-        def clean_string(value: str) -> str:
-            """Clean string data to remove problematic characters for JSON."""
-            if not isinstance(value, str):
-                return value
-
-            # Remove NULL characters and other problematic control characters
-            cleaned = value.replace("\x00", "")  # Remove NULL character
-            cleaned = cleaned.replace("\u0000", "")  # Remove Unicode NULL
-            # Remove other control characters that might cause issues
-            cleaned = "".join(
-                char for char in cleaned if ord(char) >= 32 or char in "\n\r\t"
-            )
-            return cleaned
-
-        def serialize_value(value: Any) -> Any:
-            # Handle Pydantic models (BaseModel)
-            if hasattr(value, "model_dump"):
-                return serialize_value(value.model_dump())
-            elif callable(getattr(value, "to_dict", None)):
-                return serialize_value(value.to_dict())
-            elif hasattr(value, "dict"):  # Fallback for older Pydantic
-                return serialize_value(value.dict())
-            elif isinstance(value, datetime):
-                if value.tzinfo is None:
-                    value = value.replace(tzinfo=timezone.utc)
-                return value.timestamp()
-            elif isinstance(value, str):
-                return clean_string(value)
-            elif isinstance(value, dict):
-                return {k: serialize_value(v) for k, v in value.items()}
-            elif isinstance(value, (list, tuple)):
-                return [serialize_value(item) for item in value]
-            elif isinstance(value, bytes):
-                try:
-                    return clean_string(value.decode("utf-8"))
-                except UnicodeDecodeError:
-                    return f"<bytes: {len(value)}>"
-            else:
-                return value
-
-        try:
-            # First clean and serialize the data
-            cleaned_data = serialize_value(data)
-
-            # Test if cleaned data is JSON serializable
-            json.dumps(cleaned_data)
-            return cleaned_data  # type: ignore[no-any-return]
-        except (TypeError, ValueError) as e:
-            # If still not serializable, return a safe fallback
-            logger.warning(
-                f"Failed to serialize data for JSON: {e}, data type: {type(data)}"
-            )
-            return {
-                "_serialization_error": f"Failed to serialize {type(data).__name__}",
-                "_original_type": type(data).__name__,
-                "_error": str(e),
-            }
+        Thin instance wrapper -- the actual pass is ``serialize_trace_data``
+        (module level, doesn't read ``self``) so the v1 SSE content
+        projector can reuse the identical logic on live broadcast frames
+        without going through this class.
+        """
+        return serialize_trace_data(data)

--- a/src/xagent/web/api/ws_trace_handlers.py
+++ b/src/xagent/web/api/ws_trace_handlers.py
@@ -229,9 +229,9 @@ def serialize_trace_data(data: Dict[str, Any]) -> Dict[str, Any]:
     Module-level so the v1 SSE content-projection layer
     (``v1/_events_stream.py``) can reuse the exact same pass on live
     broadcast frames that the WebSocket handler applies before
-    persisting/broadcasting -- this function never reads ``self``, so
-    lifting it out of ``WebSocketTraceHandler`` changes nothing about
-    its behavior for the existing caller below.
+    broadcasting -- this function never reads ``self``, so lifting it
+    out of ``WebSocketTraceHandler`` changes nothing about its
+    behavior for the existing caller below.
     """
     import json
     from datetime import datetime

--- a/tests/web/api/test_ws_trace_handlers_serializer.py
+++ b/tests/web/api/test_ws_trace_handlers_serializer.py
@@ -1,0 +1,91 @@
+"""Direct coverage for ``serialize_trace_data``.
+
+This is the module-level function ``WebSocketTraceHandler._serialize_data``
+now delegates to (see ``ws_trace_handlers.py``). The whole point of lifting
+it out of the class was to let a second caller -- the v1 SSE
+content-projection layer -- reuse the exact same pass without going through
+``WebSocketTraceHandler``. These tests call it directly, the way that
+second caller will, instead of only exercising it indirectly through the
+handler class (as ``tests/core/agent/test_react_clarification_draft.py``
+already does).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from xagent.web.api.ws_trace_handlers import serialize_trace_data
+
+
+def test_recursively_serializes_nested_structures_into_json_safe_data() -> None:
+    """Nested dicts/lists/datetimes/bytes all come out JSON-encodable."""
+
+    payload = {
+        "when": datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        "nested": {
+            "items": [1, "two", {"three": 3.0}],
+            "raw": b"hello",
+        },
+        "tuple_becomes_list": (1, 2, 3),
+    }
+
+    result = serialize_trace_data(payload)
+
+    # No exception on json.dumps means every leaf is now JSON-safe.
+    json.dumps(result)
+    assert (
+        result["when"]
+        == datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    )
+    assert result["nested"]["items"] == [1, "two", {"three": 3.0}]
+    assert result["nested"]["raw"] == "hello"
+    assert result["tuple_becomes_list"] == [1, 2, 3]
+
+
+def test_serializes_model_dump_and_to_dict_objects() -> None:
+    """Pydantic-style ``model_dump()`` and plain ``to_dict()`` objects
+    are unwrapped into their dict form, then recursively serialized."""
+
+    class ModelDumpLike:
+        def model_dump(self) -> dict:
+            return {
+                "kind": "model_dump",
+                "created": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            }
+
+    class ToDictLike:
+        def to_dict(self) -> dict:
+            return {"kind": "to_dict"}
+
+    result = serialize_trace_data({"a": ModelDumpLike(), "b": ToDictLike()})
+
+    json.dumps(result)
+    assert result["a"]["kind"] == "model_dump"
+    assert result["b"] == {"kind": "to_dict"}
+
+
+def test_strips_control_characters_but_keeps_newline_tab_and_cr() -> None:
+    dirty = "keep\nthis\tand\rthis" + "\x00" + "\x01" + "drop-that"
+
+    result = serialize_trace_data({"text": dirty})
+
+    assert result["text"] == "keep\nthis\tand\rthisdrop-that"
+
+
+def test_falls_back_to_serialization_error_stub_instead_of_raising() -> None:
+    """An object the serializer has no unwrap path for (no ``model_dump``,
+    ``to_dict``, or ``dict``, and not JSON-native) survives the recursive
+    pass unchanged, then fails ``json.dumps`` -- at which point
+    ``serialize_trace_data`` must degrade to the ``_serialization_error``
+    stub rather than propagating the ``TypeError``."""
+
+    class Unserializable:
+        pass
+
+    result = serialize_trace_data({"bad": Unserializable()})
+
+    # Must not raise, and must not silently produce non-JSON-safe output.
+    json.dumps(result)
+    assert result["_serialization_error"] == "Failed to serialize dict"
+    assert result["_original_type"] == "dict"


### PR DESCRIPTION
## Why

`WebSocketTraceHandler._serialize_data` holds its entire recursive
JSON-safety pass (Pydantic/`to_dict` unwrapping, datetime-to-timestamp
conversion, control-character stripping, and a `_serialization_error`
fallback) as a closure inside the method body. That makes it usable only
through an instance of `WebSocketTraceHandler`.

The v1 SSE content-projection layer needs to apply the exact same pass to
live broadcast frames without going through the WebSocket handler class.
Since the closure never reads `self`, lifting it to module level costs
nothing and lets both callers share one implementation instead of two
copies drifting apart over time.

## What

- Moved the closure out of `WebSocketTraceHandler._serialize_data` into a
  new module-level function, `serialize_trace_data`, in
  `src/xagent/web/api/ws_trace_handlers.py`.
- `_serialize_data` is now a one-line wrapper that calls straight through
  to `serialize_trace_data`.
- No behavior change for the existing WebSocket path: same input, same
  output, same fallback on non-serializable data.

## Verification

- `python -c "import xagent.web.api.ws_trace_handlers"` -- imports clean.
- New direct-call tests added in
  `tests/web/api/test_ws_trace_handlers_serializer.py`, calling
  `serialize_trace_data` without going through `WebSocketTraceHandler`:
  recursive serialization into JSON-safe structures, `model_dump`/`to_dict`
  unwrapping, control-character stripping, and the `_serialization_error`
  fallback for objects the serializer has no unwrap path for.
- Existing indirect coverage still passes:
  `tests/core/agent/test_react_clarification_draft.py` (parametrized
  across `DatabaseTraceHandler`, `WebSocketTraceHandler`, and
  `SharedWebSocketTracer`), `tests/web/api/test_public_trace_events.py`,
  `tests/core/tools/test_create_agent_tool.py`,
  `tests/core/agent/pattern/test_llm_trace_audit.py`,
  `tests/web/test_tracing_factory.py`,
  `tests/web/test_agent_checkpoint_stream.py`, and the mocked
  `TestWebSocket::test_websocket_trace_handler_integration` case in
  `tests/integration/test_websocket.py`.
- Full `tests/web/api/` suite passes (only Postgres-only tests skip, as
  they do without a Postgres URL configured).
- Mutation checks, each reverted before the next:
  - `_serialize_data` changed to return its input unchanged instead of
    delegating: the parametrized `WebSocketTraceHandler` cells in
    `test_react_clarification_draft.py` go red.
  - `clean_string` inside `serialize_trace_data` changed to a no-op:
    the new direct control-character test goes red. (The pre-existing
    indirect tests don't exercise control characters in their payloads,
    so they stay green under this mutation -- the new test covers
    something the old ones didn't reach.)
- `pre-commit run` passes on both changed files (ruff check, ruff format,
  mypy, isort, codespell, end-of-file/whitespace fixers).
