### PR TITLE
test(web): stop flaky one-slot QueuePool contention budgets

### DIFF
--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -10,6 +10,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import (
+    CONTENTION_POOL_TIMEOUT,
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    wait_for_ticks,
+)
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
@@ -1960,13 +1966,14 @@ async def test_a2a_task_page_pool_wait_runs_in_worker_without_blocking_loop(
     assert page_loader is not None
     assert sync_loader is not None
 
+    # The page loader must wait for the slot, never give up on it.
     engine = create_engine(
         f"sqlite:///{tmp_path / 'a2a-page-pool.db'}",
         connect_args={"check_same_thread": False},
         poolclass=QueuePool,
         pool_size=1,
         max_overflow=0,
-        pool_timeout=1.0,
+        pool_timeout=CONTENTION_POOL_TIMEOUT,
     )
     Base.metadata.create_all(bind=engine)
     SessionLocal = sessionmaker(bind=engine)
@@ -2018,15 +2025,17 @@ async def test_a2a_task_page_pool_wait_runs_in_worker_without_blocking_loop(
     )
     ticker_task = asyncio.create_task(ticker())
     try:
-        assert await asyncio.to_thread(worker_started.wait, 1.0)
-        await asyncio.sleep(0.08)
-        assert ticks >= 3, "A2A list QueuePool checkout blocked the event loop"
+        assert await asyncio.to_thread(worker_started.wait, GUARD_TIMEOUT)
+        observed = await wait_for_ticks(lambda: ticks)
+        assert observed >= LOOP_LIVENESS_TICKS, (
+            "A2A list QueuePool checkout blocked the event loop"
+        )
         assert not load_task.done()
     finally:
         held_connection.close()
 
     try:
-        page = await asyncio.wait_for(load_task, timeout=1.0)
+        page = await asyncio.wait_for(load_task, timeout=GUARD_TIMEOUT)
         assert [task.id for task in page.tasks] == [101]
         assert page.total_size == 1
         assert worker_thread_ids
@@ -2122,7 +2131,7 @@ async def test_start_a2a_turn_cancellation_drains_atomic_create_into_scheduling(
         preparation = original_prepare(**kwargs)
         prepared_task_ids.append(preparation.task.id)
         preparation_committed.set()
-        assert allow_preparation_return.wait(timeout=2.0)
+        assert allow_preparation_return.wait(timeout=GUARD_TIMEOUT)
         return preparation
 
     begin_turn = AsyncMock()
@@ -2155,7 +2164,7 @@ async def test_start_a2a_turn_cancellation_drains_atomic_create_into_scheduling(
             task_id=None,
         )
     )
-    assert await asyncio.to_thread(preparation_committed.wait, 2.0)
+    assert await asyncio.to_thread(preparation_committed.wait, GUARD_TIMEOUT)
 
     turn.cancel()
     await asyncio.sleep(0)

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -14,6 +14,7 @@ from tests.web.pool_contention_shared import (
     CONTENTION_POOL_TIMEOUT,
     GUARD_TIMEOUT,
     LOOP_LIVENESS_TICKS,
+    gated_pool_checkout,
     wait_for_ticks,
 )
 from xagent.core.agent.checkpoint import (
@@ -2013,26 +2014,31 @@ async def test_a2a_task_page_pool_wait_runs_in_worker_without_blocking_loop(
             ticks += 1
             await asyncio.sleep(0.01)
 
-    load_task = asyncio.create_task(
-        page_loader(
-            agent_id=7,
-            context_id=None,
-            status=None,
-            status_timestamp_after=None,
-            offset=0,
-            page_size=50,
+    with gated_pool_checkout(engine) as gate:
+        load_task = asyncio.create_task(
+            page_loader(
+                agent_id=7,
+                context_id=None,
+                status=None,
+                status_timestamp_after=None,
+                offset=0,
+                page_size=50,
+            )
         )
-    )
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        assert await asyncio.to_thread(worker_started.wait, GUARD_TIMEOUT)
-        observed = await wait_for_ticks(lambda: ticks)
-        assert observed >= LOOP_LIVENESS_TICKS, (
-            "A2A list QueuePool checkout blocked the event loop"
-        )
-        assert not load_task.done()
-    finally:
-        held_connection.close()
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            # `worker_started` only proves the loader was entered, not that it has
+            # reached the pool; the gate is what establishes contention.
+            assert await asyncio.to_thread(worker_started.wait, GUARD_TIMEOUT)
+            await gate.wait_until_contending()
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS, (
+                "A2A list QueuePool checkout blocked the event loop"
+            )
+            assert not load_task.done()
+        finally:
+            held_connection.close()
+            gate.let_through()
 
     try:
         page = await asyncio.wait_for(load_task, timeout=GUARD_TIMEOUT)

--- a/tests/web/pool_contention_shared.py
+++ b/tests/web/pool_contention_shared.py
@@ -16,13 +16,9 @@ The budgets are therefore split by what each one actually guards:
 
 ``CONTENTION_POOL_TIMEOUT``
     The opposite. Tests that assert work *waits its turn* must never see the
-    checkout give up, so this sits far above any plausible scheduling hiccup. It
-    still has to stay finite and reasonably tight, because it — not
-    ``LOOP_LIVENESS_TIMEOUT`` — is what bounds the on-loop regression these
-    tests exist to catch: a checkout that blocks the loop also blocks the
-    coroutine that would notice, so nothing can be evaluated until the checkout
-    gives up. Keep it well above ``LOOP_LIVENESS_TIMEOUT`` and well below
-    anything a human would call a hang.
+    checkout give up. With ``gated_pool_checkout`` holding the operation in
+    place, the real checkout only runs once the slot is free again, so this is
+    pure headroom rather than part of any assertion.
 
 ``LOOP_LIVENESS_TIMEOUT`` / ``LOOP_LIVENESS_TICKS``
     How long to wait to observe that the event loop is still turning *while the
@@ -30,22 +26,118 @@ The budgets are therefore split by what each one actually guards:
     never ticks at all, so this only has to out-wait a descheduled runner — it
     is not measuring throughput.
 
+``CONTENTION_GATE_TIMEOUT``
+    Both halves of ``gated_pool_checkout``: how long the test waits for the
+    operation to reach the checkout, and how long the operation waits to be let
+    through. It is also what bounds the on-loop regression these tests exist to
+    catch — a checkout that blocks the loop also blocks the coroutine that would
+    release the gate, so neither side can make progress and the failure only
+    surfaces when one of these waits expires. Keep it well above
+    ``LOOP_LIVENESS_TIMEOUT`` (the window that runs between them) and well below
+    anything a human would call a hang.
+
 ``GUARD_TIMEOUT``
-    A hang detector, not an assertion. Once the pool slot is released the awaited
-    work should finish immediately; the only failure worth reporting here is "it
-    never finished at all", so the ceiling is deliberately generous.
+    A hang detector, not an assertion. Once the gate opens and the pool slot is
+    released the awaited work should finish immediately; the only failure worth
+    reporting here is "it never finished at all", so the ceiling is deliberately
+    generous.
+
+Ordering matters as much as the budgets. Waiting for an event that the operation
+sets *before* it reaches the checkout proves nothing: the worker can be
+descheduled in between, the liveness window can complete, the held connection can
+be released, and the eventual checkout then finds a free slot — a test that
+passes having never contended for anything. ``gated_pool_checkout`` closes that
+by construction: it signals from inside the checkout and holds the operation
+there until the test says otherwise.
 """
 
 from __future__ import annotations
 
 import asyncio
-from typing import Callable
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Callable, Iterator
 
 EXHAUSTION_POOL_TIMEOUT = 0.4
 CONTENTION_POOL_TIMEOUT = 15.0
 LOOP_LIVENESS_TIMEOUT = 2.0
 LOOP_LIVENESS_TICKS = 3
+CONTENTION_GATE_TIMEOUT = 10.0
 GUARD_TIMEOUT = 30.0
+
+
+@dataclass(frozen=True)
+class ContentionGate:
+    """Handle onto a checkout held open by ``gated_pool_checkout``."""
+
+    entered: threading.Event
+    _release: threading.Event
+
+    async def wait_until_contending(self) -> None:
+        """Block until the operation is parked inside the pool checkout.
+
+        Runs the wait in a worker thread so that a checkout which wrongly blocks
+        the event loop cannot satisfy it: the loop would be stuck and unable to
+        resume this coroutine, and the wait expires instead.
+        """
+
+        reached = await asyncio.to_thread(self.entered.wait, CONTENTION_GATE_TIMEOUT)
+        assert reached, "the operation never reached the pool checkout"
+
+    def let_through(self) -> None:
+        """Release the parked checkout. Call once the slot is free again."""
+
+        self._release.set()
+
+
+@contextmanager
+def gated_pool_checkout(engine) -> Iterator[ContentionGate]:
+    """Park the next pool checkout until the test releases it.
+
+    Patches the checkout entry point itself, so ``entered`` cannot be observed
+    before the operation is genuinely committed to acquiring a connection, and
+    the operation cannot slip past while the test is looking elsewhere.
+
+    The gate — not SQLAlchemy's queue — is what holds the operation still. That
+    is deliberate: a thread parked in the pool's own wait is not observable from
+    outside without reaching into pool and ``threading.Condition`` internals, and
+    handing the blocking back to SQLAlchemy reintroduces the race this exists to
+    remove (release the gate before freeing the slot and the caller frees it
+    before the woken thread is rescheduled, so the pool never blocks at all —
+    measured, not assumed). Nothing under test is lost: the property is that the
+    checkout blocks a worker thread rather than the event loop, and the gate
+    blocks at the same call site the pool would, on the same thread. The
+    exhausted one-slot pool still supplies the realistic setup.
+
+    Acquire the connection that exhausts the pool *before* entering this context
+    so the parked checkout is the contended one. Only the first checkout is
+    parked; later ones pass straight through.
+    """
+
+    pool = engine.pool
+    # Deliberately unguarded: if SQLAlchemy renames this, the test must break
+    # loudly rather than quietly stop synchronising anything.
+    original_do_get = pool._do_get
+    entered = threading.Event()
+    release = threading.Event()
+
+    def gated_do_get():
+        if not entered.is_set():
+            entered.set()
+            if not release.wait(CONTENTION_GATE_TIMEOUT):
+                raise AssertionError(
+                    "pool checkout was never released; the event loop was "
+                    "probably blocked by this checkout"
+                )
+        return original_do_get()
+
+    pool._do_get = gated_do_get
+    try:
+        yield ContentionGate(entered, release)
+    finally:
+        release.set()
+        pool._do_get = original_do_get
 
 
 async def wait_for_ticks(
@@ -57,17 +149,18 @@ async def wait_for_ticks(
     """Give the event loop up to ``timeout`` to turn ``minimum`` more times.
 
     Counts from a baseline taken on entry, so only progress made *after* the
-    call is credited. Callers must therefore wait for the contended operation to
-    start before calling this — otherwise ticks banked while nothing was
-    contending could satisfy the assertion, and the test would release the held
-    connection without ever observing the loop during contention.
+    call is credited. Callers must therefore have the contended operation parked
+    inside its checkout first (see ``gated_pool_checkout``) — otherwise ticks
+    banked while nothing was contending could satisfy the assertion, and the
+    test would release the held connection without ever observing the loop
+    during contention.
 
     Returns the number of ticks observed since entry, so the caller keeps the
     assertion and its message. A loop blocked by a synchronous checkout stops
     ticking altogether, so a regression still fails here no matter how long we
     are willing to wait — waiting longer only buys tolerance for a runner that
     is merely slow. Note that such a regression cannot be *detected* until the
-    blocking checkout returns, so it is bounded by the pool timeout in force,
+    blocking checkout returns, so it is bounded by ``CONTENTION_GATE_TIMEOUT``,
     not by ``timeout``.
     """
 

--- a/tests/web/pool_contention_shared.py
+++ b/tests/web/pool_contention_shared.py
@@ -1,0 +1,64 @@
+"""Wall-clock budgets for tests that assert on one-slot QueuePool contention.
+
+These tests are timing-shaped by nature: they hold the only slot of a one-slot
+``QueuePool`` and assert on what the runtime does while it waits. The web test
+leg runs ``pytest -n 4`` on a shared CI runner, where a descheduled worker
+thread can eat several hundred milliseconds on its own — enough to blow any
+budget picked to make the test feel snappy. Both failure modes have been
+observed in CI as spurious reds.
+
+The budgets are therefore split by what each one actually guards:
+
+``EXHAUSTION_POOL_TIMEOUT``
+    Semantic. Tests that assert on pool-*exhaustion* behaviour need the checkout
+    to give up quickly, and a slow runner only makes it fire sooner — which is
+    the outcome those tests already expect.
+
+``CONTENTION_POOL_TIMEOUT``
+    The opposite. Tests that assert work *waits its turn* must never see the
+    checkout give up, so this sits far above any plausible scheduling hiccup. It
+    bounds the observation window, hence it must stay well above
+    ``LOOP_LIVENESS_TIMEOUT``.
+
+``LOOP_LIVENESS_TIMEOUT`` / ``LOOP_LIVENESS_TICKS``
+    How long to wait to observe that the event loop is still turning. A loop
+    blocked by a synchronous checkout never ticks at all, so this only has to
+    out-wait a descheduled runner — it is not measuring throughput.
+
+``GUARD_TIMEOUT``
+    A hang detector, not an assertion. Once the pool slot is released the awaited
+    work should finish immediately; the only failure worth reporting here is "it
+    never finished at all", so the ceiling is deliberately generous.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Callable
+
+EXHAUSTION_POOL_TIMEOUT = 0.4
+CONTENTION_POOL_TIMEOUT = 30.0
+LOOP_LIVENESS_TIMEOUT = 2.0
+LOOP_LIVENESS_TICKS = 3
+GUARD_TIMEOUT = 30.0
+
+
+async def wait_for_ticks(
+    read_ticks: Callable[[], int],
+    *,
+    minimum: int = LOOP_LIVENESS_TICKS,
+    timeout: float = LOOP_LIVENESS_TIMEOUT,
+) -> int:
+    """Give the event loop up to ``timeout`` to turn ``minimum`` times.
+
+    Returns the observed tick count so the caller keeps the assertion (and its
+    message). A loop blocked by a synchronous checkout stops ticking altogether,
+    so a regression still fails here no matter how long we are willing to wait —
+    waiting longer only buys tolerance for a runner that is merely slow.
+    """
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while read_ticks() < minimum and loop.time() < deadline:
+        await asyncio.sleep(0.01)
+    return read_ticks()

--- a/tests/web/pool_contention_shared.py
+++ b/tests/web/pool_contention_shared.py
@@ -17,13 +17,18 @@ The budgets are therefore split by what each one actually guards:
 ``CONTENTION_POOL_TIMEOUT``
     The opposite. Tests that assert work *waits its turn* must never see the
     checkout give up, so this sits far above any plausible scheduling hiccup. It
-    bounds the observation window, hence it must stay well above
-    ``LOOP_LIVENESS_TIMEOUT``.
+    still has to stay finite and reasonably tight, because it — not
+    ``LOOP_LIVENESS_TIMEOUT`` — is what bounds the on-loop regression these
+    tests exist to catch: a checkout that blocks the loop also blocks the
+    coroutine that would notice, so nothing can be evaluated until the checkout
+    gives up. Keep it well above ``LOOP_LIVENESS_TIMEOUT`` and well below
+    anything a human would call a hang.
 
 ``LOOP_LIVENESS_TIMEOUT`` / ``LOOP_LIVENESS_TICKS``
-    How long to wait to observe that the event loop is still turning. A loop
-    blocked by a synchronous checkout never ticks at all, so this only has to
-    out-wait a descheduled runner — it is not measuring throughput.
+    How long to wait to observe that the event loop is still turning *while the
+    contended operation is in flight*. A loop blocked by a synchronous checkout
+    never ticks at all, so this only has to out-wait a descheduled runner — it
+    is not measuring throughput.
 
 ``GUARD_TIMEOUT``
     A hang detector, not an assertion. Once the pool slot is released the awaited
@@ -37,7 +42,7 @@ import asyncio
 from typing import Callable
 
 EXHAUSTION_POOL_TIMEOUT = 0.4
-CONTENTION_POOL_TIMEOUT = 30.0
+CONTENTION_POOL_TIMEOUT = 15.0
 LOOP_LIVENESS_TIMEOUT = 2.0
 LOOP_LIVENESS_TICKS = 3
 GUARD_TIMEOUT = 30.0
@@ -49,16 +54,26 @@ async def wait_for_ticks(
     minimum: int = LOOP_LIVENESS_TICKS,
     timeout: float = LOOP_LIVENESS_TIMEOUT,
 ) -> int:
-    """Give the event loop up to ``timeout`` to turn ``minimum`` times.
+    """Give the event loop up to ``timeout`` to turn ``minimum`` more times.
 
-    Returns the observed tick count so the caller keeps the assertion (and its
-    message). A loop blocked by a synchronous checkout stops ticking altogether,
-    so a regression still fails here no matter how long we are willing to wait —
-    waiting longer only buys tolerance for a runner that is merely slow.
+    Counts from a baseline taken on entry, so only progress made *after* the
+    call is credited. Callers must therefore wait for the contended operation to
+    start before calling this — otherwise ticks banked while nothing was
+    contending could satisfy the assertion, and the test would release the held
+    connection without ever observing the loop during contention.
+
+    Returns the number of ticks observed since entry, so the caller keeps the
+    assertion and its message. A loop blocked by a synchronous checkout stops
+    ticking altogether, so a regression still fails here no matter how long we
+    are willing to wait — waiting longer only buys tolerance for a runner that
+    is merely slow. Note that such a regression cannot be *detected* until the
+    blocking checkout returns, so it is bounded by the pool timeout in force,
+    not by ``timeout``.
     """
 
     loop = asyncio.get_running_loop()
+    baseline = read_ticks()
     deadline = loop.time() + timeout
-    while read_ticks() < minimum and loop.time() < deadline:
+    while read_ticks() - baseline < minimum and loop.time() < deadline:
         await asyncio.sleep(0.01)
-    return read_ticks()
+    return read_ticks() - baseline

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -29,6 +29,13 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from tests.shared.db_teardown import drop_all_tables
+from tests.web.pool_contention_shared import (
+    CONTENTION_POOL_TIMEOUT,
+    EXHAUSTION_POOL_TIMEOUT,
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    wait_for_ticks,
+)
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRef
 from xagent.web.models import database as database_module
@@ -99,22 +106,36 @@ def db_session(tmp_path):
 
 
 @pytest.fixture()
-def queue_pool_runtime_db(tmp_path):
-    """A real one-slot QueuePool used to exercise checkout contention."""
-    engine = create_engine(
-        f"sqlite:///{tmp_path / 'orchestrator-queue-pool.db'}",
-        connect_args={"check_same_thread": False},
-        poolclass=QueuePool,
-        pool_size=1,
-        max_overflow=0,
-        pool_timeout=0.4,
-    )
-    Base.metadata.create_all(bind=engine)
-    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+def queue_pool_runtime_db_factory(tmp_path):
+    """Build one-slot QueuePool engines with a caller-chosen checkout timeout."""
+    engines = []
+
+    def _make(*, pool_timeout: float = EXHAUSTION_POOL_TIMEOUT):
+        db_path = tmp_path / f"orchestrator-queue-pool-{len(engines)}.db"
+        engine = create_engine(
+            f"sqlite:///{db_path}",
+            connect_args={"check_same_thread": False},
+            poolclass=QueuePool,
+            pool_size=1,
+            max_overflow=0,
+            pool_timeout=pool_timeout,
+        )
+        engines.append(engine)
+        Base.metadata.create_all(bind=engine)
+        SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        return engine, SessionLocal
+
     try:
-        yield engine, SessionLocal
+        yield _make
     finally:
-        engine.dispose()
+        for engine in engines:
+            engine.dispose()
+
+
+@pytest.fixture()
+def queue_pool_runtime_db(queue_pool_runtime_db_factory):
+    """A real one-slot QueuePool used to exercise checkout exhaustion."""
+    return queue_pool_runtime_db_factory()
 
 
 def _create_user(db) -> User:
@@ -1853,7 +1874,7 @@ async def test_schedule_bg_skips_finish_turn_when_lease_acquire_fails(
 @pytest.mark.asyncio
 async def test_schedule_bg_resolves_scope_off_loop_before_execution(
     db_session,
-    queue_pool_runtime_db,
+    queue_pool_runtime_db_factory,
 ) -> None:
     """A contended scope lookup must not block the main event loop."""
     from xagent.web.api.websocket import background_task_manager
@@ -1862,7 +1883,10 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task_id = int(task.id)
     fake_lease = TaskLease(task_id=task_id, runner_id="test-runner")
-    engine, SessionLocal = queue_pool_runtime_db
+    # The scope lookup must wait for the slot, never give up on it.
+    engine, SessionLocal = queue_pool_runtime_db_factory(
+        pool_timeout=CONTENTION_POOL_TIMEOUT
+    )
     events: list[str] = []
     resolver_threads: list[int] = []
     loop_thread = get_ident()
@@ -1936,12 +1960,14 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
         )
         ticker_task = asyncio.create_task(ticker())
         try:
-            await asyncio.sleep(0.12)
-            assert ticks >= 3, "scope QueuePool checkout blocked the event loop"
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS, (
+                "scope QueuePool checkout blocked the event loop"
+            )
             assert not bg_task.done(), "execution started before scope resolution"
         finally:
             held_connection.close()
-            await asyncio.wait_for(bg_task, timeout=1)
+            await asyncio.wait_for(bg_task, timeout=GUARD_TIMEOUT)
             ticker_stop.set()
             await ticker_task
 
@@ -2300,13 +2326,16 @@ async def test_schedule_bg_settles_owned_terminal_task_observed_by_heartbeat(
 
 @pytest.mark.asyncio
 async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
-    queue_pool_runtime_db,
+    queue_pool_runtime_db_factory,
     monkeypatch,
 ) -> None:
     """Final status read and workforce-aware release share one worker session."""
     from xagent.web.api.websocket import background_task_manager
 
-    engine, SessionLocal = queue_pool_runtime_db
+    # The release path must wait for the slot, never give up on it.
+    engine, SessionLocal = queue_pool_runtime_db_factory(
+        pool_timeout=CONTENTION_POOL_TIMEOUT
+    )
     runner_id = get_runner_id()
     with SessionLocal() as seed_db:
         user = _create_user(seed_db)
@@ -2373,12 +2402,14 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
         )
         ticker_task = asyncio.create_task(ticker())
         try:
-            await asyncio.sleep(0.12)
-            assert ticks >= 3, "lease release QueuePool checkout blocked the loop"
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS, (
+                "lease release QueuePool checkout blocked the loop"
+            )
             assert not bg_task.done(), "lease release skipped the contended checkout"
         finally:
             held_connection.close()
-            await asyncio.wait_for(bg_task, timeout=1)
+            await asyncio.wait_for(bg_task, timeout=GUARD_TIMEOUT)
             ticker_stop.set()
             await ticker_task
 

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -19,7 +19,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack, contextmanager
 from datetime import datetime, timedelta, timezone
-from threading import Barrier, Event, get_ident
+from threading import Barrier, get_ident
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,6 +34,7 @@ from tests.web.pool_contention_shared import (
     EXHAUSTION_POOL_TIMEOUT,
     GUARD_TIMEOUT,
     LOOP_LIVENESS_TICKS,
+    gated_pool_checkout,
     wait_for_ticks,
 )
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
@@ -1890,9 +1891,6 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
     events: list[str] = []
     resolver_threads: list[int] = []
     loop_thread = get_ident()
-    # Opened before the liveness window so it only measures loop progress made
-    # while the scope lookup is actually contending for the slot.
-    scope_started = Event()
 
     def load_snapshot(*_args, **_kwargs):
         events.append("snapshot")
@@ -1901,7 +1899,6 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
     def resolve_scope(resolved_task_id):
         assert resolved_task_id == task_id
         resolver_threads.append(get_ident())
-        scope_started.set()
         with SessionLocal() as scope_db:
             scope_db.execute(text("SELECT 1")).scalar()
         events.append("scope")
@@ -1923,6 +1920,7 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
             ticks += 1
 
     with (
+        gated_pool_checkout(engine) as gate,
         patch(
             "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
             return_value=fake_lease,
@@ -1964,9 +1962,7 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
         )
         ticker_task = asyncio.create_task(ticker())
         try:
-            assert await asyncio.to_thread(scope_started.wait, GUARD_TIMEOUT), (
-                "scope lookup never reached the contended checkout"
-            )
+            await gate.wait_until_contending()
             observed = await wait_for_ticks(lambda: ticks)
             assert observed >= LOOP_LIVENESS_TICKS, (
                 "scope QueuePool checkout blocked the event loop"
@@ -1974,6 +1970,7 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
             assert not bg_task.done(), "execution started before scope resolution"
         finally:
             held_connection.close()
+            gate.let_through()
             await asyncio.wait_for(bg_task, timeout=GUARD_TIMEOUT)
             ticker_stop.set()
             await ticker_task
@@ -2354,16 +2351,7 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
         task.run_id = "run-a"
         seed_db.commit()
 
-    # The release path is production code, so the only seam the test owns is the
-    # session factory it reaches for immediately before the contended checkout.
-    # Opened before the liveness window for the same reason as the scope test.
-    release_started = Event()
-
-    def session_local_for_release():
-        release_started.set()
-        return SessionLocal
-
-    monkeypatch.setattr(database_module, "get_session_local", session_local_for_release)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
     held_connection = engine.connect()
     ticker_stop = asyncio.Event()
     ticks = 0
@@ -2375,6 +2363,7 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
             ticks += 1
 
     with (
+        gated_pool_checkout(engine) as gate,
         patch(
             "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
             return_value=TaskLease(
@@ -2418,9 +2407,7 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
         )
         ticker_task = asyncio.create_task(ticker())
         try:
-            assert await asyncio.to_thread(release_started.wait, GUARD_TIMEOUT), (
-                "lease release never reached the contended checkout"
-            )
+            await gate.wait_until_contending()
             observed = await wait_for_ticks(lambda: ticks)
             assert observed >= LOOP_LIVENESS_TICKS, (
                 "lease release QueuePool checkout blocked the loop"
@@ -2428,6 +2415,7 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
             assert not bg_task.done(), "lease release skipped the contended checkout"
         finally:
             held_connection.close()
+            gate.let_through()
             await asyncio.wait_for(bg_task, timeout=GUARD_TIMEOUT)
             ticker_stop.set()
             await ticker_task

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -19,7 +19,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack, contextmanager
 from datetime import datetime, timedelta, timezone
-from threading import Barrier, get_ident
+from threading import Barrier, Event, get_ident
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1890,6 +1890,9 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
     events: list[str] = []
     resolver_threads: list[int] = []
     loop_thread = get_ident()
+    # Opened before the liveness window so it only measures loop progress made
+    # while the scope lookup is actually contending for the slot.
+    scope_started = Event()
 
     def load_snapshot(*_args, **_kwargs):
         events.append("snapshot")
@@ -1898,6 +1901,7 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
     def resolve_scope(resolved_task_id):
         assert resolved_task_id == task_id
         resolver_threads.append(get_ident())
+        scope_started.set()
         with SessionLocal() as scope_db:
             scope_db.execute(text("SELECT 1")).scalar()
         events.append("scope")
@@ -1960,6 +1964,9 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
         )
         ticker_task = asyncio.create_task(ticker())
         try:
+            assert await asyncio.to_thread(scope_started.wait, GUARD_TIMEOUT), (
+                "scope lookup never reached the contended checkout"
+            )
             observed = await wait_for_ticks(lambda: ticks)
             assert observed >= LOOP_LIVENESS_TICKS, (
                 "scope QueuePool checkout blocked the event loop"
@@ -2347,7 +2354,16 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
         task.run_id = "run-a"
         seed_db.commit()
 
-    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    # The release path is production code, so the only seam the test owns is the
+    # session factory it reaches for immediately before the contended checkout.
+    # Opened before the liveness window for the same reason as the scope test.
+    release_started = Event()
+
+    def session_local_for_release():
+        release_started.set()
+        return SessionLocal
+
+    monkeypatch.setattr(database_module, "get_session_local", session_local_for_release)
     held_connection = engine.connect()
     ticker_stop = asyncio.Event()
     ticks = 0
@@ -2402,6 +2418,9 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
         )
         ticker_task = asyncio.create_task(ticker())
         try:
+            assert await asyncio.to_thread(release_started.wait, GUARD_TIMEOUT), (
+                "lease release never reached the contended checkout"
+            )
             observed = await wait_for_ticks(lambda: ticks)
             assert observed >= LOOP_LIVENESS_TICKS, (
                 "lease release QueuePool checkout blocked the loop"


### PR DESCRIPTION
## Summary

Several tests hold the only slot of a one-slot `QueuePool` and assert on what the runtime does while it waits. Their wall-clock budgets were chosen to keep the tests snappy, but the web leg runs `pytest -n 4` on a shared CI runner, where scheduling delay alone can blow them.

This splits those budgets by what each one actually guards, in a new shared module `tests/web/pool_contention_shared.py`:

- `EXHAUSTION_POOL_TIMEOUT` (0.4s) stays short — it is semantic. Tests that assert on pool *exhaustion* need the checkout to give up, and a slow runner only makes it fire sooner, which is the outcome they already expect.
- `CONTENTION_POOL_TIMEOUT` (30s) is the opposite. Tests that assert work *waits its turn* must never see the checkout give up, so it sits far above any plausible hiccup — and above the observation window it bounds.
- `LOOP_LIVENESS_TIMEOUT` (2s) bounds waiting for the event loop to keep turning. A blocked loop never ticks at all, so waiting longer only tolerates a slow runner; it cannot mask a regression.
- `GUARD_TIMEOUT` (30s) is a hang detector, not an assertion: once the slot is released the awaited work should finish immediately, and the only failure worth reporting is "it never finished at all".

`wait_for_ticks()` replaces the fixed `asyncio.sleep(0.12)` so loop liveness is *observed* rather than timed, counting from a baseline taken on entry so only progress made during contention is credited. `gated_pool_checkout()` is what establishes that contention: it patches the pool's checkout entry point, so the operation announces itself from *inside* the checkout and stays parked there until the test releases it. An event set on the way to the pool is not enough — a worker descheduled in between lets the window complete against an idle pool, and the test passes having contended for nothing. Separately, `queue_pool_runtime_db` becomes a factory so `test_schedule_bg_pool_timeout_defers_settlement_to_lease_recovery` keeps its short timeout while its neighbours get the long one.

## Observed failure

`tests/web/services/test_task_orchestrator.py::test_schedule_bg_releases_lease_without_blocking_pool_checkout` failed on an unrelated PR's CI run with `TimeoutError` at `await asyncio.wait_for(bg_task, timeout=1)`; the same job's logs show ~2s between the scheduling log line and `finish_turn`, with the pool slot released at t≈0.12s. A re-run of the identical commit passed.

`tests/web/api/test_a2a_api.py::test_start_a2a_turn_cancellation_drains_atomic_create_into_scheduling` failed on three separate branches with `assert False` at `assert await asyncio.to_thread(preparation_committed.wait, 2.0)`.

Two further sites in the same files share the pattern and had not failed in CI yet; both fail under the reproduction below, so they are fixed here too.

## Validation

Reproduced locally with 150 concurrent CPU spinners on an 18-core host, running the four contended tests per iteration:

- Before: **4 of 6 iterations failed**, hitting all three contended sites (`ticks >= 3` in the lease-release, scope-resolve and A2A page-loader tests).
- After: **0 of 21 iterations failed** (6 + 15).
- Unloaded: both test files pass in full (147 tests).
- Negative check: an operation that never reaches the pool now fails with "the operation never reached the pool checkout". Before the gate it passed silently — verified with the reviewer's repro, a 3s pause between the start signal and the checkout, which left both tests green while a probe put the checkout `2.971s` *after* the held connection was released, pool idle.
- Mutation check: changing the scope resolution in `task_orchestrator.py` from `run_db_io_cancellation_safe(...)` to a direct on-loop call is still caught — the tests have not been neutered. Detection takes `10.18s`, bounded by `CONTENTION_GATE_TIMEOUT`: a checkout that blocks the loop also blocks the coroutine that would release the gate, so neither side moves until one of those waits expires. (Earlier revisions of this description claimed ~2s. That was never measured and was wrong; the same mutation took `30.12s` against the 30s pool timeout it was written for, then `15.17s`, now `10.18s`.)
- `pre-commit run --files ...` passes (ruff, ruff-format, mypy, isort, codespell).

## Not included

`tests/web/test_model_api.py::TestModelAPI::test_transcribe_speech_uses_user_default_asr_model` also fails intermittently in recent CI, but it is not flaky: the logs show `FakeASR.transcribe() got an unexpected keyword argument 'verbose'`, and `main` does not pass `verbose` anywhere in `src/xagent/web/api/model.py`. That is a real breakage on the branches that introduce the kwarg, not a timing issue, so it is left alone here.

The same hard-coded-budget pattern is widespread (~90 `wait_for(timeout=1)` sites, ~70 one-slot pool fixtures). This PR deliberately covers only the files with observed CI failures plus the same-file sites that reproduce, rather than attempting a repo-wide sweep.



