### PR TITLE
fix(openrouter): default DeepSeek-served models to thinking disabled

### DIFF
--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -381,8 +381,11 @@ class OpenRouterLLM(OpenAILLM):
             # DeepSeek-served endpoints can default to thinking mode, and once a
             # response carries reasoning_content they require it to be replayed
             # verbatim on the next request of a tool-call chain — which this
-            # client does not do. Keep thinking off unless the caller asks for
-            # it, matching DeepSeekLLM's default.
+            # client does not do (#1537). Keep thinking off unless the caller
+            # asks for it, matching DeepSeekLLM's default. This deliberately
+            # ignores supports_thinking_mode: the blocker is the missing
+            # replay, not model capability, so a declared thinking_mode
+            # ability must not re-enable the failing default before #1537.
             should_disable = self._uses_deepseek_tool_protocol
             should_enable = False
 

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -364,7 +364,6 @@ class OpenRouterLLM(OpenAILLM):
     ) -> Dict[str, Any]:
         _ = tools, output_config
         updated_extra_body = dict(extra_body)
-        should_disable = False
 
         if thinking is not None:
             should_enable = thinking.get("type") == "enabled" or thinking.get(
@@ -374,9 +373,17 @@ class OpenRouterLLM(OpenAILLM):
                 thinking.get("type") == "disabled" or not thinking.get("enable", False)
             )
         elif is_streaming and response_format:
-            should_disable = self.supports_thinking_mode
+            should_disable = (
+                self.supports_thinking_mode or self._uses_deepseek_tool_protocol
+            )
             should_enable = False
         else:
+            # DeepSeek-served endpoints can default to thinking mode, and once a
+            # response carries reasoning_content they require it to be replayed
+            # verbatim on the next request of a tool-call chain — which this
+            # client does not do. Keep thinking off unless the caller asks for
+            # it, matching DeepSeekLLM's default.
+            should_disable = self._uses_deepseek_tool_protocol
             should_enable = False
 
         if should_disable:

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -494,7 +494,8 @@ async def test_openrouter_official_provider_pinning_disabled_by_default(
     await llm.chat([{"role": "user", "content": "Hello"}])
 
     call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-    assert "extra_body" not in call_kwargs
+    assert "provider" not in call_kwargs["extra_body"]
+    assert call_kwargs["extra_body"]["thinking"] == {"type": "disabled"}
 
 
 @pytest.mark.asyncio
@@ -582,6 +583,8 @@ async def test_openrouter_provider_override_is_preserved(
     assert call_kwargs["extra_body"] == {
         "provider": {"only": ["deepinfra"]},
         "trace_id": "manual",
+        "reasoning": {"enabled": False},
+        "thinking": {"type": "disabled"},
     }
 
 
@@ -979,6 +982,83 @@ def test_openrouter_reasoning_hook_enables_reasoning_payload(monkeypatch):
         "reasoning": {"enabled": True},
         "thinking": {"type": "enabled"},
     }
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "deepseek/deepseek-v4-flash",
+        "openrouter/deepseek/deepseek-v4-flash",
+    ],
+)
+def test_openrouter_deepseek_defaults_to_disabled_thinking(monkeypatch, model_name):
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    llm = OpenRouterLLM(
+        model_name=model_name,
+        api_key="test-key",
+        abilities=["chat", "tool_calling"],
+    )
+
+    extra_body = llm._prepare_provider_reasoning_extra_body(
+        extra_body={"trace_id": "abc"},
+        thinking=None,
+        tools=None,
+        response_format=None,
+        output_config=None,
+        is_streaming=True,
+    )
+
+    assert extra_body == {
+        "trace_id": "abc",
+        "reasoning": {"enabled": False},
+        "thinking": {"type": "disabled"},
+    }
+
+
+def test_openrouter_deepseek_structured_streaming_disables_thinking(monkeypatch):
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling"],
+    )
+
+    extra_body = llm._prepare_provider_reasoning_extra_body(
+        extra_body={},
+        thinking=None,
+        tools=None,
+        response_format={"type": "json_object"},
+        output_config=None,
+        is_streaming=True,
+    )
+
+    assert extra_body == {
+        "reasoning": {"enabled": False},
+        "thinking": {"type": "disabled"},
+    }
+
+
+@pytest.mark.parametrize("response_format", [None, {"type": "json_object"}])
+def test_openrouter_non_deepseek_defaults_leave_thinking_unset(
+    monkeypatch, response_format
+):
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    llm = OpenRouterLLM(
+        model_name="openai/gpt-5",
+        api_key="test-key",
+        abilities=["chat", "tool_calling"],
+    )
+
+    extra_body = llm._prepare_provider_reasoning_extra_body(
+        extra_body={"trace_id": "abc"},
+        thinking=None,
+        tools=None,
+        response_format=response_format,
+        output_config=None,
+        is_streaming=True,
+    )
+
+    assert extra_body == {"trace_id": "abc"}
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -991,7 +991,11 @@ def test_openrouter_reasoning_hook_enables_reasoning_payload(monkeypatch):
         "openrouter/deepseek/deepseek-v4-flash",
     ],
 )
-def test_openrouter_deepseek_defaults_to_disabled_thinking(monkeypatch, model_name):
+@pytest.mark.parametrize("is_streaming", [True, False])
+@pytest.mark.parametrize("response_format", [None, {"type": "json_object"}])
+def test_openrouter_deepseek_defaults_to_disabled_thinking(
+    monkeypatch, model_name, is_streaming, response_format
+):
     monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
     llm = OpenRouterLLM(
         model_name=model_name,
@@ -1003,9 +1007,9 @@ def test_openrouter_deepseek_defaults_to_disabled_thinking(monkeypatch, model_na
         extra_body={"trace_id": "abc"},
         thinking=None,
         tools=None,
-        response_format=None,
+        response_format=response_format,
         output_config=None,
-        is_streaming=True,
+        is_streaming=is_streaming,
     )
 
     assert extra_body == {
@@ -1059,6 +1063,35 @@ def test_openrouter_non_deepseek_defaults_leave_thinking_unset(
     )
 
     assert extra_body == {"trace_id": "abc"}
+
+
+@pytest.mark.parametrize(
+    ("is_streaming", "expected_extra_body"),
+    [
+        (True, {"reasoning": {"enabled": False}, "thinking": {"type": "disabled"}}),
+        (False, {}),
+    ],
+)
+def test_openrouter_non_deepseek_thinking_structured_output_fork(
+    monkeypatch, is_streaming, expected_extra_body
+):
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    llm = OpenRouterLLM(
+        model_name="openai/gpt-5",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    extra_body = llm._prepare_provider_reasoning_extra_body(
+        extra_body={},
+        thinking=None,
+        tools=None,
+        response_format={"type": "json_object"},
+        output_config=None,
+        is_streaming=is_streaming,
+    )
+
+    assert extra_body == expected_extra_body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`OpenRouterLLM` now explicitly disables thinking mode for DeepSeek-authored model slugs when the caller does not request thinking, sending `reasoning: {"enabled": false}` and `thinking: {"type": "disabled"}` — the same default the direct DeepSeek provider has applied since #689.

## Why

When no thinking field is sent, DeepSeek-served OpenRouter endpoints can default to thinking mode and return `reasoning_content`. DeepSeek's API then requires that `reasoning_content` be replayed verbatim on the next request of a tool-call chain. The OpenRouter client does not implement that replay (only `DeepSeekLLM` does), so any tool-calling conversation fails on its second request with:

> 400: The `reasoning_content` in the thinking mode must be passed back to the API.

Whether this triggers depends on which provider OpenRouter selects for the slug, so it can surface abruptly when provider routing shifts toward DeepSeek's own endpoint. Disabling thinking by default removes the failure mode while leaving explicit `thinking` requests untouched. Persisting and replaying `reasoning_content` so thinking can stay enabled on this path is tracked in #1537.

## Known boundary

`RouterLLM`'s "reasoning is mandatory" retry re-enables thinking when an endpoint rejects the disable payload, so on such an endpoint a tool-call chain can still hit the original 400 until #1537 lands. That retry exists only inside `RouterLLM`, which is constructed only for the literal `auto` model name: a directly-configured DeepSeek slug gets a bare `OpenRouterLLM` with no recovery, so a mandatory-reasoning endpoint would fail on every request there. No DeepSeek-authored slug is currently known to behave this way.

## Testing

- New tests: default disable for `deepseek/...` and `openrouter/deepseek/...` slugs, parametrized over `is_streaming` and `response_format` (the non-streaming cells are reachable via `chat`/`vision_chat` with a JSON response_format); the streaming + response_format branch; non-DeepSeek slugs staying unaffected with and without a response_format; and the non-DeepSeek `thinking_mode` fork (streaming structured output disables thinking, non-streaming leaves it unset).
- Updated the two provider-pinning tests for the new default payload; their original assertions (pinning off by default, explicit provider override preserved) still hold.
- 48 tests in `test_openrouter.py` plus the `test_deepseek.py` / `test_router.py` suites pass; pre-commit clean.