### PR TITLE
fix(jobs): enforce the retry budget on stale requeue and redelivery

### DIFF
--- a/example.env
+++ b/example.env
@@ -98,7 +98,11 @@ PORT="80"
 # budget-exhausted, refusal-guarded job stays visibly RUNNING before the
 # sweep retires it (worst case: this value plus one sweep interval). Keep it
 # above XAGENT_BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS, or the sweep can
-# act on a job before the broker has redelivered it even once.
+# act on a job before the broker has redelivered it even once. RUNNING
+# liveness depends on the handler actually writing progress; a handler that
+# never does looks silent from the first tick. The retirement bound above
+# also assumes the scheduler (Beat) service is deployed and running -- with
+# no Beat, this sweep never runs at all.
 # XAGENT_BACKGROUND_JOB_STALE_SECONDS="7200"
 # Scheduler interval for scanning stale background jobs.
 # XAGENT_BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS="300"

--- a/example.env
+++ b/example.env
@@ -94,7 +94,11 @@ PORT="80"
 # Default max attempts for newly-created durable jobs.
 # XAGENT_BACKGROUND_JOB_MAX_RETRIES="3"
 # Stale non-terminal jobs past this age are requeued by the scheduler when
-# retry budget remains, otherwise marked failed.
+# retry budget remains, otherwise marked failed. This also bounds how long a
+# budget-exhausted, refusal-guarded job stays visibly RUNNING before the
+# sweep retires it (worst case: this value plus one sweep interval). Keep it
+# above XAGENT_BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS, or the sweep can
+# act on a job before the broker has redelivered it even once.
 # XAGENT_BACKGROUND_JOB_STALE_SECONDS="7200"
 # Scheduler interval for scanning stale background jobs.
 # XAGENT_BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS="300"

--- a/example.env
+++ b/example.env
@@ -93,7 +93,8 @@ PORT="80"
 # XAGENT_BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS="3600"
 # Default max attempts for newly-created durable jobs.
 # XAGENT_BACKGROUND_JOB_MAX_RETRIES="3"
-# Stale non-terminal jobs are requeued by the scheduler after this age.
+# Stale non-terminal jobs past this age are requeued by the scheduler when
+# retry budget remains, otherwise marked failed.
 # XAGENT_BACKGROUND_JOB_STALE_SECONDS="7200"
 # Scheduler interval for scanning stale background jobs.
 # XAGENT_BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS="300"

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -130,9 +130,9 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
         if job.status == BackgroundJobStatus.FAILED.value:
             logger.info("Skipping failed background job %s", job_id)
             return {
+                **dict(job.result or {}),
                 "status": "failed",
                 "error": job.error_message,
-                **dict(job.result or {}),
             }
 
         if int(job.attempts or 0) >= int(job.max_attempts or 1):

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sqlalchemy.orm import Session
 
-from ...config import get_background_job_stale_seconds
 from ..models.background_job import (
     BackgroundJob,
     BackgroundJobStatus,
@@ -136,42 +134,16 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
             }
 
         if int(job.attempts or 0) >= int(job.max_attempts or 1):
-            stale_cutoff = datetime.now(timezone.utc) - timedelta(
-                seconds=get_background_job_stale_seconds()
+            logger.warning(
+                "Refusing redelivered background job %s: retry budget exhausted (attempts=%s, max_attempts=%s)",
+                job_id,
+                job.attempts,
+                job.max_attempts,
             )
-            is_fresh = (
-                db.query(BackgroundJob.id)
-                .filter(
-                    BackgroundJob.id == job.id,
-                    BackgroundJob.updated_at.is_not(None),
-                    BackgroundJob.updated_at > stale_cutoff,
-                )
-                .first()
-                is not None
-            )
-            if is_fresh:
-                logger.warning(
-                    "Refusing redelivered background job %s: retry budget exhausted (attempts=%s, max_attempts=%s) but the job shows recent progress",
-                    job_id,
-                    job.attempts,
-                    job.max_attempts,
-                )
-                return {
-                    "status": "skipped",
-                    "reason": "Retry budget exhausted; refusing duplicate execution while the job shows recent progress",
-                }
-            error_message = (
-                f"Background job exceeded its retry budget "
-                f"(attempts={int(job.attempts or 0)} of {int(job.max_attempts or 1)})"
-            )
-            logger.warning("Failing background job %s: %s", job_id, error_message)
-            mark_job_failed(
-                db,
-                job,
-                error_message=error_message,
-                result={"last_progress": dict(job.progress or {})},
-            )
-            return {"status": "failed", "error": error_message}
+            return {
+                "status": "skipped",
+                "reason": "Retry budget exhausted; refusing duplicate execution",
+            }
 
         mark_job_running(db, job)
         try:

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -40,6 +40,12 @@ def register_background_job_handler(
 ) -> None:
     """Register a handler for a job type defined outside this package.
 
+    A handler that runs longer than the stale window must call
+    update_job_progress from within its own run, not just at the start: that
+    is what the stale sweep reads to tell a live handler from a hung one. A
+    handler that goes silent past the window is treated as hung, and once its
+    retry budget is exhausted the sweep marks the row FAILED.
+
     Args:
         job_type: Durable ``BackgroundJob.job_type`` value the handler owns.
         handler: Callable invoked by ``_execute_job_handler`` for that job type.

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sqlalchemy.orm import Session
 
+from ...config import get_background_job_stale_seconds
 from ..models.background_job import (
     BackgroundJob,
     BackgroundJobStatus,
@@ -125,6 +127,51 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
         if job.status == BackgroundJobStatus.SUCCEEDED.value:
             logger.info("Skipping already completed background job %s", job_id)
             return dict(job.result or {"status": "succeeded"})
+        if job.status == BackgroundJobStatus.FAILED.value:
+            logger.info("Skipping failed background job %s", job_id)
+            return {
+                "status": "failed",
+                "error": job.error_message,
+                **dict(job.result or {}),
+            }
+
+        if int(job.attempts or 0) >= int(job.max_attempts or 1):
+            stale_cutoff = datetime.now(timezone.utc) - timedelta(
+                seconds=get_background_job_stale_seconds()
+            )
+            is_fresh = (
+                db.query(BackgroundJob.id)
+                .filter(
+                    BackgroundJob.id == job.id,
+                    BackgroundJob.updated_at.is_not(None),
+                    BackgroundJob.updated_at > stale_cutoff,
+                )
+                .first()
+                is not None
+            )
+            if is_fresh:
+                logger.warning(
+                    "Refusing redelivered background job %s: retry budget exhausted (attempts=%s, max_attempts=%s) but the job shows recent progress",
+                    job_id,
+                    job.attempts,
+                    job.max_attempts,
+                )
+                return {
+                    "status": "skipped",
+                    "reason": "Retry budget exhausted; refusing duplicate execution while the job shows recent progress",
+                }
+            error_message = (
+                f"Background job exceeded its retry budget "
+                f"(attempts={int(job.attempts or 0)} of {int(job.max_attempts or 1)})"
+            )
+            logger.warning("Failing background job %s: %s", job_id, error_message)
+            mark_job_failed(
+                db,
+                job,
+                error_message=error_message,
+                result={"last_progress": dict(job.progress or {})},
+            )
+            return {"status": "failed", "error": error_message}
 
         mark_job_running(db, job)
         try:

--- a/src/xagent/web/jobs/trigger_tasks.py
+++ b/src/xagent/web/jobs/trigger_tasks.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from ..models.background_job import BackgroundJob
 from ..models.database import get_session_local, init_db
 from ..services.background_jobs import (
+    SweepResult,
     requeue_stale_background_jobs,
     update_job_progress,
 )
@@ -43,6 +44,21 @@ def _reap_and_pause_stale_preview_runs(db: Session) -> int:
             )
         )
     return len(reaped_pause_targets)
+
+
+def _sweep_stale_jobs(db: Session) -> SweepResult:
+    """Run the stale-job sweep without letting its failure poison the tick.
+
+    Shared by both sync trigger-scan entrypoints below. A flush-level failure
+    inside the sweep leaves the session needing rollback; roll it back here so
+    the rest of the tick keeps a usable session.
+    """
+    try:
+        return requeue_stale_background_jobs(db)
+    except Exception:
+        logger.exception("Stale background job sweep failed this tick")
+        db.rollback()
+        return SweepResult(requeued=[], failed_count=0)
 
 
 def handle_trigger_event(db: Session, job: BackgroundJob) -> dict[str, Any]:
@@ -95,11 +111,7 @@ def handle_trigger_event(db: Session, job: BackgroundJob) -> dict[str, Any]:
 def handle_trigger_scan(db: Session, job: BackgroundJob) -> dict[str, Any]:
     payload = dict(job.payload or {})
     update_job_progress(db, job, message="Scanning scheduled triggers")
-    try:
-        requeued_jobs = requeue_stale_background_jobs(db)
-    except Exception:
-        logger.exception("Stale background job sweep failed this tick")
-        requeued_jobs = []
+    sweep = _sweep_stale_jobs(db)
     runs = scan_due_scheduled_triggers(db)
     # This is the BackgroundJob-driven variant of the same scan
     # `scan_due_triggers` below runs for Celery Beat -- the reaper must run
@@ -109,7 +121,8 @@ def handle_trigger_scan(db: Session, job: BackgroundJob) -> dict[str, Any]:
     return {
         "status": "scanned",
         "scan_scope": payload.get("scope", "all"),
-        "requeued_stale_jobs": len(requeued_jobs),
+        "requeued_stale_jobs": len(sweep.requeued),
+        "failed_stale_jobs": sweep.failed_count,
         "trigger_runs_created": len(runs),
         "reaped_preview_run_pause_dispatches": reaped_preview_run_pause_dispatches,
         "processed_at": datetime.now(timezone.utc).isoformat(),
@@ -134,18 +147,15 @@ def scan_due_triggers() -> dict[str, Any]:
 
     db = SessionLocal()
     try:
-        try:
-            requeued_jobs = requeue_stale_background_jobs(db)
-        except Exception:
-            logger.exception("Stale background job sweep failed this tick")
-            requeued_jobs = []
+        sweep = _sweep_stale_jobs(db)
         runs = scan_due_scheduled_triggers(db)
         # Only counts reaped runs whose Task was still RUNNING (i.e. that
         # needed an explicit PAUSE dispatch), not every reaped run.
         reaped_preview_run_pause_dispatches = _reap_and_pause_stale_preview_runs(db)
         return {
             "status": "ok",
-            "requeued_stale_jobs": len(requeued_jobs),
+            "requeued_stale_jobs": len(sweep.requeued),
+            "failed_stale_jobs": sweep.failed_count,
             "trigger_runs_created": len(runs),
             "reaped_preview_run_pause_dispatches": reaped_preview_run_pause_dispatches,
             "processed_at": datetime.now(timezone.utc).isoformat(),

--- a/src/xagent/web/jobs/trigger_tasks.py
+++ b/src/xagent/web/jobs/trigger_tasks.py
@@ -95,7 +95,11 @@ def handle_trigger_event(db: Session, job: BackgroundJob) -> dict[str, Any]:
 def handle_trigger_scan(db: Session, job: BackgroundJob) -> dict[str, Any]:
     payload = dict(job.payload or {})
     update_job_progress(db, job, message="Scanning scheduled triggers")
-    requeued_jobs = requeue_stale_background_jobs(db)
+    try:
+        requeued_jobs = requeue_stale_background_jobs(db)
+    except Exception:
+        logger.exception("Stale background job sweep failed this tick")
+        requeued_jobs = []
     runs = scan_due_scheduled_triggers(db)
     # This is the BackgroundJob-driven variant of the same scan
     # `scan_due_triggers` below runs for Celery Beat -- the reaper must run
@@ -130,7 +134,11 @@ def scan_due_triggers() -> dict[str, Any]:
 
     db = SessionLocal()
     try:
-        requeued_jobs = requeue_stale_background_jobs(db)
+        try:
+            requeued_jobs = requeue_stale_background_jobs(db)
+        except Exception:
+            logger.exception("Stale background job sweep failed this tick")
+            requeued_jobs = []
         runs = scan_due_scheduled_triggers(db)
         # Only counts reaped runs whose Task was still RUNNING (i.e. that
         # needed an explicit PAUSE dispatch), not every reaped run.

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -282,20 +282,21 @@ def requeue_stale_background_jobs(
     refresh updated_at, so an actively progressing job is never swept just
     because it has been running a long time. A RUNNING row whose updated_at is
     still NULL (no write since creation) is swept by the NULL-updated_at
-    branch below, which carries no status condition; that behavior is
-    unchanged.
+    branch below, which carries no status condition; rows created by this
+    code always have updated_at set (server_default), so that branch exists
+    for legacy rows only.
 
     A job whose attempts already reached max_attempts is marked FAILED instead
-    of requeued; its last progress snapshot is kept under the result key
-    "last_progress". Returns only the rows it attempted to requeue, never the
-    ones it failed.
+    of requeued; its failure result carries "status", "message", and the last
+    progress snapshot under "last_progress". Returns only the rows it
+    attempted to requeue, never the ones it failed.
 
     There is no execution lease on this table, so a worker that is alive but
     silent past the cutoff can still race this sweep and later overwrite the
-    terminal state it writes. Once a redelivery is refused because the row
-    still shows recent progress, Celery acks the message and no further
-    redelivery exists for it, so this sweep is then the only path that turns
-    the row terminal.
+    terminal state it writes. A redelivery of a budget-exhausted row is always
+    refused without writing anything, so Celery acks the message and no further redelivery exists for
+    it; the sweep is the path that later turns such a row terminal, though
+    other enqueue paths can still transition a row independently before then.
     """
     stale_seconds = stale_after_seconds or get_background_job_stale_seconds()
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=stale_seconds)
@@ -333,10 +334,14 @@ def requeue_stale_background_jobs(
         .all()
     )
 
+    # The partition below commits (or rolls back) per row, so it must finish
+    # before the requeue mutation loop: a rollback here may only ever discard
+    # this row's own half-written state, never pending requeue mutations.
     requeue_targets: list[BackgroundJob] = []
+    failed_count = 0
     for job in stale_jobs:
         if int(job.attempts or 0) >= int(job.max_attempts or 1):
-            logger.warning(
+            logger.error(
                 "Failing stale background job %s type=%s status=%s: retry budget exhausted (attempts=%s, max_attempts=%s)",
                 job.id,
                 job.job_type,
@@ -344,18 +349,38 @@ def requeue_stale_background_jobs(
                 job.attempts,
                 job.max_attempts,
             )
-            mark_job_failed(
-                db,
-                job,
-                error_message=(
-                    f"Background job exceeded its retry budget "
-                    f"(attempts={int(job.attempts or 0)} of {int(job.max_attempts or 1)}); "
-                    "not requeueing"
-                ),
-                result={"last_progress": dict(job.progress or {})},
+            error_message = (
+                f"Background job exceeded its retry budget "
+                f"(attempts={int(job.attempts or 0)} of {int(job.max_attempts or 1)}); "
+                "not requeueing"
             )
+            try:
+                mark_job_failed(
+                    db,
+                    job,
+                    error_message=error_message,
+                    result={
+                        "status": "error",
+                        "message": error_message,
+                        "last_progress": dict(job.progress or {}),
+                    },
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to mark budget-exhausted background job %s as failed",
+                    job.id,
+                )
+                db.rollback()
+                continue
+            failed_count += 1
         else:
             requeue_targets.append(job)
+
+    if failed_count:
+        logger.error(
+            "Stale sweep marked %s budget-exhausted background job(s) failed",
+            failed_count,
+        )
 
     requeued: list[BackgroundJob] = []
     for job in requeue_targets:

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -44,7 +44,7 @@ TERMINAL_JOB_STATUSES = frozenset(
 
 
 class SweepResult(NamedTuple):
-    requeued: list["BackgroundJob"]
+    requeued: list[BackgroundJob]
     failed_count: int
 
 
@@ -306,12 +306,13 @@ def requeue_stale_background_jobs(
     This table has not yet adopted the lease pattern used elsewhere in the
     repo (task_lease_service), so a worker that is alive but silent past the
     cutoff can still race this sweep and later overwrite the terminal state
-    it writes. A redelivery of a budget-exhausted row is always
-    refused without writing anything, so Celery acks the message and no further redelivery exists for
-    it; the sweep is the path that later turns such a row terminal, though
-    other enqueue paths can still transition a row independently before then.
+    it writes. This function owns the transaction boundary of the session it
+    is given: it commits per retired row and rolls back on a failed write.
     """
     stale_seconds = stale_after_seconds or get_background_job_stale_seconds()
+    # cutoff is computed on the app server's clock; updated_at is written by
+    # the database's clock. The default window (hours) dwarfs realistic clock
+    # skew between the two, so no synchronization between them is attempted.
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=stale_seconds)
     requeue_statuses = {
         BackgroundJobStatus.PENDING.value,
@@ -358,7 +359,7 @@ def requeue_stale_background_jobs(
     failed_count = 0
     for job in stale_jobs:
         if int(job.attempts or 0) >= int(job.max_attempts or 1):
-            logger.error(
+            logger.warning(
                 "Failing stale background job %s type=%s status=%s: retry budget exhausted (attempts=%s, max_attempts=%s)",
                 job.id,
                 job.job_type,
@@ -372,6 +373,14 @@ def requeue_stale_background_jobs(
                 "not requeueing"
             )
             try:
+                db.refresh(job)
+                if str(job.status) in TERMINAL_JOB_STATUSES:
+                    logger.info(
+                        "Skipping stale background job %s: already %s",
+                        job.id,
+                        job.status,
+                    )
+                    continue
                 mark_job_failed(
                     db,
                     job,
@@ -387,6 +396,21 @@ def requeue_stale_background_jobs(
                     "Failed to mark budget-exhausted background job %s as failed",
                     job.id,
                 )
+                # The commit inside mark_job_failed may have durably succeeded
+                # even though a later step in that call (e.g. its post-commit
+                # refresh) raised; check what actually landed instead of
+                # assuming the write was lost. This session's sessionmaker has
+                # autoflush=False (models/database.py), so this query only
+                # ever reads what is already committed, never triggers the
+                # very write we are trying to classify.
+                committed_status = (
+                    db.query(BackgroundJob.status)
+                    .filter(BackgroundJob.id == job.id)
+                    .scalar()
+                )
+                if committed_status == BackgroundJobStatus.FAILED.value:
+                    failed_count += 1
+                    continue
                 db.rollback()
                 continue
             failed_count += 1

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -271,11 +271,27 @@ def requeue_stale_background_jobs(
     stale_after_seconds: int | None = None,
     limit: int = 100,
 ) -> list[BackgroundJob]:
-    """Requeue non-terminal jobs whose durable DB state is stale.
+    """Requeue stale non-terminal jobs that still have retry budget.
 
     Redis/Celery can lose in-flight delivery state during broker loss or worker
     crashes. The database row remains authoritative, so the scheduler can safely
     put old pending/enqueued/running jobs back on the broker.
+
+    A RUNNING row counts as stale only when both started_at and updated_at are
+    older than the cutoff: progress writes refresh updated_at, so an actively
+    progressing job is never swept just because it has been running a long time.
+
+    A job whose attempts already reached max_attempts is marked FAILED instead
+    of requeued; its last progress snapshot is kept under the result key
+    "last_progress". Returns only the rows it attempted to requeue, never the
+    ones it failed.
+
+    There is no execution lease on this table, so a worker that is alive but
+    silent past the cutoff can still race this sweep and later overwrite the
+    terminal state it writes. This sweep is the sole recovery path that turns a
+    silent, budget-exhausted row terminal: a broker redelivery for a fresh row
+    is refused without writing anything, and once Celery acks that refusal no
+    further redelivery follows it, so only this sweep converges the row.
     """
     stale_seconds = stale_after_seconds or get_background_job_stale_seconds()
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=stale_seconds)
@@ -294,6 +310,7 @@ def requeue_stale_background_jobs(
                     BackgroundJob.status == BackgroundJobStatus.RUNNING.value,
                     BackgroundJob.started_at.is_not(None),
                     BackgroundJob.started_at <= cutoff,
+                    BackgroundJob.updated_at <= cutoff,
                 ),
                 and_(
                     BackgroundJob.status != BackgroundJobStatus.RUNNING.value,
@@ -312,8 +329,32 @@ def requeue_stale_background_jobs(
         .all()
     )
 
-    requeued: list[BackgroundJob] = []
+    requeue_targets: list[BackgroundJob] = []
     for job in stale_jobs:
+        if int(job.attempts or 0) >= int(job.max_attempts or 1):
+            logger.warning(
+                "Failing stale background job %s type=%s status=%s: retry budget exhausted (attempts=%s, max_attempts=%s)",
+                job.id,
+                job.job_type,
+                job.status,
+                job.attempts,
+                job.max_attempts,
+            )
+            mark_job_failed(
+                db,
+                job,
+                error_message=(
+                    f"Background job exceeded its retry budget "
+                    f"(attempts={int(job.attempts or 0)} of {int(job.max_attempts or 1)}); "
+                    "not requeueing"
+                ),
+                result={"last_progress": dict(job.progress or {})},
+            )
+        else:
+            requeue_targets.append(job)
+
+    requeued: list[BackgroundJob] = []
+    for job in requeue_targets:
         logger.warning(
             "Requeueing stale background job %s type=%s status=%s",
             job.id,
@@ -331,38 +372,38 @@ def requeue_stale_background_jobs(
         )
         db.add(job)
 
-    if not stale_jobs:
+    if not requeue_targets:
         return requeued
 
     db.commit()
-    for job in stale_jobs:
+    for job in requeue_targets:
         db.refresh(job)
 
     if not get_celery_enabled():
-        return stale_jobs
+        return requeue_targets
 
     if get_celery_broker_url() is None:
         error_message = "Celery background jobs are enabled but no broker URL is set"
-        for job in stale_jobs:
+        for job in requeue_targets:
             setattr(
                 job, "error_message", f"Failed to requeue stale job: {error_message}"
             )
             db.add(job)
         db.commit()
-        for job in stale_jobs:
+        for job in requeue_targets:
             db.refresh(job)
-        return stale_jobs
+        return requeue_targets
 
     from ..jobs.tasks import execute_background_job
 
-    for job in stale_jobs:
+    for job in requeue_targets:
         setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
         db.add(job)
     db.commit()
-    for job in stale_jobs:
+    for job in requeue_targets:
         db.refresh(job)
 
-    for job in stale_jobs:
+    for job in requeue_targets:
         try:
             async_result = execute_background_job.apply_async(
                 args=[job.id],

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -277,9 +277,13 @@ def requeue_stale_background_jobs(
     crashes. The database row remains authoritative, so the scheduler can safely
     put old pending/enqueued/running jobs back on the broker.
 
-    A RUNNING row counts as stale only when both started_at and updated_at are
-    older than the cutoff: progress writes refresh updated_at, so an actively
-    progressing job is never swept just because it has been running a long time.
+    A RUNNING row with a non-NULL updated_at counts as stale only when both
+    started_at and updated_at are older than the cutoff: progress writes
+    refresh updated_at, so an actively progressing job is never swept just
+    because it has been running a long time. A RUNNING row whose updated_at is
+    still NULL (no write since creation) is swept by the NULL-updated_at
+    branch below, which carries no status condition; that behavior is
+    unchanged.
 
     A job whose attempts already reached max_attempts is marked FAILED instead
     of requeued; its last progress snapshot is kept under the result key
@@ -288,10 +292,10 @@ def requeue_stale_background_jobs(
 
     There is no execution lease on this table, so a worker that is alive but
     silent past the cutoff can still race this sweep and later overwrite the
-    terminal state it writes. This sweep is the sole recovery path that turns a
-    silent, budget-exhausted row terminal: a broker redelivery for a fresh row
-    is refused without writing anything, and once Celery acks that refusal no
-    further redelivery follows it, so only this sweep converges the row.
+    terminal state it writes. Once a redelivery is refused because the row
+    still shows recent progress, Celery acks the message and no further
+    redelivery exists for it, so this sweep is then the only path that turns
+    the row terminal.
     """
     stale_seconds = stale_after_seconds or get_background_job_stale_seconds()
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=stale_seconds)

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, NamedTuple
 from urllib.parse import urlsplit
 
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
 
 from ...config import (
     get_background_job_max_retries,
@@ -40,6 +41,11 @@ TERMINAL_JOB_STATUSES = frozenset(
         BackgroundJobStatus.CANCELLED.value,
     }
 )
+
+
+class SweepResult(NamedTuple):
+    requeued: list["BackgroundJob"]
+    failed_count: int
 
 
 def _is_redis_broker_reachable(broker_url: str) -> bool:
@@ -259,6 +265,10 @@ def update_job_progress(
     if extra:
         progress.update(extra)
     setattr(job, "progress", progress)
+    # A replaced dict that compares equal to the stored value emits no UPDATE,
+    # so onupdate would not advance updated_at; force the write so progress
+    # calls always refresh the liveness timestamp the stale sweep reads.
+    flag_modified(job, "progress")
     db.add(job)
     db.commit()
     db.refresh(job)
@@ -270,7 +280,7 @@ def requeue_stale_background_jobs(
     *,
     stale_after_seconds: int | None = None,
     limit: int = 100,
-) -> list[BackgroundJob]:
+) -> SweepResult:
     """Requeue stale non-terminal jobs that still have retry budget.
 
     Redis/Celery can lose in-flight delivery state during broker loss or worker
@@ -282,14 +292,16 @@ def requeue_stale_background_jobs(
     refresh updated_at, so an actively progressing job is never swept just
     because it has been running a long time. A RUNNING row whose updated_at is
     still NULL (no write since creation) is swept by the NULL-updated_at
-    branch below, which carries no status condition; rows created by this
-    code always have updated_at set (server_default), so that branch exists
-    for legacy rows only.
+    branch below, which carries no status condition. No current code path
+    produces a NULL updated_at -- the column has had a server default since
+    the table's first migration -- so that branch is kept defensively.
 
     A job whose attempts already reached max_attempts is marked FAILED instead
     of requeued; its failure result carries "status", "message", and the last
-    progress snapshot under "last_progress". Returns only the rows it
-    attempted to requeue, never the ones it failed.
+    progress snapshot under "last_progress". Returns a SweepResult: the rows
+    it attempted to requeue (never the ones it failed) and the count of rows
+    it marked failed this pass (only successful mark_job_failed calls count;
+    a row skipped by the per-row guard above is not counted).
 
     This table has not yet adopted the lease pattern used elsewhere in the
     repo (task_lease_service), so a worker that is alive but silent past the
@@ -323,6 +335,10 @@ def requeue_stale_background_jobs(
                     BackgroundJob.updated_at.is_not(None),
                     BackgroundJob.updated_at <= cutoff,
                 ),
+                # A RUNNING row with a NULL updated_at would match this branch
+                # and skip the started_at/liveness check entirely; unreachable
+                # today (updated_at has a server default), kept as a
+                # defensive net.
                 and_(
                     BackgroundJob.updated_at.is_(None),
                     BackgroundJob.created_at.is_not(None),
@@ -403,14 +419,14 @@ def requeue_stale_background_jobs(
         db.add(job)
 
     if not requeue_targets:
-        return requeued
+        return SweepResult(requeued=requeued, failed_count=failed_count)
 
     db.commit()
     for job in requeue_targets:
         db.refresh(job)
 
     if not get_celery_enabled():
-        return requeue_targets
+        return SweepResult(requeued=requeue_targets, failed_count=failed_count)
 
     if get_celery_broker_url() is None:
         error_message = "Celery background jobs are enabled but no broker URL is set"
@@ -422,7 +438,7 @@ def requeue_stale_background_jobs(
         db.commit()
         for job in requeue_targets:
             db.refresh(job)
-        return requeue_targets
+        return SweepResult(requeued=requeue_targets, failed_count=failed_count)
 
     from ..jobs.tasks import execute_background_job
 
@@ -452,7 +468,7 @@ def requeue_stale_background_jobs(
     for job in requeued:
         db.refresh(job)
 
-    return requeued
+    return SweepResult(requeued=requeued, failed_count=failed_count)
 
 
 def mark_job_succeeded(

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -291,9 +291,10 @@ def requeue_stale_background_jobs(
     progress snapshot under "last_progress". Returns only the rows it
     attempted to requeue, never the ones it failed.
 
-    There is no execution lease on this table, so a worker that is alive but
-    silent past the cutoff can still race this sweep and later overwrite the
-    terminal state it writes. A redelivery of a budget-exhausted row is always
+    This table has not yet adopted the lease pattern used elsewhere in the
+    repo (task_lease_service), so a worker that is alive but silent past the
+    cutoff can still race this sweep and later overwrite the terminal state
+    it writes. A redelivery of a budget-exhausted row is always
     refused without writing anything, so Celery acks the message and no further redelivery exists for
     it; the sweep is the path that later turns such a row terminal, though
     other enqueue paths can still transition a row independently before then.

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -29,6 +29,7 @@ from xagent.web.services.background_jobs import (
     enqueue_background_job,
     is_background_job_enqueue_available,
     requeue_stale_background_jobs,
+    update_job_progress,
 )
 from xagent.web.services.triggers import enqueue_trigger_event_job
 
@@ -1545,6 +1546,7 @@ def test_requeue_stale_fails_job_with_exhausted_attempts(tmp_path, monkeypatch, 
             user_id=int(user.id),
             job_type=BackgroundJobType.KB_INGEST_WEB,
             payload={"collection": "kb"},
+            max_attempts=3,
         )
         old = datetime.now(timezone.utc) - timedelta(hours=3)
         progress = {"message": "Crawling page 7", "completed": 7, "total": 40}
@@ -1567,6 +1569,8 @@ def test_requeue_stale_fails_job_with_exhausted_attempts(tmp_path, monkeypatch, 
         assert job.status == BackgroundJobStatus.FAILED.value
         assert job.finished_at is not None
         assert "retry budget" in str(job.error_message)
+        assert job.result["status"] == "error"
+        assert "retry budget" in job.result["message"]
         assert job.result["last_progress"] == progress
     finally:
         db.close()
@@ -1602,6 +1606,7 @@ def test_requeue_stale_with_celery_never_dispatches_exhausted_job(
             user_id=int(user.id),
             job_type=BackgroundJobType.KB_INGEST_WEB,
             payload={"collection": "kb-exhausted"},
+            max_attempts=3,
         )
         setattr(exhausted, "status", BackgroundJobStatus.RUNNING.value)
         setattr(exhausted, "attempts", 3)
@@ -1614,6 +1619,7 @@ def test_requeue_stale_with_celery_never_dispatches_exhausted_job(
             user_id=int(user.id),
             job_type=BackgroundJobType.KB_INGEST_WEB,
             payload={"collection": "kb-under-budget"},
+            max_attempts=3,
         )
         setattr(under_budget, "status", BackgroundJobStatus.RUNNING.value)
         setattr(under_budget, "attempts", 0)
@@ -1636,6 +1642,235 @@ def test_requeue_stale_with_celery_never_dispatches_exhausted_job(
 
         db.refresh(under_budget)
         assert under_budget.status == BackgroundJobStatus.ENQUEUED.value
+    finally:
+        db.close()
+
+
+def test_requeue_stale_skips_job_with_real_progress_write(tmp_path, monkeypatch):
+    """A real update_job_progress call must refresh updated_at through the
+    ORM's onupdate mechanism, not just through a test fixture's explicit set.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-real-progress-write.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="real-progress-write")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb"},
+        )
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(job, "started_at", old)
+        setattr(job, "updated_at", old)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+
+        update_job_progress(db, job, message="tick")
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert requeued == []
+        db.refresh(job)
+        assert job.status == BackgroundJobStatus.RUNNING.value
+    finally:
+        db.close()
+
+
+def test_requeue_stale_mixed_batch_returns_only_requeued(tmp_path, monkeypatch):
+    """A mixed batch of stale rows returns only the ones actually requeued.
+
+    With only an exhausted row in the batch, the early-return check
+    `if not requeue_targets: return requeued` can't tell requeue_targets and
+    stale_jobs apart (both are empty/absent the same way); a mixed batch is
+    what exercises the distinction between the two lists on both the
+    Celery-disabled and Celery-enabled return paths.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-mixed-batch-no-celery.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="mixed-batch-no-celery")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+
+        exhausted = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb-exhausted"},
+            max_attempts=3,
+        )
+        setattr(exhausted, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(exhausted, "attempts", 3)
+        setattr(exhausted, "started_at", old)
+        setattr(exhausted, "updated_at", old)
+        db.add(exhausted)
+
+        under_budget = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb-under-budget"},
+            max_attempts=3,
+        )
+        setattr(under_budget, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(under_budget, "attempts", 0)
+        setattr(under_budget, "started_at", old)
+        setattr(under_budget, "updated_at", old)
+        db.add(under_budget)
+
+        db.commit()
+        db.refresh(exhausted)
+        db.refresh(under_budget)
+        under_budget_id = under_budget.id
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert [item.id for item in requeued] == [under_budget_id]
+
+        db.refresh(exhausted)
+        assert exhausted.status == BackgroundJobStatus.FAILED.value
+
+        db.refresh(under_budget)
+        assert under_budget.status == BackgroundJobStatus.PENDING.value
+    finally:
+        db.close()
+
+    from xagent.web.jobs import tasks as tasks_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    apply_async_calls: list[str] = []
+
+    def fake_apply_async(*, args, queue):
+        apply_async_calls.append(args[0])
+        return MagicMock(id=f"fake-task-{args[0]}")
+
+    monkeypatch.setattr(
+        tasks_module.execute_background_job, "apply_async", fake_apply_async
+    )
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-mixed-batch-celery.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="mixed-batch-celery")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+
+        exhausted = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb-exhausted"},
+            max_attempts=3,
+        )
+        setattr(exhausted, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(exhausted, "attempts", 3)
+        setattr(exhausted, "started_at", old)
+        setattr(exhausted, "updated_at", old)
+        db.add(exhausted)
+
+        under_budget = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb-under-budget"},
+            max_attempts=3,
+        )
+        setattr(under_budget, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(under_budget, "attempts", 0)
+        setattr(under_budget, "started_at", old)
+        setattr(under_budget, "updated_at", old)
+        db.add(under_budget)
+
+        db.commit()
+        db.refresh(exhausted)
+        db.refresh(under_budget)
+        under_budget_id = under_budget.id
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert apply_async_calls == [under_budget_id]
+        assert [item.id for item in requeued] == [under_budget_id]
+
+        db.refresh(exhausted)
+        assert exhausted.status == BackgroundJobStatus.FAILED.value
+
+        db.refresh(under_budget)
+        assert under_budget.status == BackgroundJobStatus.ENQUEUED.value
+    finally:
+        db.close()
+
+
+def test_requeue_stale_survives_mark_failed_error(tmp_path, monkeypatch):
+    """A commit error while failing one exhausted row must not stall the rest
+    of the Beat tick's work: the under-budget row in the same batch still
+    gets requeued, and the sweep call itself does not raise.
+    """
+    from xagent.web.services import background_jobs as bg_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    def poisoned_mark_job_failed(*args, **kwargs):
+        raise RuntimeError("simulated commit failure")
+
+    monkeypatch.setattr(bg_module, "mark_job_failed", poisoned_mark_job_failed)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-mark-failed-poisoned.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="mark-failed-poisoned")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+
+        exhausted = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb-exhausted"},
+            max_attempts=3,
+        )
+        setattr(exhausted, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(exhausted, "attempts", 3)
+        setattr(exhausted, "started_at", old)
+        setattr(exhausted, "updated_at", old)
+        db.add(exhausted)
+
+        under_budget = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb-under-budget"},
+            max_attempts=3,
+        )
+        setattr(under_budget, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(under_budget, "attempts", 0)
+        setattr(under_budget, "started_at", old)
+        setattr(under_budget, "updated_at", old)
+        db.add(under_budget)
+
+        db.commit()
+        db.refresh(exhausted)
+        db.refresh(under_budget)
+        exhausted_prior_status = exhausted.status
+        under_budget_id = under_budget.id
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert [item.id for item in requeued] == [under_budget_id]
+
+        db.refresh(exhausted)
+        assert exhausted.status == exhausted_prior_status
+
+        db.refresh(under_budget)
+        assert under_budget.status == BackgroundJobStatus.PENDING.value
     finally:
         db.close()
 
@@ -2053,9 +2288,10 @@ def test_execute_background_job_skips_failed_job_with_conflicting_result(
         verify_db.close()
 
 
-def test_execute_background_job_fails_exhausted_stale_job(tmp_path, monkeypatch):
-    """A redelivered message for a silent, budget-exhausted RUNNING row terminates
-    it instead of running the handler a fourth time."""
+def test_execute_background_job_refuses_exhausted_stale_job(tmp_path, monkeypatch):
+    """A redelivered message for a silent, budget-exhausted RUNNING row is
+    refused without writing anything; the sweep is the sole terminal author,
+    so the entry guard never distinguishes a stale row from a fresh one."""
     from xagent.web.jobs import tasks as tasks_module
 
     monkeypatch.setenv(CELERY_ENABLED, "false")
@@ -2072,6 +2308,7 @@ def test_execute_background_job_fails_exhausted_stale_job(tmp_path, monkeypatch)
             user_id=int(user.id),
             job_type=job_type,
             payload={},
+            max_attempts=3,
         )
         old = datetime.now(timezone.utc) - timedelta(hours=3)
         progress = {"message": "Crawling page 9", "completed": 9, "total": 50}
@@ -2084,6 +2321,7 @@ def test_execute_background_job_fails_exhausted_stale_job(tmp_path, monkeypatch)
         db.commit()
         db.refresh(job)
         job_id = str(job.id)
+        updated_at_before = job.updated_at
     finally:
         db.close()
 
@@ -2096,8 +2334,10 @@ def test_execute_background_job_fails_exhausted_stale_job(tmp_path, monkeypatch)
     finally:
         tasks_module._EXTRA_HANDLERS.pop(job_type, None)
 
-    assert outcome.result["status"] == "failed"
-    assert "retry budget" in outcome.result["error"]
+    assert outcome.result == {
+        "status": "skipped",
+        "reason": "Retry budget exhausted; refusing duplicate execution",
+    }
 
     verify_db = SessionLocal()
     try:
@@ -2105,8 +2345,8 @@ def test_execute_background_job_fails_exhausted_stale_job(tmp_path, monkeypatch)
             verify_db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
         )
         assert refreshed is not None
-        assert refreshed.status == BackgroundJobStatus.FAILED.value
-        assert refreshed.result["last_progress"] == progress
+        assert refreshed.status == BackgroundJobStatus.RUNNING.value
+        assert refreshed.updated_at == updated_at_before
     finally:
         verify_db.close()
 
@@ -2131,6 +2371,7 @@ def test_execute_background_job_refuses_exhausted_fresh_job(tmp_path, monkeypatc
             user_id=int(user.id),
             job_type=job_type,
             payload={},
+            max_attempts=3,
         )
         setattr(job, "status", BackgroundJobStatus.RUNNING.value)
         setattr(job, "attempts", 3)
@@ -2153,10 +2394,7 @@ def test_execute_background_job_refuses_exhausted_fresh_job(tmp_path, monkeypatc
 
     assert outcome.result == {
         "status": "skipped",
-        "reason": (
-            "Retry budget exhausted; refusing duplicate execution while the job "
-            "shows recent progress"
-        ),
+        "reason": "Retry budget exhausted; refusing duplicate execution",
     }
 
     verify_db = SessionLocal()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -1454,6 +1454,43 @@ def test_background_web_file_new_branch_returns_rollback_callback(
         get_unscoped_file_storage.cache_clear()
 
 
+def test_requeue_stale_skips_actively_progressing_running_job(tmp_path, monkeypatch):
+    """A RUNNING job that keeps writing progress must not be swept as stale.
+
+    started_at ages past the cutoff for any long-running job; a fresh updated_at
+    is what actually distinguishes a live worker from a silent one.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-stale-fresh-progress.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="stale-fresh-progress")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb"},
+        )
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(hours=3)
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(job, "started_at", old)
+        setattr(job, "updated_at", now)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert requeued == []
+        db.refresh(job)
+        assert job.status == BackgroundJobStatus.RUNNING.value
+    finally:
+        db.close()
+
+
 def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monkeypatch):
     monkeypatch.setenv(CELERY_ENABLED, "false")
     monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
@@ -1471,6 +1508,7 @@ def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monke
         old = datetime.now(timezone.utc) - timedelta(hours=3)
         setattr(job, "status", BackgroundJobStatus.RUNNING.value)
         setattr(job, "started_at", old)
+        setattr(job, "updated_at", old)
         db.add(job)
         db.commit()
         db.refresh(job)
@@ -1483,6 +1521,121 @@ def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monke
         assert job.celery_task_id is None
         assert job.started_at is None
         assert job.progress["message"] == "Requeued stale background job"
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("shape", ["running_aged", "pending_aged"])
+def test_requeue_stale_fails_job_with_exhausted_attempts(tmp_path, monkeypatch, shape):
+    """A stale row that already burned its retry budget is failed, not requeued.
+
+    Covers both shapes a pre-fix production row can be stuck in: RUNNING (worker
+    died mid-run) and PENDING (an old requeue cycle flipped it back without ever
+    checking the budget).
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    SessionLocal = _init_test_db(tmp_path / f"jobs-stale-exhausted-{shape}.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username=f"stale-exhausted-{shape}")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb"},
+        )
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+        progress = {"message": "Crawling page 7", "completed": 7, "total": 40}
+        setattr(job, "attempts", 3)
+        setattr(job, "progress", progress)
+        if shape == "running_aged":
+            setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+            setattr(job, "started_at", old)
+        else:
+            setattr(job, "status", BackgroundJobStatus.PENDING.value)
+        setattr(job, "updated_at", old)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert requeued == []
+        db.refresh(job)
+        assert job.status == BackgroundJobStatus.FAILED.value
+        assert job.finished_at is not None
+        assert "retry budget" in str(job.error_message)
+        assert job.result["last_progress"] == progress
+    finally:
+        db.close()
+
+
+def test_requeue_stale_with_celery_never_dispatches_exhausted_job(
+    tmp_path, monkeypatch
+):
+    """The Celery-enabled sweep path must never hand an exhausted job to apply_async."""
+    from xagent.web.jobs import tasks as tasks_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    apply_async_calls: list[str] = []
+
+    def fake_apply_async(*, args, queue):
+        apply_async_calls.append(args[0])
+        return MagicMock(id=f"fake-task-{args[0]}")
+
+    monkeypatch.setattr(
+        tasks_module.execute_background_job, "apply_async", fake_apply_async
+    )
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-stale-celery-budget.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="stale-celery-budget")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+
+        exhausted = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb-exhausted"},
+        )
+        setattr(exhausted, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(exhausted, "attempts", 3)
+        setattr(exhausted, "started_at", old)
+        setattr(exhausted, "updated_at", old)
+        db.add(exhausted)
+
+        under_budget = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb-under-budget"},
+        )
+        setattr(under_budget, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(under_budget, "attempts", 0)
+        setattr(under_budget, "started_at", old)
+        setattr(under_budget, "updated_at", old)
+        db.add(under_budget)
+
+        db.commit()
+        db.refresh(exhausted)
+        db.refresh(under_budget)
+        under_budget_id = under_budget.id
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert apply_async_calls == [under_budget_id]
+        assert [item.id for item in requeued] == [under_budget_id]
+
+        db.refresh(exhausted)
+        assert exhausted.status == BackgroundJobStatus.FAILED.value
+
+        db.refresh(under_budget)
+        assert under_budget.status == BackgroundJobStatus.ENQUEUED.value
     finally:
         db.close()
 
@@ -1767,6 +1920,185 @@ def test_registered_handler_retryable_error_flows_through_execute_background_job
         assert refreshed.status == BackgroundJobStatus.ENQUEUED.value
         assert refreshed.attempts == 1
         assert "transient downstream failure" in str(refreshed.error_message)
+    finally:
+        verify_db.close()
+
+
+def test_execute_background_job_skips_failed_job(tmp_path, monkeypatch):
+    """A redelivered broker message must never resurrect a terminal FAILED row."""
+    from xagent.web.jobs import tasks as tasks_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    job_type = "test.skip-failed-job"
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-skip-failed.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "skip-failed-job")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=job_type,
+            payload={},
+        )
+        stored_progress = {"message": "x", "completed": 1, "total": 2}
+        setattr(job, "status", BackgroundJobStatus.FAILED.value)
+        setattr(
+            job,
+            "error_message",
+            "Background job exceeded its retry budget (attempts=3 of 3)",
+        )
+        setattr(job, "result", {"last_progress": stored_progress})
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        job_id = str(job.id)
+        stored_error = job.error_message
+    finally:
+        db.close()
+
+    def handler_spy(session, received):
+        pytest.fail("handler must not run for a FAILED background job")
+
+    tasks_module.register_background_job_handler(job_type, handler_spy)
+    try:
+        outcome = tasks_module.execute_background_job.apply(args=[job_id], throw=False)
+    finally:
+        tasks_module._EXTRA_HANDLERS.pop(job_type, None)
+
+    assert outcome.result == {
+        "status": "failed",
+        "error": stored_error,
+        "last_progress": stored_progress,
+    }
+
+    verify_db = SessionLocal()
+    try:
+        refreshed = (
+            verify_db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        )
+        assert refreshed is not None
+        assert refreshed.status == BackgroundJobStatus.FAILED.value
+    finally:
+        verify_db.close()
+
+
+def test_execute_background_job_fails_exhausted_stale_job(tmp_path, monkeypatch):
+    """A redelivered message for a silent, budget-exhausted RUNNING row terminates
+    it instead of running the handler a fourth time."""
+    from xagent.web.jobs import tasks as tasks_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    job_type = "test.exhausted-stale-job"
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-exhausted-stale.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "exhausted-stale-job")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=job_type,
+            payload={},
+        )
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+        progress = {"message": "Crawling page 9", "completed": 9, "total": 50}
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(job, "attempts", 3)
+        setattr(job, "started_at", old)
+        setattr(job, "updated_at", old)
+        setattr(job, "progress", progress)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        job_id = str(job.id)
+    finally:
+        db.close()
+
+    def handler_spy(session, received):
+        pytest.fail("handler must not run for a budget-exhausted stale job")
+
+    tasks_module.register_background_job_handler(job_type, handler_spy)
+    try:
+        outcome = tasks_module.execute_background_job.apply(args=[job_id], throw=False)
+    finally:
+        tasks_module._EXTRA_HANDLERS.pop(job_type, None)
+
+    assert outcome.result["status"] == "failed"
+    assert "retry budget" in outcome.result["error"]
+
+    verify_db = SessionLocal()
+    try:
+        refreshed = (
+            verify_db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        )
+        assert refreshed is not None
+        assert refreshed.status == BackgroundJobStatus.FAILED.value
+        assert refreshed.result["last_progress"] == progress
+    finally:
+        verify_db.close()
+
+
+def test_execute_background_job_refuses_exhausted_fresh_job(tmp_path, monkeypatch):
+    """A redelivered message for a still-live, budget-exhausted RUNNING row is
+    refused without writing terminal state, so the live worker can finish and
+    write its own outcome."""
+    from xagent.web.jobs import tasks as tasks_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    job_type = "test.exhausted-fresh-job"
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-exhausted-fresh.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "exhausted-fresh-job")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=job_type,
+            payload={},
+        )
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(job, "attempts", 3)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        job_id = str(job.id)
+        updated_at_before = job.updated_at
+    finally:
+        db.close()
+
+    def handler_spy(session, received):
+        pytest.fail("handler must not run for a fresh budget-exhausted job")
+
+    tasks_module.register_background_job_handler(job_type, handler_spy)
+    try:
+        outcome = tasks_module.execute_background_job.apply(args=[job_id], throw=False)
+    finally:
+        tasks_module._EXTRA_HANDLERS.pop(job_type, None)
+
+    assert outcome.result == {
+        "status": "skipped",
+        "reason": (
+            "Retry budget exhausted; refusing duplicate execution while the job "
+            "shows recent progress"
+        ),
+    }
+
+    verify_db = SessionLocal()
+    try:
+        refreshed = (
+            verify_db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        )
+        assert refreshed is not None
+        assert refreshed.status == BackgroundJobStatus.RUNNING.value
+        assert refreshed.updated_at == updated_at_before
     finally:
         verify_db.close()
 

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -1790,6 +1790,7 @@ def test_requeue_stale_mixed_batch_returns_only_requeued(tmp_path, monkeypatch):
         requeued = sweep.requeued
 
         assert [item.id for item in requeued] == [under_budget_id]
+        assert sweep.failed_count == 1
 
         db.refresh(exhausted)
         assert exhausted.status == BackgroundJobStatus.FAILED.value
@@ -1856,6 +1857,7 @@ def test_requeue_stale_mixed_batch_returns_only_requeued(tmp_path, monkeypatch):
 
         assert apply_async_calls == [under_budget_id]
         assert [item.id for item in requeued] == [under_budget_id]
+        assert sweep.failed_count == 1
 
         db.refresh(exhausted)
         assert exhausted.status == BackgroundJobStatus.FAILED.value
@@ -1944,6 +1946,125 @@ def test_requeue_stale_survives_mark_failed_error(tmp_path, monkeypatch):
 
         db.refresh(under_budget)
         assert under_budget.status == BackgroundJobStatus.PENDING.value
+    finally:
+        db.close()
+
+
+def test_requeue_stale_skips_row_that_reached_terminal_state_mid_sweep(
+    tmp_path, monkeypatch
+):
+    """A row that reaches a terminal state between the sweep's SELECT and its
+    write must not be overwritten, and must not be counted as failed.
+
+    Simulates a live worker finishing the job concurrently with the sweep: the
+    row is exhausted and stale at SELECT time, but a separate session flips it
+    to SUCCEEDED before the sweep's own write. Hooked at the per-row log call
+    that fires right after selection and right before the write -- the only
+    point available without an actual second thread/process racing the sweep.
+    """
+    from xagent.web.services import background_jobs as bg_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-terminal-race.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="terminal-race")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb"},
+            max_attempts=3,
+        )
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(job, "attempts", 3)
+        setattr(job, "started_at", old)
+        setattr(job, "updated_at", old)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        job_id = job.id
+
+        real_result = {"status": "success", "message": "finished before the sweep"}
+        real_warning = bg_module.logger.warning
+        hook_calls: list[str] = []
+
+        def hooked_warning(msg, *args, **kwargs):
+            hook_calls.append(msg)
+            if len(hook_calls) == 1:
+                other_db = SessionLocal()
+                try:
+                    other_job = (
+                        other_db.query(BackgroundJob)
+                        .filter(BackgroundJob.id == job_id)
+                        .first()
+                    )
+                    setattr(other_job, "status", BackgroundJobStatus.SUCCEEDED.value)
+                    setattr(other_job, "error_message", None)
+                    setattr(other_job, "result", real_result)
+                    other_db.add(other_job)
+                    other_db.commit()
+                finally:
+                    other_db.close()
+            return real_warning(msg, *args, **kwargs)
+
+        monkeypatch.setattr(bg_module.logger, "warning", hooked_warning)
+
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert hook_calls, "the hook never fired; this test proves nothing"
+        assert sweep.requeued == []
+        assert sweep.failed_count == 0
+
+        db.expire_all()
+        refreshed = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert refreshed is not None
+        assert refreshed.status == BackgroundJobStatus.SUCCEEDED.value
+        assert refreshed.result == real_result
+        assert refreshed.error_message is None
+    finally:
+        db.close()
+
+
+def test_requeue_stale_requeues_job_one_attempt_below_budget(tmp_path, monkeypatch):
+    """A row one attempt below max_attempts is still under budget: requeued,
+    not retired. Pins the boundary itself (attempts == max_attempts - 1),
+    distinct from the exhausted case (attempts == max_attempts).
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-one-below-budget.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="one-below-budget")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb"},
+            max_attempts=3,
+        )
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(job, "attempts", 2)
+        setattr(job, "started_at", old)
+        setattr(job, "updated_at", old)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert [item.id for item in sweep.requeued] == [job.id]
+        assert sweep.failed_count == 0
+        db.refresh(job)
+        assert job.status == BackgroundJobStatus.PENDING.value
     finally:
         db.close()
 

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -1819,7 +1819,9 @@ def test_requeue_stale_survives_mark_failed_error(tmp_path, monkeypatch):
     monkeypatch.setenv(CELERY_ENABLED, "false")
     monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
 
-    def poisoned_mark_job_failed(*args, **kwargs):
+    def poisoned_mark_job_failed(db_arg, job_arg, **kwargs):
+        setattr(job_arg, "status", BackgroundJobStatus.FAILED.value)
+        db_arg.add(job_arg)
         raise RuntimeError("simulated commit failure")
 
     monkeypatch.setattr(bg_module, "mark_job_failed", poisoned_mark_job_failed)
@@ -1859,6 +1861,7 @@ def test_requeue_stale_survives_mark_failed_error(tmp_path, monkeypatch):
         db.commit()
         db.refresh(exhausted)
         db.refresh(under_budget)
+        exhausted_id = exhausted.id
         exhausted_prior_status = exhausted.status
         under_budget_id = under_budget.id
 
@@ -1866,8 +1869,20 @@ def test_requeue_stale_survives_mark_failed_error(tmp_path, monkeypatch):
 
         assert [item.id for item in requeued] == [under_budget_id]
 
-        db.refresh(exhausted)
-        assert exhausted.status == exhausted_prior_status
+        # Re-query in a fresh session rather than refreshing the original
+        # `db`'s identity-mapped object, so this proves the DB-persisted row
+        # survived unchanged, not just that our own object happens to.
+        verify_db = SessionLocal()
+        try:
+            refreshed_exhausted = (
+                verify_db.query(BackgroundJob)
+                .filter(BackgroundJob.id == exhausted_id)
+                .first()
+            )
+            assert refreshed_exhausted is not None
+            assert refreshed_exhausted.status == exhausted_prior_status
+        finally:
+            verify_db.close()
 
         db.refresh(under_budget)
         assert under_budget.status == BackgroundJobStatus.PENDING.value
@@ -2273,9 +2288,11 @@ def test_execute_background_job_skips_failed_job_with_conflicting_result(
     finally:
         tasks_module._EXTRA_HANDLERS.pop(job_type, None)
 
+    # Contract: status and error always reflect the row's actual failure; any
+    # other stored key (like this stale "message") is passed through as-is,
+    # not pinned to a particular value.
     assert outcome.result["status"] == "failed"
     assert outcome.result["error"] == stored_error
-    assert outcome.result["message"] == "x"
 
     verify_db = SessionLocal()
     try:
@@ -2321,6 +2338,8 @@ def test_execute_background_job_refuses_exhausted_stale_job(tmp_path, monkeypatc
         db.commit()
         db.refresh(job)
         job_id = str(job.id)
+        attempts_before = job.attempts
+        started_at_before = job.started_at
         updated_at_before = job.updated_at
     finally:
         db.close()
@@ -2346,6 +2365,8 @@ def test_execute_background_job_refuses_exhausted_stale_job(tmp_path, monkeypatc
         )
         assert refreshed is not None
         assert refreshed.status == BackgroundJobStatus.RUNNING.value
+        assert refreshed.attempts == attempts_before
+        assert refreshed.started_at == started_at_before
         assert refreshed.updated_at == updated_at_before
     finally:
         verify_db.close()
@@ -2379,6 +2400,8 @@ def test_execute_background_job_refuses_exhausted_fresh_job(tmp_path, monkeypatc
         db.commit()
         db.refresh(job)
         job_id = str(job.id)
+        attempts_before = job.attempts
+        started_at_before = job.started_at
         updated_at_before = job.updated_at
     finally:
         db.close()
@@ -2404,6 +2427,8 @@ def test_execute_background_job_refuses_exhausted_fresh_job(tmp_path, monkeypatc
         )
         assert refreshed is not None
         assert refreshed.status == BackgroundJobStatus.RUNNING.value
+        assert refreshed.attempts == attempts_before
+        assert refreshed.started_at == started_at_before
         assert refreshed.updated_at == updated_at_before
     finally:
         verify_db.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -1483,7 +1483,8 @@ def test_requeue_stale_skips_actively_progressing_running_job(tmp_path, monkeypa
         db.commit()
         db.refresh(job)
 
-        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        requeued = sweep.requeued
 
         assert requeued == []
         db.refresh(job)
@@ -1514,7 +1515,8 @@ def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monke
         db.commit()
         db.refresh(job)
 
-        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        requeued = sweep.requeued
 
         assert [item.id for item in requeued] == [job.id]
         db.refresh(job)
@@ -1562,7 +1564,8 @@ def test_requeue_stale_fails_job_with_exhausted_attempts(tmp_path, monkeypatch, 
         db.commit()
         db.refresh(job)
 
-        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        requeued = sweep.requeued
 
         assert requeued == []
         db.refresh(job)
@@ -1632,7 +1635,8 @@ def test_requeue_stale_with_celery_never_dispatches_exhausted_job(
         db.refresh(under_budget)
         under_budget_id = under_budget.id
 
-        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        requeued = sweep.requeued
 
         assert apply_async_calls == [under_budget_id]
         assert [item.id for item in requeued] == [under_budget_id]
@@ -1673,11 +1677,62 @@ def test_requeue_stale_skips_job_with_real_progress_write(tmp_path, monkeypatch)
 
         update_job_progress(db, job, message="tick")
 
-        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        requeued = sweep.requeued
 
         assert requeued == []
         db.refresh(job)
         assert job.status == BackgroundJobStatus.RUNNING.value
+    finally:
+        db.close()
+
+
+def test_update_job_progress_with_identical_content_still_advances_updated_at(
+    tmp_path, monkeypatch
+):
+    """A heartbeat write whose content repeats the stored progress must still
+    advance updated_at, or a live job idles straight into the sweep.
+
+    Reachable for real: a web crawl reporting "Crawled N pages" during a
+    stretch with no net-new pages calls update_job_progress with the exact
+    same message/completed/total it already stored.
+    """
+    SessionLocal = _init_test_db(tmp_path / "jobs-identical-progress-heartbeat.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="identical-progress-heartbeat")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb"},
+        )
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+
+        update_job_progress(db, job, message="Crawled 5 pages", completed=5, total=20)
+        stored_progress = dict(job.progress or {})
+
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+        setattr(job, "updated_at", old)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        aged_updated_at = job.updated_at
+
+        update_job_progress(
+            db,
+            job,
+            message=stored_progress["message"],
+            completed=stored_progress["completed"],
+            total=stored_progress["total"],
+        )
+
+        db.refresh(job)
+        assert job.progress == stored_progress
+        assert job.updated_at != aged_updated_at
     finally:
         db.close()
 
@@ -1731,7 +1786,8 @@ def test_requeue_stale_mixed_batch_returns_only_requeued(tmp_path, monkeypatch):
         db.refresh(under_budget)
         under_budget_id = under_budget.id
 
-        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        requeued = sweep.requeued
 
         assert [item.id for item in requeued] == [under_budget_id]
 
@@ -1795,7 +1851,8 @@ def test_requeue_stale_mixed_batch_returns_only_requeued(tmp_path, monkeypatch):
         db.refresh(under_budget)
         under_budget_id = under_budget.id
 
-        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        requeued = sweep.requeued
 
         assert apply_async_calls == [under_budget_id]
         assert [item.id for item in requeued] == [under_budget_id]
@@ -1865,7 +1922,8 @@ def test_requeue_stale_survives_mark_failed_error(tmp_path, monkeypatch):
         exhausted_prior_status = exhausted.status
         under_budget_id = under_budget.id
 
-        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        sweep = requeue_stale_background_jobs(db, stale_after_seconds=60)
+        requeued = sweep.requeued
 
         assert [item.id for item in requeued] == [under_budget_id]
 

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -1985,6 +1985,74 @@ def test_execute_background_job_skips_failed_job(tmp_path, monkeypatch):
         verify_db.close()
 
 
+def test_execute_background_job_skips_failed_job_with_conflicting_result(
+    tmp_path, monkeypatch
+):
+    """A FAILED row's own error_message must win even when its stored result
+    carries a stale success verdict from the handler that produced it.
+
+    This happens for real: a document handler can finish ingestion, then fail
+    while publishing the collection config, and store a result dict whose
+    "status" is "success" from the ingestion step alongside the FAILED row's
+    own error_message. The short-circuit must report the row's failure, not
+    let the embedded result displace it.
+    """
+    from xagent.web.jobs import tasks as tasks_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    job_type = "test.skip-failed-job-conflicting-result"
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-skip-failed-conflicting.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "skip-failed-job-conflicting-result")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=job_type,
+            payload={},
+        )
+        setattr(job, "status", BackgroundJobStatus.FAILED.value)
+        setattr(job, "error_message", "Failed to publish collection config")
+        setattr(
+            job,
+            "result",
+            {"status": "success", "error": None, "message": "x"},
+        )
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+        job_id = str(job.id)
+        stored_error = job.error_message
+    finally:
+        db.close()
+
+    def handler_spy(session, received):
+        pytest.fail("handler must not run for a FAILED background job")
+
+    tasks_module.register_background_job_handler(job_type, handler_spy)
+    try:
+        outcome = tasks_module.execute_background_job.apply(args=[job_id], throw=False)
+    finally:
+        tasks_module._EXTRA_HANDLERS.pop(job_type, None)
+
+    assert outcome.result["status"] == "failed"
+    assert outcome.result["error"] == stored_error
+    assert outcome.result["message"] == "x"
+
+    verify_db = SessionLocal()
+    try:
+        refreshed = (
+            verify_db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        )
+        assert refreshed is not None
+        assert refreshed.status == BackgroundJobStatus.FAILED.value
+    finally:
+        verify_db.close()
+
+
 def test_execute_background_job_fails_exhausted_stale_job(tmp_path, monkeypatch):
     """A redelivered message for a silent, budget-exhausted RUNNING row terminates
     it instead of running the handler a fourth time."""

--- a/tests/web/test_trigger_tasks.py
+++ b/tests/web/test_trigger_tasks.py
@@ -101,3 +101,67 @@ def test_handle_trigger_scan_skips_dispatch_when_nothing_reaped(
     reap_mock.assert_called_once_with(db)
     dispatch_mock.assert_not_called()
     assert result["reaped_preview_run_pause_dispatches"] == 0
+
+
+def test_handle_trigger_scan_survives_stale_sweep_failure(
+    tmp_path, monkeypatch
+) -> None:
+    """A stale-sweep failure must not stall the rest of the scan tick's work."""
+    SessionLocal = _init_test_db(tmp_path / "trigger-scan-sweep-failure.db")
+    db = SessionLocal()
+    user = _create_user(db)
+
+    def raise_sweep(_db):
+        raise RuntimeError("simulated sweep failure")
+
+    scan_calls: list[object] = []
+
+    def fake_scan(_db):
+        scan_calls.append(_db)
+        return []
+
+    monkeypatch.setattr(trigger_tasks, "requeue_stale_background_jobs", raise_sweep)
+    monkeypatch.setattr(trigger_tasks, "scan_due_scheduled_triggers", fake_scan)
+    monkeypatch.setattr(
+        trigger_tasks, "reap_stale_preview_workforce_runs", MagicMock(return_value=[])
+    )
+
+    job = BackgroundJob(
+        user_id=int(user.id),
+        job_type=BackgroundJobType.TRIGGER_SCAN.value,
+        payload={},
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    result = trigger_tasks.handle_trigger_scan(db, job)
+
+    assert result["requeued_stale_jobs"] == 0
+    assert scan_calls == [db]
+
+
+def test_scan_due_triggers_survives_stale_sweep_failure(tmp_path, monkeypatch) -> None:
+    """The Celery Beat entrypoint must survive a stale-sweep failure the same
+    way the BackgroundJob-driven variant does."""
+    _init_test_db(tmp_path / "scan-due-triggers-sweep-failure.db")
+
+    def raise_sweep(_db):
+        raise RuntimeError("simulated sweep failure")
+
+    scan_calls: list[object] = []
+
+    def fake_scan(_db):
+        scan_calls.append(_db)
+        return []
+
+    monkeypatch.setattr(trigger_tasks, "requeue_stale_background_jobs", raise_sweep)
+    monkeypatch.setattr(trigger_tasks, "scan_due_scheduled_triggers", fake_scan)
+    monkeypatch.setattr(
+        trigger_tasks, "reap_stale_preview_workforce_runs", MagicMock(return_value=[])
+    )
+
+    result = trigger_tasks.scan_due_triggers()
+
+    assert result["requeued_stale_jobs"] == 0
+    assert len(scan_calls) == 1

--- a/tests/web/test_trigger_tasks.py
+++ b/tests/web/test_trigger_tasks.py
@@ -15,6 +15,7 @@ from xagent.web.jobs import trigger_tasks
 from xagent.web.models.background_job import BackgroundJob, BackgroundJobType
 from xagent.web.models.database import get_session_local, init_db
 from xagent.web.models.user import User
+from xagent.web.services.background_jobs import SweepResult
 from xagent.web.services.workforce_runtime import WorkforceRunPauseTarget
 
 
@@ -51,7 +52,11 @@ def test_handle_trigger_scan_reaps_stale_preview_workforce_runs(
     monkeypatch.setattr(
         trigger_tasks, "pause_workforce_tasks_after_archive", fake_dispatch
     )
-    monkeypatch.setattr(trigger_tasks, "requeue_stale_background_jobs", lambda _db: [])
+    monkeypatch.setattr(
+        trigger_tasks,
+        "requeue_stale_background_jobs",
+        lambda _db: SweepResult(requeued=[], failed_count=0),
+    )
     monkeypatch.setattr(trigger_tasks, "scan_due_scheduled_triggers", lambda _db: [])
 
     job = BackgroundJob(
@@ -84,7 +89,11 @@ def test_handle_trigger_scan_skips_dispatch_when_nothing_reaped(
     monkeypatch.setattr(
         trigger_tasks, "pause_workforce_tasks_after_archive", dispatch_mock
     )
-    monkeypatch.setattr(trigger_tasks, "requeue_stale_background_jobs", lambda _db: [])
+    monkeypatch.setattr(
+        trigger_tasks,
+        "requeue_stale_background_jobs",
+        lambda _db: SweepResult(requeued=[], failed_count=0),
+    )
     monkeypatch.setattr(trigger_tasks, "scan_due_scheduled_triggers", lambda _db: [])
 
     job = BackgroundJob(
@@ -106,13 +115,36 @@ def test_handle_trigger_scan_skips_dispatch_when_nothing_reaped(
 def test_handle_trigger_scan_survives_stale_sweep_failure(
     tmp_path, monkeypatch
 ) -> None:
-    """A stale-sweep failure must not stall the rest of the scan tick's work."""
+    """A stale-sweep failure must not stall the rest of the scan tick's work,
+    and must leave the session usable for the queries that follow it.
+
+    A bare exception from the sweep does not dirty a SQLAlchemy session; only
+    a real flush-level failure does (e.g. a UNIQUE constraint violation). This
+    poisons the session with a duplicate idempotency_key flush so the poison
+    is the same class of failure a real sweep bug would produce.
+    """
     SessionLocal = _init_test_db(tmp_path / "trigger-scan-sweep-failure.db")
     db = SessionLocal()
     user = _create_user(db)
 
-    def raise_sweep(_db):
-        raise RuntimeError("simulated sweep failure")
+    def poisoned_sweep(db_arg, *args, **kwargs):
+        first = BackgroundJob(
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB.value,
+            payload={},
+            idempotency_key="poison-key",
+        )
+        db_arg.add(first)
+        db_arg.flush()
+        duplicate = BackgroundJob(
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB.value,
+            payload={},
+            idempotency_key="poison-key",
+        )
+        db_arg.add(duplicate)
+        db_arg.flush()
+        return []
 
     scan_calls: list[object] = []
 
@@ -120,7 +152,7 @@ def test_handle_trigger_scan_survives_stale_sweep_failure(
         scan_calls.append(_db)
         return []
 
-    monkeypatch.setattr(trigger_tasks, "requeue_stale_background_jobs", raise_sweep)
+    monkeypatch.setattr(trigger_tasks, "requeue_stale_background_jobs", poisoned_sweep)
     monkeypatch.setattr(trigger_tasks, "scan_due_scheduled_triggers", fake_scan)
     monkeypatch.setattr(
         trigger_tasks, "reap_stale_preview_workforce_runs", MagicMock(return_value=[])
@@ -139,23 +171,54 @@ def test_handle_trigger_scan_survives_stale_sweep_failure(
 
     assert result["requeued_stale_jobs"] == 0
     assert scan_calls == [db]
+    # Proves the rollback actually ran: the poisoned rows are gone and the
+    # session is usable again, leaving only the committed scan job.
+    assert db.query(BackgroundJob).count() == 1
 
 
 def test_scan_due_triggers_survives_stale_sweep_failure(tmp_path, monkeypatch) -> None:
     """The Celery Beat entrypoint must survive a stale-sweep failure the same
-    way the BackgroundJob-driven variant does."""
-    _init_test_db(tmp_path / "scan-due-triggers-sweep-failure.db")
+    way the BackgroundJob-driven variant does.
 
-    def raise_sweep(_db):
-        raise RuntimeError("simulated sweep failure")
+    scan_due_triggers owns and closes its session internally, so the
+    follow-up query that proves the session survived has to run inside the
+    scan stub, on the same session the sweep just poisoned, before the
+    function closes it.
+    """
+    SessionLocal = _init_test_db(tmp_path / "scan-due-triggers-sweep-failure.db")
+    db = SessionLocal()
+    user = _create_user(db)
+    db.close()
 
-    scan_calls: list[object] = []
-
-    def fake_scan(_db):
-        scan_calls.append(_db)
+    def poisoned_sweep(db_arg, *args, **kwargs):
+        first = BackgroundJob(
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB.value,
+            payload={},
+            idempotency_key="poison-key",
+        )
+        db_arg.add(first)
+        db_arg.flush()
+        duplicate = BackgroundJob(
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB.value,
+            payload={},
+            idempotency_key="poison-key",
+        )
+        db_arg.add(duplicate)
+        db_arg.flush()
         return []
 
-    monkeypatch.setattr(trigger_tasks, "requeue_stale_background_jobs", raise_sweep)
+    scan_calls: list[int] = []
+
+    def fake_scan(_db):
+        # A real query on the same session the sweep just poisoned: this is
+        # what raises PendingRollbackError if the sweep's failure was never
+        # rolled back.
+        scan_calls.append(_db.query(BackgroundJob).count())
+        return []
+
+    monkeypatch.setattr(trigger_tasks, "requeue_stale_background_jobs", poisoned_sweep)
     monkeypatch.setattr(trigger_tasks, "scan_due_scheduled_triggers", fake_scan)
     monkeypatch.setattr(
         trigger_tasks, "reap_stale_preview_workforce_runs", MagicMock(return_value=[])
@@ -164,4 +227,4 @@ def test_scan_due_triggers_survives_stale_sweep_failure(tmp_path, monkeypatch) -
     result = trigger_tasks.scan_due_triggers()
 
     assert result["requeued_stale_jobs"] == 0
-    assert len(scan_calls) == 1
+    assert scan_calls == [0]

--- a/tests/web/test_trigger_tasks.py
+++ b/tests/web/test_trigger_tasks.py
@@ -144,7 +144,7 @@ def test_handle_trigger_scan_survives_stale_sweep_failure(
         )
         db_arg.add(duplicate)
         db_arg.flush()
-        return []
+        return SweepResult(requeued=[], failed_count=0)
 
     scan_calls: list[object] = []
 
@@ -207,7 +207,7 @@ def test_scan_due_triggers_survives_stale_sweep_failure(tmp_path, monkeypatch) -
         )
         db_arg.add(duplicate)
         db_arg.flush()
-        return []
+        return SweepResult(requeued=[], failed_count=0)
 
     scan_calls: list[int] = []
 
@@ -228,3 +228,60 @@ def test_scan_due_triggers_survives_stale_sweep_failure(tmp_path, monkeypatch) -
 
     assert result["requeued_stale_jobs"] == 0
     assert scan_calls == [0]
+
+
+def test_handle_trigger_scan_surfaces_failed_stale_jobs_count(
+    tmp_path, monkeypatch
+) -> None:
+    """failed_stale_jobs in the result must reflect the sweep's own count,
+    not be silently dropped or hardcoded."""
+    SessionLocal = _init_test_db(tmp_path / "trigger-scan-failed-count.db")
+    db = SessionLocal()
+    user = _create_user(db)
+
+    monkeypatch.setattr(
+        trigger_tasks,
+        "requeue_stale_background_jobs",
+        lambda _db: SweepResult(requeued=[], failed_count=2),
+    )
+    monkeypatch.setattr(trigger_tasks, "scan_due_scheduled_triggers", lambda _db: [])
+    monkeypatch.setattr(
+        trigger_tasks, "reap_stale_preview_workforce_runs", MagicMock(return_value=[])
+    )
+
+    job = BackgroundJob(
+        user_id=int(user.id),
+        job_type=BackgroundJobType.TRIGGER_SCAN.value,
+        payload={},
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    result = trigger_tasks.handle_trigger_scan(db, job)
+
+    assert result["failed_stale_jobs"] == 2
+    assert result["requeued_stale_jobs"] == 0
+
+
+def test_scan_due_triggers_surfaces_failed_stale_jobs_count(
+    tmp_path, monkeypatch
+) -> None:
+    """Same propagation check as handle_trigger_scan's, for the Celery Beat
+    entrypoint."""
+    _init_test_db(tmp_path / "scan-due-triggers-failed-count.db")
+
+    monkeypatch.setattr(
+        trigger_tasks,
+        "requeue_stale_background_jobs",
+        lambda _db: SweepResult(requeued=[], failed_count=2),
+    )
+    monkeypatch.setattr(trigger_tasks, "scan_due_scheduled_triggers", lambda _db: [])
+    monkeypatch.setattr(
+        trigger_tasks, "reap_stale_preview_workforce_runs", MagicMock(return_value=[])
+    )
+
+    result = trigger_tasks.scan_due_triggers()
+
+    assert result["failed_stale_jobs"] == 2
+    assert result["requeued_stale_jobs"] == 0


### PR DESCRIPTION
Part of #1564. Implements heartbeat-based staleness for RUNNING rows (the concern tracked in #1565, via an added conjunct rather than a replaced one) and the budget enforcement around it; the atomic claim/fencing work stays in #1566.

## What

Background-job recovery has two paths that never consulted a job's retry budget (`max_attempts`), so a long-running job could be re-dispatched indefinitely:

- The stale sweep (`requeue_stale_background_jobs`) treated any RUNNING row whose `started_at` passed the cutoff as hung — even while the job was actively writing progress — and requeued it without reading `max_attempts`.
- A redelivered Celery message (broker visibility timeout with `task_acks_late=True`) re-ran the handler for any non-terminal row, and `mark_job_running` increments `attempts` unconditionally, so `attempts` could grow far past `max_attempts` while each incarnation restarted the work from scratch.

## Changes

- A RUNNING row now counts as stale only when `updated_at` is also past the cutoff, so progress writes act as a liveness signal. `update_job_progress` force-marks the progress column dirty so an identical-content heartbeat still emits an UPDATE and advances `updated_at` (SQLAlchemy's value-equality dirty tracking would otherwise skip the write and freeze the signal). Rows with a NULL `updated_at` keep their existing sweep path (defensive only; no code path produces such rows).
- The stale sweep partitions by budget before mutating anything: a stale row with `attempts >= max_attempts` is marked FAILED instead of being requeued. Its failure result carries `status`, `message`, and the last progress snapshot under `last_progress`. Each terminal write is guarded per row (a failing row is rolled back and skipped), and both callers run the sweep through a shared wrapper that logs, rolls the session back, and continues the tick on failure. The sweep returns a named result (`requeued`, `failed_count`); both scheduler entry points surface `failed_stale_jobs` alongside `requeued_stale_jobs`.
- `execute_background_job` refuses terminal and exhausted rows without writing anything: a FAILED row returns its stored failure (the failure verdict wins over any `status` key inside the stored result), and a row whose `attempts` already reached `max_attempts` is skipped so its live worker can finish. The sweep is the sole author of the budget-exhausted terminal verdict.

Net contract: execution count is capped at `max_attempts`, and a terminal FAILED from the budget path is only written by the sweep, for a row with no write activity within one stale window.

Stated trade-offs and scope boundaries:

- State transitions on this table remain read-modify-write; the atomic claim (conditional UPDATE with a rowcount check) plus status-guarded terminal writers — which would also close the FAILED-to-SUCCEEDED late-overwrite window and the idempotency-key release race — is tracked in #1566 and deliberately not grown here.
- A sweep-written terminal failure does not run the job's handler, so handler-owned cleanup (such as staged ingest artifacts) is not performed for a job that dies silent on its final attempt; previously such a job was requeued without bound and cleanup eventually ran on a later failure. A handler-owned terminal callback is the follow-up shape.
- Trigger-event jobs change behavior: once such a job exhausts its budget, its handler no longer re-runs (the enqueue path currently has no production callers, so this is dormant). An operator retry/reset surface plus a fix at the trigger-enqueue layer is the follow-up.
- The budget-exhausted terminal verdict depends on the sweep running. Deployments without the Beat/`scheduler` service never run the sweep (the in-process fallback dispatcher does not call it yet), leaving a budget-exhausted row RUNNING until a scheduler is deployed; hooking the sweep into the in-process fallback dispatcher is the follow-up.

## Verification

- `uv run pytest tests/web/test_background_jobs.py tests/web/test_trigger_tasks.py`: 51 passed (baseline 37). Coverage includes the liveness predicate through the real `update_job_progress`/`onupdate` path and through an identical-content heartbeat (which froze `updated_at` before the fix), budget-exhausted sweeps with and without a broker, mixed batches, a poisoned terminal write that must leave the row's prior state intact, sweep failures injected as real flush-level errors (a plain raised exception does not poison the session; a UNIQUE-constraint flush failure does, and before the rollback fix the next statement raised `PendingRollbackError`), and the FAILED/exhausted entry refusals pinned via `attempts`/`started_at` (SQLite timestamps are whole-second, so `updated_at` alone cannot detect a same-second re-stamp).
- Every guard is mutation-checked: reverting each one turns its pinned test red on the target assertion; deleting `onupdate=func.now()` from the model turns exactly the liveness test red.
- pre-commit (ruff check/format, mypy, isort, codespell) is green on the changed files.
