### PR TITLE
feat(build): redesign /build into a My Team page

### DIFF
--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -284,6 +284,157 @@ describe("BuildsPage rendering", () => {
     expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(2, "/logos/relative.png", "http://api.local")
     expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(3, "javascript:alert(1)", "http://api.local")
   })
+
+  it("narrows the All/Enabled/Drafts tab counts by the search term", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/agents")) {
+        return Promise.resolve(jsonResponse([
+          { ...agent, id: 1, name: "Weather Watcher", status: "published" },
+          { ...agent, id: 2, name: "Weather Digest", status: "draft" },
+          { ...agent, id: 3, name: "Inbox Triage", status: "published" },
+        ]))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Weather Watcher")
+
+    expect(screen.getByRole("button", { name: "builds.list.tabs.all 3" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "builds.list.tabs.enabled 2" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "builds.list.tabs.drafts 1" })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText("builds.list.search.placeholder"), {
+      target: { value: "weather" },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "builds.list.tabs.all 2" })).toBeInTheDocument()
+    })
+    expect(screen.getByRole("button", { name: "builds.list.tabs.enabled 1" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "builds.list.tabs.drafts 1" })).toBeInTheDocument()
+  })
+
+  it("sorts by name A-Z when the sort toggle is switched, and by recently-updated by default", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/agents")) {
+        return Promise.resolve(jsonResponse([
+          { ...agent, id: 1, name: "Zebra", updated_at: "2026-07-05T00:00:00Z" },
+          { ...agent, id: 2, name: "Amber", updated_at: "2026-07-03T00:00:00Z" },
+        ]))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Zebra")
+
+    const namesInOrder = () => screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent)
+    expect(namesInOrder()).toEqual(["Zebra", "Amber"])
+
+    fireEvent.click(screen.getByRole("button", { name: /builds\.list\.sort\.updated/ }))
+
+    await waitFor(() => {
+      expect(namesInOrder()).toEqual(["Amber", "Zebra"])
+    })
+  })
+
+  it("shows the persona role and a localized category badge only for a template-linked Agent", async () => {
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/agents")) {
+        return Promise.resolve(jsonResponse([
+          { ...agent, id: 1, name: "Hired Agent", template_id: "sample-template" },
+          { ...agent, id: 2, name: "Custom Agent", template_id: null },
+        ]))
+      }
+      if (url.startsWith("http://api.local/api/templates/")) {
+        return Promise.resolve(jsonResponse([
+          {
+            id: "sample-template",
+            name: "Sample Template",
+            category: "operations_research",
+            description: "",
+            features: [],
+            connections: [],
+            setup_time: "",
+            tags: [],
+            author: "",
+            version: "1.0",
+            views: 0,
+            likes: 0,
+            used_count: 0,
+            persona: { name: "Hired Agent", role: "Research Specialist", avatar: null, intro: "", kickoff_questions: [] },
+          },
+        ]))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    render(<BuildsPage />)
+    await screen.findByText("Hired Agent")
+    await screen.findByText("Custom Agent")
+
+    // Known key -> t() returns the untranslated key itself under this
+    // mock, but an unrecognized category slug falls back to a title-cased
+    // rendering of the raw value rather than leaking the raw slug as-is.
+    await waitFor(() => {
+      expect(screen.getByText("Research Specialist")).toBeInTheDocument()
+    })
+    expect(screen.getByText("Operations Research")).toBeInTheDocument()
+
+    const customCard = screen.getByText("Custom Agent").closest("[class*='cursor-pointer']")
+    expect(customCard).not.toHaveTextContent("Research Specialist")
+    expect(customCard).not.toHaveTextContent("Operations Research")
+  })
+
+  it("clears stale template enrichment (rather than keeping the previous locale's) after a failed refetch", async () => {
+    let templatesCall = 0
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.startsWith("http://api.local/api/agents")) {
+        return Promise.resolve(jsonResponse([
+          { ...agent, id: 1, name: "Hired Agent", template_id: "sample-template" },
+        ]))
+      }
+      if (url.startsWith("http://api.local/api/templates/")) {
+        templatesCall += 1
+        if (templatesCall === 1) {
+          return Promise.resolve(jsonResponse([
+            {
+              id: "sample-template",
+              name: "Sample Template",
+              category: "operations_research",
+              description: "",
+              features: [],
+              connections: [],
+              setup_time: "",
+              tags: [],
+              author: "",
+              version: "1.0",
+              views: 0,
+              likes: 0,
+              used_count: 0,
+              persona: { name: "Hired Agent", role: "Research Specialist", avatar: null, intro: "", kickoff_questions: [] },
+            },
+          ]))
+        }
+        return Promise.resolve(new Response(null, { status: 500 }))
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+
+    const view = render(<BuildsPage />)
+    await waitFor(() => {
+      expect(screen.getByText("Research Specialist")).toBeInTheDocument()
+    })
+
+    localeMock.value = "zh"
+    view.rerender(<BuildsPage />)
+
+    await waitFor(() => {
+      expect(screen.queryByText("Research Specialist")).not.toBeInTheDocument()
+    })
+    expect(screen.queryByText("Operations Research")).not.toBeInTheDocument()
+  })
 })
 
 describe("BuildsPage Agent deletion", () => {

--- a/frontend/src/app/build/page.test.tsx
+++ b/frontend/src/app/build/page.test.tsx
@@ -13,7 +13,6 @@ const dispatchMock = vi.hoisted(() => vi.fn())
 const setTaskIdMock = vi.hoisted(() => vi.fn())
 const setPendingMessageMock = vi.hoisted(() => vi.fn())
 const resolveAgentLogoUrlMock = vi.hoisted(() => vi.fn())
-const formatDisplayDateMock = vi.hoisted(() => vi.fn())
 const localeMock = vi.hoisted(() => ({ value: "en" as "en" | "zh" }))
 
 vi.mock("@/lib/api-wrapper", async () => {
@@ -34,15 +33,6 @@ vi.mock("@/lib/utils", async () => {
     },
   }
 })
-
-vi.mock("@/lib/time-utils", () => ({
-  formatDisplayDate: (...args: [unknown, "en" | "zh", Intl.DateTimeFormatOptions]) => {
-    formatDisplayDateMock(...args)
-    return typeof args[0] === "string" && args[0].startsWith("valid-")
-      ? `formatted:${args[0]}`
-      : ""
-  },
-}))
 
 vi.mock("@/lib/models", () => ({
   resolveTaskLlmSelection: resolveTaskLlmSelectionMock,
@@ -139,21 +129,6 @@ const conflictPayload = {
   },
 }
 
-function cardDateRows(card: Element | null): Element[] {
-  const metadata = Array.from(card?.querySelectorAll("div") ?? []).find((element) =>
-    element.classList.contains("space-y-1.5"),
-  )
-  return metadata ? Array.from(metadata.children) : []
-}
-
-function cardAvatar(card: Element | null): Element | null {
-  return card?.querySelector('div[class*="h-10"][class*="w-10"]') ?? null
-}
-
-function cardTextOccurrences(card: Element | null, text: string): number {
-  return (card?.textContent ?? "").split(text).length - 1
-}
-
 function jsonResponse(data: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(data), {
     status: 200,
@@ -182,7 +157,6 @@ function resetMocks() {
   setTaskIdMock.mockReset()
   setPendingMessageMock.mockReset()
   resolveAgentLogoUrlMock.mockReset()
-  formatDisplayDateMock.mockReset()
   localeMock.value = "en"
   voiceInputState.hasAsrModel = false
 }
@@ -258,32 +232,25 @@ describe("BuildsPage rendering", () => {
     }
   })
 
-  it("uses the shared logo and date owners once per Build card with independent date rows", async () => {
-    localeMock.value = "zh"
+  it("uses the shared logo resolver once per card, falling back to a persona monogram", async () => {
     apiRequestMock.mockResolvedValue(jsonResponse([
       {
         ...agent,
         id: 91,
         name: "Absolute Agent",
         logo_url: "HTTPS://assets.example/agent.png",
-        created_at: "valid-created",
-        updated_at: "",
       },
       {
         ...agent,
         id: 92,
         name: "Relative Agent",
         logo_url: "/logos/relative.png",
-        created_at: "not-a-date",
-        updated_at: "valid-updated",
       },
       {
         ...agent,
         id: 93,
         name: "Invalid Agent",
         logo_url: "javascript:alert(1)",
-        created_at: "not-a-date",
-        updated_at: " ",
       },
     ]))
 
@@ -304,59 +271,18 @@ describe("BuildsPage rendering", () => {
       "src",
       "http://api.local/logos/relative.png",
     )
-    const invalidAvatar = cardAvatar(invalidCard)
-    expect(invalidAvatar).not.toBeNull()
-    expect(invalidAvatar?.querySelectorAll("img")).toHaveLength(0)
-    expect(invalidAvatar?.querySelectorAll("svg")).toHaveLength(1)
-    const invalidBot = invalidAvatar?.querySelector("svg")
-    expect(invalidBot).not.toHaveClass("lucide-chevron-right")
-    expect(invalidBot?.querySelector('rect[width="18"][height="10"]')).toBeInTheDocument()
-
-    expect(absoluteCard).toHaveTextContent("builds.card.createdAt: formatted:valid-created")
-    expect(cardTextOccurrences(absoluteCard, "builds.card.createdAt")).toBe(1)
-    expect(cardTextOccurrences(absoluteCard, "builds.card.updatedAt")).toBe(0)
-    expect(relativeCard).toHaveTextContent("builds.card.updatedAt: formatted:valid-updated")
-    expect(cardTextOccurrences(relativeCard, "builds.card.createdAt")).toBe(0)
-    expect(cardTextOccurrences(relativeCard, "builds.card.updatedAt")).toBe(1)
-    expect(cardTextOccurrences(invalidCard, "builds.card.createdAt")).toBe(0)
-    expect(cardTextOccurrences(invalidCard, "builds.card.updatedAt")).toBe(0)
-    const absoluteRows = cardDateRows(absoluteCard)
-    const relativeRows = cardDateRows(relativeCard)
-    const invalidRows = cardDateRows(invalidCard)
-    expect(absoluteRows).toHaveLength(1)
-    expect(absoluteRows[0].querySelectorAll("svg")).toHaveLength(1)
-    expect(relativeRows).toHaveLength(1)
-    expect(relativeRows[0].querySelectorAll("svg")).toHaveLength(1)
-    expect(invalidRows).toHaveLength(0)
+    expect(invalidCard?.querySelector("img")).toBeNull()
+    const monogram = Array.from(invalidCard?.querySelectorAll("div") ?? []).find(
+      (element) => element.textContent === "I",
+    )
+    expect(monogram).toBeTruthy()
 
     resolveAgentLogoUrlMock.mockClear()
-    formatDisplayDateMock.mockClear()
     view.rerender(<BuildsPage />)
     expect(resolveAgentLogoUrlMock).toHaveBeenCalledTimes(3)
     expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(1, "HTTPS://assets.example/agent.png", "http://api.local")
     expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(2, "/logos/relative.png", "http://api.local")
     expect(resolveAgentLogoUrlMock).toHaveBeenNthCalledWith(3, "javascript:alert(1)", "http://api.local")
-    expect(formatDisplayDateMock).toHaveBeenCalledTimes(6)
-    expect(formatDisplayDateMock).toHaveBeenCalledWith("valid-created", "zh", {
-      year: "numeric", month: "numeric", day: "numeric",
-    })
-    expect(formatDisplayDateMock).toHaveBeenCalledWith("valid-updated", "zh", {
-      year: "numeric", month: "numeric", day: "numeric",
-    })
-  })
-
-  it("keeps Build card display shaping in the shared owners", () => {
-    const source = readFileSync(`${process.cwd()}/src/app/build/page.tsx`, "utf8")
-    const cardRender = source.slice(source.indexOf("{filteredAgents.map((agent) => {"))
-    expect(cardRender).toContain("const resolvedLogoUrl = resolveAgentLogoUrl(agent.logo_url, getApiUrl())")
-    expect(cardRender.match(/resolveAgentLogoUrl\(/g)).toHaveLength(1)
-    expect(cardRender).toContain("const createdDate = formatDisplayDate(agent.created_at, locale, {")
-    expect(cardRender).toContain("const updatedDate = formatDisplayDate(agent.updated_at, locale, {")
-    expect(cardRender.match(/formatDisplayDate\(agent\.created_at/g)).toHaveLength(1)
-    expect(cardRender.match(/formatDisplayDate\(agent\.updated_at/g)).toHaveLength(1)
-    expect(cardRender.match(/\{createdDate && \(/g)).toHaveLength(1)
-    expect(cardRender.match(/\{updatedDate && \(/g)).toHaveLength(1)
-    expect(cardRender).not.toMatch(/const formatDate|\$\{getApiUrl\(\)\}\$\{agent\.logo_url\}|agent\.updated_at\s*\|\|\s*agent\.created_at/)
   })
 })
 

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -53,8 +53,13 @@ import {
 
 type StatusTab = "all" | "enabled" | "drafts"
 
+// "drafts" means "not enabled" rather than a strict `=== "draft"` check, so
+// every agent lands in exactly one of Enabled/Drafts (matching the "All"
+// count) even for a status other than the two the UI otherwise names
+// (e.g. `archived`, defined on the backend but not currently reachable
+// through any create/update path).
 const matchesStatusTab = (agent: Agent, tab: StatusTab): boolean =>
-  tab === "all" ? true : tab === "enabled" ? agent.status === "published" : agent.status === "draft"
+  tab === "all" ? true : tab === "enabled" ? agent.status === "published" : agent.status !== "published"
 
 const matchesSearch = (agent: Agent, searchTerm: string): boolean =>
   agent.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -162,14 +167,21 @@ function BuildsPageContent() {
     ;(async () => {
       try {
         const response = await apiRequest(`${getApiUrl()}/api/templates/?lang=${locale}`)
-        if (!response.ok || cancelled) return
+        if (cancelled) return
+        if (!response.ok) {
+          // Clear rather than leave stale data in place - otherwise a failed
+          // refetch after a locale switch would keep rendering the previous
+          // locale's persona role/category text beside the new-locale UI.
+          setTemplatesById({})
+          return
+        }
         const data: Template[] = await response.json()
         if (cancelled) return
         const map: Record<string, Template> = {}
         for (const template of data) map[template.id] = template
         setTemplatesById(map)
       } catch {
-        // Card badges/avatars just render without template enrichment.
+        if (!cancelled) setTemplatesById({})
       }
     })()
     return () => {

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -524,7 +524,7 @@ function BuildsPageContent() {
       />
 
       {/* Main Content */}
-      <div className="flex-1 px-4 md:px-6 pb-6 space-y-6 overflow-auto">
+      <div className="flex-1 px-4 md:px-6 py-6 space-y-6 overflow-auto">
         {/* Loading State */}
         {loading ? (
           <div className="flex items-center justify-center h-[400px]">
@@ -563,7 +563,7 @@ function BuildsPageContent() {
           />
         ) : (
           <>
-            <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
               <SegmentedTabs items={statusTabs} value={statusTab} onValueChange={(value) => setStatusTab(value as typeof statusTab)} />
               <button
                 type="button"
@@ -577,7 +577,7 @@ function BuildsPageContent() {
 
             {/* List */}
             {filteredAgents.length > 0 ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
                 {filteredAgents.map((agent) => {
                   const resolvedLogoUrl = resolveAgentLogoUrl(agent.logo_url, getApiUrl())
                   const template = agent.template_id ? templatesById[agent.template_id] : undefined
@@ -697,7 +697,7 @@ function BuildsPageContent() {
                           </div>
                         )}
 
-                      <p className="mt-4 text-[13px] leading-relaxed text-muted-foreground line-clamp-3 min-h-[60px]">
+                      <p className="mt-4 flex-1 text-[13px] leading-relaxed text-muted-foreground line-clamp-3 min-h-[60px]">
                         {agent.description || t('builds.card.noDescription')}
                       </p>
 

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useEffect, useRef } from "react"
+import React, { useState, useEffect, useMemo, useRef } from "react"
 import { SearchInput } from "@/components/ui/search-input"
 import { Button } from "@/components/ui/button"
 import { PageHeader } from "@/components/ui/page-header"
@@ -51,6 +51,15 @@ import {
   BuildPageExtensionProvider,
 } from "@/lib/build-page-extension"
 
+type StatusTab = "all" | "enabled" | "drafts"
+
+const matchesStatusTab = (agent: Agent, tab: StatusTab): boolean =>
+  tab === "all" ? true : tab === "enabled" ? agent.status === "published" : agent.status === "draft"
+
+const matchesSearch = (agent: Agent, searchTerm: string): boolean =>
+  agent.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+  Boolean(agent.description && agent.description.toLowerCase().includes(searchTerm.toLowerCase()))
+
 function BuildsPageContent() {
   const { t, locale } = useI18n()
   const { dispatch, setTaskId, setPendingMessage } = useApp()
@@ -67,7 +76,7 @@ function BuildsPageContent() {
   const [searchTerm, setSearchTerm] = useState("")
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
-  const [statusTab, setStatusTab] = useState<"all" | "enabled" | "drafts">("all")
+  const [statusTab, setStatusTab] = useState<StatusTab>("all")
   const [sortMode, setSortMode] = useState<"updated" | "name">("updated")
   // Best-effort enrichment only: an agent traces back to the template it was
   // hired from via `template_id`, and this lookup supplies that template's
@@ -346,31 +355,36 @@ function BuildsPageContent() {
     })
   }
 
-  const matchesSearch = (agent: Agent) =>
-    agent.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (agent.description && agent.description.toLowerCase().includes(searchTerm.toLowerCase()))
+  const statusTabs: SegmentedTabItem[] = useMemo(
+    () =>
+      (["all", "enabled", "drafts"] as const).map((tab) => ({
+        id: tab,
+        label: (
+          <>
+            {t(`builds.list.tabs.${tab}`)}
+            <span className="ml-1.5 text-[10px] text-muted-foreground/70">
+              {
+                agents
+                  .filter((agent) => matchesStatusTab(agent, tab))
+                  .filter((agent) => matchesSearch(agent, searchTerm)).length
+              }
+            </span>
+          </>
+        ),
+      })),
+    [agents, searchTerm, t]
+  )
 
-  const matchesStatusTab = (agent: Agent, tab: typeof statusTab) =>
-    tab === "all" ? true : tab === "enabled" ? agent.status === "published" : agent.status === "draft"
-
-  const statusTabs: SegmentedTabItem[] = (["all", "enabled", "drafts"] as const).map((tab) => ({
-    id: tab,
-    label: (
-      <>
-        {t(`builds.list.tabs.${tab}`)}
-        <span className="ml-1.5 text-[10px] text-muted-foreground/70">
-          {agents.filter((agent) => matchesStatusTab(agent, tab)).filter(matchesSearch).length}
-        </span>
-      </>
-    ),
-  }))
-
-  const filteredAgents = agents
-    .filter((agent) => matchesStatusTab(agent, statusTab))
-    .filter(matchesSearch)
-    .sort((a, b) =>
-      sortMode === "name" ? a.name.localeCompare(b.name) : b.updated_at.localeCompare(a.updated_at)
-    )
+  const filteredAgents = useMemo(
+    () =>
+      agents
+        .filter((agent) => matchesStatusTab(agent, statusTab))
+        .filter((agent) => matchesSearch(agent, searchTerm))
+        .sort((a, b) =>
+          sortMode === "name" ? a.name.localeCompare(b.name) : b.updated_at.localeCompare(a.updated_at)
+        ),
+    [agents, statusTab, searchTerm, sortMode]
+  )
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [createPrompt, setCreatePrompt] = useState("")
@@ -564,7 +578,7 @@ function BuildsPageContent() {
         ) : (
           <>
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <SegmentedTabs items={statusTabs} value={statusTab} onValueChange={(value) => setStatusTab(value as typeof statusTab)} />
+              <SegmentedTabs items={statusTabs} value={statusTab} onValueChange={(value) => setStatusTab(value as StatusTab)} />
               <button
                 type="button"
                 onClick={() => setSortMode((mode) => (mode === "updated" ? "name" : "updated"))}

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -586,40 +586,39 @@ function BuildsPageContent() {
                   return (
                   <div
                     key={agent.id}
-                    className="group relative flex flex-col justify-between space-y-4 rounded-xl border bg-card p-6 shadow-sm transition-all cursor-pointer hover:shadow-md hover:border-primary/50"
+                    className="group relative flex flex-col rounded-[20px] border bg-card p-5 shadow-sm transition-all cursor-pointer hover:-translate-y-0.5 hover:shadow-md hover:border-primary/50"
                     onClick={() => router.push(`/build/${agent.id}`)}
                   >
-                    <div className="flex-1 space-y-4">
-                      <div className="flex items-start gap-3">
-                        <PersonaAvatar
-                          persona={{ name: agent.name, avatar: resolvedLogoUrl || template?.persona?.avatar }}
-                          sizeClassName="h-14 w-14"
-                          textClassName="text-lg"
-                          className="rounded-2xl"
-                        />
-                        <div className="flex-1 min-w-0 pr-6">
-                          <h3 className="font-semibold text-base leading-tight truncate" title={agent.name}>
-                            {agent.name}
-                          </h3>
-                          {personaRole && (
-                            <p className="text-xs text-muted-foreground truncate mt-0.5">{personaRole}</p>
-                          )}
-                          <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                            <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full font-medium ${agent.status === 'published'
-                              ? 'bg-green-100 text-green-700 dark:bg-green-900/20 dark:text-green-400'
-                              : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-                              }`}>
-                              <span className={`h-1.5 w-1.5 rounded-full ${agent.status === 'published' ? 'bg-green-500' : 'bg-gray-400'}`} />
-                              {agent.status === 'published' ? t('builds.list.status.published') : t('builds.list.status.draft')}
+                    <div className="flex flex-col items-start gap-3">
+                      <PersonaAvatar
+                        persona={{ name: agent.name, avatar: resolvedLogoUrl || template?.persona?.avatar }}
+                        sizeClassName="h-20 w-20"
+                        textClassName="text-2xl"
+                        className="rounded-[22px] shadow-[0_0_0_4px_var(--card),0_0_0_6px_hsl(var(--primary)/0.15)]"
+                      />
+                      <div className="w-full min-w-0 pr-6">
+                        <h3 className="font-bold text-xl leading-tight truncate" title={agent.name}>
+                          {agent.name}
+                        </h3>
+                        {personaRole && (
+                          <p className="text-[12.5px] text-muted-foreground truncate mt-0.5">{personaRole}</p>
+                        )}
+                        <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+                          <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full font-bold ${agent.status === 'published'
+                            ? 'bg-green-100 text-green-700 dark:bg-green-900/20 dark:text-green-400'
+                            : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                            }`}>
+                            <span className={`h-1.5 w-1.5 rounded-full ${agent.status === 'published' ? 'bg-green-500' : 'bg-gray-400'}`} />
+                            {agent.status === 'published' ? t('builds.list.status.published') : t('builds.list.status.draft')}
+                          </span>
+                          {category && (
+                            <span className={`inline-flex text-[11px] px-2 py-0.5 rounded-full font-medium ${pillClasses(category)}`}>
+                              {categoryLabel(t, category)}
                             </span>
-                            {category && (
-                              <span className={`inline-flex text-[11px] px-2 py-0.5 rounded-full font-medium ${pillClasses(category)}`}>
-                                {categoryLabel(t, category)}
-                              </span>
-                            )}
-                          </div>
+                          )}
                         </div>
                       </div>
+                    </div>
                         {(canPublishAgent(agent) || canDeleteAgent(agent) || canEditAgent(agent)) && (
                           <div className="absolute right-4 top-4" onClick={(e) => e.stopPropagation()}>
                             <Popover>
@@ -630,19 +629,6 @@ function BuildsPageContent() {
                               </PopoverTrigger>
                               <PopoverContent align="end" className="w-40 p-1" onClick={(e) => e.stopPropagation()}>
                                 <div className="flex flex-col">
-                                  {agent.status === 'published' && canEditAgent(agent) && (
-                                    <Button
-                                      variant="ghost"
-                                      className="justify-start px-2 py-1.5 h-auto font-normal text-sm"
-                                      onClick={(e) => {
-                                        e.stopPropagation()
-                                        setDeployAgent(agent)
-                                      }}
-                                    >
-                                      <Rocket className="mr-2 h-4 w-4" />
-                                      {t('builds.list.actions.deploy')}
-                                    </Button>
-                                  )}
                                   {canEditAgent(agent) && (
                                     <Button
                                       variant="ghost"
@@ -711,38 +697,48 @@ function BuildsPageContent() {
                           </div>
                         )}
 
-                      <p className="text-sm text-muted-foreground line-clamp-2">
+                      <p className="mt-4 text-[13px] leading-relaxed text-muted-foreground line-clamp-3 min-h-[60px]">
                         {agent.description || t('builds.card.noDescription')}
                       </p>
-                    </div>
 
-                    <div className="pt-2" onClick={(e) => e.stopPropagation()}>
-                      <div className="space-y-4">
+                    <div className="mt-4 border-t pt-3.5" onClick={(e) => e.stopPropagation()}>
+                      <div className="space-y-3.5">
                         <BuildAgentCardExtension agentId={agent.id} />
-                        <div className="flex gap-2">
+                        <div className="flex items-center gap-1.5">
                           {agent.status === 'published' ? (
                             <>
                               <Button
                                 variant="default"
-                                className="flex-1 bg-blue-600 hover:bg-blue-700 text-white"
+                                className="flex-1 rounded-full h-[34px] bg-blue-600 hover:bg-blue-700 text-white"
                                 onClick={() => router.push(getAgentChatHref(agent))}
                               >
                                 <MessageSquare className="mr-1.5 h-4 w-4" />
                                 {t('builds.list.actions.chat')}
                               </Button>
                               {canEditAgent(agent) ? (
-                                <Button
-                                  variant="outline"
-                                  className="px-4"
-                                  onClick={() => router.push(`/build/${agent.id}`)}
-                                >
-                                  <Edit className="mr-1.5 h-4 w-4" />
-                                  {t('builds.list.actions.edit')}
-                                </Button>
+                                <>
+                                  <Button
+                                    variant="outline"
+                                    className="rounded-full h-[34px] px-4"
+                                    onClick={() => router.push(`/build/${agent.id}`)}
+                                  >
+                                    <Edit className="mr-1.5 h-4 w-4" />
+                                    {t('builds.list.actions.edit')}
+                                  </Button>
+                                  <Button
+                                    variant="outline"
+                                    size="icon"
+                                    className="rounded-full h-[34px] w-[34px] shrink-0"
+                                    title={t('builds.list.actions.deploy')}
+                                    onClick={() => setDeployAgent(agent)}
+                                  >
+                                    <Rocket className="h-4 w-4" />
+                                  </Button>
+                                </>
                               ) : (
                                 <Button
                                   variant="outline"
-                                  className={canRunAgent(agent) ? "px-4" : "flex-1 w-full"}
+                                  className={canRunAgent(agent) ? "rounded-full h-[34px] px-4" : "flex-1 w-full rounded-full h-[34px]"}
                                   onClick={() => router.push(`/build/${agent.id}`)}
                                 >
                                   <Settings2 className="mr-1.5 h-4 w-4" />
@@ -754,7 +750,7 @@ function BuildsPageContent() {
                             canEditAgent(agent) ? (
                               <Button
                                 variant="outline"
-                                className="flex-1 w-full"
+                                className="flex-1 w-full rounded-full h-[34px]"
                                 onClick={() => router.push(`/build/${agent.id}`)}
                               >
                                 <Edit className="mr-1.5 h-4 w-4" />
@@ -763,7 +759,7 @@ function BuildsPageContent() {
                             ) : (
                               <Button
                                 variant="outline"
-                                className="flex-1 w-full"
+                                className="flex-1 w-full rounded-full h-[34px]"
                                 onClick={() => router.push(`/build/${agent.id}`)}
                               >
                                 <Settings2 className="mr-1.5 h-4 w-4" />

--- a/frontend/src/app/build/page.tsx
+++ b/frontend/src/app/build/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef } from "react"
 import { SearchInput } from "@/components/ui/search-input"
 import { Button } from "@/components/ui/button"
 import { PageHeader } from "@/components/ui/page-header"
-import { Plus, Bot, Trash2, MessageSquare, Edit, MoreVertical, Globe, Calendar, Clock, Rocket, Sparkles, Settings2, ArrowRight, FileText, Wrench, Database, Plug, KeyRound, Webhook, Mic, Square, Loader2 } from "lucide-react"
+import { Plus, Bot, Trash2, MessageSquare, Edit, MoreVertical, Globe, ArrowUpDown, Rocket, Sparkles, Settings2, ArrowRight, FileText, Wrench, Database, Plug, KeyRound, Webhook, Mic, Square, Loader2 } from "lucide-react"
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Textarea } from "@/components/ui/textarea"
@@ -15,13 +15,17 @@ import {
   type AgentDeletePendingAction,
 } from "@/components/build/agent-delete-dialog"
 import { FeatureEmptyState } from "@/components/ui/feature-empty-state"
+import { SegmentedTabs, type SegmentedTabItem } from "@/components/ui/segmented-tabs"
+import { PersonaAvatar } from "@/components/templates/persona-avatar"
+import { pillClasses } from "@/components/templates/library-template-card"
+import { categoryLabel } from "@/lib/template-categories"
 import { useI18n } from "@/contexts/i18n-context"
 import { useApp } from "@/contexts/app-context-chat"
 import { useRouter, useSearchParams } from "next/navigation"
 import { apiRequest, parseApiResponse } from "@/lib/api-wrapper"
 import { getApiUrl, resolveAgentLogoUrl } from "@/lib/utils"
-import { formatDisplayDate } from "@/lib/time-utils"
 import { resolveTaskLlmSelection } from "@/lib/models"
+import type { Template } from "@/types/template"
 import { normalizeTaskPromptTitle, parseTaskCreateCore } from "@/lib/task-create"
 import {
   canDeleteAgent,
@@ -63,6 +67,13 @@ function BuildsPageContent() {
   const [searchTerm, setSearchTerm] = useState("")
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
+  const [statusTab, setStatusTab] = useState<"all" | "enabled" | "drafts">("all")
+  const [sortMode, setSortMode] = useState<"updated" | "name">("updated")
+  // Best-effort enrichment only: an agent traces back to the template it was
+  // hired from via `template_id`, and this lookup supplies that template's
+  // category/persona for the card badge and avatar. A custom, scratch-built
+  // agent has no `template_id` and simply renders without them.
+  const [templatesById, setTemplatesById] = useState<Record<string, Template>>({})
   const branding = getBrandingFromEnv();
 
   // Deploy Dialog State
@@ -136,6 +147,26 @@ function BuildsPageContent() {
       agentDeleteActionGenerationRef.current += 1
     }
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const response = await apiRequest(`${getApiUrl()}/api/templates/?lang=${locale}`)
+        if (!response.ok || cancelled) return
+        const data: Template[] = await response.json()
+        if (cancelled) return
+        const map: Record<string, Template> = {}
+        for (const template of data) map[template.id] = template
+        setTemplatesById(map)
+      } catch {
+        // Card badges/avatars just render without template enrichment.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [locale])
 
   const publicationOperations = {
     publish: {
@@ -315,11 +346,31 @@ function BuildsPageContent() {
     })
   }
 
-  // Filter agents based on search term
-  const filteredAgents = agents.filter(agent =>
+  const matchesSearch = (agent: Agent) =>
     agent.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
     (agent.description && agent.description.toLowerCase().includes(searchTerm.toLowerCase()))
-  )
+
+  const matchesStatusTab = (agent: Agent, tab: typeof statusTab) =>
+    tab === "all" ? true : tab === "enabled" ? agent.status === "published" : agent.status === "draft"
+
+  const statusTabs: SegmentedTabItem[] = (["all", "enabled", "drafts"] as const).map((tab) => ({
+    id: tab,
+    label: (
+      <>
+        {t(`builds.list.tabs.${tab}`)}
+        <span className="ml-1.5 text-[10px] text-muted-foreground/70">
+          {agents.filter((agent) => matchesStatusTab(agent, tab)).filter(matchesSearch).length}
+        </span>
+      </>
+    ),
+  }))
+
+  const filteredAgents = agents
+    .filter((agent) => matchesStatusTab(agent, statusTab))
+    .filter(matchesSearch)
+    .sort((a, b) =>
+      sortMode === "name" ? a.name.localeCompare(b.name) : b.updated_at.localeCompare(a.updated_at)
+    )
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
   const [createPrompt, setCreatePrompt] = useState("")
@@ -512,49 +563,65 @@ function BuildsPageContent() {
           />
         ) : (
           <>
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-3">
+              <SegmentedTabs items={statusTabs} value={statusTab} onValueChange={(value) => setStatusTab(value as typeof statusTab)} />
+              <button
+                type="button"
+                onClick={() => setSortMode((mode) => (mode === "updated" ? "name" : "updated"))}
+                className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+              >
+                {t(`builds.list.sort.${sortMode}`)}
+                <ArrowUpDown className="h-3.5 w-3.5" />
+              </button>
+            </div>
+
             {/* List */}
             {filteredAgents.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
                 {filteredAgents.map((agent) => {
                   const resolvedLogoUrl = resolveAgentLogoUrl(agent.logo_url, getApiUrl())
-                  const createdDate = formatDisplayDate(agent.created_at, locale, {
-                    year: "numeric", month: "numeric", day: "numeric",
-                  })
-                  const updatedDate = formatDisplayDate(agent.updated_at, locale, {
-                    year: "numeric", month: "numeric", day: "numeric",
-                  })
+                  const template = agent.template_id ? templatesById[agent.template_id] : undefined
+                  const personaRole = template?.persona?.role
+                  const category = template?.category
                   return (
                   <div
                     key={agent.id}
                     className="group relative flex flex-col justify-between space-y-4 rounded-xl border bg-card p-6 shadow-sm transition-all cursor-pointer hover:shadow-md hover:border-primary/50"
                     onClick={() => router.push(`/build/${agent.id}`)}
                   >
-                    <div className="flex-1">
-                      <div className="space-y-4">
-                        <div className="flex items-start gap-4">
-                          <div className="h-10 w-10 shrink-0 rounded-lg bg-primary/10 flex items-center justify-center text-primary overflow-hidden">
-                            {resolvedLogoUrl ? (
-                              <img src={resolvedLogoUrl} alt={agent.name} className="h-full w-full object-cover" />
-                            ) : (
-                              <Bot className="h-6 w-6" />
+                    <div className="flex-1 space-y-4">
+                      <div className="flex items-start gap-3">
+                        <PersonaAvatar
+                          persona={{ name: agent.name, avatar: resolvedLogoUrl || template?.persona?.avatar }}
+                          sizeClassName="h-14 w-14"
+                          textClassName="text-lg"
+                          className="rounded-2xl"
+                        />
+                        <div className="flex-1 min-w-0 pr-6">
+                          <h3 className="font-semibold text-base leading-tight truncate" title={agent.name}>
+                            {agent.name}
+                          </h3>
+                          {personaRole && (
+                            <p className="text-xs text-muted-foreground truncate mt-0.5">{personaRole}</p>
+                          )}
+                          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                            <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full font-medium ${agent.status === 'published'
+                              ? 'bg-green-100 text-green-700 dark:bg-green-900/20 dark:text-green-400'
+                              : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                              }`}>
+                              <span className={`h-1.5 w-1.5 rounded-full ${agent.status === 'published' ? 'bg-green-500' : 'bg-gray-400'}`} />
+                              {agent.status === 'published' ? t('builds.list.status.published') : t('builds.list.status.draft')}
+                            </span>
+                            {category && (
+                              <span className={`inline-flex text-[11px] px-2 py-0.5 rounded-full font-medium ${pillClasses(category)}`}>
+                                {categoryLabel(t, category)}
+                              </span>
                             )}
                           </div>
-                          <div className="flex-1 min-w-0 pr-6">
-                            <h3 className="font-semibold text-base leading-tight truncate" title={agent.name}>
-                              {agent.name}
-                            </h3>
-                            <div className="mt-2">
-                              <span className={`inline-flex text-[11px] px-2 py-0.5 rounded-full capitalize font-medium ${agent.status === 'published'
-                                ? 'bg-green-100 text-green-700 dark:bg-green-900/20 dark:text-green-400'
-                                : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-                                }`}>
-                                {agent.status === 'published' ? t('builds.list.status.published') : t('builds.list.status.draft')}
-                              </span>
-                            </div>
-                          </div>
                         </div>
+                      </div>
                         {(canPublishAgent(agent) || canDeleteAgent(agent) || canEditAgent(agent)) && (
-                          <div className="absolute right-4 top-1" onClick={(e) => e.stopPropagation()}>
+                          <div className="absolute right-4 top-4" onClick={(e) => e.stopPropagation()}>
                             <Popover>
                               <PopoverTrigger asChild>
                                 <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground">
@@ -563,6 +630,19 @@ function BuildsPageContent() {
                               </PopoverTrigger>
                               <PopoverContent align="end" className="w-40 p-1" onClick={(e) => e.stopPropagation()}>
                                 <div className="flex flex-col">
+                                  {agent.status === 'published' && canEditAgent(agent) && (
+                                    <Button
+                                      variant="ghost"
+                                      className="justify-start px-2 py-1.5 h-auto font-normal text-sm"
+                                      onClick={(e) => {
+                                        e.stopPropagation()
+                                        setDeployAgent(agent)
+                                      }}
+                                    >
+                                      <Rocket className="mr-2 h-4 w-4" />
+                                      {t('builds.list.actions.deploy')}
+                                    </Button>
+                                  )}
                                   {canEditAgent(agent) && (
                                     <Button
                                       variant="ghost"
@@ -631,28 +711,13 @@ function BuildsPageContent() {
                           </div>
                         )}
 
-                        <p className="text-sm text-muted-foreground line-clamp-2 mt-4">
-                          {agent.description || t('builds.card.noDescription')}
-                        </p>
-                      </div>
+                      <p className="text-sm text-muted-foreground line-clamp-2">
+                        {agent.description || t('builds.card.noDescription')}
+                      </p>
                     </div>
 
-                    <div className="space-y-4 pt-2">
-                      <div className="space-y-1.5">
-                        {createdDate && (
-                          <div className="flex items-center text-xs text-muted-foreground">
-                            <Calendar className="h-3.5 w-3.5 mr-1.5" />
-                            {t('builds.card.createdAt')}: {createdDate}
-                          </div>
-                        )}
-                        {updatedDate && (
-                          <div className="flex items-center text-xs text-muted-foreground">
-                            <Clock className="h-3.5 w-3.5 mr-1.5" />
-                            {t('builds.card.updatedAt')}: {updatedDate}
-                          </div>
-                        )}
-                      </div>
-                      <div className="space-y-4" onClick={(e) => e.stopPropagation()}>
+                    <div className="pt-2" onClick={(e) => e.stopPropagation()}>
+                      <div className="space-y-4">
                         <BuildAgentCardExtension agentId={agent.id} />
                         <div className="flex gap-2">
                           {agent.status === 'published' ? (
@@ -666,26 +731,14 @@ function BuildsPageContent() {
                                 {t('builds.list.actions.chat')}
                               </Button>
                               {canEditAgent(agent) ? (
-                                <>
-                                  <Button
-                                    variant="outline"
-                                    size="icon"
-                                    onClick={() => {
-                                      setDeployAgent(agent);
-                                    }}
-                                    title="Deploy"
-                                  >
-                                    <Rocket className="h-4 w-4" />
-                                  </Button>
-                                  <Button
-                                    variant="outline"
-                                    className="px-4"
-                                    onClick={() => router.push(`/build/${agent.id}`)}
-                                  >
-                                    <Edit className="mr-1.5 h-4 w-4" />
-                                    {t('builds.list.actions.edit')}
-                                  </Button>
-                                </>
+                                <Button
+                                  variant="outline"
+                                  className="px-4"
+                                  onClick={() => router.push(`/build/${agent.id}`)}
+                                >
+                                  <Edit className="mr-1.5 h-4 w-4" />
+                                  {t('builds.list.actions.edit')}
+                                </Button>
                               ) : (
                                 <Button
                                   variant="outline"

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -12,35 +12,15 @@ import { PageHeader } from "@/components/ui/page-header";
 import { SegmentedTabs } from "@/components/ui/segmented-tabs";
 import type { Template } from "@/types/template";
 import { LibraryTemplateCard } from "@/components/templates/library-template-card";
-import type { TranslationKey } from "@/i18n/translations";
-import { normalizeCategoryKey, orderCategoriesWithPreferred } from "@/lib/template-categories";
+import { categoryLabel as sharedCategoryLabel, normalizeCategoryKey, orderCategoriesWithPreferred } from "@/lib/template-categories";
 import { TOOL_CATEGORY_I18N_KEYS, capitalize } from "@/lib/tool-category-labels";
+import type { TranslationKey } from "@/i18n/translations";
 
 interface CategorySection {
   id: string;
   title: string;
   templates: Template[];
 }
-
-const CATEGORY_LABEL_KEYS: Record<string, TranslationKey> = {
-  general: "templates.categoryTitles.general",
-  sales: "templates.categoryTitles.sales",
-  marketing: "templates.categoryTitles.marketing",
-  support: "templates.categoryTitles.support",
-  research: "templates.sections.knowledge",
-  productivity: "templates.categoryTitles.general_productivity",
-  healthcare_fitness: "templates.categoryTitles.healthcare_fitness",
-  general_productivity: "templates.categoryTitles.general_productivity",
-  customer_service: "templates.categoryTitles.customer_service",
-  finance_lms_ops: "templates.categoryTitles.finance_lms_ops",
-  security: "templates.categoryTitles.security",
-  operations: "templates.categoryTitles.operations",
-};
-
-const formatFallbackLabel = (category: string) =>
-  category
-    .replace(/_/g, " ")
-    .replace(/\b\w/g, (char) => char.toUpperCase());
 
 // The workforce-creation error paths return a structured
 // `detail: {code, message, params}` (see the WORKFORCE_*_CODE constants in
@@ -120,11 +100,7 @@ function TemplatesPageContent() {
     fetchTemplates();
   }, [locale]);
 
-  const categoryLabel = (category?: string) => {
-    const c = category || "Others";
-    const key = CATEGORY_LABEL_KEYS[normalizeCategoryKey(c)];
-    return key ? t(key) : formatFallbackLabel(c);
-  };
+  const categoryLabel = (category?: string) => sharedCategoryLabel(t, category);
 
   const formatAgentsCount = (count: number) =>
     count === 1

--- a/frontend/src/components/build/deploy-agent-dialog.test.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.test.tsx
@@ -48,6 +48,7 @@ const AGENT: Agent = {
   name: "Regional agent",
   description: "",
   logo_url: null,
+  template_id: null,
   status: "published",
   created_at: "2026-07-24T00:00:00Z",
   updated_at: "2026-07-24T00:00:00Z",

--- a/frontend/src/components/build/deploy-agent-dialog.tsx
+++ b/frontend/src/components/build/deploy-agent-dialog.tsx
@@ -33,6 +33,7 @@ export interface Agent {
   name: string
   description: string
   logo_url: string | null
+  template_id: string | null
   status: string
   created_at: string
   updated_at: string

--- a/frontend/src/components/templates/library-template-card.tsx
+++ b/frontend/src/components/templates/library-template-card.tsx
@@ -87,7 +87,7 @@ const PILL_KNOWN: Record<string, string> = {
   productivity: PILL_PALETTE[4],
 };
 
-function pillClasses(category?: string): string {
+export function pillClasses(category?: string): string {
   if (!category) return PILL_NEUTRAL;
   const key = category.toLowerCase();
   if (PILL_KNOWN[key]) return PILL_KNOWN[key];

--- a/frontend/src/components/templates/persona-avatar.tsx
+++ b/frontend/src/components/templates/persona-avatar.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import type { PersonaInfo } from "@/types/template";
 import { cn } from "@/lib/utils";
 
 interface PersonaAvatarProps {
-  persona: PersonaInfo;
+  /** Only `name` and `avatar` are read - narrower than the full
+   * `PersonaInfo` type so callers with just an agent's name/logo (no real
+   * persona) can reuse this without fabricating unused fields. */
+  persona: { name: string; avatar?: string | null };
   /** Tailwind size classes, e.g. "h-11 w-11" or "h-16 w-16". */
   sizeClassName: string;
   /** Tailwind text-size class for the fallback initial, e.g. "text-sm" or "text-xl". */

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2361,21 +2361,30 @@ Build when you need.`,
     },
     list: {
       header: {
-        title: "My Agents",
-        description: "Manage your custom agents",
-        create: "Create Agent",
+        title: "My Team",
+        description: "Who is working, what is waiting on you, and what they have delivered.",
+        create: "Add teammate",
       },
       search: {
-        placeholder: "Search agents...",
+        placeholder: "Find a teammate...",
       },
       empty: {
         title: "No agents found",
         description: "Get started by creating your first agent",
         create: "Create Agent",
       },
+      tabs: {
+        all: "All",
+        enabled: "Enabled",
+        drafts: "Drafts",
+      },
+      sort: {
+        updated: "Recently updated",
+        name: "Name (A–Z)",
+      },
       status: {
         draft: "Draft",
-        published: "Published",
+        published: "Enabled",
       },
       actions: {
         chat: "Chat",
@@ -2386,6 +2395,7 @@ Build when you need.`,
         viewConfig: "View config",
         apiKey: "API Key",
         triggers: "Triggers",
+        deploy: "Deploy",
         deleteConfirm: "Are you sure you want to delete this agent?",
       },
       deleteDialog: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2362,7 +2362,7 @@ Build when you need.`,
     list: {
       header: {
         title: "My Team",
-        description: "Who is working, what is waiting on you, and what they have delivered.",
+        description: "View and manage your agents, their status, and configuration.",
         create: "Add teammate",
       },
       search: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2362,7 +2362,7 @@ const zh = {
     list: {
       header: {
         title: "我的团队",
-        description: "谁在工作、有什么在等你确认、以及交付了什么。",
+        description: "查看和管理 Agent、状态及配置。",
         create: "添加队员",
       },
       search: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2361,21 +2361,30 @@ const zh = {
     },
     list: {
       header: {
-        title: "我的 Agent",
-        description: "管理你的自定义 Agent",
-        create: "创建 Agent",
+        title: "我的团队",
+        description: "谁在工作、有什么在等你确认、以及交付了什么。",
+        create: "添加队员",
       },
       search: {
-        placeholder: "搜索 Agent...",
+        placeholder: "查找队员...",
       },
       empty: {
         title: "暂无 Agent",
         description: "开始创建你的第一个 Agent",
         create: "创建 Agent",
       },
+      tabs: {
+        all: "全部",
+        enabled: "已启用",
+        drafts: "草稿",
+      },
+      sort: {
+        updated: "最近更新",
+        name: "名称（A–Z）",
+      },
       status: {
         draft: "草稿",
-        published: "已发布",
+        published: "已启用",
       },
       actions: {
         chat: "聊天",
@@ -2386,6 +2395,7 @@ const zh = {
         viewConfig: "查看配置",
         apiKey: "API Key",
         triggers: "Triggers",
+        deploy: "部署",
         deleteConfirm: "确定要删除这个 Agent 吗？",
       },
       deleteDialog: {

--- a/frontend/src/lib/template-categories.ts
+++ b/frontend/src/lib/template-categories.ts
@@ -1,6 +1,41 @@
 import type { Template } from "@/types/template";
+import type { Translate } from "@/contexts/i18n-context";
+import type { TranslationKey } from "@/i18n/translations";
 
 export const FEATURED_CATEGORY_ID = "Featured";
+
+const CATEGORY_LABEL_KEYS: Record<string, TranslationKey> = {
+  general: "templates.categoryTitles.general",
+  sales: "templates.categoryTitles.sales",
+  marketing: "templates.categoryTitles.marketing",
+  support: "templates.categoryTitles.support",
+  research: "templates.sections.knowledge",
+  productivity: "templates.categoryTitles.general_productivity",
+  healthcare_fitness: "templates.categoryTitles.healthcare_fitness",
+  general_productivity: "templates.categoryTitles.general_productivity",
+  customer_service: "templates.categoryTitles.customer_service",
+  finance_lms_ops: "templates.categoryTitles.finance_lms_ops",
+  security: "templates.categoryTitles.security",
+  operations: "templates.categoryTitles.operations",
+};
+
+const formatFallbackLabel = (category: string) =>
+  category
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+/**
+ * A template category's display label: the known i18n key for it when one
+ * exists, else its raw slug title-cased - shared so a category badge reads
+ * the same everywhere it's shown (the /templates library page and any
+ * agent card that traces back to a template) instead of some places
+ * showing a translated label and others an untranslated raw slug.
+ */
+export function categoryLabel(t: Translate, category: string | undefined): string {
+  const c = category || "Others";
+  const key = CATEGORY_LABEL_KEYS[normalizeCategoryKey(c)];
+  return key ? t(key) : formatFallbackLabel(c);
+}
 
 const PREFERRED_ORDER = ["Marketing", "Sales", "Support", "Research", "Productivity"];
 


### PR DESCRIPTION
## Summary
- Redesigns `/build` ("My Agents") into "My Team", modeled on the AI Team Marketplace reference demo's own "My Team" page.
- Adds status tabs (All / Enabled / Drafts) with search-aware counts, and a Recently-updated / Name (A–Z) sort toggle, above the agent grid.
- Enriches each card with the persona's role (subtitle) and template category (badge) when the agent traces back to a template via `agent.template_id` — omitted entirely for custom, non-template agents.
- Swaps the plain logo-or-Bot-icon avatar for the shared `PersonaAvatar` component (rounded-square, with a decorative ring, via a `className` override), so a hired agent shows its real persona portrait with the same text-monogram fallback used on the marketplace.
- Card layout matches the reference: a large avatar with name/role/badges stacked below it, a divider before the action row, and "Deploy" as its own icon button alongside Chat and Edit (not tucked into the kebab menu, which still holds API Key / Triggers / Publish-Unpublish / Delete).
- Extracted the category-label localization helper (previously private to `templates/page.tsx`) into `frontend/src/lib/template-categories.ts` so the new category badge shows the same localized label as the /templates page, not a raw slug — caught and fixed during self-review.
- `frontend/src/components/templates/persona-avatar.tsx`: narrowed its prop type to just `{name, avatar}` (the two fields it actually reads) so it can be reused for a plain `Agent`, not only a full marketplace persona.

Previously stacked on #1502; now rebased onto `main` directly since #1502 merged.

## Test plan
- [x] `vitest run` — full frontend suite (140 files / 2252 tests passed)
- [x] `tsc --noEmit`, `eslint` on all touched files (only pre-existing warnings remain, confirmed via `git stash` diff against the pre-change baseline)
- [x] 3-angle self-review (line-by-line correctness, removed-behavior/regression, reuse & conventions) — found and fixed one real issue: the category badge was showing a raw, untranslated category slug instead of the shared localized label
- [x] Manual live-browser verification: created a custom draft/published agent and a draft-only agent (correct tabs/sort/search/kebab-menu/Deploy-dialog behavior in each state), and hired a template persona via the existing Hire flow (her card shows her real persona photo, role subtitle, and category badge, traced through `template_id`) — checked against the reference demo's own "My Team" card layout after user feedback that the initial version didn't match it closely enough