### PR TITLE
fix(mcp): emit can_configure and stop gating Configure on connection state

### DIFF
--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -2133,11 +2133,10 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
   })
 
   it("shows Configure and the connected checkmark, not Authorize, for a connected custom mcp_oauth entry (#1332)", async () => {
-    // The isGloballyConnected branch of the footer ternary is checked first
-    // and must keep winning: a connected entry shows Configure plus the
-    // checkmark, never Authorize -- including now that can_authorize is true
-    // for it (re-consent is legitimate; the picker suppresses the trigger on
-    // connected state itself, which is why the backend does not).
+    // A connected entry shows Configure plus the checkmark, never Authorize --
+    // including when can_authorize is true for it (re-consent is legitimate;
+    // the Authorize block's own !isGloballyConnected term suppresses the
+    // trigger on connected state, which is why the backend does not).
     const onConnectSelected = vi.fn()
     renderSelectModeWith(
       [{ ...unauthorizedCustomMcp(), is_connected: true, can_attach: true }],
@@ -2397,6 +2396,10 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       ...hookResolvedCustomMcp(),
       name: "Team Records",
       id: "team-records",
+      // The base factory is the owner's shape, which is configurable; a member
+      // reaching this connector through the team overlay holds no association
+      // of their own, so the listing reports false here.
+      can_configure: false,
     }
     delete teamOwned.auth_type
     renderSelectModeWith([teamOwned], onConnectSelected)

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -298,6 +298,9 @@ function mcpOauthApp() {
     // /apps/{id}/oauth/connect rather than the per-server route.
     can_attach: false,
     can_authorize: false,
+    // The catalog branch's can_configure equals is_connected: its Configure
+    // equivalent (manage-my-key / re-run OAuth) only exists once connected.
+    can_configure: false,
   }
 }
 
@@ -322,6 +325,10 @@ function customMcpOauthApp() {
     // consent flow itself is available and is the recovery.
     can_attach: false,
     can_authorize: true,
+    // The owner holds the personal association the edit routes require, so
+    // this base shape is configurable -- independent of can_attach/
+    // can_authorize, which is the entire point of the field.
+    can_configure: true,
   }
 }
 
@@ -2021,6 +2028,39 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     is_connected: false,
   })
 
+  // A team-owned stdio connector the viewer holds no personal association
+  // for. The listing reports it connected -- the connected-state predicate
+  // returns True unconditionally for every non-mcp_oauth shape -- while the
+  // edit route answers 404 without a personal association row. That
+  // combination is the *narrowing* direction of the disagreement between the
+  // connected gate and can_configure; the widening direction (is_connected:
+  // false + can_configure: true) is the population this change exists for,
+  // covered by the hook-resolved fixtures above.
+  const teamOwnedStdio = () => ({
+    id: "team-files",
+    name: "Team Files",
+    description: "",
+    icon: "",
+    transport: "stdio",
+    is_custom: true,
+    is_local: true,
+    server_id: 11,
+    is_connected: true,
+    can_attach: true,
+    can_authorize: false,
+    can_configure: false,
+  })
+
+  // Same disagreement on the Custom API half, where the listing reports
+  // every entry connected unconditionally.
+  const teamOwnedCustomApi = () => ({
+    ...teamOwnedStdio(),
+    id: "team-billing",
+    name: "Team Billing",
+    transport: "custom_api",
+    server_id: 12,
+  })
+
   // Shared by renderSelectModeWith below and the non-select-mode card-click
   // test, which otherwise duplicated this exact mockImplementation block.
   function mockAppsList(apps: object[]) {
@@ -2055,6 +2095,10 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     // And no Authorize trigger: there is no consent flow behind it, so the
     // label would assert a step this connector does not have (#1347).
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
+    // Configure does show: the owner's personal association makes the edit
+    // route resolve even though the connector is not "connected" by this
+    // field's usual meaning -- the bug this change exists to fix.
+    screen.getByRole("button", { name: "tools.mcp.dialog.configure" })
     // Becoming attachable must not change connected-state display: this
     // connector is still unconnected (is_connected: false), so it must stay
     // unchecked. Scoped through the card: connected-check is non-unique
@@ -2068,6 +2112,22 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
     // Removal has to work too, or an accidental attach would be unrevertable.
     fireEvent.click(screen.getByText("Records MCP"))
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("opens the detail modal without toggling the selection when Configure is clicked in select mode", async () => {
+    // Configure's onClick carries the same stopPropagation() as Authorize's:
+    // without it, a click on the button would bubble to the card and toggle
+    // this attachable entry's selection as a side effect.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([hookResolvedCustomMcp()], onConnectSelected)
+    await screen.findByText("Records MCP")
+
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.configure" }))
+    expect(screen.getByTestId("connector-card-records")).toHaveAttribute("data-selected", "false")
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
+
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })
@@ -2116,6 +2176,20 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     )
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("offers Authorize alongside Configure for a never-authorized connector its owner can still edit", async () => {
+    // The two fields answer different questions and neither implies the
+    // other: this connector needs consent (can_authorize) and its owner can
+    // also fix its configuration (can_configure) -- e.g. a wrong URL entered
+    // before consent was ever attempted. A ternary could only ever show one.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([unauthorizedCustomMcp()], onConnectSelected)
+    await screen.findByText("Records MCP")
+
+    // getBy* throws when absent, so the bare calls are the assertions.
+    screen.getByRole("button", { name: "tools.mcp.dialog.authorize" })
+    screen.getByRole("button", { name: "tools.mcp.dialog.configure" })
   })
 
   // #1390: the create path into the selection, which ignored can_attach
@@ -2335,6 +2409,56 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(onConnectSelected).toHaveBeenLastCalledWith(["Team Records"])
   })
 
+  it("offers no Configure for a team-owned connector the viewer holds no association for", async () => {
+    // The listing reports this connector connected (every non-mcp_oauth
+    // shape does), but the viewer has no row of their own, so the edit
+    // route would 404 -- the collapsing direction of the disagreement
+    // between the connected gate and can_configure.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([teamOwnedStdio()], onConnectSelected)
+    await screen.findByText("Team Files")
+
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+    // The collapse must not have cost the team member their ability to
+    // select this connector -- can_attach is unaffected.
+    fireEvent.click(screen.getByText("Team Files"))
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith(["Team Files"])
+  })
+
+  it("offers no Configure for a team-owned custom API the viewer holds no association for", async () => {
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([teamOwnedCustomApi()], onConnectSelected)
+    await screen.findByText("Team Billing")
+
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+    fireEvent.click(screen.getByText("Team Billing"))
+    fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
+    expect(onConnectSelected).toHaveBeenLastCalledWith(["Team Billing"])
+  })
+
+  it("falls back to the connected gate for an entry that carries no can_configure field", async () => {
+    // teamOwnedStdio() is the shape where the connected gate and
+    // can_configure actively disagree (is_connected: true, can_configure:
+    // false) -- deleting the field here proves the fallback reads the
+    // connected gate rather than happening to agree with it by coincidence.
+    const connectedNoField: Record<string, unknown> = teamOwnedStdio()
+    delete connectedNoField.can_configure
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([connectedNoField], onConnectSelected)
+    await screen.findByText("Team Files")
+    screen.getByRole("button", { name: "tools.mcp.dialog.configure" })
+    cleanup()
+
+    const disconnectedNoField: Record<string, unknown> = {
+      ...connectedNoField,
+      is_connected: false,
+    }
+    renderSelectModeWith([disconnectedNoField], onConnectSelected)
+    await screen.findByText("Team Files")
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+  })
+
   it("still gates selection on connected state for unconnected catalog apps", async () => {
     // mcpOauthApp() (Granola) is the load-bearing fixture: it carries the
     // exact same auth_type as the custom mcp_oauth population, but it is a
@@ -2364,6 +2488,20 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "tools.mcp.dialog.connect" }))
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
+  })
+
+  it("offers no Configure for an unconnected catalog entry", async () => {
+    // Guards against the dead-button regression an unconditional True would
+    // reintroduce: Granola's Configure equivalent (manage-my-key / re-run
+    // OAuth) does not exist until it is connected, so nothing here must show.
+    const onConnectSelected = vi.fn()
+    renderSelectModeWith([mcpOauthApp()], onConnectSelected)
+    await screen.findByText("Granola")
+
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+    // Connect stays reachable through the card click.
+    fireEvent.click(screen.getByText("Granola"))
+    expect(screen.getByTestId("settings-open-app").textContent).toBe("Granola")
   })
 
   it("refuses a deactivated association even when it lists as connected", async () => {
@@ -2428,12 +2566,13 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })
 
-  it("routes a buttonless deactivated-before-consent entry to the modal", async () => {
-    // All four signals false and no auth_type: no checkmark, no Configure, no
-    // Authorize. The card click must still reach the detail modal — that route
-    // offers no recovery for this population (Connect has no auth_type to
-    // dispatch on), but it is the only thing the card has left, and the
-    // isAttachable comment records why.
+  it("routes a deactivated-before-consent entry to its edit form and the modal", async () => {
+    // No checkmark, no Authorize -- but its owner's personal association
+    // still exists (only its is_active flag is false, which the edit routes
+    // do not filter on), so Configure now opens. This does not re-enable the
+    // connector: the edit form's save payload carries no is_active key, so
+    // there is still no way to flip it back on from here. That gap is
+    // unrelated to this field and tracked on its own.
     const onConnectSelected = vi.fn()
     renderSelectModeWith([dormantBeforeConsent()], onConnectSelected)
     await screen.findByText("Records MCP")
@@ -2441,7 +2580,7 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(
       within(screen.getByTestId("connector-card-records")).queryByTestId("connected-check"),
     ).toBeNull()
-    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+    screen.getByRole("button", { name: "tools.mcp.dialog.configure" })
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
 
     fireEvent.click(screen.getByText("Records MCP"))
@@ -2450,11 +2589,12 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(onConnectSelected).toHaveBeenLastCalledWith([])
   })
 
-  it("deselects a buttonless entry on the first click, then opens the modal on the second", async () => {
-    // The buttonless shape carries no affordance of its own, so the removal
-    // has to read from the card itself: the ring drops and the footer count
-    // decrements. The second click, with nothing left to remove, falls through
-    // to the modal like any other unattachable card.
+  it("deselects a deactivated-before-consent entry on the first click, then opens the modal on the second", async () => {
+    // This shape now carries a Configure button, but it renders on the card
+    // footer only, never on the card body the click below targets -- so the
+    // removal still has to read from the card itself: the ring drops and the
+    // footer count decrements. The second click, with nothing left to
+    // remove, falls through to the modal like any other unattachable card.
     const onConnectSelected = vi.fn()
     mockAppsList([dormantBeforeConsent()])
     render(
@@ -2488,6 +2628,9 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     await screen.findByText("Records MCP")
 
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.authorize" })).toBeNull()
+    // Configure is not scoped to select mode -- unlike Authorize, it does not
+    // exist to explain a diverted click, so it renders here too.
+    screen.getByRole("button", { name: "tools.mcp.dialog.configure" })
     fireEvent.click(screen.getByText("Records MCP"))
     expect(screen.getByTestId("settings-open-app").textContent).toBe("Records MCP")
   })

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -266,6 +266,25 @@ export function ConnectMcpDialog({
   // second would 404 on /{server_id}/oauth/connect.
   const canAuthorize = (app: AppIntegration) => Boolean(app.can_authorize)
 
+  // Whether this viewer may open this entry's configuration surface, decided
+  // by the backend (list_mcp_apps.can_configure) rather than re-derived from
+  // is_connected. A connector whose tokens arrive through a
+  // deployment-installed resolver hook is never "connected" for its own
+  // creator -- no personal grant row is ever written -- so the connected gate
+  // hid the edit route from the one person entitled to it.
+  //
+  // The `??` default reproduces the pre-field gate and exists only for a
+  // rolling deploy of the multi-container layout, where a new frontend
+  // container can briefly talk to an older backend. It is a UI hint, never a
+  // permission: the edit route itself answers 404 without a personal
+  // association row (GET/PUT /api/mcp/servers/{id}, /api/custom-apis/{id}).
+  // Producer-side coverage is not in question -- all three emitting branches
+  // are pinned to emit a bool by
+  // test_every_listed_entry_carries_all_three_decisions (tests/web, which CI
+  // runs) -- so dropping this default needs no repository audit, only a
+  // decision that the supported backend floor emits the field.
+  const canConfigure = (app: AppIntegration) => Boolean(app.can_configure ?? app.is_connected)
+
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300)
     return () => clearTimeout(timer)
@@ -1486,50 +1505,76 @@ export function ConnectMcpDialog({
                               <div className="flex items-center gap-2">
                                 {isLoading ? (
                                   <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
-                                ) : isGloballyConnected ? (
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-7 text-xs text-slate-600 hover:text-slate-900 px-2 bg-slate-100 hover:bg-slate-200"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      setSelectedApp(app);
-                                    }}
-                                  >
-                                    <Settings className="h-3 w-3 mr-1" /> {t('tools.mcp.dialog.configure')}
-                                  </Button>
-                                ) : isSelectMode && canAuthorize(app) ? (
-                                  // One-click entry to the per-server OAuth
-                                  // flow repaired in #1323, kept from #1332
-                                  // where the card click stopped reaching the
-                                  // detail modal it is started from.
-                                  //
-                                  // Driven by can_authorize alone (#1347), not
-                                  // by the attach gate: those two now select
-                                  // disjoint populations. An entry that is
-                                  // attachable-but-unconnected got there
-                                  // through hook-supplied credentials or a team
-                                  // link, and has no consent this editor could
-                                  // complete — the button asserted "needs
-                                  // authorization" and opened a popup that
-                                  // could never finish. What is left is the
-                                  // connector whose consent was never started:
-                                  // not attachable until it is, so its card
-                                  // click still opens the modal, and this
-                                  // labels that route rather than leaving the
-                                  // one card in a grid of toggles unexplained.
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-7 text-xs text-blue-600 hover:text-blue-700 px-2 bg-blue-50 hover:bg-blue-100"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      setSelectedApp(app);
-                                    }}
-                                  >
-                                    <Plug className="h-3 w-3 mr-1" /> {t('tools.mcp.dialog.authorize')}
-                                  </Button>
-                                ) : null}
+                                ) : (
+                                  <>
+                                    {isSelectMode && canAuthorize(app) && !isGloballyConnected && (
+                                      // One-click entry to the per-server OAuth
+                                      // flow repaired in #1323, kept from #1332
+                                      // where the card click stopped reaching the
+                                      // detail modal it is started from.
+                                      //
+                                      // Driven by can_authorize alone (#1347), not
+                                      // by the attach gate: those two now select
+                                      // disjoint populations. An entry that is
+                                      // attachable-but-unconnected got there
+                                      // through hook-supplied credentials or a team
+                                      // link, and has no consent this editor could
+                                      // complete — the button asserted "needs
+                                      // authorization" and opened a popup that
+                                      // could never finish. What is left is the
+                                      // connector whose consent was never started:
+                                      // not attachable until it is, so its card
+                                      // click still opens the modal, and this
+                                      // labels that route rather than leaving the
+                                      // one card in a grid of toggles unexplained.
+                                      //
+                                      // !isGloballyConnected keeps a connected
+                                      // entry showing Configure only, never
+                                      // Authorize: re-consenting an already
+                                      // granted server is legitimate (can_authorize
+                                      // can be true here too), but the picker
+                                      // suppresses the trigger on connected state
+                                      // itself. A ternary used to give this for
+                                      // free by testing isGloballyConnected first;
+                                      // now that Configure and Authorize are
+                                      // independent blocks (they can both apply --
+                                      // a connector can need both a URL fix and
+                                      // consent), the suppression has to be
+                                      // written out.
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-7 text-xs text-blue-600 hover:text-blue-700 px-2 bg-blue-50 hover:bg-blue-100"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          setSelectedApp(app);
+                                        }}
+                                      >
+                                        <Plug className="h-3 w-3 mr-1" /> {t('tools.mcp.dialog.authorize')}
+                                      </Button>
+                                    )}
+                                    {canConfigure(app) && (
+                                      // Independent of the Authorize block above:
+                                      // whether the edit route resolves for this
+                                      // viewer (list_mcp_apps.can_configure) has
+                                      // nothing to do with whether consent is
+                                      // outstanding. Every entry this file lists
+                                      // carries a boolean can_configure, pinned by
+                                      // test_every_listed_entry_carries_all_three_decisions.
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-7 text-xs text-slate-600 hover:text-slate-900 px-2 bg-slate-100 hover:bg-slate-200"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          setSelectedApp(app);
+                                        }}
+                                      >
+                                        <Settings className="h-3 w-3 mr-1" /> {t('tools.mcp.dialog.configure')}
+                                      </Button>
+                                    )}
+                                  </>
+                                )}
                               </div>
                             </div>
                           </CardContent>
@@ -1691,6 +1736,7 @@ export function ConnectMcpDialog({
         }}
         app={selectedApp}
         isGloballyConnected={selectedApp ? isAppConnected(selectedApp) : false}
+        canConfigure={selectedApp ? canConfigure(selectedApp) : false}
         isConnecting={!!selectedApp && loadingApps.has(selectedApp.id)}
         onSuccess={() => {
           if (onSuccess) onSuccess();

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -1534,13 +1534,10 @@ export function ConnectMcpDialog({
                                       // granted server is legitimate (can_authorize
                                       // can be true here too), but the picker
                                       // suppresses the trigger on connected state
-                                      // itself. A ternary used to give this for
-                                      // free by testing isGloballyConnected first;
-                                      // now that Configure and Authorize are
-                                      // independent blocks (they can both apply --
-                                      // a connector can need both a URL fix and
-                                      // consent), the suppression has to be
-                                      // written out.
+                                      // itself. It has to be spelled out because
+                                      // this block and Configure below are
+                                      // independent: both can apply at once -- a
+                                      // connector can need a URL fix and consent.
                                       <Button
                                         variant="ghost"
                                         size="sm"
@@ -1558,9 +1555,7 @@ export function ConnectMcpDialog({
                                       // whether the edit route resolves for this
                                       // viewer (list_mcp_apps.can_configure) has
                                       // nothing to do with whether consent is
-                                      // outstanding. Every entry this file lists
-                                      // carries a boolean can_configure, pinned by
-                                      // test_every_listed_entry_carries_all_three_decisions.
+                                      // outstanding.
                                       <Button
                                         variant="ghost"
                                         size="sm"

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -1502,7 +1502,7 @@ export function ConnectMcpDialog({
                                   </Badge>
                                 )}
                               </div>
-                              <div className="flex items-center gap-2">
+                              <div className="flex items-center gap-2 flex-wrap">
                                 {isLoading ? (
                                   <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
                                 ) : (

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
@@ -15,8 +15,9 @@ vi.mock("@/lib/utils", async () => {
   return { ...actual, getApiUrl: () => "http://api.local" }
 })
 
+const authState = vi.hoisted(() => ({ inTeam: false }))
 vi.mock("@/contexts/auth-context", () => ({
-  useAuth: () => ({ token: "token", inTeam: false }),
+  useAuth: () => ({ token: "token", inTeam: authState.inTeam }),
 }))
 
 vi.mock("@/contexts/i18n-context", () => ({
@@ -66,10 +67,14 @@ describe("OfficialMcpSettingsDialog connected-state actions", () => {
 
   afterEach(() => {
     cleanup()
+    authState.inTeam = false
   })
 
   it("offers only disconnect for a connected keyless app", () => {
-    renderDialog()
+    // canConfigure: true and it must still not show -- proving the keyless
+    // gate is independent of configurability, not a side effect of the
+    // connected-entry default being false somewhere.
+    renderDialog({ canConfigure: true })
 
     // No key to manage and no editable config — the configure/manage-key
     // button must be suppressed for keyless apps.
@@ -91,6 +96,100 @@ describe("OfficialMcpSettingsDialog connected-state actions", () => {
     const manageButton = screen.getByRole("button", { name: /manageKey/ })
     fireEvent.click(manageButton)
     expect(onManageKey).toHaveBeenCalledTimes(1)
+  })
+
+  it("offers Configure for an unconnected entry the viewer may still configure", () => {
+    // This is the bug's shape in the settings dialog: is_connected is false
+    // (no grant was ever written for a hook-resolved connector), yet the
+    // owner's personal association means the edit route would resolve.
+    const onConfigure = vi.fn()
+    renderDialog({
+      app: app({
+        is_connected: false,
+        is_custom: true,
+        auth_type: "mcp_oauth",
+        transport: "streamable_http",
+        server_id: 9,
+      }),
+      isGloballyConnected: false,
+      canConfigure: true,
+      onConfigure,
+    })
+
+    const configureButton = screen.getByRole("button", { name: "tools.mcp.dialog.configure" })
+    fireEvent.click(configureButton)
+    expect(onConfigure).toHaveBeenCalledTimes(1)
+    // Neither element gated on isGloballyConnected renders in this shape:
+    // Configure is the only door this population gets.
+    expect(
+      screen.queryByRole("button", { name: /disconnect|deleteService/ }),
+    ).toBeNull()
+    expect(screen.queryByRole("button", { name: /share|unshare/ })).toBeNull()
+  })
+
+  it("keeps sharing and disconnect on the connection gate when only Configure is unlocked", () => {
+    authState.inTeam = true
+    const onConfigure = vi.fn()
+    renderDialog({
+      app: app({
+        server_id: 9,
+        transport: "streamable_http",
+        auth_type: "mcp_oauth",
+        is_custom: true,
+      }),
+      isGloballyConnected: false, // the precondition this test proves against
+      canConfigure: true,
+      onConfigure,
+    })
+
+    // Configure appears (the new gate).
+    screen.getByRole("button", { name: "tools.mcp.dialog.configure" })
+    // Share does not: inTeam is true and server_id is an integer, so the only
+    // thing still withholding it is isGloballyConnected being false — exactly
+    // what this test exists to pin.
+    expect(screen.queryByRole("button", { name: /share|unshare/ })).toBeNull()
+    // Disconnect does not either -- its gate does not read inTeam at all, so
+    // this holds under either harness default.
+    expect(screen.queryByRole("button", { name: /disconnect|deleteService/ })).toBeNull()
+  })
+
+  it("withholds Configure for a connected entry the viewer may not configure", () => {
+    renderDialog({
+      app: app({ auth_type: "mcp_oauth", is_custom: true, server_id: 9 }),
+      isGloballyConnected: true,
+      canConfigure: false,
+    })
+
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+    // Disconnect is unaffected -- only Configure was withheld.
+    screen.getByRole("button", { name: /disconnect|deleteService/ })
+  })
+
+  it("falls back to the connection gate when no canConfigure is provided", () => {
+    // The Tools page's call site: it always passes isGloballyConnected={true}
+    // and never passes canConfigure at all.
+    renderDialog({
+      app: app({ auth_type: "api_key" }),
+      isGloballyConnected: true,
+    })
+
+    screen.getByRole("button", { name: "tools.mcp.dialog.manageKey" })
+  })
+
+  it("withholds Configure for a non-owned team tool even when configurable", () => {
+    renderDialog({
+      app: app({
+        auth_type: "mcp_oauth",
+        is_custom: true,
+        server_id: 9,
+        shared: true,
+        is_owner: false,
+      }),
+      isGloballyConnected: true,
+      canConfigure: true,
+    })
+
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
   })
 })
 

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
@@ -176,6 +176,18 @@ describe("OfficialMcpSettingsDialog connected-state actions", () => {
     screen.getByRole("button", { name: "tools.mcp.dialog.manageKey" })
   })
 
+  it("withholds Configure when no canConfigure is provided and the connection gate is closed", () => {
+    // Mirrors the fallback case above with isGloballyConnected flipped to
+    // false: the omitted-prop shape must read the connection gate rather
+    // than defaulting Configure on regardless of it.
+    renderDialog({
+      app: app({ auth_type: "mcp_oauth" }),
+      isGloballyConnected: false,
+    })
+
+    expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
+  })
+
   it("withholds Configure for a non-owned team tool even when configurable", () => {
     renderDialog({
       app: app({

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
@@ -169,10 +169,10 @@ export function OfficialMcpSettingsDialog({
 
   if (!app) return null;
 
-  // configurable answers "would the edit route resolve for this viewer" —
-  // independent of connection state (D6/D8): a connector whose tokens arrive
-  // through a deployment-installed resolver hook is never "connected" for its
-  // own creator, yet its owner holds the association the edit routes require.
+  // configurable answers "would the edit route resolve for this viewer",
+  // independent of connection state: a connector whose tokens arrive through a
+  // deployment-installed resolver hook is never "connected" for its own
+  // creator, yet its owner holds the association the edit routes require.
   // The `??` fallback exists only for the caller that omits the prop entirely
   // (the Tools page's hand-built entry) and reproduces the pre-field gate.
   const configurable = Boolean(canConfigure ?? isGloballyConnected)
@@ -249,12 +249,10 @@ export function OfficialMcpSettingsDialog({
             )}
 
             {/* Configure / manage-my-key: gated on configurable, not on
-                isGloballyConnected. This is the one button whose availability
-                answers a different question than the other three below — "does
-                the edit route resolve for this viewer" rather than "is this
-                entry connected" — which is why it was pulled out of the IIFE
-                that used to wrap all four as a single isGloballyConnected
-                block. */}
+                isGloballyConnected. It is the one button here whose
+                availability answers a different question than the two below —
+                "does the edit route resolve for this viewer" rather than "is
+                this entry connected". */}
             {configurable && !isNonOwnedTeamTool && !isKeyless && (
               <Button
                 className="w-full max-w-[200px] rounded-full h-11 font-medium bg-slate-900 text-white hover:bg-slate-800"

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
@@ -19,6 +19,13 @@ interface OfficialMcpSettingsDialogProps {
   onSuccess?: () => void
   onDisconnect?: (app: AppIntegration) => void
   isGloballyConnected?: boolean
+  // Whether this viewer's Configure route would resolve — a backend fact
+  // (list_mcp_apps.can_configure), passed in like isGloballyConnected rather
+  // than read off `app`, because the two call sites answer it differently: the
+  // connector picker reads the listing field, while the Tools page hands this
+  // dialog a hand-built entry that carries no listing fields at all. Omitted
+  // means "use the connection state", which is exactly the gate this replaced.
+  canConfigure?: boolean
   onConnectStart?: (app: AppIntegration) => void
   onConfigure?: (app: AppIntegration) => void
   onManageKey?: (app: AppIntegration) => void
@@ -37,6 +44,7 @@ export function OfficialMcpSettingsDialog({
   onSuccess,
   onDisconnect,
   isGloballyConnected = false,
+  canConfigure,
   onConnectStart,
   onConfigure,
   onManageKey,
@@ -161,6 +169,21 @@ export function OfficialMcpSettingsDialog({
 
   if (!app) return null;
 
+  // configurable answers "would the edit route resolve for this viewer" —
+  // independent of connection state (D6/D8): a connector whose tokens arrive
+  // through a deployment-installed resolver hook is never "connected" for its
+  // own creator, yet its owner holds the association the edit routes require.
+  // The `??` fallback exists only for the caller that omits the prop entirely
+  // (the Tools page's hand-built entry) and reproduces the pre-field gate.
+  const configurable = Boolean(canConfigure ?? isGloballyConnected)
+  const isKeyBased = app.auth_type === "api_key"
+  // Keyless apps have no key and no editable config — once connected,
+  // disconnect is the only sensible action.
+  const isKeyless = app.auth_type === "keyless"
+  // Team tool the viewer doesn't own: they can use it, but the backend
+  // rejects edit/delete/unshare (403), so don't render those buttons.
+  const isNonOwnedTeamTool = Boolean(app.shared) && app.is_owner === false
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md text-center p-0 overflow-hidden bg-white shadow-xl">
@@ -225,66 +248,63 @@ export function OfficialMcpSettingsDialog({
               </Button>
             )}
 
-            {isGloballyConnected && (
-              <>
-                {(() => {
-                  const isKeyBased = app.auth_type === "api_key"
-                  // Keyless apps have no key and no editable config — once
-                  // connected, disconnect is the only sensible action.
-                  const isKeyless = app.auth_type === "keyless"
-                  // Team tool the viewer doesn't own: they can use it, but the backend
-                  // rejects edit/delete/unshare (403), so don't render those buttons.
-                  const isNonOwnedTeamTool = Boolean(app.shared) && app.is_owner === false
-                  return (
-                    <>
-                      {!isNonOwnedTeamTool && !isKeyless && (
-                        <Button
-                          className="w-full max-w-[200px] rounded-full h-11 font-medium bg-slate-900 text-white hover:bg-slate-800"
-                          onClick={() => {
-                            // Key-based apps: users only manage their own key, never the
-                            // shared server config. Route to the key dialog, not the form.
-                            if (isKeyBased && onManageKey) {
-                              onManageKey(app);
-                            } else if (app.is_custom && onConfigure) {
-                              onConfigure(app);
-                            } else {
-                              handleConnectApp(app);
-                            }
-                          }}
-                        >
-                          <Settings className="h-4 w-4 mr-2" />
-                          {isKeyBased ? t('tools.mcp.dialog.manageKey') : t('tools.mcp.dialog.configure')}
-                        </Button>
-                      )}
-                      {/* "Make team" / "Make personal": only the owner (or a team admin,
-                          enforced server-side) can change ownership. Hidden on non-owned
-                          team tools. */}
-                      {inTeam && Number.isInteger(app.server_id) && !isNonOwnedTeamTool && (
-                        <Button
-                          variant="outline"
-                          className="w-full max-w-[200px] rounded-full h-11 font-medium"
-                          onClick={() => handleToggleShare(app, !app.shared)}
-                        >
-                          {app.shared ? (
-                            <><UserMinus className="h-4 w-4 mr-2" /> {t('tools.mcp.sharing.unshare')}</>
-                          ) : (
-                            <><Users className="h-4 w-4 mr-2" /> {t('tools.mcp.sharing.share')}</>
-                          )}
-                        </Button>
-                      )}
-                      {!isNonOwnedTeamTool && (
-                        <Button
-                          variant="outline"
-                          className="w-full max-w-[200px] rounded-full h-11 font-medium text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200"
-                          onClick={() => handleDisconnectApp(app)}
-                        >
-                          <Unlink className="h-4 w-4 mr-2" /> {(app.is_custom && !isKeyBased) ? t('tools.mcp.dialog.deleteService') : t('tools.mcp.dialog.disconnect')}
-                        </Button>
-                      )}
-                    </>
-                  )
-                })()}
-              </>
+            {/* Configure / manage-my-key: gated on configurable, not on
+                isGloballyConnected. This is the one button whose availability
+                answers a different question than the other three below — "does
+                the edit route resolve for this viewer" rather than "is this
+                entry connected" — which is why it was pulled out of the IIFE
+                that used to wrap all four as a single isGloballyConnected
+                block. */}
+            {configurable && !isNonOwnedTeamTool && !isKeyless && (
+              <Button
+                className="w-full max-w-[200px] rounded-full h-11 font-medium bg-slate-900 text-white hover:bg-slate-800"
+                onClick={() => {
+                  // Key-based apps: users only manage their own key, never the
+                  // shared server config. Route to the key dialog, not the form.
+                  if (isKeyBased && onManageKey) {
+                    onManageKey(app);
+                  } else if (app.is_custom && onConfigure) {
+                    onConfigure(app);
+                  } else {
+                    handleConnectApp(app);
+                  }
+                }}
+              >
+                <Settings className="h-4 w-4 mr-2" />
+                {isKeyBased ? t('tools.mcp.dialog.manageKey') : t('tools.mcp.dialog.configure')}
+              </Button>
+            )}
+            {/* "Make team" / "Make personal": only the owner (or a team admin,
+                enforced server-side) can change ownership. Hidden on non-owned
+                team tools. Unlike Configure, this route lives entirely in the
+                overlay layer, whose precondition upstream cannot answer, so it
+                keeps reading isGloballyConnected. */}
+            {isGloballyConnected && inTeam && Number.isInteger(app.server_id) && !isNonOwnedTeamTool && (
+              <Button
+                variant="outline"
+                className="w-full max-w-[200px] rounded-full h-11 font-medium"
+                onClick={() => handleToggleShare(app, !app.shared)}
+              >
+                {app.shared ? (
+                  <><UserMinus className="h-4 w-4 mr-2" /> {t('tools.mcp.sharing.unshare')}</>
+                ) : (
+                  <><Users className="h-4 w-4 mr-2" /> {t('tools.mcp.sharing.share')}</>
+                )}
+              </Button>
+            )}
+            {/* Disconnect deletes the row outright (DELETE .../servers/{id} or
+                .../custom-apis/{id}), so it is meaningful even with zero
+                grants — unlike Configure it keeps its own is_connected-based
+                door, which is a separate, pre-existing gate mismatch tracked
+                on its own and not addressed here. */}
+            {isGloballyConnected && !isNonOwnedTeamTool && (
+              <Button
+                variant="outline"
+                className="w-full max-w-[200px] rounded-full h-11 font-medium text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200"
+                onClick={() => handleDisconnectApp(app)}
+              >
+                <Unlink className="h-4 w-4 mr-2" /> {(app.is_custom && !isKeyBased) ? t('tools.mcp.dialog.deleteService') : t('tools.mcp.dialog.disconnect')}
+              </Button>
             )}
           </div>
         </div>

--- a/frontend/src/components/mcp/types.ts
+++ b/frontend/src/components/mcp/types.ts
@@ -46,6 +46,15 @@ export interface AppIntegration {
   // a deployment whose tokens arrive through the resolver hook, where no
   // interactive consent exists at all.
   can_authorize?: boolean
+  // Whether this viewer's Configure route would resolve, decided by the
+  // backend (list_mcp_apps._local_mcp_can_configure for local entries; the
+  // connection state for a catalog entry, whose Configure equivalent is
+  // "manage my key" or "re-run OAuth" and only exists once connected) rather
+  // than re-derived here from is_connected. A connector whose tokens arrive
+  // through a deployment-installed resolver hook is never "connected" for
+  // its own creator -- no personal grant row is ever written -- so the
+  // connected gate hid the edit route from the one person entitled to it.
+  can_configure?: boolean
   // Team-sharing status (from POST /api/connectors/status), merged in after list load.
   shared?: boolean
   is_owner?: boolean

--- a/frontend/src/components/mcp/types.ts
+++ b/frontend/src/components/mcp/types.ts
@@ -47,8 +47,9 @@ export interface AppIntegration {
   // interactive consent exists at all.
   can_authorize?: boolean
   // Whether this viewer's Configure route would resolve, decided by the
-  // backend (list_mcp_apps._local_mcp_can_configure for local entries; the
-  // connection state for a catalog entry, whose Configure equivalent is
+  // backend (_local_mcp_can_configure in src/xagent/web/api/mcp.py for
+  // local entries; the connection state for a catalog entry, whose
+  // Configure equivalent is
   // "manage my key" or "re-run OAuth" and only exists once connected) rather
   // than re-derived here from is_connected. A connector whose tokens arrive
   // through a deployment-installed resolver hook is never "connected" for

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2000,6 +2000,43 @@ def _local_mcp_can_authorize(
     return _local_mcp_consent_association_ok(server, user_mcp)
 
 
+def _local_mcp_can_configure(
+    association: Union[UserMCPServer, UserCustomApi, None],
+) -> bool:
+    """Whether this viewer's configuration route would resolve for a local entry.
+
+    One rule for both local branches: the four routes the picker's Configure
+    button reaches all take the same first gate -- a personal association row
+    for the calling user -- and answer 404 without one. ``GET``/``PUT
+    /api/mcp/servers/{id}`` (mcp.py) and ``GET``/``PUT /api/custom-apis/{id}``
+    (custom_api.py) each query by ``user_id`` + connector id and raise 404 on
+    an empty result, which is why a team-owned connector reaching a member
+    through the visibility overlay alone (``association is None``) is not
+    configurable however visible or attachable it is.
+
+    Deliberately reads nothing but the association's existence:
+
+    - Not the connector's shape. Unlike ``can_attach``/``can_authorize``, no
+      route this answers for treats the mcp_oauth shape differently.
+    - Not ``is_active``. Neither route filters it, so a deactivated connector's
+      owner can still open and save its form -- and withholding the button
+      there would remove the only affordance that population has left.
+    - Not ``can_edit``. Existence alone is what the four routes' first gate
+      reads, and it is what this answers. Custom API's ``PUT`` has a second,
+      owner-side gate on ``can_edit`` (403), so this field's accuracy there
+      rests on a convention rather than an identity: the one production write
+      point sets ``can_edit=True`` (custom_api.py), and no other code path
+      creates the row. A future writer that leaves the column at its ``False``
+      default would make this field claim an editable entry whose save is
+      refused -- add that gate here if that ever happens.
+
+    This is a UI hint, never a permission. Editing the shared configuration is
+    additionally gated owner-side (``_check_mcp_permission(require="edit")``
+    for MCP, ``can_edit`` for Custom API), and a forged value grants nothing.
+    """
+    return association is not None
+
+
 @mcp_router.get("/apps", response_model=List[dict])
 def list_mcp_apps(
     search: Optional[str] = None,
@@ -2152,6 +2189,13 @@ def list_mcp_apps(
             # inferring it from is_custom's absence on this branch (#1347).
             app_copy["can_attach"] = is_connected
             app_copy["can_authorize"] = False
+            # A catalog entry's Configure equivalent is "manage my key" or
+            # "re-run OAuth" (settings dialog dispatch on auth_type), and both
+            # only exist once connected -- an unconnected entry's action is
+            # Connect, a different button. Equal to is_connected on this
+            # branch only; the local branches below answer a different
+            # question (association existence), see _local_mcp_can_configure.
+            app_copy["can_configure"] = is_connected
             app_copy["shared_env_available"] = app_shared_env
             app_copy["platform_env_available"] = app_platform_env
             app_copy["user_env_configured"] = app_user_env
@@ -2274,6 +2318,7 @@ def list_mcp_apps(
                     user_mcp,
                     token_resolver_installed=token_resolver_installed,
                 ),
+                "can_configure": _local_mcp_can_configure(user_mcp),
             }
             # The picker dispatches its Connect button on auth_type, and custom
             # entries used to omit the field entirely — so an mcp_oauth server
@@ -2313,8 +2358,9 @@ def list_mcp_apps(
 
         # Same overlay as the MCP half above: a team-owned Custom API has no
         # UserCustomApi row for the member, so it is carried as (api, None).
-        # The association is read only for can_attach below — a team-owned API
-        # is one the runtime overlays by id, exactly like the MCP half.
+        # The association is read for can_attach and can_configure below — a
+        # team-owned API is one the runtime overlays by id, exactly like the
+        # MCP half.
         local_custom_apis: list[tuple[CustomApi, UserCustomApi | None]] = [
             (api, user_api) for user_api, api in user_custom_apis
         ]
@@ -2367,6 +2413,7 @@ def list_mcp_apps(
                         team_ids=team_ids["custom_api"],
                     ),
                     "can_authorize": False,
+                    "can_configure": _local_mcp_can_configure(user_api),
                     "runtime_input_schema": api.runtime_input_schema,
                     "runtime_bindings": api.runtime_bindings,
                     "allow_delegated_authorization": bool(

--- a/tests/web/api/test_mcp_apps_attachability.py
+++ b/tests/web/api/test_mcp_apps_attachability.py
@@ -1,19 +1,22 @@
-"""`/api/mcp/apps` must emit its attachability decisions, not their inputs
-(#1347).
+"""`/api/mcp/apps` must emit its attachability and configurability decisions,
+not their inputs (#1347).
 
-The connector picker used to reconstruct two decisions from
+The connector picker used to reconstruct these decisions from
 `is_connected` + `is_custom` + `auth_type`, which made three unstated backend
 emission rules load-bearing on the client: that `is_connected` for an
 mcp_oauth entry requires an active grant, that `auth_type` appears on a local
 entry only alongside an active personal association, and that `is_custom` is
-never set by the catalog branch. These tests pin `can_attach` and
-`can_authorize` directly, so changing any of those rules fails here instead of
-silently mis-gating the picker.
+never set by the catalog branch. These tests pin `can_attach`, `can_authorize`
+and `can_configure` directly, so changing any of those rules fails here
+instead of silently mis-gating the picker.
 
-The two fields answer different questions and diverge on real populations:
+The three fields answer different questions and diverge on real populations:
 a team-owned mcp_oauth connector is attachable but has no consent flow the
-member could start, and a hook-resolved connector is attachable with no
-consent flow existing at all.
+member could start; a hook-resolved connector is attachable with no consent
+flow existing at all; and `can_configure` answers whether the entry's edit
+route would resolve for the caller -- a personal association row for a local
+entry, or an existing connection for a catalog entry -- which is independent
+of both.
 """
 
 from __future__ import annotations
@@ -184,8 +187,10 @@ def _grant(db, server: MCPServer, user: User, *, status: str = "active") -> None
 
 
 def _add_custom_api(
-    db, owner: User, name: str = "billing", *, is_active: bool = True
+    db, owner: User | None, name: str = "billing", *, is_active: bool = True
 ) -> CustomApi:
+    """A custom API. ``owner=None`` writes no association at all, which is how
+    a team-owned custom API reaches a member."""
     api = CustomApi(
         name=name,
         description=f"{name} API",
@@ -195,15 +200,20 @@ def _add_custom_api(
     db.add(api)
     db.commit()
     db.refresh(api)
-    db.add(
-        UserCustomApi(
-            user_id=owner.id,
-            custom_api_id=api.id,
-            is_owner=True,
-            is_active=is_active,
+    if owner is not None:
+        db.add(
+            UserCustomApi(
+                user_id=owner.id,
+                custom_api_id=api.id,
+                is_owner=True,
+                # Matches the one production write point (custom_api.py:248);
+                # the column defaults to False, and PUT's second gate reads it,
+                # so a fixture without it is a shape production never creates.
+                can_edit=True,
+                is_active=is_active,
+            )
         )
-    )
-    db.commit()
+        db.commit()
     return api
 
 
@@ -662,12 +672,176 @@ def test_a_connected_catalog_app_is_attachable(db_session):
     assert entry["can_authorize"] is False
 
 
-# --- Every entry carries both fields ---------------------------------------
+# --- AC: can_configure, the picker's edit-route gate ------------------------
 
 
-def test_every_listed_entry_carries_both_decisions(db_session):
+def test_a_hook_resolved_connector_is_configurable_by_its_owner(db_session):
+    """#1332's population again: is_connected and can_authorize are both
+    false for a hook-resolved connector, yet its owner holds the personal
+    association the edit routes require, so the three fields must disagree."""
+    db, owner, _member = db_session
+    _add_oauth_server(db, owner)
+    _install_token_resolver()
+
+    entry = _entry(db, owner, "records")
+    assert entry["is_connected"] is False
+    assert entry["can_authorize"] is False
+    assert entry["can_configure"] is True
+
+
+def test_a_never_authorized_connector_is_both_configurable_and_authorizable(
+    db_session,
+):
+    """A connector whose owner has an active association but never completed
+    consent needs both: Configure to fix a misconfigured field, Authorize to
+    complete consent. Neither implies the other."""
+    db, owner, _member = db_session
+    _add_oauth_server(db, owner)
+
+    entry = _entry(db, owner, "records")
+    assert entry["can_configure"] is True and entry["can_authorize"] is True
+
+
+def test_a_deactivated_association_stays_configurable(db_session):
+    """Neither GET nor PUT /api/mcp/servers/{id} filters is_active, so a
+    deactivated connector's owner can still open and save its form -- unlike
+    can_attach, which the runtime's own query does filter on."""
+    db, owner, _member = db_session
+    _add_stdio_server(db, owner, is_active=False)
+
+    entry = _entry(db, owner, "files")
+    assert entry["can_attach"] is False and entry["can_configure"] is True
+
+
+def test_a_team_owned_connector_without_a_personal_association_is_not_configurable(
+    db_session,
+):
+    """The overlay makes this connector attachable for the member, but the
+    edit routes require a row of the member's own, which does not exist here
+    -- so GET/PUT /api/mcp/servers/{id} would 404."""
+    db, _owner, member = db_session
+    server = _add_oauth_server(db, None)
+    _install_visibility(
+        {int(member.id): {"mcp": {int(server.id)}, "custom_api": set()}}
+    )
+    _install_token_resolver()
+
+    entry = _entry(db, member, "records")
+    assert entry["can_attach"] is True and entry["can_configure"] is False
+
+
+def test_a_team_owned_custom_api_without_a_personal_association_is_not_configurable(
+    db_session,
+):
+    """The Custom API half of the same rule. `is_connected` is hardcoded True
+    for every Custom API entry, and must not be mistaken for configurability."""
+    db, _owner, member = db_session
+    api = _add_custom_api(db, None)
+    _install_visibility({int(member.id): {"mcp": set(), "custom_api": {int(api.id)}}})
+
+    entry = _entry(db, member, "billing")
+    assert entry["is_connected"] is True and entry["can_configure"] is False
+
+
+def test_an_own_custom_api_is_configurable(db_session):
+    db, owner, _member = db_session
+    _add_custom_api(db, owner)
+
+    entry = _entry(db, owner, "billing")
+    assert entry["can_configure"] is True
+
+
+def test_an_unconnected_catalog_app_is_not_configurable(db_session):
+    """The catalog branch's Configure equivalent is "manage my key" or
+    "re-run OAuth", both of which only exist once connected -- guarding
+    against the dead-button regression an unconditional True would reintroduce."""
+    db, owner, _member = db_session
+    _add_catalog_oauth_app(db)
+    _add_catalog_builtin_oauth_app(db)
+
+    granola = _entry(db, owner, "granola", location="remote")
+    acme = _entry(db, owner, "acme-crm", location="remote")
+    assert granola["can_configure"] is False
+    assert acme["can_configure"] is False
+
+
+def test_a_connected_catalog_app_is_configurable(db_session):
+    db, owner, _member = db_session
+    app = PublicMCPApp(
+        app_id="acme-docs",
+        name="Acme Docs",
+        description="A catalog app",
+        icon="",
+        category="Productivity",
+        transport="stdio",
+        launch_config={"command": "acme-docs-mcp"},
+        is_visible_in_connector=True,
+    )
+    db.add(app)
+    db.commit()
+    server = MCPServer.from_config(
+        {
+            "name": "acme-docs",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "acme-docs-mcp",
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=owner.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    entry = _entry(db, owner, "acme-docs", location="remote")
+    assert entry["can_configure"] is True
+
+
+def test_a_resolver_hook_does_not_make_a_catalog_app_configurable(db_session):
+    """The resolver hook only relaxes the credential gate on the local mcp_oauth
+    branch; the catalog branch's can_configure is the connection state, which
+    the hook does not touch."""
+    db, owner, _member = db_session
+    _add_catalog_oauth_app(db)
+    _install_token_resolver()
+
+    entry = _entry(db, owner, "granola", location="remote")
+    assert entry["can_configure"] is False
+
+
+def test_a_non_owner_with_a_personal_association_is_configurable(db_session):
+    """A non-owner's personal env override is still their own row to edit:
+    the edit routes' first gate is association existence, not is_owner."""
+    db, owner, member = db_session
+    server = _add_stdio_server(db, owner)
+    db.add(
+        UserMCPServer(
+            user_id=member.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    entry = _entry(db, member, "files")
+    assert entry["can_configure"] is True
+
+
+# --- Every entry carries all three decisions ---------------------------------
+
+
+def test_every_listed_entry_carries_all_three_decisions(db_session):
     """A consumer reading `can_attach` must never see undefined and silently
-    treat an entry as unattachable, whichever branch emitted it."""
+    treat an entry as unattachable, whichever branch emitted it. Same for
+    `can_authorize` and `can_configure`."""
     db, owner, _member = db_session
     _add_stdio_server(db, owner)
     _add_oauth_server(db, owner)
@@ -682,3 +856,4 @@ def test_every_listed_entry_carries_both_decisions(db_session):
     for entry in entries:
         assert isinstance(entry.get("can_attach"), bool), entry["id"]
         assert isinstance(entry.get("can_authorize"), bool), entry["id"]
+        assert isinstance(entry.get("can_configure"), bool), entry["id"]


### PR DESCRIPTION
Closes #1512.

## What this does

`GET /api/mcp/apps` now emits a `can_configure` decision on every entry, and the "+ Connector" picker card plus the detail modal gate the Configure action on it instead of on `is_connected`. This is the same shape #1384 introduced for `can_attach` / `can_authorize`. Connected-state display — the checkmark, sharing badges, and the modal's Share / Disconnect group — stays on `is_connected`.

## Field contract

`can_configure` answers "does the entry's Configure action have something behind it", per producing branch:

- **catalog entries**: `= is_connected`. Their button manages keys or re-runs authorization, which only exist once connected — unchanged from today.
- **local custom MCP entries**: the caller holds an association row for the server. That row is exactly the first gate of `GET`/`PUT /api/mcp/servers/{id}`, so the field mirrors what the edit routes will answer.
- **Custom API entries**: same, on the caller's `UserCustomApi` row.

The decision deliberately reads nothing but the association's existence — not the server's auth shape, not `is_active`, not `can_edit` — for the reasons documented on the helper's docstring. It is a UI hint, never a permission: editing remains gated server-side by the association row (404) and the owner-side checks (403), and a forged value grants nothing.

## Frontend changes

- The card footer's Configure / Authorize ternary becomes two independent blocks: a connector that is configurable and separately authorizable (created but never authorized) now shows both, and suppressing one can no longer silently suppress the other.
- The detail modal takes an optional `canConfigure` prop; when omitted it falls back to `isGloballyConnected`, so the Tools page call site — which hand-builds its app object and hard-codes the connected flag — keeps today's behavior without changes. The fallback also covers a rolling-deploy window where an older backend does not emit the field; producer-side coverage is pinned by `test_every_listed_entry_carries_all_three_decisions`.

## Behavior changes

| Entry | Before | After |
|---|---|---|
| Custom mcp_oauth connector with hook-resolved tokens (never any grant) | No Configure, no Authorize — no action at all | Configure renders; owner reaches the edit form from the picker |
| Custom mcp_oauth connector, never authorized, interactive flow | Authorize only | Configure and Authorize side by side |
| Custom connector whose association row is deactivated, no grant | No action | Configure renders (its edit form has always been reachable from the Tools page) |
| Team-owned stdio connector, viewer holds no association row | Configure rendered, but its target routes 404 for this viewer | No Configure — matches the Tools page, whose team stubs already report `can_edit: false` for these rows |
| Team-owned Custom API, viewer holds no association row | Same dead Configure | Same tightening |

The two tightened rows align the picker with `/api/mcp/servers` and the Tools page, which already deny editing for team entries the viewer holds no row for. In select mode those two cards no longer offer a route into the detail modal; the modal's own actions were already hidden for them.

## Out of scope

- The detail modal's Connect button is unchanged; in a hook deployment it can still start an OAuth popup that cannot complete (the `can_connect` residual #1384 already noted).
- #1389 (deactivated connector still reporting `is_connected: true`) is not addressed; the entry keeps its checkmark. The new field only stops Configure from borrowing that state.

## Verification

- `tests/web/api/test_mcp_apps_attachability.py`: 34 passed (was 24); the new tests cover all three producing branches, both tightened cells, and pin that every listed entry carries a boolean `can_configure`.
- `frontend/src/components/mcp`: 96 passed across 5 files (was 85), including both directions of the gate swap: removing the field's effect re-lights the dead-button cells, and reverting the gate to `isGloballyConnected` fails the hook-resolved and team-owned cases.
- Mutation checks: forcing the backend helper to `True` fails only the two tightened-cell tests; forcing the catalog branch to `False` fails the connected-catalog test; reverting either frontend gate to `isGloballyConnected` fails the corresponding card/modal tests.
- `tests/web` + `tests/architecture` (CI marker set): zero failures. `tsc --noEmit` clean, i18n literal-count pin green, pre-commit green.
