### PR TITLE
enh(web): log startup phase durations and sandbox quiesce summary

### DIFF
--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -2,7 +2,9 @@ import asyncio
 import json
 import logging
 import os
-from contextlib import suppress
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from typing import Any, cast
 
 from fastapi import FastAPI, Request
@@ -110,6 +112,28 @@ setup_logging()  # Uses XAGENT_LOG_LEVEL env var or defaults to INFO
 logger = logging.getLogger(__name__)
 
 __all__ = ["app"]
+
+
+@contextmanager
+def _startup_phase(name: str) -> Iterator[None]:
+    """Log a begin/end pair with duration around a startup phase.
+
+    Issue #231: the slow sandbox-quiesce phase was awaited inline with no
+    logs, so an ~8 min stall looked like a fast start. One line in, one line
+    out per phase (never per loop/tick) makes the next slow start obvious. A
+    failing phase still logs its end line before the error propagates.
+    """
+    logger.info("startup phase begin: %s", name)
+    started = time.monotonic()
+    try:
+        yield
+    except Exception:
+        logger.error(
+            "startup phase failed: %s (after %.2fs)", name, time.monotonic() - started
+        )
+        raise
+    else:
+        logger.info("startup phase done: %s (%.2fs)", name, time.monotonic() - started)
 
 
 # Ensure web, uploads directory exists before configuring static files
@@ -1093,9 +1117,8 @@ async def startup_event() -> None:
     global _migration_task
     logger.info("Agent runtime configured: %s", get_agent_runtime())
     validate_interaction_rollout_at_startup()
-    logger.info("Initializing database...")
-    init_db()
-    logger.info("Database initialized successfully")
+    with _startup_phase("database init"):
+        init_db()
 
     # Keep built-in task-runtime providers scoped to the application lifespan.
     # Register even when disabled so task creation receives a precise 403
@@ -1157,7 +1180,8 @@ async def startup_event() -> None:
     from ..skills.utils import create_skill_manager
 
     skill_manager = create_skill_manager()
-    await skill_manager.initialize()
+    with _startup_phase("skill manager init"):
+        await skill_manager.initialize()
     app.state.skill_manager = skill_manager
     logger.info(
         f"Skill manager initialized with {len(await skill_manager.list_skills())} skills"
@@ -1167,7 +1191,8 @@ async def startup_event() -> None:
     from ..templates.utils import create_template_manager
 
     template_manager = create_template_manager()
-    await template_manager.initialize()
+    with _startup_phase("template manager init"):
+        await template_manager.initialize()
     app.state.template_manager = template_manager
     logger.info(
         f"Template manager initialized with {len(await template_manager.list_templates())} templates"
@@ -1554,9 +1579,15 @@ async def startup_event() -> None:
         # This also resolves and caches the backend-capability probe as a
         # side effect, so cleanup() below reads the cached value instead of
         # resolving it again.
-        await check_sandbox_static_readiness(sandbox_mgr)
-        await sandbox_mgr.cleanup()
-        await sandbox_mgr.warmup()
+        # The phases that hid issue #231: cleanup() quiesce was awaited
+        # inline for ~8 min with no logs. Time each so the next slow start
+        # names the exact sub-phase; the quiesce summary breaks it down more.
+        with _startup_phase("sandbox static readiness"):
+            await check_sandbox_static_readiness(sandbox_mgr)
+        with _startup_phase("sandbox cleanup"):
+            await sandbox_mgr.cleanup()
+        with _startup_phase("sandbox warmup"):
+            await sandbox_mgr.warmup()
         logger.info("Sandbox manager initialized and warmed up")
 
         from ..config import get_sandbox_idle_ttl

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -127,6 +127,15 @@ def _startup_phase(name: str) -> Iterator[None]:
     started = time.monotonic()
     try:
         yield
+    except asyncio.CancelledError:
+        # WHY: CancelledError is a BaseException, so the Exception handler
+        # below misses it and the terminal line would be dropped.
+        logger.error(
+            "startup phase cancelled: %s (after %.2fs)",
+            name,
+            time.monotonic() - started,
+        )
+        raise
     except Exception:
         logger.error(
             "startup phase failed: %s (after %.2fs)", name, time.monotonic() - started
@@ -1570,7 +1579,10 @@ async def startup_event() -> None:
     # Warmup sandbox manager
     from .sandbox_manager import check_sandbox_static_readiness, get_sandbox_manager
 
-    sandbox_mgr = get_sandbox_manager()
+    # WHY: the getter can construct the backend service and inventory
+    # containers on a cold process, so a hang here needs its own phase line.
+    with _startup_phase("sandbox manager init"):
+        sandbox_mgr = get_sandbox_manager()
     if sandbox_mgr:
         # Readiness runs before cleanup/warmup and is deliberately not
         # wrapped in try/except: a static SANDBOX_VOLUMES/code-mount/

--- a/src/xagent/web/sandbox_manager.py
+++ b/src/xagent/web/sandbox_manager.py
@@ -2066,29 +2066,53 @@ class SandboxManager:
         method's. This intentionally replaces the legacy config-diff
         delete-guessing for this backend (see ``_legacy_cleanup``).
         """
+        quiesce_started = time.monotonic()
         try:
             sandboxes = await self._service.list_sandboxes()
         except Exception as exc:
             logger.error(f"Failed to list sandboxes for quiesce: {exc}")
             sandboxes = []
 
+        seen = len(sandboxes or [])
+        running = 0
+        stopped = 0
+        failed = 0
+        stop_seconds = 0.0
         for sb in sandboxes or []:
             if sb.state != "running":
                 continue
+            running += 1
+            stop_started = time.monotonic()
             try:
                 await self._service.stop_existing(
                     sb.name, timeout=_SANDBOX_STOP_TIMEOUT_SECONDS
                 )
+                stopped += 1
                 logger.debug(f"Stopped sandbox: {sb.name}")
             except Exception as exc:
+                failed += 1
                 logger.error(f"Failed to stop sandbox {sb.name} during quiesce: {exc}")
+            finally:
+                stop_seconds += time.monotonic() - stop_started
 
         self._cache.clear()
         self._config_cache.clear()
         self._lease_providers.clear()
         self._activity.clear()
         self._reconcile_budget.clear()
-        logger.info("Sandbox quiesce completed")
+        # One summary line per quiesce (issue #231): stops are serial and each
+        # rides the full stop timeout, so stop_time grows with the running
+        # count and dominates startup.
+        logger.info(
+            "Sandbox quiesce completed: seen=%d running=%d stopped=%d failed=%d "
+            "stop_time=%.2fs total=%.2fs",
+            seen,
+            running,
+            stopped,
+            failed,
+            stop_seconds,
+            time.monotonic() - quiesce_started,
+        )
 
     async def _legacy_cleanup(self) -> None:
         """Stop all running sandboxes.
@@ -2106,6 +2130,7 @@ class SandboxManager:
             between deployments, all user sandboxes will be detected as
             having stale volume mounts and will be deleted for recreation.
         """
+        cleanup_started = time.monotonic()
         try:
             sandboxes = await self._service.list_sandboxes()
             if not sandboxes:
@@ -2114,6 +2139,10 @@ class SandboxManager:
 
             image, config = self._get_sandbox_image_and_config()
 
+            seen = len(sandboxes)
+            stopped = 0
+            deleted = 0
+            failed = 0
             for sb in sandboxes:
                 try:
                     lifecycle_type, lifecycle_id = None, None
@@ -2126,6 +2155,7 @@ class SandboxManager:
                                 sb.name, template=sb.template, config=sb.config
                             )
                             await box.stop()
+                            stopped += 1
                             logger.debug(f"Stopped sandbox: {sb.name}")
                         continue
 
@@ -2196,6 +2226,7 @@ class SandboxManager:
                             f"{', '.join(changes)}, deleting"
                         )
                         await self._service.delete(sb.name)
+                        deleted += 1
                         continue
 
                     # Stop running sandboxes with matching image
@@ -2204,8 +2235,10 @@ class SandboxManager:
                             sb.name, template=sb.template, config=sb.config
                         )
                         await box.stop()
+                        stopped += 1
                         logger.debug(f"Stopped sandbox: {sb.name}")
                 except Exception as e:
+                    failed += 1
                     logger.error(f"Failed to handle sandbox {sb.name}: {e}")
 
             self._cache.clear()
@@ -2213,7 +2246,18 @@ class SandboxManager:
             self._locks.clear()
             self._lease_providers.clear()
             self._activity.clear()
-            logger.info("Sandbox cleanup completed")
+            # One summary line per cleanup (issue #231): serial stops, each
+            # rides the full stop timeout, so total grows with the running
+            # count.
+            logger.info(
+                "Sandbox cleanup completed: seen=%d stopped=%d deleted=%d "
+                "failed=%d total=%.2fs",
+                seen,
+                stopped,
+                deleted,
+                failed,
+                time.monotonic() - cleanup_started,
+            )
         except Exception as e:
             logger.error(f"Failed to cleanup sandboxes: {e}")
 

--- a/src/xagent/web/sandbox_manager.py
+++ b/src/xagent/web/sandbox_manager.py
@@ -2067,11 +2067,13 @@ class SandboxManager:
         delete-guessing for this backend (see ``_legacy_cleanup``).
         """
         quiesce_started = time.monotonic()
+        list_failed = False
         try:
             sandboxes = await self._service.list_sandboxes()
         except Exception as exc:
             logger.error(f"Failed to list sandboxes for quiesce: {exc}")
             sandboxes = []
+            list_failed = True
 
         seen = len(sandboxes or [])
         running = 0
@@ -2105,13 +2107,15 @@ class SandboxManager:
         # count and dominates startup.
         logger.info(
             "Sandbox quiesce completed: seen=%d running=%d stopped=%d failed=%d "
-            "stop_time=%.2fs total=%.2fs",
+            "stop_time=%.2fs total=%.2fs status=%s",
             seen,
             running,
             stopped,
             failed,
             stop_seconds,
             time.monotonic() - quiesce_started,
+            # status keeps a list-discovery failure from reading as clean empty work
+            "list_failed" if list_failed else "ok",
         )
 
     async def _legacy_cleanup(self) -> None:
@@ -2131,19 +2135,24 @@ class SandboxManager:
             having stale volume mounts and will be deleted for recreation.
         """
         cleanup_started = time.monotonic()
+        seen = 0
+        running = 0
+        stopped = 0
+        deleted = 0
+        failed = 0
+        stop_seconds = 0.0
+        status = "ok"
         try:
             sandboxes = await self._service.list_sandboxes()
+            seen = len(sandboxes or [])
             if not sandboxes:
-                logger.info("No sandboxes to clean up")
                 return
 
             image, config = self._get_sandbox_image_and_config()
 
-            seen = len(sandboxes)
-            stopped = 0
-            deleted = 0
-            failed = 0
             for sb in sandboxes:
+                if sb.state == "running":
+                    running += 1
                 try:
                     lifecycle_type, lifecycle_id = None, None
                     try:
@@ -2154,7 +2163,11 @@ class SandboxManager:
                             box = await self._service.get_or_create(
                                 sb.name, template=sb.template, config=sb.config
                             )
-                            await box.stop()
+                            stop_started = time.monotonic()
+                            try:
+                                await box.stop()
+                            finally:
+                                stop_seconds += time.monotonic() - stop_started
                             stopped += 1
                             logger.debug(f"Stopped sandbox: {sb.name}")
                         continue
@@ -2234,7 +2247,11 @@ class SandboxManager:
                         box = await self._service.get_or_create(
                             sb.name, template=sb.template, config=sb.config
                         )
-                        await box.stop()
+                        stop_started = time.monotonic()
+                        try:
+                            await box.stop()
+                        finally:
+                            stop_seconds += time.monotonic() - stop_started
                         stopped += 1
                         logger.debug(f"Stopped sandbox: {sb.name}")
                 except Exception as e:
@@ -2246,20 +2263,26 @@ class SandboxManager:
             self._locks.clear()
             self._lease_providers.clear()
             self._activity.clear()
-            # One summary line per cleanup (issue #231): serial stops, each
-            # rides the full stop timeout, so total grows with the running
-            # count.
+        except Exception as e:
+            status = "error"
+            logger.error(f"Failed to cleanup sandboxes: {e}")
+        finally:
+            # One summary per cleanup (issue #231): serial stops each ride the
+            # full stop timeout, so stop_time grows with the running count.
+            # Always emitted (empty/error paths too) so no outcome reads as
+            # clean empty work.
             logger.info(
-                "Sandbox cleanup completed: seen=%d stopped=%d deleted=%d "
-                "failed=%d total=%.2fs",
+                "Sandbox cleanup completed: seen=%d running=%d stopped=%d "
+                "deleted=%d failed=%d stop_time=%.2fs total=%.2fs status=%s",
                 seen,
+                running,
                 stopped,
                 deleted,
                 failed,
+                stop_seconds,
                 time.monotonic() - cleanup_started,
+                status,
             )
-        except Exception as e:
-            logger.error(f"Failed to cleanup sandboxes: {e}")
 
 
 def _check_no_conflicting_readiness_volumes(

--- a/tests/web/test_sandbox_manager_cleanup.py
+++ b/tests/web/test_sandbox_manager_cleanup.py
@@ -1,5 +1,6 @@
 """Test SandboxManager.cleanup — delete sandbox if config changed."""
 
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -467,3 +468,43 @@ class TestQuiesceReconcilingBackend:
         service.stop_existing.assert_awaited_once_with(
             "user::1", timeout=_SANDBOX_STOP_TIMEOUT_SECONDS
         )
+
+    @pytest.mark.asyncio
+    async def test_quiesce_logs_diagnostic_summary(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Quiesce emits one summary line with seen/running/stopped counts so a
+        slow startup is diagnosable from logs alone (issue #231)."""
+        service = FakeSandboxService(runtime_spec_supported=True)
+        spec = ResolvedSandboxRuntimeSpec.from_parts(
+            template_type="image", image="img:v1"
+        )
+        for name, state in (
+            ("user::1", "running"),
+            ("user::2", "running"),
+            ("user::3", "stopped"),
+        ):
+            service._containers[name] = _FakeReconcileContainer(
+                state=state,
+                spec=spec,
+                fingerprint_label=spec.fingerprint(),
+                version_label="1",
+            )
+        service.containers = {"user::1", "user::2", "user::3"}
+
+        manager = SandboxManager(service)
+
+        with caplog.at_level(logging.INFO, logger="xagent.web.sandbox_manager"):
+            await manager.cleanup()
+
+        summaries = [
+            r.getMessage()
+            for r in caplog.records
+            if "Sandbox quiesce completed" in r.getMessage()
+        ]
+        assert len(summaries) == 1, "expected exactly one quiesce summary line"
+        msg = summaries[0]
+        assert "seen=3" in msg
+        assert "running=2" in msg
+        assert "stopped=2" in msg
+        assert "failed=0" in msg

--- a/tests/web/test_sandbox_manager_cleanup.py
+++ b/tests/web/test_sandbox_manager_cleanup.py
@@ -1,10 +1,16 @@
 """Test SandboxManager.cleanup — delete sandbox if config changed."""
 
+import asyncio
 import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+# WHY: importing app runs its module-level setup_logging(), which resets the
+# root handlers via dictConfig. Import it at collection so that reset happens
+# before caplog attaches per-test, not inside a caplog context.
+from xagent.web.app import _startup_phase
 
 from tests.web.sandbox_fakes import FakeSandboxService, _FakeReconcileContainer
 from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
@@ -508,3 +514,131 @@ class TestQuiesceReconcilingBackend:
         assert "running=2" in msg
         assert "stopped=2" in msg
         assert "failed=0" in msg
+        # Lock the full schema so a dropped/renamed duration field is caught.
+        assert "stop_time=" in msg
+        assert "total=" in msg
+        assert "status=ok" in msg
+
+    @pytest.mark.asyncio
+    async def test_quiesce_list_failure_marks_status(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A ``list_sandboxes`` failure must not read as clean empty work: the
+        summary reports ``status=list_failed`` rather than a zero-count success."""
+        service = FakeSandboxService(runtime_spec_supported=True)
+        service.list_sandboxes.side_effect = RuntimeError("boom")
+
+        manager = SandboxManager(service)
+
+        with caplog.at_level(logging.INFO, logger="xagent.web.sandbox_manager"):
+            await manager.cleanup()
+
+        summaries = [
+            r.getMessage()
+            for r in caplog.records
+            if "Sandbox quiesce completed" in r.getMessage()
+        ]
+        assert len(summaries) == 1
+        assert "seen=0" in summaries[0]
+        assert "status=list_failed" in summaries[0]
+
+
+class TestLegacyCleanupSummary:
+    """``_legacy_cleanup`` (Boxlite route) emits one structured summary on every
+    path — empty, stop, and error — with the same ``running``/``stop_time``
+    fields the quiesce route carries, so cleanup telemetry stays consistent
+    across supported backends (issue #231)."""
+
+    @pytest.mark.asyncio
+    async def test_empty_listing_still_emits_summary(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        service = FakeSandboxService()  # legacy route (no runtime spec)
+        service.list_sandboxes.return_value = []
+
+        manager = SandboxManager(service)
+
+        with caplog.at_level(logging.INFO, logger="xagent.web.sandbox_manager"):
+            await manager.cleanup()
+
+        summaries = [
+            r.getMessage()
+            for r in caplog.records
+            if "Sandbox cleanup completed" in r.getMessage()
+        ]
+        assert len(summaries) == 1
+        assert "seen=0" in summaries[0]
+        assert "status=ok" in summaries[0]
+
+    @pytest.mark.asyncio
+    async def test_running_sandbox_reports_running_and_stop_time(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        service = FakeSandboxService()
+        service.list_sandboxes.return_value = [
+            _make_sb_info("__warmup__", image="img:v1", state="running")
+        ]
+        service.get_or_create.return_value = AsyncMock()
+
+        manager = SandboxManager(service)
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "SANDBOX_IMAGE": "img:v1",
+                    "SANDBOX_CPUS": "1",
+                    "SANDBOX_MEMORY": "512",
+                },
+                clear=True,
+            ),
+            caplog.at_level(logging.INFO, logger="xagent.web.sandbox_manager"),
+        ):
+            await manager.cleanup()
+
+        summaries = [
+            r.getMessage()
+            for r in caplog.records
+            if "Sandbox cleanup completed" in r.getMessage()
+        ]
+        assert len(summaries) == 1
+        assert "running=1" in summaries[0]
+        assert "stopped=1" in summaries[0]
+        assert "stop_time=" in summaries[0]
+        assert "status=ok" in summaries[0]
+
+
+class TestStartupPhaseLogging:
+    """``_startup_phase`` emits a terminal line on every exit — success, error,
+    and cancellation — so a stalled/aborted startup is never left showing only
+    its begin line (issue #231)."""
+
+    def test_success_logs_done(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.INFO, logger="xagent.web.app"):
+            with _startup_phase("demo"):
+                pass
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("startup phase done: demo" in m for m in messages)
+
+    def test_error_logs_failed_and_reraises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="xagent.web.app"):
+            with pytest.raises(ValueError):
+                with _startup_phase("demo"):
+                    raise ValueError("boom")
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("startup phase failed: demo" in m for m in messages)
+
+    def test_cancellation_logs_terminal_and_reraises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.INFO, logger="xagent.web.app"):
+            with pytest.raises(asyncio.CancelledError):
+                with _startup_phase("demo"):
+                    raise asyncio.CancelledError()
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("startup phase cancelled: demo" in m for m in messages)

--- a/tests/web/test_sandbox_manager_cleanup.py
+++ b/tests/web/test_sandbox_manager_cleanup.py
@@ -7,11 +7,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# WHY: importing app runs its module-level setup_logging(), which resets the
-# root handlers via dictConfig. Import it at collection so that reset happens
-# before caplog attaches per-test, not inside a caplog context.
-from xagent.web.app import _startup_phase
-
 from tests.web.sandbox_fakes import FakeSandboxService, _FakeReconcileContainer
 from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
     build_code_mount_volumes,
@@ -23,6 +18,11 @@ from xagent.sandbox.base import (
     SandboxMountIntent,
     SandboxTemplate,
 )
+
+# WHY: importing app runs its module-level setup_logging(), which resets the
+# root handlers via dictConfig. Import it at collection so that reset happens
+# before caplog attaches per-test, not inside a caplog context.
+from xagent.web.app import _startup_phase
 from xagent.web.sandbox_manager import _SANDBOX_STOP_TIMEOUT_SECONDS, SandboxManager
 
 


### PR DESCRIPTION
## What & why

Make a slow backend startup diagnosable from logs alone. The sandbox-cleanup quiesce is `await`ed inline in the ASGI lifespan, so until it returns the app cannot finish starting and `/health` cannot open — yet it produces no log output. On `xagent-cloud-prod-sg` this stalled startup for ~8 minutes and looked identical to a fast start until the port finally opened. See xorbitsai/xagent-saas#231 for the full investigation.

This is the **observability** slice of that issue: it does not change startup behavior, it makes the existing behavior legible. The two behavioral fixes (fast per-sandbox stops via `init=True`, and parallelizing the quiesce stops) are tracked separately in the same issue.

## Changes

- `web/app.py`: add a `_startup_phase()` context manager that logs one **begin** line and one **end** line carrying wall-clock duration per lifespan phase (and an ERROR end line if the phase raises, before re-raising). Wrap the phases where a hang is plausible: database init, skill-manager init, template-manager init, and the sandbox **readiness / cleanup / warmup** trio (the trio that hid #231).
- `web/sandbox_manager.py`: `_quiesce()` and `_legacy_cleanup()` now emit a single summary line — `seen / running / stopped / failed / stop_time / total` — instead of a bare `"… completed"`. Because the stops are serial and each rides the full 30s stop timeout, this surfaces the `running × 30s` relationship directly in the logs.

Deliberately **one line per phase** and one summary per cleanup — no per-tick or per-loop spam, so this stays readable at INFO in production.

## Example output (illustrative)

The shape of the logs during a slow start — the stalled phase now names itself, and the quiesce summary explains why:

```
startup phase begin: sandbox cleanup
Sandbox quiesce completed: seen=18 running=16 stopped=16 failed=0 stop_time=478.20s total=478.63s
startup phase done: sandbox cleanup (478.64s)
```

## Testing

- `pytest tests/web/test_sandbox_manager_cleanup.py tests/web/test_sandbox_manager_reconcile.py` — all pass, including a new `test_quiesce_logs_diagnostic_summary` that asserts the summary reports the right `seen / running / stopped / failed` counts.
- Logging/metrics only; no behavior change.

Refs: xorbitsai/xagent-saas#231
