### PR TITLE
fix: serialize chat attachment uploads

### DIFF
--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1398,17 +1398,28 @@ describe("ChatInput", () => {
     expect(container.querySelector('button[type="submit"]')).toBeDisabled()
   })
 
-  it("serializes immediate attachment uploads in selection order", async () => {
-    const completions = new Map<File, () => void>()
+  it("serializes production attachment requests in repeated-selection order", async () => {
+    const completions: Array<() => void> = []
+    const requestedFiles: File[] = []
     let activeUploads = 0
     let maximumActiveUploads = 0
-    const uploadFile = vi.fn((file: File) => {
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url !== "http://upload.local/api/files/upload") {
+        return Promise.resolve(emptyJsonResponse())
+      }
+
+      const body = options?.body as FormData
+      const requestedFile = body.get("file") as File
+      requestedFiles.push(requestedFile)
       activeUploads += 1
       maximumActiveUploads = Math.max(maximumActiveUploads, activeUploads)
-      return new Promise<{ file_id: string }>(resolve => {
-        completions.set(file, () => {
+      return new Promise<Response>(resolve => {
+        completions.push(() => {
           activeUploads -= 1
-          resolve({ file_id: `id-${file.name}` })
+          resolve(new Response(
+            JSON.stringify({ success: true, file_id: `id-${requestedFile.name}` }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ))
         })
       })
     })
@@ -1423,7 +1434,6 @@ describe("ChatInput", () => {
           onFilesChange={setFiles}
           onInputChange={vi.fn()}
           onSend={vi.fn()}
-          uploadFile={uploadFile}
         />
       )
     }
@@ -1439,18 +1449,139 @@ describe("ChatInput", () => {
     fireEvent.change(fileInput, { target: { files: files.slice(0, 2) } })
     fireEvent.change(fileInput, { target: { files: files.slice(2) } })
 
-    await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(1))
-    expect(uploadFile.mock.calls[0][0]).toBe(files[0])
+    await waitFor(() => expect(requestedFiles).toEqual([files[0]]))
 
     for (let index = 0; index < files.length; index += 1) {
-      await act(async () => completions.get(files[index])?.())
+      await act(async () => completions[index]?.())
       if (index + 1 < files.length) {
-        await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(index + 2))
-        expect(uploadFile.mock.calls[index + 1][0]).toBe(files[index + 1])
+        await waitFor(() => expect(requestedFiles).toHaveLength(index + 2))
+        expect(requestedFiles[index + 1]).toBe(files[index + 1])
       }
     }
 
+    expect(requestedFiles).toEqual(files)
     expect(maximumActiveUploads).toBe(1)
+  })
+
+  it("aborts an active production upload and promotes the next queued file", async () => {
+    const uploadSignals: AbortSignal[] = []
+    let completeSecondUpload: (() => void) | undefined
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url !== "http://upload.local/api/files/upload") {
+        return Promise.resolve(emptyJsonResponse())
+      }
+
+      const signal = options?.signal as AbortSignal
+      uploadSignals.push(signal)
+      if (uploadSignals.length === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener("abort", () => {
+            reject(signal.reason ?? new DOMException("Upload cancelled", "AbortError"))
+          }, { once: true })
+        })
+      }
+      return new Promise<Response>(resolve => {
+        completeSecondUpload = () => resolve(new Response(
+          JSON.stringify({ success: true, file_id: "second-id" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ))
+      })
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          files={files}
+          hideConfig
+          inputValue=""
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const first = new File(["one"], "one.txt")
+    const second = new File(["two"], "two.txt")
+
+    fireEvent.change(fileInput, { target: { files: [first, second] } })
+    await waitFor(() => expect(uploadSignals).toHaveLength(1))
+
+    fireEvent.click(screen.getAllByTitle("common.cancel")[0])
+
+    expect(uploadSignals[0].aborted).toBe(true)
+    await waitFor(() => expect(uploadSignals).toHaveLength(2))
+    expect(uploadSignals[1].aborted).toBe(false)
+    await act(async () => completeSecondUpload?.())
+    await waitFor(() => expect(screen.queryByText("one.txt")).not.toBeInTheDocument())
+    expect(screen.getByText("two.txt")).toBeInTheDocument()
+  })
+
+  it("aborts a hung production upload at its deadline and promotes the queue", async () => {
+    vi.useFakeTimers()
+    try {
+      const uploadSignals: AbortSignal[] = []
+      apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+        if (url !== "http://upload.local/api/files/upload") {
+          return Promise.resolve(emptyJsonResponse())
+        }
+
+        const signal = options?.signal as AbortSignal
+        uploadSignals.push(signal)
+        if (uploadSignals.length === 1) {
+          return new Promise<Response>((_resolve, reject) => {
+            signal.addEventListener("abort", () => {
+              reject(signal.reason ?? new DOMException("Upload timed out", "TimeoutError"))
+            }, { once: true })
+          })
+        }
+        return Promise.resolve(new Response(
+          JSON.stringify({ success: true, file_id: "second-id" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ))
+      })
+
+      function Harness() {
+        const [files, setFiles] = React.useState<File[]>([])
+        return (
+          <ChatInput
+            files={files}
+            hideConfig
+            inputValue=""
+            onFilesChange={setFiles}
+            onInputChange={vi.fn()}
+            onSend={vi.fn()}
+          />
+        )
+      }
+
+      const { container } = render(<Harness />)
+      const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+      const first = new File(["one"], "one.txt")
+      const second = new File(["two"], "two.txt")
+
+      fireEvent.change(fileInput, { target: { files: [first, second] } })
+      await act(async () => undefined)
+      expect(uploadSignals).toHaveLength(1)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+      })
+
+      expect(uploadSignals[0].aborted).toBe(true)
+      expect(uploadSignals).toHaveLength(2)
+      expect(screen.queryByText("one.txt")).not.toBeInTheDocument()
+      expect(screen.getByText("two.txt")).toBeInTheDocument()
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "files.uploadFailed",
+        expect.objectContaining({ duration: 8000 }),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("cancels a queued equal-name file without aborting the active upload", async () => {

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1513,6 +1513,63 @@ describe("ChatInput", () => {
     expect(uploadCallCount).toBe(1)
   })
 
+  it("removes the rendered attachment by identity after a failure updates the live list", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const failed = new File(["bad"], "failed.txt")
+    const target = new File(["target"], "target.txt")
+    const sibling = new File(["sibling"], "sibling.txt")
+    const uploadFile = vi.fn((file: File) => {
+      if (file === failed) return Promise.reject(new Error("storage unavailable"))
+      return Promise.resolve({ file_id: `id-${file.name}` })
+    })
+    let clickedStaleTarget = false
+    let renderedFilesAtFailure: string[] = []
+    let filesAfterRemoval: File[] | undefined
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      const handleFilesChange = (nextFiles: File[]) => {
+        if (!clickedStaleTarget && nextFiles.length === 2 && !nextFiles.includes(failed)) {
+          clickedStaleTarget = true
+          renderedFilesAtFailure = screen
+            .getAllByTitle("common.remove")
+            .map(button => button.parentElement?.textContent || "")
+          const targetChip = screen.getByText("target.txt").parentElement
+          fireEvent.click(targetChip?.querySelector("button") as HTMLButtonElement)
+          return
+        }
+        if (clickedStaleTarget) filesAfterRemoval = nextFiles
+        setFiles(nextFiles)
+      }
+
+      return (
+        <ChatInput
+          files={files}
+          hideConfig
+          inputValue=""
+          onFilesChange={handleFilesChange}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+          uploadFile={uploadFile}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(fileInput, { target: { files: [failed, target, sibling] } })
+
+    await waitFor(() => expect(clickedStaleTarget).toBe(true))
+    expect(renderedFilesAtFailure).toEqual(["failed.txt", "target.txt", "sibling.txt"])
+    expect(filesAfterRemoval).toEqual([sibling])
+    await waitFor(() => {
+      expect(screen.queryByText("target.txt")).not.toBeInTheDocument()
+      expect(screen.queryByText("failed.txt")).not.toBeInTheDocument()
+      expect(screen.getByText("sibling.txt")).toBeInTheDocument()
+    })
+    consoleError.mockRestore()
+  })
+
   it("keeps successful attachments when a queued peer fails", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const successfulOne = new File(["one"], "one.txt")

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1513,6 +1513,27 @@ describe("ChatInput", () => {
     expect(uploadCallCount).toBe(1)
   })
 
+  it("removes exactly one occurrence when the same File object is attached twice", () => {
+    const duplicate = new File(["duplicate"], "duplicate.txt")
+    const onFilesChange = vi.fn()
+
+    render(
+      <ChatInput
+        files={[duplicate, duplicate]}
+        hideConfig
+        inputValue=""
+        onFilesChange={onFilesChange}
+        onInputChange={vi.fn()}
+        onSend={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getAllByTitle("common.remove")[0])
+
+    expect(onFilesChange).toHaveBeenCalledOnce()
+    expect(onFilesChange).toHaveBeenCalledWith([duplicate])
+  })
+
   it("removes the rendered attachment by identity after a failure updates the live list", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const failed = new File(["bad"], "failed.txt")

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1397,4 +1397,304 @@ describe("ChatInput", () => {
     })
     expect(container.querySelector('button[type="submit"]')).toBeDisabled()
   })
+
+  it("serializes immediate attachment uploads in selection order", async () => {
+    const completions = new Map<File, () => void>()
+    let activeUploads = 0
+    let maximumActiveUploads = 0
+    const uploadFile = vi.fn((file: File) => {
+      activeUploads += 1
+      maximumActiveUploads = Math.max(maximumActiveUploads, activeUploads)
+      return new Promise<{ file_id: string }>(resolve => {
+        completions.set(file, () => {
+          activeUploads -= 1
+          resolve({ file_id: `id-${file.name}` })
+        })
+      })
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          files={files}
+          hideConfig
+          inputValue=""
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+          uploadFile={uploadFile}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const files = [
+      new File(["one"], "one.txt", { type: "text/plain" }),
+      new File(["two"], "two.txt", { type: "text/plain" }),
+      new File(["three"], "three.txt", { type: "text/plain" }),
+    ]
+
+    fireEvent.change(fileInput, { target: { files: files.slice(0, 2) } })
+    fireEvent.change(fileInput, { target: { files: files.slice(2) } })
+
+    await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(1))
+    expect(uploadFile.mock.calls[0][0]).toBe(files[0])
+
+    for (let index = 0; index < files.length; index += 1) {
+      await act(async () => completions.get(files[index])?.())
+      if (index + 1 < files.length) {
+        await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(index + 2))
+        expect(uploadFile.mock.calls[index + 1][0]).toBe(files[index + 1])
+      }
+    }
+
+    expect(maximumActiveUploads).toBe(1)
+  })
+
+  it("cancels a queued equal-name file without aborting the active upload", async () => {
+    let uploadCallCount = 0
+    let completeFirstUpload: (() => void) | undefined
+    const uploadSignals: AbortSignal[] = []
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url !== "http://upload.local/api/files/upload") {
+        return Promise.resolve(emptyJsonResponse())
+      }
+
+      uploadCallCount += 1
+      const signal = options?.signal as AbortSignal
+      uploadSignals.push(signal)
+      if (uploadCallCount === 1) {
+        return new Promise<Response>((resolve, reject) => {
+          completeFirstUpload = () => resolve(new Response(
+            JSON.stringify({ success: true, file_id: "first-id" }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ))
+          signal.addEventListener("abort", () => {
+            reject(new DOMException("Upload cancelled", "AbortError"))
+          }, { once: true })
+        })
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ success: true, file_id: "unexpected-id" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ))
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          files={files}
+          hideConfig
+          inputValue=""
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const lastModified = 1_700_000_000_000
+    const activeFile = new File(["first"], "duplicate.txt", { lastModified })
+    const queuedFile = new File(["second"], "duplicate.txt", { lastModified })
+
+    fireEvent.change(fileInput, { target: { files: [activeFile, queuedFile] } })
+    await waitFor(() => expect(uploadCallCount).toBe(1))
+
+    fireEvent.click(screen.getAllByTitle("common.cancel")[1])
+
+    expect(uploadSignals[0].aborted).toBe(false)
+    await act(async () => completeFirstUpload?.())
+    await waitFor(() => expect(screen.getAllByText("duplicate.txt")).toHaveLength(1))
+    expect(uploadCallCount).toBe(1)
+  })
+
+  it("keeps successful attachments when a queued peer fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const successfulOne = new File(["one"], "one.txt")
+    const failed = new File(["bad"], "failed.txt")
+    const successfulTwo = new File(["two"], "two.txt")
+    const uploadFile = vi.fn((file: File) => {
+      if (file === failed) return Promise.reject(new Error("storage unavailable"))
+      return Promise.resolve({ file_id: `id-${file.name}` })
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          files={files}
+          hideConfig
+          inputValue=""
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+          uploadFile={uploadFile}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(fileInput, {
+      target: { files: [successfulOne, failed, successfulTwo] },
+    })
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith(
+      "storage unavailable",
+      expect.objectContaining({ duration: 8000 }),
+    ))
+    expect(screen.getByText("one.txt")).toBeInTheDocument()
+    expect(screen.queryByText("failed.txt")).not.toBeInTheDocument()
+    expect(screen.getByText("two.txt")).toBeInTheDocument()
+    expect(consoleError).toHaveBeenCalledWith(
+      "Error uploading file:",
+      expect.objectContaining({ message: "storage unavailable" }),
+    )
+    consoleError.mockRestore()
+  })
+
+  it("aborts the active upload and drops queued uploads on unmount", async () => {
+    let uploadCallCount = 0
+    let activeSignal: AbortSignal | undefined
+    apiRequestMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url !== "http://upload.local/api/files/upload") {
+        return Promise.resolve(emptyJsonResponse())
+      }
+      uploadCallCount += 1
+      activeSignal = options?.signal ?? undefined
+      return new Promise<Response>((_resolve, reject) => {
+        activeSignal?.addEventListener("abort", () => {
+          reject(new DOMException("Upload cancelled", "AbortError"))
+        }, { once: true })
+      })
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          files={files}
+          hideConfig
+          inputValue=""
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+        />
+      )
+    }
+
+    const { container, unmount } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File(["one"], "one.txt"), new File(["two"], "two.txt")],
+      },
+    })
+    await waitFor(() => expect(uploadCallCount).toBe(1))
+
+    unmount()
+
+    expect(activeSignal?.aborted).toBe(true)
+    await act(async () => undefined)
+    expect(uploadCallCount).toBe(1)
+  })
+
+  it("does not publish a custom upload result after unmount", async () => {
+    let completeUpload: ((result: { file_id: string }) => void) | undefined
+    const uploadFile = vi.fn(() => new Promise<{ file_id: string }>(resolve => {
+      completeUpload = resolve
+    }))
+    const file = new File(["late"], "late.txt")
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <ChatInput
+          files={files}
+          hideConfig
+          inputValue=""
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+          uploadFile={uploadFile}
+        />
+      )
+    }
+
+    const { container, unmount } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(1))
+
+    unmount()
+    await act(async () => completeUpload?.({ file_id: "late-id" }))
+
+    expect((file as File & { file_id?: string }).file_id).toBeUndefined()
+  })
+
+  it("ignores filesDisabled from an abandoned render", async () => {
+    let completeUpload: ((result: { file_id: string }) => void) | undefined
+    let suspendedRenderStarted = false
+    const neverResolves = new Promise<never>(() => undefined)
+    const uploadFile = vi.fn(() => new Promise<{ file_id: string }>(resolve => {
+      completeUpload = resolve
+    }))
+    const file = new File(["kept"], "kept.txt")
+
+    const NeverSettles = () => {
+      suspendedRenderStarted = true
+      throw neverResolves
+    }
+    function Harness({ disabled, suspend }: { disabled: boolean; suspend: boolean }) {
+      const [files, setFiles] = React.useState<File[]>([])
+      return (
+        <Suspense fallback={null}>
+          <ChatInput
+            files={files}
+            filesDisabled={disabled}
+            hideConfig
+            inputValue=""
+            onFilesChange={setFiles}
+            onInputChange={vi.fn()}
+            onSend={vi.fn()}
+            uploadFile={uploadFile}
+          />
+          {suspend && <NeverSettles />}
+        </Suspense>
+      )
+    }
+
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    try {
+      await act(async () => {
+        root.render(<Harness disabled={false} suspend={false} />)
+      })
+      const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+      fireEvent.change(fileInput, { target: { files: [file] } })
+      await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(1))
+
+      await act(async () => {
+        startTransition(() => {
+          root.render(<Harness disabled suspend />)
+        })
+        await Promise.resolve()
+      })
+      expect(suspendedRenderStarted).toBe(true)
+
+      await act(async () => completeUpload?.({ file_id: "kept-id" }))
+
+      expect((file as File & { file_id?: string }).file_id).toBe("kept-id")
+      await waitFor(() => expect(screen.getByTitle("common.remove")).toBeInTheDocument())
+    } finally {
+      await act(async () => root.unmount())
+      container.remove()
+    }
+  })
 })

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -144,6 +144,13 @@ type ScheduledAttachmentUpload = {
 const uploadAbortError = (message: string) =>
   new DOMException(message, "AbortError");
 
+// A 15-minute request window permits a 100 MiB-class attachment to upload at
+// roughly 115 KiB/s while still ensuring one stalled request cannot own the
+// component FIFO indefinitely.
+const ATTACHMENT_UPLOAD_REQUEST_TIMEOUT_MS = 15 * 60 * 1000;
+const uploadTimeoutError = () =>
+  new DOMException("Attachment upload timed out", "TimeoutError");
+
 /** A component-owned FIFO that prevents one selection from bursting storage. */
 class AttachmentUploadQueue {
   private readonly pending: ScheduledAttachmentUpload[] = [];
@@ -495,6 +502,7 @@ export function ChatInput({
       const controller = new AbortController();
       uploadAbortControllersRef.current.set(file, controller);
       return uploadQueueRef.current!.schedule(async () => {
+        let didUploadTimeout = false;
         try {
           const currentTaskType = mode || 'task';
 
@@ -516,13 +524,33 @@ export function ChatInput({
             // Default to task mode if not specified
             formData.append('task_type', currentTaskType);
 
-            const response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
-              method: 'POST',
-              body: formData,
-              signal: controller.signal
+            let uploadDeadline: ReturnType<typeof setTimeout> | undefined;
+            const clearUploadDeadline = () => {
+              if (uploadDeadline === undefined) return;
+              clearTimeout(uploadDeadline);
+              uploadDeadline = undefined;
+            };
+            controller.signal.addEventListener("abort", clearUploadDeadline, {
+              once: true,
             });
 
-            const parsed = await parseApiResponse(response);
+            let response: Response;
+            let parsed: Awaited<ReturnType<typeof parseApiResponse>>;
+            try {
+              uploadDeadline = setTimeout(() => {
+                didUploadTimeout = true;
+                controller.abort(uploadTimeoutError());
+              }, ATTACHMENT_UPLOAD_REQUEST_TIMEOUT_MS);
+              response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
+                method: 'POST',
+                body: formData,
+                signal: controller.signal
+              });
+              parsed = await parseApiResponse(response);
+            } finally {
+              clearUploadDeadline();
+              controller.signal.removeEventListener("abort", clearUploadDeadline);
+            }
 
             if (response.ok && isJsonRecord(parsed.data)) {
               const data = parsed.data;
@@ -541,7 +569,12 @@ export function ChatInput({
             }
           }
         } catch (error) {
-          if (
+          if (didUploadTimeout) {
+            failedFiles.add(file);
+            uploadErrorMessage = uploadErrorMessage
+              || t("files.uploadFailed")
+              || "Failed to upload some files";
+          } else if (
             controller.signal.aborted
             || (error instanceof DOMException && error.name === 'AbortError')
           ) {

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -967,21 +967,18 @@ export function ChatInput({
     }
   };
 
-  const removeFile = (index: number) => {
-    const fileToRemove = enabledFiles[index];
-    if (fileToRemove) {
-      const controller = uploadAbortControllersRef.current.get(fileToRemove);
-      if (controller) {
-        controller.abort();
-        uploadAbortControllersRef.current.delete(fileToRemove);
-      }
-      setUploadingFiles(previous => {
-        const next = new Set(previous);
-        next.delete(fileToRemove);
-        return next;
-      });
+  const removeFile = (fileToRemove: File) => {
+    const controller = uploadAbortControllersRef.current.get(fileToRemove);
+    if (controller) {
+      controller.abort();
+      uploadAbortControllersRef.current.delete(fileToRemove);
     }
-    publishFiles(filesRef.current.filter((_, fileIndex) => fileIndex !== index));
+    setUploadingFiles(previous => {
+      const next = new Set(previous);
+      next.delete(fileToRemove);
+      return next;
+    });
+    publishFiles(filesRef.current.filter(file => file !== fileToRemove));
   };
 
   useEffect(() => {
@@ -1121,7 +1118,7 @@ export function ChatInput({
                     <span className="max-w-[180px] truncate font-medium">{file.name}</span>
                     <button
                       type="button"
-                      onClick={() => removeFile(index)}
+                      onClick={() => removeFile(file)}
                       className="ml-0.5 rounded-sm p-0.5 text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700"
                       title={isUploading ? t("common.cancel") : t("common.remove")}
                     >

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -978,7 +978,13 @@ export function ChatInput({
       next.delete(fileToRemove);
       return next;
     });
-    publishFiles(filesRef.current.filter(file => file !== fileToRemove));
+    const currentFiles = filesRef.current;
+    const liveIndex = currentFiles.indexOf(fileToRemove);
+    if (liveIndex === -1) return;
+    publishFiles([
+      ...currentFiles.slice(0, liveIndex),
+      ...currentFiles.slice(liveIndex + 1),
+    ]);
   };
 
   useEffect(() => {

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useMemo } from "react";
+import React, { useState, useRef, useEffect, useLayoutEffect, useMemo } from "react";
 import { createFileChipHTML } from "./FileChip";
 import { useRouter } from "next/navigation";
 import { Paperclip, X, File as FileIcon, Sparkles, Pause, Play, Loader2, ArrowUp, Globe, Mic, Square } from "lucide-react";
@@ -132,6 +132,75 @@ interface ModelRecord {
 interface DefaultModelRecord {
   config_type?: string;
   model?: ModelRecord | null;
+}
+
+type ScheduledAttachmentUpload = {
+  execute: () => Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+  detachAbortListener: () => void;
+};
+
+const uploadAbortError = (message: string) =>
+  new DOMException(message, "AbortError");
+
+/** A component-owned FIFO that prevents one selection from bursting storage. */
+class AttachmentUploadQueue {
+  private readonly pending: ScheduledAttachmentUpload[] = [];
+  private active = false;
+
+  schedule(execute: () => Promise<void>, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const task: ScheduledAttachmentUpload = {
+        execute,
+        resolve,
+        reject,
+        detachAbortListener: () => undefined,
+      };
+      const cancelBeforeStart = () => {
+        const index = this.pending.indexOf(task);
+        if (index === -1) return;
+        this.pending.splice(index, 1);
+        task.detachAbortListener();
+        reject(signal.reason ?? uploadAbortError("Upload cancelled"));
+        this.drain();
+      };
+      task.detachAbortListener = () => {
+        signal.removeEventListener("abort", cancelBeforeStart);
+      };
+
+      if (signal.aborted) {
+        reject(signal.reason ?? uploadAbortError("Upload cancelled"));
+        return;
+      }
+      signal.addEventListener("abort", cancelBeforeStart, { once: true });
+      this.pending.push(task);
+      this.drain();
+    });
+  }
+
+  cancelPending(reason: unknown): void {
+    this.pending.splice(0).forEach(task => {
+      task.detachAbortListener();
+      task.reject(reason);
+    });
+  }
+
+  private drain(): void {
+    if (this.active) return;
+    const task = this.pending.shift();
+    if (!task) return;
+    task.detachAbortListener();
+
+    this.active = true;
+    void Promise.resolve()
+      .then(task.execute)
+      .then(task.resolve, task.reject)
+      .finally(() => {
+        this.active = false;
+        this.drain();
+      });
+  }
 }
 
 export function ChatInput({
@@ -280,9 +349,19 @@ export function ChatInput({
     [files, filesDisabled],
   );
 
-  // Track files for async operations
+  // File object identity remains stable within one composer and does not
+  // collide when separate folders supply equal names and timestamps.
   const filesRef = useRef(enabledFiles);
-  const uploadAbortControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const uploadAbortControllersRef = useRef<Map<File, AbortController>>(new Map());
+  const uploadQueueRef = useRef<AttachmentUploadQueue | null>(null);
+  const uploadsMountedRef = useRef(true);
+  const uploadsEnabledRef = useRef(!filesDisabled);
+  useLayoutEffect(() => {
+    uploadsEnabledRef.current = !filesDisabled;
+  }, [filesDisabled]);
+  if (!uploadQueueRef.current) {
+    uploadQueueRef.current = new AttachmentUploadQueue();
+  }
 
   useEffect(() => {
     filesRef.current = enabledFiles;
@@ -351,8 +430,14 @@ export function ChatInput({
   }>({ model: "" });
   const [models, setModels] = useState<ModelRecord[]>([]);
 
-  // State to track files currently being uploaded
-  const [uploadingFiles, setUploadingFiles] = useState<Set<string>>(new Set());
+  // Queued and active files share one set so sending remains blocked until all
+  // selected attachments settle.
+  const [uploadingFiles, setUploadingFiles] = useState<Set<File>>(new Set());
+
+  const publishFiles = (nextFiles: File[]) => {
+    filesRef.current = nextFiles;
+    onFilesChange?.(nextFiles);
+  };
 
   const extractDroppedFiles = (dataTransfer: DataTransfer) => {
     const itemFiles = Array.from(dataTransfer.items || [])
@@ -374,100 +459,120 @@ export function ChatInput({
   useEffect(() => {
     if (!filesDisabled) return;
 
-    uploadAbortControllersRef.current.forEach((controller) => {
-      controller.abort();
-    });
+    uploadAbortControllersRef.current.forEach(controller => controller.abort());
     uploadAbortControllersRef.current.clear();
+    uploadQueueRef.current?.cancelPending(
+      uploadAbortError("File uploads disabled")
+    );
     setUploadingFiles(new Set());
     dragDepthRef.current = 0;
     setIsDraggingFiles(false);
   }, [filesDisabled]);
 
+  useEffect(() => {
+    uploadsMountedRef.current = true;
+    const abortControllers = uploadAbortControllersRef.current;
+    const uploadQueue = uploadQueueRef.current;
+    return () => {
+      uploadsMountedRef.current = false;
+      abortControllers.forEach(controller => controller.abort());
+      abortControllers.clear();
+      uploadQueue?.cancelPending(uploadAbortError("File uploader unmounted"));
+    };
+  }, []);
+
   // Helper to upload files immediately
   const uploadFiles = async (newFiles: File[]) => {
     if (filesDisabled || newFiles.length === 0) return;
 
-    // Mark as uploading (use name + lastModified as rough unique ID)
-    const fileIds = newFiles.map(f => `${f.name}-${f.lastModified}`);
-    setUploadingFiles(prev => {
-      const next = new Set(prev);
-      fileIds.forEach(id => next.add(id));
-      return next;
-    });
+    setUploadingFiles(previous => new Set([...previous, ...newFiles]));
 
     const failedFiles = new Set<File>();
     let uploadErrorMessage: string | null = null;
 
-    // Upload files individually to ensure better reliability and progress tracking
-    await Promise.all(newFiles.map(async (file) => {
-      const fileId = `${file.name}-${file.lastModified}`;
+    // Queue every selection through the same component-owned FIFO.
+    const scheduled = newFiles.map(file => {
       const controller = new AbortController();
-      uploadAbortControllersRef.current.set(fileId, controller);
+      uploadAbortControllersRef.current.set(file, controller);
+      return uploadQueueRef.current!.schedule(async () => {
+        try {
+          const currentTaskType = mode || 'task';
 
-      try {
-        const currentTaskType = mode || 'task';
-
-        if (uploadFile) {
-          const result = await uploadFile(file, { taskType: currentTaskType });
-          if (result && typeof result.file_id === 'string') {
-            (file as File & { file_id?: string }).file_id = result.file_id;
-          } else {
-            failedFiles.add(file);
-          }
-        } else {
-          const formData = new FormData();
-          formData.append('file', file);
-          // Default to task mode if not specified
-          formData.append('task_type', currentTaskType);
-
-          const response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
-            method: 'POST',
-            body: formData,
-            signal: controller.signal
-          });
-
-          const parsed = await parseApiResponse(response);
-
-          if (response.ok && isJsonRecord(parsed.data)) {
-            const data = parsed.data;
-            if (data.success && typeof data.file_id === 'string') {
-              // Attach file_id to the File object
-              (file as File & { file_id?: string }).file_id = data.file_id;
+          if (uploadFile) {
+            const result = await uploadFile(file, { taskType: currentTaskType });
+            if (
+              controller.signal.aborted
+              || !uploadsMountedRef.current
+              || !uploadsEnabledRef.current
+            ) return;
+            if (result && typeof result.file_id === 'string') {
+              (file as File & { file_id?: string }).file_id = result.file_id;
             } else {
               failedFiles.add(file);
             }
           } else {
+            const formData = new FormData();
+            formData.append('file', file);
+            // Default to task mode if not specified
+            formData.append('task_type', currentTaskType);
+
+            const response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
+              method: 'POST',
+              body: formData,
+              signal: controller.signal
+            });
+
+            const parsed = await parseApiResponse(response);
+
+            if (response.ok && isJsonRecord(parsed.data)) {
+              const data = parsed.data;
+              if (data.success && typeof data.file_id === 'string') {
+                // Attach file_id to the File object
+                (file as File & { file_id?: string }).file_id = data.file_id;
+              } else {
+                failedFiles.add(file);
+              }
+            } else {
+              failedFiles.add(file);
+              uploadErrorMessage = uploadErrorMessage || getUploadErrorMessage(response, parsed, {
+                generic: t("files.uploadFailed") || "Failed to upload some files",
+                ...UPLOAD_ERROR_MESSAGES,
+              });
+            }
+          }
+        } catch (error) {
+          if (
+            controller.signal.aborted
+            || (error instanceof DOMException && error.name === 'AbortError')
+          ) {
+            // Upload cancelled, do nothing
+          } else {
+            console.error("Error uploading file:", error);
             failedFiles.add(file);
-            uploadErrorMessage = uploadErrorMessage || getUploadErrorMessage(response, parsed, {
-              generic: t("files.uploadFailed") || "Failed to upload some files",
-              ...UPLOAD_ERROR_MESSAGES,
+            uploadErrorMessage = uploadErrorMessage || (error instanceof Error ? error.message : null);
+          }
+        } finally {
+          uploadAbortControllersRef.current.delete(file);
+          if (uploadsMountedRef.current && uploadsEnabledRef.current) {
+            setUploadingFiles(previous => {
+              const next = new Set(previous);
+              next.delete(file);
+              return next;
             });
           }
         }
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          // Upload cancelled, do nothing
-        } else {
-          console.error("Error uploading file:", error);
-          failedFiles.add(file);
-          uploadErrorMessage = uploadErrorMessage || (error instanceof Error ? error.message : null);
-        }
-      } finally {
-        uploadAbortControllersRef.current.delete(fileId);
-        setUploadingFiles(prev => {
-          const next = new Set(prev);
-          next.delete(fileId);
-          return next;
-        });
-      }
-    }));
+      }, controller.signal);
+    });
+    await Promise.allSettled(scheduled);
 
     // Handle failed files
-    if (failedFiles.size > 0) {
+    if (
+      failedFiles.size > 0
+      && uploadsMountedRef.current
+      && uploadsEnabledRef.current
+    ) {
       toast.error(uploadErrorMessage || t("files.uploadFailed") || "Failed to upload some files");
-      if (onFilesChange) {
-        onFilesChange(filesRef.current.filter(f => !failedFiles.has(f)));
-      }
+      publishFiles(filesRef.current.filter(file => !failedFiles.has(file)));
     }
   };
 
@@ -478,7 +583,7 @@ export function ChatInput({
       || !onFilesChange
       || isInputBusy
     ) return;
-    onFilesChange([...filesRef.current, ...newFiles]);
+    publishFiles([...filesRef.current, ...newFiles]);
     if (!deferFileUpload) {
       uploadFiles(newFiles);
     }
@@ -865,14 +970,18 @@ export function ChatInput({
   const removeFile = (index: number) => {
     const fileToRemove = enabledFiles[index];
     if (fileToRemove) {
-      const fileId = `${fileToRemove.name}-${fileToRemove.lastModified}`;
-      const controller = uploadAbortControllersRef.current.get(fileId);
+      const controller = uploadAbortControllersRef.current.get(fileToRemove);
       if (controller) {
         controller.abort();
-        uploadAbortControllersRef.current.delete(fileId);
+        uploadAbortControllersRef.current.delete(fileToRemove);
       }
+      setUploadingFiles(previous => {
+        const next = new Set(previous);
+        next.delete(fileToRemove);
+        return next;
+      });
     }
-    onFilesChange?.(enabledFiles.filter((_, i) => i !== index));
+    publishFiles(filesRef.current.filter((_, fileIndex) => fileIndex !== index));
   };
 
   useEffect(() => {
@@ -993,7 +1102,7 @@ export function ChatInput({
           {enabledFiles.length > 0 && (
             <div className="flex flex-wrap gap-2 px-4 pt-3">
               {enabledFiles.map((file, index) => {
-                const isUploading = uploadingFiles.has(`${file.name}-${file.lastModified}`);
+                const isUploading = uploadingFiles.has(file);
                 return (
                   <div
                     key={index}

--- a/frontend/src/components/chat/ChatStartScreen.test.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.test.tsx
@@ -1,15 +1,6 @@
 import React from "react"
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
-
-const chatInputProps = vi.hoisted(() => ({
-  current: null as null | {
-    files?: File[]
-    filesDisabled?: boolean
-    hideFileUpload?: boolean
-    onSend: (message: string, config?: unknown) => void
-  },
-}))
 
 vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({
@@ -17,22 +8,49 @@ vi.mock("@/contexts/i18n-context", () => ({
   }),
 }))
 
+vi.mock("@/contexts/app-context-chat", () => ({
+  useApp: () => ({ openFilePreview: vi.fn() }),
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ user: null }),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock("@/hooks/use-file-mention", () => ({
+  useFileMention: () => ({
+    checkTrigger: vi.fn(),
+    dropdownPosition: null,
+    fileList: [],
+    fileMentionsEnabled: false,
+    filteredFiles: [],
+    handleKeyDown: vi.fn(() => false),
+    insertFile: vi.fn(),
+    isLoadingFiles: false,
+    resetMention: vi.fn(),
+    selectedFileIndex: 0,
+    showFilePicker: false,
+  }),
+}))
+
+vi.mock("@/components/voice-input-controller", () => ({
+  useVoiceInputControls: () => ({
+    hasAsrModel: false,
+    startRecording: vi.fn(),
+    status: "idle",
+    stopRecording: vi.fn(),
+  }),
+}))
+
 vi.mock("@/lib/utils", () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
+  generateClientMessageId: () => "client-message-id",
   getApiUrl: () => "http://api.local",
-}))
-
-vi.mock("@/components/chat/ChatInput", () => ({
-  ChatInput: (props: NonNullable<typeof chatInputProps.current>) => {
-    chatInputProps.current = props
-    return <div data-testid="chat-input" />
-  },
-}))
-
-vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  getUploadApiUrl: () => "http://upload.local",
 }))
 
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
@@ -44,6 +62,8 @@ const AGENTS_SECTION = "chatPage.sections.chatWithAgents"
 const renderScreen = (agents?: React.ComponentProps<typeof ChatStartScreen>["agents"]) =>
   render(
     <ChatStartScreen
+      hideConfig
+      voiceInputEnabled={false}
       title="Support Agent"
       prompts={["Summarize this page"]}
       agents={agents}
@@ -53,7 +73,6 @@ const renderScreen = (agents?: React.ComponentProps<typeof ChatStartScreen>["age
 
 afterEach(() => {
   cleanup()
-  chatInputProps.current = null
 })
 
 describe("ChatStartScreen agents section", () => {
@@ -79,40 +98,74 @@ describe("ChatStartScreen agents section", () => {
 
 describe("ChatStartScreen file capability", () => {
   it("forwards the disabled file capability to ChatInput", () => {
-    const onSend = vi.fn()
     const file = new File(["secret"], "secret.txt", { type: "text/plain" })
-    render(
+    const { container } = render(
       <ChatStartScreen
         files={[file]}
         filesDisabled
-        onSend={onSend}
+        hideConfig
+        voiceInputEnabled={false}
+        onSend={vi.fn()}
         title="Session Agent"
       />
     )
 
-    expect(screen.getByTestId("chat-input")).toBeInTheDocument()
-    expect(chatInputProps.current?.hideFileUpload).toBe(true)
-    expect(chatInputProps.current?.filesDisabled).toBe(true)
-    expect(chatInputProps.current?.files).toEqual([])
-    chatInputProps.current?.onSend("hello", { mode: "balanced" })
-    expect(onSend).toHaveBeenCalledWith("hello", [], { mode: "balanced" })
+    expect(container.querySelector('input[type="file"]')).toBeNull()
+    expect(screen.queryByText("secret.txt")).not.toBeInTheDocument()
   })
 
-  it("preserves file input by default", () => {
-    const onSend = vi.fn()
-    const file = new File(["legacy"], "legacy.txt", { type: "text/plain" })
-    render(
+  it("owns selected files internally and removes them when no owner is supplied", async () => {
+    const { container } = render(
       <ChatStartScreen
-        files={[file]}
-        onSend={onSend}
-        title="Legacy Agent"
+        deferFileUpload
+        hideConfig
+        voiceInputEnabled={false}
+        onSend={vi.fn()}
+        title="Uncontrolled Agent"
       />
     )
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(["draft"], "draft.txt", { type: "text/plain" })
 
-    expect(chatInputProps.current?.hideFileUpload).toBe(false)
-    expect(chatInputProps.current?.filesDisabled).toBe(false)
-    expect(chatInputProps.current?.files).toEqual([file])
-    chatInputProps.current?.onSend("hello", { mode: "balanced" })
-    expect(onSend).toHaveBeenCalledWith("hello", [file], { mode: "balanced" })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    await waitFor(() => expect(screen.getByText("draft.txt")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTitle("common.remove"))
+    await waitFor(() => expect(screen.queryByText("draft.txt")).not.toBeInTheDocument())
+  })
+
+  it("preserves externally controlled files and change callback semantics", async () => {
+    const observedChanges: File[][] = []
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+      const handleFilesChange = (nextFiles: File[]) => {
+        observedChanges.push(nextFiles)
+        setFiles(nextFiles)
+      }
+      return (
+        <ChatStartScreen
+          deferFileUpload
+          files={files}
+          hideConfig
+          voiceInputEnabled={false}
+          onFilesChange={handleFilesChange}
+          onSend={vi.fn()}
+          title="Controlled Agent"
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(["owned"], "owned.txt", { type: "text/plain" })
+
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    await waitFor(() => expect(screen.getByText("owned.txt")).toBeInTheDocument())
+    expect(observedChanges).toEqual([[file]])
+
+    fireEvent.click(screen.getByTitle("common.remove"))
+    await waitFor(() => expect(screen.queryByText("owned.txt")).not.toBeInTheDocument())
+    expect(observedChanges).toEqual([[file], []])
   })
 })

--- a/frontend/src/components/chat/ChatStartScreen.tsx
+++ b/frontend/src/components/chat/ChatStartScreen.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Bot, Sparkles } from "lucide-react";
 import { ChatInput } from "@/components/chat/ChatInput";
 import { TemplateQuickAccess } from "@/components/chat/TemplateQuickAccess";
@@ -108,7 +108,7 @@ export function ChatStartScreen({
   onInputChange,
   onPromptSelect,
   promptHighlightTerms = [],
-  files = [],
+  files,
   onFilesChange,
   showModeToggle = false,
   readOnlyConfig = false,
@@ -132,7 +132,14 @@ export function ChatStartScreen({
   onRetryTemplates,
 }: ChatStartScreenProps) {
   const { t } = useI18n();
-  const enabledFiles = filesDisabled ? [] : files;
+  const [internalFiles, setInternalFiles] = useState<File[]>(() => files ?? []);
+  // Supplying a change callback makes file ownership external. Without one,
+  // this start screen owns the default file input's live attachment state.
+  const currentFiles = onFilesChange ? (files ?? []) : internalFiles;
+  const enabledFiles = filesDisabled ? [] : currentFiles;
+  const handleFilesChange = filesDisabled
+    ? undefined
+    : (onFilesChange ?? setInternalFiles);
 
   const handlePromptClick = (prompt: string, promptHighlights?: string[]) => {
     if (onPromptSelect) {
@@ -159,9 +166,7 @@ export function ChatStartScreen({
             onSend={(msg, config) => onSend(msg, enabledFiles, config)}
             isLoading={isSending}
             files={enabledFiles}
-            onFilesChange={
-              filesDisabled ? undefined : (onFilesChange || (() => { }))
-            }
+            onFilesChange={handleFilesChange}
             showModeToggle={showModeToggle}
             inputValue={inputValue}
             onInputChange={onInputChange}

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -29,6 +29,8 @@ const app = vi.hoisted(() => ({
   },
 }))
 
+const toastError = vi.hoisted(() => vi.fn())
+
 const i18n = vi.hoisted(() => ({
   t: (key: string, vars?: Record<string, string | number>) =>
     key === "files.tooManyAttachments"
@@ -66,6 +68,10 @@ vi.mock("@/contexts/app-context-chat", () => ({
 
 vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => i18n,
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: { error: toastError },
 }))
 
 vi.mock("@/components/chat/ChatStartScreen", () => ({
@@ -244,6 +250,7 @@ describe("PublicAgentChatPage", () => {
     app.rerender = null
     app.provider = null
     app.startScreenProps = null
+    toastError.mockReset()
     sessionStorage.clear()
     fetchMock.mockReset()
     vi.stubGlobal("fetch", fetchMock)
@@ -787,7 +794,6 @@ describe("PublicAgentChatPage", () => {
           { file_id: "second-id", filename: "second.txt", file_size: 6, mime_type: "text/plain" },
         ],
       }))
-      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "second-id" }))
 
     renderSharePage()
     await screen.findByRole("button", { name: "start:Support Agent" })
@@ -813,6 +819,45 @@ describe("PublicAgentChatPage", () => {
     expect(body.get("file")).toBeNull()
     expect(body.get("task_id")).toBe("42")
     expect(uploadCalls[0][1]?.signal).toBe(controller.signal)
+  })
+
+  it("keeps established-turn successes and surfaces partial upload failures", async () => {
+    const first = new File(["first"], "first.txt", { type: "text/plain" })
+    const oversized = new File(["large"], "oversized.txt", { type: "text/plain" })
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        files: [
+          {
+            success: true,
+            source_index: 0,
+            file_id: "first-id",
+            filename: "first.txt",
+            file_size: 5,
+            mime_type: "text/plain",
+          },
+          {
+            success: false,
+            source_index: 1,
+            filename: "oversized.txt",
+            error: "File size exceeds maximum limit of 100MB",
+          },
+        ],
+      }))
+
+    renderSharePage()
+    await screen.findByRole("button", { name: "start:Support Agent" })
+
+    await expect(app.provider?.transport?.uploadFiles?.([first, oversized], {
+      taskId: 42,
+      taskType: "task",
+    })).resolves.toEqual([
+      { file_id: "first-id", name: "first.txt", size: 5, type: "text/plain" },
+    ])
+    expect(toastError).toHaveBeenCalledWith(
+      "oversized.txt: File size exceeds maximum limit of 100MB",
+    )
   })
 
   it("rejects more than 10 workforce opening attachments with an empty message before any request", async () => {
@@ -866,6 +911,53 @@ describe("PublicAgentChatPage", () => {
     expect(fetchMock).not.toHaveBeenCalledWith(
       "https://api.example/api/share/chat/task/create",
       expect.anything(),
+    )
+  })
+
+  it("starts a workforce opening with successful IDs when a sibling upload fails", async () => {
+    const first = new File(["first"], "first.txt", { type: "text/plain" })
+    const invalid = new File(["invalid"], "invalid.exe", { type: "application/octet-stream" })
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "https://api.example/api/widget/auth") {
+        return Promise.resolve(jsonResponse(successfulWorkforceAuth))
+      }
+      if (url === "https://api.example/api/widget/files/upload") {
+        return Promise.resolve(jsonResponse({
+          success: true,
+          files: [
+            { success: true, source_index: 0, file_id: "first-id", filename: "first.txt" },
+            {
+              success: false,
+              source_index: 1,
+              filename: "invalid.exe",
+              error: "File type .exe not supported for task type task",
+            },
+          ],
+        }))
+      }
+      if (url === "https://api.example/api/widget/chat/task/create") {
+        return Promise.resolve(jsonResponse(widgetTaskResponse(43, "running")))
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    renderWidgetPage({ searchAgentId: null, widgetKey: "widget-secret" })
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+
+    await app.startScreenProps?.onSend(
+      "first message",
+      [first, invalid],
+      { mode: "balanced" },
+    )
+
+    const taskCreateCall = fetchMock.mock.calls.find(
+      ([url]) => url === "https://api.example/api/widget/chat/task/create",
+    )
+    expect(JSON.parse(taskCreateCall?.[1]?.body as string)).toMatchObject({
+      files: ["first-id"],
+    })
+    expect(toastError).toHaveBeenCalledWith(
+      "invalid.exe: File type .exe not supported for task type task",
     )
   })
 

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -29,7 +29,12 @@ const app = vi.hoisted(() => ({
   },
 }))
 
-const i18n = vi.hoisted(() => ({ t: (key: string) => key }))
+const i18n = vi.hoisted(() => ({
+  t: (key: string, vars?: Record<string, string | number>) =>
+    key === "files.tooManyAttachments"
+      ? `You can attach up to ${vars?.max} files at once (received ${vars?.count}).`
+      : key,
+}))
 
 vi.mock("@/contexts/app-context-chat", () => ({
   AppProvider: ({
@@ -789,9 +794,11 @@ describe("PublicAgentChatPage", () => {
 
     const uploadFiles = app.provider?.transport?.uploadFiles
     expect(uploadFiles).toEqual(expect.any(Function))
+    const controller = new AbortController()
     await expect(uploadFiles?.([first, second], {
       taskId: 42,
       taskType: "task",
+      signal: controller.signal,
     })).resolves.toEqual([
       { file_id: "first-id", name: "first.txt", size: 5, type: "text/plain" },
       { file_id: "second-id", name: "second.txt", size: 6, type: "text/plain" },
@@ -805,6 +812,36 @@ describe("PublicAgentChatPage", () => {
     expect(body.getAll("files")).toEqual([first, second])
     expect(body.get("file")).toBeNull()
     expect(body.get("task_id")).toBe("42")
+    expect(uploadCalls[0][1]?.signal).toBe(controller.signal)
+  })
+
+  it("rejects more than 10 workforce opening attachments before any request", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
+    const files = Array.from(
+      { length: 11 },
+      (_, index) => new File([String(index)], `${index}.txt`),
+    )
+
+    renderSharePage()
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+
+    await expect(app.startScreenProps?.onSend(
+      "first message",
+      files,
+      { mode: "balanced" },
+    )).rejects.toThrow(
+      "You can attach up to 10 files at once (received 11).",
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "https://api.example/api/share/files/upload",
+      expect.anything(),
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "https://api.example/api/share/chat/task/create",
+      expect.anything(),
+    )
   })
 
   it("uploads workforce opening attachments as one multipart batch", async () => {

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -20,6 +20,11 @@ const app = vi.hoisted(() => ({
     transport?: AppProviderTransportConfig
   },
   startScreenProps: null as null | {
+    onSend: (
+      message: string,
+      files: File[],
+      config?: Record<string, string>,
+    ) => Promise<void>
     voiceInputEnabled?: boolean
   },
 }))
@@ -761,5 +766,92 @@ describe("PublicAgentChatPage", () => {
     expect(app.setTaskId).toHaveBeenCalledWith(71, { navigate: false })
     expect(app.setTaskId).not.toHaveBeenCalledWith(null, { navigate: false })
     expect(localStorage.getItem(taskKey)).toBe("71")
+  })
+
+  it("uploads an established share turn as one multipart batch", async () => {
+    localStorage.clear()
+    const first = new File(["first"], "first.txt", { type: "text/plain" })
+    const second = new File(["second"], "second.txt", { type: "text/plain" })
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        file_id: "first-id",
+        files: [
+          { file_id: "first-id", filename: "first.txt", file_size: 5, mime_type: "text/plain" },
+          { file_id: "second-id", filename: "second.txt", file_size: 6, mime_type: "text/plain" },
+        ],
+      }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "second-id" }))
+
+    renderSharePage()
+    await screen.findByRole("button", { name: "start:Support Agent" })
+
+    const uploadFiles = app.provider?.transport?.uploadFiles
+    expect(uploadFiles).toEqual(expect.any(Function))
+    await expect(uploadFiles?.([first, second], {
+      taskId: 42,
+      taskType: "task",
+    })).resolves.toEqual([
+      { file_id: "first-id", name: "first.txt", size: 5, type: "text/plain" },
+      { file_id: "second-id", name: "second.txt", size: 6, type: "text/plain" },
+    ])
+
+    const uploadCalls = fetchMock.mock.calls.filter(
+      ([url]) => url === "https://api.example/api/share/files/upload",
+    )
+    expect(uploadCalls).toHaveLength(1)
+    const body = uploadCalls[0][1]?.body as FormData
+    expect(body.getAll("files")).toEqual([first, second])
+    expect(body.get("file")).toBeNull()
+    expect(body.get("task_id")).toBe("42")
+  })
+
+  it("uploads workforce opening attachments as one multipart batch", async () => {
+    const first = new File(["first"], "first.txt", { type: "text/plain" })
+    const second = new File(["second"], "second.txt", { type: "text/plain" })
+    fetchMock.mockImplementation((url: string, request?: RequestInit) => {
+      if (url === "https://api.example/api/widget/auth") {
+        return Promise.resolve(jsonResponse(successfulWorkforceAuth))
+      }
+      if (url === "https://api.example/api/widget/files/upload") {
+        const body = request?.body as FormData
+        const singleFile = body.get("file") as File | null
+        return Promise.resolve(jsonResponse({
+          success: true,
+          file_id: singleFile ? `${singleFile.name}-id` : undefined,
+          files: [
+            { file_id: "first.txt-id", filename: "first.txt", file_size: 5, mime_type: "text/plain" },
+            { file_id: "second.txt-id", filename: "second.txt", file_size: 6, mime_type: "text/plain" },
+          ],
+        }))
+      }
+      if (url === "https://api.example/api/widget/chat/task/create") {
+        return Promise.resolve(jsonResponse(widgetTaskResponse(43, "running")))
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    renderWidgetPage({ searchAgentId: null, widgetKey: "widget-secret" })
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+
+    await app.startScreenProps?.onSend(
+      "first message",
+      [first, second],
+      { mode: "balanced" },
+    )
+
+    const uploadCalls = fetchMock.mock.calls.filter(
+      ([url]) => url === "https://api.example/api/widget/files/upload",
+    )
+    expect(uploadCalls).toHaveLength(1)
+    const uploadBody = uploadCalls[0][1]?.body as FormData
+    expect(uploadBody.getAll("files")).toEqual([first, second])
+    const taskCreateCall = fetchMock.mock.calls.find(
+      ([url]) => url === "https://api.example/api/widget/chat/task/create",
+    )
+    expect(JSON.parse(taskCreateCall?.[1]?.body as string)).toMatchObject({
+      files: ["first.txt-id", "second.txt-id"],
+    })
   })
 })

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -815,6 +815,31 @@ describe("PublicAgentChatPage", () => {
     expect(uploadCalls[0][1]?.signal).toBe(controller.signal)
   })
 
+  it("rejects more than 10 workforce opening attachments with an empty message before any request", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
+    const files = Array.from(
+      { length: 11 },
+      (_, index) => new File([String(index)], `${index}.txt`),
+    )
+
+    renderSharePage()
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+
+    await expect(app.startScreenProps?.onSend(
+      "",
+      files,
+      { mode: "balanced" },
+    )).rejects.toThrow(
+      "You can attach up to 10 files at once (received 11).",
+    )
+
+    const openingRequests = fetchMock.mock.calls.filter(
+      ([url]) => url === "https://api.example/api/share/files/upload"
+        || url === "https://api.example/api/share/chat/task/create",
+    )
+    expect(openingRequests).toHaveLength(0)
+  })
+
   it("rejects more than 10 workforce opening attachments before any request", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
     const files = Array.from(

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -127,6 +127,8 @@ const shareGuestIdFromToken = (token: string): string => {
 
 type PublicMessageConfig = Record<string, unknown>
 
+const MAX_TASKLESS_PUBLIC_ATTACHMENTS = 10
+
 function PublicConversationContent({
   authMode,
   routeToken,
@@ -255,6 +257,12 @@ function PublicConversationContent({
     // never uploaded for a turn that cannot start.
     if (workforceId && !message.trim()) {
       return
+    }
+    if (workforceId && files && files.length > MAX_TASKLESS_PUBLIC_ATTACHMENTS) {
+      throw new Error(t("files.tooManyAttachments", {
+        count: files.length,
+        max: MAX_TASKLESS_PUBLIC_ATTACHMENTS,
+      }))
     }
 
     setIsBootstrappingTask(true)
@@ -608,6 +616,7 @@ export function PublicAgentChatPage({
         taskType: params.taskType,
         taskId: params.taskId,
         fallbackError: t("files.uploadFailed"),
+        signal: params.signal,
       }),
   }), [authMode, fileAccess, publicAccessToken, t])
 

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -251,18 +251,18 @@ function PublicConversationContent({
       return
     }
 
+    if (workforceId && files && files.length > MAX_TASKLESS_PUBLIC_ATTACHMENTS) {
+      throw new Error(t("files.tooManyAttachments", {
+        count: files.length,
+        max: MAX_TASKLESS_PUBLIC_ATTACHMENTS,
+      }))
+    }
     // For a workforce share the first turn starts inside task creation, which
     // rejects an empty message server-side (400) — AFTER any files uploaded
     // above would already be orphaned. Guard the empty case here so files are
     // never uploaded for a turn that cannot start.
     if (workforceId && !message.trim()) {
       return
-    }
-    if (workforceId && files && files.length > MAX_TASKLESS_PUBLIC_ATTACHMENTS) {
-      throw new Error(t("files.tooManyAttachments", {
-        count: files.length,
-        max: MAX_TASKLESS_PUBLIC_ATTACHMENTS,
-      }))
     }
 
     setIsBootstrappingTask(true)

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { Loader2, MessageSquarePlus } from "lucide-react"
+import { toast } from "@/components/ui/sonner"
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
 import { AppProvider, useApp, type AppProviderTransportConfig } from "@/contexts/app-context-chat"
@@ -288,6 +289,9 @@ function PublicConversationContent({
           files,
           taskType: "task",
           fallbackError: t("files.uploadFailed"),
+          onFailures: failures => failures.forEach(({ name, error }) => {
+            toast.error(`${name}: ${error}`)
+          }),
         })
         taskPayload.files = uploaded.map((item) => item.file_id)
       }
@@ -617,6 +621,9 @@ export function PublicAgentChatPage({
         taskId: params.taskId,
         fallbackError: t("files.uploadFailed"),
         signal: params.signal,
+        onFailures: failures => failures.forEach(({ name, error }) => {
+          toast.error(`${name}: ${error}`)
+        }),
       }),
   }), [authMode, fileAccess, publicAccessToken, t])
 

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -7,7 +7,7 @@ import { TaskConversationPanel } from "@/components/task/task-conversation-panel
 import { AppProvider, useApp, type AppProviderTransportConfig } from "@/contexts/app-context-chat"
 import { usePublicFileAccessPolicy } from "@/contexts/file-access-context"
 import { useI18n } from "@/contexts/i18n-context"
-import { uploadPublicChatFile } from "@/lib/public-chat-file-upload"
+import { uploadPublicChatFiles } from "@/lib/public-chat-file-upload"
 import { normalizeTaskStatus } from "@/lib/task-status"
 import {
   getApiUrl,
@@ -274,13 +274,13 @@ function PublicConversationContent({
       // exists yet) and threaded in as file ids BEFORE the run begins;
       // otherwise the first turn never sees them.
       if (workforceId && files?.length) {
-        const uploaded = await Promise.all(files.map((file) => uploadPublicChatFile({
+        const uploaded = await uploadPublicChatFiles({
           url: `${getApiUrl()}${publicApiPrefix}/files/upload`,
           accessToken,
-          file,
+          files,
           taskType: "task",
           fallbackError: t("files.uploadFailed"),
-        })))
+        })
         taskPayload.files = uploaded.map((item) => item.file_id)
       }
 
@@ -601,16 +601,14 @@ export function PublicAgentChatPage({
       `${baseUrl}/${authMode === "share" ? "api/share" : "api/widget"}/chat/ws/${taskId}${token ? `?token=${token}` : ""}`,
     fileAccess,
     uploadFiles: (files, params) =>
-      Promise.all(files.map((file) =>
-        uploadPublicChatFile({
-          url: `${getApiUrl()}/${authMode === "share" ? "api/share" : "api/widget"}/files/upload`,
-          accessToken: publicAccessToken,
-          file,
-          taskType: params.taskType,
-          taskId: params.taskId,
-          fallbackError: t("files.uploadFailed"),
-        }),
-      )),
+      uploadPublicChatFiles({
+        url: `${getApiUrl()}/${authMode === "share" ? "api/share" : "api/widget"}/files/upload`,
+        accessToken: publicAccessToken,
+        files,
+        taskType: params.taskType,
+        taskId: params.taskId,
+        fallbackError: t("files.uploadFailed"),
+      }),
   }), [authMode, fileAccess, publicAccessToken, t])
 
   if (isInitializing) {

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -296,6 +296,8 @@ describe("SessionAgentChatPage", () => {
       filesDisabled: true,
       voiceInputEnabled: false,
     }))
+    expect(app.startProps).not.toHaveProperty("files")
+    expect(app.startProps).not.toHaveProperty("onFilesChange")
 
     fireEvent.click(screen.getByRole("button", { name: "start:Support Agent" }))
     expect(app.sendMessage).toHaveBeenCalledWith(

--- a/frontend/src/components/widget/session-agent-chat-page.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.tsx
@@ -222,8 +222,6 @@ function SessionConversationContent({
                   || isMessageDeliveryPending
                   || reloadRequired
                 }
-                files={[]}
-                onFilesChange={() => undefined}
                 readOnlyConfig={true}
                 hideConfig={true}
                 compactInput={true}

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1802,7 +1802,7 @@ export interface AppProviderTransportConfig {
    * transports use this to keep guest credentials instance-scoped.
    */
   fileAccess?: FileAccessPolicy
-  uploadFiles?: (files: File[], params: { taskId?: number | null; taskType: string }) => Promise<Array<{ file_id: string; name?: string; size?: number; type?: string }>>
+  uploadFiles?: (files: File[], params: { taskId?: number | null; taskType: string; signal?: AbortSignal }) => Promise<Array<{ file_id: string; name?: string; size?: number; type?: string }>>
   capabilities?: AppProviderTransportCapabilities
   session?: {
     connection: WebSocketConnection | null

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -2366,6 +2366,65 @@ describe("useWebSocket normalized connections", () => {
     expect(socket.send).not.toHaveBeenCalled()
   })
 
+  it("aborts a custom upload when its preparation claim is cancelled", async () => {
+    let uploadSignal: AbortSignal | undefined
+    const uploadFiles = vi.fn((
+      _files: File[],
+      params: { signal?: AbortSignal },
+    ) => {
+      uploadSignal = params.signal
+      return new Promise<Array<{ file_id: string }>>(() => undefined)
+    })
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+      uploadFiles,
+    }))
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    act(() => MockWebSocket.instances[0].open())
+
+    const delivery = result.current.sendChatMessage(
+      "upload",
+      [new File(["data"], "data.txt")],
+    )
+    await waitFor(() => expect(uploadFiles).toHaveBeenCalledOnce())
+
+    act(() => result.current.disconnect())
+
+    await expect(delivery).rejects.toThrow("Disconnected")
+    expect(uploadSignal?.aborted).toBe(true)
+  })
+
+  it("aborts the fallback upload request when its preparation claim is cancelled", async () => {
+    let requestSignal: AbortSignal | null | undefined
+    const fetchMock = vi.fn((
+      _input: RequestInfo | URL,
+      request?: RequestInit,
+    ) => {
+      requestSignal = request?.signal
+      return new Promise<Response>(() => undefined)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    act(() => MockWebSocket.instances[0].open())
+
+    const delivery = result.current.sendChatMessage(
+      "upload",
+      [new File(["data"], "data.txt")],
+    )
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+
+    act(() => result.current.disconnect())
+
+    await expect(delivery).rejects.toThrow("Disconnected")
+    expect(requestSignal).toBeDefined()
+    expect(requestSignal?.aborted).toBe(true)
+  })
+
   it("claims a client message id before awaiting its upload", async () => {
     const upload = deferred<Array<{ file_id: string }>>()
     const uploadFiles = vi.fn(() => upload.promise)
@@ -2455,11 +2514,9 @@ describe("useWebSocket normalized connections", () => {
   it("rejects replaced upload preparation promptly and preserves the replacement claim", async () => {
     const oldUpload = deferred<Array<{ file_id: string }>>()
     const replacementUpload = deferred<Array<{ file_id: string }>>()
-    const unexpectedThirdUpload = deferred<Array<{ file_id: string }>>()
     const uploadFiles = vi.fn()
       .mockReturnValueOnce(oldUpload.promise)
       .mockReturnValueOnce(replacementUpload.promise)
-      .mockReturnValueOnce(unexpectedThirdUpload.promise)
     const { result, rerender } = renderHook(
       ({ taskId }) => useWebSocket({
         url: "ws://localhost",
@@ -2516,7 +2573,6 @@ describe("useWebSocket normalized connections", () => {
 
     await act(async () => {
       replacementUpload.resolve([{ file_id: "replacement-file" }])
-      unexpectedThirdUpload.resolve([{ file_id: "unexpected-file" }])
       await Promise.resolve()
     })
     act(() => replacementSocket.receive({

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -121,6 +121,7 @@ interface PendingDelivery {
 }
 
 interface MessagePreparationClaim {
+  abortController: AbortController
   cancellation: Promise<never>
   cancel: (error: Error) => void
   cancelled: boolean
@@ -208,7 +209,7 @@ export interface UseWebSocketOptions {
   taskId?: number
   token?: string
   buildWebSocketUrl?: (params: { baseUrl: string; taskId: number; token?: string }) => string
-  uploadFiles?: (files: File[], params: { taskId?: number | null; taskType: string }) => Promise<Array<{ file_id: string; name?: string; size?: number; type?: string }>>
+  uploadFiles?: (files: File[], params: { taskId?: number | null; taskType: string; signal?: AbortSignal }) => Promise<Array<{ file_id: string; name?: string; size?: number; type?: string }>>
   connection?: WebSocketConnection | null
   deliveryGeneration?: number
   onConnectionClose?: (event: CloseEvent) => "handled" | "default"
@@ -1146,12 +1147,15 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     const cancellation = new Promise<never>((_resolve, reject) => {
       rejectCancellation = reject
     })
+    const abortController = new AbortController()
     const claim: MessagePreparationClaim = {
+      abortController,
       cancellation,
       cancel: (error) => {
         if (claim.cancelled) return
         claim.cancelled = true
         rejectCancellation(error)
+        claim.abortController.abort()
       },
       cancelled: false,
       connectionIdentity: connection.identity,
@@ -1193,6 +1197,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
             uploadFiles(filesToUpload, {
               taskId: currentTaskId,
               taskType: 'task',
+              signal: claim.abortController.signal,
             }),
             claim.cancellation,
           ])
@@ -1208,6 +1213,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
                 'Authorization': `Bearer ${tokenRef.current ?? localStorage.getItem('token') ?? ''}`,
               },
               body: formData,
+              signal: claim.abortController.signal,
             })
             const parsed = await parseApiResponse(response)
             if (!response.ok || !isJsonRecord(parsed.data)) {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1362,6 +1362,7 @@ Build when you need.`,
   },
   files: {
     uploadFailed: "Upload failed",
+    tooManyAttachments: "You can attach up to {max} files at once (received {count}).",
     fileTooLarge: "File is too large for the configured upload limit",
     uploadProxyError: "Upload failed before reaching the application. Please check the server upload limit.",
     header: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1362,6 +1362,7 @@ const zh = {
   },
   files: {
     uploadFailed: "上传失败",
+    tooManyAttachments: "一次最多可附加 {max} 个文件（已选择 {count} 个）。",
     fileTooLarge: "文件大小超过当前配置的上传限制",
     uploadProxyError: "上传在到达应用前被拦截，请检查服务器上传大小限制。",
     header: {

--- a/frontend/src/lib/public-chat-file-upload.test.ts
+++ b/frontend/src/lib/public-chat-file-upload.test.ts
@@ -38,6 +38,30 @@ describe("uploadPublicChatFiles", () => {
     expect(body.get("task_id")).toBe("42")
   })
 
+  it("forwards the caller-owned abort signal", async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        success: true,
+        files: [{ file_id: "file-1" }],
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+
+    await uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files: [new File(["first"], "first.txt")],
+      taskType: "task",
+      fallbackError: "Upload failed",
+      signal: controller.signal,
+    })
+
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal)
+  })
+
   it("normalizes successful batch metadata", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({

--- a/frontend/src/lib/public-chat-file-upload.test.ts
+++ b/frontend/src/lib/public-chat-file-upload.test.ts
@@ -1,60 +1,112 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { uploadPublicChatFile } from "./public-chat-file-upload"
+import { uploadPublicChatFiles } from "./public-chat-file-upload"
 
-describe("uploadPublicChatFile", () => {
+describe("uploadPublicChatFiles", () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it("rejects backend HTTP failures instead of silently accepting them", async () => {
+  it("sends all files in one authenticated multipart request", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ detail: "File is too large" }), {
         status: 413,
         headers: { "Content-Type": "application/json" },
       }),
     )
-    const file = new File(["trip"], "trip.txt", { type: "text/plain" })
+    const first = new File(["first"], "first.txt", { type: "text/plain" })
+    const second = new File(["second"], "second.txt", { type: "text/plain" })
 
-    await expect(uploadPublicChatFile({
+    await expect(uploadPublicChatFiles({
       url: "http://api.local/api/share/files/upload",
       accessToken: "guest-token",
-      file,
+      files: [first, second],
       taskType: "task",
       taskId: 42,
       fallbackError: "Upload failed",
     })).rejects.toThrow("File is too large")
 
+    expect(fetchMock).toHaveBeenCalledTimes(1)
     const [, request] = fetchMock.mock.calls[0]
     expect(new Headers(request?.headers).get("Authorization")).toBe(
       "Bearer guest-token",
     )
     const body = request?.body as FormData
-    expect(body.get("file")).toBe(file)
+    expect(body.getAll("files")).toEqual([first, second])
+    expect(body.get("file")).toBeNull()
     expect(body.get("task_type")).toBe("task")
     expect(body.get("task_id")).toBe("42")
   })
 
-  it("returns normalized file metadata for successful uploads", async () => {
+  it("normalizes successful batch metadata", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ success: true, file_id: "file-1" }), {
+      new Response(JSON.stringify({
+        success: true,
+        files: [
+          {
+            file_id: "file-1",
+            filename: "first.txt",
+            file_size: 5,
+            mime_type: "text/plain",
+          },
+          {
+            file_id: "file-2",
+            filename: "second.txt",
+            file_size: 6,
+            mime_type: "text/plain",
+          },
+        ],
+      }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
     )
-    const file = new File(["trip"], "trip.txt", { type: "text/plain" })
+    const first = new File(["first"], "first.txt", { type: "text/plain" })
+    const second = new File(["second"], "second.txt", { type: "text/plain" })
 
-    await expect(uploadPublicChatFile({
+    await expect(uploadPublicChatFiles({
       url: "http://api.local/api/share/files/upload",
       accessToken: "guest-token",
-      file,
+      files: [first, second],
       taskType: "task",
       fallbackError: "Upload failed",
-    })).resolves.toEqual({
-      file_id: "file-1",
-      name: "trip.txt",
-      size: 4,
-      type: "text/plain",
-    })
+    })).resolves.toEqual([
+      { file_id: "file-1", name: "first.txt", size: 5, type: "text/plain" },
+      { file_id: "file-2", name: "second.txt", size: 6, type: "text/plain" },
+    ])
+  })
+
+  it("rejects an incomplete batch response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        success: true,
+        files: [{ file_id: "file-1" }],
+        message: "Successfully uploaded 2 files",
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+
+    await expect(uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files: [new File(["first"], "first.txt"), new File(["second"], "second.txt")],
+      taskType: "task",
+      fallbackError: "Upload failed",
+    })).rejects.toThrow("Upload failed")
+  })
+
+  it("does not issue an empty upload request", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+
+    await expect(uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files: [],
+      taskType: "task",
+      fallbackError: "Upload failed",
+    })).resolves.toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/lib/public-chat-file-upload.test.ts
+++ b/frontend/src/lib/public-chat-file-upload.test.ts
@@ -100,6 +100,205 @@ describe("uploadPublicChatFiles", () => {
     ])
   })
 
+  it("preserves successful siblings without filtered-array positional drift", async () => {
+    const onFailures = vi.fn()
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        success: true,
+        files: [
+          {
+            success: false,
+            source_index: 0,
+            filename: "oversized.txt",
+            error: "File size exceeds maximum limit of 100MB",
+          },
+          {
+            success: true,
+            source_index: 1,
+            file_id: "file-1",
+            filename: "second.txt",
+            file_size: 6,
+            mime_type: "text/plain",
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+
+    await expect(uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files: [new File(["large"], "oversized.txt"), new File(["second"], "second.txt")],
+      taskType: "task",
+      taskId: 42,
+      fallbackError: "Upload failed",
+      onFailures,
+    })).resolves.toEqual([
+      { file_id: "file-1", name: "second.txt", size: 6, type: "text/plain" },
+    ])
+    expect(onFailures).toHaveBeenCalledWith([
+      {
+        name: "oversized.txt",
+        error: "File size exceeds maximum limit of 100MB",
+      },
+    ])
+  })
+
+  it.each([
+    { file_id: 123 },
+    { file_id: null },
+    { file_id: "" },
+  ])("rejects a malformed file_id: $file_id", async malformed => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        success: true,
+        files: [{ success: true, source_index: 0, ...malformed }],
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+
+    await expect(uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files: [new File(["first"], "first.txt")],
+      taskType: "task",
+      taskId: 42,
+      fallbackError: "Upload failed",
+    })).rejects.toThrow("Upload failed")
+  })
+
+  it("partitions task-bound files by the conservative multipart byte budget", async () => {
+    const files = ["first", "second", "third"].map(name => {
+      const file = new File([name], `${name}.txt`)
+      Object.defineProperty(file, "size", { value: 200 * 1024 * 1024 })
+      return file
+    })
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_url, request) => {
+        const chunk = (request?.body as FormData).getAll("files") as File[]
+        return new Response(JSON.stringify({
+          success: true,
+          files: chunk.map((file, source_index) => ({
+            success: true,
+            source_index,
+            file_id: `${file.name}-id`,
+          })),
+        }), { status: 200, headers: { "Content-Type": "application/json" } })
+      },
+    )
+
+    await expect(uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files,
+      taskType: "task",
+      taskId: 42,
+      fallbackError: "Upload failed",
+    })).resolves.toEqual(files.map(file => ({
+      file_id: `${file.name}-id`,
+      name: file.name,
+      size: file.size,
+      type: file.type,
+    })))
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect((fetchMock.mock.calls[0][1]?.body as FormData).getAll("files")).toEqual(files.slice(0, 2))
+    expect((fetchMock.mock.calls[1][1]?.body as FormData).getAll("files")).toEqual(files.slice(2))
+  })
+
+  it("does not send a task-bound file that exceeds the multipart budget", async () => {
+    const oversized = new File(["large"], "oversized.txt")
+    Object.defineProperty(oversized, "size", { value: 451 * 1024 * 1024 })
+    const valid = new File(["valid"], "valid.txt")
+    const onFailures = vi.fn()
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        success: true,
+        files: [{ success: true, source_index: 0, file_id: "valid-id" }],
+      }), { status: 200, headers: { "Content-Type": "application/json" } }),
+    )
+
+    await expect(uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files: [oversized, valid],
+      taskType: "task",
+      taskId: 42,
+      fallbackError: "Upload failed",
+      onFailures,
+    })).resolves.toEqual([
+      { file_id: "valid-id", name: "valid.txt", size: 5, type: "" },
+    ])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect((fetchMock.mock.calls[0][1]?.body as FormData).getAll("files")).toEqual([valid])
+    expect(onFailures).toHaveBeenCalledWith([{
+      name: "oversized.txt",
+      error: "File exceeds the public upload request limit",
+    }])
+  })
+
+  it("bounds task-bound chunks by file count", async () => {
+    const files = Array.from({ length: 21 }, (_, index) => new File(["x"], `${index}.txt`))
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_url, request) => {
+        const chunk = (request?.body as FormData).getAll("files") as File[]
+        return new Response(JSON.stringify({
+          success: true,
+          files: chunk.map((file, source_index) => ({
+            success: true,
+            source_index,
+            file_id: `${file.name}-id`,
+          })),
+        }), { status: 200, headers: { "Content-Type": "application/json" } })
+      },
+    )
+
+    await uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files,
+      taskType: "task",
+      taskId: 42,
+      fallbackError: "Upload failed",
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect((fetchMock.mock.calls[0][1]?.body as FormData).getAll("files")).toHaveLength(20)
+    expect((fetchMock.mock.calls[1][1]?.body as FormData).getAll("files")).toHaveLength(1)
+  })
+
+  it("stops before the next chunk when the caller aborts", async () => {
+    const controller = new AbortController()
+    const files = ["first", "second"].map(name => {
+      const file = new File([name], `${name}.txt`)
+      Object.defineProperty(file, "size", { value: 300 * 1024 * 1024 })
+      return file
+    })
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      controller.abort()
+      return new Response(JSON.stringify({
+        success: true,
+        files: [{ success: true, source_index: 0, file_id: "first-id" }],
+      }), { status: 200, headers: { "Content-Type": "application/json" } })
+    })
+
+    await expect(uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files,
+      taskType: "task",
+      taskId: 42,
+      fallbackError: "Upload failed",
+      signal: controller.signal,
+    })).rejects.toMatchObject({ name: "AbortError" })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it("rejects an incomplete batch response", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({

--- a/frontend/src/lib/public-chat-file-upload.ts
+++ b/frontend/src/lib/public-chat-file-upload.ts
@@ -5,10 +5,10 @@ export interface PublicChatUploadedFile {
   type?: string
 }
 
-interface UploadPublicChatFileOptions {
+interface UploadPublicChatFilesOptions {
   url: string
   accessToken: string
-  file: File
+  files: File[]
   taskType: string
   taskId?: number | string | null
   fallbackError: string
@@ -16,21 +16,35 @@ interface UploadPublicChatFileOptions {
 
 interface PublicChatUploadResponse {
   success?: boolean
-  file_id?: unknown
+  files?: unknown
   detail?: unknown
   message?: unknown
 }
 
-export async function uploadPublicChatFile({
+function uploadErrorMessage(
+  data: PublicChatUploadResponse | null,
+  fallbackError: string,
+): string {
+  return typeof data?.detail === "string"
+    ? data.detail
+    : typeof data?.message === "string"
+      ? data.message
+      : fallbackError
+}
+
+/** Uploads one public-chat attachment set in a single backend transaction. */
+export async function uploadPublicChatFiles({
   url,
   accessToken,
-  file,
+  files,
   taskType,
   taskId,
   fallbackError,
-}: UploadPublicChatFileOptions): Promise<PublicChatUploadedFile> {
+}: UploadPublicChatFilesOptions): Promise<PublicChatUploadedFile[]> {
+  if (files.length === 0) return []
+
   const formData = new FormData()
-  formData.append("file", file)
+  files.forEach(file => formData.append("files", file))
   formData.append("task_type", taskType)
   if (taskId != null) {
     formData.append("task_id", taskId.toString())
@@ -42,21 +56,27 @@ export async function uploadPublicChatFile({
     body: formData,
   })
   const data = await response.json().catch(() => null) as PublicChatUploadResponse | null
-  const fileId = typeof data?.file_id === "string" ? data.file_id : null
+  const uploaded = Array.isArray(data?.files)
+    ? data.files.flatMap((item, index) => {
+        if (typeof item !== "object" || item === null) return []
+        const record = item as Record<string, unknown>
+        if (typeof record.file_id !== "string") return []
+        const source = files[index]
+        return [{
+          file_id: record.file_id,
+          name: typeof record.filename === "string" ? record.filename : source?.name,
+          size: typeof record.file_size === "number" ? record.file_size : source?.size,
+          type: typeof record.mime_type === "string" ? record.mime_type : source?.type,
+        }]
+      })
+    : []
 
-  if (!response.ok || data?.success !== true || !fileId) {
-    const backendMessage = typeof data?.detail === "string"
-      ? data.detail
-      : typeof data?.message === "string"
-        ? data.message
-        : null
-    throw new Error(backendMessage || fallbackError)
+  if (!response.ok || data?.success !== true) {
+    throw new Error(uploadErrorMessage(data, fallbackError))
+  }
+  if (uploaded.length !== files.length) {
+    throw new Error(fallbackError)
   }
 
-  return {
-    file_id: fileId,
-    name: file.name,
-    size: file.size,
-    type: file.type,
-  }
+  return uploaded
 }

--- a/frontend/src/lib/public-chat-file-upload.ts
+++ b/frontend/src/lib/public-chat-file-upload.ts
@@ -5,6 +5,11 @@ export interface PublicChatUploadedFile {
   type?: string
 }
 
+export interface PublicChatUploadFailure {
+  name: string
+  error: string
+}
+
 interface UploadPublicChatFilesOptions {
   url: string
   accessToken: string
@@ -13,6 +18,7 @@ interface UploadPublicChatFilesOptions {
   taskId?: number | string | null
   fallbackError: string
   signal?: AbortSignal
+  onFailures?: (failures: PublicChatUploadFailure[]) => void
 }
 
 interface PublicChatUploadResponse {
@@ -21,6 +27,25 @@ interface PublicChatUploadResponse {
   detail?: unknown
   message?: unknown
 }
+
+interface IndexedFile {
+  file: File
+  index: number
+}
+
+interface NormalizedOutcome {
+  index: number
+  uploaded?: PublicChatUploadedFile
+  failure?: PublicChatUploadFailure
+}
+
+/**
+ * Keep public multipart requests comfortably below nginx's fixed 500M body
+ * ceiling. The 450 MiB payload budget leaves at least 50 MiB for multipart
+ * boundaries and headers while retaining the ordinary one-request path.
+ */
+const PUBLIC_UPLOAD_MULTIPART_BYTE_BUDGET = 450 * 1024 * 1024
+const PUBLIC_UPLOAD_MAX_FILES_PER_REQUEST = 20
 
 function uploadErrorMessage(
   data: PublicChatUploadResponse | null,
@@ -33,7 +58,95 @@ function uploadErrorMessage(
       : fallbackError
 }
 
-/** Uploads one public-chat attachment set in a single backend transaction. */
+function partitionTaskBoundFiles(files: IndexedFile[]): IndexedFile[][] {
+  const chunks: IndexedFile[][] = []
+  let current: IndexedFile[] = []
+  let currentBytes = 0
+
+  files.forEach(indexedFile => {
+    const exceedsCurrentChunk = current.length > 0 && (
+      current.length >= PUBLIC_UPLOAD_MAX_FILES_PER_REQUEST
+      || currentBytes + indexedFile.file.size > PUBLIC_UPLOAD_MULTIPART_BYTE_BUDGET
+    )
+    if (exceedsCurrentChunk) {
+      chunks.push(current)
+      current = []
+      currentBytes = 0
+    }
+    current.push(indexedFile)
+    currentBytes += indexedFile.file.size
+  })
+
+  if (current.length > 0) chunks.push(current)
+  return chunks
+}
+
+function normalizeChunkOutcomes(
+  rawFiles: unknown,
+  chunk: IndexedFile[],
+  fallbackError: string,
+): NormalizedOutcome[] {
+  if (!Array.isArray(rawFiles) || rawFiles.length !== chunk.length) {
+    throw new Error(fallbackError)
+  }
+
+  const records = rawFiles.map(item => {
+    if (typeof item !== "object" || item === null) throw new Error(fallbackError)
+    return item as Record<string, unknown>
+  })
+  const hasExplicitCorrelation = records.some(record => "source_index" in record)
+  const usedIndexes = new Set<number>()
+
+  return records.map((record, responseIndex) => {
+    const sourceIndex = hasExplicitCorrelation ? record.source_index : responseIndex
+    if (
+      typeof sourceIndex !== "number"
+      || !Number.isInteger(sourceIndex)
+      || sourceIndex < 0
+      || sourceIndex >= chunk.length
+      || usedIndexes.has(sourceIndex)
+    ) {
+      throw new Error(fallbackError)
+    }
+    usedIndexes.add(sourceIndex)
+    const source = chunk[sourceIndex]
+
+    if (record.success === false) {
+      if (typeof record.error !== "string" || !record.error) {
+        throw new Error(fallbackError)
+      }
+      return {
+        index: source.index,
+        failure: {
+          name: typeof record.filename === "string" && record.filename
+            ? record.filename
+            : source.file.name,
+          error: record.error,
+        },
+      }
+    }
+
+    if (typeof record.file_id !== "string" || !record.file_id) {
+      throw new Error(fallbackError)
+    }
+    return {
+      index: source.index,
+      uploaded: {
+        file_id: record.file_id,
+        name: typeof record.filename === "string" ? record.filename : source.file.name,
+        size: typeof record.file_size === "number" ? record.file_size : source.file.size,
+        type: typeof record.mime_type === "string" ? record.mime_type : source.file.type,
+      },
+    }
+  })
+}
+
+/**
+ * Upload public-chat attachments and retain every successful per-file outcome.
+ * Task-bound sets are sent sequentially in bounded multipart chunks; task-less
+ * workforce openings intentionally stay as one request so their existing
+ * ten-file guard remains authoritative.
+ */
 export async function uploadPublicChatFiles({
   url,
   accessToken,
@@ -42,44 +155,53 @@ export async function uploadPublicChatFiles({
   taskId,
   fallbackError,
   signal,
+  onFailures,
 }: UploadPublicChatFilesOptions): Promise<PublicChatUploadedFile[]> {
   if (files.length === 0) return []
 
-  const formData = new FormData()
-  files.forEach(file => formData.append("files", file))
-  formData.append("task_type", taskType)
-  if (taskId != null) {
-    formData.append("task_id", taskId.toString())
+  const indexedFiles = files.map((file, index) => ({ file, index }))
+  const locallyRejected = taskId == null
+    ? []
+    : indexedFiles.filter(({ file }) => file.size > PUBLIC_UPLOAD_MULTIPART_BYTE_BUDGET)
+  const eligibleFiles = taskId == null
+    ? indexedFiles
+    : indexedFiles.filter(({ file }) => file.size <= PUBLIC_UPLOAD_MULTIPART_BYTE_BUDGET)
+  const chunks = taskId == null ? [eligibleFiles] : partitionTaskBoundFiles(eligibleFiles)
+  const outcomes: NormalizedOutcome[] = locallyRejected.map(({ file, index }) => ({
+    index,
+    failure: {
+      name: file.name,
+      error: "File exceeds the public upload request limit",
+    },
+  }))
+
+  for (const chunk of chunks) {
+    signal?.throwIfAborted()
+    const formData = new FormData()
+    chunk.forEach(({ file }) => formData.append("files", file))
+    formData.append("task_type", taskType)
+    if (taskId != null) formData.append("task_id", taskId.toString())
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${accessToken}` },
+      body: formData,
+      signal,
+    })
+    const data = await response.json().catch(() => null) as PublicChatUploadResponse | null
+    if (!response.ok || data?.success !== true) {
+      throw new Error(uploadErrorMessage(data, fallbackError))
+    }
+    outcomes.push(...normalizeChunkOutcomes(data.files, chunk, fallbackError))
   }
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: { "Authorization": `Bearer ${accessToken}` },
-    body: formData,
-    signal,
-  })
-  const data = await response.json().catch(() => null) as PublicChatUploadResponse | null
-  const uploaded = Array.isArray(data?.files)
-    ? data.files.flatMap((item, index) => {
-        if (typeof item !== "object" || item === null) return []
-        const record = item as Record<string, unknown>
-        if (typeof record.file_id !== "string") return []
-        const source = files[index]
-        return [{
-          file_id: record.file_id,
-          name: typeof record.filename === "string" ? record.filename : source?.name,
-          size: typeof record.file_size === "number" ? record.file_size : source?.size,
-          type: typeof record.mime_type === "string" ? record.mime_type : source?.type,
-        }]
-      })
-    : []
+  const ordered = outcomes.sort((left, right) => left.index - right.index)
+  const failures = ordered.flatMap(outcome => outcome.failure ? [outcome.failure] : [])
+  if (failures.length > 0) onFailures?.(failures)
 
-  if (!response.ok || data?.success !== true) {
-    throw new Error(uploadErrorMessage(data, fallbackError))
+  const uploaded = ordered.flatMap(outcome => outcome.uploaded ? [outcome.uploaded] : [])
+  if (uploaded.length === 0 && failures.length > 0) {
+    throw new Error(`${failures[0].name}: ${failures[0].error}`)
   }
-  if (uploaded.length !== files.length) {
-    throw new Error(fallbackError)
-  }
-
   return uploaded
 }

--- a/frontend/src/lib/public-chat-file-upload.ts
+++ b/frontend/src/lib/public-chat-file-upload.ts
@@ -12,6 +12,7 @@ interface UploadPublicChatFilesOptions {
   taskType: string
   taskId?: number | string | null
   fallbackError: string
+  signal?: AbortSignal
 }
 
 interface PublicChatUploadResponse {
@@ -40,6 +41,7 @@ export async function uploadPublicChatFiles({
   taskType,
   taskId,
   fallbackError,
+  signal,
 }: UploadPublicChatFilesOptions): Promise<PublicChatUploadedFile[]> {
   if (files.length === 0) return []
 
@@ -54,6 +56,7 @@ export async function uploadPublicChatFiles({
     method: "POST",
     headers: { "Authorization": `Bearer ${accessToken}` },
     body: formData,
+    signal,
   })
   const data = await response.json().catch(() => null) as PublicChatUploadResponse | null
   const uploaded = Array.isArray(data?.files)

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -588,7 +588,7 @@ async def store_uploaded_files(
             )
         completed = True
     except DurableStorageOperationError as exc:
-        logger.exception(
+        logger.warning(
             "Durable storage unavailable during upload: "
             "operation=register_local_uploads backend=%s user_id=%s task_id=%s "
             "file_count=%s",
@@ -596,6 +596,7 @@ async def store_uploaded_files(
             user_id,
             parsed_task_id,
             len(upload_items),
+            exc_info=True,
         )
         raise _durable_storage_unavailable() from exc
     finally:

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -37,7 +37,7 @@ from ...config import (
     get_uploads_dir,
 )
 from ...core.execution_scope import resolve_execution_scope
-from ...core.file_storage import get_user_file_storage
+from ...core.file_storage import get_file_storage_backend, get_user_file_storage
 from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
 from ...core.utils.svg import rasterize_svg_bytes
@@ -588,7 +588,15 @@ async def store_uploaded_files(
             )
         completed = True
     except DurableStorageOperationError as exc:
-        logger.warning("Durable storage unavailable during upload: %s", exc)
+        logger.exception(
+            "Durable storage unavailable during upload: "
+            "operation=register_local_uploads backend=%s user_id=%s task_id=%s "
+            "file_count=%s",
+            get_file_storage_backend(),
+            user_id,
+            parsed_task_id,
+            len(upload_items),
+        )
         raise _durable_storage_unavailable() from exc
     finally:
         if not completed:

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -806,6 +806,117 @@ def _enforce_public_upload_storage_gate(db: Session, owner: User) -> None:
         raise HTTPException(status_code=402, detail=reason)
 
 
+def _public_upload_filename(uploaded: UploadFile) -> str:
+    """Return a bounded basename suitable for a public per-file outcome."""
+
+    filename = (uploaded.filename or "").replace("\\", "/").rsplit("/", 1)[-1]
+    return filename[:255] or "Unnamed file"
+
+
+def _is_public_item_failure(exc: HTTPException) -> bool:
+    """Whether an upload error belongs to one file rather than the request.
+
+    Durable-storage 503s and unexpected server failures retain their existing
+    HTTP response. The legacy unsupported-extension validation uses status 500,
+    so recognize only that established detail as a per-file validation result.
+    """
+
+    return (
+        exc.status_code == 413
+        or (exc.status_code == 422 and exc.detail == "No filename provided")
+        or (
+            exc.status_code == 500
+            and isinstance(exc.detail, str)
+            and exc.detail.startswith("File type ")
+        )
+    )
+
+
+async def _store_public_upload_items(
+    *,
+    upload_items: list[UploadFile],
+    task_type: str,
+    task_id: str | None,
+    folder: str | None,
+    user_id: int,
+    single_file_mode: bool,
+    upload_source: str | None = None,
+) -> dict[str, Any]:
+    """Store a public batch with an opt-in transaction boundary per item.
+
+    Authenticated and other shared callers continue using
+    :func:`store_uploaded_files` atomically. A pure singular ``file`` request
+    also delegates unchanged so its long-standing response shape is preserved.
+    """
+
+    if single_file_mode:
+        return await store_uploaded_files(
+            upload_items=upload_items,
+            task_type=task_type,
+            task_id=task_id,
+            folder=folder,
+            user_id=user_id,
+            single_file_mode=True,
+            upload_source=upload_source,
+        )
+
+    outcomes: list[dict[str, Any]] = []
+    uploaded_count = 0
+    for source_index, uploaded in enumerate(upload_items):
+        try:
+            result = await store_uploaded_files(
+                upload_items=[uploaded],
+                task_type=task_type,
+                task_id=task_id,
+                folder=folder,
+                user_id=user_id,
+                single_file_mode=True,
+                upload_source=upload_source,
+            )
+        except HTTPException as exc:
+            if not _is_public_item_failure(exc):
+                raise
+            detail = exc.detail if isinstance(exc.detail, str) else "Upload failed"
+            outcomes.append(
+                {
+                    "success": False,
+                    "source_index": source_index,
+                    "filename": _public_upload_filename(uploaded),
+                    "error": detail[:500],
+                    "status_code": exc.status_code,
+                }
+            )
+            continue
+
+        uploaded_count += 1
+        outcomes.append(
+            {
+                "success": True,
+                "source_index": source_index,
+                **{
+                    key: result[key]
+                    for key in (
+                        "file_id",
+                        "filename",
+                        "file_size",
+                        "mime_type",
+                        "content_preview",
+                    )
+                },
+            }
+        )
+
+    return {
+        "success": True,
+        "files": outcomes,
+        "total_files": len(outcomes),
+        "uploaded_files": uploaded_count,
+        "failed_files": len(outcomes) - uploaded_count,
+        "task_type": task_type,
+        "message": (f"Successfully uploaded {uploaded_count} of {len(outcomes)} files"),
+    }
+
+
 async def upload_public_chat_files(
     *,
     file: UploadFile | None,
@@ -860,7 +971,7 @@ async def upload_public_chat_files(
         # Stamp the task-less provenance marker so orphan GC (#973) can reap
         # these rows if the guest never completes task creation, without a
         # coarse task_id-IS-NULL sweep touching other paths' unbound drafts.
-        return await store_uploaded_files(
+        return await _store_public_upload_items(
             upload_items=upload_items,
             task_type=task_type,
             task_id=None,
@@ -881,7 +992,7 @@ async def upload_public_chat_files(
             detail="Upload authorization could not be finalized",
         )
 
-    return await store_uploaded_files(
+    return await _store_public_upload_items(
         upload_items=upload_items,
         task_type=task_type,
         task_id=task_id,
@@ -943,7 +1054,7 @@ async def upload_share_chat_files(
         # Stamp the task-less-share provenance marker so orphan GC (#973) can
         # reap these rows if the guest never completes task creation, without
         # a coarse task_id-IS-NULL sweep touching other paths' unbound drafts.
-        return await store_uploaded_files(
+        return await _store_public_upload_items(
             upload_items=upload_items,
             task_type=task_type,
             task_id=None,
@@ -964,7 +1075,7 @@ async def upload_share_chat_files(
             detail="Upload authorization could not be finalized",
         )
 
-    return await store_uploaded_files(
+    return await _store_public_upload_items(
         upload_items=upload_items,
         task_type=task_type,
         task_id=task_id,

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -18,6 +18,7 @@ from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.core.file_storage.storage import FsspecFileStorage
 from xagent.core.workspace import TaskWorkspace
 from xagent.web.api import files as files_api
+from xagent.web.api import public_chat_access as public_chat_access_api
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.public_chat_access import (
     PublicChatAccessContext,
@@ -652,6 +653,137 @@ def test_jwt_upload_releases_auth_session_before_durable_io(
         assert engine.pool.checkedout() == 0
     finally:
         engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auth_mode", ["widget", "share"])
+async def test_public_batch_upload_preserves_successful_sibling_outcomes(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_mode: str,
+) -> None:
+    """Public ``files`` batches isolate storage per item and correlate results."""
+
+    user = User(id=1, username="owner")
+    context = (
+        PublicChatAccessContext(
+            user=user,
+            channel_id=None,
+            guest_id="guest",
+            widget_workforce_id=1,
+        )
+        if auth_mode == "widget"
+        else ShareChatAccessContext(
+            user=user,
+            share_token="share",
+            guest_id="guest",
+            workforce=object(),  # type: ignore[arg-type]
+        )
+    )
+    stored: list[str] = []
+
+    async def store_each(*, upload_items, **_kwargs):  # type: ignore[no-untyped-def]
+        filename = upload_items[0].filename
+        stored.append(filename)
+        if filename.endswith("oversized.txt"):
+            raise HTTPException(
+                status_code=413, detail="File size exceeds maximum limit"
+            )
+        return {
+            "success": True,
+            "file_id": f"{filename}-id",
+            "filename": filename,
+            "file_size": 2,
+            "mime_type": "text/plain",
+            "content_preview": "",
+        }
+
+    monkeypatch.setattr(public_chat_access_api, "store_uploaded_files", store_each)
+    monkeypatch.setattr(
+        public_chat_access_api, "release_db_connection_if_clean", lambda _db: True
+    )
+    kwargs = {
+        "file": None,
+        "files": [
+            UploadFile(filename="ok.txt", file=io.BytesIO(b"ok")),
+            UploadFile(filename="../../oversized.txt", file=io.BytesIO(b"large")),
+        ],
+        "task_type": "general",
+        "message": "",
+        "task_id": None,
+        "folder": None,
+        "access_context": context,
+        "db": object(),
+    }
+
+    response = (
+        await upload_public_chat_files(**kwargs)  # type: ignore[arg-type]
+        if auth_mode == "widget"
+        else await upload_share_chat_files(**kwargs)  # type: ignore[arg-type]
+    )
+
+    assert stored == ["ok.txt", "../../oversized.txt"]
+    assert response == {
+        "success": True,
+        "files": [
+            {
+                "success": True,
+                "source_index": 0,
+                "file_id": "ok.txt-id",
+                "filename": "ok.txt",
+                "file_size": 2,
+                "mime_type": "text/plain",
+                "content_preview": "",
+            },
+            {
+                "success": False,
+                "source_index": 1,
+                "filename": "oversized.txt",
+                "error": "File size exceeds maximum limit",
+                "status_code": 413,
+            },
+        ],
+        "total_files": 2,
+        "uploaded_files": 1,
+        "failed_files": 1,
+        "task_type": "general",
+        "message": "Successfully uploaded 1 of 2 files",
+    }
+
+
+@pytest.mark.asyncio
+async def test_public_batch_upload_preserves_durable_storage_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = User(id=1, username="owner")
+    context = PublicChatAccessContext(
+        user=user,
+        channel_id=None,
+        guest_id="guest",
+        widget_workforce_id=1,
+    )
+
+    async def unavailable(**_kwargs):  # type: ignore[no-untyped-def]
+        raise HTTPException(status_code=503, detail="File storage is unavailable")
+
+    monkeypatch.setattr(public_chat_access_api, "store_uploaded_files", unavailable)
+    monkeypatch.setattr(
+        public_chat_access_api, "release_db_connection_if_clean", lambda _db: True
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await upload_public_chat_files(
+            file=None,
+            files=[UploadFile(filename="ok.txt", file=io.BytesIO(b"ok"))],
+            task_type="general",
+            message="",
+            task_id=None,
+            folder=None,
+            access_context=context,
+            db=object(),  # type: ignore[arg-type]
+        )
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == "File storage is unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -1,5 +1,6 @@
 """Test file upload API functionality - Fixed for multi-tenant architecture"""
 
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -522,8 +523,14 @@ class TestFileUpload:
         assert "x-accel-redirect" not in preview.headers
         assert preview.content == b"<h1>preview</h1>"
 
-    def test_upload_remote_storage_outage_returns_503_and_rolls_back(
-        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch
+    def test_upload_remote_storage_outage_returns_503_and_logs_cause(
+        self,
+        client,
+        test_db,
+        temp_uploads_dir,
+        auth_headers,
+        monkeypatch,
+        caplog,
     ):
         from xagent.core.file_storage.storage import FsspecFileStorage
 
@@ -533,6 +540,7 @@ class TestFileUpload:
             raise RuntimeError("simulated remote write outage")
 
         monkeypatch.setattr(FsspecFileStorage, "put_file", fail_put_file)
+        caplog.set_level(logging.WARNING, logger="xagent.web.api.files")
 
         response = client.post(
             "/api/files/upload",
@@ -542,7 +550,22 @@ class TestFileUpload:
         )
 
         assert response.status_code == 503
-        assert "durable storage" in response.json()["detail"].lower()
+        assert response.json() == {
+            "detail": "Durable storage is temporarily unavailable"
+        }
+        failure_record = next(
+            record
+            for record in caplog.records
+            if "Durable storage unavailable during upload" in record.getMessage()
+        )
+        assert failure_record.exc_info is not None
+        assert "operation=register_local_uploads" in failure_record.getMessage()
+        assert "backend=file" in failure_record.getMessage()
+        assert f"user_id={admin_user.id}" in failure_record.getMessage()
+        assert "task_id=None" in failure_record.getMessage()
+        assert "file_count=1" in failure_record.getMessage()
+        assert "simulated remote write outage" in caplog.text
+        assert "simulated remote write outage" not in response.text
         assert not list(temp_uploads_dir.rglob("outage.txt"))
 
         db = next(test_app.dependency_overrides[get_db]())

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -558,6 +558,7 @@ class TestFileUpload:
             for record in caplog.records
             if "Durable storage unavailable during upload" in record.getMessage()
         )
+        assert failure_record.levelno == logging.WARNING
         assert failure_record.exc_info is not None
         assert "operation=register_local_uploads" in failure_record.getMessage()
         assert "backend=file" in failure_record.getMessage()


### PR DESCRIPTION
## Summary

- serialize immediate chat attachment uploads through one component-owned FIFO with one active request
- share the queue across repeated selections while preserving successful attachments and identity-safe cancellation
- abort or suppress stale work on removal, disablement, unmount, and abandoned concurrent renders
- batch share/widget attachment sets into one multipart request instead of concurrent one-file requests
- reuse the backend's existing ordered `files` response contract for established public turns and workforce opening attachments
- log durable-storage exception chains with safe operation context while preserving the generic HTTP 503 response

This is a focused follow-up to #1494 for the remaining multi-file upload 503s.

## Testing

- `npm run --prefix frontend test:run -- src/components/chat/ChatInput.test.tsx src/lib/public-chat-file-upload.test.ts src/components/widget/public-agent-chat-page.test.tsx` (67 passed)
- `npm run --prefix frontend type-check`
- `uv run pytest tests/web/test_file_upload.py::TestFileUpload -q` (39 passed)
- `uv run pytest tests/web/test_file_upload.py::TestFileUpload::test_upload_remote_storage_outage_returns_503_and_logs_cause -q`
- `uv run pre-commit run --all-files`

## Notes

The complete `tests/web/test_file_upload.py` suite has three unchanged SVG preview tests returning 422 in the local environment. They reproduced on the clean baseline before this change and are outside this diff.
