### PR TITLE
enh: use native vision for uploaded images

### DIFF
--- a/src/xagent/core/agent/attachments.py
+++ b/src/xagent/core/agent/attachments.py
@@ -83,15 +83,16 @@ def build_image_context_references(files: Any) -> tuple[ContextReference, ...]:
         if not file_id or file_id in seen_file_ids:
             continue
 
-        filename = str(
-            info.get("original_name")
-            or info.get("name")
-            or info.get("filename")
-            or "uploaded image"
-        ).strip()
-        declared_mime_type = (
-            str(info.get("mime_type") or info.get("type") or "").strip().lower()
-        )
+        filename = "uploaded image"
+        for key in ("original_name", "name", "filename"):
+            candidate = str(info.get(key) or "").strip()
+            if candidate:
+                filename = candidate
+                break
+        declared_mime_type = str(
+            info.get("mime_type") or info.get("type") or ""
+        ).lower()
+        declared_mime_type = declared_mime_type.split(";", 1)[0].strip()
         if declared_mime_type == "image/jpg":
             declared_mime_type = "image/jpeg"
         guessed_mime_type = guess_mime_type(filename).lower()
@@ -104,9 +105,17 @@ def build_image_context_references(files: Any) -> tuple[ContextReference, ...]:
         if mime_type not in _DIRECT_CONTEXT_IMAGE_MIME_TYPES:
             continue
 
+        size: int | None = None
         raw_size = info.get("size")
+        if raw_size is not None:
+            try:
+                parsed_size = int(raw_size)
+            except (TypeError, ValueError):
+                pass
+            else:
+                if parsed_size >= 0:
+                    size = parsed_size
         try:
-            size = int(raw_size) if raw_size is not None else None
             reference = ContextReference(
                 file_ref=build_file_ref(
                     file_id=file_id,

--- a/src/xagent/core/agent/attachments.py
+++ b/src/xagent/core/agent/attachments.py
@@ -124,9 +124,8 @@ def build_image_context_references(files: Any) -> tuple[ContextReference, ...]:
                     size=size,
                 ),
                 text_fallback=(
-                    "This uploaded image is available by FileRef. If it is not "
-                    "visible in the current model context, inspect it with "
-                    "understand_media."
+                    "An uploaded image was referenced by FileRef but is not "
+                    "available as native visual context in this model call."
                 ),
                 metadata={"source": "user_upload"},
             )

--- a/src/xagent/core/agent/attachments.py
+++ b/src/xagent/core/agent/attachments.py
@@ -17,6 +17,20 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from ..context_ref import ContextReference
+from ..file_ref import build_file_ref, guess_mime_type
+
+# Keep the direct-context contract to the formats shared by the supported chat
+# providers. SVG remains a source-inspection case for ``understand_media`` and
+# uncommon raster formats can use the same fallback instead of making the
+# primary chat request fail at the provider boundary.
+_DIRECT_CONTEXT_IMAGE_MIME_TYPES = {
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+}
+
 
 def project_file_info_to_chip(file_info_list: Any) -> List[Dict[str, Any]]:
     """Project ``file_info_list`` to the chip shape; tolerant to None/garbage.
@@ -46,3 +60,71 @@ def project_file_info_to_chip(file_info_list: Any) -> List[Dict[str, Any]]:
             }
         )
     return projected
+
+
+def build_image_context_references(files: Any) -> tuple[ContextReference, ...]:
+    """Project trusted uploaded-image metadata to durable model context refs.
+
+    The input may be the full runtime ``file_info`` shape or the path-stripped
+    attachment-chip shape persisted in chat history. Absolute paths are never
+    copied: provider image bytes are resolved just in time from the registered
+    ``file_id`` by :mod:`xagent.core.context_materializer`.
+    """
+
+    if not isinstance(files, list):
+        return ()
+
+    references: list[ContextReference] = []
+    seen_file_ids: set[str] = set()
+    for info in files:
+        if not isinstance(info, dict):
+            continue
+        file_id = str(info.get("file_id") or "").strip()
+        if not file_id or file_id in seen_file_ids:
+            continue
+
+        filename = str(
+            info.get("original_name")
+            or info.get("name")
+            or info.get("filename")
+            or "uploaded image"
+        ).strip()
+        declared_mime_type = (
+            str(info.get("mime_type") or info.get("type") or "").strip().lower()
+        )
+        if declared_mime_type == "image/jpg":
+            declared_mime_type = "image/jpeg"
+        guessed_mime_type = guess_mime_type(filename).lower()
+        if declared_mime_type in _DIRECT_CONTEXT_IMAGE_MIME_TYPES:
+            mime_type = declared_mime_type
+        elif declared_mime_type in {"", "application/octet-stream"}:
+            mime_type = guessed_mime_type
+        else:
+            continue
+        if mime_type not in _DIRECT_CONTEXT_IMAGE_MIME_TYPES:
+            continue
+
+        raw_size = info.get("size")
+        try:
+            size = int(raw_size) if raw_size is not None else None
+            reference = ContextReference(
+                file_ref=build_file_ref(
+                    file_id=file_id,
+                    filename=filename,
+                    mime_type=mime_type,
+                    size=size,
+                ),
+                text_fallback=(
+                    "This uploaded image is available by FileRef. If it is not "
+                    "visible in the current model context, inspect it with "
+                    "understand_media."
+                ),
+                metadata={"source": "user_upload"},
+            )
+        except (TypeError, ValueError):
+            continue
+
+        seen_file_ids.add(file_id)
+        references.append(reference)
+
+    return tuple(references)

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ...config import get_tool_max_concurrency, get_tool_parallel_enabled
+from ..context_ref import ContextReference
 from ..task_runtime import (
     PREFERRED_INPUT_MODALITIES_METADATA_KEY,
     normalize_input_modalities,
@@ -340,10 +341,10 @@ class AgentExecutionAdapter:
     @staticmethod
     def _request_context_refs(
         context: dict[str, Any] | None,
-    ) -> tuple[Any, ...]:
+    ) -> tuple[ContextReference, ...]:
         if not isinstance(context, dict):
             return ()
-        references = []
+        references: list[ContextReference] = []
         seen: set[str] = set()
         for key in ("file_info", "files", "attachments"):
             for reference in build_image_context_references(context.get(key)):

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -10,6 +10,7 @@ from ..task_runtime import (
     normalize_input_modalities,
 )
 from .agent import Agent
+from .attachments import build_image_context_references
 from .pattern import AutoPattern, DAGPattern, LLMPlanGenerator, ReActPattern
 from .registry import ExecutionRegistry
 from .result import NO_OUTPUT_PLACEHOLDER
@@ -103,6 +104,7 @@ class AgentExecutionAdapter:
             workspace_id=self._workspace_id(execution_id),
             allowed_external_dirs=self.config.allowed_external_dirs,
             initial_messages=self._initial_messages(),
+            task_context_refs=self._request_context_refs(context),
             interrupt_checker=self.config.interrupt_checker,
         )
         if handle.task is None:
@@ -141,6 +143,7 @@ class AgentExecutionAdapter:
             workspace_id=self._workspace_id(execution_id),
             allowed_external_dirs=self.config.allowed_external_dirs,
             initial_messages=self._initial_messages(),
+            task_context_refs=self._request_context_refs(context),
             interrupt_checker=self.config.interrupt_checker,
         )
         return handle.to_dict()
@@ -333,6 +336,22 @@ class AgentExecutionAdapter:
             *self.config.execution_context_messages,
             *self.config.conversation_history,
         ]
+
+    @staticmethod
+    def _request_context_refs(
+        context: dict[str, Any] | None,
+    ) -> tuple[Any, ...]:
+        if not isinstance(context, dict):
+            return ()
+        references = []
+        seen: set[str] = set()
+        for key in ("file_info", "files", "attachments"):
+            for reference in build_image_context_references(context.get(key)):
+                if reference.file_id in seen:
+                    continue
+                seen.add(reference.file_id)
+                references.append(reference)
+        return tuple(references)
 
     def _execution_type(self) -> str:
         if self.config.pattern == "dag_plan_execute":

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -16,6 +16,7 @@ from ..task_runtime import (
     normalize_input_modalities,
 )
 from ..workspace import WorkspaceManager
+from .attachments import build_image_context_references
 from .checkpoint import CheckpointCorruptError, read_latest_checkpoint_payload
 from .context import ContextManager, ExecutionContext
 from .result import extract_assistant_message
@@ -77,6 +78,7 @@ class AgentRunner:
         extra_tools: list[Any] | None = None,
         metadata: dict[str, Any] | None = None,
         initial_messages: list[dict[str, Any]] | None = None,
+        task_context_refs: Any = (),
     ) -> dict[str, Any]:
         execution_id = execution_id or str(uuid4())
         checkpoint = checkpoint or (
@@ -131,6 +133,7 @@ class AgentRunner:
                 context.add_user_message(
                     task,
                     metadata=self._initial_user_message_metadata(context),
+                    context_refs=task_context_refs,
                 )
 
         runtime = runtime or PatternRuntime(
@@ -471,7 +474,11 @@ class AgentRunner:
             metadata["turn_id"] = requested_turn_id
         self._ensure_user_message_turn_id(metadata)
 
-        added = context.add_user_message(resolved_execution_message, metadata=metadata)
+        added = context.add_user_message(
+            resolved_execution_message,
+            metadata=metadata,
+            context_refs=build_image_context_references(files),
+        )
         # Set a "this turn is waiting to be traced" pending marker before
         # we persist. The resume catch-up logic uses this to disambiguate
         # an old checkpoint that pre-dates this PR (no watermark, no

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from ...config import get_compact_threshold_default, get_compact_threshold_ratio
 from ..context_materializer import WorkspaceContextReferenceResolver
-from ..context_ref import CONTEXT_REFS_KEY
+from ..context_ref import CONTEXT_REFS_KEY, ContextReference
 from ..model.intent import enter_goal, exit_goal
 from ..task_runtime import (
     PREFERRED_INPUT_MODALITIES_METADATA_KEY,
@@ -78,7 +78,7 @@ class AgentRunner:
         extra_tools: list[Any] | None = None,
         metadata: dict[str, Any] | None = None,
         initial_messages: list[dict[str, Any]] | None = None,
-        task_context_refs: Any = (),
+        task_context_refs: tuple[ContextReference, ...] = (),
     ) -> dict[str, Any]:
         execution_id = execution_id or str(uuid4())
         checkpoint = checkpoint or (

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -134,7 +134,7 @@ class AgentService:
         self._outbound_message_handler: Callable[[dict[str, Any]], Any] | None = None
         self._interrupt_checker: Callable[[], Any] | None = None
         self._conversation_history: list[dict[str, Any]] = []
-        self._execution_context_messages: list[dict[str, str]] = []
+        self._execution_context_messages: list[dict[str, Any]] = []
         self._recovered_skill_context: str | None = None
         self.allowed_skills = self._get_allowed_skills_from_config(tool_config)
         self.skill_scope_context = self._get_skill_scope_context_from_config(

--- a/src/xagent/core/agent/transcript.py
+++ b/src/xagent/core/agent/transcript.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
+from ..context_ref import CONTEXT_REFS_KEY, normalize_context_references
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,19 +77,32 @@ def build_assistant_transcript_content(
 
 def normalize_transcript_messages(
     messages: List[Dict[str, Any]],
-) -> List[Dict[str, str]]:
+) -> List[Dict[str, Any]]:
     """Normalize transcript messages for use by LLM-backed chat patterns."""
-    normalized: List[Dict[str, str]] = []
+    normalized: List[Dict[str, Any]] = []
     for message in messages:
         role = str(message.get("role", "")).strip().lower()
         content = str(message.get("content", "")).strip()
 
-        if role not in {"user", "assistant", "system"} or not content:
+        try:
+            context_refs = normalize_context_references(
+                message.get(CONTEXT_REFS_KEY, message.get("context_refs"))
+            )
+        except (TypeError, ValueError):
+            logger.debug("Filtered invalid transcript context refs", exc_info=True)
+            context_refs = ()
+
+        if role not in {"user", "assistant", "system"} or not (content or context_refs):
             logger.debug(
                 f"Filtered invalid message: role={role}, content_length={len(content)}"
             )
             continue
-        normalized.append({"role": role, "content": content})
+        normalized_message: Dict[str, Any] = {"role": role, "content": content}
+        if context_refs:
+            normalized_message[CONTEXT_REFS_KEY] = [
+                reference.durable_dict() for reference in context_refs
+            ]
+        normalized.append(normalized_message)
     return normalized
 
 

--- a/src/xagent/core/context_materializer.py
+++ b/src/xagent/core/context_materializer.py
@@ -20,6 +20,7 @@ from .context_ref import (
 logger = logging.getLogger(__name__)
 
 _IMAGE_CONTEXT_PLACEHOLDER = "Image context for the preceding message."
+_DEFAULT_CACHE_ENTRIES = 32
 _DEFAULT_CACHE_BYTES = 32 * 1024 * 1024
 _DEFAULT_CONTEXT_REF_TOKEN_BUDGET = 8_192
 _MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST = 32 * 1024 * 1024
@@ -71,7 +72,7 @@ class WorkspaceContextReferenceResolver:
         self,
         workspace: Any,
         *,
-        cache_size: int = 8,
+        cache_size: int = _DEFAULT_CACHE_ENTRIES,
         cache_ttl_seconds: float = 300,
         max_image_bytes: int = 20 * 1024 * 1024,
         max_cache_bytes: int = _DEFAULT_CACHE_BYTES,
@@ -274,7 +275,7 @@ def _context_ref_fallback(
     reason: str | None = None,
 ) -> str:
     compact = reference.compact_text()
-    return f"{compact} ({reason})" if reason else compact
+    return f"{compact} {reason}" if reason else compact
 
 
 def _context_ref_token_budget(llm: Any) -> int:
@@ -294,7 +295,7 @@ def _prioritized_reference_positions(
 ]:
     """Return unique current-turn refs first and older refs newest-first."""
 
-    current_turn_start = 0
+    current_turn_start: int | None = None
     for message_index in range(len(messages) - 1, -1, -1):
         if messages[message_index].get("role") == "user":
             current_turn_start = message_index
@@ -317,7 +318,7 @@ def _prioritized_reference_positions(
                 reference_index,
                 reference,
             )
-            if message_index >= current_turn_start:
+            if current_turn_start is not None and message_index >= current_turn_start:
                 current.append(position)
             else:
                 historical.append(position)
@@ -346,6 +347,10 @@ async def materialize_messages(
             historical_positions,
             duplicate_positions,
         ) = _prioritized_reference_positions(messages, references_by_message)
+        for message_index, reference_index in duplicate_positions:
+            fallback_reasons[(message_index, reference_index)] = (
+                "The same image is included with a more recent message."
+            )
         token_budget = _context_ref_token_budget(llm)
         materialized_tokens = 0
         materialized_image_bytes = 0
@@ -359,7 +364,7 @@ async def materialize_messages(
                 OSError,
             ):
                 fallback_reasons[(position.message_index, position.reference_index)] = (
-                    "image data could not be resolved from its FileRef"
+                    "The image could not be loaded."
                 )
                 logger.debug(
                     "Falling back to text for unresolved context ref %s",
@@ -368,36 +373,12 @@ async def materialize_messages(
                 )
                 return None
 
-        for position in current_positions:
-            url = await resolve(position)
-            if url is None:
-                continue
-            estimated_tokens = position.reference.estimated_tokens()
-            if materialized_tokens + estimated_tokens > token_budget:
-                raise ContextReferenceResolutionError(
-                    "current-turn context images exceed the materialization "
-                    f"token budget ({materialized_tokens + estimated_tokens} "
-                    f"estimated tokens > {token_budget})"
-                )
-            image_bytes = len(url.encode("utf-8"))
-            if (
-                materialized_image_bytes + image_bytes
-                > _MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST
-            ):
-                raise ContextReferenceResolutionError(
-                    "current-turn context images exceed the materialized byte "
-                    f"budget ({materialized_image_bytes + image_bytes} bytes > "
-                    f"{_MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST})"
-                )
-            materialized_tokens += estimated_tokens
-            materialized_image_bytes += image_bytes
-            resolved_images[(position.message_index, position.reference_index)] = url
-
-        for position in historical_positions:
+        for position in (*current_positions, *historical_positions):
             estimated_tokens = position.reference.estimated_tokens()
             if materialized_tokens + estimated_tokens > token_budget:
                 fallback_reasons[(position.message_index, position.reference_index)] = (
-                    "omitted to fit the native image context budget"
+                    "The image was omitted because this request contains more "
+                    "images than the model can accept."
                 )
                 continue
             url = await resolve(position)
@@ -409,7 +390,8 @@ async def materialize_messages(
                 > _MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST
             ):
                 fallback_reasons[(position.message_index, position.reference_index)] = (
-                    "omitted to fit the native image context budget"
+                    "The image was omitted because this request contains more "
+                    "image data than the model can accept."
                 )
                 continue
             materialized_tokens += estimated_tokens
@@ -433,9 +415,9 @@ async def materialize_messages(
         if not refs or not supports_vision or resolver is None:
             if refs:
                 if not supports_vision:
-                    reason = "the active model does not support native visual context"
+                    reason = "This model cannot view the image directly."
                 elif resolver is None:
-                    reason = "the native visual context resolver is unavailable"
+                    reason = "The image is not available for direct viewing."
                 else:
                     reason = None
                 fallback = "\n".join(
@@ -468,8 +450,6 @@ async def materialize_messages(
 
         unresolved: list[tuple[ContextReference, str | None]] = []
         for reference_index, reference in enumerate(refs):
-            if (index, reference_index) in duplicate_positions:
-                continue
             url = resolved_images.get((index, reference_index))
             if url is None:
                 unresolved.append(

--- a/src/xagent/core/context_materializer.py
+++ b/src/xagent/core/context_materializer.py
@@ -5,8 +5,11 @@ import base64
 import logging
 import time
 from collections import OrderedDict
+from io import BytesIO
 from pathlib import Path
 from typing import Any, NamedTuple, Protocol
+
+from PIL import Image
 
 from .context_ref import (
     CONTEXT_REFS_KEY,
@@ -21,6 +24,12 @@ _DEFAULT_CACHE_BYTES = 32 * 1024 * 1024
 _DEFAULT_CONTEXT_REF_TOKEN_BUDGET = 8_192
 _MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST = 32 * 1024 * 1024
 _CONTEXT_REF_TOKEN_BUDGET_RATIO = 0.25
+_SUPPORTED_IMAGE_MIME_TYPES = {
+    "GIF": "image/gif",
+    "JPEG": "image/jpeg",
+    "PNG": "image/png",
+    "WEBP": "image/webp",
+}
 
 
 class ContextReferenceResolutionError(RuntimeError):
@@ -43,6 +52,12 @@ class _CacheEntry(NamedTuple):
     created_at: float
     data_url: str
     encoded_bytes: int
+
+
+class _ReferencePosition(NamedTuple):
+    message_index: int
+    reference_index: int
+    reference: ContextReference
 
 
 class ContextReferenceResolver(Protocol):
@@ -70,10 +85,15 @@ class WorkspaceContextReferenceResolver:
         self._cache_bytes = 0
 
     async def resolve_image(self, reference: ContextReference) -> str:
-        mime_type = str(reference.safe_file_ref.get("mime_type") or "image/png")
-        if not mime_type.startswith("image/"):
+        declared_mime_type = str(reference.safe_file_ref.get("mime_type") or "").lower()
+        declared_mime_type = declared_mime_type.split(";", 1)[0].strip()
+        if declared_mime_type == "image/jpg":
+            declared_mime_type = "image/jpeg"
+        if declared_mime_type and declared_mime_type not in (
+            _SUPPORTED_IMAGE_MIME_TYPES.values()
+        ):
             raise ContextReferenceResolutionError(
-                f"unsupported context image MIME type: {mime_type}"
+                f"unsupported context image MIME type: {declared_mime_type}"
             )
 
         for attempt in range(2):
@@ -86,7 +106,11 @@ class WorkspaceContextReferenceResolver:
                     f"context image exceeds {self.max_image_bytes} bytes"
                 )
 
-            cache_key = self._cache_key(reference, generation)
+            cache_key = self._cache_key(
+                reference,
+                generation,
+                declared_mime_type,
+            )
             now = time.monotonic()
             cached = self._cache.get(cache_key)
             if cached is not None:
@@ -113,6 +137,11 @@ class WorkspaceContextReferenceResolver:
                 raise ContextReferenceResolutionError(
                     f"context image exceeds {self.max_image_bytes} bytes"
                 )
+            mime_type = await asyncio.to_thread(
+                self._validated_image_mime_type,
+                image_bytes,
+                declared_mime_type,
+            )
             encoded = base64.b64encode(image_bytes).decode("ascii")
             data_url = f"data:{mime_type};base64,{encoded}"
             encoded_bytes = len(data_url)
@@ -178,12 +207,43 @@ class WorkspaceContextReferenceResolver:
         return image_bytes
 
     @staticmethod
+    def _validated_image_mime_type(
+        image_bytes: bytes,
+        declared_mime_type: str,
+    ) -> str:
+        try:
+            with Image.open(BytesIO(image_bytes)) as image:
+                image_format = str(image.format or "").upper()
+                image.verify()
+        except (
+            Image.DecompressionBombError,
+            OSError,
+            SyntaxError,
+            ValueError,
+        ) as exc:
+            raise ContextReferenceResolutionError(
+                "context FileRef does not contain a valid supported image"
+            ) from exc
+
+        mime_type = _SUPPORTED_IMAGE_MIME_TYPES.get(image_format)
+        if mime_type is None:
+            raise ContextReferenceResolutionError(
+                f"unsupported context image format: {image_format or 'unknown'}"
+            )
+        if declared_mime_type and declared_mime_type != mime_type:
+            raise ContextReferenceResolutionError(
+                "context image MIME type does not match its encoded format"
+            )
+        return mime_type
+
+    @staticmethod
     def _cache_key(
         reference: ContextReference,
         generation: _FileGeneration,
+        declared_mime_type: str,
     ) -> str:
         generation_key = ":".join(str(part) for part in generation)
-        return f"{reference.file_id}:{generation_key}"
+        return f"{reference.file_id}:{declared_mime_type}:{generation_key}"
 
 
 def llm_supports_vision(llm: Any) -> bool:
@@ -208,6 +268,15 @@ def _append_text(content: Any, text: str) -> Any:
     return f"{current}\n{text}".strip()
 
 
+def _context_ref_fallback(
+    reference: ContextReference,
+    *,
+    reason: str | None = None,
+) -> str:
+    compact = reference.compact_text()
+    return f"{compact} ({reason})" if reason else compact
+
+
 def _context_ref_token_budget(llm: Any) -> int:
     context_window = getattr(llm, "context_window", None)
     if isinstance(context_window, int) and context_window > 0:
@@ -215,22 +284,44 @@ def _context_ref_token_budget(llm: Any) -> int:
     return _DEFAULT_CONTEXT_REF_TOKEN_BUDGET
 
 
-def _enforce_context_ref_request_budget(
-    llm: Any,
+def _prioritized_reference_positions(
     messages: list[dict[str, Any]],
-) -> None:
-    references = [
-        reference
-        for message in messages
-        for reference in normalize_context_references(message.get(CONTEXT_REFS_KEY))
-    ]
-    estimated_tokens = sum(reference.estimated_tokens() for reference in references)
-    token_budget = _context_ref_token_budget(llm)
-    if estimated_tokens > token_budget:
-        raise ContextReferenceResolutionError(
-            "context image request exceeds the materialization token budget "
-            f"({estimated_tokens} estimated tokens > {token_budget})"
-        )
+    references_by_message: list[tuple[ContextReference, ...]],
+) -> tuple[
+    list[_ReferencePosition],
+    list[_ReferencePosition],
+    set[tuple[int, int]],
+]:
+    """Return unique current-turn refs first and older refs newest-first."""
+
+    current_turn_start = 0
+    for message_index in range(len(messages) - 1, -1, -1):
+        if messages[message_index].get("role") == "user":
+            current_turn_start = message_index
+            break
+
+    current: list[_ReferencePosition] = []
+    historical: list[_ReferencePosition] = []
+    duplicates: set[tuple[int, int]] = set()
+    seen_file_ids: set[str] = set()
+    for message_index in range(len(messages) - 1, -1, -1):
+        references = references_by_message[message_index]
+        for reference_index in range(len(references) - 1, -1, -1):
+            reference = references[reference_index]
+            if reference.file_id in seen_file_ids:
+                duplicates.add((message_index, reference_index))
+                continue
+            seen_file_ids.add(reference.file_id)
+            position = _ReferencePosition(
+                message_index,
+                reference_index,
+                reference,
+            )
+            if message_index >= current_turn_start:
+                current.append(position)
+            else:
+                historical.append(position)
+    return current, historical, duplicates
 
 
 async def materialize_messages(
@@ -242,11 +333,91 @@ async def materialize_messages(
     """Materialize durable context refs without mutating persisted messages."""
 
     supports_vision = llm_supports_vision(llm)
+    references_by_message = [
+        normalize_context_references(message.get(CONTEXT_REFS_KEY))
+        for message in messages
+    ]
+    resolved_images: dict[tuple[int, int], str] = {}
+    fallback_reasons: dict[tuple[int, int], str] = {}
+    duplicate_positions: set[tuple[int, int]] = set()
     if supports_vision and resolver is not None:
-        _enforce_context_ref_request_budget(llm, messages)
+        (
+            current_positions,
+            historical_positions,
+            duplicate_positions,
+        ) = _prioritized_reference_positions(messages, references_by_message)
+        token_budget = _context_ref_token_budget(llm)
+        materialized_tokens = 0
+        materialized_image_bytes = 0
+
+        async def resolve(position: _ReferencePosition) -> str | None:
+            try:
+                return await resolver.resolve_image(position.reference)
+            except (
+                ContextReferenceResolutionError,
+                FileNotFoundError,
+                OSError,
+            ):
+                fallback_reasons[(position.message_index, position.reference_index)] = (
+                    "image data could not be resolved from its FileRef"
+                )
+                logger.debug(
+                    "Falling back to text for unresolved context ref %s",
+                    position.reference.file_id,
+                    exc_info=True,
+                )
+                return None
+
+        for position in current_positions:
+            url = await resolve(position)
+            if url is None:
+                continue
+            estimated_tokens = position.reference.estimated_tokens()
+            if materialized_tokens + estimated_tokens > token_budget:
+                raise ContextReferenceResolutionError(
+                    "current-turn context images exceed the materialization "
+                    f"token budget ({materialized_tokens + estimated_tokens} "
+                    f"estimated tokens > {token_budget})"
+                )
+            image_bytes = len(url.encode("utf-8"))
+            if (
+                materialized_image_bytes + image_bytes
+                > _MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST
+            ):
+                raise ContextReferenceResolutionError(
+                    "current-turn context images exceed the materialized byte "
+                    f"budget ({materialized_image_bytes + image_bytes} bytes > "
+                    f"{_MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST})"
+                )
+            materialized_tokens += estimated_tokens
+            materialized_image_bytes += image_bytes
+            resolved_images[(position.message_index, position.reference_index)] = url
+
+        for position in historical_positions:
+            estimated_tokens = position.reference.estimated_tokens()
+            if materialized_tokens + estimated_tokens > token_budget:
+                fallback_reasons[(position.message_index, position.reference_index)] = (
+                    "omitted to fit the native image context budget"
+                )
+                continue
+            url = await resolve(position)
+            if url is None:
+                continue
+            image_bytes = len(url.encode("utf-8"))
+            if (
+                materialized_image_bytes + image_bytes
+                > _MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST
+            ):
+                fallback_reasons[(position.message_index, position.reference_index)] = (
+                    "omitted to fit the native image context budget"
+                )
+                continue
+            materialized_tokens += estimated_tokens
+            materialized_image_bytes += image_bytes
+            resolved_images[(position.message_index, position.reference_index)] = url
+
     result: list[dict[str, Any]] = []
     deferred_user_messages: list[dict[str, Any]] = []
-    materialized_image_bytes = 0
 
     def flush_deferred() -> None:
         if deferred_user_messages:
@@ -255,12 +426,21 @@ async def materialize_messages(
 
     for index, message in enumerate(messages):
         copied = dict(message)
-        refs = normalize_context_references(copied.pop(CONTEXT_REFS_KEY, None))
+        copied.pop(CONTEXT_REFS_KEY, None)
+        refs = references_by_message[index]
         role = copied.get("role")
 
         if not refs or not supports_vision or resolver is None:
             if refs:
-                fallback = "\n".join(ref.compact_text() for ref in refs)
+                if not supports_vision:
+                    reason = "the active model does not support native visual context"
+                elif resolver is None:
+                    reason = "the native visual context resolver is unavailable"
+                else:
+                    reason = None
+                fallback = "\n".join(
+                    _context_ref_fallback(ref, reason=reason) for ref in refs
+                )
                 copied["content"] = _append_text(copied.get("content"), fallback)
             if role != "tool":
                 flush_deferred()
@@ -286,34 +466,19 @@ async def materialize_messages(
         else:
             content_parts.append({"type": "text", "text": _IMAGE_CONTEXT_PLACEHOLDER})
 
-        unresolved: list[ContextReference] = []
-        for reference in refs:
-            try:
-                url = await resolver.resolve_image(reference)
-            except (
-                ContextReferenceResolutionError,
-                FileNotFoundError,
-                OSError,
-            ):
-                logger.debug(
-                    "Falling back to text for unresolved context ref %s",
-                    reference.file_id,
-                    exc_info=True,
-                )
-                unresolved.append(reference)
+        unresolved: list[tuple[ContextReference, str | None]] = []
+        for reference_index, reference in enumerate(refs):
+            if (index, reference_index) in duplicate_positions:
                 continue
-
-            image_bytes = len(url.encode("utf-8"))
-            if (
-                materialized_image_bytes + image_bytes
-                > _MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST
-            ):
-                raise ContextReferenceResolutionError(
-                    "context image request exceeds the materialized byte budget "
-                    f"({materialized_image_bytes + image_bytes} bytes > "
-                    f"{_MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST})"
+            url = resolved_images.get((index, reference_index))
+            if url is None:
+                unresolved.append(
+                    (
+                        reference,
+                        fallback_reasons.get((index, reference_index)),
+                    )
                 )
-            materialized_image_bytes += image_bytes
+                continue
             image_url: dict[str, Any] = {"url": url}
             detail = (
                 "high"
@@ -330,13 +495,18 @@ async def materialize_messages(
             )
 
         if unresolved:
-            fallback = "\n".join(ref.compact_text() for ref in unresolved)
+            fallback = "\n".join(
+                _context_ref_fallback(ref, reason=reason) for ref, reason in unresolved
+            )
             content_parts.append({"type": "text", "text": fallback})
 
         if not any(part.get("type") == "image_url" for part in content_parts):
             copied["content"] = _append_text(
                 copied.get("content"),
-                "\n".join(ref.compact_text() for ref in unresolved),
+                "\n".join(
+                    _context_ref_fallback(ref, reason=reason)
+                    for ref, reason in unresolved
+                ),
             )
             if role != "tool":
                 flush_deferred()

--- a/src/xagent/core/tools/adapters/vibe/vision_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/vision_tool.py
@@ -283,6 +283,12 @@ Use this tool to:
 - Comparing multiple images or videos
 - Answering specific questions about visual content
 
+Do not call this tool merely to inspect a standard uploaded image that is
+already attached to the current conversation as visual context; answer from the
+attached image directly. Use this tool as the fallback when that image is only
+available by file_id, or for video and SVG source inspection. Structured object
+localization and marked-image generation belong to detect_objects instead.
+
 Parameters:
 - media (required): One image/video path or file_id, or a list of them. Always use
   the exact file_id or filename from uploaded/generated file metadata.

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -174,12 +174,13 @@ and do not make reading a required reference document its own deliverable step.
 
 ## Use brand and reference assets intentionally
 
-Inspect standard raster reference images already attached to the conversation
-directly from visual context. Use `understand_media` when a reference is only
-available by file_id, was recovered from the workspace, or requires video or
-SVG source inspection. Pass useful product, campaign, style, or layout
-references to image generation or editing so the result belongs to the intended
-visual world.
+On vision-capable calls, inspect standard raster reference images already
+attached to the conversation directly from visual context. Use
+`understand_media` when the active model cannot receive native visual context,
+a reference is only available by file_id, was recovered from the workspace, or
+requires video or SVG source inspection. Pass useful product, campaign, style,
+or layout references to image generation or editing so the result belongs to
+the intended visual world.
 
 For work naming a real brand, resolve the brand identity before rendering final
 candidates. Three sources are legitimate: an asset the user gave you in this task

--- a/src/xagent/skills/builtin/static-visual-design/SKILL.md
+++ b/src/xagent/skills/builtin/static-visual-design/SKILL.md
@@ -174,9 +174,12 @@ and do not make reading a required reference document its own deliverable step.
 
 ## Use brand and reference assets intentionally
 
-Inspect the reference images this task provides with `understand_media`. Pass
-useful product, campaign, style, or layout references to image generation or
-editing so the result belongs to the intended visual world.
+Inspect standard raster reference images already attached to the conversation
+directly from visual context. Use `understand_media` when a reference is only
+available by file_id, was recovered from the workspace, or requires video or
+SVG source inspection. Pass useful product, campaign, style, or layout
+references to image generation or editing so the result belongs to the intended
+visual world.
 
 For work naming a real brand, resolve the brand identity before rendering final
 candidates. Three sources are legitimate: an asset the user gave you in this task

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -36,9 +36,9 @@ QUESTION_MESSAGE_TYPE = "question"
 SUPERSEDED_MESSAGE_TYPE = "question_superseded"
 
 # Historical attachments are replayed context rather than the current upload
-# batch. Keep a bounded recent window so an image-heavy task cannot exhaust the
-# materializer's request budget and make every later turn fail. Sixteen AUTO
-# refs remain comfortably below the materializer's default 8k-token allowance.
+# batch. Keep a bounded recent window as a secondary replay limit; the shared
+# materializer applies the active model's token and encoded-byte budgets while
+# preserving current-turn priority.
 _MAX_HISTORICAL_IMAGE_CONTEXT_REFS = 16
 
 

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -11,10 +11,12 @@ from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
+from ...core.agent.attachments import build_image_context_references
 from ...core.agent.transcript import (
     build_assistant_transcript_content,
     normalize_transcript_messages,
 )
+from ...core.context_ref import CONTEXT_REFS_KEY
 from ..models.chat_message import TaskChatMessage
 from .file_reference_output_service import reconcile_assistant_file_references
 from .ops_signals import (
@@ -704,7 +706,7 @@ def load_task_transcript(
     task_id: int,
     *,
     before_message_id: Optional[int] = None,
-) -> List[Dict[str, str]]:
+) -> List[Dict[str, Any]]:
     if before_message_id is not None:
         # Check if the reference message actually exists
         exists = (
@@ -725,10 +727,18 @@ def load_task_transcript(
     if before_message_id is not None:
         query = query.filter(TaskChatMessage.id < before_message_id)
 
-    messages = [
-        {"role": str(message.role), "content": str(message.content)}
-        for message in query.order_by(TaskChatMessage.id.asc()).all()
-    ]
+    messages: List[Dict[str, Any]] = []
+    for message in query.order_by(TaskChatMessage.id.asc()).all():
+        item: Dict[str, Any] = {
+            "role": str(message.role),
+            "content": str(message.content),
+        }
+        references = build_image_context_references(message.attachments)
+        if references:
+            item[CONTEXT_REFS_KEY] = [
+                reference.durable_dict() for reference in references
+            ]
+        messages.append(item)
     return normalize_transcript_messages(messages)
 
 

--- a/src/xagent/web/services/chat_history_service.py
+++ b/src/xagent/web/services/chat_history_service.py
@@ -16,7 +16,7 @@ from ...core.agent.transcript import (
     build_assistant_transcript_content,
     normalize_transcript_messages,
 )
-from ...core.context_ref import CONTEXT_REFS_KEY
+from ...core.context_ref import CONTEXT_REFS_KEY, ContextReference
 from ..models.chat_message import TaskChatMessage
 from .file_reference_output_service import reconcile_assistant_file_references
 from .ops_signals import (
@@ -34,6 +34,12 @@ DELIVERY_FAILED = "failed"
 
 QUESTION_MESSAGE_TYPE = "question"
 SUPERSEDED_MESSAGE_TYPE = "question_superseded"
+
+# Historical attachments are replayed context rather than the current upload
+# batch. Keep a bounded recent window so an image-heavy task cannot exhaust the
+# materializer's request budget and make every later turn fail. Sixteen AUTO
+# refs remain comfortably below the materializer's default 8k-token allowance.
+_MAX_HISTORICAL_IMAGE_CONTEXT_REFS = 16
 
 
 def _assistant_question_filters(task_id: int) -> tuple[ColumnElement[bool], ...]:
@@ -727,13 +733,24 @@ def load_task_transcript(
     if before_message_id is not None:
         query = query.filter(TaskChatMessage.id < before_message_id)
 
+    stored_messages = query.order_by(TaskChatMessage.id.asc()).all()
+    retained_references: list[tuple[ContextReference, ...]] = [
+        () for _ in stored_messages
+    ]
+    remaining_references = _MAX_HISTORICAL_IMAGE_CONTEXT_REFS
+    for index in range(len(stored_messages) - 1, -1, -1):
+        if remaining_references <= 0:
+            break
+        references = build_image_context_references(stored_messages[index].attachments)
+        retained_references[index] = references[:remaining_references]
+        remaining_references -= len(retained_references[index])
+
     messages: List[Dict[str, Any]] = []
-    for message in query.order_by(TaskChatMessage.id.asc()).all():
+    for message, references in zip(stored_messages, retained_references):
         item: Dict[str, Any] = {
             "role": str(message.role),
             "content": str(message.content),
         }
-        references = build_image_context_references(message.attachments)
         if references:
             item[CONTEXT_REFS_KEY] = [
                 reference.durable_dict() for reference in references

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -1765,6 +1765,7 @@ def _schedule_bg(
                         context=_execution_context_with_turn_id(
                             context,
                             payload.turn_id,
+                            files=payload.attachments,
                         ),
                         agent_manager=_get_agent_manager(),
                         task_owner_user_id=task_owner_user_id,
@@ -1968,9 +1969,14 @@ def _schedule_bg(
 
 
 def _execution_context_with_turn_id(
-    context: Optional[Dict[str, Any]], turn_id: str
+    context: Optional[Dict[str, Any]],
+    turn_id: str,
+    *,
+    files: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     execution_context = dict(context or {})
     if turn_id:
         execution_context["turn_id"] = turn_id
+    if files and not execution_context.get("files"):
+        execution_context["files"] = [dict(file_info) for file_info in files]
     return execution_context

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -1977,6 +1977,7 @@ def _execution_context_with_turn_id(
     execution_context = dict(context or {})
     if turn_id:
         execution_context["turn_id"] = turn_id
+    # A resumed/retried turn may already carry its authoritative file batch.
     if files and not execution_context.get("files"):
         execution_context["files"] = [dict(file_info) for file_info in files]
     return execution_context

--- a/src/xagent/web/services/task_setup_snapshot.py
+++ b/src/xagent/web/services/task_setup_snapshot.py
@@ -118,7 +118,7 @@ class TaskSetupSnapshot:
     agent: Optional[AgentRuntimeFields]
     agent_config: Optional[dict]
     excluded_agent_id: Optional[int]
-    conversation_history: tuple[dict[str, str], ...] = ()
+    conversation_history: tuple[dict[str, Any], ...] = ()
     execution_recovery: TaskExecutionRecoverySnapshot = TaskExecutionRecoverySnapshot()
     reconstruction: TaskReconstructionSnapshot = TaskReconstructionSnapshot()
     # Resolved by ``resolve_task_runtime_config_core`` using this same Session.

--- a/tests/core/agent/test_attachments.py
+++ b/tests/core/agent/test_attachments.py
@@ -107,3 +107,32 @@ def test_build_image_context_references_infers_mime_and_deduplicates_file_ids():
 
     assert [reference.file_id for reference in references] == ["image-id"]
     assert references[0].safe_file_ref["mime_type"] == "image/webp"
+
+
+def test_build_image_context_references_normalizes_optional_upload_metadata():
+    references = build_image_context_references(
+        [
+            {
+                "file_id": "parameterized-mime",
+                "name": "diagram.png",
+                "type": " Image/PNG; charset=binary ",
+                "size": "12kb",
+            },
+            {
+                "file_id": "blank-name",
+                "original_name": "   ",
+                "name": "  ",
+                "type": "image/jpeg",
+                "size": -1,
+            },
+        ]
+    )
+
+    assert [reference.file_id for reference in references] == [
+        "parameterized-mime",
+        "blank-name",
+    ]
+    assert references[0].safe_file_ref["mime_type"] == "image/png"
+    assert "size" not in references[0].safe_file_ref
+    assert references[1].safe_file_ref["filename"] == "uploaded image"
+    assert "size" not in references[1].safe_file_ref

--- a/tests/core/agent/test_attachments.py
+++ b/tests/core/agent/test_attachments.py
@@ -1,6 +1,9 @@
 """Tests for the shared file_info → chip-shape projector."""
 
-from xagent.core.agent.attachments import project_file_info_to_chip
+from xagent.core.agent.attachments import (
+    build_image_context_references,
+    project_file_info_to_chip,
+)
 
 
 def test_project_keeps_chip_fields_and_strips_paths():
@@ -60,3 +63,47 @@ def test_project_tolerates_garbage_input():
     assert project_file_info_to_chip("not a list") == []  # type: ignore[arg-type]
     assert project_file_info_to_chip([None, "garbage", 42]) == []  # type: ignore[list-item]
     assert project_file_info_to_chip([]) == []
+
+
+def test_build_image_context_references_keeps_only_direct_provider_formats():
+    references = build_image_context_references(
+        [
+            {
+                "file_id": "png-id",
+                "original_name": "diagram.png",
+                "type": "image/png",
+                "size": 123,
+                "path": "/private/uploads/diagram.png",
+            },
+            {
+                "file_id": "svg-id",
+                "name": "drawing.svg",
+                "type": "image/svg+xml",
+            },
+            {
+                "file_id": "pdf-id",
+                "name": "notes.pdf",
+                "type": "application/pdf",
+            },
+        ]
+    )
+
+    assert len(references) == 1
+    reference = references[0]
+    assert reference.file_id == "png-id"
+    assert reference.safe_file_ref["filename"] == "diagram.png"
+    assert reference.safe_file_ref["mime_type"] == "image/png"
+    assert "path" not in reference.durable_dict()["file_ref"]
+    assert reference.metadata == {"source": "user_upload"}
+
+
+def test_build_image_context_references_infers_mime_and_deduplicates_file_ids():
+    references = build_image_context_references(
+        [
+            {"file_id": "image-id", "name": "photo.webp", "type": None},
+            {"file_id": "image-id", "name": "duplicate.png", "type": "image/png"},
+        ]
+    )
+
+    assert [reference.file_id for reference in references] == ["image-id"]
+    assert references[0].safe_file_ref["mime_type"] == "image/webp"

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -236,6 +236,50 @@ def test_execution_adapter_uses_service_id_as_runner_workspace_id() -> None:
     assert registry.start_kwargs["workspace_id"] == "web_task_458"
 
 
+def test_execution_adapter_projects_request_images_to_task_context_refs() -> None:
+    registry = RecordingRegistry()
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="vision-task",
+            pattern="react",
+            llm=FakeLLM(["unused"]),
+            service_id="vision-service",
+            registry=cast(Any, registry),
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    adapter.start(
+        task="Inspect the upload",
+        task_id="vision-exec",
+        context={
+            "file_info": [
+                {
+                    "file_id": "image-id",
+                    "name": "screen.png",
+                    "type": "image/png",
+                    "path": "/private/runtime/screen.png",
+                }
+            ],
+            # The display-safe projection can be present at the same time and
+            # must not duplicate the provider image.
+            "files": [
+                {
+                    "file_id": "image-id",
+                    "name": "display-screen.png",
+                    "type": "image/png",
+                }
+            ],
+        },
+    )
+
+    assert registry.start_kwargs is not None
+    references = registry.start_kwargs["task_context_refs"]
+    assert len(references) == 1
+    assert references[0].file_id == "image-id"
+    assert "path" not in references[0].durable_dict()["file_ref"]
+
+
 @pytest.mark.asyncio
 async def test_execution_adapter_routes_single_call_to_one_tool_then_final_answer() -> (
     None

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -14,6 +14,7 @@ from xagent.core.agent import (
     PatternRuntime,
     TraceEventCallback,
 )
+from xagent.core.agent.attachments import build_image_context_references
 from xagent.core.agent.checkpoint import (
     CheckpointCorruptError,
     CheckpointUnavailableError,
@@ -1275,6 +1276,58 @@ async def test_runner_initial_user_message_preserves_display_metadata(
     )
     assert user_event["data"]["message"] == "Read file"
     assert user_event["data"]["turn_id"] == turn_id
+
+
+@pytest.mark.asyncio
+async def test_runner_attaches_uploaded_image_refs_to_initial_user_message(
+    tmp_path: Path,
+) -> None:
+    agent = Agent(
+        name="vision",
+        patterns=[FakePattern({"success": True, "response": "Done"})],
+    )
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    references = build_image_context_references(
+        [{"file_id": "image-123", "name": "diagram.png", "type": "image/png"}]
+    )
+
+    result = await runner.run(
+        task="What is shown?",
+        execution_id="exec-initial-image",
+        task_context_refs=references,
+    )
+
+    first_user = next(
+        message for message in result["context"].messages if message.role == "user"
+    )
+    assert first_user.context_refs == references
+
+
+@pytest.mark.asyncio
+async def test_runner_attaches_uploaded_image_refs_to_injected_user_message(
+    tmp_path: Path,
+) -> None:
+    tracer = TracerCheckpointStore()
+    agent = Agent(name="vision", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    await runner.run(task="Start", execution_id="exec-injected-image")
+
+    context = await runner.inject_user_message(
+        "exec-injected-image",
+        "Inspect the new image",
+        files=[{"file_id": "image-456", "name": "screen.jpg", "type": "image/jpeg"}],
+        request_interrupt=False,
+    )
+
+    assert context is not None
+    assert context.messages[-1].context_refs[0].file_id == "image-456"
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_transcript.py
+++ b/tests/core/agent/test_transcript.py
@@ -1,0 +1,54 @@
+from xagent.core.agent.transcript import normalize_transcript_messages
+from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
+
+
+def _image_reference() -> ContextReference:
+    return ContextReference(
+        file_ref={
+            "file_id": "image-id",
+            "filename": "diagram.png",
+            "mime_type": "image/png",
+        },
+        metadata={"source": "user_upload"},
+    )
+
+
+def test_normalize_transcript_retains_refs_only_message_and_alias() -> None:
+    reference = _image_reference()
+
+    normalized = normalize_transcript_messages(
+        [
+            {
+                "role": "user",
+                "content": "",
+                "context_refs": [reference.durable_dict()],
+            }
+        ]
+    )
+
+    assert normalized == [
+        {
+            "role": "user",
+            "content": "",
+            CONTEXT_REFS_KEY: [reference.durable_dict()],
+        }
+    ]
+
+
+def test_normalize_transcript_filters_malformed_refs_without_losing_text() -> None:
+    normalized = normalize_transcript_messages(
+        [
+            {
+                "role": "user",
+                "content": "Keep this text",
+                CONTEXT_REFS_KEY: [{"type": "image"}],
+            },
+            {
+                "role": "user",
+                "content": "",
+                CONTEXT_REFS_KEY: [{"type": "image"}],
+            },
+        ]
+    )
+
+    assert normalized == [{"role": "user", "content": "Keep this text"}]

--- a/tests/core/computer/test_store.py
+++ b/tests/core/computer/test_store.py
@@ -4,9 +4,11 @@ import asyncio
 import os
 import threading
 import time
+from io import BytesIO
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from xagent.core.computer.schema import (
     COMPUTER_FRAME_ID_METADATA_KEY,
@@ -81,6 +83,12 @@ class MissingInternalTempWorkspace(FakeWorkspace):
         del self.internal_temp_dir
 
 
+def _png_bytes() -> bytes:
+    output = BytesIO()
+    Image.new("RGB", (2, 2), color="red").save(output, format="PNG")
+    return output.getvalue()
+
+
 @pytest.mark.asyncio
 async def test_observation_store_persists_and_resolves_file_ref(
     tmp_path: Path,
@@ -88,11 +96,12 @@ async def test_observation_store_persists_and_resolves_file_ref(
     workspace = FakeWorkspace(tmp_path / "workspace")
     store = ObservationStore(workspace)
     event_loop_thread = threading.get_ident()
+    image_bytes = _png_bytes()
 
     reference = await store.save_screenshot(
         session_id="session/unsafe",
         frame_id="frame-1",
-        image_bytes=b"fake-png-bytes",
+        image_bytes=image_bytes,
         mime_type="image/png",
         viewport=Viewport(width=1280, height=720),
         text_fallback="browser screenshot",
@@ -120,7 +129,6 @@ async def test_observation_store_persists_and_resolves_file_ref(
         reference
     )
     assert materialized.startswith("data:image/png;base64,")
-    assert "fake-png-bytes" not in materialized
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_context_materializer.py
+++ b/tests/core/test_context_materializer.py
@@ -16,6 +16,7 @@ from xagent.core.agent import (
     PatternRuntime,
     ReActPattern,
 )
+from xagent.core.agent.attachments import build_image_context_references
 from xagent.core.context_materializer import (
     ContextReferenceResolutionError,
     WorkspaceContextReferenceResolver,
@@ -184,39 +185,45 @@ async def test_tool_image_follows_complete_tool_result_group() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("resolver", [None, MissingResolver()])
 async def test_unresolved_vision_reference_degrades_to_text(resolver: Any) -> None:
+    reference = build_image_context_references(
+        [{"file_id": "image-1", "name": "settings.png", "type": "image/png"}]
+    )[0]
     result = await materialize_messages(
         llm=VisionLLM(),
         messages=[
             {
                 "role": "user",
                 "content": "Inspect this",
-                CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+                CONTEXT_REFS_KEY: [reference.durable_dict()],
             }
         ],
         resolver=resolver,
     )
 
     assert "file_id=image-1" in result[0]["content"]
-    assert "A settings dialog" in result[0]["content"]
+    assert "understand_media" in result[0]["content"]
     assert "base64" not in result[0]["content"]
 
 
 @pytest.mark.asyncio
 async def test_nonvision_model_receives_file_ref_text_fallback() -> None:
+    reference = build_image_context_references(
+        [{"file_id": "image-1", "name": "settings.png", "type": "image/png"}]
+    )[0]
     result = await materialize_messages(
         llm=TextLLM(),
         messages=[
             {
                 "role": "user",
                 "content": "Inspect this",
-                CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+                CONTEXT_REFS_KEY: [reference.durable_dict()],
             }
         ],
         resolver=None,
     )
 
     assert "file_id=image-1" in result[0]["content"]
-    assert "A settings dialog" in result[0]["content"]
+    assert "understand_media" in result[0]["content"]
     assert "base64" not in result[0]["content"]
 
 
@@ -371,15 +378,20 @@ async def test_workspace_resolver_invalidates_cache_when_file_id_generation_chan
 
 
 @pytest.mark.asyncio
-async def test_materializer_rejects_image_request_over_token_budget() -> None:
+async def test_uploaded_refs_enforce_materializer_token_budget() -> None:
     class VisionLLMWithContextWindow(VisionLLM):
-        context_window = 32_768
+        context_window = 4_096
 
-    references = [
-        image_reference(detail=ImageDetail.HIGH, file_id=f"image-{index}")
-        for index in range(12)
-    ]
-
+    references = build_image_context_references(
+        [
+            {
+                "file_id": f"image-{index}",
+                "name": f"image-{index}.png",
+                "type": "image/png",
+            }
+            for index in range(5)
+        ]
+    )
     with pytest.raises(
         ContextReferenceResolutionError,
         match="materialization token budget",

--- a/tests/core/test_context_materializer.py
+++ b/tests/core/test_context_materializer.py
@@ -222,8 +222,8 @@ async def test_tool_image_follows_complete_tool_result_group() -> None:
 @pytest.mark.parametrize(
     ("resolver", "expected_reason"),
     [
-        (None, "native visual context resolver is unavailable"),
-        (MissingResolver(), "image data could not be resolved from its FileRef"),
+        (None, "not available for direct viewing"),
+        (MissingResolver(), "image could not be loaded"),
     ],
 )
 async def test_unresolved_vision_reference_degrades_to_text(
@@ -270,7 +270,7 @@ async def test_nonvision_model_receives_file_ref_text_fallback() -> None:
 
     assert "file_id=image-1" in result[0]["content"]
     assert "not available as native visual context" in result[0]["content"]
-    assert "active model does not support native visual context" in result[0]["content"]
+    assert "cannot view the image directly" in result[0]["content"]
     assert "base64" not in result[0]["content"]
 
 
@@ -505,7 +505,40 @@ async def test_workspace_resolver_invalidates_cache_when_file_id_generation_chan
 
 
 @pytest.mark.asyncio
-async def test_uploaded_refs_enforce_materializer_token_budget() -> None:
+async def test_workspace_resolver_default_cache_covers_history_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths: dict[str, Path] = {}
+    for index in range(17):
+        path = tmp_path / f"image-{index}.png"
+        path.write_bytes(encoded_image_bytes(color=f"#{index:06x}"))
+        paths[f"image-{index}"] = path
+
+    class Workspace:
+        def resolve_file_id(self, file_id: str) -> Path:
+            return paths[file_id]
+
+    resolver = WorkspaceContextReferenceResolver(Workspace())
+    read_calls = 0
+    original_read_generation = resolver._read_generation
+
+    def counted_read_generation(*args: Any) -> bytes:
+        nonlocal read_calls
+        read_calls += 1
+        return original_read_generation(*args)
+
+    monkeypatch.setattr(resolver, "_read_generation", counted_read_generation)
+    references = [image_reference(file_id=f"image-{index}") for index in range(17)]
+
+    for reference in (*references, *references):
+        await resolver.resolve_image(reference)
+
+    assert read_calls == 17
+
+
+@pytest.mark.asyncio
+async def test_uploaded_refs_degrade_within_materializer_token_budget() -> None:
     class VisionLLMWithContextWindow(VisionLLM):
         context_window = 4_096
 
@@ -519,27 +552,29 @@ async def test_uploaded_refs_enforce_materializer_token_budget() -> None:
             for index in range(5)
         ]
     )
-    with pytest.raises(
-        ContextReferenceResolutionError,
-        match="materialization token budget",
-    ):
-        await materialize_messages(
-            llm=VisionLLMWithContextWindow(),
-            messages=[
-                {
-                    "role": "user",
-                    "content": "Inspect every image",
-                    CONTEXT_REFS_KEY: [
-                        reference.durable_dict() for reference in references
-                    ],
-                }
-            ],
-            resolver=RecordingResolver(),
-        )
+    resolver = RecordingResolver()
+    result = await materialize_messages(
+        llm=VisionLLMWithContextWindow(),
+        messages=[
+            {
+                "role": "user",
+                "content": "Inspect every image",
+                CONTEXT_REFS_KEY: [
+                    reference.durable_dict() for reference in references
+                ],
+            }
+        ],
+        resolver=resolver,
+    )
+
+    assert resolver.file_ids == ["image-4", "image-3", "image-2"]
+    assert sum(part["type"] == "image_url" for part in result[0]["content"]) == 3
+    assert "file_id=image-0" in result[0]["content"][-1]["text"]
+    assert "more images than the model can accept" in result[0]["content"][-1]["text"]
 
 
 @pytest.mark.asyncio
-async def test_materializer_rejects_aggregate_materialized_image_bytes(
+async def test_materializer_degrades_aggregate_materialized_image_bytes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -548,21 +583,20 @@ async def test_materializer_rejects_aggregate_materialized_image_bytes(
         32,
     )
 
-    with pytest.raises(
-        ContextReferenceResolutionError,
-        match="materialized byte budget",
-    ):
-        await materialize_messages(
-            llm=VisionLLM(),
-            messages=[
-                {
-                    "role": "user",
-                    "content": "Inspect this image",
-                    CONTEXT_REFS_KEY: [image_reference().durable_dict()],
-                }
-            ],
-            resolver=Resolver(),
-        )
+    result = await materialize_messages(
+        llm=VisionLLM(),
+        messages=[
+            {
+                "role": "user",
+                "content": "Inspect this image",
+                CONTEXT_REFS_KEY: [image_reference().durable_dict()],
+            }
+        ],
+        resolver=Resolver(),
+    )
+
+    assert isinstance(result[0]["content"], str)
+    assert "more image data than the model can accept" in result[0]["content"]
 
 
 @pytest.mark.asyncio
@@ -612,8 +646,42 @@ async def test_materializer_prioritizes_current_and_newest_unique_history() -> N
 
     assert resolver.file_ids == ["current", "history-newest", "history-middle"]
     assert "file_id=history-oldest" in result[0]["content"]
-    assert result[2]["content"] == "duplicate current"
+    assert "same image is included with a more recent message" in result[2]["content"]
     assert isinstance(result[4]["content"], list)
+
+
+@pytest.mark.asyncio
+async def test_materializer_without_user_message_treats_refs_as_history() -> None:
+    reference = uploaded_image_reference("tool-image")
+    llm = VisionLLM()
+    llm.context_window = 4
+    resolver = RecordingResolver()
+    messages = [
+        {
+            "role": "tool",
+            "content": "captured",
+            CONTEXT_REFS_KEY: [reference.durable_dict()],
+        }
+    ]
+
+    current, historical, duplicates = (
+        context_materializer._prioritized_reference_positions(
+            messages,
+            [(reference,)],
+        )
+    )
+    assert current == []
+    assert [position.reference.file_id for position in historical] == ["tool-image"]
+    assert duplicates == set()
+
+    result = await materialize_messages(
+        llm=llm,
+        messages=messages,
+        resolver=resolver,
+    )
+
+    assert resolver.file_ids == []
+    assert "more images than the model can accept" in result[0]["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_context_materializer.py
+++ b/tests/core/test_context_materializer.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import threading
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 
 import pytest
+from PIL import Image
 
 import xagent.core.context_materializer as context_materializer
 from xagent.core.agent import (
@@ -46,6 +49,18 @@ def image_reference(
     )
 
 
+def uploaded_image_reference(file_id: str) -> ContextReference:
+    return build_image_context_references(
+        [{"file_id": file_id, "name": f"{file_id}.png", "type": "image/png"}]
+    )[0]
+
+
+def encoded_image_bytes(*, image_format: str = "PNG", color: str = "red") -> bytes:
+    output = BytesIO()
+    Image.new("RGB", (2, 2), color=color).save(output, format=image_format)
+    return output.getvalue()
+
+
 class Resolver:
     async def resolve_image(self, reference: ContextReference) -> str:
         assert reference.file_id == "image-1"
@@ -55,6 +70,27 @@ class Resolver:
 class MissingResolver:
     async def resolve_image(self, reference: ContextReference) -> str:
         raise FileNotFoundError(reference.file_id)
+
+
+class RecordingResolver:
+    def __init__(
+        self,
+        *,
+        missing: set[str] | None = None,
+        urls: dict[str, str] | None = None,
+    ) -> None:
+        self.missing = missing or set()
+        self.urls = urls or {}
+        self.file_ids: list[str] = []
+
+    async def resolve_image(self, reference: ContextReference) -> str:
+        self.file_ids.append(reference.file_id)
+        if reference.file_id in self.missing:
+            raise FileNotFoundError(reference.file_id)
+        return self.urls.get(
+            reference.file_id,
+            "data:image/png;base64,c2NyZWVuc2hvdA==",
+        )
 
 
 class VisionLLM:
@@ -183,8 +219,17 @@ async def test_tool_image_follows_complete_tool_result_group() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("resolver", [None, MissingResolver()])
-async def test_unresolved_vision_reference_degrades_to_text(resolver: Any) -> None:
+@pytest.mark.parametrize(
+    ("resolver", "expected_reason"),
+    [
+        (None, "native visual context resolver is unavailable"),
+        (MissingResolver(), "image data could not be resolved from its FileRef"),
+    ],
+)
+async def test_unresolved_vision_reference_degrades_to_text(
+    resolver: Any,
+    expected_reason: str,
+) -> None:
     reference = build_image_context_references(
         [{"file_id": "image-1", "name": "settings.png", "type": "image/png"}]
     )[0]
@@ -201,7 +246,8 @@ async def test_unresolved_vision_reference_degrades_to_text(resolver: Any) -> No
     )
 
     assert "file_id=image-1" in result[0]["content"]
-    assert "understand_media" in result[0]["content"]
+    assert "not available as native visual context" in result[0]["content"]
+    assert expected_reason in result[0]["content"]
     assert "base64" not in result[0]["content"]
 
 
@@ -223,7 +269,8 @@ async def test_nonvision_model_receives_file_ref_text_fallback() -> None:
     )
 
     assert "file_id=image-1" in result[0]["content"]
-    assert "understand_media" in result[0]["content"]
+    assert "not available as native visual context" in result[0]["content"]
+    assert "active model does not support native visual context" in result[0]["content"]
     assert "base64" not in result[0]["content"]
 
 
@@ -233,7 +280,8 @@ async def test_workspace_resolver_enforces_size_limit_and_caches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     image_path = tmp_path / "frame.png"
-    image_path.write_bytes(b"image")
+    image_bytes = encoded_image_bytes()
+    image_path.write_bytes(image_bytes)
 
     class Workspace:
         calls = 0
@@ -247,7 +295,7 @@ async def test_workspace_resolver_enforces_size_limit_and_caches(
     resolver = WorkspaceContextReferenceResolver(
         workspace,
         cache_size=1,
-        max_image_bytes=5,
+        max_image_bytes=len(image_bytes),
     )
     read_calls = 0
     original_read_generation = resolver._read_generation
@@ -266,8 +314,80 @@ async def test_workspace_resolver_enforces_size_limit_and_caches(
     assert workspace.calls == 2
     assert read_calls == 1
 
-    image_path.write_bytes(b"too-large")
+    image_path.write_bytes(image_bytes + b"too-large")
     with pytest.raises(RuntimeError, match="exceeds"):
+        await resolver.resolve_image(image_reference())
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolver_rejects_malformed_image_bytes(
+    tmp_path: Path,
+) -> None:
+    image_path = tmp_path / "malformed.png"
+    image_path.write_bytes(b"not-an-image")
+
+    class Workspace:
+        def resolve_file_id(self, file_id: str) -> Path:
+            assert file_id == "image-1"
+            return image_path
+
+    with pytest.raises(
+        ContextReferenceResolutionError,
+        match="valid supported image",
+    ):
+        await WorkspaceContextReferenceResolver(Workspace()).resolve_image(
+            image_reference()
+        )
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolver_rejects_mismatched_image_mime_type(
+    tmp_path: Path,
+) -> None:
+    image_path = tmp_path / "mislabeled.png"
+    image_path.write_bytes(encoded_image_bytes(image_format="JPEG"))
+
+    class Workspace:
+        def resolve_file_id(self, file_id: str) -> Path:
+            assert file_id == "image-1"
+            return image_path
+
+    with pytest.raises(
+        ContextReferenceResolutionError,
+        match="does not match its encoded format",
+    ):
+        await WorkspaceContextReferenceResolver(Workspace()).resolve_image(
+            image_reference()
+        )
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolver_uses_canonical_detected_mime_type(
+    tmp_path: Path,
+) -> None:
+    image_path = tmp_path / "photo.jpg"
+    image_path.write_bytes(encoded_image_bytes(image_format="JPEG"))
+
+    class Workspace:
+        def resolve_file_id(self, file_id: str) -> Path:
+            assert file_id == "image-1"
+            return image_path
+
+    reference = ContextReference(
+        file_ref={
+            "file_id": "image-1",
+            "filename": "photo.jpg",
+            "mime_type": "image/jpg",
+        }
+    )
+    resolver = WorkspaceContextReferenceResolver(Workspace())
+    result = await resolver.resolve_image(reference)
+
+    assert result.startswith("data:image/jpeg;base64,")
+    with pytest.raises(
+        ContextReferenceResolutionError,
+        match="does not match its encoded format",
+    ):
         await resolver.resolve_image(image_reference())
 
 
@@ -278,9 +398,16 @@ async def test_workspace_resolver_bounds_cache_by_encoded_bytes(
 ) -> None:
     first_path = tmp_path / "first.png"
     second_path = tmp_path / "second.png"
-    first_path.write_bytes(b"first")
-    second_path.write_bytes(b"second")
+    first_bytes = encoded_image_bytes(color="red")
+    second_bytes = encoded_image_bytes(color="blue")
+    first_path.write_bytes(first_bytes)
+    second_path.write_bytes(second_bytes)
     paths = {"image-1": first_path, "image-2": second_path}
+
+    max_encoded_bytes = max(
+        len("data:image/png;base64,") + len(base64.b64encode(image_bytes))
+        for image_bytes in (first_bytes, second_bytes)
+    )
 
     class Workspace:
         def resolve_file_id(self, file_id: str) -> Path:
@@ -289,7 +416,7 @@ async def test_workspace_resolver_bounds_cache_by_encoded_bytes(
     resolver = WorkspaceContextReferenceResolver(
         Workspace(),
         cache_size=8,
-        max_cache_bytes=35,
+        max_cache_bytes=max_encoded_bytes,
     )
     read_calls = 0
     original_read_generation = resolver._read_generation
@@ -307,7 +434,7 @@ async def test_workspace_resolver_bounds_cache_by_encoded_bytes(
 
     assert read_calls == 3
     assert len(resolver._cache) == 1
-    assert resolver._cache_bytes <= 35
+    assert resolver._cache_bytes <= max_encoded_bytes
 
 
 @pytest.mark.asyncio
@@ -316,7 +443,7 @@ async def test_workspace_resolver_counts_concurrent_same_key_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     image_path = tmp_path / "frame.png"
-    image_path.write_bytes(b"image")
+    image_path.write_bytes(encoded_image_bytes())
     read_barrier = threading.Barrier(2)
 
     class Workspace:
@@ -355,8 +482,8 @@ async def test_workspace_resolver_invalidates_cache_when_file_id_generation_chan
 ) -> None:
     first_path = tmp_path / "first.png"
     second_path = tmp_path / "second.png"
-    first_path.write_bytes(b"first")
-    second_path.write_bytes(b"second")
+    first_path.write_bytes(encoded_image_bytes(color="red"))
+    second_path.write_bytes(encoded_image_bytes(color="blue"))
 
     class Workspace:
         current_path = first_path
@@ -372,8 +499,8 @@ async def test_workspace_resolver_invalidates_cache_when_file_id_generation_chan
     workspace.current_path = second_path
     second = await resolver.resolve_image(image_reference())
 
-    assert first.endswith("Zmlyc3Q=")
-    assert second.endswith("c2Vjb25k")
+    assert first.startswith("data:image/png;base64,")
+    assert second.startswith("data:image/png;base64,")
     assert first != second
 
 
@@ -407,7 +534,7 @@ async def test_uploaded_refs_enforce_materializer_token_budget() -> None:
                     ],
                 }
             ],
-            resolver=Resolver(),
+            resolver=RecordingResolver(),
         )
 
 
@@ -439,11 +566,152 @@ async def test_materializer_rejects_aggregate_materialized_image_bytes(
 
 
 @pytest.mark.asyncio
+async def test_materializer_prioritizes_current_and_newest_unique_history() -> None:
+    current = uploaded_image_reference("current")
+    newest = uploaded_image_reference("history-newest")
+    middle = uploaded_image_reference("history-middle")
+    oldest = uploaded_image_reference("history-oldest")
+    token_budget = sum(
+        reference.estimated_tokens() for reference in (current, newest, middle)
+    )
+    llm = VisionLLM()
+    llm.context_window = token_budget * 4
+    resolver = RecordingResolver()
+
+    result = await materialize_messages(
+        llm=llm,
+        messages=[
+            {
+                "role": "user",
+                "content": "oldest",
+                CONTEXT_REFS_KEY: [oldest.durable_dict()],
+            },
+            {
+                "role": "user",
+                "content": "middle",
+                CONTEXT_REFS_KEY: [middle.durable_dict()],
+            },
+            {
+                "role": "user",
+                "content": "duplicate current",
+                CONTEXT_REFS_KEY: [current.durable_dict()],
+            },
+            {
+                "role": "user",
+                "content": "newest",
+                CONTEXT_REFS_KEY: [newest.durable_dict()],
+            },
+            {
+                "role": "user",
+                "content": "current turn",
+                CONTEXT_REFS_KEY: [current.durable_dict()],
+            },
+        ],
+        resolver=resolver,
+    )
+
+    assert resolver.file_ids == ["current", "history-newest", "history-middle"]
+    assert "file_id=history-oldest" in result[0]["content"]
+    assert result[2]["content"] == "duplicate current"
+    assert isinstance(result[4]["content"], list)
+
+
+@pytest.mark.asyncio
+async def test_stale_history_does_not_consume_materialization_budget() -> None:
+    current = uploaded_image_reference("current")
+    stale = uploaded_image_reference("history-stale")
+    older = uploaded_image_reference("history-older")
+    token_budget = current.estimated_tokens() + older.estimated_tokens()
+    llm = VisionLLM()
+    llm.context_window = token_budget * 4
+    resolver = RecordingResolver(missing={"history-stale"})
+
+    result = await materialize_messages(
+        llm=llm,
+        messages=[
+            {
+                "role": "user",
+                "content": "older",
+                CONTEXT_REFS_KEY: [older.durable_dict()],
+            },
+            {
+                "role": "user",
+                "content": "stale",
+                CONTEXT_REFS_KEY: [stale.durable_dict()],
+            },
+            {
+                "role": "user",
+                "content": "current",
+                CONTEXT_REFS_KEY: [current.durable_dict()],
+            },
+        ],
+        resolver=resolver,
+    )
+
+    assert resolver.file_ids == ["current", "history-stale", "history-older"]
+    assert isinstance(result[0]["content"], list)
+    assert "file_id=history-stale" in result[1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_oversized_history_degrades_with_current_byte_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prefix = "data:image/png;base64,"
+    current_url = prefix + ("c" * 20)
+    newest_url = prefix + ("n" * 30)
+    older_url = prefix + ("o" * 5)
+    monkeypatch.setattr(
+        context_materializer,
+        "_MAX_CONTEXT_IMAGE_BYTES_PER_REQUEST",
+        len(current_url) + len(older_url),
+    )
+    resolver = RecordingResolver(
+        urls={
+            "current": current_url,
+            "history-newest": newest_url,
+            "history-older": older_url,
+        }
+    )
+
+    result = await materialize_messages(
+        llm=VisionLLM(),
+        messages=[
+            {
+                "role": "user",
+                "content": "older",
+                CONTEXT_REFS_KEY: [
+                    uploaded_image_reference("history-older").durable_dict()
+                ],
+            },
+            {
+                "role": "user",
+                "content": "newest",
+                CONTEXT_REFS_KEY: [
+                    uploaded_image_reference("history-newest").durable_dict()
+                ],
+            },
+            {
+                "role": "user",
+                "content": "current",
+                CONTEXT_REFS_KEY: [uploaded_image_reference("current").durable_dict()],
+            },
+        ],
+        resolver=resolver,
+    )
+
+    assert resolver.file_ids == ["current", "history-newest", "history-older"]
+    assert isinstance(result[0]["content"], list)
+    assert "file_id=history-newest" in result[1]["content"]
+    assert isinstance(result[2]["content"], list)
+
+
+@pytest.mark.asyncio
 async def test_workspace_resolver_prefers_detached_resolution_off_event_loop(
     tmp_path: Path,
 ) -> None:
     image_path = tmp_path / "frame.png"
-    image_path.write_bytes(b"image")
+    image_path.write_bytes(encoded_image_bytes())
     event_loop_thread = threading.get_ident()
 
     class Workspace:

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -293,6 +293,20 @@ def test_execution_context_carries_path_stripped_turn_attachments() -> None:
     assert context["files"] is not files
 
 
+def test_execution_context_preserves_existing_turn_attachments() -> None:
+    existing_files = [
+        {"file_id": "existing", "name": "existing.png", "type": "image/png"}
+    ]
+
+    context = task_orchestrator_module._execution_context_with_turn_id(
+        {"files": existing_files},
+        "turn-2",
+        files=[{"file_id": "new", "name": "new.png", "type": "image/png"}],
+    )
+
+    assert context["files"] is existing_files
+
+
 # ---------------------------------------------------------------------------
 # begin_turn — happy paths
 # ---------------------------------------------------------------------------

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -276,6 +276,23 @@ def test_payload_uses_execution_when_provided() -> None:
     assert p.for_agent == "summarize this\n\n[file context]"
 
 
+def test_execution_context_carries_path_stripped_turn_attachments() -> None:
+    files = [{"file_id": "image-id", "name": "screen.png", "type": "image/png"}]
+
+    context = task_orchestrator_module._execution_context_with_turn_id(
+        {"existing": True},
+        "turn-1",
+        files=files,
+    )
+
+    assert context == {
+        "existing": True,
+        "turn_id": "turn-1",
+        "files": files,
+    }
+    assert context["files"] is not files
+
+
 # ---------------------------------------------------------------------------
 # begin_turn — happy paths
 # ---------------------------------------------------------------------------

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -13,6 +13,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.services.chat_history_service import (
+    _MAX_HISTORICAL_IMAGE_CONTEXT_REFS,
     DELIVERY_COMPLETED,
     DELIVERY_DISPATCHED,
     DELIVERY_FAILED,
@@ -133,6 +134,41 @@ def test_load_task_transcript_preserves_uploaded_images_as_context_refs():
         assert len(references) == 1
         assert references[0]["file_ref"]["file_id"] == "image-id"
         assert references[0]["metadata"] == {"source": "user_upload"}
+    finally:
+        db_session.close()
+
+
+def test_load_task_transcript_bounds_historical_images_to_recent_window():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        total_images = _MAX_HISTORICAL_IMAGE_CONTEXT_REFS + 2
+        for index in range(total_images):
+            persist_user_message(
+                db_session,
+                int(task.id),
+                int(task.user_id),
+                f"Image {index}",
+                attachments=[
+                    {
+                        "file_id": f"image-{index}",
+                        "name": f"image-{index}.png",
+                        "type": "image/png",
+                    }
+                ],
+            )
+
+        transcript = load_task_transcript(db_session, int(task.id))
+
+        assert len(transcript) == total_images
+        assert CONTEXT_REFS_KEY not in transcript[0]
+        assert CONTEXT_REFS_KEY not in transcript[1]
+        retained_ids = [
+            message[CONTEXT_REFS_KEY][0]["file_ref"]["file_id"]
+            for message in transcript
+            if CONTEXT_REFS_KEY in message
+        ]
+        assert retained_ids == [f"image-{index}" for index in range(2, total_images)]
     finally:
         db_session.close()
 

--- a/tests/web/test_chat_history_service.py
+++ b/tests/web/test_chat_history_service.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from xagent.core.agent.transcript import build_assistant_transcript_content
+from xagent.core.context_ref import CONTEXT_REFS_KEY
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task, TaskStatus
@@ -95,6 +96,43 @@ def test_load_task_transcript_returns_prior_turns_only():
                 "content": "The main risks are architecture drift and persistence gaps.",
             },
         ]
+    finally:
+        db_session.close()
+
+
+def test_load_task_transcript_preserves_uploaded_images_as_context_refs():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        image_message = persist_user_message(
+            db_session,
+            int(task.id),
+            int(task.user_id),
+            "What is shown?",
+            attachments=[
+                {
+                    "file_id": "image-id",
+                    "name": "diagram.png",
+                    "size": 321,
+                    "type": "image/png",
+                },
+                {
+                    "file_id": "pdf-id",
+                    "name": "notes.pdf",
+                    "size": 654,
+                    "type": "application/pdf",
+                },
+            ],
+        )
+        assert image_message is not None
+
+        transcript = load_task_transcript(db_session, int(task.id))
+
+        assert transcript[0]["content"] == "What is shown?"
+        references = transcript[0][CONTEXT_REFS_KEY]
+        assert len(references) == 1
+        assert references[0]["file_ref"]["file_id"] == "image-id"
+        assert references[0]["metadata"] == {"source": "user_upload"}
     finally:
         db_session.close()
 


### PR DESCRIPTION
## Summary

- project supported uploaded images into trusted context references so vision-capable models receive them directly
- preserve image context references across runner injection, transcript normalization, task history, and resumed executions
- keep understand_media and object detection as fallbacks for unsupported formats and structured visual analysis

## Validation

- related pytest regression suite covering attachments, execution adapter, runner, context materialization, chat history, task orchestration, file turns, task APIs, and WebSocket uploads
- pre-commit hooks: ruff check, ruff format, mypy, isort, codespell, and whitespace checks
- git diff --check