### PR TITLE
fix(router): enforce hard input modalities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,8 @@ command-path-guard = ["bashlex>=0.18"]
 # does not declare its bundled predictor runtime deps, so keep them explicit
 # here until upstream does.
 router = [
-  "xrouter-llm>=0.1.2",
+  "xrouter-llm>=0.3.1",
+  "scikit-learn>=1.9.0",
   "sentence-transformers>=3.0.0",
   # xrouter-llm's embedding model is a Qwen3-architecture checkpoint; transformers
   # only registered the `qwen3` model type in 4.51.
@@ -158,7 +159,8 @@ all = [
   "curl_cffi>=0.14.0",
   "chromadb",
   "pymilvus>=2.6.9,<3.0.0",
-  "xrouter-llm>=0.1.2",
+  "xrouter-llm>=0.3.1",
+  "scikit-learn>=1.9.0",
   "sentence-transformers>=3.0.0",
 ]
 
@@ -195,7 +197,8 @@ backend-image = [
   "pymilvus>=2.6.9,<3.0.0",
   "torch",
   "torchvision",
-  "xrouter-llm>=0.1.2",
+  "xrouter-llm>=0.3.1",
+  "scikit-learn>=1.9.0",
   "sentence-transformers>=3.0.0",
 ]
 

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -631,16 +631,36 @@ class RouterLLM(BaseLLM):
                     exc,
                     self._fallback_model,
                 )
-                return self._fallback_model
+                return await self._validated_fallback_model(preferred_input_modalities)
             raise RuntimeError(
                 f"xrouter-llm routing failed: {exc}. "
                 "Set XAGENT_ROUTER_FALLBACK_MODEL to degrade gracefully."
             ) from exc
         if not selected:
             if self._fallback_model:
-                return self._fallback_model
+                return await self._validated_fallback_model(preferred_input_modalities)
             raise RuntimeError("xrouter-llm returned no selected model")
         return str(selected[0])
+
+    async def _validated_fallback_model(
+        self,
+        required_input_modalities: tuple[str, ...],
+    ) -> str:
+        """Return the configured fallback without relaxing hard requirements."""
+        assert self._fallback_model is not None
+        if required_input_modalities:
+            fallback_modalities = await asyncio.to_thread(
+                self._profile_input_modalities,
+                self._fallback_model,
+            )
+            if not set(required_input_modalities).issubset(fallback_modalities):
+                required = ", ".join(required_input_modalities)
+                raise RouterModalityRoutingError(
+                    f"The fallback model {self._fallback_model} does not support "
+                    f"required input modalities ({required}). Choose an explicit "
+                    "compatible model."
+                )
+        return self._fallback_model
 
     def _route_sync(
         self,
@@ -654,7 +674,9 @@ class RouterLLM(BaseLLM):
         conversation's own content; ``advisory_input_modalities`` are
         preferences declared by a task runtime extension. When the installed
         router cannot express modality preferences at all, the hard
-        requirements raise while the advisory ones are simply dropped.
+        requirements raise while the advisory ones are simply dropped. A
+        best-effort router may also decline a combined hard-and-advisory filter;
+        retrying with only the hard requirements preserves that distinction.
         """
         service = _get_service()
         route_kwargs: dict[str, Any] = {"config_name": self._config_name}
@@ -692,7 +714,59 @@ class RouterLLM(BaseLLM):
                 ", ".join(advisory_input_modalities),
             )
         result = service.route(prompt, **route_kwargs)
-        return list(result.get("selected") or [])
+        selected = list(result.get("selected") or [])
+        selected_supports_hard_requirements = self._selected_model_supports_modalities(
+            selected,
+            preferred_input_modalities,
+        )
+        if (
+            preferred_input_modalities
+            and advisory_input_modalities
+            and not selected_supports_hard_requirements
+        ):
+            logger.info(
+                "xrouter selected a model that does not satisfy hard input "
+                "modalities after combining them with advisory preferences; "
+                "retrying with hard requirements only."
+            )
+            result = service.route(
+                prompt,
+                config_name=self._config_name,
+                preferred_input_modalities=preferred_input_modalities,
+            )
+            selected = list(result.get("selected") or [])
+            selected_supports_hard_requirements = (
+                self._selected_model_supports_modalities(
+                    selected,
+                    preferred_input_modalities,
+                )
+            )
+        if preferred_input_modalities and not selected_supports_hard_requirements:
+            requested = ", ".join(preferred_input_modalities)
+            raise RouterModalityRoutingError(
+                "The installed xrouter-llm RoutingService could not enforce input "
+                f"modalities ({requested}). Choose an explicit compatible model."
+            )
+        return selected
+
+    def _selected_model_supports_modalities(
+        self,
+        selected_models: list[str],
+        required_modalities: tuple[str, ...],
+    ) -> bool:
+        """Confirm the selected model accepts the conversation's modalities.
+
+        Xrouter can return a fusion set, but Xagent consumes only its first
+        model. Xrouter also treats modality input as a preference and can fall
+        back to its full candidate set. Validate the model Xagent will use
+        directly instead of relying on optional routing telemetry.
+        """
+        if not required_modalities:
+            return True
+        if not selected_models:
+            return False
+        selected_modalities = self._profile_input_modalities(str(selected_models[0]))
+        return set(required_modalities).issubset(selected_modalities)
 
     @staticmethod
     def _preferred_input_modalities(

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, AsyncIterator
 
 import pytest
@@ -25,6 +26,16 @@ _MANDATORY_REASONING_ERROR = (
     "OpenAI bad request (400): Reasoning is mandatory for this endpoint "
     "and cannot be disabled."
 )
+
+
+def _profiles(
+    modalities_by_model: dict[str, tuple[str, ...]],
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        get=lambda model_id: SimpleNamespace(
+            input_modalities=modalities_by_model[model_id]
+        )
+    )
 
 
 def _tool_schema() -> dict[str, Any]:
@@ -310,6 +321,8 @@ def test_route_sync_forwards_modalities_when_router_supports_them(
     calls: list[dict[str, Any]] = []
 
     class Service:
+        profiles = _profiles({"openai/gpt-5.5": ("text", "image")})
+
         def route(
             self,
             prompt: str,
@@ -343,10 +356,131 @@ def test_route_sync_forwards_modalities_when_router_supports_them(
     ]
 
 
+def test_route_sync_accepts_selected_model_that_supports_hard_modalities(
+    monkeypatch,
+) -> None:
+    """Enforcement depends on the selected profile, not optional telemetry."""
+
+    class Service:
+        profiles = _profiles({"vision/model": ("text", "image")})
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            preferred_input_modalities: tuple[str, ...] = (),
+        ) -> dict[str, Any]:
+            del prompt, config_name, preferred_input_modalities
+            return {"selected": ["vision/model"]}
+
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    assert RouterLLM()._route_sync("inspect", ("image",)) == ["vision/model"]
+
+
+def test_route_sync_validates_only_the_selected_model_xagent_uses(monkeypatch) -> None:
+    """Xagent consumes the first route result even when xrouter returns fusion."""
+
+    class Service:
+        profiles = _profiles(
+            {
+                "vision/model": ("text", "image"),
+                "text/model": ("text",),
+            }
+        )
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            preferred_input_modalities: tuple[str, ...] = (),
+        ) -> dict[str, Any]:
+            del prompt, config_name, preferred_input_modalities
+            return {"selected": ["vision/model", "text/model"]}
+
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    assert RouterLLM()._route_sync("inspect", ("image",)) == [
+        "vision/model",
+        "text/model",
+    ]
+
+
+def test_route_sync_rejects_unapplied_hard_modalities(monkeypatch) -> None:
+    """A best-effort router cannot silently relax message requirements."""
+
+    class Service:
+        profiles = _profiles({"text/model": ("text",)})
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            preferred_input_modalities: tuple[str, ...] = (),
+        ) -> dict[str, Any]:
+            del prompt, config_name, preferred_input_modalities
+            return {"selected": ["text/model"]}
+
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    with pytest.raises(RouterModalityRoutingError, match="could not enforce.*image"):
+        RouterLLM()._route_sync("inspect", ("image",))
+
+
+def test_route_sync_retries_without_advisory_modalities(monkeypatch) -> None:
+    """Advisory preferences may degrade without relaxing hard requirements."""
+
+    calls: list[tuple[str, ...]] = []
+
+    class Service:
+        profiles = _profiles(
+            {
+                "text/model": ("text",),
+                "vision/model": ("text", "image"),
+            }
+        )
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            preferred_input_modalities: tuple[str, ...] = (),
+        ) -> dict[str, Any]:
+            del prompt, config_name
+            calls.append(preferred_input_modalities)
+            hard_only = preferred_input_modalities == ("image",)
+            return {"selected": ["vision/model" if hard_only else "text/model"]}
+
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    selected = RouterLLM()._route_sync("inspect", ("image",), ("audio",))
+
+    assert selected == ["vision/model"]
+    assert calls == [("audio", "image"), ("image",)]
+
+
 def test_route_sync_forwards_advisory_modalities_when_supported(monkeypatch) -> None:
     calls: list[tuple[str, ...]] = []
 
     class Service:
+        profiles = _profiles({"openai/gpt-5.5": ("text", "audio", "image")})
+
         def route(
             self,
             prompt: str,
@@ -402,6 +536,36 @@ async def test_modality_support_error_is_not_hidden_by_generic_fallback(
 
     with pytest.raises(RouterModalityRoutingError, match="explicit compatible model"):
         await router._select_model(
+            "inspect",
+            preferred_input_modalities=("image",),
+        )
+
+
+@pytest.mark.asyncio
+async def test_generic_router_fallback_cannot_relax_hard_modalities(
+    monkeypatch,
+) -> None:
+    class Service:
+        profiles = _profiles({"fallback/model": ("text",)})
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            preferred_input_modalities: tuple[str, ...] = (),
+        ) -> dict[str, Any]:
+            del prompt, config_name, preferred_input_modalities
+            raise ValueError("predictor unavailable")
+
+    monkeypatch.setenv("XAGENT_ROUTER_FALLBACK_MODEL", "fallback/model")
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    with pytest.raises(RouterModalityRoutingError, match="fallback/model.*image"):
+        await RouterLLM()._select_model(
             "inspect",
             preferred_input_modalities=("image",),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -3843,6 +3843,16 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6372,26 +6382,47 @@ torch = [
 
 [[package]]
 name = "scikit-learn"
-version = "1.5.0"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
+    { name = "narwhals" },
     { name = "numpy" },
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/8a/06e499bca463905000f50e461c9445e949aafdd33ea3b62024aa2238b83d/scikit_learn-1.5.0.tar.gz", hash = "sha256:789e3db01c750ed6d496fa2db7d50637857b451e57bcae863bff707c1247bef7", size = 7820839, upload-time = "2024-05-21T16:34:07.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/d4/70a9393ab88862c070a263a464042ab4e572a1353b4c3c308bc72a5b68cf/scikit_learn-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2a65af2d8a6cce4e163a7951a4cfbfa7fceb2d5c013a4b593686c7f16445cf9d", size = 12081437, upload-time = "2024-05-21T16:33:20.16Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/97/dfc635bd435655c1216756b543e0427579df144914a055a188d3c0ffd52f/scikit_learn-1.5.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4c0c56c3005f2ec1db3787aeaabefa96256580678cec783986836fc64f8ff622", size = 10973963, upload-time = "2024-05-21T16:33:22.801Z" },
-    { url = "https://files.pythonhosted.org/packages/61/f5/18dc69d22ec950225237d42b61d3338affc46e5ea63c27c6915f3678f5f2/scikit_learn-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f77547165c00625551e5c250cefa3f03f2fc92c5e18668abd90bfc4be2e0bff", size = 12480861, upload-time = "2024-05-21T16:33:26.131Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c0/63d3a8da39a2ee051df229111aa93f6dca2b56f8080abd34993938166455/scikit_learn-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:118a8d229a41158c9f90093e46b3737120a165181a1b58c03461447aa4657415", size = 13328661, upload-time = "2024-05-21T16:33:29.627Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/20/6d1a0a61d468b37a142fd90bb93c73bc1c2205db4a69ac630ed218c31612/scikit_learn-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:a03b09f9f7f09ffe8c5efffe2e9de1196c696d811be6798ad5eddf323c6f4d40", size = 10972963, upload-time = "2024-05-21T16:33:32.98Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/21/fe8e90eb7dc796ed384daaf45a83e729a41fa7a9bf14bc1a0b69fd05b39a/scikit_learn-1.5.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:460806030c666addee1f074788b3978329a5bfdc9b7d63e7aad3f6d45c67a210", size = 12096541, upload-time = "2024-05-21T16:33:36.475Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/4b/c035ce6771dd56283cd587e941054ebb38a14868729e28a0f7c6c9ff9ebd/scikit_learn-1.5.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:1b94d6440603752b27842eda97f6395f570941857456c606eb1d638efdb38184", size = 11031507, upload-time = "2024-05-21T16:33:39.896Z" },
-    { url = "https://files.pythonhosted.org/packages/66/a1/e64f125382f2fc46dd1f3a3c2d390f02db896e3803a3e7898c4ca48390e0/scikit_learn-1.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d82c2e573f0f2f2f0be897e7a31fcf4e73869247738ab8c3ce7245549af58ab8", size = 12082985, upload-time = "2024-05-21T16:33:42.807Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/54/e70102a9c12d27d985ba659f336851732415e5a02864bef2ead36afaf15d/scikit_learn-1.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3a10e1d9e834e84d05e468ec501a356226338778769317ee0b84043c0d8fb06", size = 13065320, upload-time = "2024-05-21T16:33:45.65Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ed/f607ebf69f87bcce2e3fa329bd78da8cafd3d51190a19d58012d2d7f2252/scikit_learn-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:855fc5fa8ed9e4f08291203af3d3e5fbdc4737bd617a371559aaa2088166046e", size = 10938084, upload-time = "2024-05-21T16:33:49.011Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/e844fd9586e66540a15b71924d17a6cbc1bb749e81ddd0a796bcdba4c055/scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b", size = 8789686, upload-time = "2026-06-02T11:53:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/ff880f62677a17d035817d543cb0fc8727d01eccbee81c5f7fc733a9d856/scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c", size = 8256782, upload-time = "2026-06-02T11:53:08.904Z" },
+    { url = "https://files.pythonhosted.org/packages/25/64/eb40435e1a508ab1b4e284ce43ae80f6a162e5be5e38ed5a6fab467a9ea4/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa", size = 8992419, upload-time = "2026-06-02T11:53:11.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/4810a28e473185429e45a57eebcc91fc991b33d889cc0676063e671db03d/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8", size = 9281411, upload-time = "2026-06-02T11:53:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/be3d369f40d8178ba3bd86635d132e08cb5329b023e4669d9426d84bc007/scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759", size = 8272736, upload-time = "2026-06-02T11:53:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/a733f02dc2118da7e77a134b34f39f40201a353311b011d20859d2db3556/scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28", size = 7919564, upload-time = "2026-06-02T11:53:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
 ]
 
 [[package]]
@@ -7848,6 +7879,7 @@ all = [
     { name = "pypdf2" },
     { name = "python-docx" },
     { name = "python-pptx" },
+    { name = "scikit-learn" },
     { name = "sentence-transformers" },
     { name = "typer" },
     { name = "unstructured" },
@@ -7884,6 +7916,7 @@ postgresql = [
     { name = "psycopg2-binary" },
 ]
 router = [
+    { name = "scikit-learn" },
     { name = "sentence-transformers" },
     { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
@@ -7908,6 +7941,7 @@ backend-image = [
     { name = "pypdf2" },
     { name = "python-docx" },
     { name = "python-pptx" },
+    { name = "scikit-learn" },
     { name = "sentence-transformers" },
     { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
@@ -8071,6 +8105,8 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "s3fs", specifier = ">=2026.2.0" },
+    { name = "scikit-learn", marker = "extra == 'all'", specifier = ">=1.9.0" },
+    { name = "scikit-learn", marker = "extra == 'router'", specifier = ">=1.9.0" },
     { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=3.0.0" },
     { name = "sentence-transformers", marker = "extra == 'router'", specifier = ">=3.0.0" },
     { name = "slack-sdk", specifier = ">=3.43.0" },
@@ -8087,8 +8123,8 @@ requires-dist = [
     { name = "volcengine-python-sdk", extras = ["ark"], specifier = ">=5.0.37" },
     { name = "websockets", specifier = ">=15.0.1" },
     { name = "xinference-client", specifier = ">=2.3.0" },
-    { name = "xrouter-llm", marker = "extra == 'all'", specifier = ">=0.1.2" },
-    { name = "xrouter-llm", marker = "extra == 'router'", specifier = ">=0.1.2" },
+    { name = "xrouter-llm", marker = "extra == 'all'", specifier = ">=0.3.1" },
+    { name = "xrouter-llm", marker = "extra == 'router'", specifier = ">=0.3.1" },
     { name = "zai-sdk", specifier = ">=0.0.3.2" },
 ]
 provides-extras = ["ai-document", "all", "browser", "chromadb", "command-path-guard", "document-processing", "duckdb", "milvus", "postgresql", "router", "waf-crawl"]
@@ -8107,12 +8143,13 @@ backend-image = [
     { name = "pypdf2", specifier = ">=3.0.1" },
     { name = "python-docx", specifier = ">=1.1.0" },
     { name = "python-pptx", specifier = ">=0.6.0" },
+    { name = "scikit-learn", specifier = ">=1.9.0" },
     { name = "sentence-transformers", specifier = ">=3.0.0" },
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "unstructured", specifier = ">=0.15.0" },
-    { name = "xrouter-llm", specifier = ">=0.1.2" },
+    { name = "xrouter-llm", specifier = ">=0.3.1" },
 ]
 dev = [
     { name = "asyncssh", specifier = ">=2.14.0" },
@@ -8233,9 +8270,11 @@ wheels = [
 
 [[package]]
 name = "xrouter-llm"
-version = "0.1.2"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "alembic" },
+    { name = "fastapi" },
     { name = "huggingface-hub" },
     { name = "joblib" },
     { name = "numpy" },
@@ -8243,10 +8282,12 @@ dependencies = [
     { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "sqlalchemy" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/36/63ccf8f0db5c0bdb8bcd04eae05e07ec7d013c2ec9854dd0e3c720cf74df/xrouter_llm-0.1.2.tar.gz", hash = "sha256:0d3b184f749505fc80b0049ee9a466d7472171145dad98977a778e4effd3d7c9", size = 1506669, upload-time = "2026-06-23T13:41:34.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/83/5ba60715e2896811218b6af262f6e517b67c2b210470e823d918d53386b5/xrouter_llm-0.3.1.tar.gz", hash = "sha256:4cb410d6e626b0e42b6f5c2ed6093d38c995734dc73a9c6ee4a871ed5d6bb1f8", size = 1467160, upload-time = "2026-08-18T05:32:24.976Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/77/f4082e25dad8d123bd85173735e66dd547c34a43c39aa87e43713fbe83bd/xrouter_llm-0.1.2-py3-none-any.whl", hash = "sha256:df1b5c2f36c091b27f3e97355ba154c2bb0c5cfecac52b6ca3ec5e867041ada8", size = 116349, upload-time = "2026-06-23T13:41:32.776Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f9/07847b5a07c920e3f71c1e4a1bd4fcf0ac0fa455ebc008ef639229719d82/xrouter_llm-0.3.1-py3-none-any.whl", hash = "sha256:5d53acd3a9bff232a4725cbd809f443423dfcfd49301c61d7966b9313e89c3d7", size = 147221, upload-time = "2026-08-18T05:32:23.311Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- require xrouter-llm 0.3.1 and its matching scikit-learn model runtime
- validate the selected model profile against hard input modalities
- retry without advisory modalities when a combined preference picks an incompatible model
- prevent generic fallback routing from relaxing message-derived modality requirements

## Context

xrouter-llm 0.3.1 treats `preferred_input_modalities` as best-effort. When no candidate supports the requested combination, it falls back to the full candidate set. Xagent previously discarded that outcome and could send image-bearing input to a text-only model.

This is the upstream fix required by xorbitsai/xagent-saas#691.

## Verification

- `pytest tests/core/model/chat/basic/test_router.py -n 0 -q` — 29 passed
- real xrouter 0.3.1 signature and model-profile modality contract check
- `pre-commit run --files pyproject.toml uv.lock src/xagent/core/model/chat/basic/router.py tests/core/model/chat/basic/test_router.py`
- `uv lock --check`
