### PR TITLE
fix(files): log the provider cause behind durable-storage faults

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -188,6 +188,14 @@ async def _create_knowledge_base_from_file_impl(
             try:
                 source_path = ensure_uploaded_file_local_path(record)
             except DurableStorageOperationError as exc:
+                # The message below reaches the model; the provider fault only
+                # exists in ``__cause__``, so log the chain too (#1467).
+                logger.warning(
+                    "Durable storage unavailable while restoring file for "
+                    "ingestion: file_id=%s",
+                    record.file_id,
+                    exc_info=exc,
+                )
                 errors.append(
                     f"Failed to restore {record.filename} from durable storage: {exc}"
                 )

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -121,6 +121,7 @@ async def _create_knowledge_base_from_file_impl(
         from .....web.models.database import get_db
         from .....web.models.uploaded_file import UploadedFile
         from .....web.services.managed_file_ref import (
+            DurableObjectIntegrityError,
             DurableStorageOperationError,
             ensure_uploaded_file_local_path,
             log_durable_storage_fault,
@@ -188,6 +189,19 @@ async def _create_knowledge_base_from_file_impl(
         for record in file_records:
             try:
                 source_path = ensure_uploaded_file_local_path(record)
+            except DurableObjectIntegrityError:
+                # Must precede the parent arm below, which this subclasses. A
+                # checksum mismatch is permanent corruption, already recorded
+                # at ERROR with both checksums by ``_raise_integrity_error``.
+                # Routing it through the durable-fault logger would add a
+                # "Durable storage unavailable" WARNING on top, which reads as
+                # a transient outage and can trip the alerts that watch for one
+                # -- burying the corruption diagnosis under a wrong one.
+                errors.append(
+                    f"Stored copy of {record.filename} failed its integrity "
+                    "check and must be re-uploaded"
+                )
+                continue
             except DurableStorageOperationError as exc:
                 log_durable_storage_fault(
                     logger,

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -123,6 +123,7 @@ async def _create_knowledge_base_from_file_impl(
         from .....web.services.managed_file_ref import (
             DurableStorageOperationError,
             ensure_uploaded_file_local_path,
+            log_durable_storage_fault,
         )
         from ...core.RAG_tools.core.schemas import (
             DEFAULT_EMBEDDING_MODEL_ID,
@@ -188,16 +189,20 @@ async def _create_knowledge_base_from_file_impl(
             try:
                 source_path = ensure_uploaded_file_local_path(record)
             except DurableStorageOperationError as exc:
-                # The message below reaches the model; the provider fault only
-                # exists in ``__cause__``, so log the chain too (#1467).
-                logger.warning(
-                    "Durable storage unavailable while restoring file for "
-                    "ingestion: file_id=%s",
-                    record.file_id,
-                    exc_info=exc,
+                log_durable_storage_fault(
+                    logger,
+                    "knowledge-base file restore",
+                    exc,
+                    file_id=record.file_id,
                 )
+                # Deliberately does NOT interpolate ``exc``. This string is
+                # joined into the tool result, so it reaches the model and the
+                # conversation transcript -- and ``str(exc)`` is the wrap's
+                # message, which carries the storage key, whose scope segments
+                # encode the owning user's id. The provider detail belongs in
+                # the log line above, which is server-side only.
                 errors.append(
-                    f"Failed to restore {record.filename} from durable storage: {exc}"
+                    f"Failed to restore {record.filename} from durable storage"
                 )
                 continue
             if not source_path.exists():

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -238,10 +238,18 @@ async def _create_knowledge_base_from_file_impl(
             try:
                 request_context = copy_context()
                 result = await loop.run_in_executor(None, request_context.run, func)
-            except Exception as exc:
-                errors.append(
-                    f"Failed to ingest {record.filename} due to unexpected error: {exc}"
-                )
+            except Exception:
+                # Deliberately does NOT interpolate the exception, for the same
+                # reason as the durable arm above: this string is joined into the
+                # tool result, so it reaches the model and the conversation
+                # transcript. ``HashComputationError`` wraps an OSError whose
+                # message embeds the absolute upload path, and
+                # ``DocumentValidationError`` renders "Source path does not
+                # exist: <path>" -- both under users/<user_id>/uploads/..., so
+                # both carry the owning user's id. The filename is the only part
+                # the model needs; the traceback below keeps everything else,
+                # server-side.
+                errors.append(f"Failed to ingest {record.filename}")
                 logger.exception(
                     "Unexpected error ingesting file %s",
                     record.filename,

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -1319,7 +1319,13 @@ class TaskWorkspace:
                 if should_close:
                     db.close()
         except Exception as e:
-            logger.warning(f"Failed to resolve file_id from database: {e}")
+            # ``exc_info`` because this fault is swallowed -- the caller only
+            # sees ``None`` -- so this is its only record. A durable-storage
+            # fault arrives here from ``materialize()`` carrying just the
+            # storage key; its cause lives in ``__cause__`` (#1467).
+            logger.warning(
+                f"Failed to resolve file_id from database: {e}", exc_info=True
+            )
             return None
 
     def _file_operation_path_in_authorized_storage(self, path: Path) -> bool:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2860,7 +2860,14 @@ class AgentServiceManager:
                     await self._load_persisted_execution_context(task_id, db)
 
             except Exception as e:
-                logger.error(f"Failed to create AgentService for task {task_id}: {e}")
+                # ``exc_info`` because this arm absorbs any wrapped fault --
+                # a durable-storage one from attachment restore included --
+                # whose provider cause lives only in ``__cause__`` (#1467).
+                # It re-raises, so nothing but the log line changes.
+                logger.error(
+                    f"Failed to create AgentService for task {task_id}: {e}",
+                    exc_info=True,
+                )
                 # Re-raise the exception - no fallback logic allowed
                 raise
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -327,7 +327,9 @@ def _durable_redirect_response(
     except DurableObjectIntegrityError as exc:
         raise _file_integrity_failed() from exc
     except DurableStorageOperationError as exc:
-        _raise_durable_storage_unavailable(exc, "signed durable redirect")
+        _raise_durable_storage_unavailable(
+            exc, "signed durable redirect", file_id=file_ref.record.file_id
+        )
 
     if not signed_url:
         return None

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -121,7 +121,7 @@ file_router = APIRouter(prefix="/api/files", tags=["files"])
 DELETE_CLEANUP_OPERATION = "durable cleanup before row delete"
 
 
-def _durable_storage_unavailable(exc: BaseException, operation: str) -> HTTPException:
+def _durable_storage_unavailable(exc: Exception, operation: str) -> HTTPException:
     """Record the provider fault, then answer the retryable 503.
 
     Logging belongs here rather than at each call site because the 503 is the
@@ -133,8 +133,16 @@ def _durable_storage_unavailable(exc: BaseException, operation: str) -> HTTPExce
     credentials all live in ``__cause__`` and nowhere else. ``exc_info``
     is what carries that chain into the log (see #1467).
 
-    ``exc`` is typed ``BaseException`` because not every site wraps first: the
-    delete path catches the raw provider exception directly.
+    ``exc`` is ``Exception``, not ``BaseException``, and the narrowing is load
+    bearing rather than cosmetic. Every caller catches either
+    ``DurableStorageOperationError`` (a ``RuntimeError``) or, on the delete
+    path, a bare ``Exception`` -- so ``Exception`` is the true domain. Keeping
+    it that narrow makes mypy reject a future caller that widens its ``except``
+    and hands over an ``asyncio.CancelledError`` or ``KeyboardInterrupt``,
+    which must never be reported as storage unavailability: a cancelled or
+    interrupted request has not established that the object store is unwell,
+    and answering 503 would tell the client to retry something that was
+    deliberately stopped.
 
     Level is ``warning``, not ``error``: this classification *is* the claim
     that the fault is transient and worth retrying, which is the same reason

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -113,7 +113,45 @@ logger = logging.getLogger(__name__)
 file_router = APIRouter(prefix="/api/files", tags=["files"])
 
 
-def _durable_storage_unavailable() -> HTTPException:
+# The operation label for the durable cleanup ``delete_file`` runs before it
+# drops the metadata row. Named rather than inlined so the one log message this
+# change *renames* (it replaced "Failed to clean up durable file before
+# deleting row") has a single definition that alerting can be re-keyed to, and
+# so its test cannot drift from the string the endpoint actually emits.
+DELETE_CLEANUP_OPERATION = "durable cleanup before row delete"
+
+
+def _durable_storage_unavailable(exc: BaseException, operation: str) -> HTTPException:
+    """Record the provider fault, then answer the retryable 503.
+
+    Logging belongs here rather than at each call site because the 503 is the
+    only thing that leaves the process: every site raises this ``from exc``,
+    but FastAPI's default ``HTTPException`` handler never logs a traceback, so
+    without this line the fault that actually failed is lost. And the wrap in
+    ``ManagedFileRef`` keeps only the storage key in its message -- the
+    provider error class, the HTTP status, throttle vs. timeout vs. rejected
+    credentials all live in ``__cause__`` and nowhere else. ``exc_info``
+    is what carries that chain into the log (see #1467).
+
+    ``exc`` is typed ``BaseException`` because not every site wraps first: the
+    delete path catches the raw provider exception directly.
+
+    Level is ``warning``, not ``error``: this classification *is* the claim
+    that the fault is transient and worth retrying, which is the same reason
+    the response is 503. Permanent namespace-authority faults are meant to be
+    excluded from it upstream (``_NAMESPACE_AUTHORITY_ERRORS`` in
+    services/managed_file_ref.py) and logged at ``error`` by the app-wide
+    handler in web/app.py. ``delete_file`` is the one caller that does not
+    honour that split -- its bare ``except Exception`` folds a
+    ``StorageKeyScopeError`` in here, so a permanent fault is answered 503 and
+    logged as transient. That is pre-existing and tracked in #1473, not a
+    property of this helper.
+
+    The detail stays server-side. ``str(exc)`` carries the storage key, whose
+    scope segments can encode end-user identity, so the response body remains
+    the fixed message -- the same split web/app.py makes for the 500 it owns.
+    """
+    logger.warning("Durable storage unavailable during %s", operation, exc_info=exc)
     return HTTPException(
         status_code=503,
         detail="Durable storage is temporarily unavailable",
@@ -305,7 +343,7 @@ def _durable_redirect_response(
     except DurableObjectIntegrityError as exc:
         raise _file_integrity_failed() from exc
     except DurableStorageOperationError as exc:
-        raise _durable_storage_unavailable() from exc
+        raise _durable_storage_unavailable(exc, "signed durable redirect") from exc
 
     if not signed_url:
         return None
@@ -588,8 +626,7 @@ async def store_uploaded_files(
             )
         completed = True
     except DurableStorageOperationError as exc:
-        logger.warning("Durable storage unavailable during upload: %s", exc)
-        raise _durable_storage_unavailable() from exc
+        raise _durable_storage_unavailable(exc, "upload") from exc
     finally:
         if not completed:
 
@@ -1460,7 +1497,7 @@ async def download_file(
                     },
                 )
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                raise _durable_storage_unavailable(exc, "download") from exc
     else:
         # For legacy files without records, check ownership
         if owner_user_id != _user_id_value(user) and not _is_admin_user(user):
@@ -1769,7 +1806,7 @@ async def preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                raise _durable_storage_unavailable(exc, "preview") from exc
             except DurableObjectMissingError:
                 materialized_path = file_ref.local_path
                 _ensure_under_uploads(materialized_path, owner_user_id)
@@ -1858,7 +1895,7 @@ async def preview_pptx_as_pdf(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                raise _durable_storage_unavailable(exc, "pptx preview") from exc
             except DurableObjectMissingError:
                 # Durable record points at nothing; fall back to whatever
                 # is on disk (or 404 below if it's gone too).
@@ -1950,7 +1987,7 @@ async def public_download_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                raise _durable_storage_unavailable(exc, "public download") from exc
             except DurableObjectMissingError:
                 target_path = file_ref.local_path
         else:
@@ -2016,7 +2053,7 @@ async def public_preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                raise _durable_storage_unavailable(exc, "public preview") from exc
             except DurableObjectMissingError:
                 target_path = file_ref.local_path
                 _ensure_under_uploads(target_path, owner_user_id)
@@ -2060,7 +2097,9 @@ async def public_preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                raise _durable_storage_unavailable(
+                    exc, "public preview task asset"
+                ) from exc
             except DurableObjectMissingError:
                 target_path = asset_ref.local_path
             _ensure_under_uploads(target_path, owner_user_id)
@@ -2130,11 +2169,9 @@ async def delete_file(
                     storage_key
                 )
             except Exception as exc:
-                logger.warning(
-                    "Failed to clean up durable file before deleting row: %s",
-                    storage_key,
-                )
-                raise _durable_storage_unavailable() from exc
+                raise _durable_storage_unavailable(
+                    exc, f"{DELETE_CLEANUP_OPERATION} ({storage_key})"
+                ) from exc
 
         db.delete(file_record)
         db.commit()

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -4,7 +4,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, NamedTuple, Optional, Tuple, cast
+from typing import Any, Dict, NamedTuple, NoReturn, Optional, Tuple, cast
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -75,6 +75,7 @@ from ..services.managed_file_ref import (
     DurableStorageOperationError,
     ManagedFileRef,
     guess_media_type,
+    log_durable_storage_fault,
 )
 from ..services.uploaded_file_store import (
     LocalUploadRegistration,
@@ -113,57 +114,32 @@ logger = logging.getLogger(__name__)
 file_router = APIRouter(prefix="/api/files", tags=["files"])
 
 
-# The operation label for the durable cleanup ``delete_file`` runs before it
-# drops the metadata row. Named rather than inlined so the one log message this
-# change *renames* (it replaced "Failed to clean up durable file before
-# deleting row") has a single definition that alerting can be re-keyed to, and
-# so its test cannot drift from the string the endpoint actually emits.
-DELETE_CLEANUP_OPERATION = "durable cleanup before row delete"
+def _raise_durable_storage_unavailable(
+    exc: Exception, operation: str, **fields: object
+) -> NoReturn:
+    """Log the durable-storage fault, then raise the retryable 503.
 
+    ``NoReturn`` rather than a factory returning the exception: logging and
+    raising are one step, so the type forbids a caller that logs without
+    raising (a phantom fault in the log) or raises without logging (the cause
+    lost, which is the bug #1467 was filed for). The 503 body is deliberately
+    detail-free, which is what makes the log the only record.
 
-def _durable_storage_unavailable(exc: Exception, operation: str) -> HTTPException:
-    """Record the provider fault, then answer the retryable 503.
+    ``exc``'s text carries the storage key, whose scope segments can encode
+    end-user identity, so it is only ever logged -- never returned to the
+    client. Pass request identifiers as ``fields``, and keep ``operation`` a
+    bounded label so it stays aggregatable.
 
-    Logging belongs here rather than at each call site because the 503 is the
-    only thing that leaves the process: every site raises this ``from exc``,
-    but FastAPI's default ``HTTPException`` handler never logs a traceback, so
-    without this line the fault that actually failed is lost. And the wrap in
-    ``ManagedFileRef`` keeps only the storage key in its message -- the
-    provider error class, the HTTP status, throttle vs. timeout vs. rejected
-    credentials all live in ``__cause__`` and nowhere else. ``exc_info``
-    is what carries that chain into the log (see #1467).
-
-    ``exc`` is ``Exception``, not ``BaseException``, and the narrowing is load
-    bearing rather than cosmetic. Every caller catches either
-    ``DurableStorageOperationError`` (a ``RuntimeError``) or, on the delete
-    path, a bare ``Exception`` -- so ``Exception`` is the true domain. Keeping
-    it that narrow makes mypy reject a future caller that widens its ``except``
-    and hands over an ``asyncio.CancelledError`` or ``KeyboardInterrupt``,
-    which must never be reported as storage unavailability: a cancelled or
-    interrupted request has not established that the object store is unwell,
-    and answering 503 would tell the client to retry something that was
-    deliberately stopped.
-
-    Level is ``warning``, not ``error``: this classification *is* the claim
-    that the fault is transient and worth retrying, which is the same reason
-    the response is 503. Permanent namespace-authority faults are meant to be
-    excluded from it upstream (``_NAMESPACE_AUTHORITY_ERRORS`` in
-    services/managed_file_ref.py) and logged at ``error`` by the app-wide
-    handler in web/app.py. ``delete_file`` is the one caller that does not
-    honour that split -- its bare ``except Exception`` folds a
-    ``StorageKeyScopeError`` in here, so a permanent fault is answered 503 and
-    logged as transient. That is pre-existing and tracked in #1473, not a
-    property of this helper.
-
-    The detail stays server-side. ``str(exc)`` carries the storage key, whose
-    scope segments can encode end-user identity, so the response body remains
-    the fixed message -- the same split web/app.py makes for the 500 it owns.
+    ``exc`` is ``Exception``, not ``BaseException``, so mypy rejects a caller
+    that hands over an ``asyncio.CancelledError`` or ``KeyboardInterrupt``:
+    a cancelled request has not shown the object store to be unwell, and 503
+    would tell the client to retry something deliberately stopped.
     """
-    logger.warning("Durable storage unavailable during %s", operation, exc_info=exc)
-    return HTTPException(
+    log_durable_storage_fault(logger, operation, exc, **fields)
+    raise HTTPException(
         status_code=503,
         detail="Durable storage is temporarily unavailable",
-    )
+    ) from exc
 
 
 def _file_integrity_failed() -> HTTPException:
@@ -351,7 +327,7 @@ def _durable_redirect_response(
     except DurableObjectIntegrityError as exc:
         raise _file_integrity_failed() from exc
     except DurableStorageOperationError as exc:
-        raise _durable_storage_unavailable(exc, "signed durable redirect") from exc
+        _raise_durable_storage_unavailable(exc, "signed durable redirect")
 
     if not signed_url:
         return None
@@ -634,7 +610,7 @@ async def store_uploaded_files(
             )
         completed = True
     except DurableStorageOperationError as exc:
-        raise _durable_storage_unavailable(exc, "upload") from exc
+        _raise_durable_storage_unavailable(exc, "upload")
     finally:
         if not completed:
 
@@ -1505,7 +1481,7 @@ async def download_file(
                     },
                 )
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable(exc, "download") from exc
+                _raise_durable_storage_unavailable(exc, "download", file_id=file_id)
     else:
         # For legacy files without records, check ownership
         if owner_user_id != _user_id_value(user) and not _is_admin_user(user):
@@ -1814,7 +1790,7 @@ async def preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable(exc, "preview") from exc
+                _raise_durable_storage_unavailable(exc, "preview", file_id=file_id)
             except DurableObjectMissingError:
                 materialized_path = file_ref.local_path
                 _ensure_under_uploads(materialized_path, owner_user_id)
@@ -1903,7 +1879,7 @@ async def preview_pptx_as_pdf(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable(exc, "pptx preview") from exc
+                _raise_durable_storage_unavailable(exc, "pptx preview", file_id=file_id)
             except DurableObjectMissingError:
                 # Durable record points at nothing; fall back to whatever
                 # is on disk (or 404 below if it's gone too).
@@ -1995,7 +1971,9 @@ async def public_download_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable(exc, "public download") from exc
+                _raise_durable_storage_unavailable(
+                    exc, "public download", file_id=file_id
+                )
             except DurableObjectMissingError:
                 target_path = file_ref.local_path
         else:
@@ -2061,7 +2039,9 @@ async def public_preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable(exc, "public preview") from exc
+                _raise_durable_storage_unavailable(
+                    exc, "public preview", file_id=file_id
+                )
             except DurableObjectMissingError:
                 target_path = file_ref.local_path
                 _ensure_under_uploads(target_path, owner_user_id)
@@ -2105,9 +2085,9 @@ async def public_preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable(
-                    exc, "public preview task asset"
-                ) from exc
+                _raise_durable_storage_unavailable(
+                    exc, "public preview task asset", file_id=file_id
+                )
             except DurableObjectMissingError:
                 target_path = asset_ref.local_path
             _ensure_under_uploads(target_path, owner_user_id)
@@ -2177,9 +2157,12 @@ async def delete_file(
                     storage_key
                 )
             except Exception as exc:
-                raise _durable_storage_unavailable(
-                    exc, f"{DELETE_CLEANUP_OPERATION} ({storage_key})"
-                ) from exc
+                _raise_durable_storage_unavailable(
+                    exc,
+                    "durable cleanup before row delete",
+                    file_id=file_id,
+                    storage_key=storage_key,
+                )
 
         db.delete(file_record)
         db.commit()

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -612,7 +612,13 @@ async def store_uploaded_files(
             )
         completed = True
     except DurableStorageOperationError as exc:
-        _raise_durable_storage_unavailable(exc, "upload")
+        # No single ``file_id``: this is a batch registration, and any of the
+        # files in it may be the one that failed. Tenant and task still
+        # correlate a 503 burst to who and what was affected, which is the
+        # question asked first during an outage.
+        _raise_durable_storage_unavailable(
+            exc, "upload", user_id=user_id, task_id=parsed_task_id
+        )
     finally:
         if not completed:
 
@@ -2087,8 +2093,15 @@ async def public_preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
+                # ``asset_record`` is a different row from the route's
+                # ``file_id``: the base record is the document, this is the
+                # preview asset registered under it, and it is the asset's
+                # restore that failed. Logging the route parameter here named an
+                # object that is fine.
                 _raise_durable_storage_unavailable(
-                    exc, "public preview task asset", file_id=file_id
+                    exc,
+                    "public preview task asset",
+                    file_id=asset_record.file_id,
                 )
             except DurableObjectMissingError:
                 target_path = asset_ref.local_path

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -2759,6 +2759,9 @@ def _refresh_existing_file_if_changed(
         except DurableObjectMissingError:
             return None
         except Exception as exc:  # noqa: BLE001
+            # ``exc_info`` because this fault is swallowed -- the caller only
+            # sees ``None`` -- so this line is its only record, and ``error=%s``
+            # alone drops the exception class and the cause chain (#1467).
             logger.warning(
                 "Failed to restore durable web-ingestion file before refresh: "
                 "url=%s, file_id=%s, context=%s, error=%s",
@@ -2766,6 +2769,7 @@ def _refresh_existing_file_if_changed(
                 existing_record.file_id,
                 context,
                 exc,
+                exc_info=exc,
             )
             return None
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -230,6 +230,14 @@ def _resolve_turn_files_or_400(
         )
     except DurableStorageOperationError as exc:
         # Transient storage fault, not a client error -- 503 so SDK can retry.
+        # ``exc_info`` because the wrap carries only the storage key and the
+        # V1ApiError envelope reaches the client without a traceback, so this
+        # is the only place the provider fault gets recorded (#1467).
+        logger.warning(
+            "Durable storage unavailable while resolving turn attachments: task_id=%s",
+            task_id,
+            exc_info=exc,
+        )
         raise V1ApiError(
             V1ErrorCode.INTERNAL_ERROR,
             503,

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -77,6 +77,7 @@ from ...services.hot_path_cache import (
     task_steps_key,
 )
 from ...services.managed_file_ref import (
+    DurableObjectIntegrityError,
     DurableStorageOperationError,
     log_durable_storage_fault,
 )
@@ -231,6 +232,17 @@ def _resolve_turn_files_or_400(
             db=db,
             task_id=task_id,
         )
+    except DurableObjectIntegrityError:
+        # Precedes the parent arm: permanent corruption, already logged at
+        # ERROR with both checksums where it is raised. The envelope below is
+        # left as-is deliberately -- reclassifying it for the SDK is a
+        # compatibility change, not a logging one -- but it must not also emit
+        # a transient-outage warning.
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR,
+            503,
+            message="File storage is temporarily unavailable.",
+        ) from None
     except DurableStorageOperationError as exc:
         # Transient storage fault, not a client error -- 503 so SDK can retry.
         # The V1ApiError envelope reaches the client without a traceback, so

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -76,7 +76,10 @@ from ...services.hot_path_cache import (
     task_snapshot_key,
     task_steps_key,
 )
-from ...services.managed_file_ref import DurableStorageOperationError
+from ...services.managed_file_ref import (
+    DurableStorageOperationError,
+    log_durable_storage_fault,
+)
 from ...services.task_interaction_read import get_pending_interaction_question
 from ...services.task_orchestrator import (
     TaskTurnError,
@@ -230,13 +233,18 @@ def _resolve_turn_files_or_400(
         )
     except DurableStorageOperationError as exc:
         # Transient storage fault, not a client error -- 503 so SDK can retry.
-        # ``exc_info`` because the wrap carries only the storage key and the
-        # V1ApiError envelope reaches the client without a traceback, so this
-        # is the only place the provider fault gets recorded (#1467).
-        logger.warning(
-            "Durable storage unavailable while resolving turn attachments: task_id=%s",
-            task_id,
-            exc_info=exc,
+        # The V1ApiError envelope reaches the client without a traceback, so
+        # this log line is the only record of the provider fault (#1467).
+        # ``task_id`` is None on the create path -- one of this function's two
+        # callers, not an edge case -- so the owner and the requested ids carry
+        # the identification there.
+        log_durable_storage_fault(
+            logger,
+            "turn attachment resolution",
+            exc,
+            task_id=task_id,
+            owner_user_id=owner_user_id,
+            file_ids=",".join(file_ids),
         )
         raise V1ApiError(
             V1ErrorCode.INTERNAL_ERROR,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -126,6 +126,7 @@ from ..services.hot_path_cache import (
     web_task_history_key,
 )
 from ..services.managed_file_ref import (
+    DurableObjectIntegrityError,
     DurableStorageOperationError,
     log_durable_storage_fault,
 )
@@ -6411,10 +6412,85 @@ async def _handle_chat_message_unserialized(
                     },
                     websocket,
                 )
+        except DurableObjectIntegrityError:
+            # Precedes the durable-fault arm below, which this subclasses. A
+            # checksum mismatch is permanent corruption, already recorded at
+            # ERROR with both checksums where it is raised, so it must not also
+            # be logged as a transient outage. It still owes the client an
+            # answer, and a distinct one: retrying cannot help, the stored copy
+            # has to be replaced. No exception text goes outbound either way.
+            message = (
+                "A stored file for this message failed its integrity check "
+                "and must be re-uploaded."
+            )
+            if not await finish_delivery_failure(message):
+                return
+            timestamp = datetime.now(timezone.utc).timestamp()
+            if authorized_task_id is not None:
+                error_payload = await _read_task_error_payload_offloop(
+                    authorized_task_id,
+                    message,
+                )
+                await manager.broadcast_to_task(
+                    {**error_payload, "timestamp": timestamp},
+                    authorized_task_id,
+                )
+            else:
+                await manager.send_personal_message(
+                    {
+                        "type": "error",
+                        "message": message,
+                        "timestamp": timestamp,
+                    },
+                    websocket,
+                )
+        except DurableStorageOperationError as exc:
+            # Must precede the RuntimeError arm below, which this subclasses.
+            # This is the selected-file attachment path: the fault arrives here
+            # first, is answered to the client, and is swallowed -- so this is
+            # both the only place its provider cause can be recorded and the
+            # last place its text could escape.
+            #
+            # The outbound message is fixed rather than ``str(exc)``: the wrap
+            # carries the storage key, whose scope segments encode the owning
+            # user's id, and that must not travel to a socket client any more
+            # than it may reach an HTTP body or a model (#1467). It is also the
+            # sole logging owner for this path -- the fault does not re-raise,
+            # so the endpoint-level arm never sees it and cannot double-record.
+            log_durable_storage_fault(
+                logger,
+                "websocket agent execution",
+                exc,
+                task_id=authorized_task_id,
+            )
+            message = (
+                "A stored file for this message could not be read. Please try again."
+            )
+            if not await finish_delivery_failure(message):
+                return
+            timestamp = datetime.now(timezone.utc).timestamp()
+            if authorized_task_id is not None:
+                error_payload = await _read_task_error_payload_offloop(
+                    authorized_task_id,
+                    message,
+                )
+                await manager.broadcast_to_task(
+                    {**error_payload, "timestamp": timestamp},
+                    authorized_task_id,
+                )
+            else:
+                await manager.send_personal_message(
+                    {
+                        "type": "error",
+                        "message": message,
+                        "timestamp": timestamp,
+                    },
+                    websocket,
+                )
         except RuntimeError as e:
             # Runtime error
             message = f"Runtime error: {str(e)}"
-            logger.error(f"Runtime error in agent execution: {e}")
+            logger.error(f"Runtime error in agent execution: {e}", exc_info=True)
             if not await finish_delivery_failure(message):
                 return
             timestamp = datetime.now(timezone.utc).timestamp()
@@ -7356,6 +7432,12 @@ async def websocket_chat_endpoint(
                 )
 
     except WebSocketDisconnect:
+        pass
+    except DurableObjectIntegrityError:
+        # Precedes the parent arm: permanent corruption, already recorded at
+        # ERROR with both checksums where it is raised, so it must not also be
+        # logged as a transient outage. Swallowed exactly as the parent arm
+        # swallows -- the socket is going away either way.
         pass
     except DurableStorageOperationError as exc:
         # Must precede the RuntimeError arm below, which this subclasses. A

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7370,10 +7370,18 @@ async def handle_status_request(
 # ``operation`` is meant to be a bounded, aggregatable value -- it is also not
 # sanitised the way rendered fields are (#1520), so a client must not be able to
 # reach it.
+#
+# Only the message types whose handler lets a fault propagate are listed.
+# ``execute_task`` and ``handle_intervention`` end in ``except RuntimeError``
+# with no re-raise, so a durable fault from either is swallowed there and can
+# never reach the arms below; giving them a label would claim a reachability
+# that does not exist, and the label would read as covered while never being
+# emitted. Making them reachable means giving those two handlers a durable arm
+# of their own, which is absorber work and belongs to #1515 -- at which point
+# they get a label here. ``_SWALLOWED_DISPATCH_TYPES`` in the tests pins the
+# omission against the handlers, so this cannot silently become wrong.
 _DISPATCH_OPERATIONS = {
     "chat": "websocket chat turn",
-    "execute_task": "websocket execute_task",
-    "intervention": "websocket intervention",
     "status_request": "websocket status request",
     "pause_task": "websocket pause_task",
     "resume_task": "websocket resume_task",

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5719,6 +5719,40 @@ async def _handle_chat_message_unserialized(
             )
         return not delivery_failure_pool_timeout
 
+    async def answer_turn_failure(message: str) -> bool:
+        """Reject the turn, addressed however this connection is reachable.
+
+        Every failure arm in the agent-execution block owes the client the same
+        three steps -- reject the delivery, then broadcast to the task if one is
+        authorized or answer this socket if not -- differing only in the message
+        and in what it logs first. Repeated per arm, the one line worth reviewing
+        -- what the client is told, and whether it carries exception text -- sat
+        inside twenty identical lines of dispatch. The #1467 leaks came from arms
+        at the wrong scope rather than from this duplication, but the duplication
+        is why reading these arms is harder than it needs to be.
+
+        Returns ``False`` when the delivery layer says the caller must stop
+        without dispatching, which is the caller's cue to return.
+        """
+        if not await finish_delivery_failure(message):
+            return False
+        timestamp = datetime.now(timezone.utc).timestamp()
+        if authorized_task_id is not None:
+            error_payload = await _read_task_error_payload_offloop(
+                authorized_task_id,
+                message,
+            )
+            await manager.broadcast_to_task(
+                {**error_payload, "timestamp": timestamp},
+                authorized_task_id,
+            )
+        else:
+            await manager.send_personal_message(
+                {"type": "error", "message": message, "timestamp": timestamp},
+                websocket,
+            )
+        return True
+
     async def finish_existing_delivery(
         claim: Union[UserMessageDeliveryClaim, _UserMessageDeliverySnapshot],
     ) -> None:
@@ -6388,30 +6422,8 @@ async def _handle_chat_message_unserialized(
             # Data validation and format error
             message = f"Data validation error: {str(e)}"
             logger.error(f"Data validation error in agent execution: {e}")
-            if not await finish_delivery_failure(message):
+            if not await answer_turn_failure(message):
                 return
-            timestamp = datetime.now(timezone.utc).timestamp()
-            if authorized_task_id is not None:
-                error_payload = await _read_task_error_payload_offloop(
-                    authorized_task_id,
-                    message,
-                )
-                await manager.broadcast_to_task(
-                    {
-                        **error_payload,
-                        "timestamp": timestamp,
-                    },
-                    authorized_task_id,
-                )
-            else:
-                await manager.send_personal_message(
-                    {
-                        "type": "error",
-                        "message": message,
-                        "timestamp": timestamp,
-                    },
-                    websocket,
-                )
         except DurableObjectIntegrityError:
             # Precedes the durable-fault arm below, which this subclasses. A
             # checksum mismatch is permanent corruption, already recorded at
@@ -6423,27 +6435,8 @@ async def _handle_chat_message_unserialized(
                 "A stored file for this message failed its integrity check "
                 "and must be re-uploaded."
             )
-            if not await finish_delivery_failure(message):
+            if not await answer_turn_failure(message):
                 return
-            timestamp = datetime.now(timezone.utc).timestamp()
-            if authorized_task_id is not None:
-                error_payload = await _read_task_error_payload_offloop(
-                    authorized_task_id,
-                    message,
-                )
-                await manager.broadcast_to_task(
-                    {**error_payload, "timestamp": timestamp},
-                    authorized_task_id,
-                )
-            else:
-                await manager.send_personal_message(
-                    {
-                        "type": "error",
-                        "message": message,
-                        "timestamp": timestamp,
-                    },
-                    websocket,
-                )
         except DurableStorageOperationError as exc:
             # Must precede the RuntimeError arm below, which this subclasses.
             # This is the selected-file attachment path: the fault arrives here
@@ -6466,55 +6459,14 @@ async def _handle_chat_message_unserialized(
             message = (
                 "A stored file for this message could not be read. Please try again."
             )
-            if not await finish_delivery_failure(message):
+            if not await answer_turn_failure(message):
                 return
-            timestamp = datetime.now(timezone.utc).timestamp()
-            if authorized_task_id is not None:
-                error_payload = await _read_task_error_payload_offloop(
-                    authorized_task_id,
-                    message,
-                )
-                await manager.broadcast_to_task(
-                    {**error_payload, "timestamp": timestamp},
-                    authorized_task_id,
-                )
-            else:
-                await manager.send_personal_message(
-                    {
-                        "type": "error",
-                        "message": message,
-                        "timestamp": timestamp,
-                    },
-                    websocket,
-                )
         except RuntimeError as e:
             # Runtime error
             message = f"Runtime error: {str(e)}"
             logger.error(f"Runtime error in agent execution: {e}", exc_info=True)
-            if not await finish_delivery_failure(message):
+            if not await answer_turn_failure(message):
                 return
-            timestamp = datetime.now(timezone.utc).timestamp()
-            if authorized_task_id is not None:
-                error_payload = await _read_task_error_payload_offloop(
-                    authorized_task_id,
-                    message,
-                )
-                await manager.broadcast_to_task(
-                    {
-                        **error_payload,
-                        "timestamp": timestamp,
-                    },
-                    authorized_task_id,
-                )
-            else:
-                await manager.send_personal_message(
-                    {
-                        "type": "error",
-                        "message": message,
-                        "timestamp": timestamp,
-                    },
-                    websocket,
-                )
         except Exception as e:
             # Other unknown errors, re-raise
             logger.error(f"Unexpected error in agent execution: {e}")
@@ -7413,6 +7365,22 @@ async def handle_status_request(
     await send_historical_data_as_stream(websocket, task_id, user)
 
 
+# Operation labels for the endpoint-level fault arms, keyed by message type.
+# A closed map rather than interpolation: ``type`` is client-supplied, and
+# ``operation`` is meant to be a bounded, aggregatable value -- it is also not
+# sanitised the way rendered fields are (#1520), so a client must not be able to
+# reach it.
+_DISPATCH_OPERATIONS = {
+    "chat": "websocket chat turn",
+    "execute_task": "websocket execute_task",
+    "intervention": "websocket intervention",
+    "status_request": "websocket status request",
+    "pause_task": "websocket pause_task",
+    "resume_task": "websocket resume_task",
+}
+_UNKNOWN_DISPATCH_OPERATION = "websocket unknown message type"
+
+
 @ws_router.websocket("/ws/chat/{task_id}")
 async def websocket_chat_endpoint(
     websocket: WebSocket,
@@ -7431,6 +7399,13 @@ async def websocket_chat_endpoint(
 
     await manager.connect(websocket, task_id)
 
+    # Which message the loop is currently applying, for the fault arms below:
+    # they guard the whole dispatch, so a fixed label would report a resume or
+    # an execute_task fault as a chat turn in the one line meant to name it.
+    # Initialised here, not in the loop, because the initial status request runs
+    # before the first message is ever parsed.
+    dispatching = "websocket initial status request"
+
     try:
         # Send initial state
         await handle_status_request(websocket, task_id, user)
@@ -7447,6 +7422,10 @@ async def websocket_chat_endpoint(
             # Add user info to message data
             message_data["user_id"] = user.id
             message_data["user"] = user
+
+            dispatching = _DISPATCH_OPERATIONS.get(
+                str(message_data.get("type")), _UNKNOWN_DISPATCH_OPERATION
+            )
 
             if message_data.get("type") == "chat":
                 await handle_chat_message(websocket, task_id, message_data)
@@ -7481,7 +7460,7 @@ async def websocket_chat_endpoint(
         # the very path #1467 was filed about. Still swallowed, as before:
         # the socket is going away regardless and the client has already been
         # answered; only the diagnosis changes.
-        log_durable_storage_fault(logger, "websocket chat turn", exc, task_id=task_id)
+        log_durable_storage_fault(logger, dispatching, exc, task_id=task_id)
     except (ConnectionError, RuntimeError) as e:
         # Connection error
         logger.error(f"Connection error in WebSocket: {e}")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -6532,10 +6532,45 @@ async def _handle_chat_message_unserialized(
         # Connection error
         logger.error(f"Connection error handling chat message: {e}")
         raise
+    except DurableObjectIntegrityError:
+        # Attachment preparation runs in this outer scope (see the
+        # ``_prepare_websocket_turn_sync`` call above), *before* the inner
+        # agent-execution try. So a stored-file fault surfaces here, not in the
+        # arms guarding that inner block -- which is why the fixed detail has to
+        # be applied at this level too.
+        #
+        # Corruption is permanent: the copy has to be replaced, so the client is
+        # told that rather than to retry. No exception text goes outbound; the
+        # integrity ERROR with both checksums is already logged where it is
+        # raised.
+        await finish_delivery_failure(
+            "A stored file for this message failed its integrity check "
+            "and must be re-uploaded."
+        )
+        raise
+    except DurableStorageOperationError as exc:
+        # Same scope reasoning as above. ``str(exc)`` is the wrap's message and
+        # carries the storage key, whose scope segments encode the owning user's
+        # id -- it must not reach a socket frame, a persisted rejection, or a
+        # broadcast, any more than it may reach an HTTP body or a model (#1467).
+        #
+        # Logging here rather than leaving it to the endpoint arm: the
+        # durable-command route invokes this handler directly and never reaches
+        # that arm. Double-recording is prevented at the logger, which marks the
+        # fault, so both arms are safe to write independently.
+        log_durable_storage_fault(
+            logger,
+            "websocket chat turn preparation",
+            exc,
+            task_id=task_id,
+        )
+        await finish_delivery_failure(
+            "File storage is temporarily unavailable. Please try again."
+        )
+        raise
     except Exception as e:
         # Other errors, re-raise. ``exc_info`` because this arm absorbs any
-        # wrapped fault -- a durable-storage one included -- whose cause
-        # otherwise never reaches a log (#1467).
+        # wrapped fault whose cause otherwise never reaches a log (#1467).
         logger.error(f"Unexpected error handling chat message: {e}", exc_info=True)
         await finish_delivery_failure(str(e))
         raise

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7380,8 +7380,11 @@ async def handle_status_request(
 # of their own, which is absorber work and belongs to #1515 -- at which point
 # they get a label here. ``_SWALLOWED_DISPATCH_TYPES`` in the tests pins the
 # omission against the handlers, so this cannot silently become wrong.
+# ``chat`` is absent for a third reason, distinct from the two above: its own
+# fault arm always reports before re-raising, and ``log_durable_storage_fault``
+# marks the instance, so the call here would be a no-op rather than a second
+# record. A label for it would name a line that is never emitted.
 _DISPATCH_OPERATIONS = {
-    "chat": "websocket chat turn",
     "status_request": "websocket status request",
     "pause_task": "websocket pause_task",
     "resume_task": "websocket resume_task",

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -125,6 +125,10 @@ from ..services.hot_path_cache import (
     task_cache_ttl_seconds,
     web_task_history_key,
 )
+from ..services.managed_file_ref import (
+    DurableStorageOperationError,
+    log_durable_storage_fault,
+)
 from ..services.task_command_transport import (
     COMMAND_FAILED,
     COMMAND_ID_PATTERN,
@@ -6453,8 +6457,10 @@ async def _handle_chat_message_unserialized(
         logger.error(f"Connection error handling chat message: {e}")
         raise
     except Exception as e:
-        # Other errors, re-raise
-        logger.error(f"Unexpected error handling chat message: {e}")
+        # Other errors, re-raise. ``exc_info`` because this arm absorbs any
+        # wrapped fault -- a durable-storage one included -- whose cause
+        # otherwise never reaches a log (#1467).
+        logger.error(f"Unexpected error handling chat message: {e}", exc_info=True)
         await finish_delivery_failure(str(e))
         raise
 
@@ -7351,6 +7357,14 @@ async def websocket_chat_endpoint(
 
     except WebSocketDisconnect:
         pass
+    except DurableStorageOperationError as exc:
+        # Must precede the RuntimeError arm below, which this subclasses. A
+        # storage fault reaching here would otherwise be logged as "Connection
+        # error in WebSocket" and swallowed -- mislabelled and cause-less on
+        # the very path #1467 was filed about. Still swallowed, as before:
+        # the socket is going away regardless and the client has already been
+        # answered; only the diagnosis changes.
+        log_durable_storage_fault(logger, "websocket chat turn", exc, task_id=task_id)
     except (ConnectionError, RuntimeError) as e:
         # Connection error
         logger.error(f"Connection error in WebSocket: {e}")

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -82,11 +82,17 @@ def log_durable_storage_fault(
     That is narrower than "every consumer of ``DurableStorageOperationError``",
     and the difference matters: the class is a ``RuntimeError``, so broad
     ``except Exception`` / ``except RuntimeError`` arms elsewhere absorb it
-    without ever naming it -- in the chat path, knowledge-base refresh, and
-    workspace file resolution. Those arms cannot route through this function,
-    because they handle every exception type; they carry ``exc_info`` of their
-    own instead. Anything added later that reports this fault specifically
-    belongs here.
+    without ever naming it -- agent-service setup in web/api/chat.py,
+    knowledge-base refresh in web/api/kb.py, and workspace file resolution in
+    core/workspace.py. Those arms cannot route through this function, because
+    they handle every exception type; each carries ``exc_info`` so the chain
+    survives there, but none of them produces the fields this function renders.
+
+    So the accurate claim is about *naming*, not about coverage: a site that
+    reports this fault as a durable-storage fault does it here, and a site that
+    merely absorbs it keeps its own traceback. Anything added later in the first
+    category belongs here. Do not restate this as "every consumer" -- that was
+    the wording it replaced, and it was false.
 
     The wraps in this module
     keep only the storage key in their message; the provider error class, the

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -128,22 +128,19 @@ def log_durable_storage_fault(
     # independently, instead of every new arm having to know which other arm
     # might already have run.
     #
-    # Both the read and the write are best-effort, because ``exc`` is not always
-    # one of this module's wraps: the delete path hands over the raw provider
-    # exception. A foreign object may use ``__slots__`` and reject the mark, and
-    # its ``__getattr__`` may raise something ``getattr``'s default does not
-    # absorb -- the default covers ``AttributeError`` only. Neither may become
-    # the outcome: this runs inside an ``except`` block, so an exception escaping
-    # here replaces a handled 503-with-a-log with an unhandled 500 that loses the
-    # fault, which is #1467's own failure mode. Logging twice is strictly better.
-    # (A ``BaseException`` from the same read still escapes; widening these
-    # guards module-wide is #1517.)
-    try:
-        if getattr(exc, "_durable_fault_logged", False):
+    # Only this module's own wraps are marked, and that is what makes the mark
+    # need no guarding. A wrap is what traverses several arms, so it is where
+    # dedup is needed; the raw provider exception the delete path hands over is
+    # reported by one site by definition. Restricting the mark also keeps this
+    # from setting a private attribute on an object the module does not own,
+    # where neither the read nor the write is safe in principle -- ``getattr``'s
+    # default absorbs ``AttributeError`` only -- and an exception escaping here,
+    # inside an ``except`` block, would replace a handled 503-with-a-log with an
+    # unhandled 500 that loses the fault, which is #1467's own failure mode.
+    if isinstance(exc, DurableStorageOperationError):
+        if exc._durable_fault_logged:
             return
-        exc._durable_fault_logged = True  # type: ignore[attr-defined]
-    except Exception:
-        pass
+        exc._durable_fault_logged = True
 
     rendered = "".join(
         f" {name}={_sanitize_log_value(value)}"
@@ -157,6 +154,12 @@ def log_durable_storage_fault(
 
 class DurableStorageOperationError(RuntimeError):
     """Raised when durable object storage is unavailable for an operation."""
+
+    # Set by ``log_durable_storage_fault`` so one fault yields one record even
+    # when several arms legitimately report it. Declared here rather than
+    # attached dynamically so it is typed, discoverable, and always present to
+    # read -- the reason that function needs no guard around the mark.
+    _durable_fault_logged: bool = False
 
 
 class DurableObjectIntegrityError(DurableStorageOperationError):

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -127,13 +127,22 @@ def log_durable_storage_fault(
     # cause twice. Marking the exception is what makes each arm safe to write
     # independently, instead of every new arm having to know which other arm
     # might already have run.
-    if getattr(exc, "_durable_fault_logged", False):
-        return
+    #
+    # Both the read and the write are best-effort, because ``exc`` is not always
+    # one of this module's wraps: the delete path hands over the raw provider
+    # exception. A foreign object may use ``__slots__`` and reject the mark, and
+    # its ``__getattr__`` may raise something ``getattr``'s default does not
+    # absorb -- the default covers ``AttributeError`` only. Neither may become
+    # the outcome: this runs inside an ``except`` block, so an exception escaping
+    # here replaces a handled 503-with-a-log with an unhandled 500 that loses the
+    # fault, which is #1467's own failure mode. Logging twice is strictly better.
+    # (A ``BaseException`` from the same read still escapes; widening these
+    # guards module-wide is #1517.)
     try:
+        if getattr(exc, "_durable_fault_logged", False):
+            return
         exc._durable_fault_logged = True  # type: ignore[attr-defined]
     except Exception:
-        # A provider exception using __slots__ cannot be marked; logging twice
-        # is strictly better than not logging.
         pass
 
     rendered = "".join(

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -47,6 +47,42 @@ class DurableObjectMissingError(FileNotFoundError):
     """Raised when a registered file has no local copy or durable object."""
 
 
+def log_durable_storage_fault(
+    target_logger: logging.Logger,
+    operation: str,
+    exc: Exception,
+    **fields: object,
+) -> None:
+    """Record a durable-storage fault with its full cause chain.
+
+    One implementation for every consumer of ``DurableStorageOperationError``,
+    so no site can log the fault without its cause. The wraps in this module
+    keep only the storage key in their message; the provider error class, the
+    HTTP status, and throttle vs. timeout vs. rejected credentials live in
+    ``__cause__`` and nowhere else, and none of the envelopes these faults
+    become -- FastAPI's ``HTTPException``, the ``/v1/*`` error body, a tool
+    result -- carries a traceback. ``exc_info`` is the only thing that gets the
+    chain into a log (#1467).
+
+    ``target_logger`` is the caller's logger rather than this module's, so a
+    line stays attributed to the endpoint or tool that produced it.
+
+    ``operation`` must be a bounded label -- a small fixed set of values, so it
+    stays aggregatable. Per-request identifiers belong in ``fields``, which is
+    rendered as ``key=value`` pairs *in the message*: the deployed formatter is
+    ``"%(asctime)s %(levelname)-8s %(name)s - %(message)s"``
+    (see web/logging_config.py), which never renders ``extra``, so anything
+    passed that way would be invisible in exactly the logs an incident is
+    diagnosed from.
+    """
+    rendered = "".join(
+        f" {name}={value}" for name, value in fields.items() if value is not None
+    )
+    target_logger.warning(
+        "Durable storage unavailable during %s%s", operation, rendered, exc_info=exc
+    )
+
+
 class DurableStorageOperationError(RuntimeError):
     """Raised when durable object storage is unavailable for an operation."""
 
@@ -614,12 +650,18 @@ class ManagedFileRef:
             # backend-mediated access.
             raise
         except Exception as exc:
+            # ``exc_info`` for the same reason as everywhere else on this
+            # path: this fault is swallowed -- the caller only sees ``False``
+            # and silently falls back to backend-mediated delivery -- so this
+            # line is the only record of it, and ``error=%s`` alone drops the
+            # exception class and the cause chain (#1467).
             logger.warning(
                 "Falling back to backend-mediated durable access because content "
                 "hash is unavailable: file_id=%s storage_key=%s error=%s",
                 getattr(self.record, "file_id", None),
                 self.storage_key,
                 exc,
+                exc_info=exc,
             )
             return False
 

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -105,6 +105,13 @@ def log_durable_storage_fault(
     ``target_logger`` is the caller's logger rather than this module's, so a
     line stays attributed to the endpoint or tool that produced it.
 
+    Field values are escaped and bounded, because some are client-supplied.
+    That covers the fields *this* function renders -- it does **not** make the
+    record as a whole unforgeable: the formatter renders ``exc_info`` verbatim,
+    so a newline in a provider exception message still produces a physical
+    continuation line. Closing that needs the formatter itself and is tracked in
+    #1516; do not read the sanitising below as a stronger guarantee than it is.
+
     ``operation`` must be a bounded label -- a small fixed set of values, so it
     stays aggregatable. Per-request identifiers belong in ``fields``, which is
     rendered as ``key=value`` pairs *in the message*: the deployed formatter is
@@ -113,6 +120,22 @@ def log_durable_storage_fault(
     passed that way would be invisible in exactly the logs an incident is
     diagnosed from.
     """
+    # One record per fault instance, whatever the nesting. A durable fault can
+    # pass through more than one handler that legitimately wants to report it --
+    # a request-scoped arm that answers the client, and an endpoint-scoped arm
+    # that catches whatever escaped -- and both calling this would log the same
+    # cause twice. Marking the exception is what makes each arm safe to write
+    # independently, instead of every new arm having to know which other arm
+    # might already have run.
+    if getattr(exc, "_durable_fault_logged", False):
+        return
+    try:
+        exc._durable_fault_logged = True  # type: ignore[attr-defined]
+    except Exception:
+        # A provider exception using __slots__ cannot be marked; logging twice
+        # is strictly better than not logging.
+        pass
+
     rendered = "".join(
         f" {name}={_sanitize_log_value(value)}"
         for name, value in fields.items()

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -47,6 +47,27 @@ class DurableObjectMissingError(FileNotFoundError):
     """Raised when a registered file has no local copy or durable object."""
 
 
+# Rendered fields sit in a plain-text log line, so a value carrying a newline
+# would start what reads as a new, fully-formatted record (CWE-117). Some of
+# these values are client-supplied -- ``/v1/*`` passes the ``files`` list from
+# the request body, which is an unvalidated ``list[str]`` -- so a caller cannot
+# be relied on to have checked. Sanitising here covers every field at every
+# site, including ones added later.
+_LOG_VALUE_TRANSLATION = str.maketrans({"\n": "\\n", "\r": "\\r", "\t": "\\t"})
+
+# Long enough for a UUID list of realistic size, short enough that one field
+# cannot crowd out the rest of the line.
+_MAX_LOG_VALUE_LENGTH = 256
+
+
+def _sanitize_log_value(value: object) -> str:
+    """Flatten a field value to one bounded, single-line token."""
+    text = str(value).translate(_LOG_VALUE_TRANSLATION)
+    if len(text) > _MAX_LOG_VALUE_LENGTH:
+        return f"{text[:_MAX_LOG_VALUE_LENGTH]}...[truncated]"
+    return text
+
+
 def log_durable_storage_fault(
     target_logger: logging.Logger,
     operation: str,
@@ -55,8 +76,19 @@ def log_durable_storage_fault(
 ) -> None:
     """Record a durable-storage fault with its full cause chain.
 
-    One implementation for every consumer of ``DurableStorageOperationError``,
-    so no site can log the fault without its cause. The wraps in this module
+    The single implementation for every site that reports a durable-storage
+    fault *as such*, so none of them can log it without its cause.
+
+    That is narrower than "every consumer of ``DurableStorageOperationError``",
+    and the difference matters: the class is a ``RuntimeError``, so broad
+    ``except Exception`` / ``except RuntimeError`` arms elsewhere absorb it
+    without ever naming it -- in the chat path, knowledge-base refresh, and
+    workspace file resolution. Those arms cannot route through this function,
+    because they handle every exception type; they carry ``exc_info`` of their
+    own instead. Anything added later that reports this fault specifically
+    belongs here.
+
+    The wraps in this module
     keep only the storage key in their message; the provider error class, the
     HTTP status, and throttle vs. timeout vs. rejected credentials live in
     ``__cause__`` and nowhere else, and none of the envelopes these faults
@@ -76,7 +108,9 @@ def log_durable_storage_fault(
     diagnosed from.
     """
     rendered = "".join(
-        f" {name}={value}" for name, value in fields.items() if value is not None
+        f" {name}={_sanitize_log_value(value)}"
+        for name, value in fields.items()
+        if value is not None
     )
     target_logger.warning(
         "Durable storage unavailable during %s%s", operation, rendered, exc_info=exc

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -94,8 +94,9 @@ def log_durable_storage_fault(
     category belongs here. Do not restate this as "every consumer" -- that was
     the wording it replaced, and it was false.
 
-    The wraps in this module
-    keep only the storage key in their message; the provider error class, the
+    The wraps in this module keep the storage key on the exception rather than
+    in its message (see ``DurableStorageOperationError``); the provider error
+    class, the
     HTTP status, and throttle vs. timeout vs. rejected credentials live in
     ``__cause__`` and nowhere else, and none of the envelopes these faults
     become -- FastAPI's ``HTTPException``, the ``/v1/*`` error body, a tool
@@ -141,6 +142,13 @@ def log_durable_storage_fault(
         if exc._durable_fault_logged:
             return
         exc._durable_fault_logged = True
+        # The wraps carry the key on the exception rather than in its message,
+        # so ``str(exc)`` is safe wherever it escapes. Rendering it here is what
+        # keeps that from costing the log anything: the key reaches this line
+        # from every site, including ones that never passed it as a field.
+        # An explicit field wins, so a caller can still name a different key.
+        if exc.storage_key and "storage_key" not in fields:
+            fields = {**fields, "storage_key": exc.storage_key}
 
     rendered = "".join(
         f" {name}={_sanitize_log_value(value)}"
@@ -153,13 +161,31 @@ def log_durable_storage_fault(
 
 
 class DurableStorageOperationError(RuntimeError):
-    """Raised when durable object storage is unavailable for an operation."""
+    """Raised when durable object storage is unavailable for an operation.
+
+    **The storage key belongs in ``storage_key``, never in the message.** Its
+    scope segments encode the owning user's id, and ``str(exc)`` on this class
+    reaches places this module does not control: a bare ``raise`` from a
+    WebSocket fault arm carries it into a task-wide broadcast and into a
+    persisted command row, and broad ``except RuntimeError`` arms interpolate it
+    straight into client-facing text. Redacting those egresses one at a time is
+    what #1467 spent four review rounds doing, each round finding another. With
+    the key off the message, ``str(exc)`` is safe by construction and a new
+    egress cannot reintroduce the leak.
+
+    Operators lose nothing: ``log_durable_storage_fault`` renders the attribute
+    as a field, so every line that reported the key still does.
+    """
 
     # Set by ``log_durable_storage_fault`` so one fault yields one record even
     # when several arms legitimately report it. Declared here rather than
     # attached dynamically so it is typed, discoverable, and always present to
     # read -- the reason that function needs no guard around the mark.
     _durable_fault_logged: bool = False
+
+    def __init__(self, message: str, *, storage_key: str | None = None) -> None:
+        super().__init__(message)
+        self.storage_key = storage_key
 
 
 class DurableObjectIntegrityError(DurableStorageOperationError):
@@ -488,7 +514,8 @@ class ManagedFileRef:
         except Exception as exc:
             temp_path.unlink(missing_ok=True)
             raise DurableStorageOperationError(
-                f"Failed to restore durable object: {self.storage_key}"
+                "Failed to restore durable object",
+                storage_key=self.storage_key,
             ) from exc
 
     def materialize(self, *, allow_existing_local: bool = True) -> Path:
@@ -516,13 +543,15 @@ class ManagedFileRef:
                 raise
             except Exception as exc:
                 raise DurableStorageOperationError(
-                    f"Failed to materialize durable object: {self.storage_key}"
+                    "Failed to materialize durable object",
+                    storage_key=self.storage_key,
                 ) from exc
 
         if last_integrity_error is not None:
             raise last_integrity_error
         raise DurableStorageOperationError(
-            f"Failed to materialize durable object: {self.storage_key}"
+            "Failed to materialize durable object",
+            storage_key=self.storage_key,
         )
 
     def open_read(self) -> BinaryIO:
@@ -550,7 +579,8 @@ class ManagedFileRef:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
-                f"Failed to sign durable object URL: {self.storage_key}"
+                "Failed to sign durable object URL",
+                storage_key=self.storage_key,
             ) from exc
 
     def sync_to_durable(
@@ -601,7 +631,8 @@ class ManagedFileRef:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
-                f"Failed to write durable object: {resolved_key}"
+                "Failed to write durable object",
+                storage_key=resolved_key,
             ) from exc
         self.apply_stored_object(stored_object)
         setattr(self.record, "file_size", path.stat().st_size)
@@ -620,7 +651,8 @@ class ManagedFileRef:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
-                f"Failed to inspect durable object metadata: {expected_key}"
+                "Failed to inspect durable object metadata",
+                storage_key=expected_key,
             ) from exc
 
         checksum = stored_object.checksum
@@ -664,7 +696,8 @@ class ManagedFileRef:
                 raise
             except Exception as exc:
                 raise DurableStorageOperationError(
-                    f"Failed to inspect durable object metadata: {expected_key}"
+                    "Failed to inspect durable object metadata",
+                    storage_key=expected_key,
                 ) from exc
 
         self.apply_stored_object(

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -602,10 +602,15 @@ async def test_create_kb_from_file_continues_after_unexpected_ingest_error(tmp_p
     assert result["success"] is True
     assert result["collection_name"] == "agent_file_kb"
     assert result["files_ingested"] == 1
-    assert (
-        "Failed to ingest bad.txt due to unexpected error: parser exploded"
-        in result["message"]
-    )
+    # The failing file is named, so the model can tell the user which one to
+    # retry -- but not why, because this string is joined into the tool result
+    # and reaches the conversation transcript. The exceptions reachable here
+    # (``HashComputationError`` wrapping an OSError, ``DocumentValidationError``)
+    # render the absolute upload path, which sits under users/<user_id>/uploads
+    # and so carries the owning user's id. This assertion used to require the
+    # exception text, which pinned that disclosure in place.
+    assert "Failed to ingest bad.txt" in result["message"]
+    assert "parser exploded" not in result["message"]
     service.refresh_collection_metadata.assert_awaited_once_with("agent_file_kb")
     # One file landed, so the collection is real: cleaning it up would delete it.
     service.cleanup_failed_collection.assert_not_awaited()
@@ -1399,7 +1404,7 @@ async def test_create_kb_from_file_durable_fault_logs_cause_and_hides_storage_ke
     def fail_restore(_record):
         provider_exc = _ProviderThrottled(provider_message)
         raise DurableStorageOperationError(
-            f"Failed to restore durable object: {storage_key}"
+            "Failed to restore durable object", storage_key=storage_key
         ) from provider_exc
 
     source_file = tmp_path / "notes.txt"

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -1466,3 +1466,78 @@ async def test_create_kb_from_file_durable_fault_logs_cause_and_hides_storage_ke
     assert storage_key in rendered
     assert "_ProviderThrottled" in rendered
     assert provider_message in rendered
+
+
+@pytest.mark.asyncio
+async def test_create_kb_from_file_integrity_failure_is_not_an_outage_warning(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    """A checksum mismatch must not be reported as a transient outage.
+
+    ``DurableObjectIntegrityError`` subclasses ``DurableStorageOperationError``,
+    so a parent-only catch sends permanent corruption through the durable-fault
+    logger and adds a "Durable storage unavailable" WARNING on top of the
+    integrity ERROR already recorded where it is raised. That reads as an outage
+    to whatever watches for one, and buries the real diagnosis.
+    """
+    import logging
+
+    from xagent.core.tools.core.RAG_tools import kb as kb_module
+    from xagent.web.services.managed_file_ref import (
+        FILE_INTEGRITY_REUPLOAD_MESSAGE,
+        DurableObjectIntegrityError,
+    )
+
+    def fail_restore(_record):
+        raise DurableObjectIntegrityError(FILE_INTEGRITY_REUPLOAD_MESSAGE)
+
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("hello", encoding="utf-8")
+    file_record = SimpleNamespace(
+        user_id=7,
+        filename="notes.txt",
+        storage_path=str(source_file),
+        file_id="file-1",
+    )
+    query = MagicMock()
+    query.filter.return_value = query
+    query.all.return_value = [file_record]
+    db = MagicMock()
+    db.query.return_value = query
+
+    def fake_get_db():
+        yield from _fake_db_generator(db)
+
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="agent_file_kb"))
+    coordinator = KBCoordinator(
+        storage_shim=_FakeStorageShim(metadata_store),
+        operation_compatibility=_RecordingOperationFacade(),
+    )
+    monkeypatch.setattr(kb_module, "get_kb_coordinator", lambda: coordinator)
+
+    logger_name = "xagent.core.tools.adapters.vibe.file_ingestion_tool"
+    with (
+        patch("xagent.web.models.database.get_db", side_effect=fake_get_db),
+        patch(
+            "xagent.web.services.managed_file_ref.ensure_uploaded_file_local_path",
+            side_effect=fail_restore,
+        ),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        tool = CreateKnowledgeBaseFromFileTool(user_id=7, is_admin=False)
+        result = await tool.run_json_async(
+            {"file_ids": ["file-1"], "collection_name": "agent_file_kb"}
+        )
+
+    assert result["success"] is False
+    assert "integrity check" in result["message"]
+
+    outage_lines = [
+        entry
+        for entry in caplog.records
+        if entry.name == logger_name
+        and "Durable storage unavailable" in entry.getMessage()
+    ]
+    assert outage_lines == [], "permanent corruption must not read as an outage"

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -1364,3 +1364,92 @@ async def test_agent_publish_of_a_new_collection_survives_a_config_read_failure(
     assert json.loads(save_kwargs["config_json"])["embedding_model_id"] == (
         DEFAULT_EMBEDDING_MODEL_ID
     )
+
+
+@pytest.mark.asyncio
+async def test_create_kb_from_file_durable_fault_logs_cause_and_hides_storage_key(
+    tmp_path,
+    caplog,
+):
+    """A restore failure must reach the log in full and the model in redacted form.
+
+    Two separate obligations meet in this one except-branch (#1467):
+
+    * the provider fault only exists in ``__cause__``, and no envelope this
+      path produces carries a traceback, so the log line is its only record;
+    * the error string is joined into the tool result, so it reaches the model
+      and the conversation transcript -- and the wrap's message embeds the
+      storage key, whose scope segments encode the owning user's id.
+
+    Interpolating the exception into that string satisfied the first obligation
+    while violating the second.
+    """
+    import logging
+
+    from xagent.web.services.managed_file_ref import DurableStorageOperationError
+
+    storage_key = "users/7/uploads/file-1/notes.txt"
+    provider_message = "SlowDown: Please reduce your request rate (status 503)"
+
+    class _ProviderThrottled(RuntimeError):
+        pass
+
+    def fail_restore(_record):
+        provider_exc = _ProviderThrottled(provider_message)
+        raise DurableStorageOperationError(
+            f"Failed to restore durable object: {storage_key}"
+        ) from provider_exc
+
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("hello", encoding="utf-8")
+    file_record = SimpleNamespace(
+        user_id=7,
+        filename="notes.txt",
+        storage_path=str(source_file),
+        file_id="file-1",
+    )
+
+    query = MagicMock()
+    query.filter.return_value = query
+    query.all.return_value = [file_record]
+    db = MagicMock()
+    db.query.return_value = query
+
+    def fake_get_db():
+        yield from _fake_db_generator(db)
+
+    logger_name = "xagent.core.tools.adapters.vibe.file_ingestion_tool"
+    with (
+        patch("xagent.web.models.database.get_db", side_effect=fake_get_db),
+        patch(
+            "xagent.web.services.managed_file_ref.ensure_uploaded_file_local_path",
+            side_effect=fail_restore,
+        ),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        tool = CreateKnowledgeBaseFromFileTool(user_id=7, is_admin=False)
+        result = await tool.run_json_async(
+            {"file_ids": ["file-1"], "collection_name": "agent_file_kb"}
+        )
+
+    assert result["success"] is False
+
+    # The model-facing half: named, but stripped of anything identifying.
+    assert "Failed to restore notes.txt from durable storage" in result["message"]
+    assert storage_key not in result["message"]
+    assert "users/7" not in result["message"]
+    assert provider_message not in result["message"]
+
+    # The log half: the whole chain, provider class included.
+    records = [
+        logging.Formatter("%(message)s").format(record)
+        for record in caplog.records
+        if record.name == logger_name and record.levelno == logging.WARNING
+    ]
+    assert len(records) == 1, caplog.records
+    rendered = records[0]
+    assert "during knowledge-base file restore" in rendered
+    assert "file_id=file-1" in rendered
+    assert storage_key in rendered
+    assert "_ProviderThrottled" in rendered
+    assert provider_message in rendered

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -1370,6 +1370,7 @@ async def test_agent_publish_of_a_new_collection_survives_a_config_read_failure(
 async def test_create_kb_from_file_durable_fault_logs_cause_and_hides_storage_key(
     tmp_path,
     caplog,
+    monkeypatch,
 ):
     """A restore failure must reach the log in full and the model in redacted form.
 
@@ -1386,6 +1387,7 @@ async def test_create_kb_from_file_durable_fault_logs_cause_and_hides_storage_ke
     """
     import logging
 
+    from xagent.core.tools.core.RAG_tools import kb as kb_module
     from xagent.web.services.managed_file_ref import DurableStorageOperationError
 
     storage_key = "users/7/uploads/file-1/notes.txt"
@@ -1417,6 +1419,17 @@ async def test_create_kb_from_file_durable_fault_logs_cause_and_hides_storage_ke
 
     def fake_get_db():
         yield from _fake_db_generator(db)
+
+    # Same isolation as the sibling tests in this file. Without it the test
+    # still passes, but only because ``agent_collection_exists`` swallows
+    # non-``ValueError`` exceptions and reports True -- i.e. it would be
+    # leaning on real KB storage being unreachable rather than on a stub.
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="agent_file_kb"))
+    coordinator = KBCoordinator(
+        storage_shim=_FakeStorageShim(metadata_store),
+        operation_compatibility=_RecordingOperationFacade(),
+    )
+    monkeypatch.setattr(kb_module, "get_kb_coordinator", lambda: coordinator)
 
     logger_name = "xagent.core.tools.adapters.vibe.file_ingestion_tool"
     with (

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -28,6 +28,7 @@ from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.api.v1.errors import V1ApiError
 from xagent.web.models.user import User
 from xagent.web.services.managed_file_ref import (
+    _MAX_LOG_VALUE_LENGTH,
     DurableStorageOperationError,
     ManagedFileRef,
 )
@@ -349,7 +350,7 @@ def test_v1_turn_attachment_durable_fault_logs_the_provider_cause(
 # assertions; this sweep is what makes the set itself the contract.
 _FAULT_SITES = (
     ("signed durable redirect", ("file_id",)),
-    ("upload", ()),
+    ("upload", ("user_id", "task_id")),
     ("download", ("file_id",)),
     ("preview", ("file_id",)),
     ("pptx preview", ("file_id",)),
@@ -364,13 +365,7 @@ def _identifiers(expression: ast.expr) -> set[str]:
     """Every name and attribute the expression reads.
 
     ``file_ref.record.file_id`` yields ``file_ref``, ``record`` and ``file_id``,
-    so a field may be bound to a bare variable or reached through attributes --
-    what it may not be is bound to something of an unrelated name.
-
-    This does make the field name part of the call site's vocabulary: a new site
-    whose source is spelled differently (``file_id=row.id``) has to read it
-    through a local of the field's own name. That is the point -- the alternative
-    is a check that cannot tell ``file_id=file_id`` from ``file_id=storage_key``.
+    so a field may be bound to a bare variable or reached through attributes.
     """
     found: set[str] = set()
     for node in ast.walk(expression):
@@ -381,11 +376,34 @@ def _identifiers(expression: ast.expr) -> set[str]:
     return found
 
 
+def _binds_a_matching_name(field: str, expression: ast.expr) -> bool:
+    """Whether the expression reads an identifier plausibly holding ``field``.
+
+    A qualifier prefix is allowed -- ``task_id=parsed_task_id`` and
+    ``user_id=owner_user_id`` name the thing they carry -- while an unrelated
+    name is rejected, which is what catches ``file_id=storage_key``.
+
+    **This checks spelling, not referent, and that is a real limit.** The
+    "public preview task asset" site shipped with ``file_id=file_id`` where the
+    failing object was ``asset_record`` -- a different row from the route's
+    ``file_id``, so the one line meant to identify the failure named an object
+    that was fine. This check passed it, because the spelling was right. Only a
+    test that drives the endpoint distinguishes those, which is #1522; do not
+    read a green run here as "every site logs the right object".
+    """
+    return any(
+        identifier == field or identifier.endswith(field)
+        for identifier in _identifiers(expression)
+    )
+
+
 def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
     """The nine labels are a closed set of bounded, aggregatable values.
 
-    ``upload`` carries no identifier by design: it is a batch-registration path
-    with no single file_id. Every other site identifies its subject.
+    ``upload`` carries no ``file_id`` by design -- it is a batch-registration
+    path, and any file in the batch may be the one that failed -- but it does
+    carry tenant and task, which is what correlates a 503 burst. Every other
+    site identifies its subject.
     """
     tree = ast.parse(Path(files_api.__file__).read_text(encoding="utf-8"))
     calls = [
@@ -426,7 +444,7 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
         # something of the same name is what ties the label to the variable.
         for keyword in node.keywords:
             assert keyword.arg is not None, f"site {label!r} uses **kwargs"
-            assert keyword.arg in _identifiers(keyword.value), (
+            assert _binds_a_matching_name(keyword.arg, keyword.value), (
                 f"site {label!r} binds {keyword.arg}= to "
                 f"{ast.unparse(keyword.value)!r}, which never reads "
                 f"{keyword.arg} -- the field name and the value must agree"
@@ -481,16 +499,48 @@ def test_field_values_cannot_forge_a_log_record(
     )
 
 
+@pytest.mark.parametrize("length", [_MAX_LOG_VALUE_LENGTH - 1, _MAX_LOG_VALUE_LENGTH])
+def test_a_field_value_at_or_under_the_bound_is_kept_whole(
+    caplog: pytest.LogCaptureFixture, length: int
+) -> None:
+    """The bound is inclusive, so neither of these may be marked truncated."""
+    value = "v" * length
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException):
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), "upload", file_ids=value
+            )
+
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert f"file_ids={value} " in f"{rendered.splitlines()[0]} "
+    assert "truncated" not in rendered.splitlines()[0]
+
+
 def test_an_overlong_field_value_is_truncated(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """One field must not be able to crowd out the rest of the line."""
+    """One field must not be able to crowd out the rest of the line.
+
+    Pins the boundary rather than only the marker: with the length unasserted
+    this passed for any bound at all, so a change from 256 to 4096 would have
+    kept a green run while one field again took over the line.
+    """
     with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
         with pytest.raises(HTTPException):
             files_api._raise_durable_storage_unavailable(
                 _wrapped_fault(), "upload", file_ids="x" * 5000
             )
 
-    rendered = _sole_warning(caplog, files_api.logger.name)
-    assert "...[truncated]" in rendered
-    assert len(rendered.splitlines()[0]) < 1000
+    message_line = _sole_warning(caplog, files_api.logger.name).splitlines()[0]
+    # The retained part is the intact leading prefix, at exactly the bound --
+    # one character more is the off-by-one this pins.
+    assert f"file_ids={'x' * _MAX_LOG_VALUE_LENGTH}...[truncated]" in message_line
+    assert "x" * (_MAX_LOG_VALUE_LENGTH + 1) not in message_line
+    assert len(message_line) < 1000
+    # The magnitude is part of the contract too, not just the mechanics: the
+    # cap exists so one field cannot crowd out the rest of the line, and the
+    # assertions above are all written against the constant, so they would stay
+    # green if it were raised to a value that defeats that. A ceiling rather
+    # than an equality, so the number stays tunable within its purpose.
+    assert _MAX_LOG_VALUE_LENGTH <= 512

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -98,16 +98,57 @@ class _ProviderThrottled(RuntimeError):
 def _wrapped_fault() -> DurableStorageOperationError:
     """Build a fault shaped exactly like ``ManagedFileRef``'s wraps.
 
-    The message carries the storage key and nothing else; everything an
-    operator needs to classify the failure lives in ``__cause__``. Assigning
-    ``__cause__`` directly is what ``raise ... from exc`` does, and it survives
-    a later bare ``raise`` of this object.
+    The key rides on ``storage_key``, not in the message, because ``str(exc)``
+    escapes to places the raise site does not control. Keeping this replica in
+    the production shape is the point: with the key in the message it would test
+    a shape nothing raises, and the log assertions would pass for the wrong
+    reason -- from the message text rather than from the rendered field.
+
+    Everything an operator needs to classify the failure lives in ``__cause__``.
+    Assigning it directly is what ``raise ... from exc`` does, and it survives a
+    later bare ``raise`` of this object.
     """
     fault = DurableStorageOperationError(
-        f"Failed to write durable object: {_STORAGE_KEY}"
+        "Failed to write durable object", storage_key=_STORAGE_KEY
     )
     fault.__cause__ = _ProviderThrottled(_PROVIDER_MESSAGE)
     return fault
+
+
+def test_the_wrap_keeps_the_storage_key_out_of_its_own_message() -> None:
+    """``str(exc)`` is the value that escapes; it must not carry the key.
+
+    A bare ``raise`` from a WebSocket fault arm carries this exception into a
+    task-wide broadcast and a persisted command row, and broad
+    ``except RuntimeError`` arms interpolate it into client-facing text. Those
+    egresses are pre-existing code that no arm in this PR can reach, so the
+    invariant has to hold at the exception rather than at each of them.
+    """
+    fault = _wrapped_fault()
+
+    assert _STORAGE_KEY not in str(fault)
+    assert "users/" not in str(fault)
+    assert fault.storage_key == _STORAGE_KEY
+
+    # Every real wrap site, not just this replica.
+    for path in (
+        Path(files_api.__file__).parent.parent / "services" / "managed_file_ref.py",
+    ):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id
+                in {"DurableStorageOperationError", "DurableObjectIntegrityError"}
+            ):
+                continue
+            message = node.args[0] if node.args else None
+            assert not isinstance(message, ast.JoinedStr), (
+                f"{path.name}:{node.lineno} interpolates into the message; the "
+                "identifier belongs in storage_key= so str(exc) stays safe"
+            )
 
 
 def _rendered(record: logging.LogRecord) -> str:
@@ -145,18 +186,20 @@ def _warning_matching(
     return matches[0]
 
 
-def _assert_cause_chain_recorded(rendered: str, *, wrap_message: bool = True) -> None:
+def _assert_cause_chain_recorded(rendered: str, *, wrap_key: bool = True) -> None:
     """The provider fault -- class and message -- must be in the log text.
 
-    ``wrap_message=False`` for the delete path, whose exception was never
-    wrapped by ``ManagedFileRef`` and so carries no storage key of its own.
+    ``wrap_key=False`` where the wrap's own storage key should not appear: the
+    delete path hands over a raw provider exception that has none, and a caller
+    passing an explicit ``storage_key`` field deliberately overrides it.
     """
     assert _ProviderThrottled.__name__ in rendered
     assert _PROVIDER_MESSAGE in rendered
-    if wrap_message:
-        # The wrap's own message (and with it the storage key) is the anchor an
-        # operator greps for; it must not be dropped in favour of the cause.
-        assert _STORAGE_KEY in rendered
+    if wrap_key:
+        # The key is the anchor an operator greps for. It is no longer in the
+        # message -- ``str(exc)`` escapes to clients -- so this asserts the
+        # helper renders it from the exception instead of losing it.
+        assert f"storage_key={_STORAGE_KEY}" in rendered
 
 
 def test_durable_storage_unavailable_logs_cause_and_keeps_body_detail_free(
@@ -211,7 +254,7 @@ def test_durable_storage_unavailable_accepts_an_unwrapped_provider_error(
     assert "durable cleanup before row delete" in rendered
     # The key is a named field, not part of the bounded operation label.
     assert f"storage_key={_STORAGE_KEY}" in rendered
-    _assert_cause_chain_recorded(rendered, wrap_message=False)
+    _assert_cause_chain_recorded(rendered, wrap_key=False)
 
 
 def test_one_wrap_yields_one_record_however_many_arms_report_it(
@@ -492,29 +535,60 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
 
 
 def test_no_client_supplied_message_type_can_become_an_operation_label() -> None:
-    """The WebSocket dispatch labels are a closed set, like the nine above.
+    """The label must be a literal from the map, never built from the input.
 
     ``operation`` is rendered into the message and, unlike the fields beside it,
-    is not escaped or bounded (#1520), so the received ``type`` must not reach
-    it. Mapping through a dict is what keeps that true; this pins the property
-    rather than the mechanism, so a future rewrite to interpolation fails.
+    is not escaped or bounded (#1520), so the received ``type`` reaching it would
+    reintroduce the injection this PR closed for fields.
+
+    Asserted against the **call site**, not by re-evaluating the lookup: an
+    earlier version of this test called ``_DISPATCH_OPERATIONS.get(hostile, ...)``
+    itself and claimed that pinned the property. It did not -- rewriting the call
+    site to ``f"websocket {message_data.get('type')}"`` would have left it green,
+    which is the exact leak class it claimed to guard.
     """
+    tree = ast.parse(Path(websocket_api.__file__).read_text(encoding="utf-8"))
+    endpoint = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "websocket_chat_endpoint"
+    )
+
+    assignments = [
+        node
+        for node in ast.walk(endpoint)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "dispatching"
+            for target in node.targets
+        )
+    ]
+    assert assignments, "no assignment to `dispatching` -- the label plumbing moved"
+
+    for node in assignments:
+        value = node.value
+        if isinstance(value, ast.Constant):
+            assert isinstance(value.value, str)
+            continue
+        assert isinstance(value, ast.Call) and isinstance(value.func, ast.Attribute), (
+            f"line {node.lineno}: `dispatching` is built by "
+            f"{ast.unparse(value)!r}; it must be a literal or a lookup in "
+            "_DISPATCH_OPERATIONS, never composed from the received type"
+        )
+        assert value.func.attr == "get"
+        assert (
+            isinstance(value.func.value, ast.Name)
+            and value.func.value.id == "_DISPATCH_OPERATIONS"
+        ), f"line {node.lineno}: lookup is not against _DISPATCH_OPERATIONS"
+        fallback = value.args[1] if len(value.args) > 1 else None
+        assert isinstance(fallback, ast.Name) and fallback.id == (
+            "_UNKNOWN_DISPATCH_OPERATION"
+        ), f"line {node.lineno}: unknown types must fall back to a fixed label"
+
+    # And the values a client can select between are bounded literals.
     labels = set(websocket_api._DISPATCH_OPERATIONS.values())
     labels.add(websocket_api._UNKNOWN_DISPATCH_OPERATION)
-
-    for hostile in (
-        "chat\n2026-01-01 00:00:00 ERROR xagent.web - FABRICATED",
-        "../../etc/passwd",
-        "x" * 5000,
-        "",
-        "None",
-    ):
-        resolved = websocket_api._DISPATCH_OPERATIONS.get(
-            hostile, websocket_api._UNKNOWN_DISPATCH_OPERATION
-        )
-        assert resolved in labels
-        assert hostile not in resolved or hostile == ""
-
     for label in labels:
         assert label == label.strip()
         assert not any(char in label for char in "\n\r\t")
@@ -549,10 +623,69 @@ def test_every_dispatched_message_type_has_a_label() -> None:
     }
 
     assert dispatched, "found no dispatch branches -- the parse assumption broke"
-    assert dispatched == set(websocket_api._DISPATCH_OPERATIONS), (
+    labelled = set(websocket_api._DISPATCH_OPERATIONS)
+    assert dispatched == labelled | _SWALLOWED_DISPATCH_TYPES, (
         "dispatch cascade and label map disagree: "
-        f"{dispatched ^ set(websocket_api._DISPATCH_OPERATIONS)}"
+        f"{dispatched ^ (labelled | _SWALLOWED_DISPATCH_TYPES)}"
     )
+    assert not (labelled & _SWALLOWED_DISPATCH_TYPES), (
+        "a type cannot be both labelled and declared unreachable: "
+        f"{labelled & _SWALLOWED_DISPATCH_TYPES}"
+    )
+
+
+# Message types deliberately absent from the label map because their handler
+# swallows the fault before it can reach the endpoint arm. Declared, not
+# assumed: the test below reads the handlers to confirm it.
+_SWALLOWED_DISPATCH_TYPES = {"execute_task", "intervention"}
+_SWALLOWING_HANDLERS = {
+    "execute_task": "handle_execute_task",
+    "intervention": "handle_intervention",
+}
+
+
+@pytest.mark.parametrize(
+    ("dispatch_type", "handler"), sorted(_SWALLOWING_HANDLERS.items())
+)
+def test_a_type_is_unlabelled_only_because_its_handler_swallows(
+    dispatch_type: str, handler: str
+) -> None:
+    """The omission above must stay true of the code, not just of a comment.
+
+    Leaving these two out of the label map is only correct while their handlers
+    end in ``except RuntimeError`` without re-raising, because that is what stops
+    a durable fault ever reaching the arm that would use the label. If someone
+    adds a re-raise -- or a durable arm, which is the #1515 work -- the type
+    becomes reachable and needs a label, and this is what says so.
+    """
+    tree = ast.parse(Path(websocket_api.__file__).read_text(encoding="utf-8"))
+    func = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name == handler
+    )
+    runtime_arms = [
+        arm
+        for arm in (
+            handler_arm
+            for try_node in ast.walk(func)
+            if isinstance(try_node, ast.Try)
+            for handler_arm in try_node.handlers
+        )
+        if isinstance(arm.type, ast.Name) and arm.type.id == "RuntimeError"
+    ]
+
+    assert runtime_arms, f"{handler} no longer has an except RuntimeError arm"
+    for arm in runtime_arms:
+        reraises = any(
+            isinstance(node, ast.Raise) and node.exc is None for node in ast.walk(arm)
+        )
+        assert not reraises, (
+            f"{handler}'s RuntimeError arm now re-raises, so {dispatch_type!r} "
+            "can reach the endpoint fault arm and needs a label in "
+            "_DISPATCH_OPERATIONS"
+        )
 
 
 @pytest.mark.parametrize(("label", "expected_fields"), _FAULT_SITES)
@@ -575,7 +708,11 @@ def test_fault_site_renders_its_label_and_fields(
     assert f"during {label}" in rendered
     for name in expected_fields:
         assert f"{name}=value-for-{name}" in rendered
-    _assert_cause_chain_recorded(rendered)
+    # A site that names its own storage_key overrides the wrap's, so the wrap's
+    # key is legitimately absent there -- that precedence is the point.
+    _assert_cause_chain_recorded(
+        rendered, wrap_key="storage_key" not in expected_fields
+    )
 
 
 def test_field_values_cannot_forge_a_log_record(

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -181,9 +181,10 @@ def test_durable_storage_unavailable_accepts_an_unwrapped_provider_error(
 ) -> None:
     """The delete path hands over the raw provider exception, not a wrap.
 
-    ``delete_file`` catches ``Exception`` around the durable cleanup, so the
-    helper's parameter is typed ``BaseException``; before #1467 that site
-    logged the storage key and discarded the exception entirely.
+    ``delete_file`` catches ``Exception`` around the durable cleanup rather
+    than a ``DurableStorageOperationError``, so the helper has to classify and
+    log something that was never wrapped. Before #1467 that site logged the
+    storage key and discarded the exception entirely.
     """
     with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
         response = files_api._durable_storage_unavailable(

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -24,6 +24,7 @@ from fastapi.datastructures import UploadFile
 
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.api import files as files_api
+from xagent.web.api import websocket as websocket_api
 from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.api.v1.errors import V1ApiError
 from xagent.web.models.user import User
@@ -391,6 +392,11 @@ def _binds_a_matching_name(field: str, expression: ast.expr) -> bool:
     ``user_id=owner_user_id`` name the thing they carry -- while an unrelated
     name is rejected, which is what catches ``file_id=storage_key``.
 
+    The prefix must end at an underscore. A bare suffix test would admit
+    ``file_id=profile_id``, since ``"profile_id".endswith("file_id")`` -- an
+    unrelated identifier passing on a coincidental substring, which is the
+    opposite of the point.
+
     **This checks spelling, not referent, and that is a real limit.** The
     "public preview task asset" site shipped with ``file_id=file_id`` where the
     failing object was ``asset_record`` -- a different row from the route's
@@ -400,9 +406,35 @@ def _binds_a_matching_name(field: str, expression: ast.expr) -> bool:
     read a green run here as "every site logs the right object".
     """
     return any(
-        identifier == field or identifier.endswith(field)
+        identifier == field or identifier.endswith(f"_{field}")
         for identifier in _identifiers(expression)
     )
+
+
+@pytest.mark.parametrize(
+    ("field", "source", "accepted"),
+    [
+        ("file_id", "file_id", True),
+        ("file_id", "file_ref.record.file_id", True),
+        ("task_id", "parsed_task_id", True),
+        ("user_id", "owner_user_id", True),
+        ("file_id", "storage_key", False),
+        # A coincidental suffix, not a qualified name: the underscore boundary
+        # is the whole difference, and without it this passes.
+        ("file_id", "profile_id", False),
+    ],
+)
+def test_the_binding_check_accepts_qualified_names_and_rejects_unrelated_ones(
+    field: str, source: str, accepted: bool
+) -> None:
+    """The rule the site sweep leans on, pinned on its own.
+
+    Asserted here rather than only through the sweep because the sweep can only
+    fail on the sites that exist: a rule too loose to reject anything would
+    still pass it. ``profile_id`` is the case that made this necessary.
+    """
+    expression = ast.parse(source, mode="eval").body
+    assert _binds_a_matching_name(field, expression) is accepted
 
 
 def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
@@ -457,6 +489,70 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
                 f"{ast.unparse(keyword.value)!r}, which never reads "
                 f"{keyword.arg} -- the field name and the value must agree"
             )
+
+
+def test_no_client_supplied_message_type_can_become_an_operation_label() -> None:
+    """The WebSocket dispatch labels are a closed set, like the nine above.
+
+    ``operation`` is rendered into the message and, unlike the fields beside it,
+    is not escaped or bounded (#1520), so the received ``type`` must not reach
+    it. Mapping through a dict is what keeps that true; this pins the property
+    rather than the mechanism, so a future rewrite to interpolation fails.
+    """
+    labels = set(websocket_api._DISPATCH_OPERATIONS.values())
+    labels.add(websocket_api._UNKNOWN_DISPATCH_OPERATION)
+
+    for hostile in (
+        "chat\n2026-01-01 00:00:00 ERROR xagent.web - FABRICATED",
+        "../../etc/passwd",
+        "x" * 5000,
+        "",
+        "None",
+    ):
+        resolved = websocket_api._DISPATCH_OPERATIONS.get(
+            hostile, websocket_api._UNKNOWN_DISPATCH_OPERATION
+        )
+        assert resolved in labels
+        assert hostile not in resolved or hostile == ""
+
+    for label in labels:
+        assert label == label.strip()
+        assert not any(char in label for char in "\n\r\t")
+        assert len(label) < 64
+
+
+def test_every_dispatched_message_type_has_a_label() -> None:
+    """The map and the dispatch cascade must not drift apart.
+
+    They are two switches on the same value, kept in step by hand: a seventh
+    handler added to the cascade without a label would log its faults as
+    "unknown message type", which is silent and exactly the mislabelling the
+    map was added to fix.
+    """
+    tree = ast.parse(Path(websocket_api.__file__).read_text(encoding="utf-8"))
+    endpoint = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "websocket_chat_endpoint"
+    )
+    dispatched = {
+        comparator.value
+        for node in ast.walk(endpoint)
+        if isinstance(node, ast.Compare)
+        and isinstance(node.left, ast.Call)
+        and isinstance(node.left.func, ast.Attribute)
+        and node.left.func.attr == "get"
+        and [getattr(arg, "value", None) for arg in node.left.args] == ["type"]
+        for comparator in node.comparators
+        if isinstance(comparator, ast.Constant)
+    }
+
+    assert dispatched, "found no dispatch branches -- the parse assumption broke"
+    assert dispatched == set(websocket_api._DISPATCH_OPERATIONS), (
+        "dispatch cascade and label map disagree: "
+        f"{dispatched ^ set(websocket_api._DISPATCH_OPERATIONS)}"
+    )
 
 
 @pytest.mark.parametrize(("label", "expected_fields"), _FAULT_SITES)

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -12,6 +12,7 @@ investigation in #1467.
 
 from __future__ import annotations
 
+import ast
 import io
 import logging
 from pathlib import Path
@@ -33,7 +34,9 @@ from xagent.web.services.managed_file_ref import (
 
 from .conftest import _direct_db_session, _setup_admin
 
-pytestmark = pytest.mark.usefixtures("_test_db")
+# Not module-wide: only the end-to-end upload test touches the database. The
+# other tests drive the helper directly and would pay a schema create/drop for
+# nothing.
 
 
 @pytest.fixture()
@@ -209,6 +212,7 @@ def test_durable_storage_unavailable_accepts_an_unwrapped_provider_error(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("_test_db")
 async def test_upload_durable_write_failure_logs_the_provider_cause(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -296,3 +300,122 @@ def test_v1_turn_attachment_durable_fault_logs_the_provider_cause(
     assert "owner_user_id=7" in rendered
     assert "file_ids=8ac1f2" in rendered
     _assert_cause_chain_recorded(rendered)
+
+
+# Every ``_raise_durable_storage_unavailable`` call site in files.py, with the
+# fields it is expected to carry. N2 in review -- the signed-redirect site
+# shipping with no identifier -- was invisible because only two sites had
+# assertions; this sweep is what makes the set itself the contract.
+_FAULT_SITES = (
+    ("signed durable redirect", ("file_id",)),
+    ("upload", ()),
+    ("download", ("file_id",)),
+    ("preview", ("file_id",)),
+    ("pptx preview", ("file_id",)),
+    ("public download", ("file_id",)),
+    ("public preview", ("file_id",)),
+    ("public preview task asset", ("file_id",)),
+    ("durable cleanup before row delete", ("file_id", "storage_key")),
+)
+
+
+def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
+    """The nine labels are a closed set of bounded, aggregatable values.
+
+    ``upload`` carries no identifier by design: it is a batch-registration path
+    with no single file_id. Every other site identifies its subject.
+    """
+    tree = ast.parse(Path(files_api.__file__).read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_raise_durable_storage_unavailable"
+    ]
+    # Parsed rather than grepped: a substring count also matches the ``def``
+    # line, and a label is only a contract if the count is exact.
+    assert len(calls) == len(_FAULT_SITES), (
+        f"{len(calls)} call sites but {len(_FAULT_SITES)} labels declared -- "
+        "add the new site to _FAULT_SITES with the fields it should carry"
+    )
+
+    declared = {label for label, _ in _FAULT_SITES}
+    passed = {
+        node.args[1].value
+        for node in calls
+        if len(node.args) > 1 and isinstance(node.args[1], ast.Constant)
+    }
+    # Every label is a plain literal, so it stays a bounded, aggregatable value
+    # -- an f-string here is how the storage key first became part of a label.
+    assert passed == declared, f"labels drifted: {passed ^ declared}"
+
+    for node in calls:
+        expected = dict(_FAULT_SITES)[node.args[1].value]
+        assert tuple(kw.arg for kw in node.keywords) == expected, (
+            f"site {node.args[1].value!r} passes "
+            f"{[kw.arg for kw in node.keywords]}, expected {list(expected)}"
+        )
+
+
+@pytest.mark.parametrize(("label", "expected_fields"), _FAULT_SITES)
+def test_fault_site_renders_its_label_and_fields(
+    caplog: pytest.LogCaptureFixture,
+    label: str,
+    expected_fields: tuple[str, ...],
+) -> None:
+    """Each site's label and field set must survive into the log line."""
+    fields = {name: f"value-for-{name}" for name in expected_fields}
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException) as raised:
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), label, **fields
+            )
+
+    assert raised.value.status_code == 503
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert f"during {label}" in rendered
+    for name in expected_fields:
+        assert f"{name}=value-for-{name}" in rendered
+    _assert_cause_chain_recorded(rendered)
+
+
+def test_field_values_cannot_forge_a_log_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A newline in a client-supplied field must not start a new record.
+
+    ``/v1/*`` renders the request's ``files`` list, an unvalidated ``list[str]``,
+    so a caller cannot be relied on to have checked (CWE-117).
+    """
+    forged = "ok,\n2026-01-01 00:00:00 ERROR    xagent.web - FABRICATED entry"
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException):
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), "upload", file_ids=forged
+            )
+
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    message_line = rendered.splitlines()[0]
+    assert "FABRICATED" in message_line, "the value must survive, escaped"
+    assert "\\n" in message_line
+    assert not any(line.startswith("2026-01-01") for line in rendered.splitlines()), (
+        "the injected text must not stand as its own record"
+    )
+
+
+def test_an_overlong_field_value_is_truncated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One field must not be able to crowd out the rest of the line."""
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException):
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), "upload", file_ids="x" * 5000
+            )
+
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert "...[truncated]" in rendered
+    assert len(rendered.splitlines()[0]) < 1000

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -31,7 +31,7 @@ from xagent.web.services.managed_file_ref import (
     ManagedFileRef,
 )
 
-from .conftest import _admin_headers, _direct_db_session
+from .conftest import _direct_db_session, _setup_admin
 
 pytestmark = pytest.mark.usefixtures("_test_db")
 
@@ -139,13 +139,18 @@ def _warning_matching(
     return matches[0]
 
 
-def _assert_cause_chain_recorded(rendered: str) -> None:
-    """The provider fault -- class and message -- must be in the log text."""
+def _assert_cause_chain_recorded(rendered: str, *, wrap_message: bool = True) -> None:
+    """The provider fault -- class and message -- must be in the log text.
+
+    ``wrap_message=False`` for the delete path, whose exception was never
+    wrapped by ``ManagedFileRef`` and so carries no storage key of its own.
+    """
     assert _ProviderThrottled.__name__ in rendered
     assert _PROVIDER_MESSAGE in rendered
-    # The wrap's own message (and with it the storage key) is the anchor an
-    # operator greps for; it must not be dropped in favour of the cause.
-    assert _STORAGE_KEY in rendered
+    if wrap_message:
+        # The wrap's own message (and with it the storage key) is the anchor an
+        # operator greps for; it must not be dropped in favour of the cause.
+        assert _STORAGE_KEY in rendered
 
 
 def test_durable_storage_unavailable_logs_cause_and_keeps_body_detail_free(
@@ -154,22 +159,23 @@ def test_durable_storage_unavailable_logs_cause_and_keeps_body_detail_free(
     """The shared 503 helper is where all nine file-API sites get their log.
 
     Asserting on the helper rather than on each endpoint is deliberate: the
-    exception is now a required positional argument, so a call site physically
-    cannot skip it, which leaves the helper's own body as the only place the
-    chain can still be dropped.
+    exception is a required positional argument and the helper is ``NoReturn``,
+    so a call site can neither skip the cause nor log without raising. That
+    leaves the helper's own body as the only place the chain can be dropped.
     """
     fault = _wrapped_fault()
 
     with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
-        response = files_api._durable_storage_unavailable(fault, "download")
+        with pytest.raises(HTTPException) as raised:
+            files_api._raise_durable_storage_unavailable(fault, "download")
 
-    assert isinstance(response, HTTPException)
-    assert response.status_code == 503
+    assert raised.value.status_code == 503
     # Scope segments in the key can encode end-user identity, so the body
     # stays the fixed message -- the detail is server-side only.
-    assert response.detail == _UNAVAILABLE_DETAIL
-    assert _STORAGE_KEY not in str(response.detail)
-    assert _PROVIDER_MESSAGE not in str(response.detail)
+    assert raised.value.detail == _UNAVAILABLE_DETAIL
+    assert _STORAGE_KEY not in str(raised.value.detail)
+    assert _PROVIDER_MESSAGE not in str(raised.value.detail)
+    assert raised.value.__cause__ is fault
 
     rendered = _sole_warning(caplog, files_api.logger.name)
     assert "Durable storage unavailable during download" in rendered
@@ -182,22 +188,24 @@ def test_durable_storage_unavailable_accepts_an_unwrapped_provider_error(
     """The delete path hands over the raw provider exception, not a wrap.
 
     ``delete_file`` catches ``Exception`` around the durable cleanup rather
-    than a ``DurableStorageOperationError``, so the helper has to classify and
-    log something that was never wrapped. Before #1467 that site logged the
-    storage key and discarded the exception entirely.
+    than a ``DurableStorageOperationError``, so the helper has to log something
+    that was never wrapped by ``ManagedFileRef``. Before #1467 that site logged
+    the storage key and discarded the exception entirely.
     """
     with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
-        response = files_api._durable_storage_unavailable(
-            _ProviderThrottled(_PROVIDER_MESSAGE),
-            f"{files_api.DELETE_CLEANUP_OPERATION} ({_STORAGE_KEY})",
-        )
+        with pytest.raises(HTTPException) as raised:
+            files_api._raise_durable_storage_unavailable(
+                _ProviderThrottled(_PROVIDER_MESSAGE),
+                "durable cleanup before row delete",
+                storage_key=_STORAGE_KEY,
+            )
 
-    assert response.status_code == 503
+    assert raised.value.status_code == 503
     rendered = _sole_warning(caplog, files_api.logger.name)
-    assert files_api.DELETE_CLEANUP_OPERATION in rendered
-    assert _ProviderThrottled.__name__ in rendered
-    assert _PROVIDER_MESSAGE in rendered
-    assert _STORAGE_KEY in rendered
+    assert "durable cleanup before row delete" in rendered
+    # The key is a named field, not part of the bounded operation label.
+    assert f"storage_key={_STORAGE_KEY}" in rendered
+    _assert_cause_chain_recorded(rendered, wrap_message=False)
 
 
 @pytest.mark.asyncio
@@ -213,7 +221,8 @@ async def test_upload_durable_write_failure_logs_the_provider_cause(
     the reported 503 bursts were observed.
     """
     upload_root = isolated_upload_storage
-    _admin_headers()
+    # Side effect only: lays down the admin row the upload is attributed to.
+    _setup_admin()
     db = _direct_db_session()
     try:
         user_id = int(db.query(User.id).filter(User.username == "admin").scalar())
@@ -280,6 +289,10 @@ def test_v1_turn_attachment_durable_fault_logs_the_provider_cause(
     assert _PROVIDER_MESSAGE not in raised.value.message
 
     rendered = _warning_matching(
-        caplog, v1_tasks.logger.name, "resolving turn attachments: task_id=42"
+        caplog, v1_tasks.logger.name, "during turn attachment resolution"
     )
+    assert "task_id=42" in rendered
+    # The create path has task_id=None, so these carry identification there.
+    assert "owner_user_id=7" in rendered
+    assert "file_ids=8ac1f2" in rendered
     _assert_cause_chain_recorded(rendered)

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -92,6 +92,20 @@ class _ProviderThrottled(RuntimeError):
     """Stand-in for the boto/S3 error class the wrap discards."""
 
 
+class _HostileProviderError(RuntimeError):
+    """A provider exception whose non-dunder attribute reads raise.
+
+    Dunder lookups are left alone so ``traceback`` can still render the object;
+    the point is only that reading an attribute the helper invents is not safe
+    on a foreign exception.
+    """
+
+    def __getattr__(self, name: str) -> object:
+        if name.startswith("__"):
+            raise AttributeError(name)
+        raise RuntimeError(f"attribute access is not supported: {name}")
+
+
 def _wrapped_fault() -> DurableStorageOperationError:
     """Build a fault shaped exactly like ``ManagedFileRef``'s wraps.
 
@@ -211,6 +225,33 @@ def test_durable_storage_unavailable_accepts_an_unwrapped_provider_error(
     _assert_cause_chain_recorded(rendered, wrap_message=False)
 
 
+def test_a_provider_exception_that_rejects_attribute_reads_is_still_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The one-record-per-fault marker must not become the outcome.
+
+    Pairs with the test above: because the delete path hands over an unwrapped
+    provider exception, ``exc`` can be a foreign object, and the marker read
+    ``getattr(exc, ..., False)`` absorbs ``AttributeError`` only. Anything else a
+    ``__getattr__`` raises would propagate out of the helper -- from inside an
+    ``except`` block -- replacing the intended 503-with-a-log with an unhandled
+    500 that loses the fault. That is #1467's own failure mode, reintroduced by
+    the code meant to report it.
+    """
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException) as raised:
+            files_api._raise_durable_storage_unavailable(
+                _HostileProviderError(_PROVIDER_MESSAGE),
+                "durable cleanup before row delete",
+                storage_key=_STORAGE_KEY,
+            )
+
+    assert raised.value.status_code == 503
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert _HostileProviderError.__name__ in rendered
+    assert _PROVIDER_MESSAGE in rendered
+
+
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("_test_db")
 async def test_upload_durable_write_failure_logs_the_provider_cause(
@@ -319,6 +360,27 @@ _FAULT_SITES = (
 )
 
 
+def _identifiers(expression: ast.expr) -> set[str]:
+    """Every name and attribute the expression reads.
+
+    ``file_ref.record.file_id`` yields ``file_ref``, ``record`` and ``file_id``,
+    so a field may be bound to a bare variable or reached through attributes --
+    what it may not be is bound to something of an unrelated name.
+
+    This does make the field name part of the call site's vocabulary: a new site
+    whose source is spelled differently (``file_id=row.id``) has to read it
+    through a local of the field's own name. That is the point -- the alternative
+    is a check that cannot tell ``file_id=file_id`` from ``file_id=storage_key``.
+    """
+    found: set[str] = set()
+    for node in ast.walk(expression):
+        if isinstance(node, ast.Name):
+            found.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            found.add(node.attr)
+    return found
+
+
 def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
     """The nine labels are a closed set of bounded, aggregatable values.
 
@@ -351,11 +413,24 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
     assert passed == declared, f"labels drifted: {passed ^ declared}"
 
     for node in calls:
-        expected = dict(_FAULT_SITES)[node.args[1].value]
+        label = node.args[1].value
+        expected = dict(_FAULT_SITES)[label]
         assert tuple(kw.arg for kw in node.keywords) == expected, (
-            f"site {node.args[1].value!r} passes "
+            f"site {label!r} passes "
             f"{[kw.arg for kw in node.keywords]}, expected {list(expected)}"
         )
+        # Names alone are not the contract. ``file_id=storage_key`` declares the
+        # right field and renders the wrong value, which is invisible both here
+        # and to the sweep below -- that one supplies its own placeholder values
+        # and never reads the call site. Requiring the bound expression to read
+        # something of the same name is what ties the label to the variable.
+        for keyword in node.keywords:
+            assert keyword.arg is not None, f"site {label!r} uses **kwargs"
+            assert keyword.arg in _identifiers(keyword.value), (
+                f"site {label!r} binds {keyword.arg}= to "
+                f"{ast.unparse(keyword.value)!r}, which never reads "
+                f"{keyword.arg} -- the field name and the value must agree"
+            )
 
 
 @pytest.mark.parametrize(("label", "expected_fields"), _FAULT_SITES)

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -31,6 +31,7 @@ from xagent.web.services.managed_file_ref import (
     _MAX_LOG_VALUE_LENGTH,
     DurableStorageOperationError,
     ManagedFileRef,
+    log_durable_storage_fault,
 )
 
 from .conftest import _direct_db_session, _setup_admin
@@ -91,20 +92,6 @@ _UNAVAILABLE_DETAIL = "Durable storage is temporarily unavailable"
 
 class _ProviderThrottled(RuntimeError):
     """Stand-in for the boto/S3 error class the wrap discards."""
-
-
-class _HostileProviderError(RuntimeError):
-    """A provider exception whose non-dunder attribute reads raise.
-
-    Dunder lookups are left alone so ``traceback`` can still render the object;
-    the point is only that reading an attribute the helper invents is not safe
-    on a foreign exception.
-    """
-
-    def __getattr__(self, name: str) -> object:
-        if name.startswith("__"):
-            raise AttributeError(name)
-        raise RuntimeError(f"attribute access is not supported: {name}")
 
 
 def _wrapped_fault() -> DurableStorageOperationError:
@@ -226,31 +213,52 @@ def test_durable_storage_unavailable_accepts_an_unwrapped_provider_error(
     _assert_cause_chain_recorded(rendered, wrap_message=False)
 
 
-def test_a_provider_exception_that_rejects_attribute_reads_is_still_logged(
+def test_one_wrap_yields_one_record_however_many_arms_report_it(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The one-record-per-fault marker must not become the outcome.
+    """A fault crossing several handlers is recorded once.
 
-    Pairs with the test above: because the delete path hands over an unwrapped
-    provider exception, ``exc`` can be a foreign object, and the marker read
-    ``getattr(exc, ..., False)`` absorbs ``AttributeError`` only. Anything else a
-    ``__getattr__`` raises would propagate out of the helper -- from inside an
-    ``except`` block -- replacing the intended 503-with-a-log with an unhandled
-    500 that loses the fault. That is #1467's own failure mode, reintroduced by
-    the code meant to report it.
+    Two arms legitimately report the same fault -- the request-scoped one that
+    answers the client, and the endpoint-scoped one that catches whatever
+    escaped -- and neither can know whether the other ran. So the wrap carries
+    the fact that it has been logged. Without this, sustained-outage logs
+    duplicate every fault, and the duplicate looks like a second failure.
     """
-    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
-        with pytest.raises(HTTPException) as raised:
-            files_api._raise_durable_storage_unavailable(
-                _HostileProviderError(_PROVIDER_MESSAGE),
-                "durable cleanup before row delete",
-                storage_key=_STORAGE_KEY,
-            )
+    fault = _wrapped_fault()
 
-    assert raised.value.status_code == 503
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        log_durable_storage_fault(
+            files_api.logger, "websocket chat turn preparation", fault, task_id=42
+        )
+        log_durable_storage_fault(
+            files_api.logger, "websocket chat turn", fault, task_id=42
+        )
+
+    # The first arm to report wins, which is the innermost -- the one that knows
+    # what it was doing. The coarser endpoint label is the one dropped.
     rendered = _sole_warning(caplog, files_api.logger.name)
-    assert _HostileProviderError.__name__ in rendered
-    assert _PROVIDER_MESSAGE in rendered
+    assert "during websocket chat turn preparation" in rendered
+    _assert_cause_chain_recorded(rendered)
+
+
+def test_an_unwrapped_provider_error_is_not_marked(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dedup is scoped to this module's wraps, and only they carry the mark.
+
+    Setting a private attribute on a foreign exception is not safe in principle
+    -- it may reject the write, and reading it back is not guaranteed either --
+    and it buys nothing: an unwrapped provider error reaches exactly one
+    reporting site, so there is nothing to deduplicate.
+    """
+    raw = _ProviderThrottled(_PROVIDER_MESSAGE)
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        log_durable_storage_fault(files_api.logger, "download", raw)
+        log_durable_storage_fault(files_api.logger, "preview", raw)
+
+    assert len(_warnings(caplog, files_api.logger.name)) == 2
+    assert not hasattr(raw, "_durable_fault_logged")
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -1,0 +1,284 @@
+"""Every durable-storage fault must reach the log with its provider cause.
+
+The envelopes these paths return are deliberately detail-free, and neither
+FastAPI's ``HTTPException`` handler nor the ``/v1/*`` error handler logs a
+traceback for the exception it translates -- so the log line is the *only*
+record of what actually failed. ``ManagedFileRef`` wraps provider faults into
+``DurableStorageOperationError`` carrying just the storage key, which means a
+log line without ``exc_info`` leaves an operator unable to tell a throttle from
+a timeout from rejected credentials. That is the gap that blocked an incident
+investigation in #1467.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+from typing import Any, Iterator, cast
+
+import pytest
+from fastapi import HTTPException
+from fastapi.datastructures import UploadFile
+
+from xagent.core.file_storage.factory import get_unscoped_file_storage
+from xagent.web.api import files as files_api
+from xagent.web.api.v1 import tasks as v1_tasks
+from xagent.web.api.v1.errors import V1ApiError
+from xagent.web.models.user import User
+from xagent.web.services.managed_file_ref import (
+    DurableStorageOperationError,
+    ManagedFileRef,
+)
+
+from .conftest import _admin_headers, _direct_db_session
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+@pytest.fixture()
+def isolated_upload_storage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Iterator[Path]:
+    """Point staging and the object store at ``tmp_path``.
+
+    Kept local rather than shared with ``test_upload_connection_boundary``:
+    this suite's conftest deliberately exposes helpers by explicit import and
+    keeps fixtures out of it, and no fixture-sharing module exists for the
+    upload paths yet. The durable write is patched to fail before it reaches
+    the object store, but the store is still redirected so a regression that
+    lets the write through cannot touch a real backend.
+    """
+    upload_root = tmp_path / "uploads"
+    object_root = tmp_path / "objects"
+    upload_root.mkdir()
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
+    get_unscoped_file_storage.cache_clear()
+    monkeypatch.setattr(files_api, "get_uploads_dir", lambda: upload_root)
+    try:
+        yield upload_root
+    finally:
+        get_unscoped_file_storage.cache_clear()
+
+
+def _stage_under(root: Path, user_id: int):
+    """A deterministic staging-path chooser scoped to ``root``."""
+
+    def get_upload_path(
+        filename: str,
+        task_id: str | None,
+        folder: str | None,
+        requested_user_id: int,
+    ) -> Path:
+        del task_id, folder
+        assert requested_user_id == user_id
+        path = root / f"user_{user_id}" / Path(filename).name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    return get_upload_path
+
+
+_FILENAME = "quarterly-report.txt"
+_STORAGE_KEY = f"users/7/uploads/8ac1f2/{_FILENAME}"
+_PROVIDER_MESSAGE = "SlowDown: Please reduce your request rate (status 503)"
+_UNAVAILABLE_DETAIL = "Durable storage is temporarily unavailable"
+
+
+class _ProviderThrottled(RuntimeError):
+    """Stand-in for the boto/S3 error class the wrap discards."""
+
+
+def _wrapped_fault() -> DurableStorageOperationError:
+    """Build a fault shaped exactly like ``ManagedFileRef``'s wraps.
+
+    The message carries the storage key and nothing else; everything an
+    operator needs to classify the failure lives in ``__cause__``. Assigning
+    ``__cause__`` directly is what ``raise ... from exc`` does, and it survives
+    a later bare ``raise`` of this object.
+    """
+    fault = DurableStorageOperationError(
+        f"Failed to write durable object: {_STORAGE_KEY}"
+    )
+    fault.__cause__ = _ProviderThrottled(_PROVIDER_MESSAGE)
+    return fault
+
+
+def _rendered(record: logging.LogRecord) -> str:
+    """Render a record the way a handler would, ``exc_info`` included."""
+    return logging.Formatter("%(message)s").format(record)
+
+
+def _warnings(caplog: pytest.LogCaptureFixture, logger_name: str) -> list[str]:
+    return [
+        _rendered(record)
+        for record in caplog.records
+        if record.name == logger_name and record.levelno == logging.WARNING
+    ]
+
+
+def _sole_warning(caplog: pytest.LogCaptureFixture, logger_name: str) -> str:
+    """The one warning a direct helper call may emit."""
+    rendered = _warnings(caplog, logger_name)
+    assert len(rendered) == 1, f"expected exactly one warning, got {rendered}"
+    return rendered[0]
+
+
+def _warning_matching(
+    caplog: pytest.LogCaptureFixture, logger_name: str, needle: str
+) -> str:
+    """Pick the fault line out of an endpoint's warnings.
+
+    Not ``_sole_warning``: the request paths under test also run best-effort
+    cleanup that logs to this same logger when it cannot remove a staged file
+    (``_delete_staged_upload``), and an unrelated second warning must not read
+    as a failure of the line this test is about.
+    """
+    matches = [line for line in _warnings(caplog, logger_name) if needle in line]
+    assert len(matches) == 1, f"expected one warning matching {needle!r}: {matches}"
+    return matches[0]
+
+
+def _assert_cause_chain_recorded(rendered: str) -> None:
+    """The provider fault -- class and message -- must be in the log text."""
+    assert _ProviderThrottled.__name__ in rendered
+    assert _PROVIDER_MESSAGE in rendered
+    # The wrap's own message (and with it the storage key) is the anchor an
+    # operator greps for; it must not be dropped in favour of the cause.
+    assert _STORAGE_KEY in rendered
+
+
+def test_durable_storage_unavailable_logs_cause_and_keeps_body_detail_free(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shared 503 helper is where all nine file-API sites get their log.
+
+    Asserting on the helper rather than on each endpoint is deliberate: the
+    exception is now a required positional argument, so a call site physically
+    cannot skip it, which leaves the helper's own body as the only place the
+    chain can still be dropped.
+    """
+    fault = _wrapped_fault()
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        response = files_api._durable_storage_unavailable(fault, "download")
+
+    assert isinstance(response, HTTPException)
+    assert response.status_code == 503
+    # Scope segments in the key can encode end-user identity, so the body
+    # stays the fixed message -- the detail is server-side only.
+    assert response.detail == _UNAVAILABLE_DETAIL
+    assert _STORAGE_KEY not in str(response.detail)
+    assert _PROVIDER_MESSAGE not in str(response.detail)
+
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert "Durable storage unavailable during download" in rendered
+    _assert_cause_chain_recorded(rendered)
+
+
+def test_durable_storage_unavailable_accepts_an_unwrapped_provider_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The delete path hands over the raw provider exception, not a wrap.
+
+    ``delete_file`` catches ``Exception`` around the durable cleanup, so the
+    helper's parameter is typed ``BaseException``; before #1467 that site
+    logged the storage key and discarded the exception entirely.
+    """
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        response = files_api._durable_storage_unavailable(
+            _ProviderThrottled(_PROVIDER_MESSAGE),
+            f"{files_api.DELETE_CLEANUP_OPERATION} ({_STORAGE_KEY})",
+        )
+
+    assert response.status_code == 503
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert files_api.DELETE_CLEANUP_OPERATION in rendered
+    assert _ProviderThrottled.__name__ in rendered
+    assert _PROVIDER_MESSAGE in rendered
+    assert _STORAGE_KEY in rendered
+
+
+@pytest.mark.asyncio
+async def test_upload_durable_write_failure_logs_the_provider_cause(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    isolated_upload_storage: Path,
+) -> None:
+    """End to end on the incident path: a failed durable write, one 503, one log.
+
+    ``store_uploaded_files`` backs ``/api/files/upload`` and both public-chat
+    upload entry points (share and widget), so this covers every route where
+    the reported 503 bursts were observed.
+    """
+    upload_root = isolated_upload_storage
+    _admin_headers()
+    db = _direct_db_session()
+    try:
+        user_id = int(db.query(User.id).filter(User.username == "admin").scalar())
+    finally:
+        db.close()
+    monkeypatch.setattr(
+        files_api, "get_upload_path", _stage_under(upload_root, user_id)
+    )
+
+    def fail_sync(_self: ManagedFileRef, *_args: Any, **_kwargs: Any) -> None:
+        raise _wrapped_fault()
+
+    monkeypatch.setattr(ManagedFileRef, "sync_to_durable", fail_sync)
+    upload = UploadFile(
+        filename=_FILENAME,
+        file=io.BytesIO(b"payload"),
+        headers={"content-type": "text/plain"},
+    )
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException) as raised:
+            await files_api.store_uploaded_files(
+                upload_items=[upload],
+                task_type="general",
+                task_id=None,
+                folder=None,
+                user_id=user_id,
+                single_file_mode=True,
+            )
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == _UNAVAILABLE_DETAIL
+    # The cause chain still reaches the client-facing exception too.
+    assert isinstance(raised.value.__cause__, DurableStorageOperationError)
+
+    rendered = _warning_matching(
+        caplog, files_api.logger.name, "Durable storage unavailable during upload"
+    )
+    _assert_cause_chain_recorded(rendered)
+
+
+def test_v1_turn_attachment_durable_fault_logs_the_provider_cause(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The SDK path returns its own 503 envelope and needs its own log line."""
+
+    def fail_resolve(**_kwargs: Any) -> None:
+        raise _wrapped_fault()
+
+    monkeypatch.setattr(v1_tasks, "resolve_turn_file_infos", fail_resolve)
+
+    with caplog.at_level(logging.WARNING, logger=v1_tasks.logger.name):
+        with pytest.raises(V1ApiError) as raised:
+            v1_tasks._resolve_turn_files_or_400(
+                file_ids=["8ac1f2"],
+                owner_user_id=7,
+                db=cast(Any, None),
+                task_id=42,
+            )
+
+    assert raised.value.http_status == 503
+    assert _STORAGE_KEY not in raised.value.message
+    assert _PROVIDER_MESSAGE not in raised.value.message
+
+    rendered = _warning_matching(
+        caplog, v1_tasks.logger.name, "resolving turn attachments: task_id=42"
+    )
+    _assert_cause_chain_recorded(rendered)

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -396,6 +396,47 @@ def test_v1_turn_attachment_durable_fault_logs_the_provider_cause(
     _assert_cause_chain_recorded(rendered)
 
 
+def test_v1_turn_attachment_integrity_fault_is_not_reported_as_an_outage(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The integrity subclass through the real cascade, not just the parent.
+
+    The test above injects only ``DurableStorageOperationError``, so it would
+    pass with the two arms swapped -- the parent would catch the subclass and
+    this site would report permanent corruption as a retryable outage. That is
+    the safety property the ordering exists for, and injecting the subclass is
+    what actually exercises it.
+    """
+    from xagent.web.services.managed_file_ref import (
+        FILE_INTEGRITY_REUPLOAD_MESSAGE,
+        DurableObjectIntegrityError,
+    )
+
+    def fail_resolve(**_kwargs: Any) -> None:
+        raise DurableObjectIntegrityError(FILE_INTEGRITY_REUPLOAD_MESSAGE)
+
+    monkeypatch.setattr(v1_tasks, "resolve_turn_file_infos", fail_resolve)
+
+    with caplog.at_level(logging.WARNING, logger=v1_tasks.logger.name):
+        with pytest.raises(V1ApiError) as raised:
+            v1_tasks._resolve_turn_files_or_400(
+                file_ids=["8ac1f2"],
+                owner_user_id=7,
+                db=cast(Any, None),
+                task_id=42,
+            )
+
+    assert raised.value.http_status == 503
+    # The envelope is deliberately unchanged; what must not happen is a second,
+    # contradicting record calling permanent corruption a transient outage.
+    assert not [
+        line
+        for line in _warnings(caplog, v1_tasks.logger.name)
+        if "Durable storage unavailable" in line
+    ], "an integrity fault emitted an outage warning -- the arms are misordered"
+
+
 # Every ``_raise_durable_storage_unavailable`` call site in files.py, with the
 # fields it is expected to carry. N2 in review -- the signed-redirect site
 # shipping with no identifier -- was invisible because only two sites had
@@ -411,6 +452,55 @@ _FAULT_SITES = (
     ("public preview task asset", ("file_id",)),
     ("durable cleanup before row delete", ("file_id", "storage_key")),
 )
+
+
+# --- shared AST primitives -------------------------------------------------
+#
+# Several contracts in this file can only be checked against source: which
+# call sites exist, what they bind, which arms come first, and whether a
+# handler re-raises. Each of those started as its own hand-rolled walk, and
+# four near-identical parse-and-search blocks were three too many. These are
+# the pieces they share; the checks themselves stay separate because they
+# assert different things.
+
+
+def _module_ast(module: Any) -> ast.Module:
+    """Parse an imported module's own source."""
+    return ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+
+
+def _function_named(tree: ast.Module, name: str) -> ast.AST:
+    """The (async) function definition called ``name``, anywhere in ``tree``."""
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name == name
+    )
+
+
+def _handler_types(handler: ast.ExceptHandler) -> list[str]:
+    """The exception class names an ``except`` arm names, tuple or not."""
+    if isinstance(handler.type, ast.Name):
+        return [handler.type.id]
+    if isinstance(handler.type, ast.Tuple):
+        return [e.id for e in handler.type.elts if isinstance(e, ast.Name)]
+    return []
+
+
+def _durable_arm_pairs(tree: ast.Module) -> list[ast.Try]:
+    """Every ``try`` that handles both the integrity subclass and its parent."""
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Try)
+        and any(
+            "DurableObjectIntegrityError" in _handler_types(h) for h in node.handlers
+        )
+        and any(
+            "DurableStorageOperationError" in _handler_types(h) for h in node.handlers
+        )
+    ]
 
 
 def _identifiers(expression: ast.expr) -> set[str]:
@@ -488,7 +578,7 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
     carry tenant and task, which is what correlates a 503 burst. Every other
     site identifies its subject.
     """
-    tree = ast.parse(Path(files_api.__file__).read_text(encoding="utf-8"))
+    tree = _module_ast(files_api)
     calls = [
         node
         for node in ast.walk(tree)
@@ -547,13 +637,7 @@ def test_no_client_supplied_message_type_can_become_an_operation_label() -> None
     site to ``f"websocket {message_data.get('type')}"`` would have left it green,
     which is the exact leak class it claimed to guard.
     """
-    tree = ast.parse(Path(websocket_api.__file__).read_text(encoding="utf-8"))
-    endpoint = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.AsyncFunctionDef)
-        and node.name == "websocket_chat_endpoint"
-    )
+    endpoint = _function_named(_module_ast(websocket_api), "websocket_chat_endpoint")
 
     assignments = [
         node
@@ -603,13 +687,7 @@ def test_every_dispatched_message_type_has_a_label() -> None:
     "unknown message type", which is silent and exactly the mislabelling the
     map was added to fix.
     """
-    tree = ast.parse(Path(websocket_api.__file__).read_text(encoding="utf-8"))
-    endpoint = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.AsyncFunctionDef)
-        and node.name == "websocket_chat_endpoint"
-    )
+    endpoint = _function_named(_module_ast(websocket_api), "websocket_chat_endpoint")
     dispatched = {
         comparator.value
         for node in ast.walk(endpoint)
@@ -624,13 +702,14 @@ def test_every_dispatched_message_type_has_a_label() -> None:
 
     assert dispatched, "found no dispatch branches -- the parse assumption broke"
     labelled = set(websocket_api._DISPATCH_OPERATIONS)
-    assert dispatched == labelled | _SWALLOWED_DISPATCH_TYPES, (
+    unlabelled = _SWALLOWED_DISPATCH_TYPES | _INNER_REPORTED_DISPATCH_TYPES
+    assert dispatched == labelled | unlabelled, (
         "dispatch cascade and label map disagree: "
-        f"{dispatched ^ (labelled | _SWALLOWED_DISPATCH_TYPES)}"
+        f"{dispatched ^ (labelled | unlabelled)}"
     )
-    assert not (labelled & _SWALLOWED_DISPATCH_TYPES), (
+    assert not (labelled & unlabelled), (
         "a type cannot be both labelled and declared unreachable: "
-        f"{labelled & _SWALLOWED_DISPATCH_TYPES}"
+        f"{labelled & unlabelled}"
     )
 
 
@@ -638,10 +717,46 @@ def test_every_dispatched_message_type_has_a_label() -> None:
 # swallows the fault before it can reach the endpoint arm. Declared, not
 # assumed: the test below reads the handlers to confirm it.
 _SWALLOWED_DISPATCH_TYPES = {"execute_task", "intervention"}
+
+# Absent for a different reason: the handler propagates, but its own fault arm
+# reports first and the shared logger marks the instance, so the endpoint-level
+# call is a no-op. ``test_a_reported_chat_fault_needs_no_endpoint_label`` pins
+# that behaviour rather than trusting this comment.
+_INNER_REPORTED_DISPATCH_TYPES = {"chat"}
 _SWALLOWING_HANDLERS = {
     "execute_task": "handle_execute_task",
     "intervention": "handle_intervention",
 }
+
+
+def test_a_reported_chat_fault_needs_no_endpoint_label(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Why ``chat`` is not in the label map, asserted rather than asserted-in-prose.
+
+    Its own fault arm reports before re-raising, and the shared logger marks the
+    instance, so the endpoint-level call that would render a ``chat`` label is a
+    no-op. Giving it one would name a line that is never emitted -- which is what
+    it had, and what a reviewer found by tracing the marker.
+
+    If the marker or the arm ever changes so a second record *is* produced, this
+    fails and the label goes back.
+    """
+    fault = _wrapped_fault()
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        # The arm inside the chat handler.
+        log_durable_storage_fault(
+            files_api.logger, "websocket chat turn preparation", fault, task_id=42
+        )
+        # The endpoint-level arm, reached by the bare ``raise`` that follows it.
+        log_durable_storage_fault(
+            files_api.logger, "websocket chat turn", fault, task_id=42
+        )
+
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert "during websocket chat turn preparation" in rendered
+    assert "chat" in _INNER_REPORTED_DISPATCH_TYPES
 
 
 @pytest.mark.parametrize(
@@ -658,13 +773,7 @@ def test_a_type_is_unlabelled_only_because_its_handler_swallows(
     adds a re-raise -- or a durable arm, which is the #1515 work -- the type
     becomes reachable and needs a label, and this is what says so.
     """
-    tree = ast.parse(Path(websocket_api.__file__).read_text(encoding="utf-8"))
-    func = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
-        and node.name == handler
-    )
+    func = _function_named(_module_ast(websocket_api), handler)
     runtime_arms = [
         arm
         for arm in (
@@ -685,6 +794,66 @@ def test_a_type_is_unlabelled_only_because_its_handler_swallows(
             f"{handler}'s RuntimeError arm now re-raises, so {dispatch_type!r} "
             "can reach the endpoint fault arm and needs a label in "
             "_DISPATCH_OPERATIONS"
+        )
+
+
+# Every module carrying an integrity/parent arm pair. The ordering below is a
+# safety property, not a style rule: ``DurableObjectIntegrityError`` subclasses
+# ``DurableStorageOperationError``, so a parent arm placed first makes the child
+# arm dead and reports permanent corruption as a retryable outage -- loud enough
+# to trip the alerts that watch for one, and burying the real diagnosis.
+_MODULES_WITH_DURABLE_ARM_PAIRS = (
+    ("files.py", lambda: files_api),
+    ("websocket.py", lambda: websocket_api),
+    ("v1/tasks.py", lambda: v1_tasks),
+    ("file_ingestion_tool.py", lambda: _file_ingestion_tool()),
+)
+
+
+def _file_ingestion_tool() -> Any:
+    from xagent.core.tools.adapters.vibe import file_ingestion_tool
+
+    return file_ingestion_tool
+
+
+@pytest.mark.parametrize(("label", "loader"), _MODULES_WITH_DURABLE_ARM_PAIRS)
+def test_the_integrity_arm_precedes_its_parent_at_every_site(
+    label: str, loader: Any
+) -> None:
+    """Checked at all twelve pairs, because only one has real end-to-end cover.
+
+    The integrity-vs-outage distinction is asserted through a real call path in
+    exactly one place (``file_ingestion_tool``, via ``test_kb_creation_tools``).
+    Everywhere else -- seven pairs in ``files.py``, three in ``websocket.py``,
+    one in ``v1/tasks.py`` -- the tests either drive the shared helper directly
+    with a pre-built exception or inject only the parent class, so a swapped
+    ordering would change behaviour silently at ten of the twelve.
+
+    This does not replace those tests: it proves ordering, not that each arm
+    produces the right answer. What it does is make the one regression that
+    silently breaks the property at every site impossible to land. Real
+    end-to-end coverage for the ``files.py`` sites is #1522.
+    """
+    tree = _module_ast(loader())
+    pairs = _durable_arm_pairs(tree)
+    assert pairs, f"{label}: expected at least one integrity/parent pair"
+
+    for node in pairs:
+        integrity_at = min(
+            handler.lineno
+            for handler in node.handlers
+            if "DurableObjectIntegrityError" in _handler_types(handler)
+        )
+        parent_at = min(
+            handler.lineno
+            for handler in node.handlers
+            if "DurableStorageOperationError" in _handler_types(handler)
+        )
+        assert integrity_at < parent_at, (
+            f"{label}: the try at line {node.lineno} catches "
+            f"DurableStorageOperationError (line {parent_at}) before its "
+            f"subclass DurableObjectIntegrityError (line {integrity_at}), which "
+            "makes the integrity arm dead and reports corruption as an outage"
         )
 
 

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -3752,3 +3752,89 @@ async def test_resume_non_owner_non_admin_is_refused(db_session) -> None:
     # Authorized away before any runtime is built; an error is sent back.
     assert "task_owner_user_id" not in captured
     ws_manager.send_personal_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_durable_attachment_failure_keeps_the_storage_key_off_the_socket(
+    db_session,
+    caplog,
+) -> None:
+    """A stored-file fault must not send the storage key to the client.
+
+    Attachment preparation runs in the handler's *outer* scope, so this fault
+    surfaces before the inner agent-execution arms and was answered with
+    ``str(exc)`` -- whose wrap text is
+    ``Failed to restore durable object: users/<id>/uploads/...``, embedding the
+    owning user's id. Same defect as the model-facing leak in #1467, one
+    transport over, which is why the invariant is asserted per egress: frame,
+    persisted rejection, and broadcast.
+    """
+    import logging
+
+    from xagent.web.services.managed_file_ref import DurableStorageOperationError
+
+    owner = _user(db_session, "durable-leak-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    owner_id = int(owner.id)
+    task_id = int(task.id)
+    db_session.close()
+
+    storage_key = f"users/{owner_id}/uploads/8ac1f2/quarterly-report.xlsx"
+
+    class _ProviderThrottled(RuntimeError):
+        pass
+
+    def failing_prepare(**_kwargs):
+        wrap = DurableStorageOperationError(
+            f"Failed to restore durable object: {storage_key}"
+        )
+        wrap.__cause__ = _ProviderThrottled("SlowDown: reduce your request rate")
+        raise wrap
+
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    logger_name = "xagent.web.api.websocket"
+
+    with (
+        patch(
+            "xagent.web.api.websocket._prepare_websocket_turn_sync",
+            side_effect=failing_prepare,
+        ),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        with pytest.raises(DurableStorageOperationError):
+            await _handle_chat_message_unserialized(
+                MagicMock(),
+                task_id,
+                {
+                    "message": "with an attachment",
+                    "client_message_id": "durable-leak-probe",
+                    "user": SimpleNamespace(id=owner_id, is_admin=False),
+                    "files": ["8ac1f2"],
+                },
+            )
+
+    # Every outbound egress: nothing may carry the key or the provider text.
+    outbound = [
+        str(call) for call in ws_manager.send_personal_message.await_args_list
+    ] + [str(call) for call in ws_manager.broadcast_to_task.await_args_list]
+    for payload in outbound:
+        assert storage_key not in payload
+        assert f"users/{owner_id}" not in payload
+        assert "Failed to restore durable object" not in payload
+        assert "SlowDown" not in payload
+
+    # The server-side record keeps the whole chain, exactly once.
+    fault_lines = [
+        logging.Formatter("%(message)s").format(entry)
+        for entry in caplog.records
+        if entry.name == logger_name
+        and "Durable storage unavailable" in entry.getMessage()
+    ]
+    assert len(fault_lines) == 1, fault_lines
+    assert "during websocket chat turn preparation" in fault_lines[0]
+    assert storage_key in fault_lines[0]
+    assert "_ProviderThrottled" in fault_lines[0]

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -3943,3 +3943,76 @@ async def test_a_dispatch_fault_is_labelled_with_the_message_that_failed(
     assert "chat turn" not in fault_lines[0]
     # The key still reaches the log, from the attribute rather than the message.
     assert f"storage_key=users/{owner_id}/uploads/a/b.txt" in fault_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_a_durable_integrity_fault_is_answered_as_corruption_not_an_outage(
+    db_session,
+    caplog,
+) -> None:
+    """The integrity subclass through the real cascade, not just the parent.
+
+    ``test_durable_attachment_failure_keeps_the_storage_key_off_the_socket``
+    injects only ``DurableStorageOperationError``, so it would pass with these
+    two arms swapped -- the parent would catch the subclass and tell the client
+    to retry something retrying cannot fix, while emitting a transient-outage
+    warning over the permanent-corruption ERROR already logged upstream.
+
+    Ordering is checked across all twelve pairs by
+    ``test_the_integrity_arm_precedes_its_parent_at_every_site``; this is what
+    proves this pair's arms also produce the right answers.
+    """
+    import logging
+
+    from xagent.web.services.managed_file_ref import (
+        FILE_INTEGRITY_REUPLOAD_MESSAGE,
+        DurableObjectIntegrityError,
+    )
+
+    owner = _user(db_session, "integrity-answer-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    owner_id = int(owner.id)
+    task_id = int(task.id)
+    db_session.close()
+
+    def failing_prepare(**_kwargs):
+        raise DurableObjectIntegrityError(FILE_INTEGRITY_REUPLOAD_MESSAGE)
+
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    logger_name = "xagent.web.api.websocket"
+
+    with (
+        patch(
+            "xagent.web.api.websocket._prepare_websocket_turn_sync",
+            side_effect=failing_prepare,
+        ),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        with pytest.raises(DurableObjectIntegrityError):
+            await _handle_chat_message_unserialized(
+                MagicMock(),
+                task_id,
+                {
+                    "message": "with a corrupted attachment",
+                    "client_message_id": "integrity-probe",
+                    "user": SimpleNamespace(id=owner_id, is_admin=False),
+                    "files": ["8ac1f2"],
+                },
+            )
+
+    frames = [str(call) for call in ws_manager.send_personal_message.await_args_list]
+    assert any("message_rejected" in frame for frame in frames), frames
+    # Told to re-upload, not to retry: retrying cannot repair corruption.
+    assert any("integrity check" in frame for frame in frames), frames
+    assert not any("temporarily unavailable" in frame for frame in frames), frames
+
+    assert not [
+        entry
+        for entry in caplog.records
+        if entry.name == logger_name
+        and "Durable storage unavailable" in entry.getMessage()
+    ], "an integrity fault emitted an outage warning -- the arms are misordered"

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -3763,10 +3763,16 @@ async def test_durable_attachment_failure_keeps_the_storage_key_off_the_socket(
 
     Attachment preparation runs in the handler's *outer* scope, so this fault
     surfaces before the inner agent-execution arms and was answered with
-    ``str(exc)`` -- whose wrap text is
-    ``Failed to restore durable object: users/<id>/uploads/...``, embedding the
+    ``str(exc)``, which then read
+    ``Failed to restore durable object: users/<id>/uploads/...`` and embedded the
     owning user's id. Same defect as the model-facing leak in #1467, one
     transport over.
+
+    The key has since moved off the message onto ``storage_key``, so ``str(exc)``
+    no longer carries it and this arm is no longer the only thing standing
+    between the fault and the client. Both still matter: this pins the arm's
+    fixed message, and ``test_the_wrap_keeps_the_storage_key_out_of_its_own_message``
+    pins the exception. Neither alone would have caught both rounds of this.
 
     What this proves is the *rejection frame*: it asserts one was sent, so the
     negative assertions below cannot pass over an empty list. The broadcast
@@ -3794,7 +3800,7 @@ async def test_durable_attachment_failure_keeps_the_storage_key_off_the_socket(
 
     def failing_prepare(**_kwargs):
         wrap = DurableStorageOperationError(
-            f"Failed to restore durable object: {storage_key}"
+            "Failed to restore durable object", storage_key=storage_key
         )
         wrap.__cause__ = _ProviderThrottled("SlowDown: reduce your request rate")
         raise wrap
@@ -3862,13 +3868,22 @@ async def test_a_dispatch_fault_is_labelled_with_the_message_that_failed(
     """The endpoint arm must name the message it was applying, not "chat turn".
 
     That arm guards the whole receive-loop dispatch, so it sees faults from
-    ``execute_task``, ``resume_task`` and the rest. It logged a fixed
-    ``"websocket chat turn"``, which mislabelled every one of them in the single
-    line meant to be authoritative about what failed.
+    every message type whose handler lets one through. It logged a fixed
+    ``"websocket chat turn"``, mislabelling all of them in the single line meant
+    to be authoritative about what failed.
 
-    Driven through the real endpoint rather than asserted on the label map: the
-    map agreeing with the cascade is checked separately, and neither of those
-    would notice the arm going back to a constant.
+    ``resume_task`` rather than ``execute_task``, and the difference matters:
+    ``handle_execute_task`` ends in ``except RuntimeError`` with no re-raise, so
+    a durable fault there never reaches this arm at all. An earlier version of
+    this test mocked that handler and asserted a label for a path production
+    cannot take -- green, and describing nothing.
+    ``handle_resume_task`` propagates, so mocking it to raise stands in for a
+    real fault, and
+    ``test_a_type_is_unlabelled_only_because_its_handler_swallows`` is what keeps
+    that distinction true rather than remembered.
+
+    Driven through the real endpoint, because neither the label map nor its
+    agreement with the cascade would notice this arm going back to a constant.
     """
     import json
     import logging
@@ -3885,7 +3900,7 @@ async def test_a_dispatch_fault_is_labelled_with_the_message_that_failed(
 
     websocket = MagicMock()
     websocket.receive_text = AsyncMock(
-        side_effect=[json.dumps({"type": "execute_task"}), WebSocketDisconnect()]
+        side_effect=[json.dumps({"type": "resume_task"}), WebSocketDisconnect()]
     )
     ws_manager = MagicMock(
         connect=AsyncMock(),
@@ -3905,10 +3920,11 @@ async def test_a_dispatch_fault_is_labelled_with_the_message_that_failed(
         patch.object(websocket_api, "handle_status_request", AsyncMock()),
         patch.object(
             websocket_api,
-            "handle_execute_task",
+            "handle_resume_task",
             AsyncMock(
                 side_effect=DurableStorageOperationError(
-                    f"Failed to restore durable object: users/{owner_id}/uploads/a/b.txt"
+                    "Failed to restore durable object",
+                    storage_key=f"users/{owner_id}/uploads/a/b.txt",
                 )
             ),
         ),
@@ -3923,5 +3939,7 @@ async def test_a_dispatch_fault_is_labelled_with_the_message_that_failed(
         and "Durable storage unavailable" in entry.getMessage()
     ]
     assert len(fault_lines) == 1, fault_lines
-    assert "during websocket execute_task" in fault_lines[0]
+    assert "during websocket resume_task" in fault_lines[0]
     assert "chat turn" not in fault_lines[0]
+    # The key still reaches the log, from the attribute rather than the message.
+    assert f"storage_key=users/{owner_id}/uploads/a/b.txt" in fault_lines[0]

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -3852,3 +3852,76 @@ async def test_durable_attachment_failure_keeps_the_storage_key_off_the_socket(
     assert "during websocket chat turn preparation" in fault_lines[0]
     assert storage_key in fault_lines[0]
     assert "_ProviderThrottled" in fault_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_a_dispatch_fault_is_labelled_with_the_message_that_failed(
+    db_session,
+    caplog,
+) -> None:
+    """The endpoint arm must name the message it was applying, not "chat turn".
+
+    That arm guards the whole receive-loop dispatch, so it sees faults from
+    ``execute_task``, ``resume_task`` and the rest. It logged a fixed
+    ``"websocket chat turn"``, which mislabelled every one of them in the single
+    line meant to be authoritative about what failed.
+
+    Driven through the real endpoint rather than asserted on the label map: the
+    map agreeing with the cascade is checked separately, and neither of those
+    would notice the arm going back to a constant.
+    """
+    import json
+    import logging
+
+    from fastapi import WebSocketDisconnect
+
+    from xagent.web.services.managed_file_ref import DurableStorageOperationError
+
+    owner = _user(db_session, "dispatch-label-owner")
+    task = _task(db_session, owner.id)
+    owner_id = int(owner.id)
+    task_id = int(task.id)
+    db_session.close()
+
+    websocket = MagicMock()
+    websocket.receive_text = AsyncMock(
+        side_effect=[json.dumps({"type": "execute_task"}), WebSocketDisconnect()]
+    )
+    ws_manager = MagicMock(
+        connect=AsyncMock(),
+        disconnect=MagicMock(),
+        send_personal_message=AsyncMock(),
+        broadcast_to_task=AsyncMock(),
+    )
+    logger_name = "xagent.web.api.websocket"
+
+    with (
+        patch.object(websocket_api, "manager", ws_manager),
+        patch.object(
+            websocket_api,
+            "get_authenticated_user",
+            AsyncMock(return_value=SimpleNamespace(id=owner_id, is_admin=False)),
+        ),
+        patch.object(websocket_api, "handle_status_request", AsyncMock()),
+        patch.object(
+            websocket_api,
+            "handle_execute_task",
+            AsyncMock(
+                side_effect=DurableStorageOperationError(
+                    f"Failed to restore durable object: users/{owner_id}/uploads/a/b.txt"
+                )
+            ),
+        ),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        await websocket_api.websocket_chat_endpoint(websocket, task_id, None)
+
+    fault_lines = [
+        entry.getMessage()
+        for entry in caplog.records
+        if entry.name == logger_name
+        and "Durable storage unavailable" in entry.getMessage()
+    ]
+    assert len(fault_lines) == 1, fault_lines
+    assert "during websocket execute_task" in fault_lines[0]
+    assert "chat turn" not in fault_lines[0]

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -3766,8 +3766,16 @@ async def test_durable_attachment_failure_keeps_the_storage_key_off_the_socket(
     ``str(exc)`` -- whose wrap text is
     ``Failed to restore durable object: users/<id>/uploads/...``, embedding the
     owning user's id. Same defect as the model-facing leak in #1467, one
-    transport over, which is why the invariant is asserted per egress: frame,
-    persisted rejection, and broadcast.
+    transport over.
+
+    What this proves is the *rejection frame*: it asserts one was sent, so the
+    negative assertions below cannot pass over an empty list. The broadcast
+    assertion is defence in depth -- this path does not broadcast, so it holds
+    vacuously and exists to fail if a future edit starts. The persisted
+    rejection is not reached: ``finish_delivery_failure`` only writes when
+    ``delivery_claimed`` is set, and that comes from
+    ``preparation.delivery_claimed``, which never gets assigned when preparation
+    is what raised. Do not read this test as covering all three egresses.
     """
     import logging
 
@@ -3817,10 +3825,16 @@ async def test_durable_attachment_failure_keeps_the_storage_key_off_the_socket(
                 },
             )
 
+    # The rejection frame must actually have gone out, or every negative
+    # assertion below would hold over nothing and this test would pass while
+    # answering the client with anything at all.
+    frames = [str(call) for call in ws_manager.send_personal_message.await_args_list]
+    assert any("message_rejected" in frame for frame in frames), frames
+
     # Every outbound egress: nothing may carry the key or the provider text.
-    outbound = [
-        str(call) for call in ws_manager.send_personal_message.await_args_list
-    ] + [str(call) for call in ws_manager.broadcast_to_task.await_args_list]
+    outbound = frames + [
+        str(call) for call in ws_manager.broadcast_to_task.await_args_list
+    ]
     for payload in outbound:
         assert storage_key not in payload
         assert f"users/{owner_id}" not in payload

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -581,3 +581,167 @@ def test_adopt_existing_object_refreshes_same_size_checksum_mismatch_from_local_
     assert storage.stat_calls == [record.storage_key]
     assert storage.put_calls == [(local_path, record.storage_key)]
     assert record.checksum == sha256(b"new-data").hexdigest()
+
+
+class _SentinelProviderFault(RuntimeError):
+    """The provider error a wrap must keep reachable through ``__cause__``."""
+
+
+_REMOTE_CHECKSUM = sha256(b"durable bytes").hexdigest()
+
+
+class _ProviderFaultStorage:
+    """Raise ``fault`` from one named backend call; let the others succeed.
+
+    Only the call under test may fail. If everything raised, a site could pass
+    by wrapping some *earlier* call's fault, which is the opposite of what these
+    cases pin down.
+
+    ``materialize`` and ``signed_url`` raise on their success path because no
+    case reaches them successfully; a path change that starts calling one shows
+    up as a failure instead of passing on a fault nobody meant to test.
+    """
+
+    def __init__(
+        self,
+        fault: Exception,
+        failing: str,
+        *,
+        remote_checksum: str = _REMOTE_CHECKSUM,
+        remote_size: int = 0,
+    ):
+        self.fault = fault
+        self.failing = failing
+        self.remote_checksum = remote_checksum
+        self.remote_size = remote_size
+
+    def _maybe_fail(self, name: str) -> None:
+        if name == self.failing:
+            raise self.fault
+
+    def _stored(self, key: str) -> StoredObject:
+        return StoredObject(
+            backend="s3",
+            key=key,
+            uri=f"s3://bucket/{key}",
+            size=self.remote_size,
+            checksum=self.remote_checksum,
+            etag="etag",
+        )
+
+    def copy_to_path(self, key, target_path):
+        self._maybe_fail("copy_to_path")
+        Path(target_path).write_bytes(b"durable bytes")
+
+    def materialize(self, key, filename=None):
+        self._maybe_fail("materialize")
+        raise AssertionError("unreachable in these cases")
+
+    def put_file(self, source, key, content_type=None):
+        self._maybe_fail("put_file")
+        return self._stored(key)
+
+    def signed_url(self, key, *, expires, content_type=None, content_disposition=None):
+        self._maybe_fail("signed_url")
+        raise AssertionError("unreachable in these cases")
+
+    def content_hash(self, key):
+        self._maybe_fail("content_hash")
+        return self.remote_checksum
+
+    def stat(self, key):
+        self._maybe_fail("stat")
+        return self._stored(key)
+
+
+def _durable_record(tmp_path, *, local_bytes: bytes | None, **overrides):
+    local_path = tmp_path / "uploads" / "payload.txt"
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    if local_bytes is not None:
+        local_path.write_bytes(local_bytes)
+    return _record(
+        local_path,
+        storage_backend="s3",
+        storage_key="users/7/uploads/file-123/payload.txt",
+        storage_status="available",
+        **overrides,
+    )
+
+
+def _drive_ensure_local(tmp_path, storage):
+    ref = ManagedFileRef(_durable_record(tmp_path, local_bytes=None), storage=storage)
+    return ref.ensure_local
+
+
+def _drive_materialize(tmp_path, storage):
+    ref = ManagedFileRef(_durable_record(tmp_path, local_bytes=None), storage=storage)
+    return ref.materialize
+
+
+def _drive_signed_access_url(tmp_path, storage):
+    # The signing call is reached only past the checksum gate, so the DB
+    # checksum has to agree with what ``content_hash`` reports.
+    record = _durable_record(tmp_path, local_bytes=None, checksum=_REMOTE_CHECKSUM)
+    ref = ManagedFileRef(record, storage=storage)
+    return lambda: ref.signed_access_url(expires=60)
+
+
+def _drive_sync_to_durable(tmp_path, storage):
+    ref = ManagedFileRef(
+        _durable_record(tmp_path, local_bytes=b"local bytes"), storage=storage
+    )
+    return ref.sync_to_durable
+
+
+def _drive_adopt(tmp_path, storage):
+    """Both ``adopt_existing_object`` wraps, selected by which call fails.
+
+    With no local copy, failing ``stat`` hits the metadata wrap directly; letting
+    ``stat`` succeed while reporting no checksum falls through to the second
+    ``content_hash`` lookup, which is wrapped separately a few lines further on.
+    """
+    record = _durable_record(tmp_path, local_bytes=None)
+    ref = ManagedFileRef(record, storage=storage)
+    return lambda: ref.adopt_existing_object(record.storage_key)
+
+
+@pytest.mark.parametrize(
+    ("failing", "expected_message", "driver", "storage_kwargs"),
+    [
+        ("copy_to_path", "restore durable object", _drive_ensure_local, {}),
+        ("materialize", "materialize durable object", _drive_materialize, {}),
+        ("signed_url", "sign durable object URL", _drive_signed_access_url, {}),
+        ("put_file", "write durable object", _drive_sync_to_durable, {}),
+        ("stat", "inspect durable object metadata", _drive_adopt, {}),
+        (
+            "content_hash",
+            "inspect durable object metadata",
+            _drive_adopt,
+            {"remote_checksum": ""},
+        ),
+    ],
+)
+def test_every_wrap_keeps_the_provider_fault_as_its_cause(
+    tmp_path, failing, expected_message, driver, storage_kwargs
+):
+    """``from exc`` at each real wrap site, asserted on a real raise.
+
+    The fault-logging suite builds its wraps by assigning ``__cause__`` on a
+    hand-made exception, so it proves what the logger does with a chain that is
+    already there -- not that these sites still produce one. Dropping ``from
+    exc`` at any wrap below would leave every assertion over there passing while
+    #1467 silently reopened: the provider class, the HTTP status and throttle vs.
+    timeout vs. rejected credentials live in ``__cause__`` and nowhere else.
+
+    Each case fails exactly one backend call and asserts the wrap raised for
+    *that* call carries *that* fault instance -- identity, not just type, so a
+    wrap re-raising some other error cannot pass.
+    """
+    fault = _SentinelProviderFault("SlowDown: reduce your request rate")
+    storage = _ProviderFaultStorage(fault, failing, **storage_kwargs)
+
+    with pytest.raises(DurableStorageOperationError) as raised:
+        driver(tmp_path, storage)()
+
+    assert expected_message in str(raised.value)
+    assert raised.value.__cause__ is fault

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -1561,11 +1561,11 @@ class TestFileManagement:
         # hand-built label is the point: a drift in what the endpoint passes --
         # a wrong variable, a dropped field -- would otherwise be invisible.
         fault_lines = [
-            logging.Formatter("%(message)s").format(record)
-            for record in caplog.records
-            if record.name == "xagent.web.api.files"
-            and record.levelno == logging.WARNING
-            and "durable cleanup before row delete" in record.getMessage()
+            logging.Formatter("%(message)s").format(entry)
+            for entry in caplog.records
+            if entry.name == "xagent.web.api.files"
+            and entry.levelno == logging.WARNING
+            and "durable cleanup before row delete" in entry.getMessage()
         ]
         assert len(fault_lines) == 1, caplog.records
         rendered = fault_lines[0]

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -1,5 +1,6 @@
 """Test file upload API functionality - Fixed for multi-tenant architecture"""
 
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -1510,7 +1511,7 @@ class TestFileManagement:
         assert unrelated_cache.exists()
 
     def test_delete_file_keeps_record_when_durable_cleanup_fails(
-        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch
+        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch, caplog
     ):
         """Durable cleanup failure should not orphan the object by deleting the row."""
         from xagent.core.file_storage.storage import FsspecFileStorage
@@ -1549,10 +1550,32 @@ class TestFileManagement:
 
         monkeypatch.setattr(FsspecFileStorage, "delete", fail_target_delete)
 
-        response = client.delete(f"/api/files/{file_id}", headers=auth_headers)
+        with caplog.at_level(logging.WARNING, logger="xagent.web.api.files"):
+            response = client.delete(f"/api/files/{file_id}", headers=auth_headers)
 
         assert response.status_code == 503
         assert local_path.exists()
+
+        # End-to-end on the message this endpoint actually composes (#1467).
+        # Asserting through the request rather than by calling the helper with a
+        # hand-built label is the point: a drift in what the endpoint passes --
+        # a wrong variable, a dropped field -- would otherwise be invisible.
+        fault_lines = [
+            logging.Formatter("%(message)s").format(record)
+            for record in caplog.records
+            if record.name == "xagent.web.api.files"
+            and record.levelno == logging.WARNING
+            and "durable cleanup before row delete" in record.getMessage()
+        ]
+        assert len(fault_lines) == 1, caplog.records
+        rendered = fault_lines[0]
+        assert f"file_id={file_id}" in rendered
+        assert f"storage_key={storage_key}" in rendered
+        # The cause chain, not just its str(), so the provider class survives.
+        assert "RuntimeError" in rendered
+        assert "simulated durable delete failure" in rendered
+        # The 503 body stays detail-free: the key must not reach the client.
+        assert storage_key not in response.text
         db = next(test_app.dependency_overrides[get_db]())
         try:
             assert (


### PR DESCRIPTION
Closes the logging half of #1467. Provider classification is the stacked #1480.

*Description rewritten at review round 3 to match the head; earlier revisions described intermediate shapes that no longer exist (see the operational note).*

## Problem

When a durable-storage operation failed, the only diagnostic reaching the logs was:

```
WARNING xagent.web.api.files - Durable storage unavailable during upload: Failed to write durable object: users/<id>/uploads/<file_id>/<name>
```

The provider fault was discarded twice: `ManagedFileRef` wraps any provider exception into `DurableStorageOperationError` carrying **only the storage key**, and the consumers threw the `__cause__` chain away — `logger.warning("...: %s", exc)` with no `exc_info`, and neither FastAPI's `HTTPException` handler nor the `/v1/*` handler logs a traceback for what it translates. So the boto/S3 error class, the HTTP status, and whether the fault was a throttle, a timeout, or rejected credentials existed only in `__cause__` and never reached a log. During the incident behind #1467 we saw bursts of 503s on `/api/files/upload` and `/api/widget/files/upload` and could not determine the cause.

**The gap was wider than the issue described.** `files.py:590` was the *only* site that logged anything; the other eight `DurableStorageOperationError` handlers went straight to a 503 with no log line, as did the `/v1/*` resolver. And the issue's third bullet points at the wrong layer: the raise sites already do `from exc` correctly — it is the consumers that drop it.

## Change

One shared `log_durable_storage_fault` in `managed_file_ref.py`, next to the exception it reports. It takes the caller's logger, so lines stay attributed to the endpoint or tool that produced them; a bounded `operation` label; and per-request identifiers as fields.

In `files.py`, `_raise_durable_storage_unavailable(exc, operation, **fields) -> NoReturn` logs and raises `from exc` internally. `NoReturn` rather than a factory returning the exception: the type then forbids a caller that logs without raising (a phantom fault) or raises without logging (the cause lost, which is the bug). The exception is a required positional parameter, typed `Exception` so mypy rejects a caller passing an `asyncio.CancelledError` — a cancelled request has not shown the store to be unwell, and 503 would tell the client to retry something deliberately stopped.

**Sites that report the fault as such** (all go through the shared helper): nine in `files.py` — signed durable redirect, upload, download, preview, pptx preview, public download, public preview, public preview task asset, durable cleanup before row delete — plus the `/v1/*` turn-attachment resolver, the KB ingestion tool, and three in `websocket.py`: chat turn preparation, agent execution, and the endpoint-level arm that catches whatever escaped both.

Startup durable adoption (`startup_file_storage_sync.py`) is **not** among them — an earlier revision of this description said it was. That file is untouched here; it already uses `logger.exception`, so it keeps its cause chain, but it produces none of the fields this helper renders. Routing it (and the other broad absorbers) through classification is #1515.

**Sites that merely absorb it** cannot route through a durable-specific helper, because they catch every exception type. `DurableStorageOperationError` is a `RuntimeError`, so these were silently swallowing it: agent-service setup (`chat.py`), knowledge-base refresh (`kb.py`), workspace file resolution (`core/workspace.py`), and the WebSocket terminal handler. Each now carries `exc_info`. Two of them swallow the fault entirely, so that line is its only record.

One of these was actively misleading rather than merely quiet: the WebSocket terminal handler caught `(ConnectionError, RuntimeError)` and logged a storage fault as `"Connection error in WebSocket"` before swallowing it — on the exact chat-attachment path #1467 is about.

### One dispatch path per turn failure, and a label that names the right one

Every failure arm in the agent-execution block owed the client the same three steps — reject the delivery, then broadcast to the task if one is authorized or answer this socket if not — so the twenty lines of dispatch buried the one line worth reviewing, the message. They now call a shared `answer_turn_failure(message)`, at all four arms.

Two accounting corrections, because an earlier revision of this paragraph got both wrong and nine rounds of review have leaned on this description:

- **Two of the four arms were pre-existing duplication; the other two are arms this PR added.** So the extraction removed two copies and prevented two, rather than deduplicating four.
- **`websocket.py` is +170/−49 across this PR, not "net −21".** The −21 was true of the extraction commit alone (66 insertions, 87 deletions) and became false the moment it was quoted as a fact about the PR. The extraction still removes more than it adds where it applies; the file grows because of everything else here.

`_handle_chat_message_unserialized` also still has failure-dispatch blocks that `answer_turn_failure` does not cover (`_read_task_error_payload_offloop` plus `finish_delivery(False, …)` in a different shape), so two idioms coexist in the function. Not migrated here: they answer a different question and this PR is nine rounds deep.

The endpoint-level fault arm logged a fixed `operation="websocket chat turn"` while guarding the whole receive-loop dispatch, so an `execute_task` or `resume_task` fault was reported as a chat turn in the one line meant to name it. It now derives the label from the message being applied, through a **closed map** — `type` is client-supplied, and `operation` is a bounded value that is not sanitised the way rendered fields are (#1520), so a client must not be able to reach it.

### The key never reaches a client, because it is not in the message

Two earlier revisions of this heading were wrong in opposite directions: it first claimed "the key never leaves the process" while three egresses still carried it, then narrowed to "the egresses this PR touches" while listing three it did not close. Both were symptoms of the same mistake — redacting egress by egress, so the claim had to track a list that kept growing.

The key is no longer in the exception's message:

```python
raise DurableStorageOperationError(
    "Failed to restore durable object", storage_key=self.storage_key
) from exc
```

`str(exc)` therefore cannot carry it, wherever it escapes. That closes the egresses this PR reaches:

- **HTTP** — the 503 body stays the fixed `"Durable storage is temporarily unavailable"`.
- **The model** — the KB ingestion tool no longer interpolates the exception, in either of its two arms.
- **WebSocket clients** — the chat-attachment path sends a fixed message. This took two attempts: the first guarded the inner agent-execution block, but attachment preparation runs in the handler's *outer* try, so the fault still fell through to the generic `except Exception` and its `finish_delivery_failure(str(e))`.

And, without touching any of them, three it does not:

- the **durable-command broadcast** — `_broadcast_terminal_command_error` interpolates the raw exception into `f"Task command {kind} failed: {error}"`, sent to every connection on the task;
- the persisted **`TaskExecutionCommand.error`** column;
- the pause/resume handlers' `f"Runtime error: {str(e)}"` frames.

Those three are pre-existing code no arm here can reach, which is why the fix belongs at the exception rather than at each of them. The reviewer's call was to do this in-PR rather than defer it to #1497, and this is that change; #1497 keeps the wider redaction-boundary work for every *other* exception type.

Operators lose nothing. `log_durable_storage_fault` renders `storage_key` from the exception, so every line that reported the key still does, and a caller passing an explicit `storage_key=` still overrides it. The test replicas were rebuilt in the production shape for the same reason — with the key still in the message, the log assertions would have passed from the message text rather than from the rendered field, which is passing for the wrong reason.

Two tests hold the invariant: one asserts `str(exc)` carries no `users/` segment, and one parses `managed_file_ref.py` and fails if any construction of these classes interpolates into the message.

### Integrity failures are kept distinct

`DurableObjectIntegrityError` subclasses `DurableStorageOperationError`, so a parent-only catch would report permanent checksum corruption as a transient outage — on top of the integrity `ERROR` (with both checksums) already logged where it is raised, and loud enough to trip alerts watching for an outage. The three parent-only consumers now handle the subclass first. Existing envelopes are unchanged; reclassifying them is a compatibility decision, not a logging one.

### Rendered fields are escaped and bounded

Identifiers go into the message, not `extra=`: the deployed formatter is `"%(asctime)s %(levelname)-8s %(name)s - %(message)s"` (`web/logging_config.py`) and never renders `extra`, so those fields would be invisible in exactly the logs an incident is read from. This matches what `managed_file_ref` already does with `file_id`/`storage_key`.

Because some values are client-supplied — `/v1/*` renders the request's `files` list, an unvalidated `list[str]` — the renderer escapes newlines/tabs and caps values at 256 characters. Without it, a newline in a file id fabricates a complete, correctly-formatted log record (CWE-117).

## Operational note — log messages change

Alerts keyed on these need re-keying:

| Before | Now |
| --- | --- |
| `Failed to clean up durable file before deleting row: <key>` (and the exception discarded) | `Durable storage unavailable during durable cleanup before row delete file_id=<id> storage_key=<key>` |
| `Durable storage unavailable while resolving turn attachments: task_id=<id>` | `Durable storage unavailable during turn attachment resolution task_id=<id> owner_user_id=<id> file_ids=<ids>` |

Every line this change emits now shares one stable prefix — `Durable storage unavailable during <operation>` — followed by `key=value` fields. **Key alerts on the prefix plus the operation label, not on the fields**, whose set may grow. The nine `files.py` labels are a closed set enforced by a test that parses the module, so a new site cannot appear without declaring its label and fields.

`Durable storage unavailable during upload` is unchanged as a substring, so existing queries on it keep working.

## Tests

`tests/web/api/test_durable_storage_fault_logging.py` — the shared helper logs the chain and keeps the 503 body detail-free; an unwrapped provider exception (the delete path hands over a raw error) is accepted; end-to-end on the incident path via `store_uploaded_files`; the `/v1/*` resolver's own line and fields; a parametrized sweep over all nine `files.py` sites asserting each label and field set reaches the log; the injection and truncation behaviour of the renderer.

The sweep also checks each site's *bindings*, not just its keyword names: a field must be bound to an expression that reads something of the same name, so `file_id=storage_key` — right keyword, wrong variable — fails. Names alone were checkable while the value was arbitrary.

`tests/web/services/test_managed_file_ref.py` — a parametrized case per real wrap site (`ensure_local`, `materialize`, `signed_access_url`, `sync_to_durable`, and both `adopt_existing_object` wraps) failing exactly one backend call and asserting the raised wrap carries *that fault instance* as `__cause__`. The fault-logging suite builds its wraps by assigning `__cause__` on a hand-made exception, which tests what the logger does with a chain that is already there — not that the sites still produce one. Verified: dropping `from exc` from all six wraps leaves every one of the 17 tests in the fault-logging suite green, and fails all six of these.

Elsewhere: the real `DELETE /api/files/{id}` endpoint asserts the message it actually composes (not a hand-built label); the KB ingestion branch asserts both that the log carries the chain and that the model-facing string carries no key; an integrity mismatch asserts no outage warning; the WebSocket regression asserts a rejection frame was sent and that no egress carries the key or provider text.

The truncation test now pins the boundary rather than the marker: the value at the bound and one under it are kept whole, the overlong one keeps an intact prefix of exactly the bound, and the bound's magnitude is asserted as a ceiling — every other assertion is written against the constant, so raising it to a value that defeats the cap would otherwise have stayed green.

The `upload` site now carries `user_id` and `task_id`. It still has no `file_id` — a batch registration has no single one — but tenant and task are what correlate a 503 burst, and they were in scope all along.

The dispatch label is pinned three ways, because the first attempt at it was covered by nothing that could fail: the arm's use of the derived label is driven through `websocket_chat_endpoint` (with `resume_task`, whose handler propagates — an earlier version used `execute_task`, whose handler swallows, so it asserted a label for a path production cannot take); the call site is required by AST to be a literal or a `_DISPATCH_OPERATIONS` lookup with a fixed fallback, so rewriting it to interpolate the client's `type` fails; and the map's keys must equal the dispatch cascade's branches minus the two whose handler swallows — with that omission read out of the handlers themselves, so it fails if either starts re-raising.

Every assertion was verified red by mutation before the fix.

**What the WebSocket regression does not cover**, stated because its first version implied otherwise: it proves the rejection frame. The broadcast assertion holds vacuously (this path does not broadcast) and exists to fail if that changes; the persisted rejection is never reached, because `finish_delivery_failure` writes only when `delivery_claimed` is set and that value comes from the preparation result, which never returns when preparation is what raised.

## Out of scope

- **#1480** — provider-fault classification (`provider_code`, `retryable`), stacked on this.
- **#1489** — `delete_durable` never wraps provider faults, so deletion failures escape unclassified. Fixing it changes the exception type callers observe.
- **#1473** — `delete_file`'s bare `except Exception` folds a permanent `StorageKeyScopeError` into the retryable 503.
- **#1468** / **#1469** — frontend retry on upload 503, and resume-reservation contention.
- **#1515** — routing the remaining broad absorbers (including startup adoption) through classification. Also owns giving `handle_execute_task` and `handle_intervention` a durable arm: both currently swallow, which is why they have no dispatch label here.
- **#1516** — log records are forgeable through exception text; this PR sanitises the fields it renders, not the `exc_info` channel.
- **#1517** — classifier hardening residuals. Also owns widening the marker-read guard in `log_durable_storage_fault` from `Exception` to `BaseException`.
- **#1518** — `StorageKeyScopeError` still reaches model-facing tool output in `file_ingestion_tool.py`. Pre-existing code outside this diff: the per-record loop catches the two durable classes, and namespace-authority faults are re-raised bare by design, so they land in the outer `except Exception` and its `message=str(e)`.
- **#1519** — `_sanitize_log_value` escapes `\n`/`\r`/`\t` and misses eight other characters `str.splitlines()` breaks on.
- **#1520** — the helpers lack a `/` separator, so a field named `exc`/`operation`/`target_logger` would `TypeError` inside an exception handler; `operation` is not sanitised; and the closed set is enforced by source parsing rather than a type.
- **#1521** — whether this translation belongs at the ASGI boundary (as the sibling namespace-authority family already does) instead of per call site. Raised at design level in every round of this review and never decided.
- **#1522** — seven of the nine `files.py` sites have no end-to-end coverage, only the source-level proxies described above. Round 5 produced a concrete example of what that misses: the "public preview task asset" site logged `file_id=file_id`, the route parameter, where the failing object was a different row (`asset_record`). Fixed here; the binding check passed it because the spelling was right, and only a test that drives the endpoint distinguishes referents.
- **#1497** — the redaction boundary for every *other* exception type reaching a client. The storage-key case it was filed to cover is closed here instead, on the reviewer's call. **#1479** — the pause/resume handlers surfacing `RuntimeError` text to the sender, a pinned tested contract and a product decision rather than a redaction.
- The S3-side root cause of the observed failures (infra, tracked internally).




