### PR TITLE
feat(interactions): recover superseded questions on the waiting-task read surface

### DIFF
--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -34,20 +34,30 @@ QUESTION_MESSAGE_TYPE = "question"
 SUPERSEDED_MESSAGE_TYPE = "question_superseded"
 
 
-def _assistant_question_filters(task_id: int) -> tuple[ColumnElement[bool], ...]:
-    """The three-leg WHERE predicate for a task's assistant question
-    rows: ``task_id``, ``role == "assistant"``,
-    ``message_type == QUESTION_MESSAGE_TYPE``. It matches every such
-    row, whether it is still waiting for an answer or was already
-    answered. Shared by the reader (``get_latest_waiting_question``)
-    and the writer (``supersede_legacy_question_rows``) so the two
-    conditions cannot drift apart by hand-editing one copy and not the
-    other.
+def _assistant_question_filters(
+    task_id: int, *, message_type: str = QUESTION_MESSAGE_TYPE
+) -> tuple[ColumnElement[bool], ...]:
+    """The three-leg WHERE predicate for a task's assistant question rows:
+    ``task_id``, ``role == "assistant"``, and one ``message_type``. It
+    matches every such row, whether it is still waiting for an answer or
+    was already answered. Shared by the reader
+    (``get_latest_waiting_question``) and the writer
+    (``supersede_legacy_question_rows``) so the two conditions cannot drift
+    apart by hand-editing one copy and not the other.
+
+    ``message_type`` defaults to ``QUESTION_MESSAGE_TYPE``: the value the
+    writer wants and the value the reader's first pass wants, so both keep
+    calling this with one argument and the drift-guard test keeps comparing
+    the same two rendered clauses. The reader's second pass passes
+    ``SUPERSEDED_MESSAGE_TYPE`` instead, because it looks for what the
+    writer *produces* rather than what the writer consumes. That one leg is
+    the only thing that legitimately differs between the two passes; the
+    other two legs stay shared, which is the whole point of this helper.
     """
     return (
         TaskChatMessage.task_id == task_id,
         TaskChatMessage.role == "assistant",
-        TaskChatMessage.message_type == QUESTION_MESSAGE_TYPE,
+        TaskChatMessage.message_type == message_type,
     )
 
 
@@ -770,9 +780,9 @@ def get_latest_waiting_question(
         latest_question = (
             db.query(TaskChatMessage)
             .filter(
-                TaskChatMessage.task_id == task_id,
-                TaskChatMessage.role == "assistant",
-                TaskChatMessage.message_type == SUPERSEDED_MESSAGE_TYPE,
+                *_assistant_question_filters(
+                    task_id, message_type=SUPERSEDED_MESSAGE_TYPE
+                )
             )
             .order_by(TaskChatMessage.id.desc())
             .first()

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -748,11 +748,18 @@ def get_latest_waiting_question(
     """Return the latest persisted ask-user question for a waiting task.
 
     Two sequential passes rather than one ``message_type.in_(...)``
-    predicate. A single predicate ordered by id lets a
-    ``SUPERSEDED_MESSAGE_TYPE`` row with a higher id outrank a
-    ``QUESTION_MESSAGE_TYPE`` row that is still live, inverting the
-    priority this reader owes its callers. The first pass is
-    unconditional and always runs first.
+    predicate. Today's writer cannot produce the inversion that shape
+    avoids: it relabels a task's question rows in one unpartitioned
+    statement, so any row still labelled ``QUESTION_MESSAGE_TYPE``
+    postdates every ``SUPERSEDED_MESSAGE_TYPE`` row on the task. The
+    passes are kept for the writer shapes that come next -- a relabel
+    narrowed to one run or turn, or one committed alongside a fresh
+    question insert -- where the two labels' ids interleave and a single
+    id-ordered predicate would rank a superseded row over a live one,
+    inverting the priority this reader owes its callers. Narrowing a
+    task-wide write to the row it actually means is already a stated
+    obligation next door, on ``close_legacy_resume_interaction``'s close
+    statement. The first pass is unconditional and always runs first.
 
     ``allow_superseded`` opens a second pass over
     ``SUPERSEDED_MESSAGE_TYPE`` rows, and only when the first pass came

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -733,9 +733,32 @@ def load_task_transcript(
 
 
 def get_latest_waiting_question(
-    db: Session, task_id: int
+    db: Session, task_id: int, *, allow_superseded: bool = False
 ) -> tuple[Optional[str], Optional[list[dict[str, Any]]]]:
-    """Return the latest persisted ask-user question for a waiting task."""
+    """Return the latest persisted ask-user question for a waiting task.
+
+    Two sequential passes rather than one ``message_type.in_(...)``
+    predicate. A single predicate ordered by id lets a
+    ``SUPERSEDED_MESSAGE_TYPE`` row with a higher id outrank a
+    ``QUESTION_MESSAGE_TYPE`` row that is still live, inverting the
+    priority this reader owes its callers. The first pass is
+    unconditional and always runs first.
+
+    ``allow_superseded`` opens a second pass over
+    ``SUPERSEDED_MESSAGE_TYPE`` rows, and only when the first pass came
+    back empty. It is off by default, and the read surface adapter
+    (``task_interaction_read.get_pending_interaction_question``) is the
+    only caller that turns it on; every other caller reads exactly what it
+    reads with the parameter absent.
+
+    What the second pass hands back is the newest question row on this
+    task that ``supersede_legacy_question_rows`` has relabelled. That
+    writer's WHERE is ``_assistant_question_filters`` -- task, assistant
+    role, message type -- with no run partition, so one call relabels
+    every round's question row on the task at once; taking the highest id
+    back is therefore this task's most recent question even on a task that
+    has asked several times.
+    """
 
     latest_question = (
         db.query(TaskChatMessage)
@@ -743,6 +766,17 @@ def get_latest_waiting_question(
         .order_by(TaskChatMessage.id.desc())
         .first()
     )
+    if not latest_question and allow_superseded:
+        latest_question = (
+            db.query(TaskChatMessage)
+            .filter(
+                TaskChatMessage.task_id == task_id,
+                TaskChatMessage.role == "assistant",
+                TaskChatMessage.message_type == SUPERSEDED_MESSAGE_TYPE,
+            )
+            .order_by(TaskChatMessage.id.desc())
+            .first()
+        )
     if not latest_question:
         return None, None
 

--- a/src/xagent/web/services/interaction_rollout.py
+++ b/src/xagent/web/services/interaction_rollout.py
@@ -173,10 +173,11 @@ COUNTER_ANCHOR_ABSENT_NO_RUN = "anchor.absent_no_run"
 COUNTER_ANCHOR_UNAVAILABLE_DANGLING_POINTER = "anchor.unavailable_dangling_pointer"
 COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE = "anchor.absent_legacy_checkpoint_type"
 
-# COUNTER_COMPAT_READ_FALLBACK is incremented by the compatibility view in
-# task_interaction_service.py; see that function's docstring for what the
-# number means. The rest below are placeholders for later owners sharing
-# this registry and are incremented by nothing yet.
+# Two constants below are actively incremented, both from
+# task_interaction_service.py: COUNTER_COMPAT_READ_FALLBACK by the
+# compatibility view, COUNTER_LIFECYCLE_RESPONSE_CONFLICT by respond().
+# The materialize.*, repair.* and command.* constants are placeholders for
+# later owners sharing this registry and are incremented by nothing yet.
 COUNTER_COMPAT_READ_FALLBACK = "compat.read_fallback"  # owner: read path
 COUNTER_LIFECYCLE_RESPONSE_CONFLICT = "lifecycle.response_conflict"  # owner: #1075
 COUNTER_MATERIALIZE_SUCCESS = "materialize.success"  # owner: #1078

--- a/src/xagent/web/services/interaction_rollout.py
+++ b/src/xagent/web/services/interaction_rollout.py
@@ -173,9 +173,11 @@ COUNTER_ANCHOR_ABSENT_NO_RUN = "anchor.absent_no_run"
 COUNTER_ANCHOR_UNAVAILABLE_DANGLING_POINTER = "anchor.unavailable_dangling_pointer"
 COUNTER_ANCHOR_ABSENT_LEGACY_CHECKPOINT_TYPE = "anchor.absent_legacy_checkpoint_type"
 
-# Not incremented by this PR -- placeholders for later owners sharing this
-# registry.
-COUNTER_COMPAT_READ_FALLBACK = "compat.read_fallback"  # owner: read-path wiring
+# COUNTER_COMPAT_READ_FALLBACK is incremented by the compatibility view in
+# task_interaction_service.py; see that function's docstring for what the
+# number means. The rest below are placeholders for later owners sharing
+# this registry and are incremented by nothing yet.
+COUNTER_COMPAT_READ_FALLBACK = "compat.read_fallback"  # owner: read path
 COUNTER_LIFECYCLE_RESPONSE_CONFLICT = "lifecycle.response_conflict"  # owner: #1075
 COUNTER_MATERIALIZE_SUCCESS = "materialize.success"  # owner: #1078
 COUNTER_MATERIALIZE_TRANSIENT = "materialize.transient"  # owner: #1078

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -129,6 +129,12 @@ INTERACTION_READ_PROTOCOL_UNRECOGNIZED = "interaction_read_protocol_unrecognized
 # request_payload fails v1 validation. Same "unreadable is not absent"
 # reasoning as the sibling signal above, and the same no-clear-site rule.
 INTERACTION_READ_PAYLOAD_UNREADABLE = "interaction_read_payload_unreadable"
+# Set by the read surface adapter (task_interaction_read.py) when a task's
+# own interaction_protocol_version marker holds a value it does not
+# recognize -- a separate name from the two signals above, which report an
+# active row's stored protocol version, because /health exposes names and
+# not details. No clear site, for the same reason as those two signals.
+INTERACTION_READ_TASK_MARKER_UNRECOGNIZED = "interaction_read_task_marker_unrecognized"
 
 _signals: dict[str, str] = {}
 _lock = threading.Lock()

--- a/src/xagent/web/services/task_interaction_read.py
+++ b/src/xagent/web/services/task_interaction_read.py
@@ -27,7 +27,10 @@ task's answer slot -- a NULL marker in step 1, and the two fallback
 branches of the rich view in step 2. A marker value this reader does not
 recognize leaves the slot's state unknown, and unknown keeps the gate
 shut. Step 1 still costs one attribute access and no query: the gate value
-comes from the marker, which is already in memory.
+comes from the marker, which is already in memory. Once a writer for those
+relabelled rows exists, this gate is a client-visible change at all four
+consumers: a waiting task that renders an empty or generic waiting state
+today starts rendering the recovered question instead.
 
 This function performs **no authorization**. It takes a ``Task`` object,
 not an id, precisely so that a caller has to have resolved and

--- a/src/xagent/web/services/task_interaction_read.py
+++ b/src/xagent/web/services/task_interaction_read.py
@@ -18,6 +18,17 @@ Two steps, in this order, and nothing else:
    implementation of "what is this waiting task's question" -- decides
    the tier, and this function projects its result down to the tuple.
 
+The marker also decides one thing beyond routing: whether the transcript
+reader may reach a question row a structured publication has already
+relabelled to ``question_superseded``. This function is the only caller
+anywhere that opens ``get_latest_waiting_question``'s ``allow_superseded``
+gate, and it opens it on exactly the outcomes where nothing holds this
+task's answer slot -- a NULL marker in step 1, and the two fallback
+branches of the rich view in step 2. A marker value this reader does not
+recognize leaves the slot's state unknown, and unknown keeps the gate
+shut. Step 1 still costs one attribute access and no query: the gate value
+comes from the marker, which is already in memory.
+
 This function performs **no authorization**. It takes a ``Task`` object,
 not an id, precisely so that a caller has to have resolved and
 authorized that row through its own layer first. All four callers do
@@ -86,6 +97,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..models.task_interaction import INTERACTION_PROTOCOL_VERSION
 from .chat_history_service import get_latest_waiting_question
 from .task_interaction_service import materialize_compatibility_view
 
@@ -107,13 +119,28 @@ def get_pending_interaction_question(
     that authorized it (see the module docstring).
     """
 
-    marker = task.interaction_protocol_version
+    # Annotated because the declarative column gives this attribute no
+    # instance-level type. Read off a loaded row it is the stored value,
+    # and comparing it below yields a plain bool rather than the SQL
+    # expression the same comparison would build on the class.
+    marker: Any = task.interaction_protocol_version
     if marker is None:
         # No native row can belong to this task under a NULL marker, so
-        # the interaction table is not queried.
-        return get_latest_waiting_question(db, int(task.id))
+        # the interaction table is not queried -- and nothing holds this
+        # task's answer slot, so a question row a structured publication
+        # already relabelled is still the honest answer.
+        return get_latest_waiting_question(db, int(task.id), allow_superseded=True)
 
-    view = materialize_compatibility_view(db, int(task.id))
+    # Only the one recognized marker lets the view's own two fallback
+    # branches decide that nothing holds the answer slot. Every other value
+    # -- including one that is not an integer at all -- compares unequal
+    # and leaves the gate shut, which is the right direction: an
+    # unrecognized marker means the slot's state is unknown.
+    view = materialize_compatibility_view(
+        db,
+        int(task.id),
+        allow_superseded=marker == INTERACTION_PROTOCOL_VERSION,
+    )
     if view.tier == "unanswerable":
         # The question text, when the tier could still read one, and no
         # controls: this question cannot be answered right now, so

--- a/src/xagent/web/services/task_interaction_read.py
+++ b/src/xagent/web/services/task_interaction_read.py
@@ -95,10 +95,14 @@ answer, written here because this adapter's projection depends on them:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ..models.task_interaction import INTERACTION_PROTOCOL_VERSION
 from .chat_history_service import get_latest_waiting_question
+from .ops_signals import (
+    INTERACTION_READ_TASK_MARKER_UNRECOGNIZED,
+    register_degradation,
+)
 from .task_interaction_service import materialize_compatibility_view
 
 if TYPE_CHECKING:
@@ -119,11 +123,11 @@ def get_pending_interaction_question(
     that authorized it (see the module docstring).
     """
 
-    # Annotated because the declarative column gives this attribute no
-    # instance-level type. Read off a loaded row it is the stored value,
-    # and comparing it below yields a plain bool rather than the SQL
-    # expression the same comparison would build on the class.
-    marker: Any = task.interaction_protocol_version
+    # Cast, not annotated: mypy sees the class-level Column, so without it
+    # the comparison below types as a SQL expression instead of the plain
+    # bool it is at runtime. ``object`` rather than ``int | None`` keeps a
+    # malformed persisted value dynamic, so it still fails closed below.
+    marker = cast("object | None", task.interaction_protocol_version)
     if marker is None:
         # No native row can belong to this task under a NULL marker, so
         # the interaction table is not queried -- and nothing holds this
@@ -133,13 +137,21 @@ def get_pending_interaction_question(
 
     # Only the one recognized marker lets the view's own two fallback
     # branches decide that nothing holds the answer slot. Every other value
-    # -- including one that is not an integer at all -- compares unequal
-    # and leaves the gate shut, which is the right direction: an
-    # unrecognized marker means the slot's state is unknown.
+    # -- including one that is not an integer at all -- leaves the gate
+    # shut: an unrecognized marker means the slot's state is unknown. Such
+    # a value is also corruption the tasks-row CHECK constraint forbids, so
+    # it registers a keyed degradation once per process, routing unchanged.
+    recognized = marker == INTERACTION_PROTOCOL_VERSION
+    if not recognized:
+        register_degradation(
+            INTERACTION_READ_TASK_MARKER_UNRECOGNIZED,
+            f"task {task.id}: interaction_protocol_version holds an "
+            f"unrecognized {type(marker).__name__} value",
+        )
     view = materialize_compatibility_view(
         db,
         int(task.id),
-        allow_superseded=marker == INTERACTION_PROTOCOL_VERSION,
+        allow_superseded=recognized,
     )
     if view.tier == "unanswerable":
         # The question text, when the tier could still read one, and no

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -106,7 +106,11 @@ from ..models.task_interaction import (
     TaskInteractionRequest,
 )
 from .chat_history_service import get_latest_waiting_question
-from .interaction_rollout import COUNTER_LIFECYCLE_RESPONSE_CONFLICT, increment_counter
+from .interaction_rollout import (
+    COUNTER_COMPAT_READ_FALLBACK,
+    COUNTER_LIFECYCLE_RESPONSE_CONFLICT,
+    increment_counter,
+)
 from .ops_signals import (
     CHECKPOINT_LOAD_UNAVAILABLE,
     CHECKPOINT_PK_ANCHOR_DANGLING,
@@ -1467,11 +1471,17 @@ def materialize_compatibility_view(
     structured record of the answer. The table-absent branch does not
     recheck: with no table there is nothing an active row could have been
     written into.
+
+    ``compat.read_fallback`` counts one per legacy tier returned from here,
+    and only from here: it is what makes the answer-from-the-transcript
+    rate readable next to how often a native row was published. A run the
+    recheck rescues is not a fallback and is not counted.
     """
 
     if not interaction_requests_table_exists(db):
         # No recheck on this branch: with no table there is nowhere for an
         # active row to have been written.
+        increment_counter(COUNTER_COMPAT_READ_FALLBACK)
         return _legacy_view(db, task_id, allow_superseded=allow_superseded)
 
     row = _active_native_row(db, task_id)
@@ -1479,6 +1489,7 @@ def materialize_compatibility_view(
         fallback = _legacy_view(db, task_id, allow_superseded=allow_superseded)
         row = _active_native_row(db, task_id)
         if row is None:
+            increment_counter(COUNTER_COMPAT_READ_FALLBACK)
             return fallback
         # An active row appeared between the two looks, so this task's tier
         # is decided from it below instead of from the transcript. Once:

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1352,8 +1352,12 @@ class CompatibilityQuestionView:
     reason: str | None = None
 
 
-def _legacy_view(db: "Session", task_id: int) -> CompatibilityQuestionView:
-    question, interactions = get_latest_waiting_question(db, task_id)
+def _legacy_view(
+    db: "Session", task_id: int, *, allow_superseded: bool = False
+) -> CompatibilityQuestionView:
+    question, interactions = get_latest_waiting_question(
+        db, task_id, allow_superseded=allow_superseded
+    )
     return CompatibilityQuestionView(
         tier="legacy", question=question, interactions=interactions
     )
@@ -1377,7 +1381,7 @@ def _validation_error_summary(exc: _PydanticValidationError) -> list[str]:
 
 
 def materialize_compatibility_view(
-    db: "Session", task_id: int
+    db: "Session", task_id: int, *, allow_superseded: bool = False
 ) -> CompatibilityQuestionView:
     """The single rich implementation of "what is this waiting task's
     question", three-tiered:
@@ -1385,7 +1389,9 @@ def materialize_compatibility_view(
     T1 (tier ``"legacy"``) -- the ``task_interaction_requests`` table does
     not exist yet, or there is no active native row for this task: falls
     back, internally, to ``get_latest_waiting_question`` and returns
-    exactly what that function would have, unconditionally. This tier's
+    exactly what that function hands back, with no filtering of its own
+    and no reason code (the caller's ``allow_superseded`` is passed
+    through to it -- see below). This tier's
     table-existence gate is not defensive decoration for a table that
     might never exist -- ``interaction_rollout.py``'s own ``/ready`` gate
     treats "the service deploys before its own migration has run" as a
@@ -1437,14 +1443,22 @@ def materialize_compatibility_view(
     first, inside a worker-owned short session, before calling this view.
     #1079's own endpoint (not written here) is meant to consume this rich
     result directly, keeping ``reason`` for its own outcome classification.
+
+    ``allow_superseded`` is passed straight to
+    ``get_latest_waiting_question`` on both T1 branches and nowhere else.
+    It lets the transcript reader reach a question row a structured
+    publication has already relabelled, which is only honest on those two
+    branches: both mean no native row holds this task's answer slot. The
+    three T3 branches never call ``_legacy_view`` at all, so the parameter
+    has no place to appear in them -- not an omission.
     """
 
     if not interaction_requests_table_exists(db):
-        return _legacy_view(db, task_id)
+        return _legacy_view(db, task_id, allow_superseded=allow_superseded)
 
     row = _active_native_row(db, task_id)
     if row is None:
-        return _legacy_view(db, task_id)
+        return _legacy_view(db, task_id, allow_superseded=allow_superseded)
 
     if row.protocol_version != INTERACTION_PROTOCOL_VERSION:
         # An active row holds this task's answer slot, so this cannot fold

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1451,14 +1451,39 @@ def materialize_compatibility_view(
     branches: both mean no native row holds this task's answer slot. The
     three T3 branches never call ``_legacy_view`` at all, so the parameter
     has no place to appear in them -- not an omission.
+
+    Deciding "no active row" and reading the transcript are two separate
+    statements, and on PostgreSQL's default READ COMMITTED each statement
+    takes a fresh snapshot, so another session can commit an active row
+    between them. The no-active-row branch therefore looks once more, after
+    the transcript read and before returning, and answers from the row if
+    one has appeared. **This narrows the window, it does not close it**:
+    another session can still commit an active row between that recheck and
+    this function's return, and the caller gets the legacy tier anyway. The
+    consequence of landing in that remaining window is bounded and worth
+    naming: the user answers through the legacy channel, the native row
+    retires as ``answered_via_legacy_resume``, and the answer is neither
+    lost nor the task left stuck -- what that one turn does not get is a
+    structured record of the answer. The table-absent branch does not
+    recheck: with no table there is nothing an active row could have been
+    written into.
     """
 
     if not interaction_requests_table_exists(db):
+        # No recheck on this branch: with no table there is nowhere for an
+        # active row to have been written.
         return _legacy_view(db, task_id, allow_superseded=allow_superseded)
 
     row = _active_native_row(db, task_id)
     if row is None:
-        return _legacy_view(db, task_id, allow_superseded=allow_superseded)
+        fallback = _legacy_view(db, task_id, allow_superseded=allow_superseded)
+        row = _active_native_row(db, task_id)
+        if row is None:
+            return fallback
+        # An active row appeared between the two looks, so this task's tier
+        # is decided from it below instead of from the transcript. Once:
+        # there is no second recheck, and a row found here is answered
+        # from rather than looked at again.
 
     if row.protocol_version != INTERACTION_PROTOCOL_VERSION:
         # An active row holds this task's answer slot, so this cannot fold

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1463,10 +1463,18 @@ def materialize_compatibility_view(
     ``allow_superseded`` is passed straight to
     ``get_latest_waiting_question`` on both T1 branches and nowhere else.
     It lets the transcript reader reach a question row a structured
-    publication has already relabelled, which is only honest on those two
-    branches: both mean no native row holds this task's answer slot. The
-    three T3 branches never call ``_legacy_view`` at all, so the parameter
-    has no place to appear in them -- not an omission.
+    publication has already relabelled. Both T1 branches mean "no active
+    native row", which is not on its own enough to make that honest: the
+    window where ``respond()`` has retired the row to ``answered`` while
+    the task stays ``WAITING_FOR_USER`` until its staged resume command is
+    consumed means it too, and a read landing there would re-offer the
+    relabelled row for a question already answered. That window is
+    unreachable here -- ``respond()`` is its only writer and has no
+    production caller, kept true by its own zero-caller gate -- and what
+    the read surface owes it belongs to the change that publishes an
+    interaction atomically with the task's status transition. The three T3
+    branches never call ``_legacy_view`` at all, so the parameter has no
+    place to appear in them -- not an omission.
 
     Deciding "no active row" and reading the transcript are two separate
     statements, and on PostgreSQL's default READ COMMITTED each statement

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1330,7 +1330,7 @@ def _resolve_read_direction_anchor(
     execution_matches = (
         not row_execution_id or row_execution_id == row.resume_execution_id
     )
-    event_id_matches = str(trace_row.event_id) == row.resume_event_id
+    event_id_matches = trace_row.event_id == row.resume_event_id
     if (
         trace_row.task_id != row.task_id
         or trace_row.event_type != str(CHECKPOINT_EVENT_TYPE)
@@ -1484,17 +1484,39 @@ def materialize_compatibility_view(
     recheck: with no table there is nothing an active row could have been
     written into.
 
+    The recheck's inverse is not narrowed by any of this and does not need
+    to be: a row it finds can retire between the find and whatever the
+    caller does next. Nothing is corrupted when that happens, because the
+    answer path never trusts this read -- ``respond()`` re-selects the row
+    inside ``_answer_fence_stmt``'s compare-and-swap and classifies the
+    zero rowcount, rather than writing into a slot that has since moved on.
+
     ``compat.read_fallback`` counts one per legacy tier returned from here,
-    and only from here: it is what makes the answer-from-the-transcript
-    rate readable next to how often a native row was published. A run the
-    recheck rescues is not a fallback and is not counted.
+    and only from here. It is a raw count and not a rate: nothing in this
+    registry records how often this function ran or how often it answered
+    from a native row, so there is no denominator to read it against, and
+    a reader who wants one has to bring their own request-volume figure.
+    Two different states increment it and they are worth keeping apart --
+    the table-absent branch counts a deployment whose interaction-table
+    migration has not landed yet, and the no-active-row branch counts a
+    read that genuinely had to fall back to the transcript. Only the second
+    says anything about the rollout; past the migration the first cannot
+    fire at all, so a non-zero count on a migrated deployment is entirely
+    the second. A run the recheck rescues is not a fallback and is not
+    counted. Like every counter in ``interaction_rollout``, this one lives
+    in process memory: it starts at zero on each start, a redeploy resets
+    it, and a reader behind a load balancer sees one process's share.
     """
 
     if not interaction_requests_table_exists(db):
         # No recheck on this branch: with no table there is nowhere for an
-        # active row to have been written.
+        # active row to have been written. The count goes up after
+        # ``_legacy_view`` returns, not before it is called, so a raise on
+        # the way through cannot leave a fallback counted that no caller
+        # ever received -- same ordering as the no-active-row branch below.
+        fallback = _legacy_view(db, task_id, allow_superseded=allow_superseded)
         increment_counter(COUNTER_COMPAT_READ_FALLBACK)
-        return _legacy_view(db, task_id, allow_superseded=allow_superseded)
+        return fallback
 
     row = _active_native_row(db, task_id)
     if row is None:

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1159,9 +1159,10 @@ def _resolve_read_direction_anchor(
     """Resolve an active interaction row's resume anchor for the read
     direction: does ``row.resume_trace_event_id`` still point at a
     structurally valid checkpoint row -- the right task, event type,
-    checkpoint type, run partition, and (when present) execution identity?
-    Returns ``None`` on success, or an ``_AnchorUnresolved`` naming which of
-    the two outcomes applies otherwise.
+    checkpoint type, run partition, (when present) execution identity, and
+    the event id the anchor itself names? Returns ``None`` on success, or
+    an ``_AnchorUnresolved`` naming which of the two outcomes applies
+    otherwise.
 
     This validates the row's *identity*, not its *payload*: unlike
     ``trace_handlers``, which also calls ``decode_trace_event_data`` and
@@ -1189,6 +1190,15 @@ def _resolve_read_direction_anchor(
       predicate the two resolvers could both import is a real
       simplification, left as a follow-up, not done here -- see the
       module docstring's delivered-here accounting.)
+    - One condition in that judgment is this resolver's alone and is not
+      expected to appear in trace_handlers': ``trace_row.event_id`` must
+      equal ``row.resume_event_id``. It is the identity the write-direction
+      resolver stored on the interaction row for exactly this comparison,
+      and it is checkable only from here -- trace_handlers reaches a
+      checkpoint by primary key with no interaction row in hand, so it has
+      no second identity to compare against. The "must agree with
+      trace_handlers' own" rule above does not reach it, and matching the
+      two sides is not a reason to remove it.
     - ``CHECKPOINT_LOAD_UNAVAILABLE`` is registered exactly the way
       trace_handlers registers it: a read failure is a read failure on
       either side.
@@ -1320,6 +1330,7 @@ def _resolve_read_direction_anchor(
     execution_matches = (
         not row_execution_id or row_execution_id == row.resume_execution_id
     )
+    event_id_matches = str(trace_row.event_id) == row.resume_event_id
     if (
         trace_row.task_id != row.task_id
         or trace_row.event_type != str(CHECKPOINT_EVENT_TYPE)
@@ -1327,6 +1338,7 @@ def _resolve_read_direction_anchor(
         or row_data.get("checkpoint_type") not in READABLE_CHECKPOINT_TYPES
         or not partition_matches
         or not execution_matches
+        or not event_id_matches
     ):
         register_degradation(
             CHECKPOINT_PK_ANCHOR_DANGLING,

--- a/tests/web/api/test_resume_interaction_seam.py
+++ b/tests/web/api/test_resume_interaction_seam.py
@@ -127,6 +127,7 @@ def _make_active_row(session_factory, *, task_id: int, run_id: str = RUN_ID) -> 
             **make_row(
                 task_id=task_id,
                 resume_trace_event_id=event.id,
+                db=db,
                 run_id=run_id,
                 request_payload={"message": "Which environment?", "interactions": []},
                 resume_run_partition=run_id,

--- a/tests/web/services/task_interaction_schema_shared.py
+++ b/tests/web/services/task_interaction_schema_shared.py
@@ -121,10 +121,38 @@ def make_trace_event(db: Session, *, task_id: int) -> int:
     return int(event.id)
 
 
+def anchor_event_id(db: Session, resume_trace_event_id: int) -> str:
+    """The ``event_id`` carried by the trace row an anchor points at.
+
+    The write direction stores exactly this string in the interaction row's
+    ``resume_event_id``, and the read-direction resolver compares the two,
+    so an anchor resolves only when the fixture takes the value from the
+    row it names. A fixture that wants an anchor to stay unresolvable
+    breaks one of the resolver's other conditions on purpose -- the run
+    partition, the execution id, the checkpoint type -- rather than leaving
+    this one mismatched, because a deliberate mismatch here is
+    indistinguishable from a fixture that simply forgot.
+
+    Raises ``LookupError`` when no trace row carries that primary key.
+    There is no sentinel return value: ``resume_event_id`` is NOT NULL, so
+    a caller has nowhere legal to put an "unknown", and every caller passes
+    an id the same fixture just created, so a miss is a broken fixture and
+    not a test condition.
+    """
+    trace_row = db.get(TraceEvent, resume_trace_event_id)
+    if trace_row is None:
+        raise LookupError(
+            f"no trace_events row with id {resume_trace_event_id}: an anchor "
+            "fixture must name a row that exists"
+        )
+    return str(trace_row.event_id)
+
+
 def make_row(
     *,
     task_id: int,
     resume_trace_event_id: int | None,
+    db: Session | None = None,
     status: str = "active",
     **overrides: object,
 ) -> dict[str, object]:
@@ -144,6 +172,17 @@ def make_row(
     request_idempotency_key gets a fresh value on every call so identity
     tests (T-uq-4/T-uq-5) only collide when a test deliberately repeats one
     via ``overrides``.
+
+    ``db`` is what makes ``resume_event_id`` agree with the trace row
+    ``resume_trace_event_id`` names: pass it and the value is read off that
+    row through ``anchor_event_id``, which is the only way a row built here
+    can resolve its read-direction anchor. Omit it -- as the
+    constraint-behaviour suites do, since no CHECK looks at the anchor's
+    identity -- and the field holds the literal
+    ``"unresolvable-anchor-event-id"``, named that way so a test which does
+    read such a row back sees at once why the anchor came out dangling,
+    instead of chasing a plausible-looking value that was never going to
+    match anything.
     """
     now = datetime.now(timezone.utc)
     row: dict[str, object] = {
@@ -158,7 +197,11 @@ def make_row(
         "response_payload": None,
         "request_idempotency_key": f"req-{next(_key_counter)}",
         "resume_trace_event_id": resume_trace_event_id,
-        "resume_event_id": "resume-event-1",
+        "resume_event_id": (
+            anchor_event_id(db, resume_trace_event_id)
+            if db is not None and resume_trace_event_id is not None
+            else "unresolvable-anchor-event-id"
+        ),
         "resume_execution_id": "resume-execution-1",
         "resume_locator_format": "trace_event_pk_v1",
         "resume_checkpoint_type": "agent_execution_checkpoint",

--- a/tests/web/services/test_read_surface_shape_contract.py
+++ b/tests/web/services/test_read_surface_shape_contract.py
@@ -53,6 +53,7 @@ from sqlalchemy.orm import Session
 
 import xagent.web.api.websocket as websocket_module
 import xagent.web.services.task_interaction_service as interaction_service_module
+from tests.web.services.task_interaction_schema_shared import anchor_event_id
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.core.agent.transcript import build_assistant_transcript_content
 from xagent.web.api.agents import router as agents_router
@@ -283,29 +284,12 @@ def _make_trace_event(db: Session, *, task_id: int, run_partition: str) -> int:
     return int(event.id)
 
 
-def _anchor_event_id(db: Session, resume_trace_event_id: int | None) -> str:
-    """The ``event_id`` carried by the trace row an anchor points at.
-
-    The write direction stores exactly this string in the interaction row's
-    ``resume_event_id``, and the read-direction resolver compares the two,
-    so an anchor resolves only when the fixture takes the value from the
-    row it names. The T3 tier below breaks the run partition on purpose;
-    every other tier is meant to resolve."""
-
-    trace_row = (
-        None
-        if resume_trace_event_id is None
-        else db.get(TraceEvent, resume_trace_event_id)
-    )
-    return "no-anchor-row" if trace_row is None else str(trace_row.event_id)
-
-
 def _make_active_row(
     db: Session,
     *,
     task_id: int,
     run_id: str,
-    resume_trace_event_id: int | None,
+    resume_trace_event_id: int,
     resume_run_partition: str,
     request_payload: dict[str, Any] | None = None,
 ) -> None:
@@ -328,7 +312,7 @@ def _make_active_row(
         },
         request_idempotency_key=f"shape-contract-key-{uuid.uuid4()}",
         resume_trace_event_id=resume_trace_event_id,
-        resume_event_id=_anchor_event_id(db, resume_trace_event_id),
+        resume_event_id=anchor_event_id(db, resume_trace_event_id),
         resume_execution_id="exec-1",
         resume_locator_format="trace_event_pk_v1",
         resume_checkpoint_type="agent_execution_checkpoint",

--- a/tests/web/services/test_read_surface_shape_contract.py
+++ b/tests/web/services/test_read_surface_shape_contract.py
@@ -283,6 +283,23 @@ def _make_trace_event(db: Session, *, task_id: int, run_partition: str) -> int:
     return int(event.id)
 
 
+def _anchor_event_id(db: Session, resume_trace_event_id: int | None) -> str:
+    """The ``event_id`` carried by the trace row an anchor points at.
+
+    The write direction stores exactly this string in the interaction row's
+    ``resume_event_id``, and the read-direction resolver compares the two,
+    so an anchor resolves only when the fixture takes the value from the
+    row it names. The T3 tier below breaks the run partition on purpose;
+    every other tier is meant to resolve."""
+
+    trace_row = (
+        None
+        if resume_trace_event_id is None
+        else db.get(TraceEvent, resume_trace_event_id)
+    )
+    return "no-anchor-row" if trace_row is None else str(trace_row.event_id)
+
+
 def _make_active_row(
     db: Session,
     *,
@@ -311,7 +328,7 @@ def _make_active_row(
         },
         request_idempotency_key=f"shape-contract-key-{uuid.uuid4()}",
         resume_trace_event_id=resume_trace_event_id,
-        resume_event_id="resume-event-1",
+        resume_event_id=_anchor_event_id(db, resume_trace_event_id),
         resume_execution_id="exec-1",
         resume_locator_format="trace_event_pk_v1",
         resume_checkpoint_type="agent_execution_checkpoint",

--- a/tests/web/services/test_read_surface_shape_contract.py
+++ b/tests/web/services/test_read_surface_shape_contract.py
@@ -736,6 +736,50 @@ def test_old_writer_new_reader_legacy_question_is_still_readable_without_a_marke
         db.close()
 
 
+def test_a_relabelled_question_reaches_the_wire_instead_of_the_default_message(
+    _environment: _Environment, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The superseded fallback's outcome on the one wire shape that has
+    something to fall back to: the websocket status reassertion event. A
+    task whose only question row carries ``question_superseded`` still
+    reaches this event with the question itself, not with the generic
+    waiting message the event falls back to when both slots are empty."""
+
+    db = _environment.session_factory()
+    try:
+        run_id = f"relabelled-{uuid.uuid4()}"
+        task = _make_task(db, env=_environment, marker=None, run_id=run_id)
+        task_id = int(task.id)
+        raw_content = "Relabelled question"
+        persist_assistant_message(
+            db,
+            task_id,
+            _environment.user_id,
+            raw_content,
+            message_type="question_superseded",
+            interactions=_LEGACY_INTERACTIONS,
+        )
+    finally:
+        db.close()
+    expected_question = build_assistant_transcript_content(
+        raw_content, _LEGACY_INTERACTIONS
+    )
+
+    _disable_websocket_cache(monkeypatch)
+    snapshot = websocket_module._load_historical_stream_snapshot_sync(
+        task_id,
+        actor_user_id=_environment.user_id,
+        actor_is_admin=False,
+    )
+    assert snapshot is not None
+
+    event = _status_reassertion_event(snapshot)
+    assert event["message"] != _DEFAULT_WAITING_MESSAGE
+    assert event["message"] == expected_question
+    assert event["question"] == expected_question
+    assert event["interactions"] == _LEGACY_INTERACTIONS
+
+
 def test_old_writer_new_reader_legacy_question_is_still_readable_with_no_active_row(
     _environment: _Environment,
 ) -> None:

--- a/tests/web/services/test_supersede_legacy_questions.py
+++ b/tests/web/services/test_supersede_legacy_questions.py
@@ -6,8 +6,17 @@ different task, and a nonexistent task_id), idempotency, the
 degrade/propagate split on the catch clause, signal pairing,
 transcript-field invariance, a caller-originated flush failure
 propagating past the catch instead of being absorbed by it, and the
-reader's and writer's compiled WHERE clauses matching at runtime. One
-property is not provable here -- that
+reader's and writer's compiled WHERE clauses matching at runtime.
+
+One fact this file holds both halves of, and the reason the pairing
+lives here: the relabel scans the whole task and carries no run
+partition. Its WHERE is task, assistant role, message type, so a single
+call relabels every round's question row on the task at once. That is
+what makes the reader's superseded-row pass correct on a task that has
+asked more than once -- ordering by id descending over rows the relabel
+just swept up lands on the newest round, not on some earlier one.
+
+One property is not provable here -- that
 the savepoint is actually necessary, i.e. that a failed statement
 without it would poison the caller's transaction. SQLite does not abort
 an open transaction after a failed statement the way PostgreSQL does, so
@@ -822,6 +831,16 @@ def _reader_and_writer_where_clauses(db, task_id: int) -> tuple[str, str]:
     such as ``message_type.in_(["question"])``, count as a difference.
     Two predicates that mean the same thing but do not render the same
     thing are exactly the state this abstraction exists to prevent.
+
+    The reader is called with ``allow_superseded`` left at its default, so
+    what this captures is its first pass and only its first pass. The
+    second pass belongs on the other side of this pairing: its predicate
+    matches ``SUPERSEDED_MESSAGE_TYPE``, which is what the writer
+    *produces*. Folding it into the captured set would demand that the
+    writer's input set equal its own output set, an assertion that can
+    never hold. ``assert len(selects) == 1`` below therefore holds because
+    the caller here left the second pass shut, not because the reader can
+    only ever emit one statement.
     """
     bind = db.get_bind()
     with _captured_statements(bind) as read_seen:
@@ -848,6 +867,11 @@ def test_the_shared_where_clause_still_has_all_three_legs():
     drift -- one side diverging from the other, and a condition
     disappearing from the shared helper, which moves both sides together
     and would keep a bare equality check green.
+
+    Scope: this pins the reader's first pass against the writer, nothing
+    else. A live question row is persisted below, so the first pass hits
+    and the reader's superseded-row pass -- which only runs when a caller
+    opens it and the first pass comes back empty -- never runs here.
     """
     db = _create_db_session()
     try:

--- a/tests/web/services/test_supersede_legacy_questions.py
+++ b/tests/web/services/test_supersede_legacy_questions.py
@@ -676,6 +676,106 @@ def test_supersede_end_to_end_with_the_reader():
         db.close()
 
 
+def test_the_reader_only_reaches_superseded_rows_when_the_caller_opens_it():
+    """``allow_superseded`` is off unless a caller passes it. The default
+    call -- the one every caller but the read surface adapter makes --
+    sees a superseded row exactly as it always did: not at all. Mutation:
+    default the parameter to True and the first assertion turns red."""
+
+    db = _create_db_session()
+    try:
+        task = _create_task(db)
+        persist_assistant_message(
+            db,
+            int(task.id),
+            int(task.user_id),
+            "A question",
+            message_type="question",
+            interactions=[{"type": "text_input", "label": "Env"}],
+        )
+        supersede_legacy_question_rows(db, task_id=int(task.id))
+
+        assert get_latest_waiting_question(db, int(task.id)) == (None, None)
+
+        question, interactions = get_latest_waiting_question(
+            db, int(task.id), allow_superseded=True
+        )
+        assert question is not None
+        assert question.startswith("A question")
+        assert interactions == [{"type": "text_input", "label": "Env"}]
+    finally:
+        db.close()
+
+
+def test_an_opened_reader_still_prefers_a_live_question_row():
+    """Two sequential passes, not one ``message_type.in_(...)`` predicate:
+    the live question row wins even when a superseded row carries a higher
+    id, because the second pass only runs when the first came back empty.
+    Mutation: match both message types in one predicate ordered by id and
+    this turns red -- the superseded row here has the higher id."""
+
+    db = _create_db_session()
+    try:
+        task = _create_task(db)
+        persist_assistant_message(
+            db,
+            int(task.id),
+            int(task.user_id),
+            "A live question",
+            message_type="question",
+        )
+        persist_assistant_message(
+            db,
+            int(task.id),
+            int(task.user_id),
+            "An older question already superseded",
+            message_type=SUPERSEDED_MESSAGE_TYPE,
+        )
+
+        question, _ = get_latest_waiting_question(
+            db, int(task.id), allow_superseded=True
+        )
+
+        assert question is not None
+        assert question.startswith("A live question")
+    finally:
+        db.close()
+
+
+def test_an_opened_reader_returns_the_newest_round_after_a_whole_task_relabel():
+    """``supersede_legacy_question_rows`` matches on task, role and message
+    type with no run partition, so one call relabels every round's question
+    row on the task at once (see its own docstring). The opened second pass
+    orders by id descending, so what it hands back on a task that has asked
+    three times is the third round's question, not the first.
+
+    Mutation: order the second pass ascending and this turns red."""
+
+    db = _create_db_session()
+    try:
+        task = _create_task(db)
+        for round_number in (1, 2, 3):
+            persist_assistant_message(
+                db,
+                int(task.id),
+                int(task.user_id),
+                f"Round {round_number} question",
+                message_type="question",
+            )
+
+        relabelled = supersede_legacy_question_rows(db, task_id=int(task.id))
+        assert relabelled == 3
+
+        question, _ = get_latest_waiting_question(
+            db, int(task.id), allow_superseded=True
+        )
+
+        assert question is not None
+        assert question.startswith("Round 3 question")
+    finally:
+        db.close()
+
+
 @contextmanager
 def _captured_statements(bind):
     """Every SQL construct SQLAlchemy sends through ``bind`` while the

--- a/tests/web/services/test_task_interaction_read.py
+++ b/tests/web/services/test_task_interaction_read.py
@@ -1044,7 +1044,14 @@ def test_a_recheck_that_finds_an_active_row_counts_no_read_fallback(
     """The recheck exists to stop a legacy answer being returned, so the
     run it saves is not a fallback and must not be counted. The active row
     is made to appear on the second look only, which is the shape a
-    concurrent publication produces."""
+    concurrent publication produces.
+
+    ``interactions`` is asserted rather than discarded: the
+    ``anchor_dangling`` tier hands back the same question text with
+    ``interactions=None``, so a test that only checked the text would stay
+    green if the recheck's fallthrough landed there instead of on the
+    native tier.
+    """
 
     task = _make_task(_db, marker=1)
     trace_event_id = _make_trace_event(_db, task_id=int(task.id))
@@ -1063,7 +1070,8 @@ def test_a_recheck_that_finds_an_active_row_counts_no_read_fallback(
     )
 
     before = _read_fallback_count()
-    question, _ = read_surface.get_pending_interaction_question(_db, task)
+    question, interactions = read_surface.get_pending_interaction_question(_db, task)
 
     assert question == "Which environment?"
+    assert interactions is not None
     assert _read_fallback_count() == before

--- a/tests/web/services/test_task_interaction_read.py
+++ b/tests/web/services/test_task_interaction_read.py
@@ -9,19 +9,22 @@ filters or reshapes what it receives (A14).
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import Select, create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
+import xagent.web.services.chat_history_service as chat_history_service
+import xagent.web.services.task_interaction_service as interaction_service_module
 from tests.web.services.task_interaction_schema_shared import make_task, make_user
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.models.database import Base
-from xagent.web.models.task import Task, TraceEvent
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import task_interaction_read as read_surface
 from xagent.web.services.chat_history_service import persist_assistant_message
@@ -196,15 +199,15 @@ def test_a1_marker_null_reads_the_live_legacy_question(_db: Session) -> None:
     assert interactions == [{"type": "text_input", "label": "Live"}]
 
 
-def test_a2_marker_null_never_reads_a_superseded_only_row(_db: Session) -> None:
-    """``get_latest_waiting_question`` filters on
-    ``message_type == QUESTION_MESSAGE_TYPE`` only (see
-    ``_assistant_question_filters``); a row a later structured publication
-    retyped to ``question_superseded`` is a different message type and is
-    never matched, for the NULL-marker cell same as every other caller.
-    Mutation: have this cell fall back to reading superseded rows when the
-    first pass finds nothing and this test turns red -- it would return
-    the superseded content instead of ``(None, None)``."""
+def test_a2_marker_null_recovers_a_superseded_only_row(_db: Session) -> None:
+    """A NULL marker means no native row holds this task's answer slot, so
+    a question row a structured publication already relabelled to
+    ``question_superseded`` is the only record of what this task is asking
+    -- and the honest answer, not an empty pair. Step 0 is the one caller
+    that opens ``allow_superseded``, which is what makes the second pass
+    run here after the first finds no live row. Mutation: pass
+    ``allow_superseded=False`` from step 0 and this turns red -- the pair
+    comes back empty and the question is unreachable."""
 
     task = _make_task(_db, marker=None)
     persist_assistant_message(
@@ -218,7 +221,9 @@ def test_a2_marker_null_never_reads_a_superseded_only_row(_db: Session) -> None:
 
     question, interactions = read_surface.get_pending_interaction_question(_db, task)
 
-    assert (question, interactions) == (None, None)
+    assert question is not None
+    assert question.startswith("An old question")
+    assert interactions == [{"type": "text_input", "label": "Old"}]
 
 
 def test_a3_marker_null_prefers_the_live_row_over_a_higher_id_superseded_row(
@@ -353,7 +358,7 @@ def test_a5_marker_fast_path_never_calls_the_rich_view(
     and confirming it still passes. Mutation: delete the marker check (so
     every task always calls the rich view) and this test turns red."""
 
-    def _explode(db: Session, task_id: int):
+    def _explode(db: Session, task_id: int, *, allow_superseded: bool = False):
         raise AssertionError("materialize_compatibility_view must not be called")
 
     monkeypatch.setattr(read_surface, "materialize_compatibility_view", _explode)
@@ -422,16 +427,17 @@ def test_a7_marker_matches_table_absent_reads_the_legacy_transcript(
     assert interactions == [{"type": "text_input", "label": "Live"}]
 
 
-def test_a8_marker_matches_no_active_row_never_reads_a_superseded_only_row(
+def test_a8_marker_matches_no_active_row_recovers_a_superseded_only_row(
     _db: Session,
 ) -> None:
-    """T1's fallback (marker == 1, no active row) goes through the same
-    single-pass ``get_latest_waiting_question`` as the NULL-marker T0 cell
-    (see A2) -- a structured row was expected for this wait (the marker
-    says so) but none is active, and the transcript fallback still never
-    matches a row already retyped to ``question_superseded``. Mutation:
-    have this fallback read superseded rows and this test turns red -- it
-    would return the superseded content instead of ``(None, None)``."""
+    """T1's "no active row" fallback reaches relabelled rows for the same
+    reason the NULL-marker cell does (see A2): no native row holds this
+    task's answer slot, so the relabelled transcript row is the only record
+    of the question and answering it lands nowhere a native row has
+    claimed. The gate value travels marker -> adapter ->
+    ``materialize_compatibility_view`` -> ``_legacy_view``. Mutation: stop
+    threading ``allow_superseded`` into either legacy branch of the
+    compatibility view and this turns red."""
 
     task = _make_task(_db, marker=1)
     persist_assistant_message(
@@ -445,7 +451,107 @@ def test_a8_marker_matches_no_active_row_never_reads_a_superseded_only_row(
 
     question, interactions = read_surface.get_pending_interaction_question(_db, task)
 
-    assert (question, interactions) == (None, None)
+    assert question is not None
+    assert question.startswith("An old question")
+    assert interactions == [{"type": "text_input", "label": "Old"}]
+
+
+# ---------------------------------------------------------------------------
+# Superseded recovery: what the read surface answers once a structured
+# publication has relabelled the transcript row it replaced.
+# ---------------------------------------------------------------------------
+
+
+def _make_terminated_row(db: Session, *, task_id: int) -> None:
+    """One interaction row in a terminal state: it holds no answer slot, so
+    the active-row predicate does not match it and the compatibility view
+    falls back to the transcript."""
+
+    now = _now()
+    row = TaskInteractionRequest(
+        task_id=task_id,
+        run_id="run-a",
+        kind="clarification",
+        protocol_version=1,
+        status="terminated",
+        active_slot=None,
+        origin="internal",
+        request_payload={"message": "Which environment?", "interactions": []},
+        request_idempotency_key=f"read-terminal-key-{task_id}",
+        resume_trace_event_id=None,
+        resume_event_id="resume-event-1",
+        resume_execution_id="exec-1",
+        resume_locator_format="trace_event_pk_v1",
+        resume_checkpoint_type="agent_execution_checkpoint",
+        resume_run_partition="run-a",
+        terminal_reason="deadline_elapsed",
+        terminated_at=now,
+        created_at=now,
+        expires_at=now + timedelta(minutes=15),
+    )
+    db.add(row)
+    db.commit()
+
+
+def test_read_surface_recovers_a_superseded_question(_db: Session) -> None:
+    """The steady state a structured publication leaves behind on a task
+    whose marker was never advanced: the task is waiting, its interaction
+    row has reached a terminal state, and the transcript row that carried
+    the question has been relabelled. Nothing holds the answer slot, so the
+    relabelled row is what this task is asking and the read surface hands
+    it back."""
+
+    task = _make_task(_db, marker=None)
+    task.status = TaskStatus.WAITING_FOR_USER
+    _db.commit()
+    _make_terminated_row(_db, task_id=int(task.id))
+    persist_assistant_message(
+        _db,
+        int(task.id),
+        int(task.user_id),
+        "Which environment?",
+        message_type="question_superseded",
+        interactions=[{"type": "text_input", "label": "Environment"}],
+    )
+
+    question, interactions = read_surface.get_pending_interaction_question(_db, task)
+
+    assert question is not None
+    assert question.startswith("Which environment?")
+    assert interactions == [{"type": "text_input", "label": "Environment"}]
+
+
+def test_recovery_still_applies_when_an_active_row_exists_under_a_null_marker(
+    _db: Session,
+) -> None:
+    """A known boundary, pinned as current behavior rather than as the
+    behavior anyone wants: step 0 reads the marker off the task row and
+    queries nothing else, so a NULL marker sitting on a task that does have
+    an active interaction row still opens the gate and answers from the
+    relabelled transcript row.
+
+    The pair "active row staged" and "marker advanced to 1" is written by
+    the staging side, which is what keeps this combination from occurring;
+    the read surface does not second-guess it, and the superseded fallback
+    does not take that duty on either."""
+
+    task = _make_task(_db, marker=None)
+    trace_event_id = _make_trace_event(_db, task_id=int(task.id))
+    _make_active_row(_db, task_id=int(task.id), resume_trace_event_id=trace_event_id)
+    persist_assistant_message(
+        _db,
+        int(task.id),
+        int(task.user_id),
+        "An old question",
+        message_type="question_superseded",
+        interactions=[{"type": "text_input", "label": "Old"}],
+    )
+
+    question, interactions = read_surface.get_pending_interaction_question(_db, task)
+
+    assert question is not None
+    assert question.startswith("An old question")
+    assert interactions == [{"type": "text_input", "label": "Old"}]
 
 
 # ---------------------------------------------------------------------------
@@ -586,7 +692,9 @@ def test_a13b_unanswerable_tier_never_leaks_interactions_even_if_the_view_carrie
     Mutation: change the branch to ``return view.question,
     view.interactions`` and this test turns red; A10-A13 stay green."""
 
-    def _fake_view(db: Session, task_id: int) -> CompatibilityQuestionView:
+    def _fake_view(
+        db: Session, task_id: int, *, allow_superseded: bool = False
+    ) -> CompatibilityQuestionView:
         return CompatibilityQuestionView(
             tier="unanswerable",
             question="q",
@@ -677,3 +785,205 @@ def test_a15_interaction_element_key_sets_differ_between_legacy_and_native_tiers
         "accept",
         "multiple",
     }
+
+
+# ---------------------------------------------------------------------------
+# The gate value itself: which of the read surface's outcomes lets the
+# transcript reader reach relabelled rows, and which does not. Every cell
+# below records the ``allow_superseded`` value that actually arrived at
+# ``get_latest_waiting_question``, from whichever of its two call sites ran.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _recorded_gate_values(monkeypatch: pytest.MonkeyPatch):
+    """Every ``allow_superseded`` value ``get_latest_waiting_question``
+    receives while the block runs, in call order, patched at both of its
+    call sites: step 0 in the adapter and ``_legacy_view`` in the
+    compatibility view. An empty list means the transcript reader was never
+    reached at all."""
+
+    seen: list[bool] = []
+    real = chat_history_service.get_latest_waiting_question
+
+    def _record(db, task_id, *, allow_superseded: bool = False):
+        seen.append(allow_superseded)
+        return real(db, task_id, allow_superseded=allow_superseded)
+
+    monkeypatch.setattr(read_surface, "get_latest_waiting_question", _record)
+    monkeypatch.setattr(
+        interaction_service_module, "get_latest_waiting_question", _record
+    )
+    yield seen
+
+
+def _gate_marker_null(db: Session) -> Task:
+    task = _make_task(db, marker=None)
+    _persist_live_question(db, task)
+    return task
+
+
+def _gate_unrecognized_marker(db: Session) -> Task:
+    task = _make_task(db, marker=None)
+    _persist_live_question(db, task)
+    # ck_tasks_interaction_protocol_version pins the column to NULL-or-1, so
+    # this value is set on the in-memory row only -- the same construction
+    # A4 uses, and faithful because the adapter only ever reads it.
+    task.interaction_protocol_version = 2
+    return task
+
+
+def _gate_table_absent(db: Session) -> Task:
+    task = _make_task(db, marker=1)
+    _persist_live_question(db, task)
+    TaskInteractionRequest.__table__.drop(bind=db.get_bind())
+    return task
+
+
+def _gate_no_active_row(db: Session) -> Task:
+    task = _make_task(db, marker=1)
+    _persist_live_question(db, task)
+    return task
+
+
+def _gate_unanswerable_payload(db: Session) -> Task:
+    task = _make_task(db, marker=1)
+    trace_event_id = _make_trace_event(db, task_id=int(task.id))
+    _make_active_row(
+        db,
+        task_id=int(task.id),
+        resume_trace_event_id=trace_event_id,
+        request_payload={"not": "a valid v1 payload"},
+    )
+    return task
+
+
+def _gate_unanswerable_anchor(db: Session) -> Task:
+    task = _make_task(db, marker=1)
+    trace_event_id = _make_trace_event(
+        db, task_id=int(task.id), run_partition="a-different-run"
+    )
+    _make_active_row(db, task_id=int(task.id), resume_trace_event_id=trace_event_id)
+    return task
+
+
+def _persist_live_question(db: Session, task: Task) -> None:
+    persist_assistant_message(
+        db,
+        int(task.id),
+        int(task.user_id),
+        "A live question",
+        message_type="question",
+        interactions=[{"type": "text_input", "label": "Live"}],
+    )
+
+
+_GATE_CASES: dict[str, tuple[Any, list[bool]]] = {
+    # No native row can belong to this task, so the relabelled transcript
+    # row is reachable.
+    "marker_null": (_gate_marker_null, [True]),
+    # A marker value this reader does not recognize means the slot's state
+    # is unknown, and unknown closes the gate.
+    "unrecognized_marker": (_gate_unrecognized_marker, [False]),
+    # Both compatibility-view fallbacks mean nothing holds the slot.
+    "table_absent": (_gate_table_absent, [True]),
+    "no_active_row": (_gate_no_active_row, [True]),
+    # The unanswerable tiers never reach the transcript reader at all.
+    "unanswerable_payload": (_gate_unanswerable_payload, []),
+    "unanswerable_anchor": (_gate_unanswerable_anchor, []),
+}
+
+
+@pytest.mark.parametrize("case", sorted(_GATE_CASES))
+def test_gate_value_per_read_surface_outcome(
+    _db: Session, monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    build, expected = _GATE_CASES[case]
+    task = build(_db)
+
+    with _recorded_gate_values(monkeypatch) as seen:
+        read_surface.get_pending_interaction_question(_db, task)
+
+    assert seen == expected
+
+
+def test_gate_is_closed_for_an_unrecognized_protocol_version_row(
+    _db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The third unanswerable tier, which needs its own construction: an
+    active row's protocol_version cannot be written to anything but 1
+    (ck_task_interaction_requests_active_protocol), so it is mutated in
+    memory behind the accessor that reads it, the same way A12 does."""
+
+    task = _make_task(_db, marker=1)
+    trace_event_id = _make_trace_event(_db, task_id=int(task.id))
+    row = _make_active_row(
+        _db, task_id=int(task.id), resume_trace_event_id=trace_event_id
+    )
+    row.protocol_version = 2
+    monkeypatch.setattr(
+        interaction_service_module, "_active_native_row", lambda db, task_id: row
+    )
+
+    with _recorded_gate_values(monkeypatch) as seen:
+        read_surface.get_pending_interaction_question(_db, task)
+
+    assert seen == []
+
+
+# ---------------------------------------------------------------------------
+# Statement count: step 0 still costs nothing beyond what the transcript
+# reader itself costs.
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _counted_selects(bind):
+    seen: list[object] = []
+
+    def _record(conn, clauseelement, multiparams, params, execution_options):
+        if isinstance(clauseelement, Select):
+            seen.append(clauseelement)
+
+    event.listen(bind, "before_execute", _record)
+    try:
+        yield seen
+    finally:
+        event.remove(bind, "before_execute", _record)
+
+
+@pytest.mark.parametrize("message_type", ["question", "question_superseded"])
+def test_m3_marker_null_issues_no_statement_the_reader_would_not(
+    _db: Session, message_type: str
+) -> None:
+    """Under a NULL marker the adapter must emit exactly the statements
+    ``get_latest_waiting_question`` emits on its own -- one when the first
+    pass hits, two when the gate is open and the first pass comes back
+    empty -- and nothing else. Mutation: add any query to step 0, for
+    instance a lookup into the interaction table, and this turns red."""
+
+    task = _make_task(_db, marker=None)
+    persist_assistant_message(
+        _db,
+        int(task.id),
+        int(task.user_id),
+        "A question",
+        message_type=message_type,
+    )
+    # Load the task's own columns before counting: persist_assistant_message
+    # commits, which expires them, and the refresh SELECT that first touch
+    # would otherwise emit belongs to the fixture, not to either function
+    # under measurement.
+    _db.refresh(task)
+    task_id = int(task.id)
+    bind = _db.get_bind()
+
+    with _counted_selects(bind) as through_adapter:
+        read_surface.get_pending_interaction_question(_db, task)
+    with _counted_selects(bind) as direct:
+        chat_history_service.get_latest_waiting_question(
+            _db, task_id, allow_superseded=True
+        )
+
+    assert len(through_adapter) == len(direct)
+    assert len(direct) == (1 if message_type == "question" else 2)

--- a/tests/web/services/test_task_interaction_read.py
+++ b/tests/web/services/test_task_interaction_read.py
@@ -28,6 +28,10 @@ from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import task_interaction_read as read_surface
 from xagent.web.services.chat_history_service import persist_assistant_message
+from xagent.web.services.interaction_rollout import (
+    COUNTER_COMPAT_READ_FALLBACK,
+    counters_snapshot,
+)
 from xagent.web.services.ops_signals import (
     CHECKPOINT_LOAD_UNAVAILABLE,
     CHECKPOINT_PK_ANCHOR_DANGLING,
@@ -987,3 +991,75 @@ def test_m3_marker_null_issues_no_statement_the_reader_would_not(
 
     assert len(through_adapter) == len(direct)
     assert len(direct) == (1 if message_type == "question" else 2)
+
+
+# ---------------------------------------------------------------------------
+# compat.read_fallback: where the counter is incremented, and where it must
+# not be.
+# ---------------------------------------------------------------------------
+
+
+def _read_fallback_count() -> int:
+    return counters_snapshot().get(COUNTER_COMPAT_READ_FALLBACK, 0)
+
+
+@pytest.mark.parametrize("case", ["table_absent", "no_active_row"])
+def test_each_compatibility_view_legacy_branch_counts_one_read_fallback(
+    _db: Session, case: str
+) -> None:
+    task = _make_task(_db, marker=1)
+    _persist_live_question(_db, task)
+    if case == "table_absent":
+        TaskInteractionRequest.__table__.drop(bind=_db.get_bind())
+
+    before = _read_fallback_count()
+    read_surface.get_pending_interaction_question(_db, task)
+
+    assert _read_fallback_count() == before + 1
+
+
+def test_the_marker_fast_path_counts_no_read_fallback(_db: Session) -> None:
+    """The counter measures how often the compatibility view had to answer
+    from the transcript, which is only meaningful next to how often it was
+    asked. Counting step 0 as well would make it every read of a task whose
+    marker is NULL -- today that is every task -- and the ratio would carry
+    no information. Mutation: increment in step 0 and this turns red."""
+
+    task = _make_task(_db, marker=None)
+    _persist_live_question(_db, task)
+
+    before = _read_fallback_count()
+    read_surface.get_pending_interaction_question(_db, task)
+
+    assert _read_fallback_count() == before
+
+
+def test_a_recheck_that_finds_an_active_row_counts_no_read_fallback(
+    _db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The recheck exists to stop a legacy answer being returned, so the
+    run it saves is not a fallback and must not be counted. The active row
+    is made to appear on the second look only, which is the shape a
+    concurrent publication produces."""
+
+    task = _make_task(_db, marker=1)
+    trace_event_id = _make_trace_event(_db, task_id=int(task.id))
+    row = _make_active_row(
+        _db, task_id=int(task.id), resume_trace_event_id=trace_event_id
+    )
+    looks = 0
+
+    def _appears_on_the_second_look(db, task_id: int):
+        nonlocal looks
+        looks += 1
+        return None if looks == 1 else row
+
+    monkeypatch.setattr(
+        interaction_service_module, "_active_native_row", _appears_on_the_second_look
+    )
+
+    before = _read_fallback_count()
+    question, _ = read_surface.get_pending_interaction_question(_db, task)
+
+    assert question == "Which environment?"
+    assert _read_fallback_count() == before

--- a/tests/web/services/test_task_interaction_read.py
+++ b/tests/web/services/test_task_interaction_read.py
@@ -20,7 +20,11 @@ from sqlalchemy.orm import Session, sessionmaker
 
 import xagent.web.services.chat_history_service as chat_history_service
 import xagent.web.services.task_interaction_service as interaction_service_module
-from tests.web.services.task_interaction_schema_shared import make_task, make_user
+from tests.web.services.task_interaction_schema_shared import (
+    anchor_event_id,
+    make_task,
+    make_user,
+)
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.models.database import Base
@@ -135,29 +139,11 @@ def _make_trace_event(
     return int(event.id)
 
 
-def _anchor_event_id(db: Session, resume_trace_event_id: int | None) -> str:
-    """The ``event_id`` carried by the trace row an anchor points at.
-
-    The write direction stores exactly this string in the interaction row's
-    ``resume_event_id``, and the read-direction resolver compares the two,
-    so an anchor resolves only when the fixture takes the value from the
-    row it names. A cell that wants an unresolvable anchor breaks one of
-    the other conditions on purpose rather than leaving this one mismatched
-    by accident."""
-
-    trace_row = (
-        None
-        if resume_trace_event_id is None
-        else db.get(TraceEvent, resume_trace_event_id)
-    )
-    return "no-anchor-row" if trace_row is None else str(trace_row.event_id)
-
-
 def _make_active_row(
     db: Session,
     *,
     task_id: int,
-    resume_trace_event_id: int | None,
+    resume_trace_event_id: int,
     run_id: str = "run-a",
     resume_run_partition: str = "run-a",
     resume_execution_id: str = "exec-1",
@@ -183,7 +169,7 @@ def _make_active_row(
         },
         request_idempotency_key=f"read-key-{task_id}",
         resume_trace_event_id=resume_trace_event_id,
-        resume_event_id=_anchor_event_id(db, resume_trace_event_id),
+        resume_event_id=anchor_event_id(db, resume_trace_event_id),
         resume_execution_id=resume_execution_id,
         resume_locator_format="trace_event_pk_v1",
         resume_checkpoint_type="agent_execution_checkpoint",

--- a/tests/web/services/test_task_interaction_read.py
+++ b/tests/web/services/test_task_interaction_read.py
@@ -135,6 +135,24 @@ def _make_trace_event(
     return int(event.id)
 
 
+def _anchor_event_id(db: Session, resume_trace_event_id: int | None) -> str:
+    """The ``event_id`` carried by the trace row an anchor points at.
+
+    The write direction stores exactly this string in the interaction row's
+    ``resume_event_id``, and the read-direction resolver compares the two,
+    so an anchor resolves only when the fixture takes the value from the
+    row it names. A cell that wants an unresolvable anchor breaks one of
+    the other conditions on purpose rather than leaving this one mismatched
+    by accident."""
+
+    trace_row = (
+        None
+        if resume_trace_event_id is None
+        else db.get(TraceEvent, resume_trace_event_id)
+    )
+    return "no-anchor-row" if trace_row is None else str(trace_row.event_id)
+
+
 def _make_active_row(
     db: Session,
     *,
@@ -165,7 +183,7 @@ def _make_active_row(
         },
         request_idempotency_key=f"read-key-{task_id}",
         resume_trace_event_id=resume_trace_event_id,
-        resume_event_id="resume-event-1",
+        resume_event_id=_anchor_event_id(db, resume_trace_event_id),
         resume_execution_id=resume_execution_id,
         resume_locator_format="trace_event_pk_v1",
         resume_checkpoint_type="agent_execution_checkpoint",
@@ -599,7 +617,7 @@ def test_a10_anchor_dangling_keeps_the_question_text_drops_controls(
     task = _make_task(_db, marker=1)
     # A trace event on a different run partition than the interaction
     # row's own resume_run_partition breaks the anchor's row-validity
-    # judgment -- one of _resolve_read_direction_anchor's six conditions
+    # judgment -- one of _resolve_read_direction_anchor's seven conditions
     # -- producing "anchor_dangling" through a real write, no monkeypatch.
     trace_event_id = _make_trace_event(
         _db, task_id=int(task.id), run_partition="a-different-run"

--- a/tests/web/services/test_task_interaction_read.py
+++ b/tests/web/services/test_task_interaction_read.py
@@ -41,6 +41,8 @@ from xagent.web.services.ops_signals import (
     CHECKPOINT_PK_ANCHOR_DANGLING,
     INTERACTION_READ_PAYLOAD_UNREADABLE,
     INTERACTION_READ_PROTOCOL_UNRECOGNIZED,
+    INTERACTION_READ_TASK_MARKER_UNRECOGNIZED,
+    active_degradations,
     clear_degradation,
 )
 from xagent.web.services.task_interaction_service import CompatibilityQuestionView
@@ -51,6 +53,7 @@ _DEGRADATION_SIGNALS_UNDER_TEST = (
     CHECKPOINT_LOAD_UNAVAILABLE,
     INTERACTION_READ_PROTOCOL_UNRECOGNIZED,
     INTERACTION_READ_PAYLOAD_UNREADABLE,
+    INTERACTION_READ_TASK_MARKER_UNRECOGNIZED,
 )
 
 
@@ -355,6 +358,25 @@ def test_a4b_unrecognized_marker_with_an_active_native_row_never_leaks_the_legac
             "multiple": False,
         }
     ]
+
+
+def test_a4c_unrecognized_marker_registers_a_degradation_signal(
+    _db: Session,
+) -> None:
+    """A4 pins where an unrecognized marker routes; this pins that it is
+    also reported. Every corruption branch inside the compatibility view
+    raises a signal and this one did not, leaving an operator nothing to
+    look at. Keyed and process-local, so the assertion reads the registry
+    rather than logs. Mutation: drop the register call and this turns red."""
+
+    task = _make_task(_db, marker=None)
+    _persist_live_question(_db, task)
+    task.interaction_protocol_version = 2
+
+    read_surface.get_pending_interaction_question(_db, task)
+
+    detail = active_degradations()[INTERACTION_READ_TASK_MARKER_UNRECOGNIZED]
+    assert f"task {task.id}" in detail
 
 
 def test_a5_marker_fast_path_never_calls_the_rich_view(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -828,6 +828,24 @@ def _make_trace_event(
     return int(event.id)
 
 
+def _anchor_event_id(db: Session, resume_trace_event_id: int | None) -> str:
+    """The ``event_id`` carried by the trace row an anchor points at.
+
+    The write direction stores exactly this string in the interaction row's
+    ``resume_event_id``, and this resolver compares the two, so an anchor
+    resolves only when the fixture takes the value from the row it names. A
+    cell that wants an unresolvable anchor breaks one of the other
+    conditions on purpose rather than leaving this one mismatched by
+    accident."""
+
+    trace_row = (
+        None
+        if resume_trace_event_id is None
+        else db.get(TraceEvent, resume_trace_event_id)
+    )
+    return "no-anchor-row" if trace_row is None else str(trace_row.event_id)
+
+
 def _make_active_interaction_row(
     db: Session,
     *,
@@ -836,6 +854,7 @@ def _make_active_interaction_row(
     resume_trace_event_id: int | None,
     resume_run_partition: str = "run-a",
     resume_execution_id: str = "exec-1",
+    resume_event_id: str | None = None,
     protocol_version: int = 1,
     request_payload: dict[str, Any] | None = None,
 ) -> TaskInteractionRequest:
@@ -858,7 +877,9 @@ def _make_active_interaction_row(
         },
         request_idempotency_key=f"key-{task_id}",
         resume_trace_event_id=resume_trace_event_id,
-        resume_event_id="resume-event-1",
+        resume_event_id=resume_event_id
+        if resume_event_id is not None
+        else _anchor_event_id(db, resume_trace_event_id),
         resume_execution_id=resume_execution_id,
         resume_locator_format="trace_event_pk_v1",
         resume_checkpoint_type="agent_execution_checkpoint",
@@ -1271,14 +1292,14 @@ def test_t3_prime_anchor_dangling_when_the_row_fails_validation(
 
 
 # ---------------------------------------------------------------------------
-# T3', the other five conditions: _resolve_read_direction_anchor's row-
-# validity judgment is six self-consistency conditions ANDed together (task
-# id, event type, build id, checkpoint type, run partition, execution
-# identity -- see that function's own docstring). The run-partition cell is
-# covered above; each of these five breaks exactly one of the remaining
-# conditions, following the same one-condition-per-cell shape
-# test_task_interaction_anchor.py's own _CONDITION_BREAKS table uses for the
-# sibling resolver it covers.
+# T3', the other six conditions: _resolve_read_direction_anchor's row-
+# validity judgment is seven self-consistency conditions ANDed together
+# (task id, event type, build id, checkpoint type, run partition, execution
+# identity, anchor event id -- see that function's own docstring). The
+# run-partition cell is covered above; each of these six breaks exactly one
+# of the remaining conditions, following the same one-condition-per-cell
+# shape test_task_interaction_anchor.py's own _CONDITION_BREAKS table uses
+# for the sibling resolver it covers.
 # ---------------------------------------------------------------------------
 
 _T3_ANCHOR_VALIDATION_BREAKS: dict[str, dict[str, Any]] = {
@@ -1287,6 +1308,7 @@ _T3_ANCHOR_VALIDATION_BREAKS: dict[str, dict[str, Any]] = {
     "build_id": {"build_id": "build-x"},
     "checkpoint_type": {"checkpoint_type": "not_a_checkpoint_type"},
     "execution_id": {"mismatched_resume_execution_id": "exec-mismatch"},
+    "resume_event_id": {"mismatched_resume_event_id": "resume-event-mismatch"},
 }
 
 
@@ -1294,11 +1316,11 @@ _T3_ANCHOR_VALIDATION_BREAKS: dict[str, dict[str, Any]] = {
 def test_t3_prime_anchor_dangling_for_each_remaining_validity_condition(
     _db: Session, _seeded_task: int, condition: str
 ) -> None:
-    """Every other cell in this file leaves all six conditions passing (or,
-    for the run-partition cell above, breaks exactly one). Deleting any one
-    of the five conditions exercised here from
+    """Every other cell in this file leaves all seven conditions passing
+    (or, for the run-partition cell above, breaks exactly one). Deleting any
+    one of the six conditions exercised here from
     _resolve_read_direction_anchor's boolean guard must turn exactly this
-    cell red and leave every other cell -- including the four remaining
+    cell red and leave every other cell -- including the five remaining
     parametrizations of this same test -- green."""
 
     overrides = dict(_T3_ANCHOR_VALIDATION_BREAKS[condition])
@@ -1314,6 +1336,10 @@ def test_t3_prime_anchor_dangling_for_each_remaining_validity_condition(
     # the other four cells is what keeps this condition passing everywhere
     # else.
     resume_execution_id = overrides.pop("mismatched_resume_execution_id", "exec-1")
+    # None leaves the row builder to take the anchor's event id from the
+    # trace row it points at, which is what makes every other cell here
+    # break exactly one condition.
+    resume_event_id = overrides.pop("mismatched_resume_event_id", None)
 
     trace_event_id = _make_trace_event(_db, task_id=trace_task_id, **overrides)
     _make_active_interaction_row(
@@ -1321,18 +1347,20 @@ def test_t3_prime_anchor_dangling_for_each_remaining_validity_condition(
         task_id=_seeded_task,
         resume_trace_event_id=trace_event_id,
         resume_execution_id=resume_execution_id,
+        resume_event_id=resume_event_id,
     )
 
     view = svc.materialize_compatibility_view(_db, _seeded_task)
     assert view.tier == "unanswerable"
     assert view.reason == "anchor_dangling"
+    assert CHECKPOINT_PK_ANCHOR_DANGLING in active_degradations()
 
 
 def test_t3_row_validity_failure_raises_checkpoint_pk_anchor_dangling(
     _db: Session, _seeded_task: int
 ) -> None:
     """The row-invalid branch of
-    _resolve_read_direction_anchor's six-condition guard must register
+    _resolve_read_direction_anchor's seven-condition guard must register
     CHECKPOINT_PK_ANCHOR_DANGLING, same as the missing-row branch above.
     Mutation: delete that register_degradation() call and this test turns
     red."""

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -131,7 +131,11 @@ import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
-from tests.web.services.task_interaction_schema_shared import make_task, make_user
+from tests.web.services.task_interaction_schema_shared import (
+    anchor_event_id,
+    make_task,
+    make_user,
+)
 from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.models.database import Base
@@ -828,30 +832,12 @@ def _make_trace_event(
     return int(event.id)
 
 
-def _anchor_event_id(db: Session, resume_trace_event_id: int | None) -> str:
-    """The ``event_id`` carried by the trace row an anchor points at.
-
-    The write direction stores exactly this string in the interaction row's
-    ``resume_event_id``, and this resolver compares the two, so an anchor
-    resolves only when the fixture takes the value from the row it names. A
-    cell that wants an unresolvable anchor breaks one of the other
-    conditions on purpose rather than leaving this one mismatched by
-    accident."""
-
-    trace_row = (
-        None
-        if resume_trace_event_id is None
-        else db.get(TraceEvent, resume_trace_event_id)
-    )
-    return "no-anchor-row" if trace_row is None else str(trace_row.event_id)
-
-
 def _make_active_interaction_row(
     db: Session,
     *,
     task_id: int,
     run_id: str = "run-a",
-    resume_trace_event_id: int | None,
+    resume_trace_event_id: int,
     resume_run_partition: str = "run-a",
     resume_execution_id: str = "exec-1",
     resume_event_id: str | None = None,
@@ -879,7 +865,7 @@ def _make_active_interaction_row(
         resume_trace_event_id=resume_trace_event_id,
         resume_event_id=resume_event_id
         if resume_event_id is not None
-        else _anchor_event_id(db, resume_trace_event_id),
+        else anchor_event_id(db, resume_trace_event_id),
         resume_execution_id=resume_execution_id,
         resume_locator_format="trace_event_pk_v1",
         resume_checkpoint_type="agent_execution_checkpoint",

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -58,6 +58,7 @@ from sqlalchemy.orm import sessionmaker
 
 import xagent.web.models.database as database_module
 from tests.web.services.task_interaction_schema_shared import (
+    anchor_event_id,
     assert_rejected,
     make_row,
     make_task,
@@ -163,22 +164,6 @@ def _make_trace_event(db, *, task_id: int, run_partition: str = "run-a") -> int:
     return int(event.id)
 
 
-def _anchor_event_id(db, resume_trace_event_id: int | None) -> str:
-    """The ``event_id`` carried by the trace row an anchor points at.
-
-    The write direction stores exactly this string in the interaction row's
-    ``resume_event_id``, and the read-direction resolver compares the two,
-    so an anchor resolves only when the fixture takes the value from the
-    row it names."""
-
-    trace_row = (
-        None
-        if resume_trace_event_id is None
-        else db.get(TraceEvent, resume_trace_event_id)
-    )
-    return "no-anchor-row" if trace_row is None else str(trace_row.event_id)
-
-
 def _make_active_row(
     db,
     *,
@@ -204,7 +189,7 @@ def _make_active_row(
         },
         request_idempotency_key=f"pg-key-{next(_key_counter)}",
         resume_trace_event_id=resume_trace_event_id,
-        resume_event_id=_anchor_event_id(db, resume_trace_event_id),
+        resume_event_id=anchor_event_id(db, resume_trace_event_id),
         resume_execution_id="exec-1",
         resume_locator_format="trace_event_pk_v1",
         resume_checkpoint_type="agent_execution_checkpoint",

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -70,7 +70,10 @@ from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import task_interaction_read as read_surface
 from xagent.web.services import task_interaction_service as svc
-from xagent.web.services.chat_history_service import persist_assistant_message
+from xagent.web.services.chat_history_service import (
+    persist_assistant_message,
+    supersede_legacy_question_rows,
+)
 from xagent.web.services.interaction_rollout import counters_snapshot
 from xagent.web.services.ops_signals import (
     CHECKPOINT_LOAD_UNAVAILABLE,
@@ -1444,3 +1447,149 @@ def test_respond_races_a_committed_duplicate_command_and_conflicts_on_mismatched
         assert task.control_state == "waiting_for_user"
     finally:
         verify_db.close()
+
+
+# ---------------------------------------------------------------------------
+# The legacy fallback's ownership recheck, and the stale marker it makes
+# benign. Both need two real sessions committing independently, which is
+# what puts them on this backend rather than in the SQLite-backed file.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_fallback_rechecks_active_ownership_across_sessions(
+    engine, session_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deciding "no active row" and reading the transcript are separate
+    statements, so another session can publish an active row in between.
+    Rechecking the active row after the transcript read and before
+    returning is what stops this reader handing back a legacy question
+    whose answer a native row has already claimed."""
+
+    db = session_factory()
+    try:
+        user_id = make_user(db)
+        task_id = make_task(db, user_id=user_id)
+        task = db.query(Task).filter(Task.id == task_id).first()
+        task.run_id = "run-a"
+        task.interaction_protocol_version = 1
+        db.commit()
+        persist_assistant_message(
+            db,
+            task_id,
+            user_id,
+            "A live legacy question",
+            message_type="question",
+            interactions=[{"type": "text_input", "label": "Legacy"}],
+        )
+        db.commit()
+
+        active_row_calls = 0
+        real_active_row = svc._active_native_row
+
+        def _counted_active_row(session, active_task_id: int):
+            nonlocal active_row_calls
+            active_row_calls += 1
+            return real_active_row(session, active_task_id)
+
+        monkeypatch.setattr(svc, "_active_native_row", _counted_active_row)
+
+        real_reader = svc.get_latest_waiting_question
+        published = False
+
+        def _publish_then_read(session, read_task_id: int, **kwargs):
+            # The window itself: session A has already decided there is no
+            # active row and has not read the transcript yet.
+            nonlocal published
+            if not published:
+                published = True
+                writer = session_factory()
+                try:
+                    trace_id = _make_trace_event(
+                        writer, task_id=task_id, run_partition="run-a"
+                    )
+                    _make_active_row(
+                        writer,
+                        task_id=task_id,
+                        run_id="run-a",
+                        resume_trace_event_id=trace_id,
+                        resume_run_partition="run-a",
+                    )
+                finally:
+                    writer.close()
+            return real_reader(session, read_task_id, **kwargs)
+
+        monkeypatch.setattr(svc, "get_latest_waiting_question", _publish_then_read)
+
+        view = svc.materialize_compatibility_view(db, task_id)
+
+        assert view.tier == "native"
+        assert view.question == "Which environment?"
+        # Two calls: the first decision and the one recheck. The recheck
+        # never loops -- an active row found on the second look is answered
+        # from, not rechecked again.
+        assert active_row_calls == 2
+    finally:
+        db.close()
+
+
+def test_stale_null_marker_reader_still_sees_the_question_text(
+    engine, session_factory
+) -> None:
+    """The reader holds a Task row loaded before a publication committed,
+    so its ``interaction_protocol_version`` is still NULL while the
+    database says 1. Step 0 believes the stale value and answers from the
+    transcript -- and because the publication relabelled the transcript row
+    on its way past, what it finds is the question itself rather than an
+    empty pair."""
+
+    reader = session_factory()
+    try:
+        writer = session_factory()
+        try:
+            user_id = make_user(writer)
+            task_id = make_task(writer, user_id=user_id)
+            task = writer.query(Task).filter(Task.id == task_id).first()
+            task.run_id = "run-a"
+            writer.commit()
+            persist_assistant_message(
+                writer,
+                task_id,
+                user_id,
+                "Which environment?",
+                message_type="question",
+                interactions=[{"type": "text_input", "label": "Environment"}],
+            )
+            writer.commit()
+        finally:
+            writer.close()
+
+        # The reader loads the task while the marker is still NULL.
+        stale_task = reader.query(Task).filter(Task.id == task_id).first()
+        assert stale_task.interaction_protocol_version is None
+
+        writer = session_factory()
+        try:
+            trace_id = _make_trace_event(writer, task_id=task_id, run_partition="run-a")
+            _make_active_row(
+                writer,
+                task_id=task_id,
+                run_id="run-a",
+                resume_trace_event_id=trace_id,
+                resume_run_partition="run-a",
+            )
+            published_task = writer.query(Task).filter(Task.id == task_id).first()
+            published_task.interaction_protocol_version = 1
+            supersede_legacy_question_rows(writer, task_id=task_id)
+            writer.commit()
+        finally:
+            writer.close()
+
+        question, interactions = read_surface.get_pending_interaction_question(
+            reader, stale_task
+        )
+
+        assert question is not None
+        assert question.startswith("Which environment?")
+        assert interactions == [{"type": "text_input", "label": "Environment"}]
+    finally:
+        reader.close()

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -163,6 +163,22 @@ def _make_trace_event(db, *, task_id: int, run_partition: str = "run-a") -> int:
     return int(event.id)
 
 
+def _anchor_event_id(db, resume_trace_event_id: int | None) -> str:
+    """The ``event_id`` carried by the trace row an anchor points at.
+
+    The write direction stores exactly this string in the interaction row's
+    ``resume_event_id``, and the read-direction resolver compares the two,
+    so an anchor resolves only when the fixture takes the value from the
+    row it names."""
+
+    trace_row = (
+        None
+        if resume_trace_event_id is None
+        else db.get(TraceEvent, resume_trace_event_id)
+    )
+    return "no-anchor-row" if trace_row is None else str(trace_row.event_id)
+
+
 def _make_active_row(
     db,
     *,
@@ -188,7 +204,7 @@ def _make_active_row(
         },
         request_idempotency_key=f"pg-key-{next(_key_counter)}",
         resume_trace_event_id=resume_trace_event_id,
-        resume_event_id="resume-event-1",
+        resume_event_id=_anchor_event_id(db, resume_trace_event_id),
         resume_execution_id="exec-1",
         resume_locator_format="trace_event_pk_v1",
         resume_checkpoint_type="agent_execution_checkpoint",

--- a/tests/web/test_interaction_rollout_observability.py
+++ b/tests/web/test_interaction_rollout_observability.py
@@ -316,7 +316,11 @@ async def test_to6b_active_row_present_yields_positive_count_and_age(
     anchor_id = make_trace_event(sqlite_session_with_table, task_id=task_id)
     assert_accepted(
         sqlite_session_with_table,
-        make_row(task_id=task_id, resume_trace_event_id=anchor_id),
+        make_row(
+            task_id=task_id,
+            resume_trace_event_id=anchor_id,
+            db=sqlite_session_with_table,
+        ),
     )
 
     response = await get_interaction_rollout_diagnostics(


### PR DESCRIPTION

## Summary

When a structured publication replaces a transcript question, it relabels
the original row's `message_type` from `question` to
`question_superseded`. The transcript reader matched `question` only, so
a task left holding nothing but a relabelled row answered
`(None, None)` — the client saw an empty field, or the generic
"Task waiting for user response" message, with nothing to answer.

This change lets the read surface reach those rows, threads the decision
through the compatibility view, closes most of a window where the view
could hand back a legacy question that a native row had already claimed
the answer slot for, adds the counter that records how many reads fell
back to the transcript, and fixes a comparison the read-direction anchor
resolver was supposed to make and never did.

## What changed

**`get_latest_waiting_question` takes `allow_superseded`, off by
default.** When it is set and the first pass finds no live question row,
a second pass reads the newest row on the task carrying
`question_superseded`. The read surface adapter
(`task_interaction_read.get_pending_interaction_question`) is the only
caller anywhere that turns it on. Every other caller reads exactly what
it reads with the parameter absent.

**Two sequential passes, not one `message_type.in_(...)` predicate.** A
single predicate ordered by id would let a relabelled row with a higher
id outrank a question row that is still live, which inverts the priority
this reader owes its callers. The second pass runs only after the first
comes back empty.

**`materialize_compatibility_view` takes the same keyword and passes it
to the transcript reader on both of its legacy branches** — the branch
where the interaction table does not exist, and the branch where the task
has no active interaction row. Both mean nothing holds the task's answer
slot, which is what makes reaching a relabelled row honest there. The
branches that report a question as currently unanswerable never consult
the transcript at all, so the keyword does not appear in them.

**The adapter computes the value from the protocol marker.** A NULL
marker opens it directly. The recognized marker passes it down so the
view's own two legacy branches can decide. Any other value leaves it
shut: an unrecognized marker means the slot's state is unknown, and
unknown fails closed. A value that is not an integer at all compares
unequal and shuts the gate rather than raising. An unrecognized marker
is also persisted corruption the tasks-row CHECK constraint forbids, so
the adapter registers a keyed degradation for it — once per process,
not once per read — rather than logging every read.

**The no-active-row branch rechecks ownership before returning.**
Deciding that a task has no active interaction row and reading its
transcript are two statements, and under READ COMMITTED each takes its
own snapshot, so another session can commit an active row between them.
The branch now looks once more, after the transcript read and before
returning, and answers from the row if one has appeared. It looks once —
a row found on the recheck is answered from, not examined again.

This narrows the window; it does not close it. A row committed between
the recheck and the return still yields the legacy result. What that
costs is bounded and worth stating plainly: the user answers through the
legacy channel, the native row retires as `answered_via_legacy_resume`,
the answer is not lost and the task is not stuck — that one turn simply
gets no structured record of the answer. The table-absent branch does not
recheck, because with no table there is nowhere an active row could have
been written.

**`compat.read_fallback` is incremented once per legacy result the
compatibility view returns**, on both of its legacy branches and nowhere
else. It is a raw process-local count with no denominator, not a rate. It
is deliberately not incremented on the adapter's marker fast path: a task
whose marker is NULL never consults the compatibility view, so counting
there would make this number equal the total read count instead of the
number of reads that actually fell back to the transcript. A run the
ownership recheck rescues is not a fallback and is not counted. There is
no switch to turn the counter off.

**The read-direction anchor resolver now compares the anchor's event
id.** An interaction row stores the trace event's own `event_id` in
`resume_event_id`, written there by the write-direction resolver for
exactly this comparison, and the read-direction row-validity judgment
never read it — so a pointer that resolved to a checkpoint belonging to
some other event passed as valid. It is now a seventh conjunct in the
same judgment and fails the same way the other six do: one
`checkpoint_pk_anchor_dangling` signal and the `anchor_dangling` reason.
No new reason value, no new signal, no separate log line.

One thing about that comparison is worth saying out loud, because it is
the part most easily misread as a harmless refactor: the fixtures in four
test files gave the two sides values that could never be equal, which is
why every cell asserting a resolved anchor stayed green without the
comparison existing. Those fixtures now take the value from the trace row
the anchor points at, so a cell that wants an unresolvable anchor has to
break a condition on purpose.

## Behavior on merge

Default-off is the whole of it. The only caller that opens the gate is
the adapter, and it opens it on outcomes where nothing holds the answer
slot. Two facts make the change inert until a writer exists, and both are
checkable in this tree rather than asserted here:
`supersede_legacy_question_rows` has no production caller, so no row is
relabelled and the second pass finds nothing; and the staging entry
points that would write an active interaction row are held at zero
production callers by `test_interaction_staging_production_gate.py`, so
the recheck and the counter have nothing to observe.

## Test coverage

Behavior is covered as table-driven parametrized cells rather than
copy-pasted bodies:

- The gate value itself, per read-surface outcome: NULL marker,
  unrecognized marker, table absent, no active row, and each of the three
  outcomes that report a question as unanswerable — asserted on the value
  that actually reached the transcript reader, with an empty record
  meaning the reader was never called.
- Statement count under a NULL marker: the adapter emits exactly what the
  transcript reader emits on its own, one statement when the first pass
  hits and two when the gate is open and it does not.
- Priority between a live question row and a higher-id relabelled row,
  and the newest-round result on a task that has asked several times.
- The counter's two increment sites, its absence on the marker fast path,
  and its absence on a run the recheck rescues.
- The anchor's seventh condition, added to the existing one-condition-
  per-cell table so it asserts the same outcome the other six do.
- Two PostgreSQL cells that need two real sessions: one drives an active
  row into the window between the no-active-row decision and the
  transcript read and asserts the recheck answers from it, counting the
  lookups to pin that the recheck happens once; the other loads a task
  while its marker is still NULL, commits a full publication from a
  second session, and asserts the stale reader still sees the question
  text.

Two existing cells changed their expected value, both by design: the
NULL-marker cell and the no-active-row cell that previously asserted a
relabelled row was unreachable.

These guards were re-run by name and are green:

- `test_chat_history_service_imports_nothing_from_native_rollout`
- `test_nothing_writes_message_type_back_to_question`
- `test_the_shared_where_clause_still_has_all_three_legs`
- `test_supersede_end_to_end_with_the_reader`
- `test_tw1a_import_guard_modules_do_not_import_interaction_rollout`
- `test_tw1b_closure_seeds_reference_no_banned_names`
- `test_tw2a_evaluate_native_publication_has_zero_production_callers`

The reader/writer pairing guard keeps its assertions unchanged. Its
docstrings now state what it covers — the reader's first pass — and why
the second pass cannot join the same captured set: that pass matches the
message type the writer produces, so requiring it there would assert that
the writer's input set equals its output set.

