### PR TITLE
test(e2e): let Docker allocate host ports for container fixtures

### DIFF
--- a/tests/e2e/minio_harness.py
+++ b/tests/e2e/minio_harness.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import socket
 import subprocess
 import time
 from collections.abc import Iterator
@@ -12,7 +11,6 @@ from uuid import uuid4
 
 import fsspec
 import pytest
-from docker.errors import APIError
 
 from tests.e2e.app_harness import (
     E2EAppClient,
@@ -88,36 +86,19 @@ def run_minio_storage(monkeypatch: pytest.MonkeyPatch) -> Iterator[MinioStorage]
 
     bucket = f"xagent-e2e-{uuid4().hex}"
     client = _docker_client()
-    container = None
-    api_port = 0
-    for _ in range(5):
-        api_port = _free_port()
-        console_port = _free_port()
-        container_name = f"xagent-minio-e2e-{uuid4().hex[:12]}"
-        try:
-            container = client.containers.run(
-                "minio/minio",  # Docker Hub — more reliable than quay.io
-                "server /data --console-address :9001",
-                detach=True,
-                name=container_name,
-                ports={"9000/tcp": api_port, "9001/tcp": console_port},
-                tmpfs={"/data": "size=64m"},
-                environment={
-                    "MINIO_ROOT_USER": MINIO_ACCESS_KEY,
-                    "MINIO_ROOT_PASSWORD": MINIO_SECRET_KEY,
-                },
-            )
-            break
-        except APIError as exc:
-            if "address already in use" not in str(exc):
-                raise
-            try:
-                stale = client.containers.get(container_name)
-                stale.remove(force=True)
-            except Exception:
-                pass
-    if container is None:
-        pytest.skip("Could not allocate free host ports for MinIO")
+    container, host_ports = run_container_with_dynamic_ports(
+        client,
+        "minio/minio",  # Docker Hub — more reliable than quay.io
+        "server /data --console-address :9001",
+        name=f"xagent-minio-e2e-{uuid4().hex[:12]}",
+        container_ports=("9000/tcp", "9001/tcp"),
+        tmpfs={"/data": "size=64m"},
+        environment={
+            "MINIO_ROOT_USER": MINIO_ACCESS_KEY,
+            "MINIO_ROOT_PASSWORD": MINIO_SECRET_KEY,
+        },
+    )
+    api_port = host_ports["9000/tcp"]
 
     endpoint_url = f"http://127.0.0.1:{api_port}"
     storage_options = {
@@ -209,10 +190,59 @@ def run_file_persistence_app(
         )
 
 
-def _free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
+def run_container_with_dynamic_ports(
+    client: Any,
+    image: str,
+    command: str | None = None,
+    *,
+    name: str,
+    container_ports: tuple[str, ...],
+    **kwargs: Any,
+) -> tuple[Any, dict[str, int]]:
+    """Start a detached container and let Docker pick the host ports.
+
+    Publishing to ``("127.0.0.1", None)`` makes Docker choose a free host port
+    while it holds the allocation lock, so the port cannot be taken between the
+    choice and the bind. Picking a port in-process first (bind to 0, read the
+    number, close the socket) leaves exactly that window open, and concurrent
+    e2e fixtures lost it often enough to fail CI with
+    ``Bind for 0.0.0.0:<port> failed: port is already allocated``.
+
+    Returns the container and the host port each ``container_ports`` entry was
+    published on. Binding to loopback also keeps the test container off the
+    machine's external interfaces.
+    """
+    container = client.containers.run(
+        image,
+        command,
+        detach=True,
+        name=name,
+        ports={port: ("127.0.0.1", None) for port in container_ports},
+        **kwargs,
+    )
+    try:
+        # The published ports are only in NetworkSettings once the container is
+        # started, which `run(detach=True)` has already done by the time it
+        # returns; `reload()` just refreshes the local copy of the inspect data.
+        container.reload()
+        host_ports = {
+            port: _published_host_port(container, port) for port in container_ports
+        }
+    except Exception:
+        container.remove(force=True)
+        raise
+    return container, host_ports
+
+
+def _published_host_port(container: Any, container_port: str) -> int:
+    for binding in (container.ports or {}).get(container_port) or []:
+        host_port = binding.get("HostPort")
+        if host_port:
+            return int(host_port)
+    raise RuntimeError(
+        f"Docker did not publish a host port for {container_port} "
+        f"(ports={container.ports!r})"
+    )
 
 
 def _docker_available() -> bool:

--- a/tests/e2e/test_minio_harness_ports.py
+++ b/tests/e2e/test_minio_harness_ports.py
@@ -1,0 +1,109 @@
+"""Guards for the Docker host-port allocation used by the e2e container fixtures.
+
+These run without a Docker daemon: they drive ``run_container_with_dynamic_ports``
+against a fake client and assert the contract that removed the port-collision
+race — the fixtures must never name a host port themselves.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.e2e.minio_harness import run_container_with_dynamic_ports
+
+
+class _FakeContainer:
+    def __init__(self, ports: dict[str, Any] | None) -> None:
+        self.ports = ports
+        self.removed = False
+        self.reload_calls = 0
+
+    def reload(self) -> None:
+        self.reload_calls += 1
+
+    def remove(self, force: bool = False) -> None:
+        del force
+        self.removed = True
+
+
+class _FakeContainers:
+    def __init__(self, container: _FakeContainer) -> None:
+        self._container = container
+        self.run_kwargs: dict[str, Any] = {}
+
+    def run(
+        self, image: str, command: str | None = None, **kwargs: Any
+    ) -> _FakeContainer:
+        self.run_kwargs = {"image": image, "command": command, **kwargs}
+        return self._container
+
+
+class _FakeClient:
+    def __init__(self, container: _FakeContainer) -> None:
+        self.containers = _FakeContainers(container)
+
+
+def test_publishes_with_docker_chosen_loopback_ports() -> None:
+    """The fixture must hand Docker the choice, not a port it picked itself.
+
+    A concrete host port here would reintroduce the check-then-bind window that
+    produced ``port is already allocated`` failures in CI.
+    """
+    container = _FakeContainer(
+        {
+            "9000/tcp": [{"HostIp": "127.0.0.1", "HostPort": "51001"}],
+            "9001/tcp": [{"HostIp": "127.0.0.1", "HostPort": "51002"}],
+        }
+    )
+    client = _FakeClient(container)
+
+    returned, host_ports = run_container_with_dynamic_ports(
+        client,
+        "minio/minio",
+        "server /data",
+        name="fixture-container",
+        container_ports=("9000/tcp", "9001/tcp"),
+        tmpfs={"/data": "size=64m"},
+    )
+
+    assert returned is container
+    assert host_ports == {"9000/tcp": 51001, "9001/tcp": 51002}
+    assert client.containers.run_kwargs["ports"] == {
+        "9000/tcp": ("127.0.0.1", None),
+        "9001/tcp": ("127.0.0.1", None),
+    }
+    assert client.containers.run_kwargs["detach"] is True
+    assert client.containers.run_kwargs["tmpfs"] == {"/data": "size=64m"}
+    assert container.reload_calls == 1
+    assert not container.removed
+
+
+@pytest.mark.parametrize(
+    "ports",
+    [
+        pytest.param(None, id="no-inspect-data"),
+        pytest.param({}, id="no-published-ports"),
+        pytest.param({"5432/tcp": []}, id="empty-binding-list"),
+        pytest.param(
+            {"5432/tcp": [{"HostIp": "127.0.0.1", "HostPort": ""}]}, id="unbound"
+        ),
+    ],
+)
+def test_unpublished_port_raises_and_removes_the_container(
+    ports: dict[str, Any] | None,
+) -> None:
+    """A container we cannot reach is a hard error, and must not be leaked."""
+    container = _FakeContainer(ports)
+    client = _FakeClient(container)
+
+    with pytest.raises(RuntimeError, match="did not publish a host port"):
+        run_container_with_dynamic_ports(
+            client,
+            "postgres:16-bookworm",
+            name="fixture-container",
+            container_ports=("5432/tcp",),
+        )
+
+    assert container.removed, "the unusable container must be cleaned up"

--- a/tests/e2e/test_skill_runtime_session_postgres.py
+++ b/tests/e2e/test_skill_runtime_session_postgres.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 
 import psycopg2
 import pytest
-from docker.errors import APIError
 from sqlalchemy import text
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session
@@ -29,7 +28,7 @@ from tests.e2e.app_harness import (
 from tests.e2e.minio_harness import (
     _docker_available,
     _docker_client,
-    _free_port,
+    run_container_with_dynamic_ports,
 )
 from xagent.core.agent.service import AgentService
 from xagent.core.tools.adapters.vibe.factory import ToolFactory
@@ -78,34 +77,18 @@ def postgres_url() -> Iterator[str]:
         pytest.skip("Requires reachable Docker daemon")
 
     client = _docker_client()
-    container = None
-    host_port = 0
-    for _ in range(5):
-        host_port = _free_port()
-        container_name = f"xagent-postgres-e2e-{uuid4().hex[:12]}"
-        try:
-            container = client.containers.run(
-                "postgres:16-bookworm",
-                detach=True,
-                name=container_name,
-                ports={"5432/tcp": host_port},
-                tmpfs={"/var/lib/postgresql/data": "rw,size=256m"},
-                environment={
-                    "POSTGRES_PASSWORD": POSTGRES_PASSWORD,
-                    "POSTGRES_DB": POSTGRES_DATABASE,
-                },
-            )
-            break
-        except APIError as exc:
-            if "address already in use" not in str(exc):
-                raise
-            try:
-                stale = client.containers.get(container_name)
-                stale.remove(force=True)
-            except Exception:
-                pass
-    if container is None:
-        pytest.skip("Could not allocate a free host port for PostgreSQL")
+    container, host_ports = run_container_with_dynamic_ports(
+        client,
+        "postgres:16-bookworm",
+        name=f"xagent-postgres-e2e-{uuid4().hex[:12]}",
+        container_ports=("5432/tcp",),
+        tmpfs={"/var/lib/postgresql/data": "rw,size=256m"},
+        environment={
+            "POSTGRES_PASSWORD": POSTGRES_PASSWORD,
+            "POSTGRES_DB": POSTGRES_DATABASE,
+        },
+    )
+    host_port = host_ports["5432/tcp"]
 
     database_url = (
         "postgresql+psycopg2://postgres:"


### PR DESCRIPTION
## Problem

The e2e MinIO fixture intermittently fails CI at setup:

```
docker.errors.APIError: 500 Server Error ...
Bind for 0.0.0.0:53633 failed: port is already allocated
```

`tests/e2e/minio_harness.py` picked the host port itself — bind to port 0, read the number, close the socket — and only then asked Docker to bind it. Between the close and the bind the port is free for anything else to take, and concurrent e2e fixtures took it often enough to matter. The same helper is called twice per MinIO fixture and once more by the PostgreSQL fixture, so the suite races against itself.

Both fixtures already wrapped the call in a 5-attempt retry, but the guard was:

```python
if "address already in use" not in str(exc):
    raise
```

The message above comes from Docker's own port-allocation table, not from the docker-proxy bind, so it never matched. The first conflict re-raised immediately and none of the five retries were used.

## Fix

Remove the race instead of retrying it. Publishing to `("127.0.0.1", None)` makes Docker choose a free host port while it holds the allocation lock, so there is no window; the chosen port is read back from the container's inspect data. The retry loop and its skip-on-exhaustion path are no longer needed and are gone.

Binding to loopback also keeps the test containers off the machine's external interfaces (they were published on `0.0.0.0` before).

`tests/e2e/test_skill_runtime_session_postgres.py` had a verbatim copy of the same loop; both fixtures now share `run_container_with_dynamic_ports()`.

## Testing

- New `tests/e2e/test_minio_harness_ports.py` (5 tests) drives the helper against a fake client, so it runs without a Docker daemon. It pins that the fixtures never name a host port themselves, and that a container whose port was not published is raised on and removed rather than leaked.
- Mutation-checked, so the tests are not vacuous: replacing `("127.0.0.1", None)` with a concrete port, and dropping the cleanup on the failure path, each fail the suite.
- `ruff`, `ruff format`, `mypy`, `isort`, `codespell` pass.

Not verified locally: the machine used has no Docker runtime, so the real container path could not be exercised. The `("127.0.0.1", None)` → `{"HostIp": "127.0.0.1", "HostPort": ""}` conversion was checked against `docker.utils.utils.convert_port_bindings`, but that Docker then assigns a port and reports it back in `container.ports` is verified only by this PR's e2e job.