### PR TITLE
security(websocket): redact incidental exception text from chat clients

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -327,17 +327,22 @@ def _client_message_id(value: Any) -> str | None:
 # error bubble and the message_rejected ack, so an *incidental* validation
 # failure only ever surfaces as this fixed string; the detail stays in the log.
 #
-# Agent RuntimeError text is deliberately left alone, and narrowing it is a
-# product decision tracked in #1479 rather than a redaction bug.
+# Agent RuntimeError text is passed through to the INITIATING SENDER only -
+# the rejection ack and the personal error bubble - which is the existing
+# contract, and narrowing that wording is the product decision left in #1479.
 #
-# It is NOT sender-only. An earlier version of this comment said so and cited
-# tests/web/api/test_websocket_owner_actor.py; that file never pins the string,
-# and its one raw-RuntimeError assertion covers the sender-only pool-timeout
-# fallback. Once a task resolves, the text goes out through broadcast_to_task
-# to every connection under the task_id, anonymous widget and share visitors
-# included. DurableStorageOperationError subclasses RuntimeError, so the
-# tenant-scope leak described above is still open on that path.
+# The broadcast half of that passthrough is closed (maintainer scope ruling
+# on #1514): once a task resolves, the task-wide broadcast reaches every
+# connection under the task_id, anonymous widget and share visitors included,
+# and DurableStorageOperationError subclasses RuntimeError with tenant-scope
+# text in its message - so broadcasts carry CLIENT_SAFE_TASK_FAILURE, never
+# the exception text. Still #1479: whether the sender copy should also be
+# narrowed when the initiator is an anonymous public connection.
 CLIENT_SAFE_VALIDATION_ERROR = "The message could not be processed. Please try again."
+
+# Broadcast audiences did not send anything, so the validation wording above
+# would be misdirected; task-level failure broadcasts use this instead.
+CLIENT_SAFE_TASK_FAILURE = "Task execution failed."
 
 
 class ClientVisibleError(Exception):
@@ -6519,7 +6524,9 @@ async def _handle_chat_message_unserialized(
                     websocket,
                 )
         except RuntimeError as e:
-            # Runtime error
+            # Runtime error. The sender's rejection ack keeps the wording
+            # (#1479 contract); the task-wide broadcast reaches anonymous
+            # subscribers and gets the fixed string instead.
             message = f"Runtime error: {str(e)}"
             logger.error("Runtime error in agent execution: %s", e, exc_info=True)
             if not await finish_delivery_failure(message):
@@ -6528,7 +6535,7 @@ async def _handle_chat_message_unserialized(
             if authorized_task_id is not None:
                 error_payload = await _read_task_error_payload_offloop(
                     authorized_task_id,
-                    message,
+                    CLIENT_SAFE_TASK_FAILURE,
                 )
                 await manager.broadcast_to_task(
                     {
@@ -6768,14 +6775,16 @@ async def handle_execute_task(
                 websocket,
             )
     except RuntimeError as e:
-        # Runtime error
+        # Runtime error. The initiating sender keeps the wording (#1479
+        # contract); the task-wide broadcast reaches anonymous subscribers
+        # and gets the fixed string instead.
         message = f"Runtime error: {str(e)}"
         logger.error("Runtime error in task execution: %s", e, exc_info=True)
         timestamp = datetime.now(timezone.utc).isoformat()
         if authorized_task_id is not None:
             error_payload = await _read_task_error_payload_offloop(
                 authorized_task_id,
-                message,
+                CLIENT_SAFE_TASK_FAILURE,
             )
             await manager.broadcast_to_task(
                 {

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2,12 +2,12 @@
 
 import asyncio
 import json
-from collections import OrderedDict
 import logging
 import re
 import shutil
 import time
 import uuid
+from collections import OrderedDict
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -368,6 +368,24 @@ def client_safe_error_message(error: Exception) -> str:
     )
 
 
+def log_client_facing_failure(error: Exception, template: str, *args: object) -> None:
+    """Record a failure whose text the client will not see in full.
+
+    A ``ClientVisibleError`` is an answer written for the sender - an
+    unauthenticated frame, a task that no longer exists - so it is routine
+    and gets no traceback; otherwise any visitor could emit stack dumps on
+    demand. Anything else is incidental, and once its text is redacted the
+    traceback is the only record left.
+
+    ``template`` ends in the ``%s`` that receives ``error``; ``args`` fill the
+    placeholders before it.
+    """
+    if isinstance(error, ClientVisibleError):
+        logger.warning(template, *args, error)
+    else:
+        logger.error(template, *args, error, exc_info=True)
+
+
 async def send_message_delivery(
     websocket: WebSocket,
     *,
@@ -5013,9 +5031,7 @@ async def handle_chat_message(
             allow_missing_task=True,
         )
     except (PermissionError, ValueError) as exc:
-        logger.error(
-            "Chat command rejected for task %s: %s", task_id, exc, exc_info=True
-        )
+        log_client_facing_failure(exc, "Chat command rejected for task %s: %s", task_id)
         client_message_id = _client_message_id(message_data.get("client_message_id"))
         await send_message_delivery(
             websocket,
@@ -6493,7 +6509,8 @@ async def _handle_chat_message_unserialized(
                 )
         except Exception as e:
             # Other unknown errors, re-raise
-            logger.error("Unexpected error in agent execution: %s", e, exc_info=True)
+            # Re-raised: the outermost handler owns the traceback.
+            logger.error("Unexpected error in agent execution: %s", e)
             await finish_delivery_failure(client_safe_error_message(e))
             raise
 
@@ -6511,7 +6528,8 @@ async def _handle_chat_message_unserialized(
         raise
     except Exception as e:
         # Other errors, re-raise
-        logger.error("Unexpected error handling chat message: %s", e, exc_info=True)
+        # Re-raised: the outermost handler owns the traceback.
+        logger.error("Unexpected error handling chat message: %s", e)
         await finish_delivery_failure(client_safe_error_message(e))
         raise
 
@@ -6732,7 +6750,7 @@ async def handle_execute_task(
             )
     except Exception as e:
         # Other unknown errors, re-raise
-        logger.error(f"Unexpected error in task execution: {e}")
+        logger.error("Unexpected error in task execution: %s", e)
         raise
 
 
@@ -7453,13 +7471,13 @@ async def handle_intervention(
         )
     except RuntimeError as e:
         # Runtime error
-        logger.error(f"Runtime error in intervention: {e}")
+        logger.error("Runtime error in intervention: %s", e, exc_info=True)
         await manager.send_personal_message(
             {"type": "error", "message": f"Runtime error: {str(e)}"}, websocket
         )
     except Exception as e:
         # Other errors, re-raise
-        logger.error(f"Unexpected error in intervention: {e}")
+        logger.error("Unexpected error in intervention: %s", e)
         raise
 
 
@@ -7476,11 +7494,8 @@ async def handle_pause_task(
             command_id=_client_message_id(message_data.get("command_id")),
         )
     except (PermissionError, ValueError) as exc:
-        logger.error(
-            "Pause command rejected for task %s: %s",
-            task_id,
-            exc,
-            exc_info=True,
+        log_client_facing_failure(
+            exc, "Pause command rejected for task %s: %s", task_id
         )
         await manager.send_personal_message(
             {"type": "error", "message": client_safe_error_message(exc)},
@@ -7718,14 +7733,14 @@ async def _handle_pause_task_unserialized(
         )
     except RuntimeError as e:
         # Runtime error
-        logger.error(f"Runtime error pausing task {task_id}: {e}")
+        logger.error("Runtime error pausing task %s: %s", task_id, e)
         await manager.send_personal_message(
             {"type": "error", "message": f"Runtime error: {str(e)}"}, websocket
         )
         raise
     except Exception as e:
         # Other errors, re-raise
-        logger.error(f"Unexpected error pausing task {task_id}: {e}")
+        logger.error("Unexpected error pausing task %s: %s", task_id, e)
         raise
 
 
@@ -7742,11 +7757,8 @@ async def handle_resume_task(
             command_id=_client_message_id(message_data.get("command_id")),
         )
     except (PermissionError, ValueError) as exc:
-        logger.error(
-            "Resume command rejected for task %s: %s",
-            task_id,
-            exc,
-            exc_info=True,
+        log_client_facing_failure(
+            exc, "Resume command rejected for task %s: %s", task_id
         )
         await manager.send_personal_message(
             {"type": "error", "message": client_safe_error_message(exc)},
@@ -8116,14 +8128,14 @@ async def _handle_resume_task_unserialized(
         )
     except RuntimeError as e:
         # Runtime error
-        logger.error(f"Runtime error resuming task {task_id}: {e}")
+        logger.error("Runtime error resuming task %s: %s", task_id, e)
         await manager.send_personal_message(
             {"type": "error", "message": f"Runtime error: {str(e)}"}, websocket
         )
         raise
     except Exception as e:
         # Other errors, re-raise
-        logger.error(f"Unexpected error resuming task {task_id}: {e}")
+        logger.error("Unexpected error resuming task %s: %s", task_id, e)
         raise
 
 
@@ -8802,8 +8814,10 @@ clarification questions as plain assistant text.
                 logger.warning(f"Failed to send task_completed: {e}")
 
     except Exception as e:
-        logger.error(f"Error handling builder chat: {e}", exc_info=True)
-        await websocket.send_text(json.dumps({"type": "error", "message": str(e)}))
+        logger.error("Error handling builder chat: %s", e, exc_info=True)
+        await websocket.send_text(
+            json.dumps({"type": "error", "message": client_safe_error_message(e)})
+        )
 
 
 @ws_router.websocket("/ws/build/preview")
@@ -8886,7 +8900,9 @@ async def websocket_build_preview_endpoint(
                     json.dumps(
                         {
                             "type": "error",
-                            "message": f"Unknown message type: {message_type}",
+                            # Not echoed back: matches the main loop at the
+                            # "Unknown message type" site above.
+                            "message": "Unknown message type",
                         }
                     )
                 )

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from collections import OrderedDict
 import logging
 import re
 import shutil
@@ -4632,20 +4633,28 @@ class _CommandOriginRegistry:
     another sender's error detail to itself. Re-registering the *same* socket
     is idempotent.
 
+    Only the ingress that *created* the durable row registers (callers gate on
+    ``EnqueuedTaskCommand.created``); a payload-matching duplicate never binds,
+    which is what keeps a co-tenant, a post-disconnect resubmission, or a
+    duplicate handled on another worker from acquiring the origin.
+
     Lifecycle: an entry dies with its socket (``discard_socket`` from
-    ``ConnectionManager.disconnect``) or with its command's terminal outcome
-    (``discard_command`` from the durable dispatch wrapper), whichever comes
-    first (``detach_task_connections`` also clears them). A deferred command
-    that will retry keeps its entry. An entry whose command is claimed by
-    another worker is never resolved here (wrong worker); it is reclaimed when
-    this worker's socket disconnects, so the only unbounded case would be a
-    socket that never disconnects while submitting commands that always run
-    elsewhere - not a shape this deployment produces, and tracked rather than
-    given a TTL here.
+    ``ConnectionManager.disconnect`` and ``detach_task_connections``) or with
+    its command's terminal outcome (``discard_command`` from the durable
+    dispatch wrapper), whichever comes first. A deferred command that will
+    retry keeps its entry. An entry whose command is claimed by another worker
+    is never resolved here (wrong worker) and its local cleanup never runs, so
+    to bound that case the store is an LRU capped at ``_MAX_ORIGINS``: an
+    eviction just makes ``resolve`` miss and the executor degrade to the safe
+    discard, so a socket that never disconnects while its commands always run
+    elsewhere can cost at most the wording on the oldest few, never unbounded
+    memory.
     """
 
+    _MAX_ORIGINS = 4096
+
     def __init__(self) -> None:
-        self._origins: dict[tuple[int, str], Any] = {}
+        self._origins: OrderedDict[tuple[int, str], Any] = OrderedDict()
 
     def register(self, command_id: str, websocket: Any, task_id: int) -> None:
         if not command_id:
@@ -4657,6 +4666,11 @@ class _CommandOriginRegistry:
             # must not capture this command's origin.
             return
         self._origins[key] = websocket
+        self._origins.move_to_end(key)
+        while len(self._origins) > self._MAX_ORIGINS:
+            # Oldest first: eviction degrades that command to the safe discard,
+            # it never reroutes detail.
+            self._origins.popitem(last=False)
 
     def resolve(self, command_id: str, task_id: int) -> Any | None:
         websocket = self._origins.get((int(task_id), command_id))
@@ -5198,9 +5212,14 @@ async def handle_chat_message(
         accepted=True,
     )
     if enqueued.command_id:
-        # This connection is the verified origin of the command; personal
-        # detail from durable execution goes here or nowhere.
-        _command_origins.register(enqueued.client_command_id, websocket, task_id)
+        if enqueued.created:
+            # Only the ingress that created the durable row owns the origin.
+            # A payload-matching duplicate (created=False) - a co-tenant
+            # resubmission, one arriving after the creator disconnected, or one
+            # handled on another worker - must never bind, or it could receive
+            # the creator's raw error detail. Registered before dispatch so
+            # local execution cannot outrun the binding.
+            _command_origins.register(enqueued.client_command_id, websocket, task_id)
         await dispatch_task_command_promptly(
             execute_durable_task_command,
             command_db_id=enqueued.command_id,
@@ -7675,9 +7694,11 @@ async def handle_pause_task(
         },
         websocket,
     )
-    # This connection is the verified origin; personal detail from durable
-    # execution goes here or nowhere.
-    _command_origins.register(enqueued.client_command_id, websocket, task_id)
+    if enqueued.created:
+        # Only the creating ingress owns the origin; a payload-matching
+        # duplicate must never bind (see handle_chat_message). Registered
+        # before dispatch so local execution cannot outrun the binding.
+        _command_origins.register(enqueued.client_command_id, websocket, task_id)
     await dispatch_task_command_promptly(
         execute_durable_task_command,
         command_db_id=enqueued.command_id,
@@ -7943,9 +7964,11 @@ async def handle_resume_task(
         },
         websocket,
     )
-    # This connection is the verified origin; personal detail from durable
-    # execution goes here or nowhere.
-    _command_origins.register(enqueued.client_command_id, websocket, task_id)
+    if enqueued.created:
+        # Only the creating ingress owns the origin; a payload-matching
+        # duplicate must never bind (see handle_chat_message). Registered
+        # before dispatch so local execution cannot outrun the binding.
+        _command_origins.register(enqueued.client_command_id, websocket, task_id)
     await dispatch_task_command_promptly(
         execute_durable_task_command,
         command_db_id=enqueued.command_id,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -327,9 +327,16 @@ def _client_message_id(value: Any) -> str | None:
 # error bubble and the message_rejected ack, so an *incidental* validation
 # failure only ever surfaces as this fixed string; the detail stays in the log.
 #
-# Agent RuntimeError text is deliberately left alone: surfacing it to the sender
-# is an existing, tested contract (tests/web/api/test_websocket_owner_actor.py),
-# and narrowing it is a product decision rather than a redaction bug.
+# Agent RuntimeError text is deliberately left alone, and narrowing it is a
+# product decision tracked in #1479 rather than a redaction bug.
+#
+# It is NOT sender-only. An earlier version of this comment said so and cited
+# tests/web/api/test_websocket_owner_actor.py; that file never pins the string,
+# and its one raw-RuntimeError assertion covers the sender-only pool-timeout
+# fallback. Once a task resolves, the text goes out through broadcast_to_task
+# to every connection under the task_id, anonymous widget and share visitors
+# included. DurableStorageOperationError subclasses RuntimeError, so the
+# tenant-scope leak described above is still open on that path.
 CLIENT_SAFE_VALIDATION_ERROR = "The message could not be processed. Please try again."
 
 
@@ -351,15 +358,33 @@ class ClientVisiblePermissionError(ClientVisibleError, PermissionError):
     """An authorization refusal whose text is safe to show the sender."""
 
 
-def client_safe_error_message(error: Exception) -> str:
+class ClientVisibleTaskCommandDeferred(ClientVisibleError, TaskCommandDeferred):
+    """A deferral whose wording this module wrote for the sender.
+
+    Terminal deferral broadcasts go through the chokepoint like everything
+    else, so without the marker "waiting for the active task lease owner"
+    would reach the client as the generic string and become
+    indistinguishable from an outright failure.
+    """
+
+
+def client_safe_error_message(error: BaseException) -> str:
     """The only way an exception may become text a chat client can see.
 
-    Every ``message_rejected`` and ``error`` payload that this module builds
-    from an exception *at a direct call site* goes through here.
-    ``tests/web/api/test_websocket_client_safe_errors.py`` enforces that for
-    the shapes it recognizes; payloads assembled by a helper, spread into a
-    dict, or forwarded through a wrapper are not yet covered and still carry
-    raw text - see #1497.
+    ``tests/web/api/test_websocket_client_safe_errors.py`` enforces this for
+    the shapes it recognizes: direct calls to the delivery producers, and
+    ``error``/``agent_error`` dict *literals* handed to ``send_personal_message``,
+    ``broadcast_to_task`` or ``send_text``.
+
+    It does not reach payloads assembled by a helper, spread into a dict, or
+    forwarded through a wrapper (#1497). It also only ever inspects the
+    ``message`` key of a literal ``type`` it already knows: the background
+    failure broadcast at ``execute_task_background`` is invisible on both
+    counts at once, carrying its text under ``error`` with type ``task_error``
+    (#1497). A ``type`` built from a variable is likewise unseen (#1547).
+
+    Read a passing sweep as "the recognized shapes are clean", never as
+    "nothing reaches a client raw".
     """
     return (
         str(error)
@@ -6452,9 +6477,7 @@ async def _handle_chat_message_unserialized(
         except (ValueError, KeyError, TypeError) as e:
             # Data validation and format error
             message = client_safe_error_message(e)
-            logger.error(
-                "Data validation error in agent execution: %s", e, exc_info=True
-            )
+            log_client_facing_failure(e, "Data validation error in agent execution: %s")
             if not await finish_delivery_failure(message):
                 return
             timestamp = datetime.now(timezone.utc).timestamp()
@@ -6509,14 +6532,18 @@ async def _handle_chat_message_unserialized(
                 )
         except Exception as e:
             # Other unknown errors, re-raise
-            # Re-raised: the outermost handler owns the traceback.
-            logger.error("Unexpected error in agent execution: %s", e)
+            # The branch that withholds the detail logs it, rather than
+            # relying on a caller: the durable dispatcher does record a stack
+            # (task_command_transport.py:1100, logger.exception) but
+            # websocket_chat_endpoint and both public_chat_access.py endpoints
+            # log without exc_info, so the record depends on who called.
+            logger.error("Unexpected error in agent execution: %s", e, exc_info=True)
             await finish_delivery_failure(client_safe_error_message(e))
             raise
 
     except (ValueError, KeyError, TypeError) as e:
         # Message format error
-        logger.error("Message format error: %s", e, exc_info=True)
+        log_client_facing_failure(e, "Message format error: %s")
         message = client_safe_error_message(e)
         await finish_delivery_failure(message)
         await manager.send_personal_message(
@@ -6524,12 +6551,12 @@ async def _handle_chat_message_unserialized(
         )
     except (ConnectionError, WebSocketDisconnect) as e:
         # Connection error
-        logger.error(f"Connection error handling chat message: {e}")
+        logger.error("Connection error handling chat message: %s", e)
         raise
     except Exception as e:
         # Other errors, re-raise
-        # Re-raised: the outermost handler owns the traceback.
-        logger.error("Unexpected error handling chat message: %s", e)
+        # Redacted below, so the traceback is the only record left.
+        logger.error("Unexpected error handling chat message: %s", e, exc_info=True)
         await finish_delivery_failure(client_safe_error_message(e))
         raise
 
@@ -6663,7 +6690,9 @@ async def handle_execute_task(
             )
         )
         if request is None:
-            raise Exception(f"Task {task_id} not found or access denied")
+            raise ClientVisibleValidationError(
+                f"Task {task_id} not found or access denied"
+            )
         authorized_task_id = request.task_id
 
         await manager.broadcast_to_task(
@@ -6699,7 +6728,7 @@ async def handle_execute_task(
     except (ValueError, KeyError, TypeError) as e:
         # Data validation and format error
         message = client_safe_error_message(e)
-        logger.error("Data validation error in task execution: %s", e, exc_info=True)
+        log_client_facing_failure(e, "Data validation error in task execution: %s")
         timestamp = datetime.now(timezone.utc).isoformat()
         if authorized_task_id is not None:
             error_payload = await _read_task_error_payload_offloop(
@@ -7454,7 +7483,10 @@ async def handle_intervention(
         await manager.broadcast_to_task(
             {
                 "type": "intervention_processed",
-                "message": f"Manual intervention processed: {intervention_data['action']}",
+                # The action is client-supplied and reaches every connection on
+                # the task, so it travels as a structured field only.
+                "message": "Manual intervention processed",
+                "action": intervention_data["action"],
                 "intervention_id": intervention_data["step_id"],
                 "timestamp": datetime.now(
                     timezone.utc
@@ -7465,7 +7497,7 @@ async def handle_intervention(
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
-        logger.error("Data validation error in intervention: %s", e, exc_info=True)
+        log_client_facing_failure(e, "Data validation error in intervention: %s")
         await manager.send_personal_message(
             {"type": "error", "message": client_safe_error_message(e)}, websocket
         )
@@ -7733,6 +7765,8 @@ async def _handle_pause_task_unserialized(
         )
     except RuntimeError as e:
         # Runtime error
+        # No traceback: this branch passes the text through to the client
+        # unredacted (#1479), so nothing is being withheld from the log.
         logger.error("Runtime error pausing task %s: %s", task_id, e)
         await manager.send_personal_message(
             {"type": "error", "message": f"Runtime error: {str(e)}"}, websocket
@@ -8128,6 +8162,8 @@ async def _handle_resume_task_unserialized(
         )
     except RuntimeError as e:
         # Runtime error
+        # No traceback: this branch passes the text through to the client
+        # unredacted (#1479), so nothing is being withheld from the log.
         logger.error("Runtime error resuming task %s: %s", task_id, e)
         await manager.send_personal_message(
             {"type": "error", "message": f"Runtime error: {str(e)}"}, websocket
@@ -8214,7 +8250,7 @@ async def _execute_durable_task_command(
     } and await run_db_io_cancellation_safe(
         lambda: task_has_live_foreign_runner(command.task_id)
     ):
-        raise TaskCommandDeferred(
+        raise ClientVisibleTaskCommandDeferred(
             f"{command.kind.value.title()} command {command.command_id} is waiting "
             "for the active task lease owner"
         )
@@ -8224,7 +8260,7 @@ async def _execute_durable_task_command(
             websocket, command.task_id, message_data
         )
         if message_data.get("_commit_outcome_unknown") == command.command_id:
-            raise TaskCommandDeferred(
+            raise ClientVisibleTaskCommandDeferred(
                 f"Message {command.command_id} has an unknown commit outcome"
             )
         if message_data.get("_registered_turn_handoff") == command.command_id:
@@ -8240,7 +8276,7 @@ async def _execute_durable_task_command(
             )
         )
         if delivery_status == DELIVERY_PENDING:
-            raise TaskCommandDeferred(
+            raise ClientVisibleTaskCommandDeferred(
                 f"Message {command.command_id} is waiting for runtime injection"
             )
         if delivery_status == DELIVERY_FAILED:
@@ -8314,7 +8350,11 @@ async def _broadcast_terminal_command_error(
     await manager.broadcast_to_task(
         {
             "type": "agent_error",
-            "message": (f"Task command {command.kind.value} failed: {error}"),
+            # Kept a plain chokepoint call rather than an f-string: the guard
+            # cannot see inside an interpolation, and the command kind travels
+            # as a structured field instead.
+            "message": client_safe_error_message(error),
+            "command_kind": command.kind.value,
             "task_id": command.task_id,
             "command_id": command.command_id,
             "timestamp": datetime.now(timezone.utc).timestamp(),

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5033,17 +5033,17 @@ async def handle_chat_message(
     except (PermissionError, ValueError) as exc:
         log_client_facing_failure(exc, "Chat command rejected for task %s: %s", task_id)
         client_message_id = _client_message_id(message_data.get("client_message_id"))
+        message = client_safe_error_message(exc)
         await send_message_delivery(
             websocket,
             client_message_id=client_message_id,
             turn_id=client_message_id or str(uuid.uuid4()),
             accepted=False,
-            message=client_safe_error_message(exc),
+            message=message,
             rejection_outcome="not_accepted",
         )
         await manager.send_personal_message(
-            {"type": "error", "message": client_safe_error_message(exc)},
-            websocket,
+            {"type": "error", "message": message}, websocket
         )
         return
     if enqueued is None:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -5013,6 +5013,9 @@ async def handle_chat_message(
             allow_missing_task=True,
         )
     except (PermissionError, ValueError) as exc:
+        logger.error(
+            "Chat command rejected for task %s: %s", task_id, exc, exc_info=True
+        )
         client_message_id = _client_message_id(message_data.get("client_message_id"))
         await send_message_delivery(
             websocket,
@@ -5085,7 +5088,7 @@ def _enqueue_websocket_task_command_sync(
         if task is None:
             if allow_missing_task:
                 return None
-            raise ValueError(f"Task {task_id} not found")
+            raise ClientVisibleValidationError(f"Task {task_id} not found")
         if not actor_is_admin and int(task.user_id) != actor_user_id:
             raise ClientVisiblePermissionError(
                 f"Access denied: Task {task_id} does not belong to you"
@@ -7444,7 +7447,7 @@ async def handle_intervention(
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
-        logger.error(f"Data validation error in intervention: {e}")
+        logger.error("Data validation error in intervention: %s", e, exc_info=True)
         await manager.send_personal_message(
             {"type": "error", "message": client_safe_error_message(e)}, websocket
         )
@@ -7473,6 +7476,12 @@ async def handle_pause_task(
             command_id=_client_message_id(message_data.get("command_id")),
         )
     except (PermissionError, ValueError) as exc:
+        logger.error(
+            "Pause command rejected for task %s: %s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
         await manager.send_personal_message(
             {"type": "error", "message": client_safe_error_message(exc)},
             websocket,
@@ -7701,7 +7710,9 @@ async def _handle_pause_task_unserialized(
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
         message_data["_durable_command_error"] = str(e)
-        logger.error(f"Data validation error pausing task {task_id}: {e}")
+        logger.error(
+            "Data validation error pausing task %s: %s", task_id, e, exc_info=True
+        )
         await manager.send_personal_message(
             {"type": "error", "message": client_safe_error_message(e)}, websocket
         )
@@ -7731,6 +7742,12 @@ async def handle_resume_task(
             command_id=_client_message_id(message_data.get("command_id")),
         )
     except (PermissionError, ValueError) as exc:
+        logger.error(
+            "Resume command rejected for task %s: %s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
         await manager.send_personal_message(
             {"type": "error", "message": client_safe_error_message(exc)},
             websocket,
@@ -8091,7 +8108,9 @@ async def _handle_resume_task_unserialized(
     except (ValueError, KeyError, TypeError) as e:
         # Data validation error
         message_data["_durable_command_error"] = str(e)
-        logger.error(f"Data validation error resuming task {task_id}: {e}")
+        logger.error(
+            "Data validation error resuming task %s: %s", task_id, e, exc_info=True
+        )
         await manager.send_personal_message(
             {"type": "error", "message": client_safe_error_message(e)}, websocket
         )

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -322,6 +322,52 @@ def _client_message_id(value: Any) -> str | None:
     return normalized
 
 
+# Exception text can carry file paths, SQL fragments, provider payloads and
+# other internals. It reaches anonymous widget/share visitors through both the
+# error bubble and the message_rejected ack, so an *incidental* validation
+# failure only ever surfaces as this fixed string; the detail stays in the log.
+#
+# Agent RuntimeError text is deliberately left alone: surfacing it to the sender
+# is an existing, tested contract (tests/web/api/test_websocket_owner_actor.py),
+# and narrowing it is a product decision rather than a redaction bug.
+CLIENT_SAFE_VALIDATION_ERROR = "The message could not be processed. Please try again."
+
+
+class ClientVisibleError(Exception):
+    """Marker: this exception's text was written for the end user.
+
+    Raise a subclass - never a bare builtin - when the message itself is the
+    actionable answer ("authentication required", "access denied"). Everything
+    else reaching a client-facing handler is treated as incidental and
+    redacted, so forgetting the marker fails closed.
+    """
+
+
+class ClientVisibleValidationError(ClientVisibleError, ValueError):
+    """A validation failure whose text is safe to show the sender."""
+
+
+class ClientVisiblePermissionError(ClientVisibleError, PermissionError):
+    """An authorization refusal whose text is safe to show the sender."""
+
+
+def client_safe_error_message(error: Exception) -> str:
+    """The only way an exception may become text a chat client can see.
+
+    Every ``message_rejected`` and ``error`` payload that this module builds
+    from an exception *at a direct call site* goes through here.
+    ``tests/web/api/test_websocket_client_safe_errors.py`` enforces that for
+    the shapes it recognizes; payloads assembled by a helper, spread into a
+    dict, or forwarded through a wrapper are not yet covered and still carry
+    raw text - see #1497.
+    """
+    return (
+        str(error)
+        if isinstance(error, ClientVisibleError)
+        else CLIENT_SAFE_VALIDATION_ERROR
+    )
+
+
 async def send_message_delivery(
     websocket: WebSocket,
     *,
@@ -2446,7 +2492,7 @@ async def execute_task_background(
                 )
             )
         if snapshot is None:
-            raise ValueError(f"Task {task_id} not found")
+            raise ClientVisibleValidationError(f"Task {task_id} not found")
 
         context_dict = context if isinstance(context, dict) else {}
         logger.info(f"Background task execution started for task {task_id}")
@@ -4860,7 +4906,7 @@ def _claim_user_message_delivery_isolated(
                     db=db,
                 )
                 if missing:
-                    raise ValueError(
+                    raise ClientVisibleValidationError(
                         "Files are no longer bindable: " + ", ".join(missing)
                     )
             claim_snapshot = _snapshot_user_message_delivery(claim)
@@ -4973,11 +5019,12 @@ async def handle_chat_message(
             client_message_id=client_message_id,
             turn_id=client_message_id or str(uuid.uuid4()),
             accepted=False,
-            message=str(exc),
+            message=client_safe_error_message(exc),
             rejection_outcome="not_accepted",
         )
         await manager.send_personal_message(
-            {"type": "error", "message": str(exc)}, websocket
+            {"type": "error", "message": client_safe_error_message(exc)},
+            websocket,
         )
         return
     if enqueued is None:
@@ -5040,7 +5087,7 @@ def _enqueue_websocket_task_command_sync(
                 return None
             raise ValueError(f"Task {task_id} not found")
         if not actor_is_admin and int(task.user_id) != actor_user_id:
-            raise PermissionError(
+            raise ClientVisiblePermissionError(
                 f"Access denied: Task {task_id} does not belong to you"
             )
         if kind == TaskCommandKind.MESSAGE:
@@ -5104,7 +5151,9 @@ async def _enqueue_websocket_task_command(
 ) -> EnqueuedTaskCommand | None:
     user = message_data.get("user")
     if user is None:
-        raise ValueError("User authentication required for task command")
+        raise ClientVisibleValidationError(
+            "User authentication required for task command"
+        )
     resolved_command_id = command_id or f"{kind.value}:{uuid.uuid4()}"
     # User ORM instances and server-only authentication fields are never put
     # into the JSON inbox. The consumer re-resolves the actor by id.
@@ -5748,13 +5797,15 @@ async def _handle_chat_message_unserialized(
         authorized_task_id: int | None = None
 
         if user is None:
-            raise ValueError("User authentication required for task access")
+            raise ClientVisibleValidationError(
+                "User authentication required for task access"
+            )
         if not isinstance(user_message, str):
-            raise TypeError("Chat message must be a string")
+            raise ClientVisibleValidationError("Chat message must be a string")
         if not isinstance(raw_context, dict):
-            raise TypeError("Chat context must be an object")
+            raise ClientVisibleValidationError("Chat context must be an object")
         if not isinstance(raw_files, list):
-            raise TypeError("Chat files must be a list")
+            raise ClientVisibleValidationError("Chat files must be a list")
 
         actor_user_id = int(user.id)
         actor_is_admin = bool(user.is_admin)
@@ -6381,8 +6432,10 @@ async def _handle_chat_message_unserialized(
             )
         except (ValueError, KeyError, TypeError) as e:
             # Data validation and format error
-            message = f"Data validation error: {str(e)}"
-            logger.error(f"Data validation error in agent execution: {e}")
+            message = client_safe_error_message(e)
+            logger.error(
+                "Data validation error in agent execution: %s", e, exc_info=True
+            )
             if not await finish_delivery_failure(message):
                 return
             timestamp = datetime.now(timezone.utc).timestamp()
@@ -6410,7 +6463,7 @@ async def _handle_chat_message_unserialized(
         except RuntimeError as e:
             # Runtime error
             message = f"Runtime error: {str(e)}"
-            logger.error(f"Runtime error in agent execution: {e}")
+            logger.error("Runtime error in agent execution: %s", e, exc_info=True)
             if not await finish_delivery_failure(message):
                 return
             timestamp = datetime.now(timezone.utc).timestamp()
@@ -6437,16 +6490,17 @@ async def _handle_chat_message_unserialized(
                 )
         except Exception as e:
             # Other unknown errors, re-raise
-            logger.error(f"Unexpected error in agent execution: {e}")
-            await finish_delivery_failure(str(e))
+            logger.error("Unexpected error in agent execution: %s", e, exc_info=True)
+            await finish_delivery_failure(client_safe_error_message(e))
             raise
 
     except (ValueError, KeyError, TypeError) as e:
         # Message format error
-        logger.error(f"Message format error: {e}")
-        await finish_delivery_failure(f"Message format error: {str(e)}")
+        logger.error("Message format error: %s", e, exc_info=True)
+        message = client_safe_error_message(e)
+        await finish_delivery_failure(message)
         await manager.send_personal_message(
-            {"type": "error", "message": f"Message format error: {str(e)}"}, websocket
+            {"type": "error", "message": message}, websocket
         )
     except (ConnectionError, WebSocketDisconnect) as e:
         # Connection error
@@ -6454,8 +6508,8 @@ async def _handle_chat_message_unserialized(
         raise
     except Exception as e:
         # Other errors, re-raise
-        logger.error(f"Unexpected error handling chat message: {e}")
-        await finish_delivery_failure(str(e))
+        logger.error("Unexpected error handling chat message: %s", e, exc_info=True)
+        await finish_delivery_failure(client_safe_error_message(e))
         raise
 
 
@@ -6564,7 +6618,9 @@ async def handle_execute_task(
         user = message_data.get("user")
         authorized_task_id: int | None = None
         if not user:
-            raise ValueError("User authentication required for task execution")
+            raise ClientVisibleValidationError(
+                "User authentication required for task execution"
+            )
         actor_user_id = int(user.id)
         actor_is_admin = bool(user.is_admin)
 
@@ -6621,8 +6677,8 @@ async def handle_execute_task(
 
     except (ValueError, KeyError, TypeError) as e:
         # Data validation and format error
-        message = f"Data validation error: {str(e)}"
-        logger.error(f"Data validation error in task execution: {e}")
+        message = client_safe_error_message(e)
+        logger.error("Data validation error in task execution: %s", e, exc_info=True)
         timestamp = datetime.now(timezone.utc).isoformat()
         if authorized_task_id is not None:
             error_payload = await _read_task_error_payload_offloop(
@@ -6648,7 +6704,7 @@ async def handle_execute_task(
     except RuntimeError as e:
         # Runtime error
         message = f"Runtime error: {str(e)}"
-        logger.error(f"Runtime error in task execution: {e}")
+        logger.error("Runtime error in task execution: %s", e, exc_info=True)
         timestamp = datetime.now(timezone.utc).isoformat()
         if authorized_task_id is not None:
             error_payload = await _read_task_error_payload_offloop(
@@ -7390,7 +7446,7 @@ async def handle_intervention(
         # Data validation error
         logger.error(f"Data validation error in intervention: {e}")
         await manager.send_personal_message(
-            {"type": "error", "message": f"Data validation error: {str(e)}"}, websocket
+            {"type": "error", "message": client_safe_error_message(e)}, websocket
         )
     except RuntimeError as e:
         # Runtime error
@@ -7418,7 +7474,8 @@ async def handle_pause_task(
         )
     except (PermissionError, ValueError) as exc:
         await manager.send_personal_message(
-            {"type": "error", "message": str(exc)}, websocket
+            {"type": "error", "message": client_safe_error_message(exc)},
+            websocket,
         )
         return
     assert enqueued is not None
@@ -7646,7 +7703,7 @@ async def _handle_pause_task_unserialized(
         message_data["_durable_command_error"] = str(e)
         logger.error(f"Data validation error pausing task {task_id}: {e}")
         await manager.send_personal_message(
-            {"type": "error", "message": f"Data validation error: {str(e)}"}, websocket
+            {"type": "error", "message": client_safe_error_message(e)}, websocket
         )
     except RuntimeError as e:
         # Runtime error
@@ -7675,7 +7732,8 @@ async def handle_resume_task(
         )
     except (PermissionError, ValueError) as exc:
         await manager.send_personal_message(
-            {"type": "error", "message": str(exc)}, websocket
+            {"type": "error", "message": client_safe_error_message(exc)},
+            websocket,
         )
         return
     assert enqueued is not None
@@ -8035,7 +8093,7 @@ async def _handle_resume_task_unserialized(
         message_data["_durable_command_error"] = str(e)
         logger.error(f"Data validation error resuming task {task_id}: {e}")
         await manager.send_personal_message(
-            {"type": "error", "message": f"Data validation error: {str(e)}"}, websocket
+            {"type": "error", "message": client_safe_error_message(e)}, websocket
         )
     except RuntimeError as e:
         # Runtime error

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -393,6 +393,18 @@ def client_safe_error_message(error: BaseException) -> str:
     )
 
 
+def client_safe_task_command_failure(
+    kind: TaskCommandKind, error: BaseException
+) -> str:
+    """Terminal command failure: server-owned kind prefix + redacted detail.
+
+    The frontend renders ``message`` verbatim for ``agent_error``, so dropping
+    the prefix entirely removed user-visible context. The kind comes from our
+    own enum, never from the exception, which is what makes the prefix safe.
+    """
+    return f"Task command {kind.value} failed: {client_safe_error_message(error)}"
+
+
 def log_client_facing_failure(error: Exception, template: str, *args: object) -> None:
     """Record a failure whose text the client will not see in full.
 
@@ -5175,13 +5187,17 @@ def _enqueue_websocket_task_command_sync(
                 kind=kind,
                 payload=payload,
             )
-        except TaskCommandTaskMissing:
+        except TaskCommandTaskMissing as exc:
             # The row was deleted after the check above, so route this through
             # the same sentinel as a task that was already gone. Otherwise the
             # caller rejects the delivery instead of creating a replacement.
             if allow_missing_task:
                 return None
-            raise
+            # Same answer as the direct lookup above, in the same wording.
+            # The sentinel is a bare ValueError, so re-raising it as-is let
+            # the pause/resume catch redact "not found" on this race alone.
+            # Converted at this boundary only; transport semantics unchanged.
+            raise ClientVisibleValidationError(str(exc)) from exc
         return result
 
 
@@ -6778,8 +6794,9 @@ async def handle_execute_task(
                 websocket,
             )
     except Exception as e:
-        # Other unknown errors, re-raise
-        logger.error("Unexpected error in task execution: %s", e)
+        # Re-raised, but the callers do not own the stack: the chat endpoint
+        # logs without exc_info and the public endpoints swallow entirely.
+        logger.error("Unexpected error in task execution: %s", e, exc_info=True)
         raise
 
 
@@ -7508,8 +7525,9 @@ async def handle_intervention(
             {"type": "error", "message": f"Runtime error: {str(e)}"}, websocket
         )
     except Exception as e:
-        # Other errors, re-raise
-        logger.error("Unexpected error in intervention: %s", e)
+        # Re-raised, but the callers do not own the stack: the chat endpoint
+        # logs without exc_info and the public endpoints swallow entirely.
+        logger.error("Unexpected error in intervention: %s", e, exc_info=True)
         raise
 
 
@@ -8350,10 +8368,10 @@ async def _broadcast_terminal_command_error(
     await manager.broadcast_to_task(
         {
             "type": "agent_error",
-            # Kept a plain chokepoint call rather than an f-string: the guard
-            # cannot see inside an interpolation, and the command kind travels
-            # as a structured field instead.
-            "message": client_safe_error_message(error),
+            # A blessed constructor rather than an f-string at the call
+            # site: the guard cannot see inside an interpolation. The kind
+            # also travels as a structured field for consumers that want it.
+            "message": client_safe_task_command_failure(command.kind, error),
             "command_kind": command.kind.value,
             "task_id": command.task_id,
             "command_id": command.command_id,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -4609,6 +4609,78 @@ async def _with_current_task_control_state(
 
 
 # Connection manager
+class _CommandOriginRegistry:
+    """(task_id, command_id) -> the exact socket that submitted the command.
+
+    Recorded at the ingress handler, where the connection is the verified
+    origin, and consulted by the durable executor in place of any guess:
+    origin is never inferred from task membership, actor id, guest id, or
+    connection order. Same-worker only, by design - when the command executes
+    after a worker restart or on a different worker, ``resolve`` finds nothing
+    and the executor degrades to a discarding socket, so personal detail is
+    dropped rather than sent to an unverified connection.
+
+    ``command_id`` is client-supplied and only unique per task (the DB carries
+    a ``(task_id, command_id)`` uniqueness constraint), so the key is the pair,
+    never the id alone - otherwise a command_id shared across two tasks would
+    let one void or overwrite the other's entry.
+
+    First registration wins. A second connection on the same task cannot
+    overwrite an existing origin by resubmitting the same command_id: the
+    enqueue dedupe returns the in-flight row for such a resubmission, so
+    without this rule a co-tenant on a public/share task could redirect
+    another sender's error detail to itself. Re-registering the *same* socket
+    is idempotent.
+
+    Lifecycle: an entry dies with its socket (``discard_socket`` from
+    ``ConnectionManager.disconnect``) or with its command's terminal outcome
+    (``discard_command`` from the durable dispatch wrapper), whichever comes
+    first (``detach_task_connections`` also clears them). A deferred command
+    that will retry keeps its entry. An entry whose command is claimed by
+    another worker is never resolved here (wrong worker); it is reclaimed when
+    this worker's socket disconnects, so the only unbounded case would be a
+    socket that never disconnects while submitting commands that always run
+    elsewhere - not a shape this deployment produces, and tracked rather than
+    given a TTL here.
+    """
+
+    def __init__(self) -> None:
+        self._origins: dict[tuple[int, str], Any] = {}
+
+    def register(self, command_id: str, websocket: Any, task_id: int) -> None:
+        if not command_id:
+            return
+        key = (int(task_id), command_id)
+        existing = self._origins.get(key)
+        if existing is not None and existing is not websocket:
+            # First registration wins; a resubmission from another socket
+            # must not capture this command's origin.
+            return
+        self._origins[key] = websocket
+
+    def resolve(self, command_id: str, task_id: int) -> Any | None:
+        websocket = self._origins.get((int(task_id), command_id))
+        if websocket is None:
+            return None
+        if not manager.is_connection_registered(websocket, int(task_id)):
+            return None
+        return websocket
+
+    def discard_command(self, command_id: str, task_id: int) -> None:
+        self._origins.pop((int(task_id), command_id), None)
+
+    def has(self, command_id: str, task_id: int) -> bool:
+        """Whether an origin is currently recorded for this command."""
+        return (int(task_id), command_id) in self._origins
+
+    def discard_socket(self, websocket: Any) -> None:
+        for key in [k for k, ws in self._origins.items() if ws is websocket]:
+            del self._origins[key]
+
+
+_command_origins = _CommandOriginRegistry()
+
+
 class ConnectionManager:
     def __init__(self) -> None:
         # task_id -> List[WebSocket]
@@ -4644,6 +4716,7 @@ class ConnectionManager:
         task_id = self._connection_task_ids.pop(websocket, None)
         if task_id is not None:
             self._remove_from_task(websocket, task_id)
+        _command_origins.discard_socket(websocket)
 
     def detach_task_connections(self, task_id: int) -> List[WebSocket]:
         """Remove and return every connection currently owned by a task."""
@@ -4651,6 +4724,7 @@ class ConnectionManager:
         for connection in connections:
             if self._connection_task_ids.get(connection) == task_id:
                 del self._connection_task_ids[connection]
+            _command_origins.discard_socket(connection)
         return connections
 
     def connections_for_task(self, task_id: int) -> List[WebSocket]:
@@ -5124,6 +5198,9 @@ async def handle_chat_message(
         accepted=True,
     )
     if enqueued.command_id:
+        # This connection is the verified origin of the command; personal
+        # detail from durable execution goes here or nowhere.
+        _command_origins.register(enqueued.client_command_id, websocket, task_id)
         await dispatch_task_command_promptly(
             execute_durable_task_command,
             command_db_id=enqueued.command_id,
@@ -6544,6 +6621,18 @@ async def _handle_chat_message_unserialized(
                     },
                     authorized_task_id,
                 )
+                # Only the durable path needs this: there the rejection ack
+                # is suppressed, so the detail bubble is the sender's only
+                # copy. On the live path finish_delivery_failure already sent
+                # the ack with the same wording, so a bubble would duplicate
+                # it. The origin socket came from the registry and is a
+                # discarding stub when unverifiable, so this is
+                # origin-or-nowhere by construction.
+                if suppress_delivery_ack:
+                    await manager.send_personal_message(
+                        {"type": "error", "message": message, "timestamp": timestamp},
+                        websocket,
+                    )
             else:
                 await manager.send_personal_message(
                     {
@@ -6792,6 +6881,12 @@ async def handle_execute_task(
                     "timestamp": timestamp,
                 },
                 authorized_task_id,
+            )
+            # This handler is invoked with its real ingress socket (it is not
+            # dispatched durably), so the initiating sender keeps the detail.
+            await manager.send_personal_message(
+                {"type": "error", "message": message, "timestamp": timestamp},
+                websocket,
             )
         else:
             await manager.send_personal_message(
@@ -7580,6 +7675,9 @@ async def handle_pause_task(
         },
         websocket,
     )
+    # This connection is the verified origin; personal detail from durable
+    # execution goes here or nowhere.
+    _command_origins.register(enqueued.client_command_id, websocket, task_id)
     await dispatch_task_command_promptly(
         execute_durable_task_command,
         command_db_id=enqueued.command_id,
@@ -7845,6 +7943,9 @@ async def handle_resume_task(
         },
         websocket,
     )
+    # This connection is the verified origin; personal detail from durable
+    # execution goes here or nowhere.
+    _command_origins.register(enqueued.client_command_id, websocket, task_id)
     await dispatch_task_command_promptly(
         execute_durable_task_command,
         command_db_id=enqueued.command_id,
@@ -8233,20 +8334,16 @@ async def _execute_durable_task_command(
 ) -> dict[str, Any] | None:
     """Apply one DB-claimed command using the existing transport adapters.
 
-    The handler is independent of the originating connection. If the socket is
-    still connected, personal validation errors go there; after a crash or on a
-    different worker they are discarded while task-level state/error events are
-    still broadcast normally.
+    Personal replies go only to the registered origin socket, verified to
+    still be connected to this task. Origin is never inferred from task
+    membership, actor id, or connection order: after a crash, a handoff to a
+    different worker, or a disconnect, personal detail is discarded while
+    task-level state/error events are still broadcast normally.
     """
 
-    connections = manager.connections_for_task(command.task_id)
-    # Broadcast-only subscribers (e.g. the v1 SSE sink) never issued this
-    # command and must not be mistaken for the originating socket, so they
-    # are skipped when picking the target for a personal reply.
-    websocket: Any = next(
-        (c for c in connections if not getattr(c, "is_broadcast_only", False)),
-        _DiscardingCommandWebSocket(),
-    )
+    websocket: Any = _command_origins.resolve(command.command_id, command.task_id)
+    if websocket is None:
+        websocket = _DiscardingCommandWebSocket()
     message_data = dict(command.payload)
     message_data.update(
         {
@@ -8396,19 +8493,25 @@ async def execute_durable_task_command(
     """Apply one command and expose only terminal transport failures to clients."""
 
     try:
-        return await _execute_durable_task_command(command)
+        result = await _execute_durable_task_command(command)
     except TaskCommandDeferred as exc:
         if command.defer_count + 1 >= MAX_COMMAND_DEFERS:
+            _command_origins.discard_command(command.command_id, command.task_id)
             await _broadcast_terminal_command_error(command, exc)
+        # A deferral that will retry keeps its origin entry.
         raise
     except TaskCommandRejected:
         # Rejections come from handlers that already expose their durable
         # domain-level outcome. The dispatcher makes them terminal immediately.
+        _command_origins.discard_command(command.command_id, command.task_id)
         raise
     except Exception as exc:
         if command.failure_count + 1 >= MAX_COMMAND_FAILURES:
+            _command_origins.discard_command(command.command_id, command.task_id)
             await _broadcast_terminal_command_error(command, exc)
         raise
+    _command_origins.discard_command(command.command_id, command.task_id)
+    return result
 
 
 def _load_command_message_delivery_status(

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -104,7 +104,6 @@ async def test_execute_task_redacts_an_incidental_validation_error(
         TaskTurnOrchestrator,
         "schedule_existing_task_execution",
         AsyncMock(side_effect=raise_at_schedule),
-        raising=False,
     )
 
     await websocket_api.handle_execute_task(
@@ -214,6 +213,10 @@ def _message_expression(node: ast.Call, index: int | None) -> ast.expr | None:
 # ``send_text`` takes a serialized payload, so the dict sits one call deeper.
 ERROR_PAYLOAD_SINKS = {"send_personal_message", "broadcast_to_task", "send_text"}
 
+# Both render in the client's conversation, so both are the same disclosure
+# surface. ``agent_error`` was missing until review found a producer using it.
+ERROR_PAYLOAD_TYPES = {"error", "agent_error"}
+
 
 def _unwrap_serializer(expr: ast.expr) -> ast.expr:
     """``json.dumps(payload)`` -> ``payload``; anything else unchanged."""
@@ -236,7 +239,7 @@ def _error_payload_message(node: ast.Call) -> ast.expr | None:
             if isinstance(key, ast.Constant)
         }
         kind = keys.get("type")
-        if isinstance(kind, ast.Constant) and kind.value == "error":
+        if isinstance(kind, ast.Constant) and kind.value in ERROR_PAYLOAD_TYPES:
             return keys.get("message")
     return None
 
@@ -297,12 +300,18 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
     """Exception text may not reach a client through the *recognized* shapes.
 
     Scope, stated honestly: this walks direct calls to the producers in
-    ``PRODUCERS`` and ``{"type": "error", ...}`` dict *literals* passed to
-    ``send_personal_message``/``broadcast_to_task``. It does NOT follow
-    dict-spread payloads, payloads built by a helper and passed as a call, or
-    wrapper functions that forward a raw argument into a producer. Those
-    shapes leak today and are tracked in #1497 - do not read a passing run as
-    "nothing can reach a client raw".
+    ``PRODUCERS`` and dict *literals* whose ``type`` is one of
+    ``ERROR_PAYLOAD_TYPES``, passed to one of ``ERROR_PAYLOAD_SINKS``.
+
+    It does NOT follow dict-spread payloads, payloads built by a helper and
+    passed as a call, wrapper functions that forward a raw argument into a
+    producer (all #1497), or payloads whose ``type`` is a variable rather than
+    a string literal (#1547). ``agent_error`` was added only after review
+    found ``_broadcast_terminal_command_error`` escaping on that dimension
+    alone - the type set is a maintained list, not a derived invariant.
+
+    Those shapes leak today. Do not read a passing run as "nothing can reach a
+    client raw"; the xfail tests below pin the ones we know about.
     """
     # Explicit encoding: this module carries non-ASCII prose, and the
     # platform default would decode it as cp1252/GBK on a Windows runner.
@@ -355,7 +364,7 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
                 f"{name}:{node.lineno} may send {ast.unparse(candidate)!r}"
             )
 
-    # Actual counts at the time of writing: 23 producers, 28 error payloads.
+    # Actual counts at the time of writing: 23 producers, 30 error payloads.
     # These floors sit below that, so a minority of sites can still vanish
     # silently; tightening them to exact equality is tracked in #1547.
     assert checked_producers >= 21, (
@@ -494,6 +503,7 @@ def test_log_level_follows_the_marker_not_the_call_site(
 @pytest.mark.asyncio
 async def test_builder_chat_redacts_through_its_own_socket_sink(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The leak found by self-review, pinned at runtime rather than by AST alone.
 
@@ -513,10 +523,17 @@ async def test_builder_chat_redacts_through_its_own_socket_sink(
     websocket.send_text = AsyncMock()
     websocket.state = SimpleNamespace()
 
-    await websocket_api.handle_builder_chat(
-        websocket,
-        {"message": "build me an agent"},
-        SimpleNamespace(id=1, is_admin=False),
+    with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
+        await websocket_api.handle_builder_chat(
+            websocket,
+            {"message": "build me an agent"},
+            SimpleNamespace(id=1, is_admin=False),
+        )
+
+    records = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert any(SECRET in r.getMessage() for r in records), (
+        "the operator half of the contract: redacting the client's copy must "
+        "not delete the server's"
     )
 
     payloads = _sent_text_payloads(websocket)
@@ -580,3 +597,185 @@ async def test_permission_wording_survives_redaction_in_every_handler(
         == f"Access denied: Task {task_id} does not belong to you"
         for payload in payloads
     ), payloads
+
+
+# Each entry is a bypass shape this module admits it does not cover: a source
+# snippet the guard reports clean even though raw exception text reaches a
+# client. Each mirrors a real site rather than a minimal repro, so the xfail
+# cannot flip on a shape nothing actually uses - dict-spread copies
+# ``execute_task_background`` (text under ``error``, type inherited from the
+# spread), helper-built copies ``send_historical_data_as_stream``, and
+# wrapper-forwarded copies ``notify_deferred_delivery``. They are pinned as strict xfails so the day the guard learns a shape,
+# its test flips to a failure and says so, instead of the hole quietly
+# outliving the issue that tracks it.
+BYPASS_SHAPES = [
+    pytest.param(
+        """
+async def leak(websocket, task_id):
+    try:
+        pass
+    except Exception as e:
+        terminal_payload = _terminal_task_error_payload(task_id, str(e))
+        message = str(e)
+        await manager.broadcast_to_task(
+            {
+                **terminal_payload,
+                "task_id": task_id,
+                "error": message,
+                "timestamp": 0,
+            },
+            task_id,
+        )
+""",
+        id="dict-spread",
+    ),
+    pytest.param(
+        """
+async def leak(websocket, task_id):
+    try:
+        pass
+    except Exception as e:
+        await manager.broadcast_to_task(
+            create_stream_event("error", task_id, {"message": str(e)}), task_id
+        )
+""",
+        id="helper-built",
+    ),
+    pytest.param(
+        """
+async def forward(websocket, raw):
+    await send_message_delivery(
+        websocket,
+        client_message_id="c",
+        turn_id="t",
+        accepted=False,
+        message=raw,
+        rejection_outcome="not_accepted",
+    )
+
+
+async def leak(websocket):
+    try:
+        pass
+    except Exception as e:
+        await forward(websocket, str(e))
+""",
+        id="wrapper-forwarded",
+    ),
+]
+
+# Deliberately NOT listed above: ``message_data["_durable_command_error"] =
+# str(e)``. Earlier rounds of this PR described that as reaching clients via
+# _broadcast_terminal_command_error, which is wrong - TaskCommandRejected is
+# re-raised without broadcasting (websocket.py, execute_durable_task_command),
+# and the two branches that do broadcast now go through the chokepoint.
+#
+# The text lands in the TaskExecutionCommand.error column. That column IS
+# read back to a client - a2a.py returns it verbatim as a 500 internal_error
+# body - so the reason this particular channel is not a client leak is
+# narrower than "nothing reads the column": a2a only ever enqueues CANCEL, so
+# the pause/resume text written here cannot reach that read path. Widening a2a
+# to another command kind would turn this into a real leak, which is why the
+# dependency is written down rather than left implicit.
+
+
+def _guard_offenders(source: str) -> list[str]:
+    """Run the sweep's recognition logic over an arbitrary module source."""
+    tree = ast.parse(source)
+    parents = _parents(tree)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _called_name(node)
+        if name in PRODUCERS:
+            expr = _message_expression(node, PRODUCERS[name])
+        else:
+            expr = _error_payload_message(node)
+        if expr is None:
+            continue
+        scopes = _enclosing_functions(node, parents)
+        if isinstance(expr, ast.Name) and _is_parameter(scopes, expr.id):
+            continue
+        candidates = (
+            _local_assignments(scopes, expr.id)
+            if isinstance(expr, ast.Name)
+            else [expr]
+        )
+        if not candidates:
+            offenders.append(f"{name}:{node.lineno} unresolvable")
+            continue
+        enclosing = next(
+            (scope.name for scope in scopes if isinstance(scope, FUNCTION_NODES)),
+            "<module>",
+        )
+        for candidate in candidates:
+            if _is_client_safe(candidate):
+                continue
+            if (enclosing, ast.unparse(candidate)) in ALLOWED_RAW_MESSAGES:
+                continue
+            offenders.append(f"{name}:{node.lineno} {ast.unparse(candidate)}")
+    return offenders
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Known guard blind spots, all tracked in #1497. When one is closed "
+    "this flips to a failure - fix the issue, then delete its param.",
+)
+@pytest.mark.parametrize("source", BYPASS_SHAPES)
+def test_known_bypass_shapes_are_still_invisible_to_the_guard(source: str) -> None:
+    """A passing sweep does not mean no raw text can reach a client.
+
+    Every snippet here puts ``str(e)`` in front of a client and the guard says
+    nothing. Asserting that out loud is the difference between a documented
+    gap and a forgotten one.
+    """
+    assert _guard_offenders(source), (
+        "the guard now sees this shape - remove it from BYPASS_SHAPES and "
+        "close the tracking issue"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_task_answers_the_sender_instead_of_dropping_them(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Silence is a worse answer than redaction.
+
+    This raise site was a bare ``Exception`` while its sibling a few lines
+    above already carried the marker. Being untyped, it escaped every typed
+    handler, reached the connection-level ``finally: manager.disconnect`` and
+    left the client with nothing at all - not the text, not even the generic
+    string.
+    """
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    missing_task_id = 987654
+    with caplog.at_level(logging.DEBUG, logger=WEBSOCKET_LOGGER):
+        await websocket_api.handle_execute_task(
+            MagicMock(),
+            missing_task_id,
+            {"user": SimpleNamespace(id=1, is_admin=False)},
+        )
+
+    payloads = _client_payloads(connection_manager)
+    assert any(
+        payload.get("message") == f"Task {missing_task_id} not found or access denied"
+        for payload in payloads
+    ), payloads
+
+    # Marking this raise made it reachable by a typed handler, which is the
+    # point - but that handler must not hand an anonymous visitor a way to
+    # make the server dump a stack for every task id they guess.
+    records = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert records, "the refusal still has to be recorded"
+    assert all(r.exc_info is None for r in records), (
+        "a curated refusal is routine; only an incidental fault earns a stack"
+    )
+    assert all(r.levelno <= logging.WARNING for r in records)

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -8,7 +8,8 @@ import json
 import logging
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from typing import NamedTuple
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -173,6 +174,12 @@ PRODUCERS: dict[str, int | None] = {
 # string between branches of an allowlisted function is NOT caught. #1547.
 ALLOWED_RAW_MESSAGES = {
     ("_handle_chat_message_unserialized", "f'Runtime error: {str(e)}'"),
+    # The same #1479 flow seen through the closure scope chain: the outer
+    # function's runtime-error string reaches these closures' ``message``
+    # parameter at their call sites. Surfaced when the parameter short-circuit
+    # stopped hiding rebound names; not a new leak.
+    ("finish_delivery", "f'Runtime error: {str(e)}'"),
+    ("finish_delivery_failure", "f'Runtime error: {str(e)}'"),
     ("handle_execute_task", "f'Runtime error: {str(e)}'"),
     ("handle_intervention", "f'Runtime error: {str(e)}'"),
     ("_handle_pause_task_unserialized", "f'Runtime error: {str(e)}'"),
@@ -216,6 +223,12 @@ ERROR_PAYLOAD_SINKS = {"send_personal_message", "broadcast_to_task", "send_text"
 # Both render in the client's conversation, so both are the same disclosure
 # surface. ``agent_error`` was missing until review found a producer using it.
 ERROR_PAYLOAD_TYPES = {"error", "agent_error"}
+
+# The only functions allowed to mint client-visible text from an exception.
+SAFE_MESSAGE_BUILDERS = {
+    "client_safe_error_message",
+    "client_safe_task_command_failure",
+}
 
 
 def _unwrap_serializer(expr: ast.expr) -> ast.expr:
@@ -284,7 +297,14 @@ def _is_client_safe(expr: ast.expr) -> bool:
     if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
         return True
     if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Name):
-        return expr.func.id == "client_safe_error_message"
+        if expr.func.id == "client_safe_error_message":
+            return True
+        if expr.func.id == "client_safe_task_command_failure":
+            # The prefix argument must be attribute access on server state
+            # (``command.kind``), never a literal or a bare name a caller
+            # could point at untrusted text.
+            return bool(expr.args) and isinstance(expr.args[0], ast.Attribute)
+        return False
     # `_TURN_REJECTION_MESSAGES.get(reason, "<literal>")` - a curated table.
     if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute):
         return expr.func.attr == "get" and all(
@@ -294,6 +314,76 @@ def _is_client_safe(expr: ast.expr) -> bool:
     if isinstance(expr, ast.BoolOp):
         return all(_is_client_safe(value) for value in expr.values)
     return False
+
+
+class _ScanResult(NamedTuple):
+    offenders: list[str]
+    producers: int
+    error_payloads: int
+    used_allowlist: set[tuple[str, str]]
+
+
+def _scan(tree: ast.Module) -> _ScanResult:
+    """The one copy of the sweep's recognition logic.
+
+    Both the production sweep and the snippet-based regression tests run
+    this same function, so a change to the analysis cannot pass the snippet
+    tests while silently not applying to the real module (or vice versa).
+    """
+    parents = _parents(tree)
+    producers = 0
+    error_payloads = 0
+    offenders: list[str] = []
+    used_allowlist: set[tuple[str, str]] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _called_name(node)
+        is_producer = name in PRODUCERS
+        if is_producer:
+            expr = _message_expression(node, PRODUCERS[name])
+        else:
+            # The error bubble renders in the same conversation as the
+            # rejection ack, so it is the same disclosure surface.
+            expr = _error_payload_message(node)
+            name = f"{name}(error payload)"
+        if expr is None:
+            continue
+        if is_producer:
+            producers += 1
+        else:
+            error_payloads += 1
+        scopes = _enclosing_functions(node, parents)
+        candidates = (
+            _local_assignments(scopes, expr.id)
+            if isinstance(expr, ast.Name)
+            else [expr]
+        )
+        if not candidates:
+            # Only a name nothing rebinds is a genuinely forwarded parameter,
+            # vetted at the wrapper's own call sites. A parameter rebound by a
+            # plain assignment lands in the candidates instead; rebinding via
+            # AnnAssign/AugAssign/walrus/tuple targets is still invisible to
+            # ``_local_assignments`` and tracked in #1547.
+            if isinstance(expr, ast.Name) and _is_parameter(scopes, expr.id):
+                continue
+            offenders.append(f"{name}:{node.lineno} passes an unresolvable name")
+            continue
+        enclosing = next(
+            (scope.name for scope in scopes if isinstance(scope, FUNCTION_NODES)),
+            "<module>",
+        )
+        for candidate in candidates:
+            if _is_client_safe(candidate):
+                continue
+            key = (enclosing, ast.unparse(candidate))
+            if key in ALLOWED_RAW_MESSAGES:
+                used_allowlist.add(key)
+                continue
+            offenders.append(
+                f"{name}:{node.lineno} may send {ast.unparse(candidate)!r}"
+            )
+    return _ScanResult(offenders, producers, error_payloads, used_allowlist)
 
 
 def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
@@ -316,66 +406,32 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
     # Explicit encoding: this module carries non-ASCII prose, and the
     # platform default would decode it as cp1252/GBK on a Windows runner.
     source = Path(websocket_api.__file__).read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    parents = _parents(tree)
+    result = _scan(ast.parse(source))
 
-    checked_producers = 0
-    checked_error_payloads = 0
-    offenders: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        name = _called_name(node)
-        is_producer = name in PRODUCERS
-        if is_producer:
-            expr = _message_expression(node, PRODUCERS[name])
-        else:
-            # The error bubble renders in the same conversation as the
-            # rejection ack, so it is the same disclosure surface.
-            expr = _error_payload_message(node)
-            name = f"{name}(error payload)"
-        if expr is None:
-            continue
-        if is_producer:
-            checked_producers += 1
-        else:
-            checked_error_payloads += 1
-        scopes = _enclosing_functions(node, parents)
-        if isinstance(expr, ast.Name) and _is_parameter(scopes, expr.id):
-            continue
-        candidates = (
-            _local_assignments(scopes, expr.id)
-            if isinstance(expr, ast.Name)
-            else [expr]
+    for builder in SAFE_MESSAGE_BUILDERS:
+        assert callable(getattr(websocket_api, builder, None)), (
+            f"SAFE_MESSAGE_BUILDERS blesses {builder!r}, which does not exist"
         )
-        if not candidates:
-            offenders.append(f"{name}:{node.lineno} passes an unresolvable name")
-            continue
-        enclosing = next(
-            (scope.name for scope in scopes if isinstance(scope, FUNCTION_NODES)),
-            "<module>",
-        )
-        for candidate in candidates:
-            if _is_client_safe(candidate):
-                continue
-            if (enclosing, ast.unparse(candidate)) in ALLOWED_RAW_MESSAGES:
-                continue
-            offenders.append(
-                f"{name}:{node.lineno} may send {ast.unparse(candidate)!r}"
-            )
 
     # Actual counts at the time of writing: 23 producers, 30 error payloads.
     # These floors sit below that, so a minority of sites can still vanish
     # silently; tightening them to exact equality is tracked in #1547.
-    assert checked_producers >= 21, (
-        f"the producers moved; only {checked_producers} matched"
+    assert result.producers >= 21, (
+        f"the producers moved; only {result.producers} matched"
     )
-    assert checked_error_payloads >= 21, (
-        f"the error payloads moved; only {checked_error_payloads} matched"
+    assert result.error_payloads >= 21, (
+        f"the error payloads moved; only {result.error_payloads} matched"
     )
-    assert not offenders, (
+    # Every allowlist entry must be earned by a live call site: a stale entry
+    # is a standing exemption nothing uses, and an unused closure entry is
+    # exactly what a reverted parameter-rebinding fix would leave behind.
+    assert result.used_allowlist == ALLOWED_RAW_MESSAGES, (
+        "stale allowlist entries: "
+        f"{sorted(ALLOWED_RAW_MESSAGES - result.used_allowlist)}"
+    )
+    assert not result.offenders, (
         "raw text can reach a chat client; route it through "
-        "client_safe_error_message: " + "; ".join(sorted(set(offenders)))
+        "client_safe_error_message: " + "; ".join(sorted(set(result.offenders)))
     )
 
 
@@ -680,42 +736,8 @@ async def leak(websocket):
 
 
 def _guard_offenders(source: str) -> list[str]:
-    """Run the sweep's recognition logic over an arbitrary module source."""
-    tree = ast.parse(source)
-    parents = _parents(tree)
-    offenders: list[str] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        name = _called_name(node)
-        if name in PRODUCERS:
-            expr = _message_expression(node, PRODUCERS[name])
-        else:
-            expr = _error_payload_message(node)
-        if expr is None:
-            continue
-        scopes = _enclosing_functions(node, parents)
-        if isinstance(expr, ast.Name) and _is_parameter(scopes, expr.id):
-            continue
-        candidates = (
-            _local_assignments(scopes, expr.id)
-            if isinstance(expr, ast.Name)
-            else [expr]
-        )
-        if not candidates:
-            offenders.append(f"{name}:{node.lineno} unresolvable")
-            continue
-        enclosing = next(
-            (scope.name for scope in scopes if isinstance(scope, FUNCTION_NODES)),
-            "<module>",
-        )
-        for candidate in candidates:
-            if _is_client_safe(candidate):
-                continue
-            if (enclosing, ast.unparse(candidate)) in ALLOWED_RAW_MESSAGES:
-                continue
-            offenders.append(f"{name}:{node.lineno} {ast.unparse(candidate)}")
-    return offenders
+    """Run the one sweep implementation over an arbitrary module source."""
+    return _scan(ast.parse(source)).offenders
 
 
 @pytest.mark.xfail(
@@ -779,3 +801,335 @@ async def test_unresolvable_task_answers_the_sender_instead_of_dropping_them(
         "a curated refusal is routine; only an incidental fault earns a stack"
     )
     assert all(r.levelno <= logging.WARNING for r in records)
+
+
+# --- Round 5: the parameter short-circuit must not hide rebound names -------
+
+REBOUND_PARAMETER_SHAPES = [
+    pytest.param(
+        """
+async def leak(websocket, message):
+    try:
+        pass
+    except Exception as e:
+        message = str(e)
+        await send_message_delivery(
+            websocket,
+            client_message_id="c",
+            turn_id="t",
+            accepted=False,
+            message=message,
+            rejection_outcome="not_accepted",
+        )
+""",
+        id="same-scope-rebind",
+    ),
+    pytest.param(
+        """
+async def outer(websocket, message):
+    async def inner(e):
+        message = str(e)
+        await send_message_delivery(
+            websocket,
+            client_message_id="c",
+            turn_id="t",
+            accepted=False,
+            message=message,
+            rejection_outcome="not_accepted",
+        )
+""",
+        id="nested-shadow",
+    ),
+]
+
+
+@pytest.mark.parametrize("source", REBOUND_PARAMETER_SHAPES)
+def test_guard_catches_a_rebound_parameter(source: str) -> None:
+    """A name is only "vetted at the caller" while nothing in scope rebinds it.
+
+    The short-circuit used to fire on the bare parameter match, before local
+    assignments were even collected, so ``message = str(e)`` shadowing a
+    ``message`` argument sailed through.
+    """
+    assert _guard_offenders(source), "the rebound parameter must be flagged"
+
+
+def test_guard_still_trusts_a_genuinely_forwarded_parameter() -> None:
+    """The wrapper shape stays clean; only its callers are judged."""
+    source = """
+async def forward(websocket, message):
+    await send_message_delivery(
+        websocket,
+        client_message_id="c",
+        turn_id="t",
+        accepted=False,
+        message=message,
+        rejection_outcome="not_accepted",
+    )
+"""
+    assert not _guard_offenders(source)
+
+
+# The concurrent-delete race (TaskCommandTaskMissing between lookup and
+# enqueue) is pinned in tests/web/services/test_task_command_transport.py:
+# recovery-allowed returns None, and the strict path converts to
+# ClientVisibleValidationError with "Task N not found" preserved.
+
+
+# --- Round 5: runtime payload contracts for the changed egresses ------------
+
+
+@pytest.mark.asyncio
+async def test_terminal_command_failure_keeps_context_and_redacts_detail() -> None:
+    """The kind prefix is ours; the exception text is not.
+
+    The frontend renders ``message`` verbatim for ``agent_error``, so the
+    redaction must not also delete the command context the client used to
+    get, and the secret must not ride along in any field.
+    """
+    connection_manager = MagicMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    command = SimpleNamespace(
+        kind=websocket_api.TaskCommandKind.PAUSE, task_id=7, command_id="cmd-7"
+    )
+    with patch.object(websocket_api, "manager", connection_manager):
+        await websocket_api._broadcast_terminal_command_error(
+            command, RuntimeError(f"lease lost at {SECRET}")
+        )
+    (payload, task_id) = connection_manager.broadcast_to_task.await_args.args
+    assert task_id == 7
+    assert SECRET not in repr(payload)
+    assert payload["message"] == (
+        f"Task command pause failed: {websocket_api.CLIENT_SAFE_VALIDATION_ERROR}"
+    )
+    assert payload["command_kind"] == "pause"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "handler_name",
+    ["_handle_pause_task_unserialized", "_handle_resume_task_unserialized"],
+    ids=["pause", "resume"],
+)
+async def test_inner_command_validation_redacts_the_client_payload(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    handler_name: str,
+) -> None:
+    """The unserialized handlers' validation branch is a client egress too."""
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    monkeypatch.setattr(
+        websocket_api,
+        "run_db_io_cancellation_safe",
+        AsyncMock(side_effect=ValueError(f"snapshot fault at {SECRET}")),
+    )
+
+    await getattr(websocket_api, handler_name)(
+        MagicMock(),
+        7,
+        {"user": SimpleNamespace(id=1, is_admin=False)},
+    )
+
+    payloads = _client_payloads(connection_manager)
+    assert payloads, "the handler must answer the client"
+    assert SECRET not in repr(payloads)
+    assert any(
+        payload.get("message") == websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+        for payload in payloads
+    )
+
+
+@pytest.mark.asyncio
+async def test_intervention_validation_redacts_the_client_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The intervention validation branch is asserted, not just swept."""
+    connection_manager = MagicMock()
+    connection_manager.broadcast_to_task = AsyncMock(
+        side_effect=ValueError(f"intervention fault at {SECRET}")
+    )
+    connection_manager.send_personal_message = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    await websocket_api.handle_intervention(
+        MagicMock(), 7, {"step_id": "s1", "action": "approve"}
+    )
+
+    sent = [c.args[0] for c in connection_manager.send_personal_message.await_args_list]
+    assert sent, "the handler must answer the sender"
+    assert SECRET not in repr(sent)
+    assert sent[-1]["message"] == websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+
+
+@pytest.mark.asyncio
+async def test_unexpected_execute_error_keeps_its_traceback(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """handle_execute_task re-raises into callers that log no stack."""
+
+    class _Unexpected(Exception):
+        pass
+
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    db = _direct_db_session()
+    try:
+        user = User(username="unexpected-owner", password_hash="hash")
+        db.add(user)
+        db.commit()
+        task = Task(
+            user_id=int(user.id),
+            title="Unexpected",
+            description="generic branch",
+            status=TaskStatus.PENDING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task_id, user_id = int(task.id), int(user.id)
+    finally:
+        db.close()
+    monkeypatch.setattr(
+        TaskTurnOrchestrator,
+        "schedule_existing_task_execution",
+        AsyncMock(side_effect=_Unexpected("boom")),
+    )
+
+    with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
+        with pytest.raises(_Unexpected):
+            await websocket_api.handle_execute_task(
+                MagicMock(),
+                task_id,
+                {"user": SimpleNamespace(id=user_id, is_admin=False)},
+            )
+
+    records = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert any(r.exc_info is not None for r in records), (
+        "the traceback must be recorded where the detail is known"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unexpected_intervention_error_keeps_its_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """handle_intervention re-raises into public endpoints that swallow."""
+
+    class _Unexpected(Exception):
+        pass
+
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock(side_effect=_Unexpected("boom"))
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
+        with pytest.raises(_Unexpected):
+            await websocket_api.handle_intervention(
+                MagicMock(), 7, {"step_id": "s1", "action": "approve"}
+            )
+
+    records = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert any(r.exc_info is not None for r in records), (
+        "the traceback must be recorded where the detail is known"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_validation_redacts_both_the_ack_and_the_broadcast(
+    _test_db: None,
+) -> None:
+    """The inner chat validation branch answers on two sinks; assert both.
+
+    The rejection ack goes to the sender and the task broadcast goes to every
+    subscriber through a dict-spread payload the AST guard cannot follow, so
+    this is runtime-only coverage: reverting the branch to ``str(e)`` must
+    fail here even though the sweep stays green.
+    """
+    db = _direct_db_session()
+    try:
+        owner = User(username="chat-validation-owner", password_hash="hash")
+        db.add(owner)
+        db.commit()
+        task = Task(
+            user_id=int(owner.id),
+            title="Live control",
+            description="validation branch",
+            status=TaskStatus.RUNNING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task.runner_id = "rt5-runner"
+        task.run_id = "rt5-run"
+        db.commit()
+        task_id, owner_id = int(task.id), int(owner.id)
+    finally:
+        db.close()
+
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(
+        side_effect=ValueError(f"validation fault at {SECRET}")
+    )
+    mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+
+    def _fake_error_payload(task_id: int, message: str, **kwargs: object) -> dict:
+        return {"type": "agent_error", "message": message, "task_id": task_id}
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch(
+            "xagent.web.api.websocket.mark_user_message_delivery_sync",
+            MagicMock(),
+        ),
+        patch(
+            "xagent.web.api.websocket._read_task_error_payload_isolated",
+            MagicMock(side_effect=_fake_error_payload),
+        ),
+    ):
+        await websocket_api._handle_chat_message_unserialized(
+            MagicMock(),
+            task_id,
+            {
+                "message": "trip the validation branch",
+                "client_message_id": "chat-validation-secret",
+                "user": SimpleNamespace(id=owner_id, is_admin=False),
+                "files": [],
+            },
+        )
+
+    personal = [c.args[0] for c in ws_manager.send_personal_message.await_args_list]
+    broadcast = [c.args[0] for c in ws_manager.broadcast_to_task.await_args_list]
+    everything = personal + broadcast
+    assert everything, "the failure must be answered somewhere"
+    assert SECRET not in repr(everything), everything
+
+    rejected = [p for p in personal if p.get("type") == "message_rejected"]
+    assert rejected and rejected[0]["message"] == (
+        websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+    )
+    task_errors = [b for b in broadcast if b.get("type") == "agent_error"]
+    assert task_errors and task_errors[0]["message"] == (
+        websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+    )

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import json
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -30,6 +31,26 @@ def _client_payloads(connection_manager: MagicMock) -> list[dict]:
         )
         if call.args and isinstance(call.args[0], dict)
     ]
+
+
+def _sent_text_payloads(websocket: MagicMock) -> list[dict]:
+    """Payloads written straight to the socket, bypassing ``manager``.
+
+    ``handle_builder_chat`` uses this sink, so a helper that only reads the
+    manager mock cannot see it - which is why that handler's leak survived
+    until the AST sweep learned to recognize ``send_text``.
+    """
+    payloads = []
+    for call in websocket.send_text.await_args_list:
+        if not call.args:
+            continue
+        try:
+            decoded = json.loads(call.args[0])
+        except (TypeError, ValueError):
+            continue
+        if isinstance(decoded, dict):
+            payloads.append(decoded)
+    return payloads
 
 
 @pytest.mark.asyncio
@@ -133,13 +154,24 @@ PRODUCERS: dict[str, int | None] = {
     "send_message_delivery": None,  # keyword-only
 }
 
-# The one deliberate exception: agent RuntimeError text is surfaced to the
-# sender by an existing, tested contract. Narrowing it is a product decision,
-# tracked in #1479 - not a hole to be quietly widened.
+# The one deliberate exception: agent RuntimeError text is passed through
+# untouched. Narrowing it is a product decision tracked in #1479.
 #
-# Anchored to (enclosing function, expression), not to the expression alone:
-# keying on source text blesses the string everywhere it is ever pasted,
-# including into a *validation* branch, which is not what #1479 describes.
+# Do NOT read this as "sender only". An earlier version of this comment cited
+# tests/web/api/test_websocket_owner_actor.py as an existing tested contract
+# for that; the citation was wrong. That file never pins this string, and its
+# one raw-RuntimeError assertion covers the sender-only fallback, not the
+# broadcast. Once a task resolves, this text goes out via broadcast_to_task to
+# every connection registered under the task_id - anonymous widget and share
+# visitors included, since they register into the same ConnectionManager.
+# DurableStorageOperationError is a RuntimeError subclass, so the tenant-scope
+# leak that motivates this module is still open on that path. #1479 owns it.
+#
+# Anchored to (enclosing function, expression) rather than to the expression
+# alone, which blessed the string in every function it appeared in. This stops
+# reuse in a *different* function only: `_local_assignments` unions every
+# assignment in the enclosing function regardless of branch, so moving the
+# string between branches of an allowlisted function is NOT caught. #1547.
 ALLOWED_RAW_MESSAGES = {
     ("_handle_chat_message_unserialized", "f'Runtime error: {str(e)}'"),
     ("handle_execute_task", "f'Runtime error: {str(e)}'"),
@@ -323,8 +355,9 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
                 f"{name}:{node.lineno} may send {ast.unparse(candidate)!r}"
             )
 
-    # Pinned near the actual counts (23 / 23 at the time of writing) so that
-    # a producer disappearing from the sweep trips this before it trips a user.
+    # Actual counts at the time of writing: 23 producers, 28 error payloads.
+    # These floors sit below that, so a minority of sites can still vanish
+    # silently; tightening them to exact equality is tracked in #1547.
     assert checked_producers >= 21, (
         f"the producers moved; only {checked_producers} matched"
     )
@@ -456,3 +489,94 @@ def test_log_level_follows_the_marker_not_the_call_site(
     assert record.levelno == expected_level
     assert (record.exc_info is not None) is expects_traceback
     assert "task 7" in record.getMessage()
+
+
+@pytest.mark.asyncio
+async def test_builder_chat_redacts_through_its_own_socket_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The leak found by self-review, pinned at runtime rather than by AST alone.
+
+    ``handle_builder_chat`` answers on ``websocket.send_text`` instead of going
+    through ``manager``, which is why it escaped both the original sweep and
+    every behavioural test in this file.
+    """
+    from xagent.web.services import builder_chat_runtime
+
+    monkeypatch.setattr(
+        builder_chat_runtime,
+        "load_builder_chat_runtime_inputs",
+        AsyncMock(side_effect=ValueError(f"builder fault at {SECRET}")),
+    )
+
+    websocket = MagicMock()
+    websocket.send_text = AsyncMock()
+    websocket.state = SimpleNamespace()
+
+    await websocket_api.handle_builder_chat(
+        websocket,
+        {"message": "build me an agent"},
+        SimpleNamespace(id=1, is_admin=False),
+    )
+
+    payloads = _sent_text_payloads(websocket)
+    errors = [p for p in payloads if p.get("type") == "error"]
+    assert errors, "the handler must answer the builder client"
+    assert SECRET not in repr(payloads)
+    assert errors[-1]["message"] == websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "handler_name", ["handle_pause_task", "handle_resume_task"], ids=["pause", "resume"]
+)
+async def test_permission_wording_survives_redaction_in_every_handler(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    handler_name: str,
+) -> None:
+    """All three handlers share one raise site; only one of them was asserted.
+
+    ``test_websocket_error_payload.py`` pins this wording for
+    ``handle_chat_message``. A regression in either sibling's ``except`` - one
+    that redacted the refusal to the generic string, or leaked something else
+    through it - would have gone unnoticed.
+    """
+    db = _direct_db_session()
+    try:
+        owner = User(username=f"owner-{handler_name}", password_hash="hash")
+        intruder = User(username=f"intruder-{handler_name}", password_hash="hash")
+        db.add_all([owner, intruder])
+        db.commit()
+        task = Task(
+            user_id=int(owner.id),
+            title="Someone else's task",
+            description="Not yours",
+            status=TaskStatus.RUNNING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task_id, intruder_id = int(task.id), int(intruder.id)
+    finally:
+        db.close()
+
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    await getattr(websocket_api, handler_name)(
+        MagicMock(),
+        task_id,
+        {"user": SimpleNamespace(id=intruder_id, is_admin=False)},
+    )
+
+    payloads = _client_payloads(connection_manager)
+    assert payloads, "the handler must refuse the intruder out loud"
+    assert any(
+        payload.get("message")
+        == f"Access denied: Task {task_id} does not belong to you"
+        for payload in payloads
+    ), payloads

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -135,9 +135,18 @@ PRODUCERS: dict[str, int | None] = {
 
 # The one deliberate exception: agent RuntimeError text is surfaced to the
 # sender by an existing, tested contract. Narrowing it is a product decision,
-# tracked in #1479 - not a hole to be quietly widened. Any *other* raw
-# expression reaching a producer must fail this test.
-ALLOWED_RAW_MESSAGE_SOURCES = {"f'Runtime error: {str(e)}'"}  # ast.unparse form
+# tracked in #1479 - not a hole to be quietly widened.
+#
+# Anchored to (enclosing function, expression), not to the expression alone:
+# keying on source text blesses the string everywhere it is ever pasted,
+# including into a *validation* branch, which is not what #1479 describes.
+ALLOWED_RAW_MESSAGES = {
+    ("_handle_chat_message_unserialized", "f'Runtime error: {str(e)}'"),
+    ("handle_execute_task", "f'Runtime error: {str(e)}'"),
+    ("handle_intervention", "f'Runtime error: {str(e)}'"),
+    ("_handle_pause_task_unserialized", "f'Runtime error: {str(e)}'"),
+    ("_handle_resume_task_unserialized", "f'Runtime error: {str(e)}'"),
+}
 
 
 def _parents(tree: ast.Module) -> dict[ast.AST, ast.AST]:
@@ -170,11 +179,23 @@ def _message_expression(node: ast.Call, index: int | None) -> ast.expr | None:
     return None
 
 
+# ``send_text`` takes a serialized payload, so the dict sits one call deeper.
+ERROR_PAYLOAD_SINKS = {"send_personal_message", "broadcast_to_task", "send_text"}
+
+
+def _unwrap_serializer(expr: ast.expr) -> ast.expr:
+    """``json.dumps(payload)`` -> ``payload``; anything else unchanged."""
+    if isinstance(expr, ast.Call) and _called_name(expr) == "dumps" and expr.args:
+        return expr.args[0]
+    return expr
+
+
 def _error_payload_message(node: ast.Call) -> ast.expr | None:
     """The message of an ``{"type": "error", ...}`` payload, if this is one."""
-    if _called_name(node) not in {"send_personal_message", "broadcast_to_task"}:
+    if _called_name(node) not in ERROR_PAYLOAD_SINKS:
         return None
-    for argument in (*node.args, *(kw.value for kw in node.keywords)):
+    for raw in (*node.args, *(kw.value for kw in node.keywords)):
+        argument = _unwrap_serializer(raw)
         if not isinstance(argument, ast.Dict):
             continue
         keys = {
@@ -257,13 +278,15 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
     tree = ast.parse(source)
     parents = _parents(tree)
 
-    checked = 0
+    checked_producers = 0
+    checked_error_payloads = 0
     offenders: list[str] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         name = _called_name(node)
-        if name in PRODUCERS:
+        is_producer = name in PRODUCERS
+        if is_producer:
             expr = _message_expression(node, PRODUCERS[name])
         else:
             # The error bubble renders in the same conversation as the
@@ -272,7 +295,10 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
             name = f"{name}(error payload)"
         if expr is None:
             continue
-        checked += 1
+        if is_producer:
+            checked_producers += 1
+        else:
+            checked_error_payloads += 1
         scopes = _enclosing_functions(node, parents)
         if isinstance(expr, ast.Name) and _is_parameter(scopes, expr.id):
             continue
@@ -284,16 +310,27 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
         if not candidates:
             offenders.append(f"{name}:{node.lineno} passes an unresolvable name")
             continue
+        enclosing = next(
+            (scope.name for scope in scopes if isinstance(scope, FUNCTION_NODES)),
+            "<module>",
+        )
         for candidate in candidates:
             if _is_client_safe(candidate):
                 continue
-            if ast.unparse(candidate) in ALLOWED_RAW_MESSAGE_SOURCES:
+            if (enclosing, ast.unparse(candidate)) in ALLOWED_RAW_MESSAGES:
                 continue
             offenders.append(
                 f"{name}:{node.lineno} may send {ast.unparse(candidate)!r}"
             )
 
-    assert checked >= 20, f"the producers moved; only {checked} call sites matched"
+    # Pinned near the actual counts (23 / 23 at the time of writing) so that
+    # a producer disappearing from the sweep trips this before it trips a user.
+    assert checked_producers >= 21, (
+        f"the producers moved; only {checked_producers} matched"
+    )
+    assert checked_error_payloads >= 21, (
+        f"the error payloads moved; only {checked_error_payloads} matched"
+    )
     assert not offenders, (
         "raw text can reach a chat client; route it through "
         "client_safe_error_message: " + "; ".join(sorted(set(offenders)))
@@ -385,3 +422,37 @@ async def test_redacted_enqueue_failure_still_reaches_the_log(
     assert records, f"{handler_name} redacted the failure without logging it"
     assert any(SECRET in record.getMessage() for record in records)
     assert any(record.exc_info is not None for record in records)
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_level", "expects_traceback"),
+    [
+        (
+            websocket_api.ClientVisibleValidationError("User authentication required"),
+            logging.WARNING,
+            False,
+        ),
+        (ValueError(f"incidental fault at {SECRET}"), logging.ERROR, True),
+    ],
+    ids=["curated", "incidental"],
+)
+def test_log_level_follows_the_marker_not_the_call_site(
+    caplog: pytest.LogCaptureFixture,
+    error: Exception,
+    expected_level: int,
+    expects_traceback: bool,
+) -> None:
+    """A curated refusal is routine; only an incidental fault earns a traceback.
+
+    Without the split, any visitor could make the server dump a stack on
+    demand by sending an unauthenticated frame in a loop.
+    """
+    with caplog.at_level(logging.DEBUG, logger=WEBSOCKET_LOGGER):
+        websocket_api.log_client_facing_failure(
+            error, "Pause command rejected for task %s: %s", 7
+        )
+
+    (record,) = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert record.levelno == expected_level
+    assert (record.exc_info is not None) is expects_traceback
+    assert "task 7" in record.getMessage()

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -250,7 +251,9 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
     shapes leak today and are tracked in #1497 - do not read a passing run as
     "nothing can reach a client raw".
     """
-    source = Path(websocket_api.__file__).read_text()
+    # Explicit encoding: this module carries non-ASCII prose, and the
+    # platform default would decode it as cp1252/GBK on a Windows runner.
+    source = Path(websocket_api.__file__).read_text(encoding="utf-8")
     tree = ast.parse(source)
     parents = _parents(tree)
 
@@ -295,3 +298,90 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
         "raw text can reach a chat client; route it through "
         "client_safe_error_message: " + "; ".join(sorted(set(offenders)))
     )
+
+
+WEBSOCKET_LOGGER = "xagent.web.api.websocket"
+
+# Every handler that turns an enqueue refusal into client-visible text. Each
+# entry is (handler, extra message_data) - the ack in handle_chat_message only
+# fires when the client supplied an id, so that one needs the extra key.
+ENQUEUE_FAILURE_HANDLERS = [
+    ("handle_chat_message", {"client_message_id": "cmid-1"}),
+    ("handle_pause_task", {}),
+    ("handle_resume_task", {}),
+]
+
+
+def test_missing_task_keeps_its_wording_for_the_sender(_test_db: None) -> None:
+    """A missing task is the sender's own answer, so redaction must spare it.
+
+    ``execute_task_background`` already raises this as client-visible; the
+    pause/resume enqueue path raised a bare ``ValueError``, which the redaction
+    turned into the generic string and left the sender with nothing to act on.
+    """
+    with pytest.raises(ValueError) as raised:
+        websocket_api._enqueue_websocket_task_command_sync(
+            task_id=424242,
+            actor_user_id=1,
+            actor_is_admin=False,
+            command_id="pause:missing-task",
+            kind=websocket_api.TaskCommandKind.PAUSE,
+            payload={},
+            allow_missing_task=False,
+        )
+
+    assert isinstance(raised.value, websocket_api.ClientVisibleValidationError)
+    assert (
+        websocket_api.client_safe_error_message(raised.value) == "Task 424242 not found"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_name", "extra_message_data"),
+    ENQUEUE_FAILURE_HANDLERS,
+    ids=[name for name, _ in ENQUEUE_FAILURE_HANDLERS],
+)
+async def test_redacted_enqueue_failure_still_reaches_the_log(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    handler_name: str,
+    extra_message_data: dict,
+) -> None:
+    """Redacting the client's copy must not delete the operator's copy.
+
+    These handlers previously leaked ``str(exc)`` to the client and logged
+    nothing; the leak was the only record. With the text redacted, an
+    incidental failure would otherwise vanish without a trace.
+    """
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    monkeypatch.setattr(
+        websocket_api,
+        "_enqueue_websocket_task_command",
+        AsyncMock(side_effect=ValueError(f"enqueue failed reading {SECRET}")),
+    )
+
+    handler = getattr(websocket_api, handler_name)
+    with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
+        await handler(
+            MagicMock(),
+            7,
+            {"user": SimpleNamespace(id=1, is_admin=False), **extra_message_data},
+        )
+
+    payloads = _client_payloads(connection_manager)
+    assert payloads, "the handler must tell the client something"
+    assert SECRET not in repr(payloads)
+    assert any(
+        payload.get("message") == websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+        for payload in payloads
+    )
+
+    records = [record for record in caplog.records if record.name == WEBSOCKET_LOGGER]
+    assert records, f"{handler_name} redacted the failure without logging it"
+    assert any(SECRET in record.getMessage() for record in records)
+    assert any(record.exc_info is not None for record in records)

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -1,0 +1,297 @@
+"""Exception text must not reach chat clients (PR #1472 review finding N3)."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from xagent.web.api import websocket as websocket_api
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.user import User
+from xagent.web.services.task_orchestrator import TaskTurnOrchestrator
+
+from .conftest import _direct_db_session
+
+SECRET = "/srv/xagent/secrets/prod.key"
+
+
+def _client_payloads(connection_manager: MagicMock) -> list[dict]:
+    return [
+        call.args[0]
+        for call in (
+            connection_manager.send_personal_message.await_args_list
+            + connection_manager.broadcast_to_task.await_args_list
+        )
+        if call.args and isinstance(call.args[0], dict)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raised",
+    [
+        ValueError(f"invalid payload while reading {SECRET}"),
+        KeyError(f"missing key near {SECRET}"),
+        TypeError(f"bad type from {SECRET}"),
+    ],
+    ids=["value", "key", "type"],
+)
+async def test_execute_task_redacts_an_incidental_validation_error(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    raised: Exception,
+) -> None:
+    """A widget visitor gets the fixed string, never the exception's text."""
+    db = _direct_db_session()
+    try:
+        user = User(
+            username=f"safe-error-owner-{type(raised).__name__}",
+            password_hash="hash",
+        )
+        db.add(user)
+        db.commit()
+        task = Task(
+            user_id=int(user.id),
+            title="Client safe errors",
+            description="Run the existing task",
+            status=TaskStatus.PENDING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task_id = int(task.id)
+        user_id = int(user.id)
+    finally:
+        db.close()
+
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    async def raise_at_schedule(**_kwargs: object) -> asyncio.Task:
+        raise raised
+
+    monkeypatch.setattr(
+        TaskTurnOrchestrator,
+        "schedule_existing_task_execution",
+        AsyncMock(side_effect=raise_at_schedule),
+        raising=False,
+    )
+
+    await websocket_api.handle_execute_task(
+        MagicMock(),
+        task_id,
+        {"user": SimpleNamespace(id=user_id, is_admin=False)},
+    )
+
+    payloads = _client_payloads(connection_manager)
+    assert payloads, "the handler must tell the client something"
+    serialized = repr(payloads)
+    assert SECRET not in serialized
+    assert str(raised) not in serialized
+    assert any(
+        payload.get("message") == websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+        for payload in payloads
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_task_keeps_a_message_written_for_the_sender(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A validation failure raised as client-visible keeps its own wording."""
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+
+    # No authenticated actor: the handler raises its own curated message.
+    await websocket_api.handle_execute_task(MagicMock(), 1, {})
+
+    payloads = _client_payloads(connection_manager)
+    assert any(
+        "authentication required" in str(payload.get("message", "")).lower()
+        for payload in payloads
+    )
+
+
+FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
+
+# arg name -> positional index of the client-visible message
+PRODUCERS: dict[str, int | None] = {
+    "finish_delivery_failure": 0,
+    "finish_delivery": 1,
+    "send_message_delivery": None,  # keyword-only
+}
+
+# The one deliberate exception: agent RuntimeError text is surfaced to the
+# sender by an existing, tested contract. Narrowing it is a product decision,
+# tracked in #1479 - not a hole to be quietly widened. Any *other* raw
+# expression reaching a producer must fail this test.
+ALLOWED_RAW_MESSAGE_SOURCES = {"f'Runtime error: {str(e)}'"}  # ast.unparse form
+
+
+def _parents(tree: ast.Module) -> dict[ast.AST, ast.AST]:
+    parents: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[child] = node
+    return parents
+
+
+def _enclosing_functions(
+    node: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> list[ast.AST]:
+    """Innermost-first chain of functions a node can read locals from."""
+    chain: list[ast.AST] = []
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, FUNCTION_NODES):
+            chain.append(current)
+        current = parents.get(current)
+    return chain
+
+
+def _message_expression(node: ast.Call, index: int | None) -> ast.expr | None:
+    for keyword in node.keywords:
+        if keyword.arg == "message":
+            return keyword.value
+    if index is not None and len(node.args) > index:
+        return node.args[index]
+    return None
+
+
+def _error_payload_message(node: ast.Call) -> ast.expr | None:
+    """The message of an ``{"type": "error", ...}`` payload, if this is one."""
+    if _called_name(node) not in {"send_personal_message", "broadcast_to_task"}:
+        return None
+    for argument in (*node.args, *(kw.value for kw in node.keywords)):
+        if not isinstance(argument, ast.Dict):
+            continue
+        keys = {
+            key.value: value
+            for key, value in zip(argument.keys, argument.values)
+            if isinstance(key, ast.Constant)
+        }
+        kind = keys.get("type")
+        if isinstance(kind, ast.Constant) and kind.value == "error":
+            return keys.get("message")
+    return None
+
+
+def _called_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return None
+
+
+def _is_parameter(scopes: list[ast.AST], name: str) -> bool:
+    """A forwarded parameter is vetted at the wrapper's own call sites."""
+    for scope in scopes:
+        if not isinstance(scope, FUNCTION_NODES):
+            continue
+        arguments = scope.args
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ):
+            if argument.arg == name:
+                return True
+    return False
+
+
+def _local_assignments(scopes: list[ast.AST], name: str) -> list[ast.expr]:
+    """Values assigned to `name` inside the given scopes only."""
+    values: list[ast.expr] = []
+    for scope in scopes:
+        for node in ast.walk(scope):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == name:
+                        values.append(node.value)
+    return values
+
+
+def _is_client_safe(expr: ast.expr) -> bool:
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        return True
+    if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Name):
+        return expr.func.id == "client_safe_error_message"
+    # `_TURN_REJECTION_MESSAGES.get(reason, "<literal>")` - a curated table.
+    if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute):
+        return expr.func.attr == "get" and all(
+            isinstance(arg, ast.Constant) or isinstance(arg, ast.Attribute)
+            for arg in expr.args[1:]
+        )
+    if isinstance(expr, ast.BoolOp):
+        return all(_is_client_safe(value) for value in expr.values)
+    return False
+
+
+def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
+    """Exception text may not reach a client through the *recognized* shapes.
+
+    Scope, stated honestly: this walks direct calls to the producers in
+    ``PRODUCERS`` and ``{"type": "error", ...}`` dict *literals* passed to
+    ``send_personal_message``/``broadcast_to_task``. It does NOT follow
+    dict-spread payloads, payloads built by a helper and passed as a call, or
+    wrapper functions that forward a raw argument into a producer. Those
+    shapes leak today and are tracked in #1497 - do not read a passing run as
+    "nothing can reach a client raw".
+    """
+    source = Path(websocket_api.__file__).read_text()
+    tree = ast.parse(source)
+    parents = _parents(tree)
+
+    checked = 0
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _called_name(node)
+        if name in PRODUCERS:
+            expr = _message_expression(node, PRODUCERS[name])
+        else:
+            # The error bubble renders in the same conversation as the
+            # rejection ack, so it is the same disclosure surface.
+            expr = _error_payload_message(node)
+            name = f"{name}(error payload)"
+        if expr is None:
+            continue
+        checked += 1
+        scopes = _enclosing_functions(node, parents)
+        if isinstance(expr, ast.Name) and _is_parameter(scopes, expr.id):
+            continue
+        candidates = (
+            _local_assignments(scopes, expr.id)
+            if isinstance(expr, ast.Name)
+            else [expr]
+        )
+        if not candidates:
+            offenders.append(f"{name}:{node.lineno} passes an unresolvable name")
+            continue
+        for candidate in candidates:
+            if _is_client_safe(candidate):
+                continue
+            if ast.unparse(candidate) in ALLOWED_RAW_MESSAGE_SOURCES:
+                continue
+            offenders.append(
+                f"{name}:{node.lineno} may send {ast.unparse(candidate)!r}"
+            )
+
+    assert checked >= 20, f"the producers moved; only {checked} call sites matched"
+    assert not offenders, (
+        "raw text can reach a chat client; route it through "
+        "client_safe_error_message: " + "; ".join(sorted(set(offenders)))
+    )

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -8,7 +8,7 @@ import json
 import logging
 from pathlib import Path
 from types import SimpleNamespace
-from typing import NamedTuple
+from typing import Iterator, NamedTuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1291,3 +1291,553 @@ async def test_execute_runtime_error_broadcast_is_redacted(
     assert any(
         b.get("message") == websocket_api.CLIENT_SAFE_TASK_FAILURE for b in broadcast
     )
+
+
+# --- Round 6: the durable command origin registry ---------------------------
+#
+# Personal detail from durable execution goes to the exact socket that
+# submitted the command, verified to still be connected to that task - or
+# nowhere. Origin is never inferred from task membership, actor id, or
+# connection order.
+
+
+@pytest.fixture()
+def _clean_origins() -> Iterator[None]:
+    saved = dict(websocket_api._command_origins._origins)
+    websocket_api._command_origins._origins.clear()
+    yield
+    websocket_api._command_origins._origins.clear()
+    websocket_api._command_origins._origins.update(saved)
+
+
+def _pause_command(
+    task_id: int = 7, command_id: str = "pause:origin"
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        task_id=task_id,
+        actor_user_id=1,
+        command_id=command_id,
+        kind=websocket_api.TaskCommandKind.PAUSE,
+        payload={"type": "pause_task"},
+        target_run_id=None,
+        attempt_count=1,
+        failure_count=0,
+        defer_count=0,
+    )
+
+
+def _origin_test_manager(registered: set) -> MagicMock:
+    """A manager mock whose registration check is membership in ``registered``."""
+    m = MagicMock()
+    m.send_personal_message = AsyncMock()
+    m.broadcast_to_task = AsyncMock()
+    m.is_connection_registered = MagicMock(
+        side_effect=lambda ws, task_id: ws in registered
+    )
+    return m
+
+
+async def _run_pause_to_runtime_error(
+    monkeypatch: pytest.MonkeyPatch, manager_mock: MagicMock, command
+) -> None:
+    monkeypatch.setattr(websocket_api, "manager", manager_mock)
+    monkeypatch.setattr(
+        websocket_api,
+        "_load_command_actor",
+        lambda actor_user_id: SimpleNamespace(id=actor_user_id or 1, is_admin=False),
+    )
+    monkeypatch.setattr(
+        websocket_api, "task_has_live_foreign_runner", lambda task_id: False
+    )
+    import xagent.web.services.task_setup_snapshot as snapshot_module
+
+    monkeypatch.setattr(
+        snapshot_module,
+        "load_task_setup_snapshot_sync",
+        MagicMock(side_effect=RuntimeError(f"storage fault at {SECRET}")),
+    )
+    with pytest.raises(RuntimeError):
+        await websocket_api._execute_durable_task_command(command)
+
+
+def _personal_targets(manager_mock: MagicMock) -> list[tuple[dict, object]]:
+    return [
+        (c.args[0], c.args[1])
+        for c in manager_mock.send_personal_message.await_args_list
+        if c.args and isinstance(c.args[0], dict)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_durable_raw_detail_reaches_only_the_verified_origin(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _clean_origins: None,
+) -> None:
+    """Reviewer-specified ordering: [public, authenticated-origin, broadcast-only].
+
+    Before the registry, the executor picked the first ordinary socket, so
+    the public visitor received the raw RuntimeError text. Now the raw
+    detail goes to the registered origin regardless of order, and the
+    public socket gets nothing personal.
+    """
+    public, owner_origin, sse = (
+        MagicMock(name="public"),
+        MagicMock(name="origin"),
+        MagicMock(name="sse"),
+    )
+    sse.is_broadcast_only = True
+    manager_mock = _origin_test_manager(registered={public, owner_origin, sse})
+    command = _pause_command()
+    websocket_api._command_origins.register(
+        command.command_id, owner_origin, command.task_id
+    )
+
+    await _run_pause_to_runtime_error(monkeypatch, manager_mock, command)
+
+    raw_sends = [
+        (payload, ws)
+        for payload, ws in _personal_targets(manager_mock)
+        if SECRET in repr(payload)
+    ]
+    assert raw_sends, "the verified origin must still receive the detail"
+    assert all(ws is owner_origin for _, ws in raw_sends), raw_sends
+    assert not any(ws is public for _, ws in _personal_targets(manager_mock)), (
+        "the public socket must receive nothing personal"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "degrade_case",
+    ["no-registration", "origin-disconnected", "wrong-task"],
+)
+async def test_durable_raw_detail_degrades_when_origin_is_unverifiable(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _clean_origins: None,
+    degrade_case: str,
+) -> None:
+    """Worker restart/handoff, disconnect, and task mismatch all degrade safely.
+
+    No registration entry (a different worker executed the command), an
+    origin that has since disconnected, or an entry recorded for another
+    task: in every case the raw text reaches no socket at all.
+    """
+    public, owner_origin = MagicMock(name="public"), MagicMock(name="origin")
+    registered = {public, owner_origin}
+    command = _pause_command()
+    if degrade_case == "origin-disconnected":
+        websocket_api._command_origins.register(
+            command.command_id, owner_origin, command.task_id
+        )
+        registered = {public}
+    elif degrade_case == "wrong-task":
+        websocket_api._command_origins.register(
+            command.command_id, owner_origin, command.task_id + 1
+        )
+    manager_mock = _origin_test_manager(registered=registered)
+
+    await _run_pause_to_runtime_error(monkeypatch, manager_mock, command)
+
+    # The handler still emits its personal reply, but the executor gave it a
+    # discarding stub, so the raw text reaches no real socket. Anything else
+    # as the target - the public socket in particular - is a rerouted leak.
+    raw_targets = [
+        ws for payload, ws in _personal_targets(manager_mock) if SECRET in repr(payload)
+    ]
+    assert all(
+        isinstance(ws, websocket_api._DiscardingCommandWebSocket) for ws in raw_targets
+    ), f"raw detail rerouted to a real socket: {raw_targets}"
+
+
+@pytest.mark.asyncio
+async def test_origin_entry_dies_with_its_command_or_socket(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _clean_origins: None,
+) -> None:
+    """Lifecycle: terminal outcomes and disconnects both clear the entry."""
+    origins = websocket_api._command_origins
+
+    # Terminal rejection clears it.
+    command = _pause_command(command_id="pause:cleanup")
+    socket = MagicMock(name="origin")
+    origins.register(command.command_id, socket, command.task_id)
+    monkeypatch.setattr(
+        websocket_api,
+        "_execute_durable_task_command",
+        AsyncMock(side_effect=websocket_api.TaskCommandRejected("done")),
+    )
+    with pytest.raises(websocket_api.TaskCommandRejected):
+        await websocket_api.execute_durable_task_command(command)
+    assert origins.resolve(command.command_id, command.task_id) is None
+    assert not origins.has(command.command_id, command.task_id)
+
+    # A deferral that will retry keeps it; exhaustion clears it.
+    origins.register(command.command_id, socket, command.task_id)
+    monkeypatch.setattr(
+        websocket_api,
+        "_execute_durable_task_command",
+        AsyncMock(side_effect=websocket_api.ClientVisibleTaskCommandDeferred("wait")),
+    )
+    monkeypatch.setattr(websocket_api, "manager", _origin_test_manager({socket}))
+    with pytest.raises(websocket_api.TaskCommandDeferred):
+        await websocket_api.execute_durable_task_command(command)
+    assert origins.has(command.command_id, command.task_id), (
+        "retrying deferral keeps the origin"
+    )
+    exhausted = _pause_command(command_id="pause:cleanup")
+    exhausted.defer_count = websocket_api.MAX_COMMAND_DEFERS
+    with pytest.raises(websocket_api.TaskCommandDeferred):
+        await websocket_api.execute_durable_task_command(exhausted)
+    assert not origins.has(command.command_id, command.task_id)
+
+    # Disconnect clears every entry for that socket.
+    origins.register("a:1", socket, 7)
+    origins.register("b:2", socket, 8)
+    real_manager = websocket_api.ConnectionManager()
+    real_manager.disconnect(socket)
+    assert not origins.has("a:1", 7) and not origins.has("b:2", 8), (
+        "disconnect must clear the socket's entries"
+    )
+
+
+@pytest.mark.asyncio
+async def test_durable_chat_detail_reaches_the_verified_origin_only(
+    _test_db: None,
+) -> None:
+    """G18: on the durable path the ack is suppressed, so the detail bubble
+    to the verified origin is the sender's only copy - and the broadcast that
+    everyone else sees stays generic."""
+    db = _direct_db_session()
+    try:
+        owner = User(username="durable-detail-owner", password_hash="hash")
+        db.add(owner)
+        db.commit()
+        task = Task(
+            user_id=int(owner.id),
+            title="Durable detail",
+            description="runtime branch, durable path",
+            status=TaskStatus.RUNNING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task.runner_id = "rt7-runner"
+        task.run_id = "rt7-run"
+        db.commit()
+        task_id, owner_id = int(task.id), int(owner.id)
+    finally:
+        db.close()
+
+    raised = RuntimeError(f"durable object scope={SECRET}")
+    mgr, ws_manager, bg_mgr, fake_payload = _chat_runtime_error_harness(raised)
+    origin_socket = MagicMock(name="verified-origin")
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch(
+            "xagent.web.api.websocket.mark_user_message_delivery_sync",
+            MagicMock(),
+        ),
+        patch(
+            "xagent.web.api.websocket._read_task_error_payload_isolated",
+            MagicMock(side_effect=fake_payload),
+        ),
+    ):
+        await websocket_api._handle_chat_message_unserialized(
+            origin_socket,
+            task_id,
+            {
+                "message": "durable runtime failure",
+                "client_message_id": "durable-detail",
+                "user": SimpleNamespace(id=owner_id, is_admin=False),
+                "files": [],
+                "_durable_ack_sent": True,
+            },
+        )
+
+    broadcast = [c.args[0] for c in ws_manager.broadcast_to_task.await_args_list]
+    assert broadcast and SECRET not in repr(broadcast), broadcast
+    personal = [
+        (c.args[0], c.args[1]) for c in ws_manager.send_personal_message.await_args_list
+    ]
+    # The suppressed ack means no message_rejected; the detail bubble is the
+    # sender's only copy and goes to the socket the executor resolved.
+    assert not any(p.get("type") == "message_rejected" for p, _ in personal)
+    detail = [(p, ws) for p, ws in personal if SECRET in repr(p)]
+    assert detail, "the verified origin must receive the detail bubble"
+    assert all(ws is origin_socket for _, ws in detail), detail
+
+
+@pytest.mark.asyncio
+async def test_execute_detail_reaches_the_ingress_socket(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G18: legacy execute keeps its real ingress socket, so the sender gets
+    the detail personally while the broadcast stays generic."""
+    db = _direct_db_session()
+    try:
+        owner = User(username="exec-detail-owner", password_hash="hash")
+        db.add(owner)
+        db.commit()
+        task = Task(
+            user_id=int(owner.id),
+            title="Exec detail",
+            description="runtime branch",
+            status=TaskStatus.PENDING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task_id, owner_id = int(task.id), int(owner.id)
+    finally:
+        db.close()
+
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    monkeypatch.setattr(
+        websocket_api,
+        "_read_task_error_payload_isolated",
+        MagicMock(
+            side_effect=lambda task_id, message, **kwargs: {
+                "type": "agent_error",
+                "message": message,
+                "task_id": task_id,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        TaskTurnOrchestrator,
+        "schedule_existing_task_execution",
+        AsyncMock(side_effect=RuntimeError(f"storage prefix {SECRET}")),
+    )
+
+    ingress = MagicMock(name="ingress")
+    await websocket_api.handle_execute_task(
+        ingress,
+        task_id,
+        {"user": SimpleNamespace(id=owner_id, is_admin=False)},
+    )
+
+    broadcast = [
+        c.args[0] for c in connection_manager.broadcast_to_task.await_args_list
+    ]
+    assert broadcast and SECRET not in repr(broadcast), broadcast
+    detail = [
+        (c.args[0], c.args[1])
+        for c in connection_manager.send_personal_message.await_args_list
+        if SECRET in repr(c.args[0])
+    ]
+    assert detail, "the ingress socket must receive the detail personally"
+    assert all(ws is ingress for _, ws in detail), detail
+
+
+@pytest.mark.asyncio
+async def test_preview_unknown_message_answers_on_the_wire_without_echo() -> None:
+    """G16: endpoint-level coverage of the unknown-message response.
+
+    Feeds an unknown type through the real receive loop and decodes the
+    actual send_text JSON, so a deleted branch, wrong wiring, or a
+    reintroduced echo of the client's message type all fail here.
+    """
+    from fastapi import WebSocketDisconnect
+
+    mock_websocket = AsyncMock()
+    mock_websocket.state = MagicMock()
+    mock_user = MagicMock(spec=User)
+    mock_user.id = 1
+    hostile_type = f"nope-{SECRET}"
+    mock_websocket.receive_text.side_effect = [
+        json.dumps({"type": hostile_type}),
+        WebSocketDisconnect(),
+    ]
+
+    with patch(
+        "xagent.web.api.websocket.get_authenticated_user", return_value=mock_user
+    ):
+        await websocket_api.websocket_build_preview_endpoint(mock_websocket)
+
+    sent = [json.loads(c.args[0]) for c in mock_websocket.send_text.call_args_list]
+    errors = [p for p in sent if p.get("type") == "error"]
+    assert errors == [{"type": "error", "message": "Unknown message type"}] or (
+        len(errors) == 1 and errors[0]["message"] == "Unknown message type"
+    ), errors
+    assert hostile_type not in repr(sent), "the client's type must not echo back"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_name", "extra"),
+    [
+        ("handle_chat_message", {"client_message_id": "reg-1"}),
+        ("handle_pause_task", {}),
+        ("handle_resume_task", {}),
+    ],
+    ids=["chat", "pause", "resume"],
+)
+async def test_ingress_handlers_register_the_command_origin(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _clean_origins: None,
+    handler_name: str,
+    extra: dict,
+) -> None:
+    """Deleting a registration line degrades every sender silently; pin it."""
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    enqueued = SimpleNamespace(
+        command_id=41,
+        client_command_id="cmd:origin-reg",
+        payload_matches=True,
+        status="claimed",
+    )
+    monkeypatch.setattr(
+        websocket_api,
+        "_enqueue_websocket_task_command",
+        AsyncMock(return_value=enqueued),
+    )
+    monkeypatch.setattr(websocket_api, "dispatch_task_command_promptly", AsyncMock())
+
+    ingress = MagicMock(name="ingress")
+    await getattr(websocket_api, handler_name)(
+        ingress,
+        7,
+        {"user": SimpleNamespace(id=1, is_admin=False), **extra},
+    )
+
+    assert websocket_api._command_origins.has("cmd:origin-reg", 7), (
+        f"{handler_name} must register its origin"
+    )
+    assert websocket_api._command_origins.resolve("cmd:origin-reg", 7) is ingress
+
+
+def test_a_resubmitted_command_id_cannot_capture_another_senders_origin(
+    _clean_origins: None,
+) -> None:
+    """First registration wins (preflight PoC: co-tenant origin hijack).
+
+    On a public/share task every visitor carries the owner principal, so the
+    enqueue dedupe returns the in-flight row for a resubmission of the same
+    command_id and the second connection would otherwise reach `register` and
+    overwrite the origin - redirecting the first sender's error detail to the
+    attacker. The registry must keep the original.
+    """
+    origins = websocket_api._command_origins
+    victim, attacker = MagicMock(name="victim"), MagicMock(name="attacker")
+
+    origins.register("shared-cmd", victim, 7)
+    origins.register("shared-cmd", attacker, 7)  # resubmission on the same task
+
+    with patch.object(
+        websocket_api.manager, "is_connection_registered", return_value=True
+    ):
+        assert origins.resolve("shared-cmd", 7) is victim, (
+            "the attacker must not capture the victim's origin"
+        )
+
+    # Re-registering the same socket stays idempotent.
+    origins.register("shared-cmd", victim, 7)
+    with patch.object(
+        websocket_api.manager, "is_connection_registered", return_value=True
+    ):
+        assert origins.resolve("shared-cmd", 7) is victim
+
+
+def test_same_command_id_on_two_tasks_is_isolated(_clean_origins: None) -> None:
+    """command_id is unique only per task, so the key is (task_id, command_id).
+
+    A shared id must not let one task's registration void or answer the
+    other's - the DB carries a (task_id, command_id) uniqueness constraint,
+    not command_id alone.
+    """
+    origins = websocket_api._command_origins
+    sock_a, sock_b = MagicMock(name="task-a"), MagicMock(name="task-b")
+    origins.register("1", sock_a, 100)
+    origins.register("1", sock_b, 200)
+
+    with patch.object(
+        websocket_api.manager, "is_connection_registered", return_value=True
+    ):
+        assert origins.resolve("1", 100) is sock_a
+        assert origins.resolve("1", 200) is sock_b
+
+    # Discarding one task's entry leaves the other intact.
+    origins.discard_command("1", 100)
+    assert not origins.has("1", 100)
+    assert origins.has("1", 200)
+
+
+@pytest.mark.asyncio
+async def test_live_chat_runtime_error_does_not_double_send_the_detail(
+    _test_db: None,
+) -> None:
+    """On the live path the rejection ack already carries the detail, so the
+    origin bubble must not fire a second copy (preflight side-effect)."""
+    db = _direct_db_session()
+    try:
+        owner = User(username="no-double-owner", password_hash="hash")
+        db.add(owner)
+        db.commit()
+        task = Task(
+            user_id=int(owner.id),
+            title="No double",
+            description="live runtime branch",
+            status=TaskStatus.RUNNING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task.runner_id = "rt8-runner"
+        task.run_id = "rt8-run"
+        db.commit()
+        task_id, owner_id = int(task.id), int(owner.id)
+    finally:
+        db.close()
+
+    raised = RuntimeError(f"live fault {SECRET}")
+    mgr, ws_manager, bg_mgr, fake_payload = _chat_runtime_error_harness(raised)
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch("xagent.web.api.websocket.mark_user_message_delivery_sync", MagicMock()),
+        patch(
+            "xagent.web.api.websocket._read_task_error_payload_isolated",
+            MagicMock(side_effect=fake_payload),
+        ),
+    ):
+        await websocket_api._handle_chat_message_unserialized(
+            MagicMock(name="live-sender"),
+            task_id,
+            {
+                "message": "live runtime failure",
+                "client_message_id": "no-double",
+                "user": SimpleNamespace(id=owner_id, is_admin=False),
+                "files": [],
+                # no _durable_ack_sent: this is the live path
+            },
+        )
+
+    personal = [
+        c.args[0]
+        for c in ws_manager.send_personal_message.await_args_list
+        if isinstance(c.args[0], dict)
+    ]
+    with_detail = [p for p in personal if SECRET in repr(p)]
+    assert len(with_detail) == 1, (
+        f"live path must carry the detail exactly once, got {with_detail}"
+    )
+    assert with_detail[0].get("type") == "message_rejected"

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -154,18 +154,18 @@ PRODUCERS: dict[str, int | None] = {
     "send_message_delivery": None,  # keyword-only
 }
 
-# The one deliberate exception: agent RuntimeError text is passed through
-# untouched. Narrowing it is a product decision tracked in #1479.
+# The one deliberate exception: agent RuntimeError text is passed through to
+# the INITIATING SENDER - the rejection ack and the personal error bubble.
+# Narrowing that wording is the product decision tracked in #1479.
 #
-# Do NOT read this as "sender only". An earlier version of this comment cited
-# tests/web/api/test_websocket_owner_actor.py as an existing tested contract
-# for that; the citation was wrong. That file never pins this string, and its
-# one raw-RuntimeError assertion covers the sender-only fallback, not the
-# broadcast. Once a task resolves, this text goes out via broadcast_to_task to
-# every connection registered under the task_id - anonymous widget and share
-# visitors included, since they register into the same ConnectionManager.
-# DurableStorageOperationError is a RuntimeError subclass, so the tenant-scope
-# leak that motivates this module is still open on that path. #1479 owns it.
+# The broadcast half of the passthrough is closed (maintainer scope ruling on
+# #1514): the task-wide broadcast reaches every connection under the task_id,
+# anonymous widget and share visitors included, and DurableStorageOperation-
+# Error subclasses RuntimeError with tenant-scope text in its message, so
+# broadcasts carry CLIENT_SAFE_TASK_FAILURE instead - pinned by the two
+# audience-boundary tests at the end of this file. Still #1479: whether the
+# sender copy should also be narrowed when the initiator is an anonymous
+# public connection.
 #
 # Anchored to (enclosing function, expression) rather than to the expression
 # alone, which blessed the string in every function it appeared in. This stops
@@ -1132,4 +1132,162 @@ async def test_chat_validation_redacts_both_the_ack_and_the_broadcast(
     task_errors = [b for b in broadcast if b.get("type") == "agent_error"]
     assert task_errors and task_errors[0]["message"] == (
         websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+    )
+
+
+def _chat_runtime_error_harness(secret_error: Exception):
+    """Shared live-control setup that raises ``secret_error`` at injection."""
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(side_effect=secret_error)
+    mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+
+    def _fake_error_payload(task_id: int, message: str, **kwargs: object) -> dict:
+        return {"type": "agent_error", "message": message, "task_id": task_id}
+
+    return mgr, ws_manager, bg_mgr, _fake_error_payload
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_broadcast_is_redacted_but_the_sender_keeps_the_detail(
+    _test_db: None,
+) -> None:
+    """The audience boundary of the #1479 passthrough (maintainer ruling).
+
+    The initiating sender keeps ``Runtime error: ...`` in the rejection ack -
+    that is the existing contract and #1479 owns narrowing it. The task-wide
+    broadcast reaches every subscriber, anonymous widget/share connections
+    included, so it must carry the fixed string and never the exception text.
+    """
+    db = _direct_db_session()
+    try:
+        owner = User(username="runtime-boundary-owner", password_hash="hash")
+        db.add(owner)
+        db.commit()
+        task = Task(
+            user_id=int(owner.id),
+            title="Audience boundary",
+            description="runtime branch",
+            status=TaskStatus.RUNNING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task.runner_id = "rt6-runner"
+        task.run_id = "rt6-run"
+        db.commit()
+        task_id, owner_id = int(task.id), int(owner.id)
+    finally:
+        db.close()
+
+    raised = RuntimeError(f"durable object scope={SECRET}")
+    mgr, ws_manager, bg_mgr, fake_payload = _chat_runtime_error_harness(raised)
+
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=mgr),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch(
+            "xagent.web.api.websocket.mark_user_message_delivery_sync",
+            MagicMock(),
+        ),
+        patch(
+            "xagent.web.api.websocket._read_task_error_payload_isolated",
+            MagicMock(side_effect=fake_payload),
+        ),
+    ):
+        await websocket_api._handle_chat_message_unserialized(
+            MagicMock(),
+            task_id,
+            {
+                "message": "trip the runtime branch",
+                "client_message_id": "runtime-boundary",
+                "user": SimpleNamespace(id=owner_id, is_admin=False),
+                "files": [],
+            },
+        )
+
+    broadcast = [c.args[0] for c in ws_manager.broadcast_to_task.await_args_list]
+    assert broadcast, "the task-wide notification must still go out"
+    assert SECRET not in repr(broadcast), broadcast
+    task_errors = [b for b in broadcast if b.get("type") == "agent_error"]
+    assert task_errors and task_errors[0]["message"] == (
+        websocket_api.CLIENT_SAFE_TASK_FAILURE
+    )
+
+    personal = [c.args[0] for c in ws_manager.send_personal_message.await_args_list]
+    rejected = [p for p in personal if p.get("type") == "message_rejected"]
+    assert rejected, "the sender still gets the rejection ack"
+    assert rejected[0]["message"] == f"Runtime error: {raised}", (
+        "the sender's copy is the existing #1479 contract and must survive"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_runtime_error_broadcast_is_redacted(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same audience boundary through handle_execute_task's runtime branch."""
+    db = _direct_db_session()
+    try:
+        owner = User(username="exec-runtime-owner", password_hash="hash")
+        db.add(owner)
+        db.commit()
+        task = Task(
+            user_id=int(owner.id),
+            title="Exec audience boundary",
+            description="runtime branch",
+            status=TaskStatus.PENDING,
+            execution_mode="balanced",
+            source="internal",
+        )
+        db.add(task)
+        db.commit()
+        task_id, owner_id = int(task.id), int(owner.id)
+    finally:
+        db.close()
+
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    monkeypatch.setattr(
+        websocket_api,
+        "_read_task_error_payload_isolated",
+        MagicMock(
+            side_effect=lambda task_id, message, **kwargs: {
+                "type": "agent_error",
+                "message": message,
+                "task_id": task_id,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        TaskTurnOrchestrator,
+        "schedule_existing_task_execution",
+        AsyncMock(side_effect=RuntimeError(f"storage prefix {SECRET}")),
+    )
+
+    await websocket_api.handle_execute_task(
+        MagicMock(),
+        task_id,
+        {"user": SimpleNamespace(id=owner_id, is_admin=False)},
+    )
+
+    broadcast = [
+        c.args[0] for c in connection_manager.broadcast_to_task.await_args_list
+    ]
+    assert broadcast, "the task-wide notification must still go out"
+    assert SECRET not in repr(broadcast), broadcast
+    assert any(
+        b.get("message") == websocket_api.CLIENT_SAFE_TASK_FAILURE for b in broadcast
     )

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -1692,16 +1692,18 @@ async def test_ingress_handlers_register_the_command_origin(
     handler_name: str,
     extra: dict,
 ) -> None:
-    """Deleting a registration line degrades every sender silently; pin it."""
+    """The creating ingress binds; deleting the line degrades senders silently."""
     connection_manager = MagicMock()
     connection_manager.send_personal_message = AsyncMock()
     connection_manager.broadcast_to_task = AsyncMock()
+    connection_manager.is_connection_registered = MagicMock(return_value=True)
     monkeypatch.setattr(websocket_api, "manager", connection_manager)
     enqueued = SimpleNamespace(
         command_id=41,
         client_command_id="cmd:origin-reg",
         payload_matches=True,
         status="claimed",
+        created=True,
     )
     monkeypatch.setattr(
         websocket_api,
@@ -1721,6 +1723,65 @@ async def test_ingress_handlers_register_the_command_origin(
         f"{handler_name} must register its origin"
     )
     assert websocket_api._command_origins.resolve("cmd:origin-reg", 7) is ingress
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_name", "extra"),
+    [
+        ("handle_chat_message", {"client_message_id": "dup-1"}),
+        ("handle_pause_task", {}),
+        ("handle_resume_task", {}),
+    ],
+    ids=["chat", "pause", "resume"],
+)
+async def test_a_duplicate_enqueue_never_binds_the_origin(
+    _test_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _clean_origins: None,
+    handler_name: str,
+    extra: dict,
+) -> None:
+    """A payload-matching duplicate (created=False) must not acquire origin.
+
+    This is the P1 blocker: a duplicate - a co-tenant resubmission, one after
+    the creator disconnected, or one handled on another worker - reaches these
+    handlers with a valid command_id but created=False. It still dispatches
+    (idempotent), but it must never register, or the durable executor could
+    resolve it and send the creator's raw detail to the wrong socket.
+    """
+    connection_manager = MagicMock()
+    connection_manager.send_personal_message = AsyncMock()
+    connection_manager.broadcast_to_task = AsyncMock()
+    connection_manager.is_connection_registered = MagicMock(return_value=True)
+    monkeypatch.setattr(websocket_api, "manager", connection_manager)
+    dispatch = AsyncMock()
+    monkeypatch.setattr(websocket_api, "dispatch_task_command_promptly", dispatch)
+    monkeypatch.setattr(
+        websocket_api,
+        "_enqueue_websocket_task_command",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                command_id=41,
+                client_command_id="dup:cmd",
+                payload_matches=True,
+                status="claimed",
+                created=False,
+            )
+        ),
+    )
+
+    duplicate = MagicMock(name="duplicate-ingress")
+    await getattr(websocket_api, handler_name)(
+        duplicate,
+        7,
+        {"user": SimpleNamespace(id=1, is_admin=False), **extra},
+    )
+
+    assert not websocket_api._command_origins.has("dup:cmd", 7), (
+        "a duplicate must never bind the origin"
+    )
+    assert dispatch.await_count == 1, "the duplicate still dispatches idempotently"
 
 
 def test_a_resubmitted_command_id_cannot_capture_another_senders_origin(
@@ -1841,3 +1902,56 @@ async def test_live_chat_runtime_error_does_not_double_send_the_detail(
         f"live path must carry the detail exactly once, got {with_detail}"
     )
     assert with_detail[0].get("type") == "message_rejected"
+
+
+def test_a_later_duplicate_cannot_rebind_after_the_creator_disconnects(
+    _clean_origins: None,
+) -> None:
+    """P1 disconnect/rebind: once the creator's entry is gone, no bind at all.
+
+    First-registration-wins protects a live entry, but the sharper case is the
+    creator disconnecting (its entry cleared) and a later duplicate arriving.
+    Because only the creating ingress registers, the duplicate never calls
+    register, so resolve stays empty rather than pointing at the late arrival.
+    """
+    origins = websocket_api._command_origins
+    creator = MagicMock(name="creator")
+    origins.register("cmd", creator, 7)
+
+    # creator disconnects
+    real_manager = websocket_api.ConnectionManager()
+    real_manager.disconnect(creator)
+    assert not origins.has("cmd", 7)
+
+    # a later duplicate is created=False at the handler, so it never registers;
+    # the registry stays empty and the executor will safe-discard.
+    assert not origins.has("cmd", 7)
+    with patch.object(
+        websocket_api.manager, "is_connection_registered", return_value=True
+    ):
+        assert origins.resolve("cmd", 7) is None
+
+
+def test_registry_is_bounded_by_lru_eviction(_clean_origins: None) -> None:
+    """P2: entries whose commands run on another worker cannot grow unbounded.
+
+    A long-lived socket whose commands are always claimed elsewhere would never
+    get local cleanup. The store is an LRU capped at _MAX_ORIGINS; the oldest
+    entry is evicted on overflow, which only makes resolve miss (safe discard),
+    never reroutes detail.
+    """
+    origins = websocket_api._command_origins
+    cap = websocket_api._CommandOriginRegistry._MAX_ORIGINS
+    socket = MagicMock(name="long-lived")
+
+    for i in range(cap + 50):
+        origins.register(f"cmd-{i}", socket, 7)
+
+    assert len(origins._origins) == cap, "the store must not grow past the cap"
+    # oldest evicted, newest retained
+    assert not origins.has("cmd-0", 7)
+    assert origins.has(f"cmd-{cap + 49}", 7)
+    with patch.object(
+        websocket_api.manager, "is_connection_registered", return_value=True
+    ):
+        assert origins.resolve("cmd-0", 7) is None  # evicted -> safe discard

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -2659,12 +2659,17 @@ def _durable_pause_command(task: Task, owner: User) -> ClaimedTaskCommand:
 
 
 @pytest.mark.asyncio
-async def test_durable_command_skips_broadcast_only_connections(db_session) -> None:
-    """A v1 SSE sink registers into the same shared connection list as
-    real WebSocket connections but only understands versioned status
-    events; it must never be selected as the target for a personal reply
-    to a durable command. With a broadcast-only connection ahead of a
-    real one in the list, the real one is still picked."""
+async def test_durable_command_targets_the_registered_origin_not_list_order(
+    db_session,
+) -> None:
+    """Origin is never inferred from connection order (#1514 round 6).
+
+    This test previously pinned the opposite: "the first real connection is
+    picked". That guess could hand a personal reply - including raw error
+    text - to whichever socket happened to be first, e.g. an anonymous
+    public visitor. A durable command now targets the socket registered as
+    its origin at enqueue; without a registration it gets the discarding
+    sink even when real connections exist."""
     owner = _user(db_session, "broadcast-skip-owner")
     task = _task(db_session, owner.id)
     task.runner_id = None
@@ -2672,23 +2677,44 @@ async def test_durable_command_skips_broadcast_only_connections(db_session) -> N
     db_session.commit()
     command = _durable_pause_command(task, owner)
 
-    broadcast_only = SimpleNamespace(is_broadcast_only=True)
-    real_connection = SimpleNamespace()  # no `is_broadcast_only` attribute at all
+    first_real = SimpleNamespace()  # would have been picked by the old guess
+    origin = SimpleNamespace()
 
-    with (
-        patch.object(
-            websocket_api.manager,
-            "connections_for_task",
-            return_value=[broadcast_only, real_connection],
-        ),
-        patch(
-            "xagent.web.api.websocket._handle_pause_task_unserialized",
-            new=AsyncMock(return_value=None),
-        ) as handler,
-    ):
-        await _execute_durable_task_command(command)
+    websocket_api._command_origins.register(command.command_id, origin, int(task.id))
+    try:
+        with (
+            patch.object(
+                websocket_api.manager,
+                "is_connection_registered",
+                return_value=True,
+            ),
+            patch(
+                "xagent.web.api.websocket._handle_pause_task_unserialized",
+                new=AsyncMock(return_value=None),
+            ) as handler,
+        ):
+            await _execute_durable_task_command(command)
+        assert handler.await_args.args[0] is origin
 
-    assert handler.await_args.args[0] is real_connection
+        # Without a registration, real connections in the list are ignored.
+        websocket_api._command_origins.discard_command(command.command_id, int(task.id))
+        with (
+            patch.object(
+                websocket_api.manager,
+                "connections_for_task",
+                return_value=[first_real],
+            ),
+            patch(
+                "xagent.web.api.websocket._handle_pause_task_unserialized",
+                new=AsyncMock(return_value=None),
+            ) as handler,
+        ):
+            await _execute_durable_task_command(command)
+        assert isinstance(
+            handler.await_args.args[0], websocket_api._DiscardingCommandWebSocket
+        )
+    finally:
+        websocket_api._command_origins.discard_command(command.command_id, int(task.id))
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -1981,7 +1981,7 @@ def test_websocket_enqueue_returns_none_when_the_task_vanishes_mid_enqueue(
     assert result is None
 
 
-def test_websocket_enqueue_reraises_missing_task_when_recovery_is_not_allowed(
+def test_websocket_enqueue_rejects_missing_task_with_client_visible_wording(
     db_session,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1996,7 +1996,11 @@ def test_websocket_enqueue_reraises_missing_task_when_recovery_is_not_allowed(
 
     monkeypatch.setattr(websocket_api, "enqueue_task_command", raise_missing)
 
-    with pytest.raises(TaskCommandTaskMissing):
+    # The rejection is re-raised as ClientVisibleValidationError at this
+    # boundary (still a ValueError, so pause/resume reject it the same way)
+    # so the redaction chokepoint keeps "not found" wording on this race
+    # instead of flattening it to the generic string (#1514 round 5).
+    with pytest.raises(ValueError) as raised:
         websocket_api._enqueue_websocket_task_command_sync(
             task_id=task_id,
             actor_user_id=int(user.id),
@@ -2006,6 +2010,8 @@ def test_websocket_enqueue_reraises_missing_task_when_recovery_is_not_allowed(
             payload={"type": "pause_task"},
             allow_missing_task=False,
         )
+    assert isinstance(raised.value, websocket_api.ClientVisibleValidationError)
+    assert str(raised.value) == f"Task {task_id} not found"
 
 
 def test_task_foreign_key_violation_is_reported_as_a_missing_task(


### PR DESCRIPTION
Part of #1497. Split out of #1472 on review feedback that it "belonged in its own PR" — it roughly doubled that PR's review surface while being unrelated to its retry work.

## Problem

Chat clients, including anonymous widget and share visitors, receive raw exception text. Several handlers in `websocket.py` put `str(e)` straight into the `message_rejected` ack and the `{"type": "error"}` bubble, both of which the frontend renders verbatim (`app-context-chat.tsx` reads the string unchanged into an assistant error bubble).

`DurableStorageOperationError` is a `RuntimeError` subclass and its text carries scope segments, storage prefixes and tenant identifiers, so a storage fault mid-turn can put tenant-identifying internals in front of a visitor.

> **Status of this specific path, kept accurate through the rounds.** Round 3 established that this PR did *not* close it — `DurableStorageOperationError` is a `RuntimeError` and fell under the passthrough allowlisted below, so the text still reached every task subscriber (anonymous widget/share visitors included) through `broadcast_to_task`. Under the maintainer scope ruling, `8d565130` **closes the broadcast half in this PR**: task-wide broadcasts from the two passthrough branches now carry the fixed `CLIENT_SAFE_TASK_FAILURE` string, pinned by audience-boundary tests on both sides. The initiating sender's rejection ack and personal error bubble deliberately keep the wording; whether that copy should also be narrowed when the initiator is an anonymous public connection is the residual core of #1479. Also closed here alongside: the `ValueError`/`KeyError`/`TypeError` and `PermissionError` surfaces.

## What changed

- `client_safe_error_message()` is the single place an exception may become client-visible text. Every direct call site that builds a rejection or error payload from an exception goes through it.
  - An adversarial self-review falsified the first version of this claim: `handle_builder_chat` reached a client through `websocket.send_text(json.dumps({"type": "error", "message": str(e)}))`, a dict literal at a direct call site that the guard could not see because it matched only `send_personal_message`/`broadcast_to_task`. Routed, and the guard now recognizes `send_text` and unwraps the `json.dumps` around its payload.
- Messages genuinely written for the sender — "authentication required", "access denied", "Task not found", "Files are no longer bindable" — raise a `ClientVisibleError` subclass (`ClientVisibleValidationError`, `ClientVisiblePermissionError`) and keep their wording. Anything without the marker is redacted, so a new `except` branch that forgets it **fails closed**.
- An AST guard walks the module and fails if a recognized producer can reach a client with raw text. Verified non-vacuous by reintroducing a leak at a delivery producer, at an error bubble, and at the `send_text` payload above; each is caught. The `RuntimeError` carve-out is anchored to `(function, expression)` rather than to unparsed source text, so the blessed string is rejected in any function outside the allowlist — verified by reintroduction. **Correction:** an earlier version of this line also claimed the anchor caught the string moving into a *validation branch of an allowlisted function*. It does not — `_local_assignments` unions every assignment in the enclosing function regardless of branch. Reproduced and tracked in #1547. The sweep floors are pinned per category; the previous single floor of 20 against an actual 45 would have let half the surface disappear silently. **Correction:** the in-code comment said "23 / 23" — the payload figure was measured before `send_text` joined the sinks and is actually 28, so the floors are looser than that comment claimed. Tightening them is #1547.

## What this does **not** cover

Stated plainly in the guard's own docstring, because an earlier version of it overclaimed and that is what let leaks survive three review rounds:

- dict-spread payloads (`{**terminal_payload, "error": message}`)
- payloads built by a helper and passed as a call (`create_stream_event(...)`)
- wrapper functions forwarding a raw argument into a producer (`notify_deferred_delivery`)
- ~~the durable-command error channel~~ — **withdrawn in round 4, this was wrong.** `TaskCommandRejected` is re-raised without broadcasting (`websocket.py:8362`); the text terminates in the `TaskExecutionCommand.error` column and nothing under `src/xagent/web/` reads it back to a client. The mechanism that *did* broadcast — `_broadcast_terminal_command_error`, reached from the deferral- and failure-exhausted branches — was never named here, and is **closed by this PR** (see below). #1497 has been corrected.

Those three still leak, and each now has a strict `xfail` test that constructs the bypass and asserts the guard stays blind to it — so when one is fixed its test flips to a failure instead of the gap outliving the issue.

**Closed in round 4, having been mis-scoped as out of scope:** `_broadcast_terminal_command_error` built a `{"type": "agent_error", ...}` dict literal directly from an exception at a direct call site. It matched none of the three caveats above and escaped purely on its event type, which the caveat list never mentioned. Its message now goes through `client_safe_error_message`, the command kind moved to a structured `command_kind` field, and `agent_error` joined the guard's recognized payload types. #1497 tracks either closing them or inverting the design so payload construction itself is the only typed path to a client — which would make the guard unnecessary rather than smarter.

The agent `RuntimeError` passthrough is deliberately allowlisted **for the initiating sender only** — since `8d565130` the broadcast half carries a fixed string. Narrowing the sender's copy is the product decision tracked in #1479.

**Accuracy note.** Four rounds of review have found five claims in this description that did not hold — the guard's branch-sensitivity, the sweep counts, the durable-command mechanism, the completeness of a retraction, and "the outermost handler owns the traceback". Each had the same cause: one instance verified, the general property reported. Every factual claim now in this description has a command behind it whose output was read.

**Retraction.** This paragraph previously said the passthrough was safe because "surfacing it to the sender is an existing tested contract (`test_websocket_owner_actor.py`)". That citation was wrong. **Correction (round 4): this retraction was itself inaccurate.** It said the citation had been removed from the code comment; it had only been removed from the test file, and `websocket.py:330-332` still carried it verbatim — so the module shipped two contradictory descriptions of the same carve-out. The source comment is now fixed too. `test_websocket_owner_actor.py` never pins that string; its one raw-`RuntimeError` assertion covers the sender-only fallback reached on a pool timeout, never the broadcast that actually fires once a task resolves. The justification was narrower than the code path it excused, on exactly the mechanism this PR is about. No behaviour changed in this round — the claim did.

## Testing

`test_websocket_client_safe_errors.py`: a secret embedded in a `ValueError`/`KeyError`/`TypeError` never reaches any client payload; a curated message keeps its wording; a missing task keeps its own wording through the pause/resume enqueue path; a redacted enqueue refusal still reaches the log with a traceback in all three handlers; the AST guard over the producers. Verified against `test_websocket_owner_actor.py` and `test_websocket_error_payload.py`, which pin the contracts this must not break. `ruff` and `mypy` clean.

## Out of scope

- #1497 — the producer shapes listed above (`execute_task_background`'s dict-spread broadcast, `send_historical_data_as_stream`'s helper-built payload, `execute_resume_background`'s wrapper forwarding), and the frontend's `getUploadErrorMessage` raw-body fallback. **Current behavior, stated accurately: these three egresses emit raw exception text to clients today** — including a `RuntimeError`'s text — because they are not routed through the chokepoint and the guard cannot see them; the strict `xfail` tests assert exactly that. They are tracked follow-up scope, not closed and not fail-safe. (This corrects an earlier convergence comment that lumped them with the #1547 test-only fail-opens as "not a live leak".)
- #1547 — four fail-open shapes in the AST guard's own resolution logic (branch-insensitive allowlist, uncollected `AnnAssign`/`AugAssign`, unchecked `.get()` receiver, slack sweep floors and producer aliasing). None is a live leak; all are future-code holes in the test.
- #1479 — narrowing the `RuntimeError` wording still delivered to the *initiating sender* (notably when the initiator is an anonymous public connection), and the `safe_for_display` / error-code contract that would also fix localization. The broadcast half was pulled into this PR by the maintainer scope ruling and is closed.

## Related

#1472, #1468





