### PR TITLE
fix(storage): use standard S3 retries

### DIFF
--- a/example.env
+++ b/example.env
@@ -694,9 +694,9 @@ XAGENT_MAX_UPLOAD_SIZE="100M"
 
 # Optional fsspec provider options as JSON. For S3-compatible providers this can
 # include endpoint_url, region_name, profile, key, secret, or config_kwargs.
-# S3 storage defaults to bounded botocore timeouts/retries so unavailable
-# storage fails quickly; override config_kwargs here if your deployment needs
-# longer waits.
+# S3 defaults use standard Botocore retry mode with three total attempts (one
+# initial plus two retries) and bounded client timeouts. An explicit
+# config_kwargs.retries mapping replaces the default retry mapping.
 # XAGENT_FILE_STORAGE_OPTIONS='{"endpoint_url":"https://s3.example.com","region_name":"us-east-1"}'
 
 # Local temp/cache directory for materializing durable files when libraries need paths.

--- a/src/xagent/core/file_storage/factory.py
+++ b/src/xagent/core/file_storage/factory.py
@@ -18,7 +18,10 @@ from .storage import FsspecFileStorage
 _DEFAULT_S3_CONFIG_KWARGS = {
     "connect_timeout": 3,
     "read_timeout": 10,
-    "retries": {"max_attempts": 1},
+    "retries": {
+        "mode": "standard",
+        "total_max_attempts": 3,
+    },
 }
 
 

--- a/src/xagent/core/file_storage/factory.py
+++ b/src/xagent/core/file_storage/factory.py
@@ -15,6 +15,8 @@ from .keys import build_user_key_prefix
 from .scoped import ScopedFileStorage
 from .storage import FsspecFileStorage
 
+# Use modest standard retries for transient failures because s3fs adds retry
+# layers around writes/range reads; timeouts are per attempt, not a total deadline.
 _DEFAULT_S3_CONFIG_KWARGS = {
     "connect_timeout": 3,
     "read_timeout": 10,

--- a/src/xagent/core/file_storage/factory.py
+++ b/src/xagent/core/file_storage/factory.py
@@ -20,7 +20,7 @@ _DEFAULT_S3_CONFIG_KWARGS = {
     "read_timeout": 10,
     "retries": {
         "mode": "standard",
-        "total_max_attempts": 5,
+        "total_max_attempts": 3,
     },
 }
 

--- a/src/xagent/core/file_storage/factory.py
+++ b/src/xagent/core/file_storage/factory.py
@@ -20,7 +20,7 @@ _DEFAULT_S3_CONFIG_KWARGS = {
     "read_timeout": 10,
     "retries": {
         "mode": "standard",
-        "total_max_attempts": 3,
+        "total_max_attempts": 5,
     },
 }
 

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -180,7 +180,7 @@ def test_s3_file_storage_uses_standard_retries_and_bounded_timeouts(
             "read_timeout": 10,
             "retries": {
                 "mode": "standard",
-                "total_max_attempts": 5,
+                "total_max_attempts": 3,
             },
         }
     }

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 import pytest
+from aiobotocore.config import AioConfig
 
 import xagent.core.file_storage.factory as file_storage_factory
 from xagent.core.file_storage.factory import get_unscoped_file_storage
@@ -163,6 +164,9 @@ def test_s3_file_storage_uses_standard_retries_and_bounded_timeouts(
     def fake_url_to_fs(uri: str, **options: object):
         captured["uri"] = uri
         captured["options"] = options
+        config_kwargs = options.get("config_kwargs")
+        assert isinstance(config_kwargs, dict)
+        AioConfig(**config_kwargs)
         return DummyStorage(), "bucket/root"
 
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", "s3://bucket/root")

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -152,7 +152,9 @@ def test_local_file_storage_round_trips_file(monkeypatch, tmp_path):
     assert not storage.exists(stored.key)
 
 
-def test_s3_file_storage_uses_bounded_client_timeouts(monkeypatch, tmp_path):
+def test_s3_file_storage_uses_standard_retries_and_bounded_timeouts(
+    monkeypatch, tmp_path
+):
     captured: dict[str, object] = {}
 
     class DummyStorage:
@@ -176,7 +178,10 @@ def test_s3_file_storage_uses_bounded_client_timeouts(monkeypatch, tmp_path):
         "config_kwargs": {
             "connect_timeout": 3,
             "read_timeout": 10,
-            "retries": {"max_attempts": 1},
+            "retries": {
+                "mode": "standard",
+                "total_max_attempts": 3,
+            },
         }
     }
 

--- a/tests/core/test_file_storage.py
+++ b/tests/core/test_file_storage.py
@@ -180,7 +180,7 @@ def test_s3_file_storage_uses_standard_retries_and_bounded_timeouts(
             "read_timeout": 10,
             "retries": {
                 "mode": "standard",
-                "total_max_attempts": 3,
+                "total_max_attempts": 5,
             },
         }
     }


### PR DESCRIPTION
## Summary

- Change the default S3 Botocore retry policy from legacy
  `{"max_attempts": 1}` to standard
  `{"mode": "standard", "total_max_attempts": 3}`.
- Keep the existing three-second connect timeout and ten-second read timeout.
- Update the focused storage configuration test and `example.env` documentation.

The old client setting was normalized by Botocore to two total attempts: one
initial request and one retry. The new setting permits three total attempts:
one initial request and two retries.

## Why three total attempts

Standard mode with two total attempts would retain the old number of attempts
for a transient HTTP 503. Although standard mode provides standardized retry
categories, jittered backoff, and retry-quota protection, it would not add
another provider-native recovery opportunity for the upload failures targeted
by this PR.

Three total attempts is the smallest bounded setting that adds one such
opportunity. It is also Botocore standard mode's native default.

## Retry layering

s3fs 2026.2.0 has its own retry wrapper around S3 client calls. For upload and
write operations, a failure class that s3fs itself reselects, such as
`SlowDown`, can conditionally produce up to:

- old configuration: 5 s3fs invocations × 2 Botocore attempts = 10 attempts
- new configuration: 5 s3fs invocations × 3 Botocore attempts = 15 attempts

A generic exhausted `ServiceUnavailable` 503 is not automatically repeated by
that outer s3fs wrapper, so its per-call provider ceiling changes directly from
two to three.

Buffered range reads have an additional s3fs wrapper around the range request
and response-body read. For failures selected by both wrappers, their
conditional per-range ceiling is therefore 5 × 5 × N: 50 attempts under the
old two-attempt Botocore setting and 75 under the new three-attempt setting.

These are conditional attempt ceilings, not wall-clock guarantees. Actual
behavior depends on the provider's error representation, Botocore retry quota,
jittered backoff, response phase, multipart operation count, and successful
intermediate calls.

## Scope

This is intentionally limited to provider-native Botocore/S3 retry
configuration. It does not add browser retries, application retry loops,
admission control, s3fs or async-handler refactors, deep-copy hardening, or
unrelated configuration changes.

## Validation

- Updated the focused S3 storage configuration unit test.
- Updated the operator-facing `example.env` documentation.
- Required CI checks pass.