### PR TITLE
fix(model): stop treating empty tool-call arguments as a fatal provider error

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1586,8 +1586,8 @@ class ReActPattern(AgentPattern):
             except json.JSONDecodeError:
                 logger.warning(
                     "ReAct tool call %s returned malformed JSON arguments "
-                    "(%d chars); dropping them for control tools and passing "
-                    "them through as `input` otherwise.",
+                    "(%d chars); dropping them for control tools and blank "
+                    "payloads, passing anything else through as `input`.",
                     tool_name or "<unknown>",
                     len(arguments),
                 )
@@ -1607,10 +1607,10 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any]:
         """Wrap unusable tool arguments, or drop them for control tools.
 
-        Work tools tolerate an opaque ``input`` passthrough, so they keep the
-        payload. Control tools drop it, because ``input`` is never a field any of
-        them declares: carrying it forward only disguises the loss as a populated
-        arguments object.
+        Work tools tolerate an opaque ``input`` passthrough, so they keep a
+        non-blank payload. Control tools drop it, because ``input`` is never a
+        field any of them declares: carrying it forward only disguises the loss
+        as a populated arguments object.
 
         For ``final_answer`` dropping it is also load-bearing. That tool owns the
         run's only user-visible exit, so a payload smuggled through as ``input``
@@ -1623,6 +1623,9 @@ class ReActPattern(AgentPattern):
         """
 
         if tool_name in self._control_tool_names():
+            return {}
+        if isinstance(payload, str) and not payload.strip():
+            # Nothing to preserve, and `input` is not a field a no-arg tool declares.
             return {}
         return {"input": payload}
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1584,13 +1584,22 @@ class ReActPattern(AgentPattern):
             try:
                 parsed = json.loads(arguments)
             except json.JSONDecodeError:
-                logger.warning(
-                    "ReAct tool call %s returned malformed JSON arguments "
-                    "(%d chars); dropping them for control tools and blank "
-                    "payloads, passing anything else through as `input`.",
-                    tool_name or "<unknown>",
-                    len(arguments),
-                )
+                if not arguments.strip():
+                    # The happy path for a parameterless tool on providers that
+                    # send `""` instead of `"{}"` (#1501) - not a malformation.
+                    logger.debug(
+                        "ReAct tool call %s returned blank arguments; "
+                        "treating as no arguments.",
+                        tool_name or "<unknown>",
+                    )
+                else:
+                    logger.warning(
+                        "ReAct tool call %s returned malformed JSON arguments "
+                        "(%d chars); dropping them for control tools, passing "
+                        "anything else through as `input`.",
+                        tool_name or "<unknown>",
+                        len(arguments),
+                    )
                 return self._fallback_arguments(tool_name, arguments)
             if isinstance(parsed, dict):
                 return parsed
@@ -1625,7 +1634,8 @@ class ReActPattern(AgentPattern):
         if tool_name in self._control_tool_names():
             return {}
         if isinstance(payload, str) and not payload.strip():
-            # Nothing to preserve, and `input` is not a field any work tool declares.
+            # A blank payload carries nothing to preserve, so there is no
+            # opaque value for the `input` passthrough to forward.
             return {}
         return {"input": payload}
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1625,7 +1625,7 @@ class ReActPattern(AgentPattern):
         if tool_name in self._control_tool_names():
             return {}
         if isinstance(payload, str) and not payload.strip():
-            # Nothing to preserve, and `input` is not a field a no-arg tool declares.
+            # Nothing to preserve, and `input` is not a field any work tool declares.
             return {}
         return {"input": payload}
 

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -242,6 +242,8 @@ def _tool_call_violation(
         )
 
     arguments = function.get("arguments", {})
+    if isinstance(arguments, str) and not arguments.strip():
+        arguments = {}
     argument_details: dict[str, Any] | None = None
     if isinstance(arguments, str):
         original_arguments = arguments

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -243,6 +243,9 @@ def _tool_call_violation(
 
     arguments = function.get("arguments", {})
     if isinstance(arguments, str) and not arguments.strip():
+        # Rebind the local for validation only. `function["arguments"]` keeps the
+        # raw blank string: normalizing it to `"{}"` would defeat pass-through
+        # and crash the auto/DAG paths on a syntactically valid empty plan.
         arguments = {}
     argument_details: dict[str, Any] | None = None
     if isinstance(arguments, str):

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -386,6 +386,8 @@ class OpenAICompatibleLLM(BaseLLM):
                     # Only handle function tool calls, not custom tool calls
                     if hasattr(tool_call, "function"):
                         func = tool_call.function
+                        # Blank arguments pass through deliberately (#1501); the
+                        # repair contract lives in the pattern layer, not here.
                         args = func.arguments or ""
 
                         tool_calls.append(
@@ -705,6 +707,8 @@ class OpenAICompatibleLLM(BaseLLM):
                     # Only handle function tool calls, not custom tool calls
                     if hasattr(tool_call, "function"):
                         func = tool_call.function
+                        # Blank arguments pass through deliberately (#1501); the
+                        # repair contract lives in the pattern layer, not here.
                         args = func.arguments or ""
 
                         tool_calls.append(
@@ -1229,6 +1233,8 @@ class OpenAICompatibleLLM(BaseLLM):
             if accumulated_tool_calls:
                 tool_calls_list = list(accumulated_tool_calls.values())
 
+                # Blank accumulated arguments pass through deliberately (#1501);
+                # the repair contract lives in the pattern layer, not here.
                 return StreamChunk(
                     type=ChunkType.TOOL_CALL,
                     tool_calls=tool_calls_list,

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -386,15 +386,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     # Only handle function tool calls, not custom tool calls
                     if hasattr(tool_call, "function"):
                         func = tool_call.function
-                        args = func.arguments if func.arguments else ""
-
-                        # Validate arguments are not empty
-                        if not args or args.strip() == "":
-                            raise RuntimeError(
-                                f"Tool '{func.name}' has empty arguments. "
-                                f"This is a bug in the LLM provider's tool calling implementation. "
-                                f"Model: {self._model_name}"
-                            )
+                        args = func.arguments or ""
 
                         tool_calls.append(
                             {
@@ -713,15 +705,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     # Only handle function tool calls, not custom tool calls
                     if hasattr(tool_call, "function"):
                         func = tool_call.function
-                        args = func.arguments if func.arguments else ""
-
-                        # Validate arguments are not empty
-                        if not args or args.strip() == "":
-                            raise RuntimeError(
-                                f"Tool '{func.name}' has empty arguments. "
-                                f"This is a bug in the LLM provider's tool calling implementation. "
-                                f"Model: {self._model_name}"
-                            )
+                        args = func.arguments or ""
 
                         tool_calls.append(
                             {
@@ -1244,18 +1228,6 @@ class OpenAICompatibleLLM(BaseLLM):
             # If there are tool calls, return complete tool calls
             if accumulated_tool_calls:
                 tool_calls_list = list(accumulated_tool_calls.values())
-
-                # Validate all tool calls have non-empty arguments
-                for tool_call_dict in tool_calls_list:
-                    func_info = tool_call_dict.get("function", {})
-                    args = func_info.get("arguments", "")
-                    if not args or args.strip() == "":
-                        tool_name = func_info.get("name", "unknown")
-                        raise RuntimeError(
-                            f"Tool '{tool_name}' has empty arguments in streaming response. "
-                            f"This is a bug in the LLM provider's tool calling implementation. "
-                            f"Model: {self._model_name}, raw tool call: {tool_call_dict}"
-                        )
 
                 return StreamChunk(
                     type=ChunkType.TOOL_CALL,

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5485,6 +5485,12 @@ def test_coerce_arguments_drops_unusable_control_tool_payloads() -> None:
         "input": [1, 2]
     }
 
+    # Blank payloads have nothing to preserve, whether the raw string is blank
+    # or the JSON literal of a blank string.
+    assert pattern._coerce_arguments("", tool_name="calculator") == {}
+    assert pattern._coerce_arguments('""', tool_name="calculator") == {}
+    assert pattern._coerce_arguments('"   "', tool_name="calculator") == {}
+
     # Control tools must not smuggle a malformed payload through as ``input``,
     # which would silently strip ``answer`` and finalize with nothing to show.
     assert pattern._coerce_arguments("not json", tool_name="final_answer") == {}
@@ -5857,3 +5863,273 @@ async def test_run_flags_missing_image_editing_and_renders_the_correction(
     rendered = llm.calls[0]["messages"][0]["content"]
     assert ("image editing is unavailable here" in rendered) is unavailable
     assert ("attach a reference through images" in rendered) is unavailable
+
+
+class NoArgToolLLM:
+    """Calls a parameterless tool with `arguments: ""`, then finishes.
+
+    Reproduces the provider shape behind xorbitsai/xagent#1501 on the streaming
+    path: a blank argument string must reach the tool as an empty call, not kill
+    the run.
+    """
+
+    def __init__(self) -> None:
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        raise AssertionError("this path should stay streaming")
+
+    async def stream_chat(
+        self, messages: list[dict[str, Any]] | None = None, **kwargs: Any
+    ) -> Any:
+        if messages is not None:
+            kwargs["messages"] = messages
+        self.stream_calls.append(kwargs)
+        if len(self.stream_calls) == 1:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "id": "call_list_0",
+                        "function": {"name": "list_models", "arguments": ""},
+                    }
+                ],
+            )
+        else:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "id": "call_final_0",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": (
+                                '{"response_language":"English",'
+                                '"answer":"gpt-4o","outcome":"completed"}'
+                            ),
+                        },
+                    }
+                ],
+            )
+        yield StreamChunk(type=ChunkType.END)
+
+
+class NoArgTool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+        class Metadata:
+            name = "list_models"
+            description = "List available models."
+
+        self.metadata = Metadata()
+
+    def args_type(self) -> type[BaseModel]:
+        return _NoArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        return {"models": ["gpt-4o"]}
+
+
+class _NoArgs(BaseModel):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_react_runs_a_parameterless_tool_called_with_blank_arguments() -> None:
+    """#1501 (a): a no-arg tool sent `""` executes instead of failing the run."""
+
+    llm = NoArgToolLLM()
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+    tool = NoArgTool()
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool, FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "gpt-4o"
+    assert tool.calls == [{}]
+
+
+@pytest.mark.asyncio
+async def test_react_repairs_final_answer_called_with_blank_arguments() -> None:
+    """The #1501 production trace shape: streaming `final_answer` with `""`.
+
+    `final_answer` is a control tool, so blank arguments short-circuit to the
+    `_empty_final_answer_call` guard, which spends the one repair retry.
+    """
+
+    llm = StreamingEmptyFinalAnswerLLM(broken_arguments="")
+    pattern, context, runtime, outbound, tracer = _react_empty_final_answer_fixture()
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert len(llm.stream_calls) == 2
+
+    retry_starts = [
+        event
+        for event in tracer.events
+        if event["event_type"] == "action_start_llm"
+        and event["data"].get("phase") == "empty_final_answer_recovery"
+    ]
+    assert len(retry_starts) == 1
+    assert outbound.events[-1]["content"] == "The result is 4."
+
+
+class BlankThenRecoverLLM:
+    """Calls a required-argument work tool with `""`, then recovers.
+
+    First turn: `calculator` with blank arguments. Second turn: a valid
+    `final_answer`. Pins what actually happens to a required-argument tool
+    handed `{}` — the tool fails internally and the error feeds back as a tool
+    result, not a dead run.
+    """
+
+    def __init__(self) -> None:
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        raise AssertionError("this path should stay streaming")
+
+    async def stream_chat(
+        self, messages: list[dict[str, Any]] | None = None, **kwargs: Any
+    ) -> Any:
+        if messages is not None:
+            kwargs["messages"] = messages
+        self.stream_calls.append(kwargs)
+        if len(self.stream_calls) == 1:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "id": "call_calc_0",
+                        "function": {"name": "calculator", "arguments": ""},
+                    }
+                ],
+            )
+        else:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "id": "call_final_0",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": (
+                                '{"response_language":"English",'
+                                '"answer":"The result is 4.","outcome":"completed"}'
+                            ),
+                        },
+                    }
+                ],
+            )
+        yield StreamChunk(type=ChunkType.END)
+
+
+@pytest.mark.asyncio
+async def test_react_survives_required_argument_tool_called_with_blank_arguments() -> (
+    None
+):
+    """#1501 (b): a required-argument work tool sent `""` receives `{}`, fails
+    inside the tool, and the error feeds back to the model instead of killing
+    the run."""
+
+    llm = BlankThenRecoverLLM()
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+    tool = FakeTool()
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "The result is 4."
+    assert len(llm.stream_calls) == 2
+
+    # Discriminating assertion for react.py's blank-string fallback branch: the
+    # old code delivered {"input": ""} here, which would fail this equality.
+    assert tool.calls == [{}]
+
+    tool_results = [m for m in context.messages if m.role == "tool"]
+    assert len(tool_results) >= 1
+    first = tool_results[0]
+    assert first.tool_call_id == "call_calc_0"
+    assert "'success': False" in first.content
+
+
+@pytest.mark.asyncio
+async def test_blank_streaming_arguments_flow_from_adapter_into_react(mocker) -> None:
+    """The seam: a real `OpenAICompatibleLLM` stream carrying `arguments: ""`
+    drives a real ReAct loop and the parameterless tool executes."""
+
+    def sdk_chunk(tool_calls=None, finish_reason=None):
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(content=None, tool_calls=tool_calls),
+                    finish_reason=finish_reason,
+                )
+            ]
+        )
+
+    def sdk_tool_call(name, arguments):
+        return SimpleNamespace(
+            index=0,
+            id=f"call_{name}",
+            type="function",
+            function=SimpleNamespace(name=name, arguments=arguments),
+        )
+
+    async def first_stream():
+        yield sdk_chunk([sdk_tool_call("list_models", "")])
+        yield sdk_chunk(finish_reason="tool_calls")
+
+    async def second_stream():
+        yield sdk_chunk(
+            [
+                sdk_tool_call(
+                    "final_answer",
+                    '{"response_language":"English",'
+                    '"answer":"gpt-4o","outcome":"completed"}',
+                )
+            ]
+        )
+        yield sdk_chunk(finish_reason="tool_calls")
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [first_stream(), second_stream()]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    from xagent.core.model.chat.basic.openai import OpenAILLM
+
+    llm = OpenAILLM(model_name="gpt-4o-mini", base_url=None, api_key="test-key")
+    pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
+    tool = NoArgTool()
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool, FakeTool()],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "gpt-4o"
+    assert tool.calls == [{}]

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5925,15 +5925,11 @@ class NoArgTool:
         self.metadata = Metadata()
 
     def args_type(self) -> type[BaseModel]:
-        return _NoArgs
+        return EmptyArgs
 
     async def run_json_async(self, args: dict[str, Any]) -> Any:
         self.calls.append(args)
         return {"models": ["gpt-4o"]}
-
-
-class _NoArgs(BaseModel):
-    pass
 
 
 @pytest.mark.asyncio
@@ -5958,10 +5954,12 @@ async def test_react_runs_a_parameterless_tool_called_with_blank_arguments() -> 
 
 @pytest.mark.asyncio
 async def test_react_repairs_final_answer_called_with_blank_arguments() -> None:
-    """The #1501 production trace shape: streaming `final_answer` with `""`.
+    """Guards the `_empty_final_answer_call` repair retry, not `_fallback_arguments`.
 
-    `final_answer` is a control tool, so blank arguments short-circuit to the
-    `_empty_final_answer_call` guard, which spends the one repair retry.
+    `final_answer` is a control tool, so blank arguments are dropped by the
+    control-tool branch and never reach the blank-string branch this PR adds.
+    What is pinned here is that the resulting empty args still spend the one
+    repair retry instead of finalizing the run.
     """
 
     llm = StreamingEmptyFinalAnswerLLM(broken_arguments="")

--- a/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
+++ b/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
@@ -48,6 +48,11 @@ WRITE_FILE_TOOL = _tool_schema(
         "content": {"type": "string"},
     },
 )
+LIST_IMAGE_MODELS_TOOL = _tool_schema(
+    "list_image_models",
+    {},
+    additional_properties=False,
+)
 
 
 def test_deepseek_codec_rejects_serialized_tool_call_content() -> None:
@@ -205,6 +210,28 @@ def test_deepseek_codec_keeps_valid_tool_call() -> None:
     }
 
     assert normalize_deepseek_response(response, tools=[WRITE_FILE_TOOL]) is response
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\n"])
+def test_deepseek_codec_keeps_blank_arguments_for_parameterless_tool(
+    blank: str,
+) -> None:
+    response = {
+        "type": "tool_call",
+        "tool_calls": [
+            {
+                "id": "call_list",
+                "type": "function",
+                "function": {"name": "list_image_models", "arguments": blank},
+            }
+        ],
+    }
+
+    assert (
+        normalize_deepseek_response(response, tools=[LIST_IMAGE_MODELS_TOOL])
+        is response
+    )
+    assert response["tool_calls"][0]["function"]["arguments"] == blank
 
 
 def test_deepseek_codec_repairs_complete_malformed_tool_arguments() -> None:

--- a/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
+++ b/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
@@ -213,25 +213,58 @@ def test_deepseek_codec_keeps_valid_tool_call() -> None:
 
 
 @pytest.mark.parametrize("blank", ["", "   ", "\n"])
-def test_deepseek_codec_keeps_blank_arguments_for_parameterless_tool(
+@pytest.mark.parametrize(
+    ("tool_name", "tool"),
+    [
+        ("list_image_models", LIST_IMAGE_MODELS_TOOL),
+        # A tool with declared properties skips the `additionalProperties`
+        # guard entirely rather than passing trivially against an empty set.
+        ("write_file", WRITE_FILE_TOOL),
+    ],
+)
+def test_deepseek_codec_keeps_blank_arguments_for_declared_tool(
     blank: str,
+    tool_name: str,
+    tool: dict[str, object],
 ) -> None:
     response = {
         "type": "tool_call",
         "tool_calls": [
             {
-                "id": "call_list",
+                "id": "call_blank",
                 "type": "function",
-                "function": {"name": "list_image_models", "arguments": blank},
+                "function": {"name": tool_name, "arguments": blank},
             }
         ],
     }
 
-    assert (
-        normalize_deepseek_response(response, tools=[LIST_IMAGE_MODELS_TOOL])
-        is response
-    )
+    assert normalize_deepseek_response(response, tools=[tool]) is response
     assert response["tool_calls"][0]["function"]["arguments"] == blank
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_deepseek_codec_still_rejects_unavailable_tool_with_blank_arguments(
+    blank: str,
+) -> None:
+    """Blank arguments must not become a bypass for the unavailable-tool guard."""
+
+    normalized = normalize_deepseek_response(
+        {
+            "type": "tool_call",
+            "tool_calls": [
+                {
+                    "id": "call_ghost",
+                    "type": "function",
+                    "function": {"name": "fetch_web_content", "arguments": blank},
+                }
+            ],
+        },
+        tools=[WRITE_FILE_TOOL],
+    )
+
+    error = get_tool_protocol_error(normalized)
+    assert error is not None
+    assert error["code"] == "unavailable_tool_call"
 
 
 def test_deepseek_codec_repairs_complete_malformed_tool_arguments() -> None:

--- a/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
+++ b/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
@@ -565,6 +565,50 @@ async def test_deepseek_stream_forwards_accumulated_valid_tool_calls() -> None:
     )
 
 
+@pytest.mark.parametrize("blank", ["", "   ", "\n"])
+@pytest.mark.asyncio
+async def test_deepseek_stream_keeps_blank_arguments_for_parameterless_tool(
+    blank: str,
+) -> None:
+    """Blank arguments must survive both of the stream adapter's gates.
+
+    The mid-stream gate skips them (`_arguments_are_ready_for_validation` is
+    False for a non-`{...}` string), so the end-of-stream check is the one that
+    reaches `_tool_call_violation` -- the production path behind #1501.
+    """
+
+    async def source() -> AsyncIterator[StreamChunk]:
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "index": 0,
+                    "id": "call_list",
+                    "type": "function",
+                    "function": {
+                        "name": "list_image_models",
+                        "arguments": blank,
+                    },
+                }
+            ],
+            finish_reason="tool_calls",
+        )
+        yield StreamChunk(type=ChunkType.END, finish_reason="tool_calls")
+
+    chunks = [
+        chunk
+        async for chunk in adapt_deepseek_stream(
+            source(),
+            tools=[LIST_IMAGE_MODELS_TOOL],
+        )
+    ]
+
+    assert not any(chunk.is_protocol_error() for chunk in chunks)
+    tool_chunks = [chunk for chunk in chunks if chunk.is_tool_call()]
+    assert tool_chunks
+    assert tool_chunks[-1].tool_calls[0]["function"]["arguments"] == blank
+
+
 @pytest.mark.asyncio
 async def test_deepseek_stream_repairs_complete_malformed_tool_arguments() -> None:
     async def source() -> AsyncIterator[StreamChunk]:

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -19,6 +19,26 @@ from xagent.core.retry.strategy import FixedDelay
 from xagent.core.retry.wrapper import create_retry_wrapper
 
 
+def _stream_chunk(tool_calls=None, finish_reason=None):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(content=None, tool_calls=tool_calls),
+                finish_reason=finish_reason,
+            )
+        ]
+    )
+
+
+def _tool_call_delta(index, call_id, name, arguments, call_type="function"):
+    return SimpleNamespace(
+        index=index,
+        id=call_id,
+        type=call_type,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
 class TestOpenAILLM:
     """Test cases for OpenAI LLM implementation."""
 
@@ -203,30 +223,12 @@ class TestOpenAILLM:
     def test_parse_stream_chunk_ignores_empty_idless_tool_call_placeholder(self, llm):
         """Some OpenAI-compatible providers emit empty id-less tool-call slots."""
 
-        def chunk(tool_calls=None, finish_reason=None):
-            return SimpleNamespace(
-                choices=[
-                    SimpleNamespace(
-                        delta=SimpleNamespace(content=None, tool_calls=tool_calls),
-                        finish_reason=finish_reason,
-                    )
-                ]
-            )
-
-        def tool_call(index, call_id, name, arguments, call_type="function"):
-            return SimpleNamespace(
-                index=index,
-                id=call_id,
-                type=call_type,
-                function=SimpleNamespace(name=name, arguments=arguments),
-            )
-
         accumulated_tool_calls = {}
 
         llm._parse_stream_chunk(
-            chunk(
+            _stream_chunk(
                 [
-                    tool_call(
+                    _tool_call_delta(
                         0,
                         "call_sum",
                         "mcp_everything_mcp_get_sum",
@@ -237,9 +239,9 @@ class TestOpenAILLM:
             accumulated_tool_calls,
         )
         llm._parse_stream_chunk(
-            chunk(
+            _stream_chunk(
                 [
-                    tool_call(
+                    _tool_call_delta(
                         1,
                         "call_long",
                         "mcp_everything_mcp_trigger_long_running_operation",
@@ -250,12 +252,12 @@ class TestOpenAILLM:
             accumulated_tool_calls,
         )
         llm._parse_stream_chunk(
-            chunk([tool_call(2, None, "", "", None)]),
+            _stream_chunk([_tool_call_delta(2, None, "", "", None)]),
             accumulated_tool_calls,
         )
 
         final_chunk = llm._parse_stream_chunk(
-            chunk(finish_reason="tool_calls"),
+            _stream_chunk(finish_reason="tool_calls"),
             accumulated_tool_calls,
         )
 
@@ -1210,3 +1212,69 @@ class TestOpenAILLM:
         assert "response_format" in call_args.kwargs
         assert call_args.kwargs["response_format"]["type"] == "json_schema"
         assert "json_schema" in call_args.kwargs["response_format"]
+
+    @pytest.mark.parametrize(
+        ("empty_arguments", "expected"),
+        [("", ""), ("   ", "   "), (None, "")],
+    )
+    @pytest.mark.parametrize("method", ["chat", "vision_chat"])
+    @pytest.mark.asyncio
+    async def test_empty_tool_arguments_are_not_fatal(
+        self,
+        openai_llm_config,
+        mock_tool_call_completion,
+        mocker,
+        method,
+        empty_arguments,
+        expected,
+    ):
+        """Providers send `""` for parameterless calls; patterns repair the rest.
+
+        Passed through rather than normalized to `"{}"`: the blank string is what
+        the patterns' retry paths key on. `None` coerces to `""`; whitespace-only
+        passes through unchanged.
+        """
+        llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
+        mock_tool_call_completion.choices[0].message.tool_calls[
+            0
+        ].function.arguments = empty_arguments
+
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_tool_call_completion
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        response = await getattr(llm, method)([{"role": "user", "content": "hi"}])
+
+        assert response["type"] == "tool_call"
+        assert response["tool_calls"][0]["function"]["arguments"] == expected
+
+    @pytest.mark.parametrize(
+        ("empty_arguments", "expected"),
+        [("", ""), ("   ", "   "), (None, "")],
+    )
+    def test_parse_stream_chunk_passes_empty_tool_arguments_through(
+        self, llm, empty_arguments, expected
+    ):
+        """Same on the streaming finish-reason path; `None` accumulates as `""`."""
+        accumulated_tool_calls = {}
+        llm._parse_stream_chunk(
+            _stream_chunk(
+                [
+                    _tool_call_delta(
+                        0, "call_empty", "list_image_models", empty_arguments
+                    )
+                ]
+            ),
+            accumulated_tool_calls,
+        )
+
+        final_chunk = llm._parse_stream_chunk(
+            _stream_chunk(finish_reason="tool_calls"),
+            accumulated_tool_calls,
+        )
+
+        assert final_chunk is not None
+        assert final_chunk.tool_calls[0]["function"]["arguments"] == expected

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -1230,9 +1230,9 @@ class TestOpenAILLM:
     ):
         """Providers send `""` for parameterless calls; patterns repair the rest.
 
-        Passed through rather than normalized to `"{}"`: the blank string is what
-        the patterns' retry paths key on. `None` coerces to `""`; whitespace-only
-        passes through unchanged.
+        Passed through rather than normalized to `"{}"`: the blank string is
+        what auto's and the DAG plan generator's retry paths key on. `None`
+        coerces to `""`; whitespace-only passes through unchanged.
         """
         llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
         mock_tool_call_completion.choices[0].message.tool_calls[


### PR DESCRIPTION
Closes #1501

> **Rescoped after review round 5.** This PR previously bundled pattern-layer
> retry hardening (`auto.py`, `plan_generator.py`, `dag.py`) under the same
> title. That work is unrelated to blank arguments — malformed payloads escape
> those retry loops regardless of what the adapter does — and each round of
> fixing it grew a new review surface, which is what kept this PR open. It is
> split out to a follow-up PR (branch `fix/pattern-retry-typed-errors`).
> Design decisions already settled in rounds 1–5 are preserved below.

## Background

Some OpenAI-compatible providers emit `arguments: ""` instead of `"{}"` on tool
calls. The adapter treated that as a provider bug and raised `RuntimeError` in
all three call paths, failing the whole run:

- `chat` (`model/chat/basic/openai.py:392`)
- `vision_chat` (`:719`) — the second non-streaming path, easy to miss
- `_parse_stream_chunk` finish-reason validation (`:1248`)

Empty arguments are legitimate for parameterless tools (`list_image_models`,
`list_video_models`, every MCP tool with an empty input schema), and even for
tools that do require fields the strictness sits at the wrong layer: the
patterns own argument adjudication and have retry/repair loops for malformed
calls. Raising in the adapter bypassed all of them and turned a model hiccup
into an unrecoverable failure.

Because the raise lives in `OpenAICompatibleLLM`, this affected the whole
compatible family — `OpenAILLM`, `OpenRouterLLM`, `DashScopeLLM`,
`AzureOpenAILLM`, `DeepSeekLLM`.

Also worth noting: the streaming guard was never a real invariant. The
`delta.tool_calls` branch returns accumulated tool calls at `openai.py:1215`
before `finish_reason` is ever tested, so providers that bundle the last
argument delta with `finish_reason` already got blank arguments through
unvalidated.

## Why pass-through, not normalize to `"{}"`

#1501 proposes normalizing empty arguments to `"{}"`. The adapter should not
invent a payload the model never sent: the patterns are the layer that decides
what a malformed argument string means, and handing them the provider's actual
value keeps that decision in one place. Concretely, `""` and `"{}"` are
*different inputs* downstream — `""` fails JSON parsing and carries no claim,
while `"{}"` parses cleanly into "an object with no fields", which for
`select_execution_pattern` or `generate_execution_plan` is a semantically wrong
answer rather than a syntax error. Normalizing would convert one into the other
behind the patterns' backs.

Scoping that claim precisely (review round 6, N4): the raw-string distinction
matters for `auto.py` and the DAG plan generator only. ReAct converges `""` and
`"{}"` to an identical `{}` in `_coerce_arguments`/`_fallback_arguments` and its
retry logic never inspects the raw string, so for ReAct alone normalizing would
have been harmless. It is the other two loops that adapter-level normalization
would have silently defeated.

ReAct recovers from `""`: `_coerce_arguments` hits a `JSONDecodeError`,
`_fallback_arguments` drops the payload, and for `final_answer` the resulting
empty args make `_empty_final_answer_call` flag a protocol violation, spending
the pattern's one repair retry. All of it was unreachable while the base class
raised first.

## Changes

- `openai.py`: remove the three `RuntimeError` guards. No normalization, no new
  helper — the adapter hands the provider's value to the patterns.
- `deepseek_tool_protocol.py`: `_tool_call_violation` no longer classifies a
  blank argument string as `malformed_tool_arguments`. Without this,
  DeepSeek/OpenRouter-via-DeepSeek-protocol — the exact path behind #1501's four
  production failures — still burned a repair retry on a parameterless tool
  while the plain OpenAI-compatible path executed it directly. The function's
  only downstream argument check rejects *unexpected* keys, not missing required
  ones, so a required-argument tool sent `""` behaves exactly as it does on the
  `openai.py` path: the tool call proceeds and the tool's own schema validation
  feeds a correctable error back to the model.
- `react.py`: `_fallback_arguments` no longer smuggles a blank payload through
  as `{"input": ""}` — nothing to preserve, and `input` is not a field any work
  tool declares. The branch fires for any work tool given a blank string, not
  only parameterless ones (round 6, N12).

## Tests

- `test_openai.py`: `chat` / `vision_chat` / streaming × `""`, `"   "`, `None`,
  with the expectation as parametrize data (`None` coerces to `""`;
  whitespace-only passes through). These paths had no coverage at all.
- `test_deepseek_tool_protocol.py`: blank arguments on a parameterless tool
  produce no violation and the payload is left untouched (not rewritten to
  `"{}"`), parametrized over `""` / `"   "` / `"\n"` — on **both** the
  non-streaming `normalize_deepseek_response` path and, via
  `adapt_deepseek_stream`, the streaming path the #1501 incident actually took.
  The streaming case is the load-bearing one: `_arguments_are_ready_for_validation`
  is `False` for a blank string, so the mid-stream gate skips it and the
  end-of-stream `_response_violation` is what reaches the fix.
- `test_react.py`: end-to-end through a real pattern loop — a parameterless tool
  sent `""` executes with `{}`; a **required-argument** tool sent `""` receives
  `{}` (asserted on the delivered payload, so the test fails if the fallback
  branch is reverted), fails inside the tool, and the error feeds back as a tool
  result; the production trace (streaming `final_answer` + `""`) spends the one
  repair retry. Plus the streaming seam: a real `OpenAICompatibleLLM` stream
  carrying `arguments: ""` (mocked SDK client) drives a real ReAct loop to
  success.

## Not in scope

- **Pattern-layer retry hardening** — `auto.py` / `plan_generator.py` /
  `dag.py` raise bare `ValueError` / `TypeError` / `KeyError` on malformed
  payloads, which escape their own retry loops and kill the run on attempt 1.
  Independent of blank arguments; follow-up PR.
- **All-optional work tools execute with defaults on `""`.** `_fallback_arguments`
  returning `{}` means a work tool whose every field is optional
  (`ListAgentsToolArgs.status_filter`, `ListKnowledgeBasesArgs.allowed_collections`,
  `BrowserScreenshotArgs`, `BrowserCloseArgs.session_id`) runs with defaults and
  the model gets no signal that a payload was dropped. Accepted as-is: a model
  sending `""` expressed no argument intent, so this is indistinguishable from a
  genuinely parameterless call without a schema-aware check, and it is strictly
  better than the pre-PR hard failure. Raised and closed as a note in review
  round 5.
  - **`ComputerToolArgs` is the one model where this is observable** (round 7,
    D6). The four models above inherit pydantic's default `extra="ignore"`, so
    `{"input": ""}` and `{}` are equivalent for them. `ComputerToolArgs`
    (`tools/adapters/vibe/computer.py:55`) sets `extra="forbid"` with every
    field optional, so pre-PR a blank payload failed validation and fed back
    "Invalid computer action"; post-PR it validates and runs the default
    `action=OBSERVE`. Bounded on purpose: `OBSERVE` is read-only, and every
    state-changing action is rejected at `computer.py:384` unless
    `expected_frame_id` is supplied, which `{}` cannot do.
- **Nameless tool calls** (#1504): pre-existing silent-success sink in ReAct,
  already reachable before this PR via nameless calls with non-blank arguments.
- **`zhipu.py` / `claude.py` normalize `""` to `"{}"`** (#1505), including
  `claude.py`'s `_coerce_tool_input` returning `{"input": ""}` on the outbound
  history path.
- **Completion assessment has no retry loop** (#1506): any parse failure goes
  straight to `_fail`; not specific to blank arguments.
- **#1479**: deleting the streaming guard removes one message that embedded
  `raw tool call: {...}`; the disclosure fix itself stays in #1479.

## Verification

`pre-commit run` clean over the diff (ruff, ruff format, mypy, isort,
codespell). `pytest tests/core/model/chat/basic/ tests/core/agent/test_react.py`
— 433 passed. Regression guards were mutation-checked: reverting the `react.py`
fallback branch turns three tests red, and reverting the
`deepseek_tool_protocol.py` guard turns eleven red across the non-streaming,
streaming, declared-tool and unavailable-tool cases.
