### PR TITLE
fix(sandbox): run container init so SIGTERM stops sandboxes fast

### DIFF
--- a/src/xagent/sandbox/docker_sandbox.py
+++ b/src/xagent/sandbox/docker_sandbox.py
@@ -1113,6 +1113,8 @@ async def _create_container(
         "name": _container_name(name, namespace),
         # Keep the container alive
         "command": ["tail", "-f", "/dev/null"],
+        # PID-1 tini forwards SIGTERM so tail exits fast, not on a SIGKILL timeout.
+        "init": True,
         "detach": True,
         # Run as root to match the file access behavior of Boxlite.
         "user": "root",

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -503,7 +503,9 @@ class TestNamespaceIsolation:
             assert captured["labels"]["xagent.sandbox.namespace"] == "alpha"
             assert captured["labels"]["xagent.sandbox.name"] == "user::1"
             assert captured["name"].startswith("xagent_sandbox_")
-            # tini as PID 1 so the tail command handles SIGTERM (issue #231).
+            # tini as PID 1 so tail gets SIGTERM and exits in ~1s instead of a
+            # ~30s SIGKILL timeout (issue #231). Only the create kwarg is asserted;
+            # the stop-time drop was verified manually, not gated by a CI timer.
             assert captured["init"] is True
 
 

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -503,6 +503,8 @@ class TestNamespaceIsolation:
             assert captured["labels"]["xagent.sandbox.namespace"] == "alpha"
             assert captured["labels"]["xagent.sandbox.name"] == "user::1"
             assert captured["name"].startswith("xagent_sandbox_")
+            # tini as PID 1 so the tail command handles SIGTERM (issue #231).
+            assert captured["init"] is True
 
 
 class TestManagerPathsRespectNamespace:


### PR DESCRIPTION
## What

Set `init=True` on sandbox container creation so Docker runs its init (tini) as PID 1. This is **root cause (A)** from xorbitsai/xagent-saas#231 (slow backend startup / oversized health `start_period`).

## Why

The sandbox container runs `command: ["tail", "-f", "/dev/null"]` as **PID 1 with no init**. A PID-1 process gets no default signal disposition, so SIGTERM is dropped and `container.stop(timeout=30)` always waits the full 30s before SIGKILL — every stopped sandbox on prod shows `exit=137`. Startup quiesce (`_quiesce()`) stops running sandboxes **serially**, so `startup ≈ running_sandboxes × 30s`, which is the 8–9 min stall reported in the issue.

With `init=True`, tini becomes PID 1 and forwards SIGTERM to `tail`, which exits in ~1s. Per-stop drops 30s → ~1s, so startup stops being dominated by the stop path — and shutdown is graceful again instead of a blanket SIGKILL.

## Scope

This PR is **only** root cause (A) — the single biggest lever. The serialized-stops lever (B: bounded `asyncio.gather` in `_quiesce()`) is independent and intentionally left to a separate change. (A) and (B) are two multiplicands of the same `N × 30s` cost; (A) alone brings startup well under the health `start_period`, and (B) is defense-in-depth that should not ship on its own.

`init` is a runtime host-config flag, not part of the committed image, so it does not affect sandbox commit/snapshot — snapshots recreate through this same `_create_container` path and get `init=True` again.

## Pre-existing container convergence

Containers created before this PR keep `Init=false`. They're brought in line only when the idle sweep reclaims and recreates them (`sweep_idle_sandboxes` → `container.remove(force=True)` → recreate through `_create_container`). That sweep is **opt-in**: `XAGENT_SANDBOX_IDLE_TTL` defaults to `None` (reclamation disabled), so by default a pre-existing container is converted on its next explicit recreate, not on a timer; deployments that enable idle reclamation converge automatically within their configured TTL. This is acceptable because `init` is a host runtime flag with no image/snapshot semantics — an un-converged container still works, it just keeps the slow-stop behavior until it is reclaimed.

## Changes

- `src/xagent/sandbox/docker_sandbox.py` — add `"init": True` to the container-create kwargs.
- `tests/sandbox/test_docker_sandbox.py` — assert `init=True` is passed to `containers.create`.

## Test

`pytest tests/sandbox/test_docker_sandbox.py tests/sandbox/test_docker_lifecycle_api.py` passes (Docker-daemon-dependent cases skip locally). `init` confirmed as a valid docker-py 7.1.0 host-config kwarg (maps to `HostConfig.Init`).

## Follow-ups (separate)

- **[xagent] (B)** parallelize stops in `_quiesce()` / `_legacy_cleanup()` with a bounded `asyncio.gather`.
- **[xagent-saas]** shorten the backend `start_period` in `docker-compose.yml` once this ships and the submodule pointer is bumped.

