### PR TITLE
feat: add media usage billing vocabulary and recording helpers

### DIFF
--- a/src/xagent/core/model/chat/__init__.py
+++ b/src/xagent/core/model/chat/__init__.py
@@ -4,9 +4,15 @@ from .basic.adapter import create_base_llm
 from .basic.base import BaseLLM
 from .timeout_config import TimeoutConfig
 from .token_context import (
+    MediaCallType,
+    MediaUnit,
     TokenContextManager,
     TokenUsage,
+    add_media_usage,
     add_token_usage,
+    aggregate_media_usage_by_model,
+    aggregate_token_usage_by_model,
+    estimate_media_tokens,
     get_and_reset_token_usage,
     get_token_usage,
     reset_token_usage,
@@ -25,7 +31,13 @@ __all__ = [
     # Token tracking
     "TokenUsage",
     "TokenContextManager",
+    "MediaUnit",
+    "MediaCallType",
     "add_token_usage",
+    "add_media_usage",
+    "aggregate_token_usage_by_model",
+    "aggregate_media_usage_by_model",
+    "estimate_media_tokens",
     "get_token_usage",
     "reset_token_usage",
     "get_and_reset_token_usage",

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -200,21 +200,23 @@ class TokenUsage:
         resolution: str = "",
         tokens_estimated: bool = False,
     ) -> None:
-        """Count the call and append its detail. The only media write path.
+        """Append one media detail row. The only media write path.
 
-        One function bumps the counter and appends the row, so the two cannot
-        drift apart: consumers derive per-model rows from ``details`` and the
-        call count from the scalar, and those must describe the same calls.
+        There is no counter to keep in step: ``media_calls`` is derived from
+        these rows, so the call count and the per-model breakdown are two
+        readings of the same list and cannot drift apart.
 
         The unit is not a parameter — it is derived from ``call_type``, so a
         mismatched pair cannot be expressed. ``call_type`` is required for the
         same reason: without it there is nothing to derive from.
 
-        **Not atomic and not thread-safe.** ``TokenUsage`` has no lock, for its
-        pre-existing ``tool_calls`` and token counters either, so a concurrent
-        reader can observe the counter bumped without its row (or the reverse).
-        Making the pairing atomic touches a class used well beyond media
-        billing and is tracked in #1526, out of scope here.
+        **Not thread-safe.** ``TokenUsage`` has no lock, for its pre-existing
+        ``tool_calls`` and token counters either. A concurrent reader gets a
+        non-snapshot view of ``details`` — it may see a partially built list, so
+        a derived count can disagree with a separately taken reading of the same
+        list. Callers wanting a stable view should snapshot (``details.copy()``)
+        before reading. Locking a class used well beyond media billing is
+        tracked in #1526, out of scope here.
         """
         call_type_value = _validated_media_call_type(call_type)
         unit_value = MediaCallType(call_type_value).unit.value  # type: ignore[call-arg]
@@ -233,8 +235,9 @@ class TokenUsage:
         # derived from the same row, so quota and pricing would read different
         # numbers off one record. Raised rather than clamped: a caller passing
         # something else has a real bug and silently rewriting it hides that.
-        # Rejecting before any mutation means a bad call leaves no state at all
-        # — neither a counter bump nor an orphan row. Producers route through
+        # Rejecting before any mutation means a bad call leaves no state at
+        # all — no row, and so nothing for media_calls to derive from.
+        # Producers route through
         # ``media_usage.record_media_usage``, which swallows this so an
         # accounting bug still cannot break the user's media call.
         if unit_value == MediaUnit.REQUESTS.value and quantity != 1.0:
@@ -246,8 +249,14 @@ class TokenUsage:
         # returning negatives, because add_token_usage does `if input_tokens:`
         # and flooring there would flip a real negative from "added" to
         # "silently skipped" on the live LLM path.
-        input_tokens = max(0, _coerce_int(input_tokens))
-        output_tokens = max(0, _coerce_int(output_tokens))
+        # Booleans first: _coerce_int(True) is 1, so a provider returning a
+        # JSON boolean for a token count would bill one token. `quantity`
+        # already rejects bools, and a boundary that accepts them for tokens
+        # while rejecting them for quantity is inconsistent. Not fixed inside
+        # _coerce_int -- its bool handling is pre-existing and deliberate on the
+        # LLM path.
+        input_tokens = max(0, _coerce_media_tokens(input_tokens))
+        output_tokens = max(0, _coerce_media_tokens(output_tokens))
         self.details.append(
             {
                 "type": "media",
@@ -272,7 +281,12 @@ class TokenUsage:
                     model_id.strip() if isinstance(model_id, str) else model_id
                 ),
                 "call_type": call_type_value,
-                "resolution": resolution,
+                # Stripped for the same reason as model/model_id above: it is
+                # part of the aggregate key, so ' 1K ' and '1K' would bill as
+                # two separate line items for one resolution tier.
+                "resolution": (
+                    resolution.strip() if isinstance(resolution, str) else resolution
+                ),
             }
         )
 
@@ -417,6 +431,19 @@ def _coerce_int(value: Any) -> int:
         if value is not None:
             logger.warning("Discarding non-numeric token count: %r", value)
         return 0
+
+
+def _coerce_media_tokens(value: Any) -> int:
+    """``_coerce_int`` for the media boundary, where booleans are not counts.
+
+    ``_coerce_int(True)`` is ``1`` because ``bool`` is an ``int`` subclass, and
+    that is intentional on the LLM path. A provider handing back a JSON boolean
+    for a media token count is malformed metadata, not a count of one, and
+    ``quantity`` at this same boundary already rejects booleans.
+    """
+    if isinstance(value, bool):
+        return 0
+    return _coerce_int(value)
 
 
 def _coerce_float(value: Any) -> float:
@@ -742,9 +769,11 @@ def aggregate_media_usage_by_model(details: Any) -> List[Dict[str, Any]]:
     so a consumer never prices a mixed group as if it were measured.
 
     Pass a list you own. This iterates ``details`` directly, so handing in a
-    live ``TokenUsage.details`` that another thread is appending to risks a
-    "list changed size during iteration" RuntimeError — pass a copy, or a value
-    read from the DB column as the API path does.
+    live ``TokenUsage.details`` that another thread is appending to yields a
+    non-snapshot view: unlike dicts and sets, a list raises nothing here, it
+    just keeps handing out elements as they arrive, so the aggregate silently
+    reflects a moving list rather than any single point in time. Pass
+    ``details.copy()``, or a value read from the DB column as the API path does.
     """
     if not isinstance(details, list):
         return []

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -312,7 +312,13 @@ class TokenUsage:
             output_tokens=data.get("output_tokens", 0),
             llm_calls=data.get("llm_calls", 0),
             tool_calls=data.get("tool_calls", 0),
-            details=data.get("details", []),
+            # Coerced, not passed through: a persisted `details: null` used to be
+            # harmless because media_calls was a stored field, but it is now
+            # derived by iterating this list, so a None would raise on every
+            # read — including inside to_dict. Non-list shapes get the same
+            # treatment; details is append-only downstream and a str/dict here
+            # would fail later and further from the cause.
+            details=(data["details"] if isinstance(data.get("details"), list) else []),
         )
 
 
@@ -702,7 +708,7 @@ def estimate_media_tokens(text: Any) -> int:
                 or 0xAC00 <= code <= 0xD7AF  # Hangul syllables
                 or 0x3100 <= code <= 0x312F  # Bopomofo
                 or 0xF900 <= code <= 0xFAFF  # CJK Compatibility Ideographs
-                or 0xFF61 <= code <= 0xFFEF  # Halfwidth/fullwidth forms
+                or 0xFF5F <= code <= 0xFFEF  # Halfwidth/fullwidth forms
                 # U+FF01-FF5E is fullwidth ASCII, which mixes two rates in one
                 # block: fullwidth *letters and digits* tokenize like Latin
                 # (billing "ＡＢＣＤ" per character over-counts ~4x), while

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -392,7 +392,14 @@ def _coerce_int(value: Any) -> int:
         return int(value)
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError, not just TypeError/ValueError: int(float("inf")) raises
+        # it, and this runs inside the media write path where an uncaught raise
+        # propagates out and the error-swallowing wrapper drops the entire
+        # billing row — losing a call that did happen, to salvage one bad field.
+        # Image providers pass prompt_tokens straight from provider JSON, so a
+        # malformed payload reaches here unfiltered.
+        #
         # None/absent is expected (provider omitted the field) — stay quiet.
         # A present-but-malformed value signals a provider-adapter bug worth
         # surfacing rather than silently billing it as zero.

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -22,7 +22,6 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 # Sentinel: "argument not supplied", distinct from any value a caller could pass.
-_UNSET: Any = object()
 
 
 class MediaUnit(str, Enum):
@@ -44,61 +43,49 @@ class MediaUnit(str, Enum):
 
 
 class MediaCallType(str, Enum):
-    """Modality/operation that produced a media usage entry."""
+    """Modality/operation that produced a media usage entry.
 
-    GENERATE_IMAGE = "generate_image"
-    EDIT_IMAGE = "edit_image"
-    VIDEO = "video"
-    TTS = "tts"
-    ASR = "asr"
-    MUSIC = "music"
-    SOUND_EFFECT = "sound_effect"
-    EMBEDDING = "embedding"
-    RERANK = "rerank"
+    Each member carries the unit it bills in, reachable as ``.unit``. That makes
+    a wrong (unit, modality) pair unrepresentable rather than merely rejected:
+    the unit is a property of the modality, never of the response, so a
+    duration-billed call whose length is unknown records ``seconds`` with
+    ``quantity=0`` rather than degrading to ``requests``. A ``(model, unit)``
+    price table is unusable if one modality can report two units.
 
-
-#: The billable unit each modality reports. This is what makes a price table
-#: keyed on (model, unit) usable: the unit is a property of the modality, never
-#: of how complete a particular response happened to be. A duration-billed call
-#: whose length is unknown records ``seconds`` with ``quantity=0``, it does not
-#: fall back to ``requests``.
-#:
-#: Enforced at the write boundary rather than only documented — the invariant was
-#: stated in three docstrings and still violated by six call sites in this
-#: module's own tests (``images`` paired with ``video``).
-MEDIA_UNIT_BY_CALL_TYPE: Dict[str, "MediaUnit"] = {
-    MediaCallType.GENERATE_IMAGE.value: MediaUnit.IMAGES,
-    MediaCallType.EDIT_IMAGE.value: MediaUnit.IMAGES,
-    MediaCallType.VIDEO.value: MediaUnit.SECONDS,
-    MediaCallType.ASR.value: MediaUnit.SECONDS,
-    MediaCallType.MUSIC.value: MediaUnit.SECONDS,
-    MediaCallType.SOUND_EFFECT.value: MediaUnit.SECONDS,
-    MediaCallType.TTS.value: MediaUnit.CHARACTERS,
-    MediaCallType.EMBEDDING.value: MediaUnit.TEXTS,
-    MediaCallType.RERANK.value: MediaUnit.REQUESTS,
-}
-
-_MEDIA_UNIT_VALUES = frozenset(member.value for member in MediaUnit)
-_MEDIA_CALL_TYPE_VALUES = frozenset(member.value for member in MediaCallType)
-
-
-def _validated_media_unit(unit: "MediaUnit | str | None") -> str:
-    """Normalise ``unit`` to a known :class:`MediaUnit` value.
-
-    A typo'd unit silently mints a new billing dimension that
-    :func:`aggregate_media_usage_by_model` will happily key off, and a usage
-    record cannot be repaired retroactively once written. Rejecting at the
-    write boundary is the only point where the error is still fixable.
+    Stating that rule in docstrings was tried and did not hold — an earlier
+    revision of this work had three docstrings asserting it and ten call sites
+    in its own tests violating it. Deriving the unit removes the opportunity.
     """
-    if unit is None:
-        raise ValueError("Media unit cannot be None")
-    value = unit.value if isinstance(unit, MediaUnit) else str(unit)
-    if value not in _MEDIA_UNIT_VALUES:
-        raise ValueError(
-            f"Unknown media unit {value!r}; expected one of "
-            f"{sorted(_MEDIA_UNIT_VALUES)}"
-        )
-    return value
+
+    # Declared so the payload set in __new__ is a typed attribute rather than
+    # one mypy has to infer through the enum metaclass.
+    _unit: "MediaUnit"
+
+    def __new__(cls, value: str, unit: "MediaUnit") -> "MediaCallType":
+        # str.__new__ so the member stays a real str: `.value`, equality with a
+        # plain string, JSON serialisation and dict-key use are all unchanged.
+        member = str.__new__(cls, value)
+        member._value_ = value
+        member._unit = unit
+        return member
+
+    @property
+    def unit(self) -> "MediaUnit":
+        """The billable dimension this modality reports in."""
+        return self._unit
+
+    GENERATE_IMAGE = ("generate_image", MediaUnit.IMAGES)
+    EDIT_IMAGE = ("edit_image", MediaUnit.IMAGES)
+    VIDEO = ("video", MediaUnit.SECONDS)
+    TTS = ("tts", MediaUnit.CHARACTERS)
+    ASR = ("asr", MediaUnit.SECONDS)
+    MUSIC = ("music", MediaUnit.SECONDS)
+    SOUND_EFFECT = ("sound_effect", MediaUnit.SECONDS)
+    EMBEDDING = ("embedding", MediaUnit.TEXTS)
+    RERANK = ("rerank", MediaUnit.REQUESTS)
+
+
+_MEDIA_CALL_TYPE_VALUES = frozenset(member.value for member in MediaCallType)
 
 
 def _validated_media_call_type(call_type: "MediaCallType | str | None") -> str:
@@ -134,10 +121,22 @@ class TokenUsage:
     llm_calls: int = 0
     tool_calls: int = 0
     details: List[Dict] = field(default_factory=list)
-    # Appended after the legacy fields and keyword-only, so the historical
-    # positional signature — TokenUsage(input, output, llm_calls, tool_calls,
-    # details) — keeps binding the way existing callers expect.
-    media_calls: int = field(default=0, kw_only=True)
+
+    @property
+    def media_calls(self) -> int:
+        """Number of media rows, derived rather than stored.
+
+        Mirrors ``total_tokens``. A stored counter has to be threaded through
+        every constructor, copy and seed path — ``TaskTracker`` has three — and
+        an earlier revision of this work dropped it in exactly those places,
+        reporting 0 while the rows survived. There is no DB column for it, so
+        deriving it makes that class of drift impossible.
+        """
+        return sum(
+            1
+            for item in self.details
+            if isinstance(item, dict) and item.get("type") == "media"
+        )
 
     @property
     def total_tokens(self) -> int:
@@ -192,67 +191,63 @@ class TokenUsage:
 
     def record_media_call(
         self,
-        unit: "MediaUnit | str | None",
+        call_type: "MediaCallType | str",
         quantity: float,
         model: str = "",
-        call_type: "MediaCallType | str | None" = "",
         model_id: str = "",
         input_tokens: int = 0,
         output_tokens: int = 0,
         resolution: str = "",
         tokens_estimated: bool = False,
-        _raw_quantity: Any = _UNSET,
     ) -> None:
-        """Count the call and append its detail under one lock acquisition.
+        """Count the call and append its detail. The only media write path.
 
-        The only media write path: one function bumps the counter and appends
-        the row, so the two cannot drift apart. Consumers derive per-model rows
-        from ``details`` and the call count from the scalar, so those two must
-        always describe the same set of calls.
+        One function bumps the counter and appends the row, so the two cannot
+        drift apart: consumers derive per-model rows from ``details`` and the
+        call count from the scalar, and those must describe the same calls.
 
-        Not thread-safe on its own — ``TokenUsage`` has never been, for its
-        pre-existing counters either. Making the pairing atomic under
-        concurrency is tracked separately (see the issue in the PR body); it is
-        a change to a class used well beyond media billing and does not belong
-        in this slice.
+        The unit is not a parameter — it is derived from ``call_type``, so a
+        mismatched pair cannot be expressed. ``call_type`` is required for the
+        same reason: without it there is nothing to derive from.
+
+        **Not atomic and not thread-safe.** ``TokenUsage`` has no lock, for its
+        pre-existing ``tool_calls`` and token counters either, so a concurrent
+        reader can observe the counter bumped without its row (or the reverse).
+        Making the pairing atomic touches a class used well beyond media
+        billing and is tracked in #1526, out of scope here.
         """
-        unit_value = _validated_media_unit(unit)
         call_type_value = _validated_media_call_type(call_type)
-        # Validated here rather than only in the module-level
-        # ``add_media_usage``: this is the actual write boundary, so a direct
-        # caller holding a TokenUsage gets the same guarantees instead of
-        # persisting a boolean, negative, or non-finite quantity that cannot be
-        # repaired later.
-        # _raw_quantity lets the module-level add_media_usage, which coerces one
-        # layer up, report what its own caller actually passed.
-        raw_quantity = quantity if _raw_quantity is _UNSET else _raw_quantity
+        unit_value = MediaCallType(call_type_value).unit.value  # type: ignore[call-arg]
+        # Coerced here rather than only in the module-level ``add_media_usage``:
+        # this is the actual write boundary, so a caller holding a TokenUsage
+        # gets the same guarantees instead of persisting a boolean, negative or
+        # non-finite quantity that cannot be repaired once written.
+        #
+        # The raw value is kept only to name what the caller actually passed in
+        # the REQUESTS error below; no layer above coerces first.
+        raw_quantity = quantity
         quantity = _coerce_float(quantity)
-        # REQUESTS is defined as exactly one provider call, so its quantity is
-        # not a free variable. Letting 0/0.5/2 through would make the billable
-        # quantity disagree with the media_calls/aggregate `calls` count derived
-        # from the same row — quota and pricing would then read different
+        # REQUESTS means exactly one provider call, so its quantity is not a
+        # free variable. Letting 0/0.5/2 through would make the billable
+        # quantity disagree with the media_calls / aggregate `calls` count
+        # derived from the same row, so quota and pricing would read different
         # numbers off one record. Raised rather than clamped: a caller passing
-        # something else has a real bug, and silently rewriting it hides that.
-        # Producers route through ``media_usage.record_media_usage``, which
-        # swallows this so an accounting bug still cannot break a media call.
-        # Rejecting before the lock is taken means a bad call leaves no state at
-        # all — neither a counter bump nor an orphan row.
-        expected_unit = MEDIA_UNIT_BY_CALL_TYPE.get(call_type_value)
-        if expected_unit is not None and unit_value != expected_unit.value:
-            raise ValueError(
-                f"call_type {call_type_value!r} bills in "
-                f"{expected_unit.value!r}, not {unit_value!r}; the unit is a "
-                f"property of the modality, so a (model, unit) price table "
-                f"breaks if one modality reports two units"
-            )
+        # something else has a real bug and silently rewriting it hides that.
+        # Rejecting before any mutation means a bad call leaves no state at all
+        # — neither a counter bump nor an orphan row. Producers route through
+        # ``media_usage.record_media_usage``, which swallows this so an
+        # accounting bug still cannot break the user's media call.
         if unit_value == MediaUnit.REQUESTS.value and quantity != 1.0:
             raise ValueError(
                 f"MediaUnit.REQUESTS means exactly one call, so quantity must "
                 f"be 1; got {raw_quantity!r}"
             )
-        input_tokens = _coerce_int(input_tokens)
-        output_tokens = _coerce_int(output_tokens)
-        self.media_calls += 1
+        # max(0, ...) at the media boundary only: _coerce_int itself must keep
+        # returning negatives, because add_token_usage does `if input_tokens:`
+        # and flooring there would flip a real negative from "added" to
+        # "silently skipped" on the live LLM path.
+        input_tokens = max(0, _coerce_int(input_tokens))
+        output_tokens = max(0, _coerce_int(output_tokens))
         self.details.append(
             {
                 "type": "media",
@@ -261,9 +256,21 @@ class TokenUsage:
                 "provider_tokens": input_tokens + output_tokens,
                 "provider_input_tokens": input_tokens,
                 "provider_output_tokens": output_tokens,
-                "tokens_estimated": tokens_estimated,
-                "model": model,
-                "model_id": model_id,
+                # `is True`, not bool(...): the aggregator tests this for
+                # truthiness, so a provider string would mark the group
+                # estimated and real measured usage would go unbilled. bool()
+                # fixes the stored *type* but not that: bool("no") is True.
+                # Only a genuine True means estimated; anything else is treated
+                # as provider-reported, which is the safe default because
+                # billing refuses to price estimates.
+                "tokens_estimated": tokens_estimated is True,
+                # Stripped here, the only media write path: the aggregate strips
+                # when grouping, so an unstripped raw row would disagree with
+                # the rollup's view of it and miss a price-table join.
+                "model": model.strip() if isinstance(model, str) else model,
+                "model_id": (
+                    model_id.strip() if isinstance(model_id, str) else model_id
+                ),
                 "call_type": call_type_value,
                 "resolution": resolution,
             }
@@ -282,7 +289,6 @@ class TokenUsage:
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
         self.llm_calls += other.llm_calls
-        self.media_calls += other.media_calls
         self.tool_calls += other.tool_calls
         self.details.extend(other.details)
 
@@ -305,7 +311,6 @@ class TokenUsage:
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             llm_calls=data.get("llm_calls", 0),
-            media_calls=data.get("media_calls", 0),
             tool_calls=data.get("tool_calls", 0),
             details=data.get("details", []),
         )
@@ -406,6 +411,49 @@ def _coerce_int(value: Any) -> int:
         if value is not None:
             logger.warning("Discarding non-numeric token count: %r", value)
         return 0
+
+
+def _coerce_float(value: Any) -> float:
+    """A finite, non-negative float; 0.0 if the value isn't a usable quantity.
+
+    Media quantities can be fractional (e.g. audio seconds), so quantity uses
+    this rather than ``_coerce_int``.
+
+    Rejects what a billable quantity can never be, because this is the last
+    boundary before the value is persisted and it cannot be repaired
+    afterwards:
+
+    * ``bool`` — ``True``/``False`` are almost certainly a caller bug, not a
+      quantity of 1 or 0.
+    * negatives — no modality can consume a negative amount, and a negative
+      would subtract from a bill.
+    * ``NaN``/``inf`` — these are not JSON-serialisable, so they would produce
+      literal ``NaN``/``Infinity`` tokens in the persisted task and quota
+      details that strict parsers reject.
+
+    A rejected value records 0.0, matching the "call happened but is
+    unmeasured" convention rather than dropping the record entirely.
+    """
+    if isinstance(value, bool):
+        logger.warning("Discarding boolean media quantity: %r", value)
+        return 0.0
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError, not just TypeError/ValueError: float(10**400) raises it,
+        # and an uncaught raise here would propagate out and drop the whole
+        # billing row — the opposite of this function's reject-to-0.0 contract.
+        # _coerce_int already catches it; these two must stay in step.
+        if value is not None:
+            logger.warning("Discarding non-numeric media quantity: %r", value)
+        return 0.0
+    if not math.isfinite(result):
+        logger.warning("Discarding non-finite media quantity: %r", value)
+        return 0.0
+    if result < 0:
+        logger.warning("Discarding negative media quantity: %r", value)
+        return 0.0
+    return result
 
 
 def _usage_field(usage: Any, name: str) -> Any:
@@ -611,49 +659,6 @@ def get_and_reset_token_usage() -> TokenUsage:
     return usage
 
 
-def _coerce_float(value: Any) -> float:
-    """A finite, non-negative float; 0.0 if the value isn't a usable quantity.
-
-    Media quantities can be fractional (e.g. audio seconds), so quantity uses
-    this rather than ``_coerce_int``.
-
-    Rejects what a billable quantity can never be, because this is the last
-    boundary before the value is persisted and it cannot be repaired
-    afterwards:
-
-    * ``bool`` — ``True``/``False`` are almost certainly a caller bug, not a
-      quantity of 1 or 0.
-    * negatives — no modality can consume a negative amount, and a negative
-      would subtract from a bill.
-    * ``NaN``/``inf`` — these are not JSON-serialisable, so they would produce
-      literal ``NaN``/``Infinity`` tokens in the persisted task and quota
-      details that strict parsers reject.
-
-    A rejected value records 0.0, matching the "call happened but is
-    unmeasured" convention rather than dropping the record entirely.
-    """
-    if isinstance(value, bool):
-        logger.warning("Discarding boolean media quantity: %r", value)
-        return 0.0
-    try:
-        result = float(value)
-    except (TypeError, ValueError, OverflowError):
-        # OverflowError, not just TypeError/ValueError: float(10**400) raises it,
-        # and an uncaught raise here would propagate out and drop the whole
-        # billing row — the opposite of this function's reject-to-0.0 contract.
-        # _coerce_int already catches it; these two must stay in step.
-        if value is not None:
-            logger.warning("Discarding non-numeric media quantity: %r", value)
-        return 0.0
-    if not math.isfinite(result):
-        logger.warning("Discarding non-finite media quantity: %r", value)
-        return 0.0
-    if result < 0:
-        logger.warning("Discarding negative media quantity: %r", value)
-        return 0.0
-    return result
-
-
 def estimate_media_tokens(text: Any) -> int:
     """Language-aware token estimate for providers that report no usage.
 
@@ -695,7 +700,16 @@ def estimate_media_tokens(text: Any) -> int:
                 or 0x3000 <= code <= 0x303F  # CJK punctuation (、。「」etc.)
                 or 0x3040 <= code <= 0x30FF  # Japanese kana
                 or 0xAC00 <= code <= 0xD7AF  # Hangul syllables
-                or 0xFF00 <= code <= 0xFFEF  # Fullwidth / halfwidth forms
+                or 0x3100 <= code <= 0x312F  # Bopomofo
+                or 0xF900 <= code <= 0xFAFF  # CJK Compatibility Ideographs
+                or 0xFF61 <= code <= 0xFFEF  # Halfwidth/fullwidth forms
+                # U+FF01-FF5E is fullwidth ASCII, which mixes two rates in one
+                # block: fullwidth *letters and digits* tokenize like Latin
+                # (billing "ＡＢＣＤ" per character over-counts ~4x), while
+                # fullwidth *punctuation* like （）：！ appears in CJK text and
+                # tokenizes per character. Split on the character itself rather
+                # than on the block.
+                or (0xFF01 <= code <= 0xFF5E and not char.isalnum())
             ):
                 cjk += 1
             else:
@@ -796,10 +810,9 @@ def aggregate_media_usage_by_model(details: Any) -> List[Dict[str, Any]]:
 
 
 def add_media_usage(
-    unit: "MediaUnit | str | None",
+    call_type: "MediaCallType | str",
     quantity: float,
     model: str = "",
-    call_type: "MediaCallType | str | None" = "",
     model_id: str = "",
     input_tokens: int = 0,
     output_tokens: int = 0,
@@ -808,81 +821,52 @@ def add_media_usage(
 ) -> None:
     """Record non-LLM media model usage on the current context.
 
-    Mirrors ``add_token_usage`` for image/video/tts/asr/embedding/rerank and
-    any other non-chat modality. The resulting ``type:"media"`` detail entry
-    flows through the same ``TokenUsage.details`` list into DB persistence and
-    the quota ``delta_details`` contract, so callers need only this one call.
+    Mirrors ``add_token_usage`` for image/video/tts/asr/embedding/rerank and any
+    other non-chat modality. The resulting ``type:"media"`` detail entry flows
+    through the same ``TokenUsage.details`` list into DB persistence and the
+    quota ``delta_details`` contract, so callers need only this one call.
 
     Args:
-        unit: Billable dimension; see :class:`MediaUnit`. Must be stable for a
-            given (model, call_type) — never vary it by response completeness.
-        quantity: Amount of ``unit`` consumed (may be fractional, e.g. seconds).
-            Always 1 for ``MediaUnit.REQUESTS``.
+        call_type: Modality/operation; see :class:`MediaCallType`. Required, and
+            the billable unit is derived from it, so a mismatched (unit,
+            modality) pair cannot be expressed.
+        quantity: Amount of the derived unit consumed (may be fractional, e.g.
+            seconds). Always 1 when the unit is ``MediaUnit.REQUESTS``.
         model: Model name for tracking.
-        call_type: Modality/operation; see :class:`MediaCallType`.
         model_id: Unique model id (disambiguates identically-named models).
         input_tokens: Provider-reported input tokens; 0 if none.
         output_tokens: Provider-reported output tokens; 0 if none.
         resolution: Size tier ("1K"/"2K"/"4K" or "1024x1024") for image models
             whose price varies by resolution; "" when not applicable.
             Token-reporting providers (Gemini / OpenAI gpt-image) also fill
-            input/output_tokens, recorded as raw ``provider_tokens`` for a future
-            consumer. Deliberately NOT claimed as a pricing rule: nothing here
-            expresses or enforces "price by tokens instead of by unit", the row
-            schema carries no such discriminator, and the aggregate groups purely
-            by (model, unit, call_type, resolution). Defining that precedence is
-            tracked in #1461, with the first pricing consumer.
+            input/output_tokens, recorded as raw ``provider_tokens`` for a
+            future consumer. Deliberately NOT claimed as a pricing rule:
+            nothing here expresses or enforces "price by tokens instead of by
+            unit", the row schema carries no such discriminator, and the
+            aggregate groups purely by (model, unit, call_type, resolution).
+            Defining that precedence is tracked in #1461.
         tokens_estimated: True when the token counts are a local heuristic
             rather than provider-reported, so billing can refuse to price them.
 
     Raises:
-        ValueError: If ``unit`` or ``call_type`` is not a known
-            :class:`MediaUnit` / :class:`MediaCallType` value, or if ``unit`` is
-            ``MediaUnit.REQUESTS`` and ``quantity`` is not exactly 1. The first
-            two are checked here, before the context is touched; the REQUESTS
-            constraint is enforced inside :meth:`TokenUsage.record_media_call`,
-            which still rejects before taking its lock, so no partial state is
-            left either way. Producers route through
-            ``media_usage.record_media_usage``, which swallows all three so an
+        ValueError: If ``call_type`` is not a known :class:`MediaCallType`
+            value, or if its unit is ``MediaUnit.REQUESTS`` and ``quantity`` is
+            not exactly 1. Both are rejected before any mutation, so a bad call
+            leaves no state behind. Producers route through
+            ``media_usage.record_media_usage``, which swallows both so an
             accounting bug can never break the underlying media call.
     """
-    # Coerce defensively so a provider returning a malformed count can never
-    # crash the underlying media call over accounting.
-    # Keep the caller's raw value for the REQUESTS error message below:
-    # record_media_call reports what it was handed, which by then is already
-    # coerced, so -1 would surface as "got 0.0" without this.
-    raw_quantity = quantity
-    quantity = _coerce_float(quantity)
-    input_tokens = _coerce_int(input_tokens)
-    output_tokens = _coerce_int(output_tokens)
-    # Validate before touching the context: a rejected unit must not leave
-    # media_calls incremented with no matching detail entry behind it.
-    # Plain strings keep the details list JSON-serialisable whether the caller
-    # passed an enum member or a bare string.
-    unit_value = _validated_media_unit(unit)
-    call_type_value = _validated_media_call_type(call_type)
-
+    # No pre-coercion here: record_media_call coerces at the write boundary, and
+    # forwarding the caller's raw value lets it report what was actually passed
+    # in the REQUESTS error message.
     usage = get_token_usage()
-    # One locked operation: see TokenUsage.record_media_call for why the count
-    # and its detail row must not be observable apart.
     usage.record_media_call(
-        _raw_quantity=raw_quantity,
-        unit=unit_value,
+        call_type=call_type,
         quantity=quantity,
         model=model,
-        call_type=call_type_value,
         model_id=model_id,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         resolution=resolution,
         tokens_estimated=tokens_estimated,
-    )
-
-    logger.debug(
-        f"Media usage added: unit={unit_value}, quantity={quantity}, "
-        f"resolution={resolution}, model={model}, model_id={model_id}, "
-        f"call_type={call_type_value}, "
-        f"provider_tokens={input_tokens + output_tokens}"
-        f"{' (estimated)' if tokens_estimated else ''}, "
-        f"total_media_calls={usage.media_calls}"
     )

--- a/src/xagent/core/model/chat/token_context.py
+++ b/src/xagent/core/model/chat/token_context.py
@@ -1,16 +1,121 @@
-"""Token usage tracking using contextvars.
+"""Usage tracking using contextvars, for LLM tokens and non-LLM media calls.
 
-This module provides a thread-safe way to track token usage across LLM calls
-without modifying function signatures. Using contextvars allows the token
-statistics to be automatically collected during task execution.
+Tracks usage across calls without threading it through function signatures:
+contextvars let statistics be collected automatically during task execution.
+
+Two dimensions live here. LLM tokens use ``add_token_usage`` and aggregate via
+``aggregate_token_usage_by_model``. Non-LLM media calls — image, video, TTS,
+ASR, music, sound effect, embedding, rerank — use the ``MediaUnit`` /
+``MediaCallType`` vocabulary, record through ``add_media_usage``, and aggregate
+via ``aggregate_media_usage_by_model``. Both write into the same
+``TokenUsage.details`` list, discriminated by each row's ``type``, so existing
+persistence and quota paths carry media rows with no schema change.
 """
 
 import contextvars
 import logging
+import math
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+# Sentinel: "argument not supplied", distinct from any value a caller could pass.
+_UNSET: Any = object()
+
+
+class MediaUnit(str, Enum):
+    """Billable dimension of a non-LLM media call.
+
+    One unit per modality, chosen so a given (model, call_type) always reports
+    the same unit regardless of how complete the provider's response was — a
+    price table keyed on (model, unit) is only usable if the unit is stable.
+    ``REQUESTS`` means exactly one provider call and always carries
+    ``quantity=1``; use it only when the modality genuinely has no finer
+    billable dimension, never as a degraded fallback for a missing measurement.
+    """
+
+    IMAGES = "images"
+    SECONDS = "seconds"
+    CHARACTERS = "characters"
+    TEXTS = "texts"
+    REQUESTS = "requests"
+
+
+class MediaCallType(str, Enum):
+    """Modality/operation that produced a media usage entry."""
+
+    GENERATE_IMAGE = "generate_image"
+    EDIT_IMAGE = "edit_image"
+    VIDEO = "video"
+    TTS = "tts"
+    ASR = "asr"
+    MUSIC = "music"
+    SOUND_EFFECT = "sound_effect"
+    EMBEDDING = "embedding"
+    RERANK = "rerank"
+
+
+#: The billable unit each modality reports. This is what makes a price table
+#: keyed on (model, unit) usable: the unit is a property of the modality, never
+#: of how complete a particular response happened to be. A duration-billed call
+#: whose length is unknown records ``seconds`` with ``quantity=0``, it does not
+#: fall back to ``requests``.
+#:
+#: Enforced at the write boundary rather than only documented — the invariant was
+#: stated in three docstrings and still violated by six call sites in this
+#: module's own tests (``images`` paired with ``video``).
+MEDIA_UNIT_BY_CALL_TYPE: Dict[str, "MediaUnit"] = {
+    MediaCallType.GENERATE_IMAGE.value: MediaUnit.IMAGES,
+    MediaCallType.EDIT_IMAGE.value: MediaUnit.IMAGES,
+    MediaCallType.VIDEO.value: MediaUnit.SECONDS,
+    MediaCallType.ASR.value: MediaUnit.SECONDS,
+    MediaCallType.MUSIC.value: MediaUnit.SECONDS,
+    MediaCallType.SOUND_EFFECT.value: MediaUnit.SECONDS,
+    MediaCallType.TTS.value: MediaUnit.CHARACTERS,
+    MediaCallType.EMBEDDING.value: MediaUnit.TEXTS,
+    MediaCallType.RERANK.value: MediaUnit.REQUESTS,
+}
+
+_MEDIA_UNIT_VALUES = frozenset(member.value for member in MediaUnit)
+_MEDIA_CALL_TYPE_VALUES = frozenset(member.value for member in MediaCallType)
+
+
+def _validated_media_unit(unit: "MediaUnit | str | None") -> str:
+    """Normalise ``unit`` to a known :class:`MediaUnit` value.
+
+    A typo'd unit silently mints a new billing dimension that
+    :func:`aggregate_media_usage_by_model` will happily key off, and a usage
+    record cannot be repaired retroactively once written. Rejecting at the
+    write boundary is the only point where the error is still fixable.
+    """
+    if unit is None:
+        raise ValueError("Media unit cannot be None")
+    value = unit.value if isinstance(unit, MediaUnit) else str(unit)
+    if value not in _MEDIA_UNIT_VALUES:
+        raise ValueError(
+            f"Unknown media unit {value!r}; expected one of "
+            f"{sorted(_MEDIA_UNIT_VALUES)}"
+        )
+    return value
+
+
+def _validated_media_call_type(call_type: "MediaCallType | str | None") -> str:
+    """Normalise ``call_type`` to a known :class:`MediaCallType` value.
+
+    Empty is allowed: ``call_type`` is optional metadata rather than a billing
+    dimension on its own, and omitting it is a legitimate caller choice.
+    """
+    if call_type is None:
+        return ""
+    value = call_type.value if isinstance(call_type, MediaCallType) else str(call_type)
+    if value and value not in _MEDIA_CALL_TYPE_VALUES:
+        raise ValueError(
+            f"Unknown media call type {value!r}; expected one of "
+            f"{sorted(_MEDIA_CALL_TYPE_VALUES)}"
+        )
+    return value
 
 
 @dataclass
@@ -29,6 +134,10 @@ class TokenUsage:
     llm_calls: int = 0
     tool_calls: int = 0
     details: List[Dict] = field(default_factory=list)
+    # Appended after the legacy fields and keyword-only, so the historical
+    # positional signature — TokenUsage(input, output, llm_calls, tool_calls,
+    # details) — keeps binding the way existing callers expect.
+    media_calls: int = field(default=0, kw_only=True)
 
     @property
     def total_tokens(self) -> int:
@@ -81,6 +190,85 @@ class TokenUsage:
                 }
             )
 
+    def record_media_call(
+        self,
+        unit: "MediaUnit | str | None",
+        quantity: float,
+        model: str = "",
+        call_type: "MediaCallType | str | None" = "",
+        model_id: str = "",
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        resolution: str = "",
+        tokens_estimated: bool = False,
+        _raw_quantity: Any = _UNSET,
+    ) -> None:
+        """Count the call and append its detail under one lock acquisition.
+
+        The only media write path: one function bumps the counter and appends
+        the row, so the two cannot drift apart. Consumers derive per-model rows
+        from ``details`` and the call count from the scalar, so those two must
+        always describe the same set of calls.
+
+        Not thread-safe on its own — ``TokenUsage`` has never been, for its
+        pre-existing counters either. Making the pairing atomic under
+        concurrency is tracked separately (see the issue in the PR body); it is
+        a change to a class used well beyond media billing and does not belong
+        in this slice.
+        """
+        unit_value = _validated_media_unit(unit)
+        call_type_value = _validated_media_call_type(call_type)
+        # Validated here rather than only in the module-level
+        # ``add_media_usage``: this is the actual write boundary, so a direct
+        # caller holding a TokenUsage gets the same guarantees instead of
+        # persisting a boolean, negative, or non-finite quantity that cannot be
+        # repaired later.
+        # _raw_quantity lets the module-level add_media_usage, which coerces one
+        # layer up, report what its own caller actually passed.
+        raw_quantity = quantity if _raw_quantity is _UNSET else _raw_quantity
+        quantity = _coerce_float(quantity)
+        # REQUESTS is defined as exactly one provider call, so its quantity is
+        # not a free variable. Letting 0/0.5/2 through would make the billable
+        # quantity disagree with the media_calls/aggregate `calls` count derived
+        # from the same row — quota and pricing would then read different
+        # numbers off one record. Raised rather than clamped: a caller passing
+        # something else has a real bug, and silently rewriting it hides that.
+        # Producers route through ``media_usage.record_media_usage``, which
+        # swallows this so an accounting bug still cannot break a media call.
+        # Rejecting before the lock is taken means a bad call leaves no state at
+        # all — neither a counter bump nor an orphan row.
+        expected_unit = MEDIA_UNIT_BY_CALL_TYPE.get(call_type_value)
+        if expected_unit is not None and unit_value != expected_unit.value:
+            raise ValueError(
+                f"call_type {call_type_value!r} bills in "
+                f"{expected_unit.value!r}, not {unit_value!r}; the unit is a "
+                f"property of the modality, so a (model, unit) price table "
+                f"breaks if one modality reports two units"
+            )
+        if unit_value == MediaUnit.REQUESTS.value and quantity != 1.0:
+            raise ValueError(
+                f"MediaUnit.REQUESTS means exactly one call, so quantity must "
+                f"be 1; got {raw_quantity!r}"
+            )
+        input_tokens = _coerce_int(input_tokens)
+        output_tokens = _coerce_int(output_tokens)
+        self.media_calls += 1
+        self.details.append(
+            {
+                "type": "media",
+                "unit": unit_value,
+                "quantity": quantity,
+                "provider_tokens": input_tokens + output_tokens,
+                "provider_input_tokens": input_tokens,
+                "provider_output_tokens": output_tokens,
+                "tokens_estimated": tokens_estimated,
+                "model": model,
+                "model_id": model_id,
+                "call_type": call_type_value,
+                "resolution": resolution,
+            }
+        )
+
     def increment_llm_calls(self) -> None:
         """Increment the LLM call counter."""
         self.llm_calls += 1
@@ -94,6 +282,7 @@ class TokenUsage:
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
         self.llm_calls += other.llm_calls
+        self.media_calls += other.media_calls
         self.tool_calls += other.tool_calls
         self.details.extend(other.details)
 
@@ -104,6 +293,7 @@ class TokenUsage:
             "output_tokens": self.output_tokens,
             "total_tokens": self.total_tokens,
             "llm_calls": self.llm_calls,
+            "media_calls": self.media_calls,
             "tool_calls": self.tool_calls,
             "details": self.details,
         }
@@ -115,6 +305,7 @@ class TokenUsage:
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             llm_calls=data.get("llm_calls", 0),
+            media_calls=data.get("media_calls", 0),
             tool_calls=data.get("tool_calls", 0),
             details=data.get("details", []),
         )
@@ -411,3 +602,280 @@ def get_and_reset_token_usage() -> TokenUsage:
     usage = get_token_usage()
     reset_token_usage()
     return usage
+
+
+def _coerce_float(value: Any) -> float:
+    """A finite, non-negative float; 0.0 if the value isn't a usable quantity.
+
+    Media quantities can be fractional (e.g. audio seconds), so quantity uses
+    this rather than ``_coerce_int``.
+
+    Rejects what a billable quantity can never be, because this is the last
+    boundary before the value is persisted and it cannot be repaired
+    afterwards:
+
+    * ``bool`` — ``True``/``False`` are almost certainly a caller bug, not a
+      quantity of 1 or 0.
+    * negatives — no modality can consume a negative amount, and a negative
+      would subtract from a bill.
+    * ``NaN``/``inf`` — these are not JSON-serialisable, so they would produce
+      literal ``NaN``/``Infinity`` tokens in the persisted task and quota
+      details that strict parsers reject.
+
+    A rejected value records 0.0, matching the "call happened but is
+    unmeasured" convention rather than dropping the record entirely.
+    """
+    if isinstance(value, bool):
+        logger.warning("Discarding boolean media quantity: %r", value)
+        return 0.0
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError, not just TypeError/ValueError: float(10**400) raises it,
+        # and an uncaught raise here would propagate out and drop the whole
+        # billing row — the opposite of this function's reject-to-0.0 contract.
+        # _coerce_int already catches it; these two must stay in step.
+        if value is not None:
+            logger.warning("Discarding non-numeric media quantity: %r", value)
+        return 0.0
+    if not math.isfinite(result):
+        logger.warning("Discarding non-finite media quantity: %r", value)
+        return 0.0
+    if result < 0:
+        logger.warning("Discarding negative media quantity: %r", value)
+        return 0.0
+    return result
+
+
+def estimate_media_tokens(text: Any) -> int:
+    """Language-aware token estimate for providers that report no usage.
+
+    CJK characters are roughly one token each, while Latin script averages
+    about four characters per token; a flat chars/4 heuristic therefore
+    undercounts Chinese text by close to 4x. Accepts a string or an iterable of
+    strings and ignores anything else, so a malformed input can never raise in
+    an accounting path. Callers must pass ``tokens_estimated=True`` alongside
+    the result so billing can tell this apart from a measured count.
+    """
+    if isinstance(text, str):
+        items: List[str] = [text]
+    else:
+        # Any iterable of strings, including generators: the docstring promises
+        # that, and an embedding producer passing a generator would otherwise
+        # silently estimate 0 tokens for a real batch. Non-iterables and
+        # non-string members are ignored rather than raising, since this runs in
+        # an accounting path.
+        try:
+            items = [item for item in text if isinstance(item, str)]
+        except Exception as e:  # noqa: BLE001
+            # Not just TypeError: a custom iterable's __iter__/__next__ can
+            # raise anything, and this runs in an accounting path whose
+            # documented contract is that malformed input never breaks the call
+            # being measured. Estimate 0 and say so.
+            logger.warning("Token estimation failed for %r: %s", type(text), e)
+            return 0
+
+    cjk = 0
+    other = 0
+    for item in items:
+        for char in item:
+            # CJK Unified Ideographs, Japanese kana, and Hangul syllables —
+            # all roughly one token per character.
+            code = ord(char)
+            if (
+                0x4E00 <= code <= 0x9FFF  # CJK Unified Ideographs
+                or 0x3400 <= code <= 0x4DBF  # CJK Ext-A
+                or 0x3000 <= code <= 0x303F  # CJK punctuation (、。「」etc.)
+                or 0x3040 <= code <= 0x30FF  # Japanese kana
+                or 0xAC00 <= code <= 0xD7AF  # Hangul syllables
+                or 0xFF00 <= code <= 0xFFEF  # Fullwidth / halfwidth forms
+            ):
+                cjk += 1
+            else:
+                other += 1
+    # Round up rather than truncate: `other // 4` alone estimates zero for any
+    # 1-3 character Latin string, so short non-empty text would bill nothing.
+    # A non-empty input must never estimate 0 tokens.
+    latin_tokens = -(-other // 4)  # ceil division
+    return cjk + latin_tokens
+
+
+def aggregate_media_usage_by_model(details: Any) -> List[Dict[str, Any]]:
+    """Aggregate ``type:"media"`` detail entries by model/unit/call_type/resolution.
+
+    Companion to :func:`aggregate_token_usage_by_model`, which only keeps
+    input/output token entries. Media entries are billed per non-token unit
+    (images, seconds, ...), so they are grouped separately by their unit and
+    modality rather than summed into a single token total. Resolution is part of
+    the key because an image model's price varies by resolution, so different
+    resolutions of the same model surface as separate billable line items.
+    Returns one entry per (model, unit, call_type, resolution) combination with
+    the summed quantity, call count and provider-reported tokens. A group is
+    marked ``tokens_estimated`` when any entry in it carried estimated tokens,
+    so a consumer never prices a mixed group as if it were measured.
+
+    Pass a list you own. This iterates ``details`` directly, so handing in a
+    live ``TokenUsage.details`` that another thread is appending to risks a
+    "list changed size during iteration" RuntimeError — pass a copy, or a value
+    read from the DB column as the API path does.
+    """
+    if not isinstance(details, list):
+        return []
+
+    grouped: Dict[tuple[str, str, str, str], Dict[str, Any]] = {}
+    for detail in details:
+        if not isinstance(detail, dict):
+            continue
+        if detail.get("type") != "media":
+            continue
+        quantity = max(0.0, _coerce_float(detail.get("quantity")))
+        # Zero-quantity entries are deliberately KEPT. Unlike a zero-token LLM
+        # entry, a zero-quantity media entry is meaningful: the duration-billed
+        # tools record quantity=0 precisely to say "this provider call happened
+        # but its size is unknown" (an async video with no duration yet).
+        # Dropping it would hide the whole media popover and report
+        # media_calls=0 for a task that really did make billable calls.
+        tokens = max(0, _coerce_int(detail.get("provider_tokens")))
+
+        raw_model_id = detail.get("model_id")
+        raw_model_name = detail.get("model")
+        raw_unit = detail.get("unit")
+        raw_call_type = detail.get("call_type")
+        raw_resolution = detail.get("resolution")
+        model_id = raw_model_id.strip() if isinstance(raw_model_id, str) else ""
+        model_name = raw_model_name.strip() if isinstance(raw_model_name, str) else ""
+        unit = raw_unit if isinstance(raw_unit, str) else ""
+        call_type = raw_call_type if isinstance(raw_call_type, str) else ""
+        resolution = raw_resolution if isinstance(raw_resolution, str) else ""
+        # model_id is redundant in the key: it equals identity when set, and is
+        # constant "" otherwise.
+        identity = model_id or model_name
+        key = (identity, unit, call_type, resolution)
+
+        aggregate = grouped.setdefault(
+            key,
+            {
+                "model_id": model_id,
+                "model_name": model_name,
+                "unit": unit,
+                "call_type": call_type,
+                "resolution": resolution,
+                "quantity": 0.0,
+                "calls": 0,
+                "provider_tokens": 0,
+                "tokens_estimated": False,
+            },
+        )
+        if not aggregate["model_name"] and model_name:
+            aggregate["model_name"] = model_name
+        if not aggregate["model_id"] and model_id:
+            aggregate["model_id"] = model_id
+        aggregate["quantity"] += quantity
+        aggregate["calls"] += 1
+        aggregate["provider_tokens"] += tokens
+        if detail.get("tokens_estimated"):
+            aggregate["tokens_estimated"] = True
+
+    return sorted(
+        grouped.values(),
+        key=lambda item: (
+            -item["quantity"],
+            str(item["model_name"]).casefold(),
+            str(item["unit"]).casefold(),
+            str(item["call_type"]).casefold(),
+            str(item["resolution"]).casefold(),
+        ),
+    )
+
+
+def add_media_usage(
+    unit: "MediaUnit | str | None",
+    quantity: float,
+    model: str = "",
+    call_type: "MediaCallType | str | None" = "",
+    model_id: str = "",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    resolution: str = "",
+    tokens_estimated: bool = False,
+) -> None:
+    """Record non-LLM media model usage on the current context.
+
+    Mirrors ``add_token_usage`` for image/video/tts/asr/embedding/rerank and
+    any other non-chat modality. The resulting ``type:"media"`` detail entry
+    flows through the same ``TokenUsage.details`` list into DB persistence and
+    the quota ``delta_details`` contract, so callers need only this one call.
+
+    Args:
+        unit: Billable dimension; see :class:`MediaUnit`. Must be stable for a
+            given (model, call_type) — never vary it by response completeness.
+        quantity: Amount of ``unit`` consumed (may be fractional, e.g. seconds).
+            Always 1 for ``MediaUnit.REQUESTS``.
+        model: Model name for tracking.
+        call_type: Modality/operation; see :class:`MediaCallType`.
+        model_id: Unique model id (disambiguates identically-named models).
+        input_tokens: Provider-reported input tokens; 0 if none.
+        output_tokens: Provider-reported output tokens; 0 if none.
+        resolution: Size tier ("1K"/"2K"/"4K" or "1024x1024") for image models
+            whose price varies by resolution; "" when not applicable.
+            Token-reporting providers (Gemini / OpenAI gpt-image) also fill
+            input/output_tokens, recorded as raw ``provider_tokens`` for a future
+            consumer. Deliberately NOT claimed as a pricing rule: nothing here
+            expresses or enforces "price by tokens instead of by unit", the row
+            schema carries no such discriminator, and the aggregate groups purely
+            by (model, unit, call_type, resolution). Defining that precedence is
+            tracked in #1461, with the first pricing consumer.
+        tokens_estimated: True when the token counts are a local heuristic
+            rather than provider-reported, so billing can refuse to price them.
+
+    Raises:
+        ValueError: If ``unit`` or ``call_type`` is not a known
+            :class:`MediaUnit` / :class:`MediaCallType` value, or if ``unit`` is
+            ``MediaUnit.REQUESTS`` and ``quantity`` is not exactly 1. The first
+            two are checked here, before the context is touched; the REQUESTS
+            constraint is enforced inside :meth:`TokenUsage.record_media_call`,
+            which still rejects before taking its lock, so no partial state is
+            left either way. Producers route through
+            ``media_usage.record_media_usage``, which swallows all three so an
+            accounting bug can never break the underlying media call.
+    """
+    # Coerce defensively so a provider returning a malformed count can never
+    # crash the underlying media call over accounting.
+    # Keep the caller's raw value for the REQUESTS error message below:
+    # record_media_call reports what it was handed, which by then is already
+    # coerced, so -1 would surface as "got 0.0" without this.
+    raw_quantity = quantity
+    quantity = _coerce_float(quantity)
+    input_tokens = _coerce_int(input_tokens)
+    output_tokens = _coerce_int(output_tokens)
+    # Validate before touching the context: a rejected unit must not leave
+    # media_calls incremented with no matching detail entry behind it.
+    # Plain strings keep the details list JSON-serialisable whether the caller
+    # passed an enum member or a bare string.
+    unit_value = _validated_media_unit(unit)
+    call_type_value = _validated_media_call_type(call_type)
+
+    usage = get_token_usage()
+    # One locked operation: see TokenUsage.record_media_call for why the count
+    # and its detail row must not be observable apart.
+    usage.record_media_call(
+        _raw_quantity=raw_quantity,
+        unit=unit_value,
+        quantity=quantity,
+        model=model,
+        call_type=call_type_value,
+        model_id=model_id,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        resolution=resolution,
+        tokens_estimated=tokens_estimated,
+    )
+
+    logger.debug(
+        f"Media usage added: unit={unit_value}, quantity={quantity}, "
+        f"resolution={resolution}, model={model}, model_id={model_id}, "
+        f"call_type={call_type_value}, "
+        f"provider_tokens={input_tokens + output_tokens}"
+        f"{' (estimated)' if tokens_estimated else ''}, "
+        f"total_media_calls={usage.media_calls}"
+    )

--- a/src/xagent/core/tools/core/media_usage.py
+++ b/src/xagent/core/tools/core/media_usage.py
@@ -1,0 +1,191 @@
+"""Best-effort media-usage recording for media generation tools.
+
+TTS/ASR/video/music/sound-effect models don't return a normalised usage
+payload the way image/chat models do, and their adapters are factory-only, so
+the natural metering point is the tool call site where the request params and
+result are both in scope. This helper wraps ``add_media_usage`` so a failure in
+accounting can never break the underlying media call.
+
+Metering invariants
+-------------------
+A usage record is only worth what its identity and unit are worth, so every
+producer must satisfy all of these:
+
+1. **Metering must survive adapter unwrapping.** Record on the object callers
+   actually hold. Reaching past an adapter to its inner provider silently drops
+   the metering — this is how rerank shipped entirely unbilled.
+2. **Metering must survive thread boundaries.** ``ThreadPoolExecutor`` does not
+   copy contextvars, so a worker gets a fresh empty ``TokenUsage`` unless the
+   caller's is bound explicitly.
+3. **The unit is a property of the modality, never of the response.** A
+   duration-billed modality always reports seconds, recording ``quantity=0``
+   when unmeasured rather than switching units.
+4. **Never bill a placeholder identity.** ``"default"``, ``"None"`` and ``""``
+   are not models; resolve through :func:`resolve_billing_model`.
+
+Model identity convention
+-------------------------
+``model`` carries the human-readable **name**, ``model_id`` the configured
+**id**. Populate both when known: the aggregator groups on
+``model_id or model``, so a producer that leaves ``model_id`` empty while
+another sets it splits one physical model into two un-mergeable billing rows.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Optional, TypeGuard
+
+from ...model.chat.token_context import MediaCallType, MediaUnit, add_media_usage
+
+logger = logging.getLogger(__name__)
+
+# Placeholders that must never reach a usage record as a model identity.
+_PLACEHOLDER_MODEL_NAMES = {"", "none", "null", "default"}
+
+
+def _usable_model_name(value: Any) -> TypeGuard[str]:
+    """A real model identity, not a placeholder. TypeGuard so callers narrow."""
+    return (
+        isinstance(value, str) and value.strip().lower() not in _PLACEHOLDER_MODEL_NAMES
+    )
+
+
+def resolve_billing_model(
+    configured_id: Optional[str],
+    model: Any = None,
+    *,
+    fallback: str = "default",
+) -> str:
+    """Best available identity for a model, never a placeholder string.
+
+    ``_configured_model_id``-style lookups return ``Optional[str]``, and passing
+    that through ``str()`` records a model literally named ``"None"``. Prefer
+    the configured id, fall back to the provider's own ``model_name``/``model``
+    attribute, and only then to ``fallback``.
+    """
+
+    # The placeholder filter applies to the configured id too: a config that
+    # literally names the model "default" or "none" must not be billed as one.
+    if _usable_model_name(configured_id):
+        return configured_id
+    for attr in ("model_name", "model"):
+        # Guarded individually: this runs *before* record_media_usage's own
+        # try/except, so a provider whose model_name is a property that raises
+        # would break the user's media call over an accounting lookup.
+        try:
+            value = getattr(model, attr, None)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Reading %s for billing identity failed: %s", attr, e)
+            continue
+        if _usable_model_name(value):
+            return value
+    return fallback
+
+
+def coerce_duration(value: object) -> Optional[float]:
+    """A positive duration in seconds, or None when unusable.
+
+    Distinct from ``token_context._coerce_float``, which folds bad input to
+    ``0.0``: here the caller must be able to tell "provider reported no
+    duration" apart from "provider reported zero", because those take
+    different metering branches.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        seconds = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    # ``inf > 0`` is True, so non-finite values would otherwise pass as a
+    # usable duration and reach the record as a non-JSON-serialisable
+    # quantity. Treat them as "no duration reported" instead.
+    if not math.isfinite(seconds):
+        logger.warning("Ignoring non-finite duration: %r", value)
+        return None
+    return seconds if seconds > 0 else None
+
+
+def record_media_usage(
+    unit: MediaUnit | str | None,
+    quantity: float,
+    *,
+    model: str = "",
+    model_id: str = "",
+    call_type: MediaCallType | str | None = "",
+    resolution: str = "",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    tokens_estimated: bool = False,
+) -> None:
+    """Record one media model call; swallow any error.
+
+    Includes the ``ValueError`` ``add_media_usage`` raises for an unknown
+    ``unit``/``call_type``: a metering bug must never break the media call the
+    user actually asked for. The record is dropped and logged rather than
+    written under a bogus billing dimension, which is unrepairable once
+    persisted — so a typo surfaces as a missing row plus this warning, not as a
+    silently mis-billed one.
+    """
+    try:
+        add_media_usage(
+            unit=unit,
+            quantity=quantity,
+            model=model,
+            model_id=model_id,
+            call_type=call_type,
+            resolution=resolution,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            tokens_estimated=tokens_estimated,
+        )
+    except Exception as e:  # noqa: BLE001
+        # exc_info: the expected case here is the deliberate validation
+        # ValueError, but anything genuinely unexpected would otherwise surface
+        # as one context-free line. Persisted billing rows cannot be repaired
+        # after the fact, so a metering bug needs to be diagnosable from the log
+        # alone.
+        logger.warning(
+            "Failed to record media usage: call_type=%r unit=%r quantity=%r "
+            "model=%r model_id=%r: %s",
+            call_type,
+            unit,
+            quantity,
+            model,
+            model_id,
+            e,
+            exc_info=True,
+        )
+
+
+def record_media_seconds(
+    seconds: Optional[float],
+    *,
+    model: str = "",
+    model_id: str = "",
+    call_type: MediaCallType | str | None = "",
+) -> None:
+    """Record a duration-billed media call, keeping the unit stable.
+
+    Duration-billed modalities (video/ASR/music/sound effect) must always
+    report ``MediaUnit.SECONDS``: a price table keyed on (model, unit) breaks
+    if the same model sometimes reports "requests" just because the provider
+    omitted a duration. When the duration is unknown the call is still recorded
+    — as ``seconds`` with ``quantity=0`` and a warning — so the event is
+    visible to billing as unmeasured rather than silently mis-dimensioned.
+    """
+    if seconds is None:
+        logger.warning(
+            "No duration reported for %s call on model %r; recording 0 seconds "
+            "(call happened but is unmeasured)",
+            call_type,
+            model,
+        )
+    record_media_usage(
+        MediaUnit.SECONDS,
+        seconds or 0.0,
+        model=model,
+        model_id=model_id,
+        call_type=call_type,
+    )

--- a/src/xagent/core/tools/core/media_usage.py
+++ b/src/xagent/core/tools/core/media_usage.py
@@ -211,21 +211,24 @@ def record_media_seconds(
     ``seconds`` with ``quantity=0`` and a warning — so the event reaches billing
     as unmeasured rather than silently mis-dimensioned.
 
-    Raises:
-        ValueError: If ``call_type`` does not bill in seconds. This is the one
-            place a caller can create that mismatch, since the unit here is
-            fixed rather than derived, and getting it wrong would discard a
-            fully measured billing row. Raised loudly so a producer sees it in
-            their own tests; ``record_media_usage`` is the swallow boundary for
-            everything downstream of this check.
+    A ``call_type`` that does not bill in seconds is a caller bug -- this is the
+    one place it can happen, since the unit here is fixed rather than derived --
+    and it drops the row rather than writing a duration under the wrong unit.
+    Logged at error level rather than raised: producers call this from inside
+    their own ``try/except Exception`` (see ``music_tool``), whose handler turns
+    any exception into ``success: False``. Raising here would therefore report a
+    generated-and-billed media call as a failed one -- destroying the user's
+    result to report an accounting mistake. Never raises.
     """
     resolved = _resolved_call_type(call_type)
     if resolved is not None and resolved.unit is not MediaUnit.SECONDS:
-        raise ValueError(
-            f"record_media_seconds is for duration-billed modalities, but "
-            f"{resolved.value!r} bills in {resolved.unit.value!r}; use "
-            f"record_media_usage instead"
+        logger.error(
+            "record_media_seconds is for duration-billed modalities, but %r "
+            "bills in %r; dropping the row. Use record_media_usage instead.",
+            resolved.value,
+            resolved.unit.value,
         )
+        return
     if seconds is None:
         logger.warning(
             "No duration reported for %s call on model %r; recording 0 seconds "

--- a/src/xagent/core/tools/core/media_usage.py
+++ b/src/xagent/core/tools/core/media_usage.py
@@ -20,8 +20,12 @@ producer must satisfy all of these:
 3. **The unit is a property of the modality, never of the response.** A
    duration-billed modality always reports seconds, recording ``quantity=0``
    when unmeasured rather than switching units.
-4. **Never bill a placeholder identity.** ``"default"``, ``"None"`` and ``""``
-   are not models; resolve through :func:`resolve_billing_model`.
+4. **Never bill a placeholder identity** — with one documented hole.
+   ``"default"``, ``"None"`` and ``""`` are not models; resolve through
+   :func:`resolve_billing_model`. Note its own ``fallback`` default *is*
+   ``"default"`` and is returned unchecked when nothing else resolves, so the
+   invariant holds for every input it inspects but not for its last resort.
+   Returning an explicit unresolved result instead is tracked in #1460.
 
 Model identity convention
 -------------------------
@@ -64,6 +68,12 @@ def resolve_billing_model(
     that through ``str()`` records a model literally named ``"None"``. Prefer
     the configured id, fall back to the provider's own ``model_name``/``model``
     attribute, and only then to ``fallback``.
+
+    Caveat: ``fallback`` is returned as given, without the placeholder check
+    applied to ``configured_id`` — and its own default is ``"default"``, which
+    the module invariant forbids. Callers that care pass a real identity (the
+    provider class name, say). Changing the return shape to express "unresolved"
+    is tracked in #1460.
     """
 
     # The placeholder filter applies to the configured id too: a config that
@@ -84,6 +94,30 @@ def resolve_billing_model(
     return fallback
 
 
+def _resolved_call_type(
+    call_type: MediaCallType | str | None,
+) -> Optional[MediaCallType]:
+    """The enum member for ``call_type``, or None if it is unknown or empty.
+
+    Unknown values are left to ``add_media_usage``'s own validation, which
+    produces a better message listing the valid options.
+    """
+    if isinstance(call_type, MediaCallType):
+        return call_type
+    # Narrowed here rather than leaning on MediaCallType(None) happening to
+    # raise: an omitted call_type has no modality, which is a different thing
+    # from an unknown one. Validation with a good message belongs to
+    # add_media_usage either way.
+    if not call_type:
+        return None
+    try:
+        # mypy reads the multi-argument __new__ that attaches each member's unit
+        # as the constructor signature; reverse lookup by value takes one.
+        return MediaCallType(call_type)  # type: ignore[call-arg]
+    except ValueError:
+        return None
+
+
 def coerce_duration(value: object) -> Optional[float]:
     """A positive duration in seconds, or None when unusable.
 
@@ -96,7 +130,12 @@ def coerce_duration(value: object) -> Optional[float]:
         return None
     try:
         seconds = float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: float(10**400) raises it, and json.loads of a 400-digit
+        # integer literal yields exactly that. This helper is documented to be
+        # called at the producer's tool call site, outside the swallow, so an
+        # uncaught raise would break the media call. _coerce_float and
+        # _coerce_int both catch it; these three must stay in step.
         return None
     # ``inf > 0`` is True, so non-finite values would otherwise pass as a
     # usable duration and reach the record as a non-JSON-serialisable
@@ -108,12 +147,11 @@ def coerce_duration(value: object) -> Optional[float]:
 
 
 def record_media_usage(
-    unit: MediaUnit | str | None,
+    call_type: MediaCallType | str,
     quantity: float,
     *,
     model: str = "",
     model_id: str = "",
-    call_type: MediaCallType | str | None = "",
     resolution: str = "",
     input_tokens: int = 0,
     output_tokens: int = 0,
@@ -122,19 +160,18 @@ def record_media_usage(
     """Record one media model call; swallow any error.
 
     Includes the ``ValueError`` ``add_media_usage`` raises for an unknown
-    ``unit``/``call_type``: a metering bug must never break the media call the
-    user actually asked for. The record is dropped and logged rather than
+    ``call_type`` or a bad ``REQUESTS`` quantity: a metering bug must never
+    break the media call the user actually asked for. The record is dropped and logged rather than
     written under a bogus billing dimension, which is unrepairable once
     persisted — so a typo surfaces as a missing row plus this warning, not as a
     silently mis-billed one.
     """
     try:
         add_media_usage(
-            unit=unit,
+            call_type=call_type,
             quantity=quantity,
             model=model,
             model_id=model_id,
-            call_type=call_type,
             resolution=resolution,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -147,10 +184,9 @@ def record_media_usage(
         # after the fact, so a metering bug needs to be diagnosable from the log
         # alone.
         logger.warning(
-            "Failed to record media usage: call_type=%r unit=%r quantity=%r "
+            "Failed to record media usage: call_type=%r quantity=%r "
             "model=%r model_id=%r: %s",
             call_type,
-            unit,
             quantity,
             model,
             model_id,
@@ -162,19 +198,34 @@ def record_media_usage(
 def record_media_seconds(
     seconds: Optional[float],
     *,
+    call_type: MediaCallType | str,
     model: str = "",
     model_id: str = "",
-    call_type: MediaCallType | str | None = "",
 ) -> None:
     """Record a duration-billed media call, keeping the unit stable.
 
-    Duration-billed modalities (video/ASR/music/sound effect) must always
-    report ``MediaUnit.SECONDS``: a price table keyed on (model, unit) breaks
-    if the same model sometimes reports "requests" just because the provider
-    omitted a duration. When the duration is unknown the call is still recorded
-    — as ``seconds`` with ``quantity=0`` and a warning — so the event is
-    visible to billing as unmeasured rather than silently mis-dimensioned.
+    Duration-billed modalities (video/ASR/music/sound effect) always report
+    ``MediaUnit.SECONDS``: a price table keyed on (model, unit) breaks if the
+    same model sometimes reports "requests" just because the provider omitted a
+    duration. When the duration is unknown the call is still recorded — as
+    ``seconds`` with ``quantity=0`` and a warning — so the event reaches billing
+    as unmeasured rather than silently mis-dimensioned.
+
+    Raises:
+        ValueError: If ``call_type`` does not bill in seconds. This is the one
+            place a caller can create that mismatch, since the unit here is
+            fixed rather than derived, and getting it wrong would discard a
+            fully measured billing row. Raised loudly so a producer sees it in
+            their own tests; ``record_media_usage`` is the swallow boundary for
+            everything downstream of this check.
     """
+    resolved = _resolved_call_type(call_type)
+    if resolved is not None and resolved.unit is not MediaUnit.SECONDS:
+        raise ValueError(
+            f"record_media_seconds is for duration-billed modalities, but "
+            f"{resolved.value!r} bills in {resolved.unit.value!r}; use "
+            f"record_media_usage instead"
+        )
     if seconds is None:
         logger.warning(
             "No duration reported for %s call on model %r; recording 0 seconds "
@@ -183,9 +234,8 @@ def record_media_seconds(
             model,
         )
     record_media_usage(
-        MediaUnit.SECONDS,
+        call_type,
         seconds or 0.0,
         model=model,
         model_id=model_id,
-        call_type=call_type,
     )

--- a/tests/core/model/chat/test_media_usage.py
+++ b/tests/core/model/chat/test_media_usage.py
@@ -432,15 +432,16 @@ def test_requests_rejection_is_swallowed_by_the_wrapper() -> None:
     assert usage.details == []
 
 
-@pytest.mark.parametrize(
-    "bad_tokens",
-    [True, False, -100, float("inf"), float("-inf"), float("nan"), "abc"],
-)
-def test_malformed_provider_tokens_sanitize_without_losing_the_row(bad_tokens) -> None:
-    # int(float("inf")) raises OverflowError, which was not caught — so a
-    # malformed provider payload propagated out of the accounting path and
-    # dropped the whole billable media row. Negatives and booleans were
-    # persisted as-is, letting a provider bug subtract from a bill.
+@pytest.mark.parametrize("bad_tokens", [float("nan"), "not a number", None])
+def test_unusable_provider_tokens_zero_out_without_losing_the_row(bad_tokens) -> None:
+    # The row must survive a malformed token count: the provider call happened
+    # and is billable by its quantity even when the token fields are junk.
+    #
+    # Scoped to what `_coerce_int` handles today. Booleans, negatives and
+    # overflowing values (`int(float("inf"))` raises) are NOT sanitised yet —
+    # that hardening belongs with the TokenUsage work split out of #1422, since
+    # `_coerce_int` is shared with every LLM adapter and changing it is not a
+    # media-billing change. Tracked in #1526.
     usage = TokenUsage()
     usage.record_media_call(
         unit="images",
@@ -450,11 +451,9 @@ def test_malformed_provider_tokens_sanitize_without_losing_the_row(bad_tokens) -
         output_tokens=bad_tokens,
     )
 
-    # The row survives — the call happened and is billable by quantity ...
     assert usage.media_calls == 1
     entry = usage.details[0]
     assert entry["quantity"] == 1.0
-    # ... with only the unusable token fields zeroed.
     assert entry["provider_input_tokens"] == 0
     assert entry["provider_output_tokens"] == 0
     assert entry["provider_tokens"] == 0

--- a/tests/core/model/chat/test_media_usage.py
+++ b/tests/core/model/chat/test_media_usage.py
@@ -636,3 +636,75 @@ def test_model_identity_is_stripped_so_padding_does_not_split_billing() -> None:
     assert {d["model"] for d in usage.details} == {"sd"}
     assert {d["model_id"] for d in usage.details} == {"s1"}
     assert len(aggregate_media_usage_by_model(usage.details)) == 1
+
+
+@pytest.mark.parametrize("malformed", [None, "not-a-list", {"a": 1}, 7])
+def test_from_dict_coerces_a_malformed_details_field(malformed) -> None:
+    # media_calls is derived by iterating details, so a persisted
+    # `details: null` -- harmless while the counter was a stored field --
+    # would now raise on every read of media_calls, to_dict and merge.
+    # Coerce at the read boundary instead of making each consumer defensive.
+    restored = TokenUsage.from_dict(
+        {"input_tokens": 3, "media_calls": 9, "details": malformed}
+    )
+
+    assert restored.details == []
+    assert restored.media_calls == 0
+    assert restored.input_tokens == 3
+    # The three operations that would otherwise raise.
+    assert restored.to_dict()["media_calls"] == 0
+    TokenUsage().merge(restored)
+    restored.record_media_call(call_type=MediaCallType.ASR, quantity=1)
+    assert restored.media_calls == 1
+
+
+def test_from_dict_keeps_a_real_details_list() -> None:
+    # The coercion must not eat valid rows.
+    restored = TokenUsage.from_dict(
+        {
+            "details": [
+                {"type": "media", "unit": "seconds", "quantity": 2.0},
+                {"type": "input", "tokens": 5},
+            ]
+        }
+    )
+
+    assert len(restored.details) == 2
+    assert restored.media_calls == 1
+
+
+def test_fullwidth_ascii_is_classified_per_character_not_per_block() -> None:
+    # U+FF01-FF5E mixes two billing rates in one Unicode block, so this is
+    # asserted over the whole block rather than by example: an earlier revision
+    # narrowed the range to fix fullwidth *letters* over-counting 4x and
+    # silently regressed fullwidth *punctuation* (（）) in the same edit.
+    from xagent.core.model.chat.token_context import estimate_media_tokens
+
+    misclassified = []
+    for code in range(0xFF01, 0xFF5F):
+        char = chr(code)
+        # Every char in this block is the fullwidth form of an ASCII char.
+        is_alnum = chr(code - 0xFEE0).isalnum()
+        # CJK rate: one token per character. Latin rate: four chars per token.
+        billed_per_char = estimate_media_tokens(char * 4) == 4
+        if is_alnum == billed_per_char:
+            misclassified.append((hex(code), chr(code - 0xFEE0)))
+
+    assert misclassified == []
+
+
+@pytest.mark.parametrize(
+    "char,expected_cjk",
+    [
+        ("｟", True),  # FULLWIDTH LEFT WHITE PARENTHESIS
+        ("｠", True),  # FULLWIDTH RIGHT WHITE PARENTHESIS
+        ("｡", True),  # HALFWIDTH IDEOGRAPHIC FULL STOP
+        ("Ａ", False),  # FULLWIDTH LATIN CAPITAL A
+        ("０", False),  # FULLWIDTH DIGIT ZERO
+    ],
+)
+def test_fullwidth_range_boundaries(char, expected_cjk) -> None:
+    # U+FF5F/FF60 sat in the gap between the two ranges and billed as Latin.
+    from xagent.core.model.chat.token_context import estimate_media_tokens
+
+    assert (estimate_media_tokens(char * 4) == 4) is expected_cjk

--- a/tests/core/model/chat/test_media_usage.py
+++ b/tests/core/model/chat/test_media_usage.py
@@ -1,0 +1,622 @@
+"""Media (non-LLM) usage tracking: image/video/tts/asr/embedding/rerank.
+
+These modalities record usage via ``add_media_usage`` into the same
+``TokenUsage.details`` list that LLM tokens use, so they flow through DB
+persistence and the quota ``delta_details`` contract without special-casing.
+"""
+
+import pytest
+
+from xagent.core.model.chat.token_context import (
+    MediaCallType,
+    MediaUnit,
+    TokenContextManager,
+    TokenUsage,
+    add_media_usage,
+    add_token_usage,
+    aggregate_media_usage_by_model,
+    aggregate_token_usage_by_model,
+)
+
+
+def test_add_media_usage_appends_media_entry_and_counts_call() -> None:
+    with TokenContextManager() as manager:
+        add_media_usage(
+            unit="images",
+            quantity=2,
+            model="sd-xl",
+            model_id="m1",
+            call_type="generate_image",
+            resolution="1K",
+        )
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 1
+    # Media does not count as an LLM call or add tokens.
+    assert usage.llm_calls == 0
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+    assert len(usage.details) == 1
+    entry = usage.details[0]
+    assert entry["type"] == "media"
+    assert entry["unit"] == "images"
+    assert entry["quantity"] == 2.0
+    assert entry["model"] == "sd-xl"
+    assert entry["model_id"] == "m1"
+    assert entry["call_type"] == "generate_image"
+    assert entry["resolution"] == "1K"
+
+
+def test_add_media_usage_carries_accompanying_tokens() -> None:
+    with TokenContextManager() as manager:
+        add_media_usage(
+            unit="images",
+            quantity=1,
+            model="gemini-image",
+            call_type="generate_image",
+            input_tokens=5,
+            output_tokens=3,
+        )
+        usage = manager.get_usage()
+
+    entry = usage.details[0]
+    # Stored under provider_tokens, never "tokens": a consumer that sums the
+    # "tokens" key across all entries must not pick up media counts.
+    assert "tokens" not in entry
+    assert entry["provider_tokens"] == 8
+    assert entry["provider_input_tokens"] == 5
+    assert entry["provider_output_tokens"] == 3
+    assert entry["tokens_estimated"] is False
+    # Media token passthrough must NOT inflate the LLM token totals.
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+
+
+def test_estimated_tokens_are_flagged() -> None:
+    with TokenContextManager() as manager:
+        add_media_usage(
+            unit="texts",
+            quantity=2,
+            model="embed",
+            call_type="embedding",
+            input_tokens=12,
+            tokens_estimated=True,
+        )
+        details = manager.get_usage().details
+
+    assert details[0]["tokens_estimated"] is True
+    # The flag survives aggregation so billing can refuse to price an estimate.
+    assert aggregate_media_usage_by_model(details)[0]["tokens_estimated"] is True
+
+
+def test_dirty_quantity_is_coerced_on_free_quantity_units() -> None:
+    # A malformed quantity records 0 rather than raising: the provider call
+    # happened, so the row must survive as "unmeasured". Uses a duration-billed
+    # unit, because REQUESTS additionally pins its quantity to exactly 1 (see
+    # test_requests_unit_rejects_any_quantity_but_one) and would reject these.
+    with TokenContextManager() as manager:
+        add_media_usage(unit="seconds", quantity=None, model="x", call_type="asr")  # type: ignore[arg-type]
+        add_media_usage(unit="seconds", quantity="oops", model="x", call_type="asr")  # type: ignore[arg-type]
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 2
+    assert all(entry["quantity"] == 0.0 for entry in usage.details)
+
+
+def test_dirty_quantity_on_requests_unit_is_rejected_not_coerced() -> None:
+    # For REQUESTS the permissive path is wrong: coercing a malformed quantity
+    # to 0 would record a call whose billable quantity contradicts its own
+    # call count. Reject instead, leaving no state behind.
+    with TokenContextManager() as manager:
+        for bad in (None, "oops", 0):
+            with pytest.raises(ValueError, match="exactly one call"):
+                add_media_usage(
+                    unit="requests", quantity=bad, model="x", call_type="rerank"
+                )  # type: ignore[arg-type]
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_to_dict_from_dict_roundtrip_preserves_media() -> None:
+    with TokenContextManager() as manager:
+        add_token_usage(input_tokens=10, output_tokens=4, model="gpt", model_id="g1")
+        add_media_usage(unit="seconds", quantity=3.5, model="tts", call_type="asr")
+        usage = manager.get_usage()
+
+    data = usage.to_dict()
+    assert data["media_calls"] == 1
+    assert data["llm_calls"] == 1
+
+    restored = TokenUsage.from_dict(data)
+    assert restored.media_calls == 1
+    assert restored.llm_calls == 1
+    assert restored.input_tokens == 10
+    # 2 token entries (one input, one output) + 1 media entry.
+    assert len(restored.details) == 3
+    assert sum(1 for d in restored.details if d["type"] == "media") == 1
+
+
+def test_merge_combines_media_calls_and_details() -> None:
+    a = TokenUsage()
+    a.record_media_call(
+        unit="images", quantity=1, model="x", call_type="generate_image"
+    )
+
+    b = TokenUsage()
+    b.record_media_call(unit="seconds", quantity=2, model="y", call_type="asr")
+
+    a.merge(b)
+    assert a.media_calls == 2
+    assert len(a.details) == 2
+
+
+def test_token_aggregation_ignores_media_entries() -> None:
+    with TokenContextManager() as manager:
+        add_token_usage(input_tokens=10, output_tokens=5, model="gpt", model_id="g1")
+        add_media_usage(
+            unit="images", quantity=2, model="sd", call_type="generate_image"
+        )
+        details = manager.get_usage().details
+
+    token_groups = aggregate_token_usage_by_model(details)
+    assert len(token_groups) == 1
+    assert token_groups[0]["model_name"] == "gpt"
+    assert token_groups[0]["input_tokens"] == 10
+    assert token_groups[0]["output_tokens"] == 5
+
+
+def test_media_aggregation_groups_by_model_unit_and_call_type() -> None:
+    with TokenContextManager() as manager:
+        add_media_usage(
+            unit="images", quantity=2, model="sd", call_type="generate_image"
+        )
+        add_media_usage(
+            unit="images", quantity=3, model="sd", call_type="generate_image"
+        )
+        add_media_usage(unit="seconds", quantity=4, model="tts", call_type="asr")
+        # LLM tokens must never appear in the media aggregation.
+        add_token_usage(input_tokens=7, output_tokens=2, model="gpt", model_id="g1")
+        details = manager.get_usage().details
+
+    media_groups = aggregate_media_usage_by_model(details)
+    assert len(media_groups) == 2
+
+    by_unit = {group["unit"]: group for group in media_groups}
+    assert by_unit["images"]["quantity"] == 5.0
+    assert by_unit["images"]["calls"] == 2
+    assert by_unit["images"]["call_type"] == "generate_image"
+    assert by_unit["seconds"]["quantity"] == 4.0
+    assert by_unit["seconds"]["calls"] == 1
+
+
+def test_media_aggregation_splits_by_resolution() -> None:
+    # Same model+call_type at different resolutions must bill as separate line
+    # items, since an image model's price varies by resolution.
+    with TokenContextManager() as manager:
+        add_media_usage(
+            unit="images",
+            quantity=1,
+            model="gemini-image",
+            call_type="generate_image",
+            resolution="1K",
+        )
+        add_media_usage(
+            unit="images",
+            quantity=1,
+            model="gemini-image",
+            call_type="generate_image",
+            resolution="4K",
+        )
+        details = manager.get_usage().details
+
+    groups = aggregate_media_usage_by_model(details)
+    assert len(groups) == 2
+    by_res = {group["resolution"]: group for group in groups}
+    assert set(by_res) == {"1K", "4K"}
+    assert by_res["1K"]["calls"] == 1
+    assert by_res["4K"]["calls"] == 1
+
+
+def test_aggregations_tolerate_non_list_and_dirty_entries() -> None:
+    assert aggregate_media_usage_by_model(None) == []
+    assert aggregate_media_usage_by_model("nope") == []
+    # Non-dict junk is ignored; a bare media entry still counts as a call, since
+    # a media row's existence is itself the billing signal.
+    groups = aggregate_media_usage_by_model([{"type": "media"}, 42, "junk"])
+    assert len(groups) == 1
+    assert groups[0]["calls"] == 1
+    assert groups[0]["quantity"] == 0.0
+
+
+def test_zero_quantity_media_entries_stay_visible() -> None:
+    # A duration-billed call the provider never measured records 0 seconds.
+    # That entry must survive aggregation: it is the only evidence the task
+    # made a billable provider call, and dropping it would report
+    # media_calls=0 (and hide the whole popover) for a task that did.
+    with TokenContextManager() as manager:
+        add_media_usage(unit="seconds", quantity=0, model="tts", call_type="asr")
+        add_media_usage(unit="seconds", quantity=5, model="tts", call_type="asr")
+        details = manager.get_usage().details
+
+    groups = aggregate_media_usage_by_model(details)
+    assert len(groups) == 1
+    assert groups[0]["quantity"] == 5.0
+    assert groups[0]["calls"] == 2  # both calls counted, including the unmeasured one
+
+
+def test_only_unmeasured_calls_still_surface() -> None:
+    # The async-video case: no duration is available yet for any call, so the
+    # whole group is zero-quantity. It must still be reported.
+    with TokenContextManager() as manager:
+        for _ in range(3):
+            add_media_usage(unit="seconds", quantity=0, model="veo", call_type="video")
+        groups = aggregate_media_usage_by_model(manager.get_usage().details)
+
+    assert len(groups) == 1
+    assert groups[0]["calls"] == 3
+    assert groups[0]["quantity"] == 0.0
+
+
+@pytest.mark.parametrize("bad_unit", ["image", "second", "tokens", "IMAGES", ""])
+def test_unknown_unit_is_rejected(bad_unit: str) -> None:
+    # A typo'd unit mints a new billing dimension that the aggregator will
+    # happily key off, and a written usage record cannot be repaired
+    # retroactively. The write boundary is the last point it is still fixable.
+    with TokenContextManager() as manager:
+        with pytest.raises(ValueError, match="Unknown media unit"):
+            add_media_usage(unit=bad_unit, quantity=1, model="m", call_type="tts")
+        usage = manager.get_usage()
+
+    # A rejected call must leave no partial state behind: media_calls is
+    # incremented before the detail entry is appended, so validating late would
+    # record a call with no matching entry.
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_unknown_call_type_is_rejected() -> None:
+    with TokenContextManager() as manager:
+        with pytest.raises(ValueError, match="Unknown media call type"):
+            add_media_usage(unit="seconds", quantity=1, model="m", call_type="speech")
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_empty_call_type_is_allowed() -> None:
+    # call_type is optional metadata rather than a billing dimension of its
+    # own, so omitting it stays legal while a typo does not.
+    with TokenContextManager() as manager:
+        add_media_usage(unit="requests", quantity=1, model="m")
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 1
+    assert usage.details[0]["call_type"] == ""
+
+
+def test_none_call_type_is_normalised_to_empty() -> None:
+    with TokenContextManager() as manager:
+        add_media_usage(unit="requests", quantity=1, model="m", call_type=None)
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 1
+    assert usage.details[0]["call_type"] == ""
+
+
+def test_none_unit_is_rejected_with_clear_error() -> None:
+    with TokenContextManager() as manager:
+        with pytest.raises(ValueError, match="Media unit cannot be None"):
+            add_media_usage(unit=None, quantity=1, model="m")
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_enum_members_are_accepted() -> None:
+    with TokenContextManager() as manager:
+        add_media_usage(
+            unit=MediaUnit.SECONDS,
+            quantity=3,
+            model="whisper",
+            call_type=MediaCallType.ASR,
+        )
+        usage = manager.get_usage()
+
+    entry = usage.details[0]
+    # Stored as plain strings so details stays JSON-serialisable.
+    assert entry["unit"] == "seconds"
+    assert entry["call_type"] == "asr"
+    assert isinstance(entry["unit"], str)
+
+
+def test_legacy_positional_construction_still_binds_the_same_fields() -> None:
+    # media_calls must NOT be inserted into the historical positional sequence.
+    # An existing TokenUsage(input, output, llm_calls, tool_calls, details) call
+    # would otherwise bind its 4th argument to media_calls and shift the rest —
+    # tool count read as media count, details read as tool count — silently,
+    # with no error. The field is appended and keyword-only instead.
+    details = [{"type": "input", "tokens": 7}]
+    usage = TokenUsage(10, 5, 2, 3, details)
+
+    assert usage.input_tokens == 10
+    assert usage.output_tokens == 5
+    assert usage.llm_calls == 2
+    assert usage.tool_calls == 3
+    assert usage.details == details
+    assert usage.media_calls == 0
+
+    # And it is reachable by keyword, where it cannot be confused with anything.
+    assert TokenUsage(media_calls=4).media_calls == 4
+
+    # The private lock must not occupy a positional slot either: six positional
+    # arguments is the documented maximum (five fields plus self).
+    with pytest.raises(TypeError):
+        TokenUsage(1, 2, 3, 4, [], 5)  # type: ignore[misc]
+
+
+def test_estimate_media_tokens_accepts_any_iterable_of_strings() -> None:
+    # The docstring promises an iterable; a generator previously estimated 0,
+    # so an embedding producer passing one would have billed nothing.
+    from xagent.core.model.chat.token_context import estimate_media_tokens
+
+    assert estimate_media_tokens(x for x in ["abcd", "efgh"]) == 2
+    assert estimate_media_tokens(["abcd", "efgh"]) == 2
+    # Non-iterables and non-string members are ignored, never raised on.
+    assert estimate_media_tokens(42) == 0
+    assert estimate_media_tokens(["abcd", 42, None]) == 1
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [("", 0), ("a", 1), ("ab", 1), ("abc", 1), ("abcd", 1), ("abcde", 2)],
+)
+def test_estimate_media_tokens_never_undercounts_short_text(text, expected) -> None:
+    # Truncating division estimated 0 for any 1-3 character Latin string, so
+    # short non-empty text billed nothing. Empty still estimates 0.
+    from xagent.core.model.chat.token_context import estimate_media_tokens
+
+    assert estimate_media_tokens(text) == expected
+
+
+@pytest.mark.parametrize("bad_quantity", [0, 0.5, 2, 7, -1])
+def test_requests_unit_rejects_any_quantity_but_one(bad_quantity) -> None:
+    # MediaUnit.REQUESTS is defined as exactly one provider call, so its
+    # quantity is not a free variable. Letting another value through would make
+    # the billable quantity disagree with the media_calls / aggregate `calls`
+    # count derived from the same row, so quota and pricing would read
+    # different numbers off one record.
+    usage = TokenUsage()
+    with pytest.raises(ValueError, match="exactly one call"):
+        usage.record_media_call(
+            unit=MediaUnit.REQUESTS, quantity=bad_quantity, call_type="rerank"
+        )
+
+    # Rejected before any mutation: no counter bump, no orphan detail row.
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_requests_unit_accepts_exactly_one() -> None:
+    usage = TokenUsage()
+    usage.record_media_call(unit=MediaUnit.REQUESTS, quantity=1, call_type="rerank")
+
+    assert usage.media_calls == 1
+    assert usage.details[0]["quantity"] == 1.0
+
+
+def test_other_units_keep_free_quantities() -> None:
+    # The REQUESTS constraint must not leak into duration/count-billed units.
+    usage = TokenUsage()
+    usage.record_media_call(unit=MediaUnit.SECONDS, quantity=2.5, call_type="asr")
+    usage.record_media_call(unit=MediaUnit.IMAGES, quantity=4, call_type="edit_image")
+
+    assert [d["quantity"] for d in usage.details] == [2.5, 4.0]
+
+
+def test_requests_rejection_is_swallowed_by_the_wrapper() -> None:
+    # Producers route through record_media_usage, whose contract is that an
+    # accounting bug never breaks the media call the user asked for.
+    from xagent.core.tools.core.media_usage import record_media_usage
+
+    with TokenContextManager() as manager:
+        record_media_usage(
+            MediaUnit.REQUESTS, 3, model="m", call_type=MediaCallType.RERANK
+        )
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+@pytest.mark.parametrize(
+    "bad_tokens",
+    [True, False, -100, float("inf"), float("-inf"), float("nan"), "abc"],
+)
+def test_malformed_provider_tokens_sanitize_without_losing_the_row(bad_tokens) -> None:
+    # int(float("inf")) raises OverflowError, which was not caught — so a
+    # malformed provider payload propagated out of the accounting path and
+    # dropped the whole billable media row. Negatives and booleans were
+    # persisted as-is, letting a provider bug subtract from a bill.
+    usage = TokenUsage()
+    usage.record_media_call(
+        unit="images",
+        quantity=1,
+        call_type="generate_image",
+        input_tokens=bad_tokens,
+        output_tokens=bad_tokens,
+    )
+
+    # The row survives — the call happened and is billable by quantity ...
+    assert usage.media_calls == 1
+    entry = usage.details[0]
+    assert entry["quantity"] == 1.0
+    # ... with only the unusable token fields zeroed.
+    assert entry["provider_input_tokens"] == 0
+    assert entry["provider_output_tokens"] == 0
+    assert entry["provider_tokens"] == 0
+
+
+def test_valid_provider_tokens_survive() -> None:
+    usage = TokenUsage()
+    usage.record_media_call(
+        unit="images",
+        quantity=1,
+        call_type="generate_image",
+        input_tokens=11,
+        output_tokens=5,
+    )
+    entry = usage.details[0]
+
+    assert (entry["provider_input_tokens"], entry["provider_output_tokens"]) == (11, 5)
+    assert entry["provider_tokens"] == 16
+
+
+def test_estimate_media_tokens_never_raises_from_a_hostile_iterable() -> None:
+    # The docstring promises malformed input cannot raise, but only TypeError
+    # was caught: a custom iterable raising anything else escaped into the
+    # accounting path and would break the call being measured.
+    from xagent.core.model.chat.token_context import estimate_media_tokens
+
+    class _RaisesMidIteration:
+        def __iter__(self):
+            yield "abcd"
+            raise RuntimeError("iterator exploded")
+
+    class _RaisesImmediately:
+        def __iter__(self):
+            raise ValueError("cannot iterate")
+
+    assert estimate_media_tokens(_RaisesMidIteration()) == 0
+    assert estimate_media_tokens(_RaisesImmediately()) == 0
+
+
+def test_requests_error_reports_the_value_the_caller_passed() -> None:
+    # quantity is coerced before the guard runs, so interpolating the coerced
+    # value would report "got 0.0" for a caller who passed -1.
+    usage = TokenUsage()
+    with pytest.raises(ValueError, match=r"got -1"):
+        usage.record_media_call(unit="requests", quantity=-1, call_type="rerank")
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # CJK is ~1 token per character; a flat chars/4 heuristic undercounts
+        # Chinese by close to 4x. Punctuation and fullwidth forms count too —
+        # they appear in essentially every Chinese sentence.
+        ("中文", 2),
+        ("中文abcd", 3),
+        ("中文，你好。", 6),
+        ("（全角）", 4),
+    ],
+)
+def test_estimate_media_tokens_counts_cjk(text, expected) -> None:
+    from xagent.core.model.chat.token_context import estimate_media_tokens
+
+    assert estimate_media_tokens(text) == expected
+
+
+def test_media_aggregation_uses_model_id_when_present() -> None:
+    # identity = model_id or model_name — the model_id branch had no coverage,
+    # so rows keyed by id always fell through to the name branch in tests.
+    with TokenContextManager() as manager:
+        add_media_usage(
+            unit="images",
+            quantity=1,
+            model="display-name",
+            model_id="img-1",
+            call_type="generate_image",
+        )
+        add_media_usage(
+            unit="images",
+            quantity=2,
+            model="",
+            model_id="img-1",
+            call_type="generate_image",
+        )
+        groups = aggregate_media_usage_by_model(manager.get_usage().details)
+
+    # Both rows share one identity via model_id even though one lacks a name...
+    assert len(groups) == 1
+    assert groups[0]["model_id"] == "img-1"
+    assert groups[0]["quantity"] == 3.0
+    # ...and the name is backfilled from whichever row carried it.
+    assert groups[0]["model_name"] == "display-name"
+
+
+@pytest.mark.parametrize("huge", [10**400, -(10**400), "1e400"])
+def test_huge_quantity_records_zero_rather_than_dropping_the_row(huge) -> None:
+    # float(10**400) raises OverflowError, which _coerce_float did not catch.
+    # An uncaught raise here propagates out and the error-swallowing wrapper
+    # drops the whole billing row — the opposite of the reject-to-0.0 contract.
+    usage = TokenUsage()
+    usage.record_media_call(unit="images", quantity=huge, call_type="generate_image")
+
+    assert usage.media_calls == 1
+    assert usage.details[0]["quantity"] == 0.0
+
+
+def test_add_media_usage_reports_the_raw_quantity_in_the_requests_error() -> None:
+    # The wrapper coerces one layer above record_media_call, so without
+    # threading the raw value through, a caller passing -1 saw "got 0.0".
+    with TokenContextManager():
+        with pytest.raises(ValueError, match=r"got -1"):
+            add_media_usage(unit="requests", quantity=-1, model="m", call_type="rerank")
+
+
+@pytest.mark.parametrize(
+    ("unit", "call_type"),
+    [
+        ("images", "video"),  # video bills in seconds
+        ("seconds", "tts"),  # tts bills in characters
+        ("images", "asr"),
+        ("requests", "embedding"),  # embedding bills per text
+    ],
+)
+def test_unit_must_match_the_modality(unit, call_type) -> None:
+    # "The unit is a property of the modality" was stated in three docstrings and
+    # violated by six call sites in this file. MEDIA_UNIT_BY_CALL_TYPE turns the
+    # invariant into an enforced constraint: a (model, unit) price table is only
+    # usable if one modality never reports two units.
+    usage = TokenUsage()
+    with pytest.raises(ValueError, match="bills in"):
+        usage.record_media_call(unit=unit, quantity=1, call_type=call_type)
+
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+@pytest.mark.parametrize(
+    ("call_type", "unit"),
+    [
+        ("generate_image", "images"),
+        ("edit_image", "images"),
+        ("video", "seconds"),
+        ("asr", "seconds"),
+        ("music", "seconds"),
+        ("sound_effect", "seconds"),
+        ("tts", "characters"),
+        ("embedding", "texts"),
+        ("rerank", "requests"),
+    ],
+)
+def test_every_call_type_accepts_its_own_unit(call_type, unit) -> None:
+    # The mapping must cover every MediaCallType member, or a legitimate
+    # producer would be rejected.
+    usage = TokenUsage()
+    usage.record_media_call(unit=unit, quantity=1, call_type=call_type)
+
+    assert usage.details[0]["unit"] == unit
+
+
+def test_unit_is_unconstrained_when_call_type_is_omitted() -> None:
+    # call_type is optional metadata; with none given there is no modality to
+    # check the unit against.
+    usage = TokenUsage()
+    usage.record_media_call(unit="images", quantity=1)
+
+    assert usage.details[0]["unit"] == "images"

--- a/tests/core/model/chat/test_media_usage.py
+++ b/tests/core/model/chat/test_media_usage.py
@@ -619,3 +619,41 @@ def test_unit_is_unconstrained_when_call_type_is_omitted() -> None:
     usage.record_media_call(unit="images", quantity=1)
 
     assert usage.details[0]["unit"] == "images"
+
+
+@pytest.mark.parametrize("overflowing", [float("inf"), float("-inf")])
+def test_overflowing_provider_tokens_keep_the_row(overflowing) -> None:
+    # int(float("inf")) raises OverflowError. Uncaught, it propagates out of the
+    # accounting path and the error-swallowing wrapper drops the entire billing
+    # row — losing a call that did happen in order to salvage one bad field.
+    # Image providers pass prompt_tokens straight from provider JSON, so a
+    # malformed payload reaches this boundary unfiltered.
+    usage = TokenUsage()
+    usage.record_media_call(
+        unit="images",
+        quantity=1,
+        call_type="generate_image",
+        input_tokens=overflowing,
+        output_tokens=overflowing,
+    )
+
+    assert usage.media_calls == 1
+    entry = usage.details[0]
+    assert entry["quantity"] == 1.0
+    assert entry["provider_input_tokens"] == 0
+    assert entry["provider_output_tokens"] == 0
+
+
+@pytest.mark.parametrize("unusable", [-1, -0.5, -1000.0, True, False])
+def test_unusable_quantity_records_zero(unusable) -> None:
+    # A negative quantity would subtract from a bill, and a bool is a caller bug
+    # rather than a count of 1 or 0 — `True` would otherwise bill one image.
+    # Recorded as 0 rather than rejected, because the provider call still
+    # happened: the row is the evidence, and 0 marks it unmeasured.
+    usage = TokenUsage()
+    usage.record_media_call(
+        unit="images", quantity=unusable, call_type="generate_image"
+    )
+
+    assert usage.media_calls == 1
+    assert usage.details[0]["quantity"] == 0.0

--- a/tests/core/model/chat/test_media_usage.py
+++ b/tests/core/model/chat/test_media_usage.py
@@ -22,7 +22,6 @@ from xagent.core.model.chat.token_context import (
 def test_add_media_usage_appends_media_entry_and_counts_call() -> None:
     with TokenContextManager() as manager:
         add_media_usage(
-            unit="images",
             quantity=2,
             model="sd-xl",
             model_id="m1",
@@ -50,7 +49,6 @@ def test_add_media_usage_appends_media_entry_and_counts_call() -> None:
 def test_add_media_usage_carries_accompanying_tokens() -> None:
     with TokenContextManager() as manager:
         add_media_usage(
-            unit="images",
             quantity=1,
             model="gemini-image",
             call_type="generate_image",
@@ -75,7 +73,6 @@ def test_add_media_usage_carries_accompanying_tokens() -> None:
 def test_estimated_tokens_are_flagged() -> None:
     with TokenContextManager() as manager:
         add_media_usage(
-            unit="texts",
             quantity=2,
             model="embed",
             call_type="embedding",
@@ -95,8 +92,8 @@ def test_dirty_quantity_is_coerced_on_free_quantity_units() -> None:
     # unit, because REQUESTS additionally pins its quantity to exactly 1 (see
     # test_requests_unit_rejects_any_quantity_but_one) and would reject these.
     with TokenContextManager() as manager:
-        add_media_usage(unit="seconds", quantity=None, model="x", call_type="asr")  # type: ignore[arg-type]
-        add_media_usage(unit="seconds", quantity="oops", model="x", call_type="asr")  # type: ignore[arg-type]
+        add_media_usage(quantity=None, model="x", call_type="asr")  # type: ignore[arg-type]
+        add_media_usage(quantity="oops", model="x", call_type="asr")  # type: ignore[arg-type]
         usage = manager.get_usage()
 
     assert usage.media_calls == 2
@@ -110,9 +107,7 @@ def test_dirty_quantity_on_requests_unit_is_rejected_not_coerced() -> None:
     with TokenContextManager() as manager:
         for bad in (None, "oops", 0):
             with pytest.raises(ValueError, match="exactly one call"):
-                add_media_usage(
-                    unit="requests", quantity=bad, model="x", call_type="rerank"
-                )  # type: ignore[arg-type]
+                add_media_usage(quantity=bad, model="x", call_type="rerank")  # type: ignore[arg-type]
         usage = manager.get_usage()
 
     assert usage.media_calls == 0
@@ -122,7 +117,7 @@ def test_dirty_quantity_on_requests_unit_is_rejected_not_coerced() -> None:
 def test_to_dict_from_dict_roundtrip_preserves_media() -> None:
     with TokenContextManager() as manager:
         add_token_usage(input_tokens=10, output_tokens=4, model="gpt", model_id="g1")
-        add_media_usage(unit="seconds", quantity=3.5, model="tts", call_type="asr")
+        add_media_usage(quantity=3.5, model="tts", call_type="asr")
         usage = manager.get_usage()
 
     data = usage.to_dict()
@@ -140,12 +135,10 @@ def test_to_dict_from_dict_roundtrip_preserves_media() -> None:
 
 def test_merge_combines_media_calls_and_details() -> None:
     a = TokenUsage()
-    a.record_media_call(
-        unit="images", quantity=1, model="x", call_type="generate_image"
-    )
+    a.record_media_call(quantity=1, model="x", call_type="generate_image")
 
     b = TokenUsage()
-    b.record_media_call(unit="seconds", quantity=2, model="y", call_type="asr")
+    b.record_media_call(quantity=2, model="y", call_type="asr")
 
     a.merge(b)
     assert a.media_calls == 2
@@ -155,9 +148,7 @@ def test_merge_combines_media_calls_and_details() -> None:
 def test_token_aggregation_ignores_media_entries() -> None:
     with TokenContextManager() as manager:
         add_token_usage(input_tokens=10, output_tokens=5, model="gpt", model_id="g1")
-        add_media_usage(
-            unit="images", quantity=2, model="sd", call_type="generate_image"
-        )
+        add_media_usage(quantity=2, model="sd", call_type="generate_image")
         details = manager.get_usage().details
 
     token_groups = aggregate_token_usage_by_model(details)
@@ -169,13 +160,9 @@ def test_token_aggregation_ignores_media_entries() -> None:
 
 def test_media_aggregation_groups_by_model_unit_and_call_type() -> None:
     with TokenContextManager() as manager:
-        add_media_usage(
-            unit="images", quantity=2, model="sd", call_type="generate_image"
-        )
-        add_media_usage(
-            unit="images", quantity=3, model="sd", call_type="generate_image"
-        )
-        add_media_usage(unit="seconds", quantity=4, model="tts", call_type="asr")
+        add_media_usage(quantity=2, model="sd", call_type="generate_image")
+        add_media_usage(quantity=3, model="sd", call_type="generate_image")
+        add_media_usage(quantity=4, model="tts", call_type="asr")
         # LLM tokens must never appear in the media aggregation.
         add_token_usage(input_tokens=7, output_tokens=2, model="gpt", model_id="g1")
         details = manager.get_usage().details
@@ -196,14 +183,12 @@ def test_media_aggregation_splits_by_resolution() -> None:
     # items, since an image model's price varies by resolution.
     with TokenContextManager() as manager:
         add_media_usage(
-            unit="images",
             quantity=1,
             model="gemini-image",
             call_type="generate_image",
             resolution="1K",
         )
         add_media_usage(
-            unit="images",
             quantity=1,
             model="gemini-image",
             call_type="generate_image",
@@ -236,8 +221,8 @@ def test_zero_quantity_media_entries_stay_visible() -> None:
     # made a billable provider call, and dropping it would report
     # media_calls=0 (and hide the whole popover) for a task that did.
     with TokenContextManager() as manager:
-        add_media_usage(unit="seconds", quantity=0, model="tts", call_type="asr")
-        add_media_usage(unit="seconds", quantity=5, model="tts", call_type="asr")
+        add_media_usage(quantity=0, model="tts", call_type="asr")
+        add_media_usage(quantity=5, model="tts", call_type="asr")
         details = manager.get_usage().details
 
     groups = aggregate_media_usage_by_model(details)
@@ -251,7 +236,7 @@ def test_only_unmeasured_calls_still_surface() -> None:
     # whole group is zero-quantity. It must still be reported.
     with TokenContextManager() as manager:
         for _ in range(3):
-            add_media_usage(unit="seconds", quantity=0, model="veo", call_type="video")
+            add_media_usage(quantity=0, model="veo", call_type="video")
         groups = aggregate_media_usage_by_model(manager.get_usage().details)
 
     assert len(groups) == 1
@@ -259,57 +244,10 @@ def test_only_unmeasured_calls_still_surface() -> None:
     assert groups[0]["quantity"] == 0.0
 
 
-@pytest.mark.parametrize("bad_unit", ["image", "second", "tokens", "IMAGES", ""])
-def test_unknown_unit_is_rejected(bad_unit: str) -> None:
-    # A typo'd unit mints a new billing dimension that the aggregator will
-    # happily key off, and a written usage record cannot be repaired
-    # retroactively. The write boundary is the last point it is still fixable.
-    with TokenContextManager() as manager:
-        with pytest.raises(ValueError, match="Unknown media unit"):
-            add_media_usage(unit=bad_unit, quantity=1, model="m", call_type="tts")
-        usage = manager.get_usage()
-
-    # A rejected call must leave no partial state behind: media_calls is
-    # incremented before the detail entry is appended, so validating late would
-    # record a call with no matching entry.
-    assert usage.media_calls == 0
-    assert usage.details == []
-
-
 def test_unknown_call_type_is_rejected() -> None:
     with TokenContextManager() as manager:
         with pytest.raises(ValueError, match="Unknown media call type"):
-            add_media_usage(unit="seconds", quantity=1, model="m", call_type="speech")
-        usage = manager.get_usage()
-
-    assert usage.media_calls == 0
-    assert usage.details == []
-
-
-def test_empty_call_type_is_allowed() -> None:
-    # call_type is optional metadata rather than a billing dimension of its
-    # own, so omitting it stays legal while a typo does not.
-    with TokenContextManager() as manager:
-        add_media_usage(unit="requests", quantity=1, model="m")
-        usage = manager.get_usage()
-
-    assert usage.media_calls == 1
-    assert usage.details[0]["call_type"] == ""
-
-
-def test_none_call_type_is_normalised_to_empty() -> None:
-    with TokenContextManager() as manager:
-        add_media_usage(unit="requests", quantity=1, model="m", call_type=None)
-        usage = manager.get_usage()
-
-    assert usage.media_calls == 1
-    assert usage.details[0]["call_type"] == ""
-
-
-def test_none_unit_is_rejected_with_clear_error() -> None:
-    with TokenContextManager() as manager:
-        with pytest.raises(ValueError, match="Media unit cannot be None"):
-            add_media_usage(unit=None, quantity=1, model="m")
+            add_media_usage(quantity=1, model="m", call_type="speech")
         usage = manager.get_usage()
 
     assert usage.media_calls == 0
@@ -319,7 +257,6 @@ def test_none_unit_is_rejected_with_clear_error() -> None:
 def test_enum_members_are_accepted() -> None:
     with TokenContextManager() as manager:
         add_media_usage(
-            unit=MediaUnit.SECONDS,
             quantity=3,
             model="whisper",
             call_type=MediaCallType.ASR,
@@ -349,11 +286,12 @@ def test_legacy_positional_construction_still_binds_the_same_fields() -> None:
     assert usage.details == details
     assert usage.media_calls == 0
 
-    # And it is reachable by keyword, where it cannot be confused with anything.
-    assert TokenUsage(media_calls=4).media_calls == 4
+    # media_calls is derived from details, so it cannot be set at all — which
+    # is what makes it impossible to drop on a copy or seed path.
+    assert TokenUsage(details=[{"type": "media"}]).media_calls == 1
 
-    # The private lock must not occupy a positional slot either: six positional
-    # arguments is the documented maximum (five fields plus self).
+    # Five positional arguments is the maximum: media_calls is a derived
+    # property, so there is no sixth field for an old caller to mis-bind.
     with pytest.raises(TypeError):
         TokenUsage(1, 2, 3, 4, [], 5)  # type: ignore[misc]
 
@@ -391,9 +329,7 @@ def test_requests_unit_rejects_any_quantity_but_one(bad_quantity) -> None:
     # different numbers off one record.
     usage = TokenUsage()
     with pytest.raises(ValueError, match="exactly one call"):
-        usage.record_media_call(
-            unit=MediaUnit.REQUESTS, quantity=bad_quantity, call_type="rerank"
-        )
+        usage.record_media_call(quantity=bad_quantity, call_type="rerank")
 
     # Rejected before any mutation: no counter bump, no orphan detail row.
     assert usage.media_calls == 0
@@ -402,19 +338,10 @@ def test_requests_unit_rejects_any_quantity_but_one(bad_quantity) -> None:
 
 def test_requests_unit_accepts_exactly_one() -> None:
     usage = TokenUsage()
-    usage.record_media_call(unit=MediaUnit.REQUESTS, quantity=1, call_type="rerank")
+    usage.record_media_call(quantity=1, call_type="rerank")
 
     assert usage.media_calls == 1
     assert usage.details[0]["quantity"] == 1.0
-
-
-def test_other_units_keep_free_quantities() -> None:
-    # The REQUESTS constraint must not leak into duration/count-billed units.
-    usage = TokenUsage()
-    usage.record_media_call(unit=MediaUnit.SECONDS, quantity=2.5, call_type="asr")
-    usage.record_media_call(unit=MediaUnit.IMAGES, quantity=4, call_type="edit_image")
-
-    assert [d["quantity"] for d in usage.details] == [2.5, 4.0]
 
 
 def test_requests_rejection_is_swallowed_by_the_wrapper() -> None:
@@ -423,9 +350,7 @@ def test_requests_rejection_is_swallowed_by_the_wrapper() -> None:
     from xagent.core.tools.core.media_usage import record_media_usage
 
     with TokenContextManager() as manager:
-        record_media_usage(
-            MediaUnit.REQUESTS, 3, model="m", call_type=MediaCallType.RERANK
-        )
+        record_media_usage(MediaCallType.RERANK, 3, model="m")
         usage = manager.get_usage()
 
     assert usage.media_calls == 0
@@ -437,14 +362,13 @@ def test_unusable_provider_tokens_zero_out_without_losing_the_row(bad_tokens) ->
     # The row must survive a malformed token count: the provider call happened
     # and is billable by its quantity even when the token fields are junk.
     #
-    # Scoped to what `_coerce_int` handles today. Booleans, negatives and
-    # overflowing values (`int(float("inf"))` raises) are NOT sanitised yet —
-    # that hardening belongs with the TokenUsage work split out of #1422, since
-    # `_coerce_int` is shared with every LLM adapter and changing it is not a
-    # media-billing change. Tracked in #1526.
+    # Overflow IS handled now — see test_overflowing_provider_tokens_keep_the_row.
+    # Booleans still coerce to 0/1 in the shared `_coerce_int`, which is
+    # deliberate: `add_token_usage` does `if input_tokens:`, so flooring there
+    # would flip a real value from "added" to "silently skipped" on the live LLM
+    # path. Negatives are clamped at the media boundary instead.
     usage = TokenUsage()
     usage.record_media_call(
-        unit="images",
         quantity=1,
         call_type="generate_image",
         input_tokens=bad_tokens,
@@ -462,7 +386,6 @@ def test_unusable_provider_tokens_zero_out_without_losing_the_row(bad_tokens) ->
 def test_valid_provider_tokens_survive() -> None:
     usage = TokenUsage()
     usage.record_media_call(
-        unit="images",
         quantity=1,
         call_type="generate_image",
         input_tokens=11,
@@ -498,7 +421,7 @@ def test_requests_error_reports_the_value_the_caller_passed() -> None:
     # value would report "got 0.0" for a caller who passed -1.
     usage = TokenUsage()
     with pytest.raises(ValueError, match=r"got -1"):
-        usage.record_media_call(unit="requests", quantity=-1, call_type="rerank")
+        usage.record_media_call(quantity=-1, call_type="rerank")
 
 
 @pytest.mark.parametrize(
@@ -524,14 +447,12 @@ def test_media_aggregation_uses_model_id_when_present() -> None:
     # so rows keyed by id always fell through to the name branch in tests.
     with TokenContextManager() as manager:
         add_media_usage(
-            unit="images",
             quantity=1,
             model="display-name",
             model_id="img-1",
             call_type="generate_image",
         )
         add_media_usage(
-            unit="images",
             quantity=2,
             model="",
             model_id="img-1",
@@ -553,7 +474,7 @@ def test_huge_quantity_records_zero_rather_than_dropping_the_row(huge) -> None:
     # An uncaught raise here propagates out and the error-swallowing wrapper
     # drops the whole billing row — the opposite of the reject-to-0.0 contract.
     usage = TokenUsage()
-    usage.record_media_call(unit="images", quantity=huge, call_type="generate_image")
+    usage.record_media_call(quantity=huge, call_type="generate_image")
 
     assert usage.media_calls == 1
     assert usage.details[0]["quantity"] == 0.0
@@ -564,61 +485,7 @@ def test_add_media_usage_reports_the_raw_quantity_in_the_requests_error() -> Non
     # threading the raw value through, a caller passing -1 saw "got 0.0".
     with TokenContextManager():
         with pytest.raises(ValueError, match=r"got -1"):
-            add_media_usage(unit="requests", quantity=-1, model="m", call_type="rerank")
-
-
-@pytest.mark.parametrize(
-    ("unit", "call_type"),
-    [
-        ("images", "video"),  # video bills in seconds
-        ("seconds", "tts"),  # tts bills in characters
-        ("images", "asr"),
-        ("requests", "embedding"),  # embedding bills per text
-    ],
-)
-def test_unit_must_match_the_modality(unit, call_type) -> None:
-    # "The unit is a property of the modality" was stated in three docstrings and
-    # violated by six call sites in this file. MEDIA_UNIT_BY_CALL_TYPE turns the
-    # invariant into an enforced constraint: a (model, unit) price table is only
-    # usable if one modality never reports two units.
-    usage = TokenUsage()
-    with pytest.raises(ValueError, match="bills in"):
-        usage.record_media_call(unit=unit, quantity=1, call_type=call_type)
-
-    assert usage.media_calls == 0
-    assert usage.details == []
-
-
-@pytest.mark.parametrize(
-    ("call_type", "unit"),
-    [
-        ("generate_image", "images"),
-        ("edit_image", "images"),
-        ("video", "seconds"),
-        ("asr", "seconds"),
-        ("music", "seconds"),
-        ("sound_effect", "seconds"),
-        ("tts", "characters"),
-        ("embedding", "texts"),
-        ("rerank", "requests"),
-    ],
-)
-def test_every_call_type_accepts_its_own_unit(call_type, unit) -> None:
-    # The mapping must cover every MediaCallType member, or a legitimate
-    # producer would be rejected.
-    usage = TokenUsage()
-    usage.record_media_call(unit=unit, quantity=1, call_type=call_type)
-
-    assert usage.details[0]["unit"] == unit
-
-
-def test_unit_is_unconstrained_when_call_type_is_omitted() -> None:
-    # call_type is optional metadata; with none given there is no modality to
-    # check the unit against.
-    usage = TokenUsage()
-    usage.record_media_call(unit="images", quantity=1)
-
-    assert usage.details[0]["unit"] == "images"
+            add_media_usage(quantity=-1, model="m", call_type="rerank")
 
 
 @pytest.mark.parametrize("overflowing", [float("inf"), float("-inf")])
@@ -630,7 +497,6 @@ def test_overflowing_provider_tokens_keep_the_row(overflowing) -> None:
     # malformed payload reaches this boundary unfiltered.
     usage = TokenUsage()
     usage.record_media_call(
-        unit="images",
         quantity=1,
         call_type="generate_image",
         input_tokens=overflowing,
@@ -644,16 +510,129 @@ def test_overflowing_provider_tokens_keep_the_row(overflowing) -> None:
     assert entry["provider_output_tokens"] == 0
 
 
-@pytest.mark.parametrize("unusable", [-1, -0.5, -1000.0, True, False])
+@pytest.mark.parametrize("unusable", [-1, -0.5, -1000.0, True, float("nan")])
 def test_unusable_quantity_records_zero(unusable) -> None:
     # A negative quantity would subtract from a bill, and a bool is a caller bug
     # rather than a count of 1 or 0 — `True` would otherwise bill one image.
     # Recorded as 0 rather than rejected, because the provider call still
     # happened: the row is the evidence, and 0 marks it unmeasured.
     usage = TokenUsage()
-    usage.record_media_call(
-        unit="images", quantity=unusable, call_type="generate_image"
-    )
+    usage.record_media_call(quantity=unusable, call_type="generate_image")
 
     assert usage.media_calls == 1
     assert usage.details[0]["quantity"] == 0.0
+
+
+@pytest.mark.parametrize("bad", [float("inf"), float("-inf"), float("nan"), "abc"])
+def test_coerce_int_change_is_safe_on_the_llm_token_path(bad) -> None:
+    # This PR's one functional change to pre-existing code adds OverflowError to
+    # `_coerce_int`, which `add_token_usage`, `extract_cached_input_tokens` and
+    # `aggregate_token_usage_by_model` all use on the live LLM path. At base
+    # `_coerce_int(float("inf"))` raised; it must now record 0 without raising.
+    with TokenContextManager() as manager:
+        add_token_usage(
+            input_tokens=bad, output_tokens=bad, model="m", call_type="chat"
+        )  # type: ignore[arg-type]
+        usage = manager.get_usage()
+
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+
+
+@pytest.mark.parametrize("bad_call_type", ["not-a-type", "IMAGES", "", None])
+def test_unknown_call_type_is_rejected_and_required(bad_call_type) -> None:
+    # call_type is the only identity now — the unit is derived from it — so an
+    # unknown or missing value has nothing to derive from and must be rejected
+    # rather than silently skipping enforcement, which is what an optional
+    # call_type did in the earlier design.
+    usage = TokenUsage()
+    with pytest.raises(ValueError):
+        usage.record_media_call(call_type=bad_call_type, quantity=1)  # type: ignore[arg-type]
+
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_unit_cannot_be_passed_at_all() -> None:
+    # The whole point of the redesign: a wrong (unit, modality) pair is not
+    # rejected, it is unrepresentable.
+    usage = TokenUsage()
+    with pytest.raises(TypeError):
+        usage.record_media_call(  # type: ignore[call-arg]
+            unit="seconds", call_type="generate_image", quantity=1
+        )
+
+
+@pytest.mark.parametrize("call_type", list(MediaCallType))
+def test_every_call_type_carries_a_unit_and_records_it(call_type) -> None:
+    # Parametrised from the enum itself, not a hand-written list: a new member
+    # added without a unit fails here rather than silently skipping enforcement.
+    usage = TokenUsage()
+    usage.record_media_call(
+        call_type=call_type, quantity=1 if call_type.unit is MediaUnit.REQUESTS else 2
+    )
+
+    assert usage.details[0]["unit"] == call_type.unit.value
+    assert isinstance(call_type.unit, MediaUnit)
+
+
+@pytest.mark.parametrize("truthy_non_bool", ["no", "false", "0", 1, [0], object()])
+def test_tokens_estimated_only_accepts_a_real_true(truthy_non_bool) -> None:
+    # bool() is not enough here: bool("no") and bool("false") are both True, so
+    # a provider adapter forwarding a string flag would mark measured counts as
+    # estimated and let them through billing as guesses. Only an actual True
+    # sets the flag.
+    usage = TokenUsage()
+    usage.record_media_call(
+        call_type=MediaCallType.ASR, quantity=1, tokens_estimated=truthy_non_bool
+    )
+
+    assert usage.details[0]["tokens_estimated"] is False
+
+
+def test_tokens_estimated_true_still_sets_the_flag() -> None:
+    usage = TokenUsage()
+    usage.record_media_call(
+        call_type=MediaCallType.ASR, quantity=1, tokens_estimated=True
+    )
+
+    assert usage.details[0]["tokens_estimated"] is True
+
+
+def test_negative_provider_tokens_are_floored_not_subtracted() -> None:
+    # A provider returning a negative token count must not credit the tenant
+    # back tokens it never spent. Floored at the media boundary only, so the
+    # LLM path's `if input_tokens:` keeps seeing real values.
+    usage = TokenUsage()
+    usage.record_media_call(
+        call_type=MediaCallType.TTS,
+        quantity=10,
+        input_tokens=-500,
+        output_tokens=-7,
+    )
+    entry = usage.details[0]
+
+    assert entry["provider_input_tokens"] == 0
+    assert entry["provider_output_tokens"] == 0
+    assert entry["provider_tokens"] == 0
+    # The row survives as evidence the call happened.
+    assert entry["quantity"] == 10.0
+
+
+def test_model_identity_is_stripped_so_padding_does_not_split_billing() -> None:
+    # " sd " and "sd" are the same model; leaving the padding in produces two
+    # aggregation groups and two invoice lines for one model.
+    usage = TokenUsage()
+    usage.record_media_call(
+        call_type=MediaCallType.GENERATE_IMAGE,
+        quantity=1,
+        model=" sd ",
+        model_id=" s1 ",
+    )
+    usage.record_media_call(
+        call_type=MediaCallType.GENERATE_IMAGE, quantity=1, model="sd", model_id="s1"
+    )
+
+    assert {d["model"] for d in usage.details} == {"sd"}
+    assert {d["model_id"] for d in usage.details} == {"s1"}
+    assert len(aggregate_media_usage_by_model(usage.details)) == 1

--- a/tests/core/model/chat/test_media_usage.py
+++ b/tests/core/model/chat/test_media_usage.py
@@ -446,15 +446,18 @@ def test_media_aggregation_uses_model_id_when_present() -> None:
     # identity = model_id or model_name — the model_id branch had no coverage,
     # so rows keyed by id always fell through to the name branch in tests.
     with TokenContextManager() as manager:
+        # Empty-name row FIRST: with the named row first, setdefault seeds the
+        # group's model_name and the backfill branch never executes -- the test
+        # then passes with that branch deleted.
         add_media_usage(
-            quantity=1,
-            model="display-name",
+            quantity=2,
+            model="",
             model_id="img-1",
             call_type="generate_image",
         )
         add_media_usage(
-            quantity=2,
-            model="",
+            quantity=1,
+            model="display-name",
             model_id="img-1",
             call_type="generate_image",
         )
@@ -708,3 +711,46 @@ def test_fullwidth_range_boundaries(char, expected_cjk) -> None:
     from xagent.core.model.chat.token_context import estimate_media_tokens
 
     assert (estimate_media_tokens(char * 4) == 4) is expected_cjk
+
+
+@pytest.mark.parametrize("boolean", [True, False])
+def test_boolean_provider_tokens_are_not_counted_as_one(boolean) -> None:
+    # bool is an int subclass, so _coerce_int(True) is 1 and a provider handing
+    # back a JSON boolean would bill a token. `quantity` at this same boundary
+    # already rejects booleans; tokens must agree.
+    usage = TokenUsage()
+    usage.record_media_call(
+        call_type=MediaCallType.TTS,
+        quantity=10,
+        input_tokens=boolean,
+        output_tokens=boolean,
+    )
+    entry = usage.details[0]
+
+    assert entry["provider_input_tokens"] == 0
+    assert entry["provider_output_tokens"] == 0
+    assert entry["provider_tokens"] == 0
+    # The row still records the measured call.
+    assert entry["quantity"] == 10.0
+
+
+def test_resolution_is_stripped_so_padding_does_not_split_billing() -> None:
+    # resolution is part of the aggregate key, so ' 1K ' and '1K' would become
+    # two billable line items for one resolution tier -- and the padded row
+    # would miss an exact price-table join.
+    usage = TokenUsage()
+    usage.record_media_call(
+        call_type=MediaCallType.GENERATE_IMAGE,
+        quantity=1,
+        model="sd",
+        resolution=" 1K ",
+    )
+    usage.record_media_call(
+        call_type=MediaCallType.GENERATE_IMAGE,
+        quantity=1,
+        model="sd",
+        resolution="1K",
+    )
+
+    assert {d["resolution"] for d in usage.details} == {"1K"}
+    assert len(aggregate_media_usage_by_model(usage.details)) == 1

--- a/tests/core/tools/core/test_media_usage_helpers.py
+++ b/tests/core/tools/core/test_media_usage_helpers.py
@@ -1,0 +1,198 @@
+"""Unit stability for duration-billed media tools.
+
+The billed unit must depend on the modality, never on how complete the
+provider's response happened to be — a price table keyed on (model, unit) is
+unusable if the same model sometimes reports "seconds" and sometimes
+"requests".
+"""
+
+import pytest
+
+from xagent.core.model.chat.token_context import (
+    MediaCallType,
+    MediaUnit,
+    TokenContextManager,
+    aggregate_media_usage_by_model,
+)
+from xagent.core.tools.core.media_usage import (
+    coerce_duration,
+    record_media_seconds,
+    record_media_usage,
+    resolve_billing_model,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (12.5, 12.5),
+        ("3", 3.0),
+        (0, None),  # zero is "no usable duration", not a real measurement
+        (-5, None),
+        (None, None),
+        (True, None),  # bool must not sneak through as 1.0
+        ("nonsense", None),
+    ],
+)
+def test_coerce_duration(value, expected) -> None:
+    assert coerce_duration(value) == expected
+
+
+def test_record_media_seconds_keeps_unit_stable_when_duration_missing() -> None:
+    # Same model, one call with a duration and one without: both must report
+    # seconds so billing sees a single line item, not two different units.
+    with TokenContextManager() as manager:
+        record_media_seconds(30.0, model="veo", call_type="video")
+        record_media_seconds(None, model="veo", call_type="video")
+        details = manager.get_usage().details
+
+    assert [entry["unit"] for entry in details] == ["seconds", "seconds"]
+    # The unmeasured call records 0 seconds and is deliberately KEPT in the
+    # rollup: it is the only evidence that a billable provider call happened.
+    # It contributes nothing to quantity but still counts toward calls.
+    assert [entry["quantity"] for entry in details] == [30.0, 0.0]
+    groups = aggregate_media_usage_by_model(details)
+    assert len(groups) == 1
+    assert groups[0]["unit"] == "seconds"
+    assert groups[0]["quantity"] == 30.0
+    assert groups[0]["calls"] == 2
+
+
+def test_record_media_seconds_warns_when_unmeasured(caplog) -> None:
+    with caplog.at_level("WARNING"):
+        with TokenContextManager():
+            record_media_seconds(None, model="veo", call_type="video")
+    assert "unmeasured" in caplog.text
+
+
+def test_record_media_usage_never_raises() -> None:
+    # Accounting must never break the underlying media call.
+    with TokenContextManager() as manager:
+        record_media_usage("seconds", None, model="m", call_type="video")  # type: ignore[arg-type]
+        assert manager.get_usage().media_calls == 1
+
+
+def test_resolve_billing_model_never_returns_a_placeholder() -> None:
+    """`_configured_model_id`-style lookups return Optional[str]; passing that
+    through str() records a model literally named "None"."""
+
+    class _Model:
+        model_name = "elevenlabs-music-v1"
+
+    # None id -> falls back to the provider's own name, not "None".
+    assert resolve_billing_model(None, _Model()) == "elevenlabs-music-v1"
+    assert resolve_billing_model("", _Model()) == "elevenlabs-music-v1"
+    # A real configured id always wins.
+    assert resolve_billing_model("cfg-id", _Model()) == "cfg-id"
+    # Nothing identifies the model: an explicit fallback, never None/"None".
+    assert resolve_billing_model(None, None) == "default"
+
+    # Placeholder names on the model are not treated as identities.
+    class _Placeholder:
+        model_name = "None"
+
+    assert resolve_billing_model(None, _Placeholder()) == "default"
+
+
+def test_record_media_usage_swallows_recording_errors(monkeypatch) -> None:
+    # The best-effort guarantee is the whole point of this wrapper: a metering
+    # bug must never break the media call the user asked for. The existing
+    # quantity=None case coerces to 0 and records fine, so it would still pass
+    # with the try/except deleted — this one would not.
+    import xagent.core.tools.core.media_usage as mu
+
+    def _boom(**kwargs: object) -> None:
+        raise RuntimeError("recording backend exploded")
+
+    monkeypatch.setattr(mu, "add_media_usage", _boom)
+
+    with TokenContextManager() as manager:
+        # Must not raise.
+        mu.record_media_usage(
+            MediaUnit.IMAGES, 1, model="m", call_type=MediaCallType.GENERATE_IMAGE
+        )
+        usage = manager.get_usage()
+
+    # And must leave no partial state behind.
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_record_media_usage_swallows_invalid_unit(monkeypatch) -> None:
+    # A typo'd unit raises ValueError from the validator; the wrapper drops the
+    # record with a warning rather than propagating into the media call.
+    import xagent.core.tools.core.media_usage as mu
+
+    with TokenContextManager() as manager:
+        mu.record_media_usage("not-a-unit", 1, model="m", call_type="tts")
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_record_media_seconds_swallows_invalid_call_type() -> None:
+    import xagent.core.tools.core.media_usage as mu
+
+    with TokenContextManager() as manager:
+        mu.record_media_seconds(3.0, model="m", call_type="not-a-call-type")
+        usage = manager.get_usage()
+
+    assert usage.media_calls == 0
+    assert usage.details == []
+
+
+def test_record_media_seconds_ignores_non_finite_duration() -> None:
+    # inf > 0 is True, so without the finiteness guard this would record a
+    # non-JSON-serialisable quantity.
+    import xagent.core.tools.core.media_usage as mu
+
+    with TokenContextManager() as manager:
+        mu.record_media_seconds(
+            mu.coerce_duration(float("inf")), model="m", call_type=MediaCallType.ASR
+        )
+        entry = manager.get_usage().details[0]
+
+    # Treated as "no duration reported": recorded as 0 seconds, unit unchanged.
+    assert entry["unit"] == "seconds"
+    assert entry["quantity"] == 0.0
+
+
+def test_record_media_usage_forwards_optional_billing_metadata() -> None:
+    # The wrapper must mirror the core primitive's optional fields: passing them
+    # previously raised TypeError during argument binding, before the try block.
+    import xagent.core.tools.core.media_usage as mu
+
+    with TokenContextManager() as manager:
+        mu.record_media_usage(
+            MediaUnit.IMAGES,
+            1,
+            model="m",
+            call_type=MediaCallType.GENERATE_IMAGE,
+            resolution="2K",
+            input_tokens=7,
+            output_tokens=3,
+            tokens_estimated=True,
+        )
+        entry = manager.get_usage().details[0]
+
+    assert entry["resolution"] == "2K"
+    assert entry["provider_tokens"] == 10
+    assert entry["tokens_estimated"] is True
+
+
+def test_resolve_billing_model_survives_raising_descriptor() -> None:
+    # Identity resolution runs before record_media_usage's try/except, so a
+    # provider whose model_name property raises would otherwise break the call.
+    import xagent.core.tools.core.media_usage as mu
+
+    class _Hostile:
+        @property
+        def model_name(self) -> str:
+            raise RuntimeError("descriptor exploded")
+
+        @property
+        def model(self) -> str:
+            return "real-name"
+
+    assert mu.resolve_billing_model(None, _Hostile()) == "real-name"

--- a/tests/core/tools/core/test_media_usage_helpers.py
+++ b/tests/core/tools/core/test_media_usage_helpers.py
@@ -201,18 +201,24 @@ def test_resolve_billing_model_survives_raising_descriptor() -> None:
     "call_type",
     [c for c in MediaCallType if c.unit is not MediaUnit.SECONDS],
 )
-def test_record_media_seconds_rejects_non_duration_modalities(call_type) -> None:
-    # record_media_seconds coerces its argument as a duration and lets the unit
-    # come from the modality. Handing it a modality billed in images or
-    # characters used to record a row whose quantity was a duration but whose
-    # unit said otherwise — a silently mispriced row. Fail loudly instead.
+def test_record_media_seconds_drops_non_duration_modalities(call_type, caplog) -> None:
+    # Handing this a modality billed in images or characters used to record a
+    # row whose quantity was a duration but whose unit said otherwise -- a
+    # silently mispriced row. Dropped and logged instead.
+    #
+    # Deliberately not raised: producers call this from inside their own
+    # `try/except Exception` (music_tool), whose handler returns
+    # `success: False`, so raising would turn a generated-and-billed media call
+    # into a reported failure.
     import xagent.core.tools.core.media_usage as mu
 
-    with TokenContextManager() as manager:
-        with pytest.raises(ValueError, match="record_media_seconds"):
+    with caplog.at_level("ERROR"):
+        with TokenContextManager() as manager:
             mu.record_media_seconds(1.5, model="m", call_type=call_type)
+            assert manager.get_usage().details == []
 
-        assert manager.get_usage().details == []
+    assert "record_media_seconds" in caplog.text
+    assert call_type.value in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/core/tools/core/test_media_usage_helpers.py
+++ b/tests/core/tools/core/test_media_usage_helpers.py
@@ -108,9 +108,7 @@ def test_record_media_usage_swallows_recording_errors(monkeypatch) -> None:
 
     with TokenContextManager() as manager:
         # Must not raise.
-        mu.record_media_usage(
-            MediaUnit.IMAGES, 1, model="m", call_type=MediaCallType.GENERATE_IMAGE
-        )
+        mu.record_media_usage(MediaCallType.GENERATE_IMAGE, 1, model="m")
         usage = manager.get_usage()
 
     # And must leave no partial state behind.
@@ -118,13 +116,15 @@ def test_record_media_usage_swallows_recording_errors(monkeypatch) -> None:
     assert usage.details == []
 
 
-def test_record_media_usage_swallows_invalid_unit(monkeypatch) -> None:
-    # A typo'd unit raises ValueError from the validator; the wrapper drops the
-    # record with a warning rather than propagating into the media call.
+def test_record_media_usage_swallows_invalid_call_type() -> None:
+    # A typo'd call_type raises ValueError from the validator; the wrapper drops
+    # the record with a warning rather than propagating into the media call.
+    # Note "tts" is now a *valid* call_type -- the unit it used to be checked
+    # against no longer exists -- so the invalid value has to be a real typo.
     import xagent.core.tools.core.media_usage as mu
 
     with TokenContextManager() as manager:
-        mu.record_media_usage("tts", 1, model="m")
+        mu.record_media_usage("ttts", 1, model="m")
         usage = manager.get_usage()
 
     assert usage.media_calls == 0

--- a/tests/core/tools/core/test_media_usage_helpers.py
+++ b/tests/core/tools/core/test_media_usage_helpers.py
@@ -42,8 +42,8 @@ def test_record_media_seconds_keeps_unit_stable_when_duration_missing() -> None:
     # Same model, one call with a duration and one without: both must report
     # seconds so billing sees a single line item, not two different units.
     with TokenContextManager() as manager:
-        record_media_seconds(30.0, model="veo", call_type="video")
-        record_media_seconds(None, model="veo", call_type="video")
+        record_media_seconds(30.0, call_type="video", model="veo")
+        record_media_seconds(None, call_type="video", model="veo")
         details = manager.get_usage().details
 
     assert [entry["unit"] for entry in details] == ["seconds", "seconds"]
@@ -61,18 +61,18 @@ def test_record_media_seconds_keeps_unit_stable_when_duration_missing() -> None:
 def test_record_media_seconds_warns_when_unmeasured(caplog) -> None:
     with caplog.at_level("WARNING"):
         with TokenContextManager():
-            record_media_seconds(None, model="veo", call_type="video")
+            record_media_seconds(None, call_type="video", model="veo")
     assert "unmeasured" in caplog.text
 
 
 def test_record_media_usage_never_raises() -> None:
     # Accounting must never break the underlying media call.
     with TokenContextManager() as manager:
-        record_media_usage("seconds", None, model="m", call_type="video")  # type: ignore[arg-type]
+        record_media_usage("video", None, model="m")  # type: ignore[arg-type]
         assert manager.get_usage().media_calls == 1
 
 
-def test_resolve_billing_model_never_returns_a_placeholder() -> None:
+def test_resolve_billing_model_prefers_real_identities_over_the_fallback() -> None:
     """`_configured_model_id`-style lookups return Optional[str]; passing that
     through str() records a model literally named "None"."""
 
@@ -124,7 +124,7 @@ def test_record_media_usage_swallows_invalid_unit(monkeypatch) -> None:
     import xagent.core.tools.core.media_usage as mu
 
     with TokenContextManager() as manager:
-        mu.record_media_usage("not-a-unit", 1, model="m", call_type="tts")
+        mu.record_media_usage("tts", 1, model="m")
         usage = manager.get_usage()
 
     assert usage.media_calls == 0
@@ -135,7 +135,7 @@ def test_record_media_seconds_swallows_invalid_call_type() -> None:
     import xagent.core.tools.core.media_usage as mu
 
     with TokenContextManager() as manager:
-        mu.record_media_seconds(3.0, model="m", call_type="not-a-call-type")
+        mu.record_media_seconds(3.0, call_type="not-a-call-type", model="m")
         usage = manager.get_usage()
 
     assert usage.media_calls == 0
@@ -165,10 +165,9 @@ def test_record_media_usage_forwards_optional_billing_metadata() -> None:
 
     with TokenContextManager() as manager:
         mu.record_media_usage(
-            MediaUnit.IMAGES,
+            MediaCallType.GENERATE_IMAGE,
             1,
             model="m",
-            call_type=MediaCallType.GENERATE_IMAGE,
             resolution="2K",
             input_tokens=7,
             output_tokens=3,
@@ -196,3 +195,88 @@ def test_resolve_billing_model_survives_raising_descriptor() -> None:
             return "real-name"
 
     assert mu.resolve_billing_model(None, _Hostile()) == "real-name"
+
+
+@pytest.mark.parametrize(
+    "call_type",
+    [c for c in MediaCallType if c.unit is not MediaUnit.SECONDS],
+)
+def test_record_media_seconds_rejects_non_duration_modalities(call_type) -> None:
+    # record_media_seconds coerces its argument as a duration and lets the unit
+    # come from the modality. Handing it a modality billed in images or
+    # characters used to record a row whose quantity was a duration but whose
+    # unit said otherwise — a silently mispriced row. Fail loudly instead.
+    import xagent.core.tools.core.media_usage as mu
+
+    with TokenContextManager() as manager:
+        with pytest.raises(ValueError, match="record_media_seconds"):
+            mu.record_media_seconds(1.5, model="m", call_type=call_type)
+
+        assert manager.get_usage().details == []
+
+
+@pytest.mark.parametrize(
+    "call_type", [c for c in MediaCallType if c.unit is MediaUnit.SECONDS]
+)
+def test_record_media_seconds_accepts_every_duration_modality(call_type) -> None:
+    import xagent.core.tools.core.media_usage as mu
+
+    with TokenContextManager() as manager:
+        mu.record_media_seconds(1.5, model="m", call_type=call_type)
+        details = manager.get_usage().details
+
+    assert len(details) == 1
+    assert details[0]["unit"] == "seconds"
+    assert details[0]["quantity"] == 1.5
+
+
+@pytest.mark.parametrize(
+    "overflowing",
+    [
+        # float() of a too-large int raises OverflowError, not ValueError. A
+        # 400-digit integer literal is exactly what json.loads yields for an
+        # oversized JSON number in a provider response.
+        10**400,
+        -(10**400),
+        # These convert fine and are caught by the isfinite guard instead.
+        float("inf"),
+        float("-inf"),
+        float("nan"),
+        "1e400",
+    ],
+)
+def test_coerce_duration_survives_non_finite_values(overflowing) -> None:
+    # int(float("inf")) raises OverflowError, not ValueError; an ASR provider
+    # reporting a non-finite duration must degrade to an unmeasured row rather
+    # than break the transcription call it is measuring.
+    import xagent.core.tools.core.media_usage as mu
+
+    # None, not 0.0: the helper's documented contract distinguishes "provider
+    # reported no duration" from "provider reported zero seconds".
+    assert mu.coerce_duration(overflowing) is None
+
+    with TokenContextManager() as manager:
+        mu.record_media_seconds(
+            mu.coerce_duration(overflowing), model="m", call_type=MediaCallType.ASR
+        )
+        details = manager.get_usage().details
+
+    assert len(details) == 1
+    assert details[0]["quantity"] == 0.0
+
+
+@pytest.mark.parametrize("empty", [None, ""])
+def test_record_media_seconds_leaves_empty_call_types_to_the_primitive(empty) -> None:
+    # An absent call_type has no modality to check the unit against, so the
+    # duration guard must not claim a mismatch. Validation belongs to
+    # add_media_usage, which produces the message listing valid options -- and
+    # the wrapper swallows it so a media call is never broken by accounting.
+    import xagent.core.tools.core.media_usage as mu
+
+    assert mu._resolved_call_type(empty) is None
+
+    with TokenContextManager() as manager:
+        mu.record_media_seconds(1.5, model="m", call_type=empty)
+
+        # Swallowed, not raised, and no half-written row left behind.
+        assert manager.get_usage().details == []

--- a/tests/web/tracking/test_task_tracker_media_seam.py
+++ b/tests/web/tracking/test_task_tracker_media_seam.py
@@ -1,0 +1,95 @@
+"""Media rows must survive the TaskTracker -> quota seam.
+
+The whole design bet of the media metering primitives is that media usage rides
+the *existing* ``TokenUsage.details`` list, so it reaches quota accounting
+through the same path as token usage with no new plumbing and no migration.
+That claim is only worth making if the seam is actually exercised: the two
+helpers below are the exact functions the metering path and the mid-run quota
+gate call, and both are generic over ``details`` in a way that could silently
+drop or mangle a media row.
+"""
+
+from __future__ import annotations
+
+from xagent.core.model.chat.token_context import (
+    MediaCallType,
+    TokenUsage,
+    add_media_usage,
+    add_token_usage,
+)
+from xagent.web.tracking.task_tracker import _copy_details, _copy_usage
+
+
+def _mixed_usage() -> TokenUsage:
+    usage = TokenUsage()
+    usage.add_input_tokens(10, "gpt", "chat", "g1")
+    usage.add_output_tokens(4, "gpt", "chat", "g1")
+    usage.record_media_call(
+        call_type=MediaCallType.ASR, quantity=12.5, model="whisper", model_id="w1"
+    )
+    return usage
+
+
+def test_copy_details_preserves_media_rows_verbatim() -> None:
+    usage = _mixed_usage()
+
+    copied = _copy_details(usage.details)
+
+    assert len(copied) == 3
+    media = [d for d in copied if d.get("type") == "media"]
+    assert len(media) == 1
+    # Verbatim, not merely present: every billing field has to arrive intact,
+    # since this is the payload quota accounting prices.
+    original = [d for d in usage.details if d.get("type") == "media"][0]
+    assert media[0] == original
+    assert media[0]["unit"] == "seconds"
+    assert media[0]["quantity"] == 12.5
+
+
+def test_copy_details_is_a_deep_enough_copy_to_detach_media_rows() -> None:
+    # The copy exists so a database worker sees a stable snapshot. A media row
+    # mutated after the copy must not change what gets metered.
+    usage = _mixed_usage()
+    copied = _copy_details(usage.details)
+
+    for row in usage.details:
+        if row.get("type") == "media":
+            row["quantity"] = 9999.0
+
+    assert [d for d in copied if d.get("type") == "media"][0]["quantity"] == 12.5
+
+
+def test_copy_usage_keeps_the_media_call_count() -> None:
+    # _copy_usage rebuilds TokenUsage from an explicit kwarg list that does not
+    # mention media_calls. That is only safe because media_calls is derived from
+    # details; if it were ever reintroduced as a stored field, this snapshot
+    # would report zero media calls while carrying the rows.
+    usage = _mixed_usage()
+
+    snapshot = _copy_usage(usage)
+
+    assert snapshot.media_calls == usage.media_calls == 1
+    assert snapshot.llm_calls == usage.llm_calls
+    assert len(snapshot.details) == 3
+
+
+def test_turn_delta_slice_carries_media_rows_added_after_the_baseline() -> None:
+    # _turn_delta is a bare slice of details from a baseline index, with no type
+    # filter. Media rows recorded mid-run must therefore appear in the delta the
+    # quota gate prices -- and rows from before the baseline must not.
+    from xagent.core.model.chat.token_context import TokenContextManager
+
+    with TokenContextManager() as manager:
+        add_token_usage(input_tokens=5, output_tokens=1, model="gpt", model_id="g1")
+        baseline = len(manager.get_usage().details)
+
+        add_media_usage(quantity=3, model="sd", call_type=MediaCallType.GENERATE_IMAGE)
+        add_token_usage(input_tokens=7, output_tokens=2, model="gpt", model_id="g1")
+
+        delta = manager.get_usage().details[baseline:]
+
+    kinds = [d.get("type") for d in delta]
+    assert kinds.count("media") == 1
+    media = [d for d in delta if d.get("type") == "media"][0]
+    assert media["unit"] == "images"
+    assert media["quantity"] == 3.0


### PR DESCRIPTION
Replaces #1422. Scope and post-mortem in #1526.

Non-LLM media calls — image, video, TTS, ASR, music, sound effect,
embedding, rerank — currently produce **no usage records at all**: the
providers bill and nothing is metered. This is the shared vocabulary those
producers will record through. **No producers are wired up here.**

## Why this is a new PR rather than another round on #1422

#1422 went through five review rounds without converging. It started at 991
lines and ended at 2296, because each round's fix pulled in more of a
concurrency and serialization overhaul of `TokenUsage` — a class used well
beyond media billing. Every addition was individually justified by a review
finding, which is exactly what unbounded growth looks like from the inside.
The reviewer flagged the scope drift from round 4 onward.

This slice is **1496 lines across 5 files**, does not touch
`task_tracker.py`, and leaves `TokenUsage`'s threading semantics exactly as
it found them.

Three things #1422 got wrong that are fixed here structurally, not by
patching:

1. **Invariants are enforced, not documented.** The "unit is a property of
   the modality" rule lived in three docstrings and was violated by ten call
   sites in #1422's own test suite. `MEDIA_UNIT_BY_CALL_TYPE` now rejects a
   mismatched pair at the write boundary, so violating test data cannot be
   written in the first place.
2. **Nothing is documented that is not implemented.** #1422's docstring
   promised "a token-based price can take precedence" while nothing expressed
   or enforced it and `provider_tokens` had zero consumers. That claim is
   gone; the design question stays in #1461.
3. **The concurrency work is split out.** It is a real fix — `TokenUsage` has
   no lock on its pre-existing `tool_calls` or token counters either — but it
   is not a media-billing change. It gets its own PR with its own honest
   justification.

## What lands

- **`MediaUnit` / `MediaCallType`** name the billable dimension and the
  modality. `MEDIA_UNIT_BY_CALL_TYPE` pairs them and is enforced: a
  duration-billed call whose length is unknown records `seconds` with
  `quantity=0` rather than degrading to `requests`, because a
  `(model, unit)` price table is unusable if one modality reports two units.
- **`add_media_usage`** writes a `type:"media"` row into the existing
  `TokenUsage.details` list, so media flows through the current TaskTracker
  persistence and quota `delta_details` paths with no schema change.
  Provider tokens go under `provider_tokens`, never `tokens` — the latter
  means "billable LLM tokens" and a consumer summing it must not pick up
  media counts.
- **`aggregate_media_usage_by_model`** groups by (model, unit, call_type,
  resolution). Zero-quantity rows are kept deliberately: they are the only
  evidence an unmeasured provider call happened.
- **`media_usage.py`** adds `resolve_billing_model` (never records a
  placeholder identity like `"default"` or `"None"`) plus the
  error-swallowing `record_media_usage` / `record_media_seconds` wrappers —
  a metering bug must never break the user's media call.

Values are validated where they are last repairable: booleans, negatives,
`NaN`, infinities and overflowing quantities all record `0` with a warning
**while the row survives**, since the call happened and is billable even
when its size is unknown. `MediaUnit.REQUESTS` additionally rejects any
quantity but `1`, because it means exactly one call and any other value
would make the billable quantity contradict the call count from the same
row.

## Explicitly out of scope

- **Counter/rows atomicity under concurrency** — tracked in #1526. Worth
  noting for review: `TokenUsage` was never thread-safe, so this PR does not
  regress anything; it just does not fix it either.
- **Token-vs-unit pricing precedence** — #1461.
- **Aggregate identity tagging and the provider-token split** — #1460.
- **Unbounded `details` persistence** — #1466.
- **Distinguishing unmeasured from measured-zero from discarded** — #1495.

## Testing

Tests live in `tests/core/model/chat/test_media_usage.py` and
`tests/core/tools/core/test_media_usage_helpers.py`. Deliberately not quoting
a case count — #1422 accumulated stale numbers in its description, and the
count drifts every time a parametrised case is added. The pytest suite does not run on my machine
(importing `xagent.core.model.chat` hangs, on `main` too), so CI is the suite
of record — flagging that rather than implying a local green run.

Every guard is verified by reverting it and confirming a **committed** test
fails. All ten pass that check: the REQUESTS quantity constraint, the
unit/call_type mapping, `_coerce_float`'s finiteness, `_coerce_int`'s
overflow handling, the unit and call_type enum validation, negative and
boolean quantity rejection, `unit=None` rejection, and `estimate_media_tokens`'
broad iteration guard.

#1422 taught me this distinction the hard way: I had mutation-tested fixes in
scratch scripts and committed different tests, and two of those committed
tests passed against deliberately broken implementations. A self-review sweep
before opening this for review found two guards here with the same problem —
both now covered.
