### PR TITLE
enh(web): run orphaned temp-file cleanup in the background (off the inline startup path)

### DIFF
--- a/example.env
+++ b/example.env
@@ -54,6 +54,11 @@ PORT="80"
 # XAGENT_UPLOADED_FILE_RECOVERY_STALE_SECONDS="300"
 # XAGENT_UPLOADED_FILE_RECOVERY_BATCH_SIZE="100"
 
+# How long shutdown waits (seconds) for the background orphaned temp-file sweep
+# to stop after its cooperative stop flag is set. Bounds only the wait, not the
+# uncancellable walk itself; raise it on very large uploads trees.
+# XAGENT_TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS="10"
+
 # Per-server timeout (seconds) for MCP tool initialization during agent
 # setup (connect + initialize + list-tools, including retries and cleanup).
 # A server that exceeds it is skipped for that task. 0 disables the timeout.

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -427,6 +427,12 @@ def get_temp_file_cleanup_shutdown_timeout_seconds() -> int:
     cancellable, so a long overrun is ultimately joined by asyncio.run()'s
     teardown. Operators on very large uploads trees may want a larger value.
 
+    Unlike XAGENT_MCP_TOOL_INIT_TIMEOUT_SECONDS and similar getters in this
+    module, "0" is not treated as "disable the timeout" here: it already has
+    a distinct, meaningful value for a wait bound -- "don't wait at all" --
+    which is the opposite of disabling it (waiting forever). So "0" falls
+    back to the default like any other invalid value instead.
+
     Priority:
         1. XAGENT_TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS environment variable
         2. Default of 10 seconds

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -49,6 +49,9 @@ UPLOADED_FILE_RECOVERY_INTERVAL_SECONDS = (
 )
 UPLOADED_FILE_RECOVERY_STALE_SECONDS = "XAGENT_UPLOADED_FILE_RECOVERY_STALE_SECONDS"
 UPLOADED_FILE_RECOVERY_BATCH_SIZE = "XAGENT_UPLOADED_FILE_RECOVERY_BATCH_SIZE"
+TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS = (
+    "XAGENT_TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS"
+)
 STORAGE_ROOT = "XAGENT_STORAGE_ROOT"
 NATIVE_BROWSER_ENABLED = "XAGENT_NATIVE_BROWSER_ENABLED"
 NATIVE_BROWSER_APP_NAME = "XAGENT_NATIVE_BROWSER_APP_NAME"
@@ -413,6 +416,26 @@ def get_uploaded_file_recovery_batch_size() -> int:
     """Get the maximum file-compensation claims examined per polling tick."""
 
     return _get_positive_int_env(UPLOADED_FILE_RECOVERY_BATCH_SIZE, 100)
+
+
+def get_temp_file_cleanup_shutdown_timeout_seconds() -> int:
+    """Get how long shutdown waits for the orphaned temp-file sweep to unwind.
+
+    At shutdown the sweep's cooperative stop flag is set and the handler waits
+    up to this long for the walk to reach its next directory boundary and exit.
+    This bounds only the wait, not the walk: the executor thread is not
+    cancellable, so a long overrun is ultimately joined by asyncio.run()'s
+    teardown. Operators on very large uploads trees may want a larger value.
+
+    Priority:
+        1. XAGENT_TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS environment variable
+        2. Default of 10 seconds
+
+    Returns:
+        Shutdown grace period in seconds
+    """
+
+    return _get_positive_int_env(TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS, 10)
 
 
 def _get_positive_int_env(env_var: str, default: int, *, minimum: int = 1) -> int:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1684,9 +1684,16 @@ def cleanup_orphaned_temp_files(
     # deleting files that might still be in use; per-entry OSError is tolerated
     # below so a file vanishing mid-scan skips instead of aborting the sweep.
     stack = [str(base_dir)]
+    # WHY: track "did we stop early" as we go instead of re-reading stop_event
+    # after the loop. The flag can be set by shutdown *while* the final
+    # directory is being scanned, in which case the tree still gets fully
+    # walked -- re-polling afterwards would report a completed sweep as
+    # truncated and tell operators to expect leftover orphans that aren't there.
+    stopped_early = False
     while stack:
         # Cooperative stop check; see the stop_event docstring above for why.
         if stop_event is not None and stop_event.is_set():
+            stopped_early = True
             break
         current = stack.pop()
         try:
@@ -1694,6 +1701,15 @@ def cleanup_orphaned_temp_files(
         except OSError as e:
             logger.warning("Failed to scan directory %s: %s", current, e)
             continue
+        # WHY: matches are collected here and unlinked only after the directory
+        # stream is closed below. Whether readdir() still returns the remaining
+        # entries of a directory that was modified mid-iteration is unspecified
+        # by POSIX, so unlinking inside the scan can silently skip siblings --
+        # and this sweep runs once per process with no resumption, so a skipped
+        # orphan is never reclaimed. Both stdlib walkers avoid this: os.walk
+        # exhausts and closes the iterator before yielding, and shutil.rmtree
+        # materializes list(scandir_it) before unlinking.
+        victims: list[str] = []
         with scandir_it:
             entries_seen = 0
             while True:
@@ -1714,14 +1730,17 @@ def cleanup_orphaned_temp_files(
                     and entries_seen % _TEMP_CLEANUP_STOP_CHECK_ENTRIES == 0
                     and stop_event.is_set()
                 ):
+                    stopped_early = True
                     break
                 try:
                     if entry.is_dir(follow_symlinks=False):
                         stack.append(entry.path)
                         continue
-                    if not entry.is_file(follow_symlinks=False):
-                        continue
+                    # Name test first: it touches no filesystem, so the vast
+                    # majority of entries are rejected before is_file()/stat().
                     if not _is_orphaned_temp_name(entry.name):
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
                         continue
                     if now - entry.stat().st_mtime <= 3600:  # 1 hour
                         continue
@@ -1730,19 +1749,23 @@ def cleanup_orphaned_temp_files(
                     # skip it rather than aborting the whole sweep.
                     logger.debug("Skipping temp-file candidate %s: %s", entry.path, e)
                     continue
+                victims.append(entry.path)
 
-                try:
-                    os.unlink(entry.path)
-                    cleaned_count += 1
-                    logger.debug("Cleaned up orphaned temp file: %s", entry.path)
-                except OSError as e:
-                    logger.warning(
-                        "Failed to clean up orphaned temp file %s: %s", entry.path, e
-                    )
+        for victim in victims:
+            try:
+                os.unlink(victim)
+                cleaned_count += 1
+                logger.debug("Cleaned up orphaned temp file: %s", victim)
+            except OSError as e:
+                logger.warning(
+                    "Failed to clean up orphaned temp file %s: %s", victim, e
+                )
 
-    if stop_event is not None and stop_event.is_set():
+    if stopped_early:
         # WHY: an interrupted sweep must not look identical to a completed one
         # in the logs -- operators need to know the tree was not fully walked.
+        # This is the authoritative signal; the background wrapper in app.py
+        # deliberately does not re-derive it from the stop flag.
         logger.info(
             "Orphaned temp-file sweep stopped early by shutdown signal after "
             "removing %d file(s); the uploads tree was not fully walked",

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1666,9 +1666,7 @@ def cleanup_orphaned_temp_files(
     # below so a file vanishing mid-scan skips instead of aborting the sweep.
     stack = [str(base_dir)]
     while stack:
-        # WHY: cooperative stop so a shutdown can interrupt a long walk; without
-        # it the executor thread keeps running and blocks process exit via
-        # asyncio.run()'s executor-thread join.
+        # Cooperative stop check; see the stop_event docstring above for why.
         if stop_event is not None and stop_event.is_set():
             break
         current = stack.pop()
@@ -1678,7 +1676,18 @@ def cleanup_orphaned_temp_files(
             logger.warning("Failed to scan directory %s: %s", current, e)
             continue
         with scandir_it:
-            for entry in scandir_it:
+            while True:
+                try:
+                    entry = next(scandir_it)
+                except StopIteration:
+                    break
+                except OSError as e:
+                    # A directory-level failure mid-iteration (e.g. NFS ESTALE,
+                    # or the directory removed mid-scan). Match os.walk's default
+                    # tolerance: skip this directory instead of aborting the
+                    # whole sweep.
+                    logger.warning("Failed while scanning directory %s: %s", current, e)
+                    break
                 try:
                     if entry.is_dir(follow_symlinks=False):
                         stack.append(entry.path)

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -8,11 +8,9 @@ import io
 import json
 import logging
 import mimetypes
-import os
 import re
 import shutil
 import threading
-import time
 import unicodedata
 import uuid
 from dataclasses import dataclass
@@ -25,7 +23,6 @@ from typing import (
     Literal,
     Mapping,
     Optional,
-    Protocol,
     TypedDict,
     TypeVar,
     Union,
@@ -1617,194 +1614,6 @@ async def _rollback_failed_cloud_ingestion(
         if restore_error is not None:
             message = f"{message}; backup restore also failed: {restore_error}"
         raise RollbackFailureError(message) from exc
-
-
-# WHY: a single very large flat directory must still be interruptible within
-# the shutdown grace period, not only at directory boundaries -- checking
-# every entry would add per-entry overhead for no benefit at typical sizes.
-# The same chunk size bounds that directory's deletion phase below.
-_TEMP_CLEANUP_STOP_CHECK_ENTRIES = 500
-
-
-class _StopSignal(Protocol):
-    """The only threading.Event behavior this walk actually needs.
-
-    A Protocol (rather than threading.Event itself) so a lightweight test
-    double satisfies the type without implementing set()/clear()/wait().
-    """
-
-    def is_set(self) -> bool: ...
-
-
-def cleanup_orphaned_temp_files(
-    upload_dir: Optional[Path] = None,
-    *,
-    stop_event: Optional[_StopSignal] = None,
-) -> int:
-    """Clean up orphaned temporary files from interrupted atomic replacements.
-
-    Removes files matching patterns like:
-    - *.tmp-replace (old pattern)
-    - .*.tmp (new NamedTemporaryFile pattern)
-
-    Args:
-        upload_dir: Base uploads directory to clean. If None, uses default uploads dir.
-        stop_event: Optional cooperative stop flag, checked once per directory and
-            periodically within a large directory's scan. When set, the walk
-            unwinds early so a shutdown can interrupt a long sweep instead of
-            the worker thread blocking process exit via asyncio.run()'s
-            executor-thread join.
-
-    Returns:
-        Number of files cleaned up.
-    """
-    from ..config import get_uploads_dir
-
-    base_dir = upload_dir or get_uploads_dir()
-    if not base_dir.exists():
-        return 0
-
-    cleaned_count = 0
-    now = time.time()
-
-    def _is_orphaned_temp_name(filename: str) -> bool:
-        # Old atomic-replace pattern (*.tmp-replace).
-        if filename.endswith(".tmp-replace"):
-            return True
-        # New NamedTemporaryFile pattern: filename.XXXXXX.tmp (has multiple
-        # extensions, so at least three dot-separated parts ending in ``tmp``).
-        if filename.endswith(".tmp") and "." in filename[:-4]:
-            parts = filename.split(".")
-            if len(parts) >= 3 and parts[-1] == "tmp":
-                return True
-        return False
-
-    # Walk the uploads tree with os.scandir, seeding the stack with a str path
-    # and appending entry.path directly so no Path object is allocated per
-    # entry on a large tree. Clean temp files older than 1 hour to avoid
-    # deleting files that might still be in use; per-entry OSError is tolerated
-    # below so a file vanishing mid-scan skips instead of aborting the sweep.
-    root = str(base_dir)
-    stack = [root]
-    # WHY: track "did we stop early" as we go instead of re-reading stop_event
-    # after the loop. The flag can be set by shutdown *while* the final
-    # directory is being scanned, in which case the tree still gets fully
-    # walked -- re-polling afterwards would report a completed sweep as
-    # truncated and tell operators to expect leftover orphans that aren't there.
-    stopped_early = False
-    while stack:
-        # Cooperative stop check; see the stop_event docstring above for why.
-        if stop_event is not None and stop_event.is_set():
-            stopped_early = True
-            break
-        current = stack.pop()
-        # WHY: os.scandir() on this str path follows symlinks, and the DFS stack
-        # can hold a queued pathname for the rest of the sweep -- so without a
-        # fresh check, a directory swapped for a symlink after its parent's
-        # is_dir(follow_symlinks=False) sends the sweep outside the uploads root.
-        # os.walk() guards the same race the same way (CPython bpo-23605), at the
-        # same cost of one lstat per directory. The root stays exempt because
-        # os.walk() never tested `top` either, and a symlinked uploads root
-        # (a mounted volume) is a legitimate deployment.
-        if current != root and os.path.islink(current):
-            logger.warning(
-                "Not descending into %s: it was replaced by a symlink during the sweep",
-                current,
-            )
-            continue
-        try:
-            scandir_it = os.scandir(current)
-        except OSError as e:
-            logger.warning("Failed to scan directory %s: %s", current, e)
-            continue
-        # WHY: matches are collected here and unlinked only after the directory
-        # stream is closed below. Whether readdir() still returns the remaining
-        # entries of a directory that was modified mid-iteration is unspecified
-        # by POSIX, so unlinking inside the scan can silently skip siblings --
-        # and this sweep runs once per process with no resumption, so a skipped
-        # orphan is never reclaimed. Both stdlib walkers avoid this: os.walk
-        # exhausts and closes the iterator before yielding, and shutil.rmtree
-        # materializes list(scandir_it) before unlinking.
-        victims: list[str] = []
-        with scandir_it:
-            entries_seen = 0
-            while True:
-                try:
-                    entry = next(scandir_it)
-                except StopIteration:
-                    break
-                except OSError as e:
-                    # A directory-level failure mid-iteration (e.g. NFS ESTALE,
-                    # or the directory removed mid-scan). Match os.walk's default
-                    # tolerance: skip this directory instead of aborting the
-                    # whole sweep.
-                    logger.warning("Failed while scanning directory %s: %s", current, e)
-                    break
-                entries_seen += 1
-                if (
-                    stop_event is not None
-                    and entries_seen % _TEMP_CLEANUP_STOP_CHECK_ENTRIES == 0
-                    and stop_event.is_set()
-                ):
-                    stopped_early = True
-                    break
-                try:
-                    if entry.is_dir(follow_symlinks=False):
-                        stack.append(entry.path)
-                        continue
-                    # Name test first: it touches no filesystem, so the vast
-                    # majority of entries are rejected before is_file()/stat().
-                    if not _is_orphaned_temp_name(entry.name):
-                        continue
-                    if not entry.is_file(follow_symlinks=False):
-                        continue
-                    if now - entry.stat().st_mtime <= 3600:  # 1 hour
-                        continue
-                except OSError as e:
-                    # The entry vanished mid-scan (e.g. a concurrent replace);
-                    # skip it rather than aborting the whole sweep.
-                    logger.debug("Skipping temp-file candidate %s: %s", entry.path, e)
-                    continue
-                victims.append(entry.path)
-
-        for victims_seen, victim in enumerate(victims):
-            # WHY: an unpolled deletion phase can outlive both the shutdown grace
-            # period and asyncio.run()'s executor join -- one directory can hold
-            # many aged temp files (an agent workspace's temp/output) and unlink
-            # latency on network storage is tens of milliseconds. Chunked rather
-            # than per-victim so a stop mid-deletion does not discard a typical
-            # directory's few victims, which nothing reclaims until next startup.
-            if (
-                stop_event is not None
-                and victims_seen
-                and victims_seen % _TEMP_CLEANUP_STOP_CHECK_ENTRIES == 0
-                and stop_event.is_set()
-            ):
-                stopped_early = True
-                break
-            try:
-                os.unlink(victim)
-                cleaned_count += 1
-                logger.debug("Cleaned up orphaned temp file: %s", victim)
-            except OSError as e:
-                logger.warning(
-                    "Failed to clean up orphaned temp file %s: %s", victim, e
-                )
-
-    if stopped_early:
-        # WHY: an interrupted sweep must not look identical to a completed one
-        # in the logs -- operators need to know the tree was not fully walked.
-        # This is the authoritative signal; the background wrapper in app.py
-        # deliberately does not re-derive it from the stop flag.
-        logger.info(
-            "Orphaned temp-file sweep stopped early by shutdown signal after "
-            "removing %d file(s); the uploads tree was not fully walked",
-            cleaned_count,
-        )
-    elif cleaned_count > 0:
-        logger.info("Cleaned up %d orphaned temporary file(s)", cleaned_count)
-
-    return cleaned_count
 
 
 def _get_file_sha256(file_path: Path) -> str:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1618,7 +1618,10 @@ async def _rollback_failed_cloud_ingestion(
         raise RollbackFailureError(message) from exc
 
 
-def cleanup_orphaned_temp_files(upload_dir: Optional[Path] = None) -> int:
+def cleanup_orphaned_temp_files(
+    upload_dir: Optional[Path] = None,
+    stop_event: Optional[threading.Event] = None,
+) -> int:
     """Clean up orphaned temporary files from interrupted atomic replacements.
 
     Removes files matching patterns like:
@@ -1627,6 +1630,10 @@ def cleanup_orphaned_temp_files(upload_dir: Optional[Path] = None) -> int:
 
     Args:
         upload_dir: Base uploads directory to clean. If None, uses default uploads dir.
+        stop_event: Optional cooperative stop flag, checked once per directory. When
+            set, the walk unwinds early so a shutdown can interrupt a long sweep
+            instead of the worker thread blocking process exit via asyncio.run()'s
+            executor-thread join.
 
     Returns:
         Number of files cleaned up.
@@ -1640,43 +1647,62 @@ def cleanup_orphaned_temp_files(upload_dir: Optional[Path] = None) -> int:
     cleaned_count = 0
     now = time.time()
 
-    # Walk through uploads directory and clean up temp files older than 1 hour
-    # to avoid deleting files that might still be in use
-    for root, dirs, files in os.walk(base_dir):
-        for filename in files:
-            file_path = Path(root) / filename
+    def _is_orphaned_temp_name(filename: str) -> bool:
+        # Old atomic-replace pattern (*.tmp-replace).
+        if filename.endswith(".tmp-replace"):
+            return True
+        # New NamedTemporaryFile pattern: filename.XXXXXX.tmp (has multiple
+        # extensions, so at least three dot-separated parts ending in ``tmp``).
+        if filename.endswith(".tmp") and "." in filename[:-4]:
+            parts = filename.split(".")
+            if len(parts) >= 3 and parts[-1] == "tmp":
+                return True
+        return False
 
-            # Check for old temp file pattern (*.tmp-replace)
-            if filename.endswith(".tmp-replace"):
-                file_age = now - file_path.stat().st_mtime
-                if file_age > 3600:  # 1 hour
-                    try:
-                        file_path.unlink()
-                        cleaned_count += 1
-                        logger.debug("Cleaned up orphaned temp file: %s", file_path)
-                    except OSError as e:
-                        logger.warning(
-                            "Failed to clean up orphaned temp file %s: %s", file_path, e
-                        )
+    # Walk the uploads tree with os.scandir, seeding the stack with a str path
+    # and appending entry.path directly so no Path object is allocated per
+    # entry on a large tree. Clean temp files older than 1 hour to avoid
+    # deleting files that might still be in use; per-entry OSError is tolerated
+    # below so a file vanishing mid-scan skips instead of aborting the sweep.
+    stack = [str(base_dir)]
+    while stack:
+        # WHY: cooperative stop so a shutdown can interrupt a long walk; without
+        # it the executor thread keeps running and blocks process exit via
+        # asyncio.run()'s executor-thread join.
+        if stop_event is not None and stop_event.is_set():
+            break
+        current = stack.pop()
+        try:
+            scandir_it = os.scandir(current)
+        except OSError as e:
+            logger.warning("Failed to scan directory %s: %s", current, e)
+            continue
+        with scandir_it:
+            for entry in scandir_it:
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(entry.path)
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    if not _is_orphaned_temp_name(entry.name):
+                        continue
+                    if now - entry.stat().st_mtime <= 3600:  # 1 hour
+                        continue
+                except OSError as e:
+                    # The entry vanished mid-scan (e.g. a concurrent replace);
+                    # skip it rather than aborting the whole sweep.
+                    logger.debug("Skipping temp-file candidate %s: %s", entry.path, e)
+                    continue
 
-            # Check for new temp file pattern (.*.tmp from NamedTemporaryFile)
-            # Pattern: filename.XXXXXX.tmp where X is random hex
-            if filename.endswith(".tmp") and "." in filename[:-4]:
-                # Verify it looks like our temp pattern (has multiple extensions)
-                parts = filename.split(".")
-                if len(parts) >= 3 and parts[-1] == "tmp":
-                    file_age = now - file_path.stat().st_mtime
-                    if file_age > 3600:  # 1 hour
-                        try:
-                            file_path.unlink()
-                            cleaned_count += 1
-                            logger.debug("Cleaned up orphaned temp file: %s", file_path)
-                        except OSError as e:
-                            logger.warning(
-                                "Failed to clean up orphaned temp file %s: %s",
-                                file_path,
-                                e,
-                            )
+                try:
+                    os.unlink(entry.path)
+                    cleaned_count += 1
+                    logger.debug("Cleaned up orphaned temp file: %s", entry.path)
+                except OSError as e:
+                    logger.warning(
+                        "Failed to clean up orphaned temp file %s: %s", entry.path, e
+                    )
 
     if cleaned_count > 0:
         logger.info("Cleaned up %d orphaned temporary file(s)", cleaned_count)

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -25,6 +25,7 @@ from typing import (
     Literal,
     Mapping,
     Optional,
+    Protocol,
     TypedDict,
     TypeVar,
     Union,
@@ -1618,9 +1619,26 @@ async def _rollback_failed_cloud_ingestion(
         raise RollbackFailureError(message) from exc
 
 
+# WHY: a single very large flat directory must still be interruptible within
+# the shutdown grace period, not only at directory boundaries -- checking
+# every entry would add per-entry overhead for no benefit at typical sizes.
+_TEMP_CLEANUP_STOP_CHECK_ENTRIES = 500
+
+
+class _StopSignal(Protocol):
+    """The only threading.Event behavior this walk actually needs.
+
+    A Protocol (rather than threading.Event itself) so a lightweight test
+    double satisfies the type without implementing set()/clear()/wait().
+    """
+
+    def is_set(self) -> bool: ...
+
+
 def cleanup_orphaned_temp_files(
     upload_dir: Optional[Path] = None,
-    stop_event: Optional[threading.Event] = None,
+    *,
+    stop_event: Optional[_StopSignal] = None,
 ) -> int:
     """Clean up orphaned temporary files from interrupted atomic replacements.
 
@@ -1630,9 +1648,10 @@ def cleanup_orphaned_temp_files(
 
     Args:
         upload_dir: Base uploads directory to clean. If None, uses default uploads dir.
-        stop_event: Optional cooperative stop flag, checked once per directory. When
-            set, the walk unwinds early so a shutdown can interrupt a long sweep
-            instead of the worker thread blocking process exit via asyncio.run()'s
+        stop_event: Optional cooperative stop flag, checked once per directory and
+            periodically within a large directory's scan. When set, the walk
+            unwinds early so a shutdown can interrupt a long sweep instead of
+            the worker thread blocking process exit via asyncio.run()'s
             executor-thread join.
 
     Returns:
@@ -1676,6 +1695,7 @@ def cleanup_orphaned_temp_files(
             logger.warning("Failed to scan directory %s: %s", current, e)
             continue
         with scandir_it:
+            entries_seen = 0
             while True:
                 try:
                     entry = next(scandir_it)
@@ -1687,6 +1707,13 @@ def cleanup_orphaned_temp_files(
                     # tolerance: skip this directory instead of aborting the
                     # whole sweep.
                     logger.warning("Failed while scanning directory %s: %s", current, e)
+                    break
+                entries_seen += 1
+                if (
+                    stop_event is not None
+                    and entries_seen % _TEMP_CLEANUP_STOP_CHECK_ENTRIES == 0
+                    and stop_event.is_set()
+                ):
                     break
                 try:
                     if entry.is_dir(follow_symlinks=False):
@@ -1713,7 +1740,15 @@ def cleanup_orphaned_temp_files(
                         "Failed to clean up orphaned temp file %s: %s", entry.path, e
                     )
 
-    if cleaned_count > 0:
+    if stop_event is not None and stop_event.is_set():
+        # WHY: an interrupted sweep must not look identical to a completed one
+        # in the logs -- operators need to know the tree was not fully walked.
+        logger.info(
+            "Orphaned temp-file sweep stopped early by shutdown signal after "
+            "removing %d file(s); the uploads tree was not fully walked",
+            cleaned_count,
+        )
+    elif cleaned_count > 0:
         logger.info("Cleaned up %d orphaned temporary file(s)", cleaned_count)
 
     return cleaned_count

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1622,6 +1622,7 @@ async def _rollback_failed_cloud_ingestion(
 # WHY: a single very large flat directory must still be interruptible within
 # the shutdown grace period, not only at directory boundaries -- checking
 # every entry would add per-entry overhead for no benefit at typical sizes.
+# The same chunk size bounds that directory's deletion phase below.
 _TEMP_CLEANUP_STOP_CHECK_ENTRIES = 500
 
 
@@ -1683,7 +1684,8 @@ def cleanup_orphaned_temp_files(
     # entry on a large tree. Clean temp files older than 1 hour to avoid
     # deleting files that might still be in use; per-entry OSError is tolerated
     # below so a file vanishing mid-scan skips instead of aborting the sweep.
-    stack = [str(base_dir)]
+    root = str(base_dir)
+    stack = [root]
     # WHY: track "did we stop early" as we go instead of re-reading stop_event
     # after the loop. The flag can be set by shutdown *while* the final
     # directory is being scanned, in which case the tree still gets fully
@@ -1696,6 +1698,20 @@ def cleanup_orphaned_temp_files(
             stopped_early = True
             break
         current = stack.pop()
+        # WHY: os.scandir() on this str path follows symlinks, and the DFS stack
+        # can hold a queued pathname for the rest of the sweep -- so without a
+        # fresh check, a directory swapped for a symlink after its parent's
+        # is_dir(follow_symlinks=False) sends the sweep outside the uploads root.
+        # os.walk() guards the same race the same way (CPython bpo-23605), at the
+        # same cost of one lstat per directory. The root stays exempt because
+        # os.walk() never tested `top` either, and a symlinked uploads root
+        # (a mounted volume) is a legitimate deployment.
+        if current != root and os.path.islink(current):
+            logger.warning(
+                "Not descending into %s: it was replaced by a symlink during the sweep",
+                current,
+            )
+            continue
         try:
             scandir_it = os.scandir(current)
         except OSError as e:
@@ -1751,7 +1767,21 @@ def cleanup_orphaned_temp_files(
                     continue
                 victims.append(entry.path)
 
-        for victim in victims:
+        for victims_seen, victim in enumerate(victims):
+            # WHY: an unpolled deletion phase can outlive both the shutdown grace
+            # period and asyncio.run()'s executor join -- one directory can hold
+            # many aged temp files (an agent workspace's temp/output) and unlink
+            # latency on network storage is tens of milliseconds. Chunked rather
+            # than per-victim so a stop mid-deletion does not discard a typical
+            # directory's few victims, which nothing reclaims until next startup.
+            if (
+                stop_event is not None
+                and victims_seen
+                and victims_seen % _TEMP_CLEANUP_STOP_CHECK_ENTRIES == 0
+                and stop_event.is_set()
+            ):
+                stopped_early = True
+                break
             try:
                 os.unlink(victim)
                 cleaned_count += 1

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
@@ -1558,30 +1559,42 @@ async def startup_event() -> None:
         logger.info("Started background uploaded files reconcile task")
 
         # Clean up orphaned temporary files from interrupted atomic replacements.
-        # This walks the entire uploads tree inline during startup and can take
-        # minutes on a large tree with no log output in between. Wrap it in a
-        # startup phase so its duration is visible and a slow start is easy to
-        # diagnose from the logs alone.
-        # WHY: try/except inside the phase keeps a tolerated failure at a single
-        # WARNING; propagating it would add a spurious ERROR from _startup_phase.
-        # exc_info keeps the traceback so an unexpected bug (not just a transient
-        # FS error) is still diagnosable despite the WARNING-level downgrade.
-        with _startup_phase("orphaned temp-file cleanup"):
-            try:
-                from .api.kb import cleanup_orphaned_temp_files
+        # This walks the entire uploads tree and can take minutes on a large
+        # tree, so it runs in the background (fire-and-forget scheduling like the
+        # reconcile step above) instead of awaiting it inline, letting the
+        # lifespan finish and /health open immediately regardless of tree size.
+        # Unlike that reconcile task, this one is tracked on app.state and stopped
+        # at shutdown: the threading.Event lets the walk unwind cooperatively so a
+        # mid-sweep restart does not block process exit on the executor thread.
+        temp_file_cleanup_stop = threading.Event()
+        app.state.temp_file_cleanup_stop = temp_file_cleanup_stop
 
-                cleaned_count = await asyncio.to_thread(cleanup_orphaned_temp_files)
-                if cleaned_count > 0:
-                    logger.info(
-                        "Startup cleanup: removed %d orphaned temporary file(s)",
-                        cleaned_count,
-                    )
+        async def run_temp_file_cleanup_background() -> None:
+            from .api.kb import cleanup_orphaned_temp_files
+
+            started = time.monotonic()
+            logger.info("Background orphaned temp-file cleanup started")
+            try:
+                cleaned_count = await asyncio.to_thread(
+                    cleanup_orphaned_temp_files, stop_event=temp_file_cleanup_stop
+                )
             except Exception as e:  # noqa: BLE001
                 logger.warning(
-                    "Temporary file cleanup skipped due to error: %s",
+                    "Background orphaned temp-file cleanup failed after %.2fs: %s",
+                    time.monotonic() - started,
                     e,
-                    exc_info=True,
                 )
+                return
+            logger.info(
+                "Background orphaned temp-file cleanup completed in %.2fs "
+                "(removed %d file(s))",
+                time.monotonic() - started,
+                cleaned_count,
+            )
+
+        app.state.temp_file_cleanup_task = asyncio.create_task(
+            run_temp_file_cleanup_background()
+        )
 
     # Warmup sandbox manager
     from .sandbox_manager import check_sandbox_static_readiness, get_sandbox_manager
@@ -1715,6 +1728,27 @@ async def shutdown_event() -> None:
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
+
+    # Stop the background orphaned temp-file cleanup task. The walk runs in an
+    # executor thread, so cancelling the task would only stop the await while the
+    # thread keeps running and blocks process exit via asyncio.run()'s executor
+    # join. Set the cooperative stop flag instead, then wait briefly for the walk
+    # to unwind at its next directory boundary.
+    if hasattr(app.state, "temp_file_cleanup_task"):
+        task = app.state.temp_file_cleanup_task
+        if task and not task.done():
+            stop = getattr(app.state, "temp_file_cleanup_stop", None)
+            if stop is not None:
+                stop.set()
+            try:
+                await asyncio.wait_for(task, timeout=10.0)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Orphaned temp-file cleanup still running 10s after stop "
+                    "signal; leaving it to finish in the background"
+                )
+            except asyncio.CancelledError:
+                pass
 
     # Shutdown chat channels before draining task finalizers.
     try:

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -1857,20 +1857,20 @@ async def shutdown_event() -> None:
     #
     # Use asyncio.wait rather than asyncio.wait_for: wait_for's cancellation only
     # kills the awaiting coroutine, not the executor thread doing the real work,
-    # so cancelling early has no benefit -- only the risk of losing the
-    # completion/failure log to an uncaught CancelledError. If the walk is still
-    # running once this bounded wait elapses, the process's own asyncio.run()
-    # teardown will join (or cancel) the outstanding task regardless.
+    # so cancelling early buys nothing. It also keeps the walk collectable after
+    # this wait -- on the timeout branch the completion/failure log is lost
+    # either way, since asyncio.run()'s teardown cancels the pending task and
+    # CancelledError is a BaseException the coroutine's handler does not catch.
     if hasattr(app.state, "temp_file_cleanup_task"):
-        task = app.state.temp_file_cleanup_task
-        if task and not task.done():
+        cleanup_task = app.state.temp_file_cleanup_task
+        if cleanup_task and not cleanup_task.done():
             timeout = get_temp_file_cleanup_shutdown_timeout_seconds()
-            done, _pending = await asyncio.wait({task}, timeout=timeout)
+            done, _pending = await asyncio.wait({cleanup_task}, timeout=timeout)
             if not done:
                 logger.warning(
                     "Orphaned temp-file cleanup still running %ss after stop "
                     "signal; the executor thread will unwind at its next "
-                    "directory boundary",
+                    "stop-check boundary",
                     timeout,
                 )
         # WHY: only release the handles once the task is actually finished.
@@ -1878,7 +1878,7 @@ async def shutdown_event() -> None:
         # stop handle and let a re-entrant startup schedule a second concurrent
         # sweep over the same tree -- exactly what the guard in
         # start_temp_file_cleanup_task exists to prevent.
-        if task is None or task.done():
+        if cleanup_task is None or cleanup_task.done():
             app.state.temp_file_cleanup_task = None
             app.state.temp_file_cleanup_stop = None
 

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -659,11 +659,19 @@ def start_temp_file_cleanup_task(
         getattr(app_instance.state, "temp_file_cleanup_task", None),
     )
     if existing_cleanup_task is not None and not existing_cleanup_task.done():
-        # WHY: keeps a re-entrant startup from orphaning an in-flight walk and
-        # discarding its only stop handle.
-        logger.debug(
-            "Orphaned temp-file cleanup already running; not scheduling another"
-        )
+        # WHY: never schedule a second concurrent walk -- it would orphan the
+        # in-flight one and discard its only stop handle. An already-signalled
+        # generation is unwinding, not sweeping, so say so instead of "running".
+        existing_stop = getattr(app_instance.state, "temp_file_cleanup_stop", None)
+        if existing_stop is not None and existing_stop.is_set():
+            logger.warning(
+                "Previous orphaned temp-file cleanup is still unwinding after a "
+                "shutdown signal; this startup gets no sweep"
+            )
+        else:
+            logger.debug(
+                "Orphaned temp-file cleanup already running; not scheduling another"
+            )
         return existing_cleanup_task
 
     if os.getenv("PYTEST_CURRENT_TEST"):
@@ -675,7 +683,7 @@ def start_temp_file_cleanup_task(
     app_instance.state.temp_file_cleanup_stop = temp_file_cleanup_stop
 
     async def run_temp_file_cleanup_background() -> None:
-        from .api.kb import cleanup_orphaned_temp_files
+        from .services.storage_maintenance import cleanup_orphaned_temp_files
 
         started = time.monotonic()
         logger.info("Background orphaned temp-file cleanup started")
@@ -708,7 +716,7 @@ def start_temp_file_cleanup_task(
 
     task = asyncio.create_task(run_temp_file_cleanup_background())
     app_instance.state.temp_file_cleanup_task = task
-    logger.info("Started background orphaned temp-file cleanup task")
+    logger.info("Scheduled background orphaned temp-file cleanup")
     return task
 
 

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -1636,10 +1636,6 @@ async def startup_event() -> None:
         asyncio.create_task(run_uploaded_file_reconcile_background())
         logger.info("Started background uploaded files reconcile task")
 
-        # Clean up orphaned temporary files from interrupted atomic replacements.
-        # See start_temp_file_cleanup_task for the backgrounding/shutdown rationale.
-        start_temp_file_cleanup_task(app)
-
     # Warmup sandbox manager
     from .sandbox_manager import check_sandbox_static_readiness, get_sandbox_manager
 
@@ -1714,6 +1710,19 @@ async def startup_event() -> None:
             logger.info("Slack channel background task created successfully")
     except Exception as e:
         logger.error(f"Failed to start chat channel managers: {e}", exc_info=True)
+
+    # Kept under the same migration toggle as the uploaded-files reconcile above;
+    # see start_temp_file_cleanup_task for the backgrounding/shutdown rationale.
+    #
+    # WHY LAST: a startup exception skips Starlette's ``async with`` teardown, so
+    # shutdown_event -- the only place the sweep's stop flag is set -- never runs.
+    # Scheduling before a step that can raise (sandbox static readiness raises on
+    # a mount conflict) leaves the walk sweeping the whole uploads tree in an
+    # executor thread that asyncio.run()'s teardown joins, untimed before 3.12.
+    # WARN: anything appended below must not raise, or must set the flag itself;
+    # test_failed_startup_leaves_no_unsignaled_temp_file_cleanup pins this.
+    if auto_migrate:
+        start_temp_file_cleanup_task(app)
 
 
 @app.on_event("shutdown")

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -27,6 +27,7 @@ from ..config import (
     get_task_lease_recovery_batch_size,
     get_task_lease_recovery_interval_seconds,
     get_taskless_upload_ttl_seconds,
+    get_temp_file_cleanup_shutdown_timeout_seconds,
     get_trigger_dispatcher_batch_size,
     get_trigger_dispatcher_enabled,
     get_trigger_dispatcher_interval_seconds,
@@ -1566,35 +1567,49 @@ async def startup_event() -> None:
         # Unlike that reconcile task, this one is tracked on app.state and stopped
         # at shutdown: the threading.Event lets the walk unwind cooperatively so a
         # mid-sweep restart does not block process exit on the executor thread.
-        temp_file_cleanup_stop = threading.Event()
-        app.state.temp_file_cleanup_stop = temp_file_cleanup_stop
-
-        async def run_temp_file_cleanup_background() -> None:
-            from .api.kb import cleanup_orphaned_temp_files
-
-            started = time.monotonic()
-            logger.info("Background orphaned temp-file cleanup started")
-            try:
-                cleaned_count = await asyncio.to_thread(
-                    cleanup_orphaned_temp_files, stop_event=temp_file_cleanup_stop
-                )
-            except Exception as e:  # noqa: BLE001
-                logger.warning(
-                    "Background orphaned temp-file cleanup failed after %.2fs: %s",
-                    time.monotonic() - started,
-                    e,
-                )
-                return
-            logger.info(
-                "Background orphaned temp-file cleanup completed in %.2fs "
-                "(removed %d file(s))",
-                time.monotonic() - started,
-                cleaned_count,
+        # Gate under pytest (like the metadata rebuild task above): the sweep
+        # walks the real uploads tree, which tests must not trigger. The
+        # idempotency guard then keeps a re-entrant startup from orphaning an
+        # in-flight walk and discarding its only stop handle.
+        existing_cleanup_task = getattr(app.state, "temp_file_cleanup_task", None)
+        if os.getenv("PYTEST_CURRENT_TEST"):
+            pass
+        elif existing_cleanup_task is not None and not existing_cleanup_task.done():
+            logger.debug(
+                "Orphaned temp-file cleanup already running; not scheduling another"
             )
+        else:
+            temp_file_cleanup_stop = threading.Event()
+            app.state.temp_file_cleanup_stop = temp_file_cleanup_stop
 
-        app.state.temp_file_cleanup_task = asyncio.create_task(
-            run_temp_file_cleanup_background()
-        )
+            async def run_temp_file_cleanup_background() -> None:
+                from .api.kb import cleanup_orphaned_temp_files
+
+                started = time.monotonic()
+                logger.info("Background orphaned temp-file cleanup started")
+                try:
+                    cleaned_count = await asyncio.to_thread(
+                        cleanup_orphaned_temp_files, stop_event=temp_file_cleanup_stop
+                    )
+                except Exception:  # noqa: BLE001
+                    # WHY: keep the traceback (exc_info) even at WARNING — the
+                    # sweep runs unattended, so a failure has no other surface.
+                    logger.warning(
+                        "Background orphaned temp-file cleanup failed after %.2fs",
+                        time.monotonic() - started,
+                        exc_info=True,
+                    )
+                    return
+                logger.info(
+                    "Background orphaned temp-file cleanup completed in %.2fs "
+                    "(removed %d file(s))",
+                    time.monotonic() - started,
+                    cleaned_count,
+                )
+
+            app.state.temp_file_cleanup_task = asyncio.create_task(
+                run_temp_file_cleanup_background()
+            )
 
     # Warmup sandbox manager
     from .sandbox_manager import check_sandbox_static_readiness, get_sandbox_manager
@@ -1681,6 +1696,16 @@ async def shutdown_event() -> None:
         _trigger_dispatcher_task, \
         _sandbox_idle_sweep_task
 
+    # WHY: signal the background temp-file cleanup walk to unwind before any other
+    # teardown runs. It sweeps in an executor thread that a task cancel cannot
+    # stop, and asyncio.run()'s teardown joins that thread at loop close, so if an
+    # earlier shutdown step hangs (e.g. an unresponsive flush_langfuse) the walk
+    # would keep running and block process exit — the exact F1 regression this
+    # guards against. Setting the flag first is unconditional and cannot hang.
+    temp_file_cleanup_stop = getattr(app.state, "temp_file_cleanup_stop", None)
+    if temp_file_cleanup_stop is not None:
+        temp_file_cleanup_stop.set()
+
     flush_langfuse()
 
     if _task_command_dispatcher_task is not None:
@@ -1729,26 +1754,28 @@ async def shutdown_event() -> None:
             with suppress(asyncio.CancelledError):
                 await task
 
-    # Stop the background orphaned temp-file cleanup task. The walk runs in an
-    # executor thread, so cancelling the task would only stop the await while the
-    # thread keeps running and blocks process exit via asyncio.run()'s executor
-    # join. Set the cooperative stop flag instead, then wait briefly for the walk
-    # to unwind at its next directory boundary.
+    # Wait briefly for the background orphaned temp-file cleanup to unwind (its
+    # stop flag was already set at the top of this handler). The walk runs in an
+    # executor thread that a cancel cannot stop, so use asyncio.wait rather than
+    # asyncio.wait_for: wait_for CANCELS the task on timeout, which here would
+    # only kill the awaiting coroutine (losing its completion/failure log via an
+    # uncaught CancelledError) while the thread keeps running. asyncio.wait bounds
+    # the wait WITHOUT cancelling, letting the task log its own outcome once the
+    # walk reaches its next directory boundary.
     if hasattr(app.state, "temp_file_cleanup_task"):
         task = app.state.temp_file_cleanup_task
         if task and not task.done():
-            stop = getattr(app.state, "temp_file_cleanup_stop", None)
-            if stop is not None:
-                stop.set()
-            try:
-                await asyncio.wait_for(task, timeout=10.0)
-            except asyncio.TimeoutError:
+            timeout = get_temp_file_cleanup_shutdown_timeout_seconds()
+            done, _pending = await asyncio.wait({task}, timeout=timeout)
+            if not done:
                 logger.warning(
-                    "Orphaned temp-file cleanup still running 10s after stop "
-                    "signal; leaving it to finish in the background"
+                    "Orphaned temp-file cleanup still running %ss after stop "
+                    "signal; the executor thread will unwind at its next "
+                    "directory boundary",
+                    timeout,
                 )
-            except asyncio.CancelledError:
-                pass
+        app.state.temp_file_cleanup_task = None
+        app.state.temp_file_cleanup_stop = None
 
     # Shutdown chat channels before draining task finalizers.
     try:

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -692,20 +692,19 @@ def start_temp_file_cleanup_task(
                 exc_info=True,
             )
             return
-        if temp_file_cleanup_stop.is_set():
-            logger.info(
-                "Background orphaned temp-file cleanup interrupted by shutdown "
-                "after %.2fs (removed %d file(s))",
-                time.monotonic() - started,
-                cleaned_count,
-            )
-        else:
-            logger.info(
-                "Background orphaned temp-file cleanup completed in %.2fs "
-                "(removed %d file(s))",
-                time.monotonic() - started,
-                cleaned_count,
-            )
+        # WHY: this reports duration/count only, and deliberately does NOT
+        # re-read temp_file_cleanup_stop to label the run interrupted. Shutdown
+        # sets that flag as its first statement, so it can flip between the
+        # walk finishing and this coroutine being resumed -- and the walk can
+        # also complete its last directory after the flag is set. Either way a
+        # completed sweep would be logged as truncated. cleanup_orphaned_temp_files
+        # tracks that state internally and logs it authoritatively.
+        logger.info(
+            "Background orphaned temp-file cleanup finished in %.2fs "
+            "(removed %d file(s))",
+            time.monotonic() - started,
+            cleaned_count,
+        )
 
     task = asyncio.create_task(run_temp_file_cleanup_background())
     app_instance.state.temp_file_cleanup_task = task
@@ -1784,30 +1783,6 @@ async def shutdown_event() -> None:
             with suppress(asyncio.CancelledError):
                 await task
 
-    # Wait briefly for the background orphaned temp-file cleanup to unwind (its
-    # stop flag was already set at the top of this handler). The walk runs in an
-    # executor thread that a cancel cannot stop, so use asyncio.wait rather than
-    # asyncio.wait_for: wait_for's cancellation only kills the awaiting coroutine,
-    # not the executor thread doing the real work, so cancelling early has no
-    # benefit -- only the risk of losing the completion/failure log to an
-    # uncaught CancelledError. If the walk is still running once this bounded
-    # wait elapses, the process's own asyncio.run() teardown will join (or
-    # cancel) the outstanding task regardless.
-    if hasattr(app.state, "temp_file_cleanup_task"):
-        task = app.state.temp_file_cleanup_task
-        if task and not task.done():
-            timeout = get_temp_file_cleanup_shutdown_timeout_seconds()
-            done, _pending = await asyncio.wait({task}, timeout=timeout)
-            if not done:
-                logger.warning(
-                    "Orphaned temp-file cleanup still running %ss after stop "
-                    "signal; the executor thread will unwind at its next "
-                    "directory boundary",
-                    timeout,
-                )
-        app.state.temp_file_cleanup_task = None
-        app.state.temp_file_cleanup_stop = None
-
     # Shutdown chat channels before draining task finalizers.
     try:
         if hasattr(app.state, "telegram_task"):
@@ -1853,6 +1828,42 @@ async def shutdown_event() -> None:
     sandbox_mgr = get_sandbox_manager()
     if sandbox_mgr:
         await sandbox_mgr.cleanup()
+
+    # Wait briefly for the background orphaned temp-file cleanup to unwind (its
+    # stop flag was already set at the top of this handler). This runs LAST on
+    # purpose: the wait has no ordering dependency on anything above -- the stop
+    # signal is already delivered and this only collects the task -- so putting
+    # it here donates every preceding teardown step's duration to the walk as
+    # free grace time, and keeps its timeout off the critical path of lease
+    # draining and sandbox cleanup, which must finish inside the orchestrator's
+    # termination grace period.
+    #
+    # Use asyncio.wait rather than asyncio.wait_for: wait_for's cancellation only
+    # kills the awaiting coroutine, not the executor thread doing the real work,
+    # so cancelling early has no benefit -- only the risk of losing the
+    # completion/failure log to an uncaught CancelledError. If the walk is still
+    # running once this bounded wait elapses, the process's own asyncio.run()
+    # teardown will join (or cancel) the outstanding task regardless.
+    if hasattr(app.state, "temp_file_cleanup_task"):
+        task = app.state.temp_file_cleanup_task
+        if task and not task.done():
+            timeout = get_temp_file_cleanup_shutdown_timeout_seconds()
+            done, _pending = await asyncio.wait({task}, timeout=timeout)
+            if not done:
+                logger.warning(
+                    "Orphaned temp-file cleanup still running %ss after stop "
+                    "signal; the executor thread will unwind at its next "
+                    "directory boundary",
+                    timeout,
+                )
+        # WHY: only release the handles once the task is actually finished.
+        # Clearing them while the walk is still running would discard its only
+        # stop handle and let a re-entrant startup schedule a second concurrent
+        # sweep over the same tree -- exactly what the guard in
+        # start_temp_file_cleanup_task exists to prevent.
+        if task is None or task.done():
+            app.state.temp_file_cleanup_task = None
+            app.state.temp_file_cleanup_stop = None
 
 
 from ..config import get_frontend_dist_dir  # noqa: E402

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -635,6 +635,84 @@ async def stop_orphan_upload_gc_task(app_instance: FastAPI) -> None:
             )
 
 
+def start_temp_file_cleanup_task(
+    app_instance: FastAPI,
+) -> asyncio.Task[Any] | None:
+    """Start the background orphaned temp-file cleanup sweep for this process.
+
+    This walks the entire uploads tree and can take minutes on a large tree,
+    so it runs in the background (fire-and-forget scheduling like the
+    uploaded-files reconcile step) instead of being awaited inline, letting
+    the lifespan finish and /health open immediately regardless of tree size.
+
+    Unlike that reconcile task, this one is tracked on app_instance.state and
+    stopped at shutdown: the threading.Event lets the walk unwind
+    cooperatively so a mid-sweep restart does not block process exit on the
+    executor thread. Extracted into its own function (matching
+    start_orphan_upload_gc_task above) so the pytest gate below can be
+    exercised directly in a test without also spinning up the other
+    startup_event background loops.
+    """
+
+    existing_cleanup_task = cast(
+        asyncio.Task[Any] | None,
+        getattr(app_instance.state, "temp_file_cleanup_task", None),
+    )
+    if existing_cleanup_task is not None and not existing_cleanup_task.done():
+        # WHY: keeps a re-entrant startup from orphaning an in-flight walk and
+        # discarding its only stop handle.
+        logger.debug(
+            "Orphaned temp-file cleanup already running; not scheduling another"
+        )
+        return existing_cleanup_task
+
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        # The sweep walks the real uploads tree, which tests must not trigger.
+        logger.info("Skipping orphaned temp-file cleanup (test environment)")
+        return None
+
+    temp_file_cleanup_stop = threading.Event()
+    app_instance.state.temp_file_cleanup_stop = temp_file_cleanup_stop
+
+    async def run_temp_file_cleanup_background() -> None:
+        from .api.kb import cleanup_orphaned_temp_files
+
+        started = time.monotonic()
+        logger.info("Background orphaned temp-file cleanup started")
+        try:
+            cleaned_count = await asyncio.to_thread(
+                cleanup_orphaned_temp_files, stop_event=temp_file_cleanup_stop
+            )
+        except Exception:  # noqa: BLE001
+            # WHY: keep the traceback (exc_info) even at WARNING -- the sweep
+            # runs unattended, so a failure has no other surface.
+            logger.warning(
+                "Background orphaned temp-file cleanup failed after %.2fs",
+                time.monotonic() - started,
+                exc_info=True,
+            )
+            return
+        if temp_file_cleanup_stop.is_set():
+            logger.info(
+                "Background orphaned temp-file cleanup interrupted by shutdown "
+                "after %.2fs (removed %d file(s))",
+                time.monotonic() - started,
+                cleaned_count,
+            )
+        else:
+            logger.info(
+                "Background orphaned temp-file cleanup completed in %.2fs "
+                "(removed %d file(s))",
+                time.monotonic() - started,
+                cleaned_count,
+            )
+
+    task = asyncio.create_task(run_temp_file_cleanup_background())
+    app_instance.state.temp_file_cleanup_task = task
+    logger.info("Started background orphaned temp-file cleanup task")
+    return task
+
+
 async def wait_for_file_storage_startup_sync(app_instance: FastAPI) -> None:
     """Wait until durable file storage startup sync has completed successfully."""
     while True:
@@ -1560,56 +1638,8 @@ async def startup_event() -> None:
         logger.info("Started background uploaded files reconcile task")
 
         # Clean up orphaned temporary files from interrupted atomic replacements.
-        # This walks the entire uploads tree and can take minutes on a large
-        # tree, so it runs in the background (fire-and-forget scheduling like the
-        # reconcile step above) instead of awaiting it inline, letting the
-        # lifespan finish and /health open immediately regardless of tree size.
-        # Unlike that reconcile task, this one is tracked on app.state and stopped
-        # at shutdown: the threading.Event lets the walk unwind cooperatively so a
-        # mid-sweep restart does not block process exit on the executor thread.
-        # Gate under pytest (like the metadata rebuild task above): the sweep
-        # walks the real uploads tree, which tests must not trigger. The
-        # idempotency guard then keeps a re-entrant startup from orphaning an
-        # in-flight walk and discarding its only stop handle.
-        existing_cleanup_task = getattr(app.state, "temp_file_cleanup_task", None)
-        if os.getenv("PYTEST_CURRENT_TEST"):
-            pass
-        elif existing_cleanup_task is not None and not existing_cleanup_task.done():
-            logger.debug(
-                "Orphaned temp-file cleanup already running; not scheduling another"
-            )
-        else:
-            temp_file_cleanup_stop = threading.Event()
-            app.state.temp_file_cleanup_stop = temp_file_cleanup_stop
-
-            async def run_temp_file_cleanup_background() -> None:
-                from .api.kb import cleanup_orphaned_temp_files
-
-                started = time.monotonic()
-                logger.info("Background orphaned temp-file cleanup started")
-                try:
-                    cleaned_count = await asyncio.to_thread(
-                        cleanup_orphaned_temp_files, stop_event=temp_file_cleanup_stop
-                    )
-                except Exception:  # noqa: BLE001
-                    # WHY: keep the traceback (exc_info) even at WARNING — the
-                    # sweep runs unattended, so a failure has no other surface.
-                    logger.warning(
-                        "Background orphaned temp-file cleanup failed after %.2fs",
-                        time.monotonic() - started,
-                        exc_info=True,
-                    )
-                    return
-                logger.info(
-                    "Background orphaned temp-file cleanup completed in %.2fs "
-                    "(removed %d file(s))",
-                    time.monotonic() - started,
-                    cleaned_count,
-                )
-
-            app.state.temp_file_cleanup_task = asyncio.create_task(
-                run_temp_file_cleanup_background()
-            )
+        # See start_temp_file_cleanup_task for the backgrounding/shutdown rationale.
+        start_temp_file_cleanup_task(app)
 
     # Warmup sandbox manager
     from .sandbox_manager import check_sandbox_static_readiness, get_sandbox_manager
@@ -1757,11 +1787,12 @@ async def shutdown_event() -> None:
     # Wait briefly for the background orphaned temp-file cleanup to unwind (its
     # stop flag was already set at the top of this handler). The walk runs in an
     # executor thread that a cancel cannot stop, so use asyncio.wait rather than
-    # asyncio.wait_for: wait_for CANCELS the task on timeout, which here would
-    # only kill the awaiting coroutine (losing its completion/failure log via an
-    # uncaught CancelledError) while the thread keeps running. asyncio.wait bounds
-    # the wait WITHOUT cancelling, letting the task log its own outcome once the
-    # walk reaches its next directory boundary.
+    # asyncio.wait_for: wait_for's cancellation only kills the awaiting coroutine,
+    # not the executor thread doing the real work, so cancelling early has no
+    # benefit -- only the risk of losing the completion/failure log to an
+    # uncaught CancelledError. If the walk is still running once this bounded
+    # wait elapses, the process's own asyncio.run() teardown will join (or
+    # cancel) the outstanding task regardless.
     if hasattr(app.state, "temp_file_cleanup_task"):
         task = app.state.temp_file_cleanup_task
         if task and not task.done():

--- a/src/xagent/web/services/storage_maintenance.py
+++ b/src/xagent/web/services/storage_maintenance.py
@@ -18,8 +18,13 @@ logger = logging.getLogger(__name__)
 # WHY: a single very large flat directory must still be interruptible within
 # the shutdown grace period, not only at directory boundaries -- checking
 # every entry would add per-entry overhead for no benefit at typical sizes.
-# The same chunk size bounds that directory's deletion phase below.
 _TEMP_CLEANUP_STOP_CHECK_ENTRIES = 500
+
+# WHY: smaller than the scan's chunk, because a step here is an unlink -- tens
+# of milliseconds on network storage -- so a scan-sized chunk would spend the
+# whole 10s default shutdown grace period. Still chunked, not per-victim, so a
+# stop does not discard a typical directory's few victims.
+_TEMP_CLEANUP_DELETION_STOP_CHECK_ENTRIES = 50
 
 
 class _StopSignal(Protocol):
@@ -40,13 +45,18 @@ def cleanup_orphaned_temp_files(
     """Clean up orphaned temporary files from interrupted atomic replacements.
 
     Removes files matching patterns like:
-    - *.tmp-replace (old pattern)
-    - .*.tmp (new NamedTemporaryFile pattern)
+    - *.tmp-replace (old pattern; no producer remains in src/, kept to reclaim
+      files left behind by deployments that predate its removal)
+    - NamedTemporaryFile temps ending in .tmp, with or without a leading dot --
+      producers spell the prefix both ways
 
     Deleting a temp whose writer stalled past the age threshold is possible,
     but bounded: every producer of these names is create-temp -> write ->
     atomic replace, so the worst case is that writer's replace failing, never
-    a partial file at the target. A producer that writes in place voids this.
+    a partial file at the target. An in-place writer would void this, and one
+    exists (web/api/files.py reserves uploads with open(..., "xb")) -- what
+    keeps it out of reach is the upload extension allowlist, which admits
+    neither .tmp nor .tmp-replace.
 
     Args:
         upload_dir: Base uploads directory to clean. If None, uses default uploads dir.
@@ -172,7 +182,10 @@ def cleanup_orphaned_temp_files(
                         continue
                     if not entry.is_file(follow_symlinks=False):
                         continue
-                    if now - entry.stat().st_mtime <= 3600:  # 1 hour
+                    # Older than 1 hour. WHY lstat: a following stat() would
+                    # read the target's mtime if the entry were swapped for a
+                    # symlink after is_file(), judging age by another file.
+                    if now - entry.stat(follow_symlinks=False).st_mtime <= 3600:
                         continue
                 except OSError as e:
                     # The entry vanished mid-scan (e.g. a concurrent replace);
@@ -184,14 +197,12 @@ def cleanup_orphaned_temp_files(
         for victims_seen, victim in enumerate(victims):
             # WHY: an unpolled deletion phase can outlive both the shutdown grace
             # period and asyncio.run()'s executor join -- one directory can hold
-            # many aged temp files (an agent workspace's temp/output) and unlink
-            # latency on network storage is tens of milliseconds. Chunked rather
-            # than per-victim so a stop mid-deletion does not discard a typical
-            # directory's few victims, which nothing reclaims until next startup.
+            # many aged temp files (an agent workspace's temp/output). See the
+            # deletion chunk size above for why it is not the scan's.
             if (
                 stop_event is not None
                 and victims_seen
-                and victims_seen % _TEMP_CLEANUP_STOP_CHECK_ENTRIES == 0
+                and victims_seen % _TEMP_CLEANUP_DELETION_STOP_CHECK_ENTRIES == 0
                 and stop_event.is_set()
             ):
                 stopped_early = True

--- a/src/xagent/web/services/storage_maintenance.py
+++ b/src/xagent/web/services/storage_maintenance.py
@@ -1,0 +1,221 @@
+"""Storage maintenance for the uploads tree.
+
+Owns the orphaned temp-file sweep: which pathnames count as an abandoned
+atomic-replace temp, how the uploads tree is traversed, and how the walk
+unwinds on a shutdown signal. Lifecycle orchestration (scheduling the sweep,
+signalling it, waiting for it) lives in ``web/app.py``.
+"""
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# WHY: a single very large flat directory must still be interruptible within
+# the shutdown grace period, not only at directory boundaries -- checking
+# every entry would add per-entry overhead for no benefit at typical sizes.
+# The same chunk size bounds that directory's deletion phase below.
+_TEMP_CLEANUP_STOP_CHECK_ENTRIES = 500
+
+
+class _StopSignal(Protocol):
+    """The only threading.Event behavior this walk actually needs.
+
+    A Protocol (rather than threading.Event itself) so a lightweight test
+    double satisfies the type without implementing set()/clear()/wait().
+    """
+
+    def is_set(self) -> bool: ...
+
+
+def cleanup_orphaned_temp_files(
+    upload_dir: Optional[Path] = None,
+    *,
+    stop_event: Optional[_StopSignal] = None,
+) -> int:
+    """Clean up orphaned temporary files from interrupted atomic replacements.
+
+    Removes files matching patterns like:
+    - *.tmp-replace (old pattern)
+    - .*.tmp (new NamedTemporaryFile pattern)
+
+    Deleting a temp whose writer stalled past the age threshold is possible,
+    but bounded: every producer of these names is create-temp -> write ->
+    atomic replace, so the worst case is that writer's replace failing, never
+    a partial file at the target. A producer that writes in place voids this.
+
+    Args:
+        upload_dir: Base uploads directory to clean. If None, uses default uploads dir.
+        stop_event: Optional cooperative stop flag, checked once per directory and
+            periodically within a large directory's scan. When set, the walk
+            unwinds early so a shutdown can interrupt a long sweep instead of
+            the worker thread blocking process exit via asyncio.run()'s
+            executor-thread join.
+
+    Returns:
+        Number of files cleaned up.
+    """
+    from ..config import get_uploads_dir
+
+    base_dir = upload_dir or get_uploads_dir()
+    if not base_dir.exists():
+        return 0
+
+    cleaned_count = 0
+    now = time.time()
+
+    def _is_orphaned_temp_name(filename: str) -> bool:
+        # Old atomic-replace pattern (*.tmp-replace).
+        if filename.endswith(".tmp-replace"):
+            return True
+        # New NamedTemporaryFile pattern: filename.XXXXXX.tmp (has multiple
+        # extensions, so at least three dot-separated parts ending in ``tmp``).
+        if filename.endswith(".tmp") and "." in filename[:-4]:
+            parts = filename.split(".")
+            if len(parts) >= 3 and parts[-1] == "tmp":
+                return True
+        return False
+
+    # Walk the uploads tree with os.scandir, seeding the stack with a str path
+    # and appending entry.path directly so no Path object is allocated per
+    # entry on a large tree. Clean temp files older than 1 hour to avoid
+    # deleting files that might still be in use; per-entry OSError is tolerated
+    # below so a file vanishing mid-scan skips instead of aborting the sweep.
+    root = str(base_dir)
+    stack = [root]
+    # WHY: track "did we stop early" as we go instead of re-reading stop_event
+    # after the loop. The flag can be set by shutdown *while* the final
+    # directory is being scanned, in which case the tree still gets fully
+    # walked -- re-polling afterwards would report a completed sweep as
+    # truncated and tell operators to expect leftover orphans that aren't there.
+    stopped_early = False
+    while stack:
+        # Cooperative stop check; see the stop_event docstring above for why.
+        if stop_event is not None and stop_event.is_set():
+            stopped_early = True
+            break
+        current = stack.pop()
+        # WHY: os.scandir() on this str path follows symlinks, and the DFS stack
+        # can hold a queued pathname for the rest of the sweep -- so without a
+        # fresh check, a directory swapped for a symlink after its parent's
+        # is_dir(follow_symlinks=False) sends the sweep outside the uploads root.
+        # os.walk() guards the same race the same way (CPython bpo-23605), at the
+        # same cost of one lstat per directory. The root stays exempt because
+        # os.walk() never tested `top` either, and a symlinked uploads root
+        # (a mounted volume) is a legitimate deployment.
+        if current != root and os.path.islink(current):
+            logger.warning(
+                "Not descending into %s: it was replaced by a symlink during the sweep",
+                current,
+            )
+            continue
+        try:
+            scandir_it = os.scandir(current)
+        except OSError as e:
+            logger.warning("Failed to scan directory %s: %s", current, e)
+            continue
+        # WHY: matches are collected here and unlinked only after the directory
+        # stream is closed below. Whether readdir() still returns the remaining
+        # entries of a directory that was modified mid-iteration is unspecified
+        # by POSIX, so unlinking inside the scan can silently skip siblings --
+        # and this sweep runs once per process with no resumption, so a skipped
+        # orphan is never reclaimed. Both stdlib walkers avoid this: os.walk
+        # exhausts and closes the iterator before yielding, and shutil.rmtree
+        # materializes list(scandir_it) before unlinking.
+        victims: list[str] = []
+        with scandir_it:
+            entries_seen = 0
+            while True:
+                try:
+                    entry = next(scandir_it)
+                except StopIteration:
+                    break
+                except OSError as e:
+                    # A directory-level failure mid-iteration (e.g. NFS ESTALE,
+                    # or the directory removed mid-scan). Match os.walk's default
+                    # tolerance: skip this directory instead of aborting the
+                    # whole sweep.
+                    logger.warning("Failed while scanning directory %s: %s", current, e)
+                    break
+                entries_seen += 1
+                if (
+                    stop_event is not None
+                    and entries_seen % _TEMP_CLEANUP_STOP_CHECK_ENTRIES == 0
+                    and stop_event.is_set()
+                ):
+                    stopped_early = True
+                    break
+                try:
+                    is_directory = entry.is_dir(follow_symlinks=False)
+                except OSError as e:
+                    # WHY: split from the candidate probes below -- a failed
+                    # directory probe silently drops every orphan beneath it,
+                    # and this one-shot sweep has no resumption to reclaim them.
+                    logger.warning(
+                        "Skipping %s: directory probe failed, so any subtree "
+                        "below it is not swept: %s",
+                        entry.path,
+                        e,
+                    )
+                    continue
+                if is_directory:
+                    stack.append(entry.path)
+                    continue
+                try:
+                    # Name test first: it touches no filesystem, so the vast
+                    # majority of entries are rejected before is_file()/stat().
+                    if not _is_orphaned_temp_name(entry.name):
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    if now - entry.stat().st_mtime <= 3600:  # 1 hour
+                        continue
+                except OSError as e:
+                    # The entry vanished mid-scan (e.g. a concurrent replace);
+                    # skip it rather than aborting the whole sweep.
+                    logger.debug("Skipping temp-file candidate %s: %s", entry.path, e)
+                    continue
+                victims.append(entry.path)
+
+        for victims_seen, victim in enumerate(victims):
+            # WHY: an unpolled deletion phase can outlive both the shutdown grace
+            # period and asyncio.run()'s executor join -- one directory can hold
+            # many aged temp files (an agent workspace's temp/output) and unlink
+            # latency on network storage is tens of milliseconds. Chunked rather
+            # than per-victim so a stop mid-deletion does not discard a typical
+            # directory's few victims, which nothing reclaims until next startup.
+            if (
+                stop_event is not None
+                and victims_seen
+                and victims_seen % _TEMP_CLEANUP_STOP_CHECK_ENTRIES == 0
+                and stop_event.is_set()
+            ):
+                stopped_early = True
+                break
+            try:
+                os.unlink(victim)
+                cleaned_count += 1
+                logger.debug("Cleaned up orphaned temp file: %s", victim)
+            except OSError as e:
+                logger.warning(
+                    "Failed to clean up orphaned temp file %s: %s", victim, e
+                )
+
+    if stopped_early:
+        # WHY: an interrupted sweep must not look identical to a completed one
+        # in the logs -- operators need to know the tree was not fully walked.
+        # This is the authoritative signal; the background wrapper in app.py
+        # deliberately does not re-derive it from the stop flag.
+        logger.info(
+            "Orphaned temp-file sweep stopped early by shutdown signal after "
+            "removing %d file(s); the uploads tree was not fully walked",
+            cleaned_count,
+        )
+    elif cleaned_count > 0:
+        logger.info("Cleaned up %d orphaned temporary file(s)", cleaned_count)
+
+    return cleaned_count

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -102,6 +102,7 @@ from xagent.config import (
     TASK_LEASE_TTL_SECONDS,
     TASK_RUNTIME_HOOK_MAX_WORKERS,
     TASK_RUNTIME_HOOK_QUEUE_TIMEOUT_SECONDS,
+    TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS,
     TRIGGER_DISPATCHER_BATCH_SIZE,
     TRIGGER_DISPATCHER_ENABLED,
     TRIGGER_DISPATCHER_INTERVAL_SECONDS,
@@ -206,6 +207,7 @@ from xagent.config import (
     get_task_lease_recovery_interval_seconds,
     get_task_runtime_hook_max_workers,
     get_task_runtime_hook_queue_timeout_seconds,
+    get_temp_file_cleanup_shutdown_timeout_seconds,
     get_trigger_dispatcher_batch_size,
     get_trigger_dispatcher_enabled,
     get_trigger_dispatcher_interval_seconds,
@@ -740,6 +742,22 @@ class TestCeleryBackgroundJobConfig:
         assert get_uploaded_file_recovery_interval_seconds() == 60
         assert get_uploaded_file_recovery_stale_seconds() == 300
         assert get_uploaded_file_recovery_batch_size() == 100
+
+    def test_temp_file_cleanup_shutdown_timeout_tuning(self, monkeypatch):
+        assert (
+            TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS
+            == "XAGENT_TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS"
+        )
+
+        monkeypatch.delenv(TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS, raising=False)
+        assert get_temp_file_cleanup_shutdown_timeout_seconds() == 10
+
+        monkeypatch.setenv(TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS, "45")
+        assert get_temp_file_cleanup_shutdown_timeout_seconds() == 45
+
+        # Invalid / non-positive values fall back to the default.
+        monkeypatch.setenv(TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS, "0")
+        assert get_temp_file_cleanup_shutdown_timeout_seconds() == 10
 
 
 class TestGetWebSearchProvider:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -759,6 +759,12 @@ class TestCeleryBackgroundJobConfig:
         monkeypatch.setenv(TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS, "0")
         assert get_temp_file_cleanup_shutdown_timeout_seconds() == 10
 
+        monkeypatch.setenv(TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS, "abc")
+        assert get_temp_file_cleanup_shutdown_timeout_seconds() == 10
+
+        monkeypatch.setenv(TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS, "-5")
+        assert get_temp_file_cleanup_shutdown_timeout_seconds() == 10
+
 
 class TestGetWebSearchProvider:
     """Test get_web_search_provider() function."""

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -7,11 +7,10 @@ startup to add user_id fields to existing LanceDB tables.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import os
 import sys
 import tempfile
-from collections.abc import Iterator
+import threading
 from types import ModuleType
 
 import pyarrow as pa
@@ -942,46 +941,19 @@ async def test_startup_event_triggers_background_auto_migration(
     monkeypatch.setattr(web_app_module.asyncio, "to_thread", _fake_to_thread)
     monkeypatch.setattr(web_app_module.asyncio, "create_task", _track_create_task)
 
-    # Prove the temp-file cleanup runs *inside* its _startup_phase wrap and the
-    # phase completes: a refactor that drops the wrap -- or keeps it but stops
-    # calling the cleanup inside it -- is caught here. Startup reconfigures
-    # logging, so spying is more reliable than capturing the phase's log lines.
-    import xagent.web.api.kb as kb_module
-
-    completed_phases: list[str] = []
-    active_phase: dict[str, str | None] = {"name": None}
-    cleanup_ran_in_phase = {"value": False}
-    real_startup_phase = web_app_module._startup_phase
-    real_cleanup = kb_module.cleanup_orphaned_temp_files
-
-    @contextlib.contextmanager
-    def _tracking_startup_phase(name: str) -> Iterator[None]:
-        previous = active_phase["name"]
-        active_phase["name"] = name
-        try:
-            with real_startup_phase(name):
-                yield
-        finally:
-            active_phase["name"] = previous
-        completed_phases.append(name)
-
-    def _spy_cleanup() -> int:
-        if active_phase["name"] == "orphaned temp-file cleanup":
-            cleanup_ran_in_phase["value"] = True
-        return real_cleanup()
-
-    monkeypatch.setattr(web_app_module, "_startup_phase", _tracking_startup_phase)
-    monkeypatch.setattr(kb_module, "cleanup_orphaned_temp_files", _spy_cleanup)
-
     await web_app_module.startup_event()
     if created_tasks:
         await asyncio.gather(*created_tasks)
 
-    # We expect 2 tasks: backfill migration + uploaded files reconcile
-    assert len(created_tasks) == 2
+    # We expect 3 tasks: backfill migration + uploaded files reconcile
+    # + orphaned temp-file cleanup
+    assert len(created_tasks) == 3
     assert migration_called["value"] is True
-    assert "orphaned temp-file cleanup" in completed_phases
-    assert cleanup_ran_in_phase["value"] is True
+    # The count bump alone can't tell whether the temp-file cleanup task was
+    # wired: assert it is tracked on app.state alongside its cooperative stop
+    # flag, so removing either would fail here (see app.py shutdown handling).
+    assert web_app_module.app.state.temp_file_cleanup_task is not None
+    assert isinstance(web_app_module.app.state.temp_file_cleanup_stop, threading.Event)
 
 
 @pytest.mark.asyncio
@@ -1092,9 +1064,15 @@ async def test_startup_event_no_task_when_no_table_needs_migration(
     if created_tasks:
         await asyncio.gather(*created_tasks)
 
-    # We expect 1 task: uploaded files reconcile (even without migration needs)
-    assert len(created_tasks) == 1
+    # We expect 2 tasks: uploaded files reconcile + orphaned temp-file cleanup
+    # (both run under auto_migrate even without migration needs)
+    assert len(created_tasks) == 2
     assert migration_called["value"] is False
+    # The count bump alone can't tell whether the temp-file cleanup task was
+    # wired: assert it is tracked on app.state alongside its cooperative stop
+    # flag, so removing either would fail here (see app.py shutdown handling).
+    assert web_app_module.app.state.temp_file_cleanup_task is not None
+    assert isinstance(web_app_module.app.state.temp_file_cleanup_stop, threading.Event)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -941,6 +941,23 @@ async def test_startup_event_triggers_background_auto_migration(
     monkeypatch.setattr(web_app_module.asyncio, "to_thread", _fake_to_thread)
     monkeypatch.setattr(web_app_module.asyncio, "create_task", _track_create_task)
 
+    # The cleanup task itself is gated off under pytest (it walks the real
+    # uploads tree), so it contributes no entry to created_tasks and the count
+    # assertion below cannot see it. Spy on the call site so deleting it from
+    # startup_event fails a test instead of silently disabling the sweep in
+    # production.
+    cleanup_scheduled: list[object] = []
+
+    def _spy_start_temp_file_cleanup_task(app_instance):
+        cleanup_scheduled.append(app_instance)
+        return None
+
+    monkeypatch.setattr(
+        web_app_module,
+        "start_temp_file_cleanup_task",
+        _spy_start_temp_file_cleanup_task,
+    )
+
     await web_app_module.startup_event()
     if created_tasks:
         await asyncio.gather(*created_tasks)
@@ -951,6 +968,7 @@ async def test_startup_event_triggers_background_auto_migration(
     # test_shutdown_event_stops_temp_file_cleanup_without_cancel below.
     assert len(created_tasks) == 2
     assert migration_called["value"] is True
+    assert cleanup_scheduled == [web_app_module.app]
 
 
 @pytest.mark.asyncio
@@ -1171,18 +1189,36 @@ async def test_shutdown_event_stops_temp_file_cleanup_without_cancel(
 
     await web_app_module.shutdown_event()
 
-    assert flush_saw_stop["set"] is True
-    assert stop.is_set()
-    # The timeout above genuinely elapsed while the walk was still blocked on
-    # `resume`. asyncio.wait_for would have cancelled the task by now;
-    # asyncio.wait leaves it running, untouched.
-    assert not task.done()
-    assert not task.cancelled()
-    assert app.state.temp_file_cleanup_task is None
-    assert app.state.temp_file_cleanup_stop is None
+    try:
+        assert flush_saw_stop["set"] is True
+        assert stop.is_set()
+        # The timeout above genuinely elapsed while the walk was still blocked on
+        # `resume`. asyncio.wait_for would have cancelled the task by now;
+        # asyncio.wait leaves it running, untouched.
+        assert not task.done()
+        assert not task.cancelled()
+        # The walk outlived the bounded wait, so its handles must be RETAINED.
+        # Clearing them here would discard the only stop handle and let a
+        # re-entrant startup schedule a second concurrent sweep over the same
+        # tree -- the exact case start_temp_file_cleanup_task's guard exists for.
+        assert app.state.temp_file_cleanup_task is task
+        assert app.state.temp_file_cleanup_stop is stop
 
-    resume.set()
-    await task
+        resume.set()
+        await task
+
+        # Once the walk has actually finished, a later shutdown releases them.
+        await web_app_module.shutdown_event()
+        assert app.state.temp_file_cleanup_task is None
+        assert app.state.temp_file_cleanup_stop is None
+    finally:
+        # Never leave a pending task or populated app.state behind for the rest
+        # of the session, even if an assertion above fails.
+        resume.set()
+        if not task.done():
+            await task
+        app.state.temp_file_cleanup_task = None
+        app.state.temp_file_cleanup_stop = None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -7,6 +7,7 @@ startup to add user_id fields to existing LanceDB tables.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 import tempfile
@@ -1253,7 +1254,7 @@ async def test_start_temp_file_cleanup_task_wires_stop_event(
         return 0
 
     monkeypatch.setattr(
-        "xagent.web.api.kb.cleanup_orphaned_temp_files",
+        "xagent.web.services.storage_maintenance.cleanup_orphaned_temp_files",
         _fake_cleanup_orphaned_temp_files,
     )
 
@@ -1410,7 +1411,8 @@ async def test_failed_startup_leaves_no_unsignaled_temp_file_cleanup(
         return 0
 
     monkeypatch.setattr(
-        "xagent.web.api.kb.cleanup_orphaned_temp_files", _blocking_cleanup
+        "xagent.web.services.storage_maintenance.cleanup_orphaned_temp_files",
+        _blocking_cleanup,
     )
 
     real_start = web_app_module.start_temp_file_cleanup_task
@@ -1743,3 +1745,79 @@ async def test_startup_event_skips_sandbox_readiness_when_manager_is_none(
         await asyncio.gather(*created_tasks)
 
     assert readiness_called["value"] is False
+
+
+@pytest.mark.asyncio
+async def test_startup_reports_a_still_unwinding_previous_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A retained generation that is already stop-signalled is not "running".
+
+    A shutdown whose bounded wait expires deliberately keeps the pending task
+    and its already-set stop event, so the next startup on the same app object
+    hits the re-entrancy guard. Scheduling a second walk there is still wrong,
+    but reporting a live sweep is a lie: that generation is unwinding and this
+    startup gets none. Only reachable when one app object runs lifespan twice
+    (the test suite's module-level app), never in a deployment that exits
+    after shutdown.
+    """
+    import importlib
+
+    web_app_module = importlib.import_module("xagent.web.app")
+    app = web_app_module.app
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    app.state.temp_file_cleanup_task = None
+    app.state.temp_file_cleanup_stop = None
+
+    unwind = threading.Event()
+    sweeps_started: list[threading.Event] = []
+
+    def _stalled_cleanup(*, stop_event=None) -> int:
+        sweeps_started.append(stop_event)
+        unwind.wait(timeout=5)
+        return 0
+
+    monkeypatch.setattr(
+        "xagent.web.services.storage_maintenance.cleanup_orphaned_temp_files",
+        _stalled_cleanup,
+    )
+
+    try:
+        first = web_app_module.start_temp_file_cleanup_task(app)
+        assert first is not None
+        first_stop = app.state.temp_file_cleanup_stop
+
+        # A shutdown whose bounded wait expired: signalled, but still pending.
+        first_stop.set()
+        assert not first.done()
+
+        # A handler on the module logger rather than caplog: this app configures
+        # root logging on import, which displaces caplog's own root handler.
+        records: list[logging.LogRecord] = []
+
+        class _Collect(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        collector = _Collect()
+        web_app_module.logger.addHandler(collector)
+        try:
+            second = web_app_module.start_temp_file_cleanup_task(app)
+        finally:
+            web_app_module.logger.removeHandler(collector)
+
+        assert second is first
+        assert app.state.temp_file_cleanup_stop is first_stop
+        assert [
+            r for r in records if r.levelno == logging.WARNING and "unwinding" in r.msg
+        ]
+        assert not [r for r in records if "Scheduled background" in r.msg]
+    finally:
+        unwind.set()
+        await first
+        app.state.temp_file_cleanup_task = None
+        app.state.temp_file_cleanup_stop = None
+
+    # The guard held: exactly one sweep ran, using the first generation's flag.
+    assert sweeps_started == [first_stop]

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -1077,6 +1077,13 @@ async def test_shutdown_event_stops_temp_file_cleanup_without_cancel(
     Covers the two round-2 majors on the shutdown path: the stop flag is set
     before any other teardown (so an earlier hang cannot strand the executor
     thread), and the task is awaited via asyncio.wait rather than cancelled.
+
+    On the happy path (the walk finishes almost immediately) asyncio.wait and
+    asyncio.wait_for behave identically, so that alone can't tell them apart --
+    a prior version of this test made exactly that mistake. The walk task
+    below deliberately blocks past a (monkeypatched, tiny) shutdown timeout
+    without checking `stop`, forcing a genuine timeout: asyncio.wait leaves
+    the task pending past it, while asyncio.wait_for would cancel it.
     """
     import importlib
 
@@ -1129,6 +1136,13 @@ async def test_shutdown_event_stops_temp_file_cleanup_without_cancel(
         lambda: None,
     )
 
+    # Real but tiny, so the wait genuinely times out without slowing the suite.
+    monkeypatch.setattr(
+        web_app_module,
+        "get_temp_file_cleanup_shutdown_timeout_seconds",
+        lambda: 0.05,
+    )
+
     stop = threading.Event()
     flush_saw_stop = {}
 
@@ -1140,11 +1154,14 @@ async def test_shutdown_event_stops_temp_file_cleanup_without_cancel(
     monkeypatch.setattr(web_app_module, "flush_langfuse", _spy_flush)
 
     started = asyncio.Event()
+    resume = asyncio.Event()
 
     async def _cooperative_walk() -> None:
         started.set()
-        while not stop.is_set():
-            await asyncio.sleep(0.01)
+        # Simulate being mid-scan, past the point where `stop` would next be
+        # polled, until the test releases `resume` below -- this is what
+        # forces the shutdown wait to genuinely time out.
+        await resume.wait()
 
     task = asyncio.create_task(_cooperative_walk())
     await started.wait()
@@ -1156,10 +1173,70 @@ async def test_shutdown_event_stops_temp_file_cleanup_without_cancel(
 
     assert flush_saw_stop["set"] is True
     assert stop.is_set()
-    assert task.done()
+    # The timeout above genuinely elapsed while the walk was still blocked on
+    # `resume`. asyncio.wait_for would have cancelled the task by now;
+    # asyncio.wait leaves it running, untouched.
+    assert not task.done()
     assert not task.cancelled()
     assert app.state.temp_file_cleanup_task is None
     assert app.state.temp_file_cleanup_stop is None
+
+    resume.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_start_temp_file_cleanup_task_wires_stop_event(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The pytest-gated wiring block itself must actually wire things up.
+
+    Regression guard: an earlier commit on this PR asserted
+    app.state.temp_file_cleanup_task is not None and
+    isinstance(app.state.temp_file_cleanup_stop, threading.Event) directly
+    against startup_event(), but those assertions were dropped rather than
+    reworked when the PYTEST_CURRENT_TEST gate was introduced, leaving this
+    block untested. Calling start_temp_file_cleanup_task directly (rather
+    than the full startup_event) exercises its own pytest gate without also
+    un-gating the unrelated trigger/lease-recovery/orphan-GC loops that share
+    the same env-var check elsewhere in startup_event.
+    """
+    import importlib
+
+    web_app_module = importlib.import_module("xagent.web.app")
+    app = web_app_module.app
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    app.state.temp_file_cleanup_task = None
+    app.state.temp_file_cleanup_stop = None
+
+    seen_stop_events: list[threading.Event] = []
+
+    def _fake_cleanup_orphaned_temp_files(*, stop_event=None) -> int:
+        seen_stop_events.append(stop_event)
+        return 0
+
+    monkeypatch.setattr(
+        "xagent.web.api.kb.cleanup_orphaned_temp_files",
+        _fake_cleanup_orphaned_temp_files,
+    )
+
+    task = web_app_module.start_temp_file_cleanup_task(app)
+    stop_event = app.state.temp_file_cleanup_stop
+
+    assert task is not None
+    assert task is app.state.temp_file_cleanup_task
+    assert isinstance(stop_event, threading.Event)
+
+    await task
+
+    # Pins that the exact stop-event object stored on app.state is the one
+    # actually threaded into the walk -- a wiring bug here would silently
+    # make shutdown's stop signal a no-op.
+    assert seen_stop_events == [stop_event]
+
+    app.state.temp_file_cleanup_task = None
+    app.state.temp_file_cleanup_stop = None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -1276,6 +1276,196 @@ async def test_start_temp_file_cleanup_task_wires_stop_event(
 
 
 @pytest.mark.asyncio
+async def test_failed_startup_leaves_no_unsignaled_temp_file_cleanup(
+    monkeypatch: pytest.MonkeyPatch, temp_lancedb_dir
+):
+    """A startup that fails must not leave the sweep walking unsignaled.
+
+    Starlette's default lifespan is an ``async with``: when startup raises,
+    ``__aexit__`` -- and therefore ``shutdown_event`` -- never runs, so the
+    only ``stop_event.set()`` is skipped. Sandbox static readiness raises
+    deliberately on a mount conflict, so the walk would keep sweeping the
+    whole uploads tree in an executor thread that ``asyncio.run()``'s teardown
+    then joins (with no timeout at all before 3.12), turning a fast
+    config-error crash into a multi-minute one.
+
+    Asserts the invariant rather than a call position: after the failure there
+    must be no cleanup task that is both unfinished and unsignaled. Scheduling
+    the sweep only after every failure-prone startup step satisfies it, and so
+    would signalling the flag on the way out.
+    """
+    import importlib
+
+    _patch_channel_modules_disabled(monkeypatch)
+    _patch_task_command_dispatcher_disabled(monkeypatch)
+    web_app_module = importlib.import_module("xagent.web.app")
+    app = web_app_module.app
+
+    class _FakeManager:
+        async def initialize(self) -> None:
+            return None
+
+        async def list_skills(self) -> list[str]:
+            return []
+
+        async def list_templates(self) -> list[str]:
+            return []
+
+    class _FakeMemoryStoreManager:
+        def get_store_info(self) -> dict[str, object]:
+            return {
+                "is_lancedb": True,
+                "embedding_model_id": "test-model",
+                "similarity_threshold": 0.5,
+            }
+
+    class _FakeSandboxManager:
+        async def _resolve_backend_probe(self) -> bool:
+            return True
+
+        async def cleanup(self) -> None:
+            return None
+
+        async def warmup(self) -> None:
+            return None
+
+    class _FakeConn:
+        pass
+
+    created_tasks: list[asyncio.Task] = []
+    original_create_task = asyncio.create_task
+    real_to_thread = asyncio.to_thread
+
+    # The sweep only runs under the auto-migrate gate, so it has to be on for
+    # the failure path under test to be reachable at all.
+    monkeypatch.setenv("LANCEDB_AUTO_MIGRATE", "true")
+    # The same genuine SANDBOX_VOLUMES/code-mount conflict as
+    # test_startup_event_raises_on_readiness_conflict_with_probe_true: startup
+    # fails *after* the point where the sweep is scheduled today.
+    monkeypatch.setenv("SANDBOX_VOLUMES", "/foo:/guest1:ro")
+    monkeypatch.setattr(
+        "xagent.web.sandbox_manager.build_code_mount_volumes",
+        lambda: [("/foo", "/guest2", "ro")],
+    )
+    monkeypatch.setattr(web_app_module, "init_db", lambda: None)
+    monkeypatch.setattr(
+        web_app_module, "start_file_storage_startup_sync_task", lambda _app: None
+    )
+    monkeypatch.setattr(web_app_module, "_migration_task", None)
+    monkeypatch.setattr(
+        "xagent.skills.utils.create_skill_manager",
+        lambda: _FakeManager(),
+    )
+    monkeypatch.setattr(
+        "xagent.templates.utils.create_template_manager",
+        lambda: _FakeManager(),
+    )
+    monkeypatch.setattr(
+        "xagent.web.dynamic_memory_store.get_memory_store_manager",
+        lambda: _FakeMemoryStoreManager(),
+    )
+    monkeypatch.setattr(
+        "xagent.web.sandbox_manager.get_sandbox_manager",
+        lambda: _FakeSandboxManager(),
+    )
+    monkeypatch.setattr(
+        "xagent.providers.vector_store.lancedb.get_connection_from_env",
+        lambda: _FakeConn(),
+    )
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.LanceDB.schema_manager.check_table_needs_migration",
+        lambda _conn, table_name: False,
+    )
+    monkeypatch.setattr(
+        "xagent.core.tools.core.RAG_tools.utils.lancedb_query_utils.list_embeddings_table_names",
+        lambda _conn: [],
+    )
+
+    # The uploaded-files reconcile task is scheduled just before the sweep and
+    # is not what this test is about; stub its units of work so it cannot spray
+    # unrelated LanceDB/DB tracebacks over this test's output.
+    class _FakeSession:
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "xagent.migrations.lancedb.backfill_uploaded_file_links.backfill_all",
+        lambda *args, **kwargs: {},
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.kb_file_service.reconcile_uploaded_files",
+        lambda *args, **kwargs: {},
+    )
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local", lambda: _FakeSession
+    )
+
+    def _blocking_cleanup(*, stop_event=None) -> int:
+        # Stand in for a real sweep of a large tree: an executor walk that only
+        # unwinds once the cooperative stop flag is set. The timeout is a test
+        # safety net so a regression cannot hang the suite, not part of the
+        # contract under test.
+        assert stop_event is not None
+        stop_event.wait(timeout=30)
+        return 0
+
+    monkeypatch.setattr(
+        "xagent.web.api.kb.cleanup_orphaned_temp_files", _blocking_cleanup
+    )
+
+    real_start = web_app_module.start_temp_file_cleanup_task
+
+    def _start_ungated(app_instance):
+        # Exercise the REAL wrapper, whose own PYTEST_CURRENT_TEST gate would
+        # otherwise skip the sweep entirely. Clearing the variable only around
+        # this call keeps the five unrelated gates in startup_event (trigger
+        # dispatcher, lease/upload recovery, orphan GC, metadata rebuild) in
+        # force, so the failure path is the only thing this test un-gates.
+        saved = os.environ.pop("PYTEST_CURRENT_TEST", None)
+        try:
+            return real_start(app_instance)
+        finally:
+            if saved is not None:
+                os.environ["PYTEST_CURRENT_TEST"] = saved
+
+    monkeypatch.setattr(web_app_module, "start_temp_file_cleanup_task", _start_ungated)
+
+    async def _selective_to_thread(fn, *args, **kwargs):
+        # The sweep must run in a real thread: the stub above blocks until the
+        # stop flag is set, which can never happen if it runs inline on the
+        # event loop. Everything else stays inline, like the sibling tests.
+        if fn is _blocking_cleanup:
+            return await real_to_thread(fn, *args, **kwargs)
+        return fn(*args, **kwargs)
+
+    def _track_create_task(coro):
+        task = original_create_task(coro)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(web_app_module.asyncio, "to_thread", _selective_to_thread)
+    monkeypatch.setattr(web_app_module.asyncio, "create_task", _track_create_task)
+
+    try:
+        with pytest.raises(SandboxRuntimeConflictError):
+            await web_app_module.startup_event()
+
+        task = getattr(app.state, "temp_file_cleanup_task", None)
+        stop = getattr(app.state, "temp_file_cleanup_stop", None)
+        assert task is None or task.done() or (stop is not None and stop.is_set())
+    finally:
+        # Never leave a blocked executor thread, a pending task, or populated
+        # app.state behind for the rest of the session.
+        stop = getattr(app.state, "temp_file_cleanup_stop", None)
+        if stop is not None:
+            stop.set()
+        app.state.temp_file_cleanup_task = None
+        app.state.temp_file_cleanup_stop = None
+        if created_tasks:
+            await asyncio.gather(*created_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_startup_event_runs_sandbox_readiness_before_cleanup_and_warmup(
     monkeypatch: pytest.MonkeyPatch, temp_lancedb_dir
 ):

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -945,15 +945,12 @@ async def test_startup_event_triggers_background_auto_migration(
     if created_tasks:
         await asyncio.gather(*created_tasks)
 
-    # We expect 3 tasks: backfill migration + uploaded files reconcile
-    # + orphaned temp-file cleanup
-    assert len(created_tasks) == 3
+    # We expect 2 tasks: backfill migration + uploaded files reconcile. The
+    # orphaned temp-file cleanup task is gated off under pytest (it walks the
+    # real uploads tree); its wiring/shutdown lifecycle is covered directly by
+    # test_shutdown_event_stops_temp_file_cleanup_without_cancel below.
+    assert len(created_tasks) == 2
     assert migration_called["value"] is True
-    # The count bump alone can't tell whether the temp-file cleanup task was
-    # wired: assert it is tracked on app.state alongside its cooperative stop
-    # flag, so removing either would fail here (see app.py shutdown handling).
-    assert web_app_module.app.state.temp_file_cleanup_task is not None
-    assert isinstance(web_app_module.app.state.temp_file_cleanup_stop, threading.Event)
 
 
 @pytest.mark.asyncio
@@ -1064,15 +1061,105 @@ async def test_startup_event_no_task_when_no_table_needs_migration(
     if created_tasks:
         await asyncio.gather(*created_tasks)
 
-    # We expect 2 tasks: uploaded files reconcile + orphaned temp-file cleanup
-    # (both run under auto_migrate even without migration needs)
-    assert len(created_tasks) == 2
+    # We expect 1 task: uploaded files reconcile (runs under auto_migrate even
+    # without migration needs). The orphaned temp-file cleanup task is gated off
+    # under pytest; its lifecycle is covered by the dedicated shutdown test.
+    assert len(created_tasks) == 1
     assert migration_called["value"] is False
-    # The count bump alone can't tell whether the temp-file cleanup task was
-    # wired: assert it is tracked on app.state alongside its cooperative stop
-    # flag, so removing either would fail here (see app.py shutdown handling).
-    assert web_app_module.app.state.temp_file_cleanup_task is not None
-    assert isinstance(web_app_module.app.state.temp_file_cleanup_stop, threading.Event)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_event_stops_temp_file_cleanup_without_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Shutdown must signal the cleanup stop flag first and NOT cancel the task.
+
+    Covers the two round-2 majors on the shutdown path: the stop flag is set
+    before any other teardown (so an earlier hang cannot strand the executor
+    thread), and the task is awaited via asyncio.wait rather than cancelled.
+    """
+    import importlib
+
+    _patch_channel_modules_disabled(monkeypatch)
+    web_app_module = importlib.import_module("xagent.web.app")
+    app = web_app_module.app
+
+    async def _anoop(*args, **kwargs):
+        return None
+
+    def _noop(*args, **kwargs):
+        return None
+
+    # Neutralize the unrelated teardown steps so only the temp-cleanup stop/await
+    # path is exercised.
+    for name in (
+        "stop_orphan_upload_gc_task",
+        "stop_uploaded_file_recovery_task",
+        "stop_task_lease_recovery_task",
+    ):
+        monkeypatch.setattr(web_app_module, name, _anoop)
+    monkeypatch.setattr(web_app_module, "unregister_local_browser_runtime", _noop)
+    for name in (
+        "_task_command_dispatcher_task",
+        "_sandbox_idle_sweep_task",
+        "_file_storage_startup_sync_task",
+        "_trigger_dispatcher_task",
+        "_migration_task",
+    ):
+        monkeypatch.setattr(web_app_module, name, None)
+
+    class _FakeBackgroundTaskManager:
+        async def shutdown(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.background_task_manager",
+        _FakeBackgroundTaskManager(),
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.task_lease_service.wait_for_heartbeat_manager_idle",
+        _anoop,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.task_runtime.shutdown_task_runtime_hook_executor",
+        _noop,
+    )
+    monkeypatch.setattr(
+        "xagent.web.sandbox_manager.get_sandbox_manager",
+        lambda: None,
+    )
+
+    stop = threading.Event()
+    flush_saw_stop = {}
+
+    def _spy_flush() -> None:
+        # N2: the stop flag must already be set by the time the first teardown
+        # step (flush_langfuse) runs.
+        flush_saw_stop["set"] = stop.is_set()
+
+    monkeypatch.setattr(web_app_module, "flush_langfuse", _spy_flush)
+
+    started = asyncio.Event()
+
+    async def _cooperative_walk() -> None:
+        started.set()
+        while not stop.is_set():
+            await asyncio.sleep(0.01)
+
+    task = asyncio.create_task(_cooperative_walk())
+    await started.wait()
+
+    app.state.temp_file_cleanup_stop = stop
+    app.state.temp_file_cleanup_task = task
+
+    await web_app_module.shutdown_event()
+
+    assert flush_saw_stop["set"] is True
+    assert stop.is_set()
+    assert task.done()
+    assert not task.cancelled()
+    assert app.state.temp_file_cleanup_task is None
+    assert app.state.temp_file_cleanup_stop is None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -1294,6 +1294,12 @@ async def test_failed_startup_leaves_no_unsignaled_temp_file_cleanup(
     must be no cleanup task that is both unfinished and unsignaled. Scheduling
     the sweep only after every failure-prone startup step satisfies it, and so
     would signalling the flag on the way out.
+
+    The invariant alone is weak here -- today it holds because the sweep is
+    never reached, so ``task is None`` satisfies it -- so this also pins the
+    reason: the induced failure must land *before* the scheduling point. That
+    is the regression worth catching, because moving the scheduling earlier is
+    what would leave a walk running with no way to stop it.
     """
     import importlib
 
@@ -1341,8 +1347,9 @@ async def test_failed_startup_leaves_no_unsignaled_temp_file_cleanup(
     # the failure path under test to be reachable at all.
     monkeypatch.setenv("LANCEDB_AUTO_MIGRATE", "true")
     # The same genuine SANDBOX_VOLUMES/code-mount conflict as
-    # test_startup_event_raises_on_readiness_conflict_with_probe_true: startup
-    # fails *after* the point where the sweep is scheduled today.
+    # test_startup_event_raises_on_readiness_conflict_with_probe_true. Static
+    # readiness runs well before the sweep is scheduled, so this failure lands
+    # ahead of every position the sweep must not be scheduled at.
     monkeypatch.setenv("SANDBOX_VOLUMES", "/foo:/guest1:ro")
     monkeypatch.setattr(
         "xagent.web.sandbox_manager.build_code_mount_volumes",
@@ -1416,6 +1423,7 @@ async def test_failed_startup_leaves_no_unsignaled_temp_file_cleanup(
     )
 
     real_start = web_app_module.start_temp_file_cleanup_task
+    scheduling_reached = []
 
     def _start_ungated(app_instance):
         # Exercise the REAL wrapper, whose own PYTEST_CURRENT_TEST gate would
@@ -1423,6 +1431,7 @@ async def test_failed_startup_leaves_no_unsignaled_temp_file_cleanup(
         # this call keeps the five unrelated gates in startup_event (trigger
         # dispatcher, lease/upload recovery, orphan GC, metadata rebuild) in
         # force, so the failure path is the only thing this test un-gates.
+        scheduling_reached.append(app_instance)
         saved = os.environ.pop("PYTEST_CURRENT_TEST", None)
         try:
             return real_start(app_instance)
@@ -1451,6 +1460,11 @@ async def test_failed_startup_leaves_no_unsignaled_temp_file_cleanup(
     try:
         with pytest.raises(SandboxRuntimeConflictError):
             await web_app_module.startup_event()
+
+        # WHY: pins the reason the invariant below holds -- the raising step
+        # comes first, so the sweep was never scheduled. Without this, moving
+        # the scheduling earlier could still satisfy it and pass on luck.
+        assert scheduling_reached == []
 
         task = getattr(app.state, "temp_file_cleanup_task", None)
         stop = getattr(app.state, "temp_file_cleanup_stop", None)
@@ -1820,4 +1834,123 @@ async def test_startup_reports_a_still_unwinding_previous_cleanup(
         app.state.temp_file_cleanup_stop = None
 
     # The guard held: exactly one sweep ran, using the first generation's flag.
+    assert sweeps_started == [first_stop]
+
+
+@pytest.mark.asyncio
+async def test_background_cleanup_logs_a_failing_sweep_with_its_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A sweep that raises must be reported with its traceback, not swallowed.
+
+    The walk runs unattended in an executor thread: nothing awaits the task
+    for a result and no request path sees the exception, so this WARNING is
+    the failure's only surface. Without it a sweep that never cleans anything
+    looks exactly like one with nothing to clean.
+    """
+    import importlib
+
+    web_app_module = importlib.import_module("xagent.web.app")
+    app = web_app_module.app
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    app.state.temp_file_cleanup_task = None
+    app.state.temp_file_cleanup_stop = None
+
+    def _failing_cleanup(*, stop_event=None) -> int:
+        raise OSError("uploads root vanished mid-sweep")
+
+    monkeypatch.setattr(
+        "xagent.web.services.storage_maintenance.cleanup_orphaned_temp_files",
+        _failing_cleanup,
+    )
+
+    records: list[logging.LogRecord] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    collector = _Collect()
+    web_app_module.logger.addHandler(collector)
+    try:
+        task = web_app_module.start_temp_file_cleanup_task(app)
+        assert task is not None
+        await task
+        # Nothing retrieves this task's result in production, so a failure
+        # left on it would surface only as an "exception was never retrieved"
+        # warning at interpreter exit -- long after the sweep mattered.
+        assert task.exception() is None
+    finally:
+        web_app_module.logger.removeHandler(collector)
+        app.state.temp_file_cleanup_task = None
+        app.state.temp_file_cleanup_stop = None
+
+    failures = [
+        r
+        for r in records
+        if r.levelno == logging.WARNING and "cleanup failed" in r.getMessage()
+    ]
+    assert len(failures) == 1
+    assert failures[0].exc_info is not None
+    assert "uploads root vanished mid-sweep" in logging.Formatter().formatException(
+        failures[0].exc_info
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_reuses_a_live_unsignaled_cleanup_generation(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A live, unsignalled sweep is handed back, not joined by a second walk.
+
+    Sibling of the still-unwinding case above: same guard, opposite state.
+    Two concurrent walks over one tree would race each other's unlinks, and
+    the newer generation's stop event would overwrite the older one's on
+    app.state -- orphaning the only handle that can stop the walk in flight.
+    """
+    import importlib
+
+    web_app_module = importlib.import_module("xagent.web.app")
+    app = web_app_module.app
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    app.state.temp_file_cleanup_task = None
+    app.state.temp_file_cleanup_stop = None
+
+    release = threading.Event()
+    sweeps_started: list[threading.Event] = []
+
+    def _stalled_cleanup(*, stop_event=None) -> int:
+        sweeps_started.append(stop_event)
+        release.wait(timeout=5)
+        return 0
+
+    monkeypatch.setattr(
+        "xagent.web.services.storage_maintenance.cleanup_orphaned_temp_files",
+        _stalled_cleanup,
+    )
+
+    try:
+        first = web_app_module.start_temp_file_cleanup_task(app)
+        assert first is not None
+        first_stop = app.state.temp_file_cleanup_stop
+
+        # Still sweeping and never signalled -- unlike the unwinding sibling.
+        assert not first.done()
+        assert not first_stop.is_set()
+
+        second = web_app_module.start_temp_file_cleanup_task(app)
+
+        assert second is first
+        assert app.state.temp_file_cleanup_task is first
+        assert app.state.temp_file_cleanup_stop is first_stop
+        assert not first_stop.is_set()
+    finally:
+        release.set()
+        await first
+        app.state.temp_file_cleanup_task = None
+        app.state.temp_file_cleanup_stop = None
+
+    # The guard held: one walk, still holding the flag shutdown would set.
     assert sweeps_started == [first_stop]

--- a/tests/web/api/test_kb_orphaned_temp_cleanup.py
+++ b/tests/web/api/test_kb_orphaned_temp_cleanup.py
@@ -1,0 +1,82 @@
+import os
+import threading
+import time
+from pathlib import Path
+
+from xagent.web.api.kb import cleanup_orphaned_temp_files
+
+# Any file whose mtime is older than this is treated as orphaned by the sweep.
+ORPHAN_AGE_SECONDS = 3600
+
+
+def _write_aged(path: Path, *, age: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x")
+    stamp = time.time() - age
+    os.utime(path, (stamp, stamp))
+
+
+def test_cleanup_removes_only_aged_orphan_temp_files_across_subtree(tmp_path: Path):
+    old = ORPHAN_AGE_SECONDS + 600
+
+    # Orphaned temp files (old enough) — should be removed, including nested.
+    _write_aged(tmp_path / "old.tmp-replace", age=old)
+    _write_aged(tmp_path / "data.ab12cd.tmp", age=old)
+    _write_aged(tmp_path / "sub" / "nested.tmp-replace", age=old)
+    _write_aged(tmp_path / "sub" / "deep" / "d.xy.tmp", age=old)
+
+    # Kept: recent orphan, non-temp file, and the two-dot-part `report.tmp`
+    # (only "report" + "tmp", so it is not a NamedTemporaryFile-style name).
+    _write_aged(tmp_path / "fresh.ab12cd.tmp", age=0)
+    _write_aged(tmp_path / "keep.txt", age=old)
+    _write_aged(tmp_path / "report.tmp", age=old)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    assert removed == 4
+    assert not (tmp_path / "old.tmp-replace").exists()
+    assert not (tmp_path / "data.ab12cd.tmp").exists()
+    assert not (tmp_path / "sub" / "nested.tmp-replace").exists()
+    assert not (tmp_path / "sub" / "deep" / "d.xy.tmp").exists()
+    assert (tmp_path / "fresh.ab12cd.tmp").exists()
+    assert (tmp_path / "keep.txt").exists()
+    assert (tmp_path / "report.tmp").exists()
+
+
+def test_cleanup_returns_zero_for_missing_dir(tmp_path: Path):
+    assert cleanup_orphaned_temp_files(upload_dir=tmp_path / "does-not-exist") == 0
+
+
+def test_cleanup_stops_early_when_stop_event_is_set(tmp_path: Path):
+    _write_aged(tmp_path / "old.tmp-replace", age=ORPHAN_AGE_SECONDS + 600)
+
+    stop = threading.Event()
+    stop.set()
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path, stop_event=stop)
+
+    assert removed == 0
+    assert (tmp_path / "old.tmp-replace").exists()
+
+
+def test_cleanup_tolerates_unlink_failure_and_keeps_sweeping(tmp_path, monkeypatch):
+    old = ORPHAN_AGE_SECONDS + 600
+    _write_aged(tmp_path / "boom.tmp-replace", age=old)
+    _write_aged(tmp_path / "ok.tmp-replace", age=old)
+
+    import xagent.web.api.kb as kb_module
+
+    real_unlink = os.unlink
+
+    def _selective_unlink(path, *args, **kwargs):
+        if str(path).endswith("boom.tmp-replace"):
+            raise OSError("permission denied")
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(kb_module.os, "unlink", _selective_unlink)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    assert removed == 1
+    assert (tmp_path / "boom.tmp-replace").exists()
+    assert not (tmp_path / "ok.tmp-replace").exists()

--- a/tests/web/api/test_kb_orphaned_temp_cleanup.py
+++ b/tests/web/api/test_kb_orphaned_temp_cleanup.py
@@ -274,3 +274,122 @@ def test_cleanup_tolerates_unlink_failure_and_keeps_sweeping(tmp_path, monkeypat
     assert removed == 1
     assert (tmp_path / "boom.tmp-replace").exists()
     assert not (tmp_path / "ok.tmp-replace").exists()
+
+
+class _TrackedScandir:
+    """Pass-through os.scandir wrapper that reports whether it is still open."""
+
+    def __init__(self, it, open_dirs: set, path: str) -> None:
+        self._it = it
+        self._open_dirs = open_dirs
+        self._path = path
+        open_dirs.add(path)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._it)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        self.close()
+        return False
+
+    def close(self) -> None:
+        self._open_dirs.discard(self._path)
+        self._it.close()
+
+
+def test_cleanup_never_unlinks_while_its_directory_scan_is_open(
+    tmp_path: Path, monkeypatch
+):
+    """Unlink must happen only after the directory's scandir stream is closed.
+
+    Whether readdir() still returns the remaining entries of a directory that
+    was modified mid-iteration is unspecified by POSIX, so unlinking inside the
+    scan can silently skip siblings -- and this sweep runs once per process with
+    no resumption, so a skipped orphan is never reclaimed. os.walk (exhausts and
+    closes before yielding) and shutil.rmtree (materializes list(scandir_it))
+    both avoid this; pin that the sweep does too.
+
+    Bookkeeping is scoped to paths under tmp_path so the pass-through wrappers
+    stay inert for any other os.scandir/os.unlink caller in the process.
+    """
+    import xagent.web.api.kb as kb_module
+
+    old = ORPHAN_AGE_SECONDS + 600
+    # Several matches in one directory: the case where a mid-scan unlink could
+    # perturb the iteration and drop siblings.
+    for i in range(20):
+        _write_aged(tmp_path / f"o{i:02d}.ab12cd.tmp", age=old)
+    _write_aged(tmp_path / "sub" / "nested.xy.tmp", age=old)
+
+    open_dirs: set = set()
+    real_scandir = os.scandir
+    real_unlink = os.unlink
+    unlinks_with_open_scan: list = []
+
+    def _tracked_scandir(path, *args, **kwargs):
+        it = real_scandir(path, *args, **kwargs)
+        if str(path).startswith(str(tmp_path)):
+            return _TrackedScandir(it, open_dirs, str(path))
+        return it
+
+    def _tracked_unlink(path, *args, **kwargs):
+        if open_dirs and str(path).startswith(str(tmp_path)):
+            unlinks_with_open_scan.append(str(path))
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(kb_module.os, "scandir", _tracked_scandir)
+    monkeypatch.setattr(kb_module.os, "unlink", _tracked_unlink)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    assert removed == 21
+    assert unlinks_with_open_scan == []
+    assert open_dirs == set()
+
+
+def test_completed_sweep_is_not_reported_as_truncated(tmp_path, monkeypatch, caplog):
+    """A sweep that finished the tree must not log itself as cut short.
+
+    Shutdown sets the stop flag as its very first statement, so it can land
+    while the final directory is being scanned -- the tree still gets fully
+    walked. Re-reading the flag after the loop would report that completed
+    sweep as truncated and tell operators to expect leftover orphans that do
+    not exist, so the walk must track "stopped early" as it goes instead.
+    """
+    import logging
+
+    import xagent.web.api.kb as kb_module
+
+    # A dedicated single-directory root: the walk must have nothing left on its
+    # stack when the flag is set, so that "flag set but tree fully walked" is
+    # the only state under test. (A shared conftest fixture seeds tmp_path
+    # itself with a lancedb/ subdirectory, which would legitimately still be
+    # pending and make an early stop the correct outcome.)
+    root = tmp_path / "uploads"
+    root.mkdir()
+    _write_aged(root / "only.ab12cd.tmp", age=ORPHAN_AGE_SECONDS + 600)
+
+    stop = threading.Event()
+    real_unlink = os.unlink
+
+    def _unlink_then_signal_shutdown(path, *args, **kwargs):
+        # Shutdown fires exactly while the last victims are being removed.
+        result = real_unlink(path, *args, **kwargs)
+        stop.set()
+        return result
+
+    monkeypatch.setattr(kb_module.os, "unlink", _unlink_then_signal_shutdown)
+
+    with caplog.at_level(logging.INFO, logger="xagent.web.api.kb"):
+        removed = cleanup_orphaned_temp_files(upload_dir=root, stop_event=stop)
+
+    assert removed == 1
+    assert stop.is_set()
+    assert "was not fully walked" not in caplog.text
+    assert "Cleaned up 1 orphaned temporary file(s)" in caplog.text

--- a/tests/web/api/test_kb_orphaned_temp_cleanup.py
+++ b/tests/web/api/test_kb_orphaned_temp_cleanup.py
@@ -3,7 +3,10 @@ import threading
 import time
 from pathlib import Path
 
-from xagent.web.api.kb import cleanup_orphaned_temp_files
+from xagent.web.api.kb import (
+    _TEMP_CLEANUP_STOP_CHECK_ENTRIES,
+    cleanup_orphaned_temp_files,
+)
 
 # Any file whose mtime is older than this is treated as orphaned by the sweep.
 ORPHAN_AGE_SECONDS = 3600
@@ -95,6 +98,40 @@ def test_cleanup_stops_midwalk_at_directory_boundary(tmp_path: Path):
     assert (tmp_path / "sub" / "nested.tmp-replace").exists()
 
 
+class _StopAfterEntryCheck:
+    """Stop flag unset for the per-directory boundary check, set thereafter.
+
+    The walk's outer per-directory check runs once before a directory is
+    opened; returning False there lets the walk actually enter the single
+    large flat directory under test. Every later poll -- all of which come
+    from the per-entry check inside that directory's scan -- returns True, so
+    only that per-entry check (not the per-directory one) can catch this stop.
+    """
+
+    def __init__(self) -> None:
+        self._calls = 0
+
+    def is_set(self) -> bool:
+        self._calls += 1
+        return self._calls > 1
+
+
+def test_cleanup_stops_mid_directory_scan_on_large_flat_directory(tmp_path: Path):
+    old = ORPHAN_AGE_SECONDS + 600
+    total = _TEMP_CLEANUP_STOP_CHECK_ENTRIES * 2
+    for i in range(total):
+        _write_aged(tmp_path / f"orphan_{i:04d}.tmp-replace", age=old)
+
+    stop = _StopAfterEntryCheck()
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path, stop_event=stop)
+
+    # A per-directory-only stop check could never interrupt a single huge
+    # flat directory. The per-entry check must have caught this stop partway
+    # through the scan, so some but not all orphans were swept.
+    assert 0 < removed < total
+
+
 def test_cleanup_excludes_symlinks_named_like_temp_files(tmp_path: Path):
     # Agent file registration creates real symlinks named like temp files under
     # the uploads tree (websocket.py _register_uploaded_files_for_agent). Those
@@ -110,6 +147,43 @@ def test_cleanup_excludes_symlinks_named_like_temp_files(tmp_path: Path):
     assert removed == 0
     assert link.is_symlink()
     assert target.exists()
+
+
+def test_cleanup_skips_symlinked_directory_named_like_temp_file(tmp_path: Path):
+    # A symlink to a directory, named like a temp file, must be neither
+    # descended into nor deleted: is_dir(follow_symlinks=False) and
+    # is_file(follow_symlinks=False) both report False for it, so it is
+    # simply skipped. The target lives outside the walked upload_dir, so the
+    # only way its contents could be reached is by following the symlink.
+    upload_dir = tmp_path / "uploads"
+    external_target = tmp_path / "external_target_not_walked"
+    _write_aged(external_target / "nested.tmp-replace", age=ORPHAN_AGE_SECONDS + 600)
+
+    upload_dir.mkdir()
+    link = upload_dir / "linked.abc123.tmp"
+    link.symlink_to(external_target, target_is_directory=True)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=upload_dir)
+
+    assert removed == 0
+    assert link.is_symlink()
+    assert (external_target / "nested.tmp-replace").exists()
+
+
+def test_cleanup_recurses_into_real_directory_named_like_temp_file(tmp_path: Path):
+    # A real (non-symlink) directory is always descended into via
+    # is_dir(follow_symlinks=False), regardless of whether its own name
+    # happens to match the temp-file pattern -- only file entries are tested
+    # against _is_orphaned_temp_name.
+    old = ORPHAN_AGE_SECONDS + 600
+    dir_named_like_temp = tmp_path / "batch.abc123.tmp"
+    _write_aged(dir_named_like_temp / "nested.tmp-replace", age=old)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    assert removed == 1
+    assert dir_named_like_temp.is_dir()
+    assert not (dir_named_like_temp / "nested.tmp-replace").exists()
 
 
 def test_cleanup_skips_directory_that_fails_to_open(tmp_path, monkeypatch):

--- a/tests/web/api/test_kb_orphaned_temp_cleanup.py
+++ b/tests/web/api/test_kb_orphaned_temp_cleanup.py
@@ -59,36 +59,40 @@ def test_cleanup_stops_early_when_stop_event_is_set(tmp_path: Path):
     assert (tmp_path / "old.tmp-replace").exists()
 
 
-class _StopAfter:
-    """Stop flag that reports 'set' only from its Nth is_set() poll onward.
+class _StopAfterFirstPoll:
+    """Stop flag that is unset on its first poll and set on every poll after.
 
-    Proves the walk checks the flag once per directory rather than only once
-    before the loop: with a nested tree, tripping after the root + one subdir
-    have been visited leaves the remaining subdir untouched.
+    The seed (root) directory is always popped on the first poll, so the walk
+    processes root and then breaks before descending into any subdirectory.
+    This pins the per-directory granularity without depending on the exact poll
+    count or on scandir ordering: if the flag were checked only once before the
+    loop it would be unset (first poll), so the subdir file would be swept too.
     """
 
-    def __init__(self, trip_on_call: int) -> None:
-        self._calls = 0
-        self._trip = trip_on_call
+    def __init__(self) -> None:
+        self._polled = False
 
     def is_set(self) -> bool:
-        self._calls += 1
-        return self._calls >= self._trip
+        if not self._polled:
+            self._polled = True
+            return False
+        return True
 
 
 def test_cleanup_stops_midwalk_at_directory_boundary(tmp_path: Path):
     old = ORPHAN_AGE_SECONDS + 600
-    _write_aged(tmp_path / "a" / "x.tmp-replace", age=old)
-    _write_aged(tmp_path / "b" / "y.tmp-replace", age=old)
+    # One orphan in the root, one nested a level down. The stop trips after the
+    # root directory is processed, so the subdir is never descended into.
+    _write_aged(tmp_path / "root_orphan.tmp-replace", age=old)
+    _write_aged(tmp_path / "sub" / "nested.tmp-replace", age=old)
 
-    # Poll 1: pop root, push a + b. Poll 2: pop one subdir, sweep its file.
-    # Poll 3: reports set -> break before the second subdir is swept.
-    stop = _StopAfter(trip_on_call=3)
+    stop = _StopAfterFirstPoll()
 
     removed = cleanup_orphaned_temp_files(upload_dir=tmp_path, stop_event=stop)
 
     assert removed == 1
-    assert len(list(tmp_path.rglob("*.tmp-replace"))) == 1
+    assert not (tmp_path / "root_orphan.tmp-replace").exists()
+    assert (tmp_path / "sub" / "nested.tmp-replace").exists()
 
 
 def test_cleanup_excludes_symlinks_named_like_temp_files(tmp_path: Path):

--- a/tests/web/api/test_kb_orphaned_temp_cleanup.py
+++ b/tests/web/api/test_kb_orphaned_temp_cleanup.py
@@ -59,6 +59,122 @@ def test_cleanup_stops_early_when_stop_event_is_set(tmp_path: Path):
     assert (tmp_path / "old.tmp-replace").exists()
 
 
+class _StopAfter:
+    """Stop flag that reports 'set' only from its Nth is_set() poll onward.
+
+    Proves the walk checks the flag once per directory rather than only once
+    before the loop: with a nested tree, tripping after the root + one subdir
+    have been visited leaves the remaining subdir untouched.
+    """
+
+    def __init__(self, trip_on_call: int) -> None:
+        self._calls = 0
+        self._trip = trip_on_call
+
+    def is_set(self) -> bool:
+        self._calls += 1
+        return self._calls >= self._trip
+
+
+def test_cleanup_stops_midwalk_at_directory_boundary(tmp_path: Path):
+    old = ORPHAN_AGE_SECONDS + 600
+    _write_aged(tmp_path / "a" / "x.tmp-replace", age=old)
+    _write_aged(tmp_path / "b" / "y.tmp-replace", age=old)
+
+    # Poll 1: pop root, push a + b. Poll 2: pop one subdir, sweep its file.
+    # Poll 3: reports set -> break before the second subdir is swept.
+    stop = _StopAfter(trip_on_call=3)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path, stop_event=stop)
+
+    assert removed == 1
+    assert len(list(tmp_path.rglob("*.tmp-replace"))) == 1
+
+
+def test_cleanup_excludes_symlinks_named_like_temp_files(tmp_path: Path):
+    # Agent file registration creates real symlinks named like temp files under
+    # the uploads tree (websocket.py _register_uploaded_files_for_agent). Those
+    # point into live workspaces and must be skipped, not unlinked. The old
+    # os.walk-based sweep would stat through the link and remove it.
+    target = tmp_path / "workspace_input" / "payload.bin"
+    _write_aged(target, age=ORPHAN_AGE_SECONDS + 600)
+    link = tmp_path / "data.v1.tmp"
+    link.symlink_to(target)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    assert removed == 0
+    assert link.is_symlink()
+    assert target.exists()
+
+
+def test_cleanup_skips_directory_that_fails_to_open(tmp_path, monkeypatch):
+    old = ORPHAN_AGE_SECONDS + 600
+    _write_aged(tmp_path / "good" / "keep.tmp-replace", age=old)
+    (tmp_path / "bad").mkdir()
+
+    import xagent.web.api.kb as kb_module
+
+    real_scandir = os.scandir
+
+    def _flaky_scandir(path, *args, **kwargs):
+        if str(path).endswith("bad"):
+            raise OSError("stale handle")
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(kb_module.os, "scandir", _flaky_scandir)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    assert removed == 1
+    assert not (tmp_path / "good" / "keep.tmp-replace").exists()
+
+
+def test_cleanup_tolerates_error_mid_iteration(tmp_path, monkeypatch):
+    # A directory-level OSError raised while iterating entries (e.g. NFS ESTALE)
+    # must skip that directory, not abort the whole sweep.
+    old = ORPHAN_AGE_SECONDS + 600
+    _write_aged(tmp_path / "root_orphan.tmp-replace", age=old)
+
+    import xagent.web.api.kb as kb_module
+
+    real_scandir = os.scandir
+
+    class _RaiseAtEnd:
+        """Yields the real entries, then raises OSError instead of stopping."""
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self._inner.close()
+            return False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            try:
+                return next(self._inner)
+            except StopIteration:
+                raise OSError("ESTALE mid-iteration") from None
+
+    def _wrapped_scandir(path, *args, **kwargs):
+        return _RaiseAtEnd(real_scandir(path, *args, **kwargs))
+
+    monkeypatch.setattr(kb_module.os, "scandir", _wrapped_scandir)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    # The orphan was unlinked before the mid-iteration error, and the sweep
+    # returned normally instead of propagating the OSError.
+    assert removed == 1
+    assert not (tmp_path / "root_orphan.tmp-replace").exists()
+
+
 def test_cleanup_tolerates_unlink_failure_and_keeps_sweeping(tmp_path, monkeypatch):
     old = ORPHAN_AGE_SECONDS + 600
     _write_aged(tmp_path / "boom.tmp-replace", age=old)

--- a/tests/web/api/test_kb_orphaned_temp_cleanup.py
+++ b/tests/web/api/test_kb_orphaned_temp_cleanup.py
@@ -393,3 +393,129 @@ def test_completed_sweep_is_not_reported_as_truncated(tmp_path, monkeypatch, cap
     assert stop.is_set()
     assert "was not fully walked" not in caplog.text
     assert "Cleaned up 1 orphaned temporary file(s)" in caplog.text
+
+
+class _StopAfterNPolls:
+    """Stop flag that stays unset for the first ``allowed`` polls, then trips.
+
+    Lets a test place the stop signal at an exact point in the walk's poll
+    sequence -- per-directory check, per-entry check, per-victim check --
+    without depending on wall-clock timing or on scandir ordering.
+    """
+
+    def __init__(self, allowed: int) -> None:
+        self._polls = 0
+        self._allowed = allowed
+
+    def is_set(self) -> bool:
+        self._polls += 1
+        return self._polls > self._allowed
+
+
+def test_cleanup_stops_mid_deletion_on_a_directory_with_many_victims(
+    tmp_path: Path, caplog
+):
+    """A stop signalled mid-deletion must leave the remaining victims alone.
+
+    The scan polls the stop flag, but the deletion phase that follows it used
+    to run every queued unlink unconditionally. A directory holding many aged
+    temp files (an agent workspace's ``temp``/``output``, where unlink latency
+    on network storage is tens of milliseconds) could therefore outlive both
+    the shutdown grace period and the executor join. The deletion phase is
+    bounded by the same chunk size as the scan, so it stops after at most one
+    chunk instead of draining the whole list.
+    """
+    import logging
+
+    # A dedicated root: a shared conftest fixture seeds tmp_path itself with a
+    # lancedb/ subdirectory, which would consume a poll and shift the counts
+    # this test pins.
+    root = tmp_path / "uploads"
+    root.mkdir()
+    leftover = 100
+    total = _TEMP_CLEANUP_STOP_CHECK_ENTRIES + leftover
+    for i in range(total):
+        _write_aged(root / f"v{i:04d}.ab12cd.tmp", age=ORPHAN_AGE_SECONDS + 600)
+
+    # Poll 1 is the per-directory check and poll 2 the scan's per-entry check
+    # at entry _TEMP_CLEANUP_STOP_CHECK_ENTRIES -- both must be unset so the
+    # walk reaches the deletion phase with a full chunk queued. Poll 3 is the
+    # deletion phase's own check, one chunk in.
+    stop = _StopAfterNPolls(2)
+
+    with caplog.at_level(logging.INFO, logger="xagent.web.api.kb"):
+        removed = cleanup_orphaned_temp_files(upload_dir=root, stop_event=stop)
+
+    assert removed == _TEMP_CLEANUP_STOP_CHECK_ENTRIES
+    assert len(list(root.iterdir())) == leftover
+    assert "was not fully walked" in caplog.text
+
+
+class _SwapQueuedDirForSymlinkOnDescend:
+    """Replaces ``target`` with a symlink to ``elsewhere`` just before descend.
+
+    The per-directory stop poll is the injection point: it runs after one
+    directory has been scanned (so ``target`` is already on the walk's stack)
+    and before the next directory is popped and opened. Never sets the flag,
+    so the walk is not interrupted -- only the queued pathname changes under
+    it, exactly as a concurrent writer could do.
+    """
+
+    def __init__(self, target: Path, elsewhere: Path) -> None:
+        self._polls = 0
+        self._target = target
+        self._elsewhere = elsewhere
+
+    def is_set(self) -> bool:
+        self._polls += 1
+        if self._polls == 2:
+            self._target.rmdir()
+            self._target.symlink_to(self._elsewhere, target_is_directory=True)
+        return False
+
+
+def test_cleanup_does_not_descend_into_a_queued_dir_swapped_for_a_symlink(
+    tmp_path: Path,
+):
+    """A queued directory replaced by a symlink must not be followed.
+
+    ``entry.is_dir(follow_symlinks=False)`` is evaluated while the *parent* is
+    being scanned, but ``os.scandir()`` on the retained str path follows
+    symlinks, and the DFS stack can hold that pathname for the rest of the
+    sweep. os.walk() guards exactly this with a fresh ``islink()`` immediately
+    before recursing (CPython bpo-23605: "the caller can replace the directory
+    entry during the yield"), so dropping the recheck would let the sweep
+    escape the uploads root and delete aged temp-named files anywhere.
+    """
+    inside = tmp_path / "uploads"
+    outside = tmp_path / "outside_the_uploads_root"
+    inside.mkdir()
+    _write_aged(outside / "secret.ab12cd.tmp", age=ORPHAN_AGE_SECONDS + 600)
+    queued = inside / "queued"
+    queued.mkdir()
+
+    swap = _SwapQueuedDirForSymlinkOnDescend(queued, outside)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=inside, stop_event=swap)
+
+    assert removed == 0
+    assert (outside / "secret.ab12cd.tmp").exists()
+
+
+def test_cleanup_walks_an_uploads_root_that_is_itself_a_symlink(tmp_path: Path):
+    """The no-follow recheck must apply to descended dirs, not to the root.
+
+    os.walk() never tested whether ``top`` itself is a symlink, and the uploads
+    root legitimately is one in deployments that point it at a mounted volume.
+    Rejecting a symlinked root would silently stop reclaiming temp files on
+    exactly those hosts.
+    """
+    real_root = tmp_path / "mounted_volume"
+    _write_aged(real_root / "old.tmp-replace", age=ORPHAN_AGE_SECONDS + 600)
+    link_root = tmp_path / "uploads"
+    link_root.symlink_to(real_root, target_is_directory=True)
+
+    removed = cleanup_orphaned_temp_files(upload_dir=link_root)
+
+    assert removed == 1
+    assert not (real_root / "old.tmp-replace").exists()

--- a/tests/web/services/test_storage_maintenance_temp_cleanup.py
+++ b/tests/web/services/test_storage_maintenance_temp_cleanup.py
@@ -1,9 +1,11 @@
+import logging
 import os
 import threading
 import time
 from pathlib import Path
 
-from xagent.web.api.kb import (
+import xagent.web.services.storage_maintenance as sweep_module
+from xagent.web.services.storage_maintenance import (
     _TEMP_CLEANUP_STOP_CHECK_ENTRIES,
     cleanup_orphaned_temp_files,
 )
@@ -191,8 +193,6 @@ def test_cleanup_skips_directory_that_fails_to_open(tmp_path, monkeypatch):
     _write_aged(tmp_path / "good" / "keep.tmp-replace", age=old)
     (tmp_path / "bad").mkdir()
 
-    import xagent.web.api.kb as kb_module
-
     real_scandir = os.scandir
 
     def _flaky_scandir(path, *args, **kwargs):
@@ -200,7 +200,7 @@ def test_cleanup_skips_directory_that_fails_to_open(tmp_path, monkeypatch):
             raise OSError("stale handle")
         return real_scandir(path, *args, **kwargs)
 
-    monkeypatch.setattr(kb_module.os, "scandir", _flaky_scandir)
+    monkeypatch.setattr(sweep_module.os, "scandir", _flaky_scandir)
 
     removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
 
@@ -213,8 +213,6 @@ def test_cleanup_tolerates_error_mid_iteration(tmp_path, monkeypatch):
     # must skip that directory, not abort the whole sweep.
     old = ORPHAN_AGE_SECONDS + 600
     _write_aged(tmp_path / "root_orphan.tmp-replace", age=old)
-
-    import xagent.web.api.kb as kb_module
 
     real_scandir = os.scandir
 
@@ -243,7 +241,7 @@ def test_cleanup_tolerates_error_mid_iteration(tmp_path, monkeypatch):
     def _wrapped_scandir(path, *args, **kwargs):
         return _RaiseAtEnd(real_scandir(path, *args, **kwargs))
 
-    monkeypatch.setattr(kb_module.os, "scandir", _wrapped_scandir)
+    monkeypatch.setattr(sweep_module.os, "scandir", _wrapped_scandir)
 
     removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
 
@@ -258,8 +256,6 @@ def test_cleanup_tolerates_unlink_failure_and_keeps_sweeping(tmp_path, monkeypat
     _write_aged(tmp_path / "boom.tmp-replace", age=old)
     _write_aged(tmp_path / "ok.tmp-replace", age=old)
 
-    import xagent.web.api.kb as kb_module
-
     real_unlink = os.unlink
 
     def _selective_unlink(path, *args, **kwargs):
@@ -267,7 +263,7 @@ def test_cleanup_tolerates_unlink_failure_and_keeps_sweeping(tmp_path, monkeypat
             raise OSError("permission denied")
         return real_unlink(path, *args, **kwargs)
 
-    monkeypatch.setattr(kb_module.os, "unlink", _selective_unlink)
+    monkeypatch.setattr(sweep_module.os, "unlink", _selective_unlink)
 
     removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
 
@@ -318,8 +314,6 @@ def test_cleanup_never_unlinks_while_its_directory_scan_is_open(
     Bookkeeping is scoped to paths under tmp_path so the pass-through wrappers
     stay inert for any other os.scandir/os.unlink caller in the process.
     """
-    import xagent.web.api.kb as kb_module
-
     old = ORPHAN_AGE_SECONDS + 600
     # Several matches in one directory: the case where a mid-scan unlink could
     # perturb the iteration and drop siblings.
@@ -343,8 +337,8 @@ def test_cleanup_never_unlinks_while_its_directory_scan_is_open(
             unlinks_with_open_scan.append(str(path))
         return real_unlink(path, *args, **kwargs)
 
-    monkeypatch.setattr(kb_module.os, "scandir", _tracked_scandir)
-    monkeypatch.setattr(kb_module.os, "unlink", _tracked_unlink)
+    monkeypatch.setattr(sweep_module.os, "scandir", _tracked_scandir)
+    monkeypatch.setattr(sweep_module.os, "unlink", _tracked_unlink)
 
     removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
 
@@ -362,10 +356,6 @@ def test_completed_sweep_is_not_reported_as_truncated(tmp_path, monkeypatch, cap
     sweep as truncated and tell operators to expect leftover orphans that do
     not exist, so the walk must track "stopped early" as it goes instead.
     """
-    import logging
-
-    import xagent.web.api.kb as kb_module
-
     # A dedicated single-directory root: the walk must have nothing left on its
     # stack when the flag is set, so that "flag set but tree fully walked" is
     # the only state under test. (A shared conftest fixture seeds tmp_path
@@ -384,9 +374,11 @@ def test_completed_sweep_is_not_reported_as_truncated(tmp_path, monkeypatch, cap
         stop.set()
         return result
 
-    monkeypatch.setattr(kb_module.os, "unlink", _unlink_then_signal_shutdown)
+    monkeypatch.setattr(sweep_module.os, "unlink", _unlink_then_signal_shutdown)
 
-    with caplog.at_level(logging.INFO, logger="xagent.web.api.kb"):
+    with caplog.at_level(
+        logging.INFO, logger="xagent.web.services.storage_maintenance"
+    ):
         removed = cleanup_orphaned_temp_files(upload_dir=root, stop_event=stop)
 
     assert removed == 1
@@ -425,8 +417,6 @@ def test_cleanup_stops_mid_deletion_on_a_directory_with_many_victims(
     bounded by the same chunk size as the scan, so it stops after at most one
     chunk instead of draining the whole list.
     """
-    import logging
-
     # A dedicated root: a shared conftest fixture seeds tmp_path itself with a
     # lancedb/ subdirectory, which would consume a poll and shift the counts
     # this test pins.
@@ -443,7 +433,9 @@ def test_cleanup_stops_mid_deletion_on_a_directory_with_many_victims(
     # deletion phase's own check, one chunk in.
     stop = _StopAfterNPolls(2)
 
-    with caplog.at_level(logging.INFO, logger="xagent.web.api.kb"):
+    with caplog.at_level(
+        logging.INFO, logger="xagent.web.services.storage_maintenance"
+    ):
         removed = cleanup_orphaned_temp_files(upload_dir=root, stop_event=stop)
 
     assert removed == _TEMP_CLEANUP_STOP_CHECK_ENTRIES
@@ -519,3 +511,129 @@ def test_cleanup_walks_an_uploads_root_that_is_itself_a_symlink(tmp_path: Path):
 
     assert removed == 1
     assert not (real_root / "old.tmp-replace").exists()
+
+
+class _EntryDouble:
+    """os.DirEntry stand-in whose is_dir/is_file/stat probe can be made to raise.
+
+    Each probe is a separate branch in the walker's shared OSError handler, and
+    a real filesystem cannot be coaxed into failing one probe but not the next.
+    """
+
+    def __init__(self, path: Path, *, raises_on: str) -> None:
+        self.path = str(path)
+        self.name = path.name
+        self._raises_on = raises_on
+
+    def _probe(self, which: str) -> None:
+        if which == self._raises_on:
+            raise OSError(f"{which} failed")
+
+    def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+        self._probe("is_dir")
+        return Path(self.path).is_dir()
+
+    def is_file(self, *, follow_symlinks: bool = True) -> bool:
+        self._probe("is_file")
+        return Path(self.path).is_file()
+
+    def stat(self, *, follow_symlinks: bool = True):
+        self._probe("stat")
+        return os.stat(self.path)
+
+
+def _scandir_yielding_double(monkeypatch, *, directory: Path, double: _EntryDouble):
+    """Make scandir(directory) substitute `double` for the real entry it shadows."""
+    real_scandir = os.scandir
+
+    class _WithDouble:
+        def __init__(self, inner) -> None:
+            self._inner = inner
+            self._pending = [double]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc) -> bool:
+            self._inner.close()
+            return False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._pending:
+                return self._pending.pop()
+            entry = next(self._inner)
+            while entry.path == double.path:
+                entry = next(self._inner)
+            return entry
+
+    def _scandir(path, *args, **kwargs):
+        inner = real_scandir(path, *args, **kwargs)
+        if Path(path) == directory:
+            return _WithDouble(inner)
+        return inner
+
+    monkeypatch.setattr(sweep_module.os, "scandir", _scandir)
+
+
+def test_cleanup_warns_and_isolates_a_failed_directory_probe(
+    tmp_path: Path, monkeypatch, caplog
+):
+    """A failing is_dir() drops a whole subtree, so it must not log as a candidate.
+
+    is_dir/is_file/stat once shared one handler, so an unreadable directory was
+    reported as a skipped "temp-file candidate" at DEBUG -- invisible at INFO,
+    and describing the wrong thing: what was lost is every orphan beneath it.
+    """
+    old = ORPHAN_AGE_SECONDS + 600
+    subtree = tmp_path / "unreadable"
+    _write_aged(subtree / "nested.tmp-replace", age=old)
+    _write_aged(tmp_path / "sibling.tmp-replace", age=old)
+
+    _scandir_yielding_double(
+        monkeypatch,
+        directory=tmp_path,
+        double=_EntryDouble(subtree, raises_on="is_dir"),
+    )
+
+    with caplog.at_level(
+        logging.DEBUG, logger="xagent.web.services.storage_maintenance"
+    ):
+        removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    assert removed == 1
+    assert not (tmp_path / "sibling.tmp-replace").exists()
+    assert (subtree / "nested.tmp-replace").exists()
+
+    probe_records = [r for r in caplog.records if str(subtree) in r.getMessage()]
+    assert [r.levelno for r in probe_records] == [logging.WARNING]
+    assert "candidate" not in probe_records[0].getMessage()
+
+
+def test_cleanup_isolates_a_failed_stat_probe(tmp_path: Path, monkeypatch, caplog):
+    """A candidate whose stat() fails is skipped without disturbing its siblings."""
+    old = ORPHAN_AGE_SECONDS + 600
+    unstattable = tmp_path / "unstattable.ab12cd.tmp"
+    _write_aged(unstattable, age=old)
+    _write_aged(tmp_path / "sibling.tmp-replace", age=old)
+
+    _scandir_yielding_double(
+        monkeypatch,
+        directory=tmp_path,
+        double=_EntryDouble(unstattable, raises_on="stat"),
+    )
+
+    with caplog.at_level(
+        logging.DEBUG, logger="xagent.web.services.storage_maintenance"
+    ):
+        removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
+
+    assert removed == 1
+    assert unstattable.exists()
+    assert not (tmp_path / "sibling.tmp-replace").exists()
+
+    stat_records = [r for r in caplog.records if str(unstattable) in r.getMessage()]
+    assert [r.levelno for r in stat_records] == [logging.DEBUG]
+    assert "temp-file candidate" in stat_records[0].getMessage()

--- a/tests/web/services/test_storage_maintenance_temp_cleanup.py
+++ b/tests/web/services/test_storage_maintenance_temp_cleanup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import xagent.web.services.storage_maintenance as sweep_module
 from xagent.web.services.storage_maintenance import (
+    _TEMP_CLEANUP_DELETION_STOP_CHECK_ENTRIES,
     _TEMP_CLEANUP_STOP_CHECK_ENTRIES,
     cleanup_orphaned_temp_files,
 )
@@ -200,6 +201,9 @@ def test_cleanup_skips_directory_that_fails_to_open(tmp_path, monkeypatch):
             raise OSError("stale handle")
         return real_scandir(path, *args, **kwargs)
 
+    # WARN: sweep_module.os *is* the global os module, so this and the sibling
+    # patches below swap os.scandir/os.unlink process-wide until monkeypatch
+    # undoes them -- hence each one delegates to the real function off-path.
     monkeypatch.setattr(sweep_module.os, "scandir", _flaky_scandir)
 
     removed = cleanup_orphaned_temp_files(upload_dir=tmp_path)
@@ -413,24 +417,27 @@ def test_cleanup_stops_mid_deletion_on_a_directory_with_many_victims(
     to run every queued unlink unconditionally. A directory holding many aged
     temp files (an agent workspace's ``temp``/``output``, where unlink latency
     on network storage is tens of milliseconds) could therefore outlive both
-    the shutdown grace period and the executor join. The deletion phase is
-    bounded by the same chunk size as the scan, so it stops after at most one
-    chunk instead of draining the whole list.
+    the shutdown grace period and the executor join.
+
+    The deletion phase gets its own, smaller chunk than the scan: at the
+    unlink latency the module's comment cites, one scan-sized chunk of
+    deletions would consume the whole default shutdown grace period.
     """
     # A dedicated root: a shared conftest fixture seeds tmp_path itself with a
     # lancedb/ subdirectory, which would consume a poll and shift the counts
     # this test pins.
     root = tmp_path / "uploads"
     root.mkdir()
-    leftover = 100
-    total = _TEMP_CLEANUP_STOP_CHECK_ENTRIES + leftover
+    # One scan chunk plus a remainder, so the scan polls exactly once and the
+    # deletion phase starts with more victims queued than it may drain.
+    total = _TEMP_CLEANUP_STOP_CHECK_ENTRIES + 100
     for i in range(total):
         _write_aged(root / f"v{i:04d}.ab12cd.tmp", age=ORPHAN_AGE_SECONDS + 600)
 
     # Poll 1 is the per-directory check and poll 2 the scan's per-entry check
     # at entry _TEMP_CLEANUP_STOP_CHECK_ENTRIES -- both must be unset so the
     # walk reaches the deletion phase with a full chunk queued. Poll 3 is the
-    # deletion phase's own check, one chunk in.
+    # deletion phase's own check, one deletion chunk in.
     stop = _StopAfterNPolls(2)
 
     with caplog.at_level(
@@ -438,8 +445,9 @@ def test_cleanup_stops_mid_deletion_on_a_directory_with_many_victims(
     ):
         removed = cleanup_orphaned_temp_files(upload_dir=root, stop_event=stop)
 
-    assert removed == _TEMP_CLEANUP_STOP_CHECK_ENTRIES
-    assert len(list(root.iterdir())) == leftover
+    assert _TEMP_CLEANUP_DELETION_STOP_CHECK_ENTRIES < _TEMP_CLEANUP_STOP_CHECK_ENTRIES
+    assert removed == _TEMP_CLEANUP_DELETION_STOP_CHECK_ENTRIES
+    assert len(list(root.iterdir())) == total - removed
     assert "was not fully walked" in caplog.text
 
 


### PR DESCRIPTION
## What & why

`cleanup_orphaned_temp_files()` walks the entire uploads tree and was `await`ed **inline** in the ASGI lifespan. On a large tree (~640k directories on `xagent-cloud-prod-sg`) a cold-cache walk dominated startup for ~6 minutes and `/health` could not open until it returned. This is the **head lever** (item #2) from the fix plan in xorbitsai/xagent#1548.

## Change

**Take the walk off the inline startup path** — `src/xagent/web/app.py`. Move `cleanup_orphaned_temp_files()` into a background `asyncio.create_task` so the lifespan finishes and `/health` opens immediately regardless of tree size. The task is gated off under `PYTEST_CURRENT_TEST` (like the metadata-rebuild task) and guarded against a re-entrant startup orphaning an in-flight sweep. It is tracked on `app.state.temp_file_cleanup_task`, with a cooperative `threading.Event` (`app.state.temp_file_cleanup_stop`) checked once per directory so the walk can unwind.

Shutdown handling is the load-bearing part, because the walk runs in an executor thread that a task `cancel()` cannot stop (`asyncio.run()`'s teardown joins that thread at loop close, so a mid-sweep restart would otherwise block process exit for the full walk — the exact large-tree case this PR targets):

- The stop flag is set as the **very first** statement of `shutdown_event`, before `flush_langfuse()` or any other teardown, so an earlier step hanging (e.g. an unresponsive Langfuse endpoint) cannot strand the executor thread.
- The handler then waits for the task with `asyncio.wait({task}, timeout=…)`, **not** `asyncio.wait_for`. `wait_for` cancels its awaitable on timeout, which here would only kill the awaiting coroutine (losing its completion/failure log to an uncaught `CancelledError`) while the thread keeps running. `asyncio.wait` bounds the wait without cancelling, letting the task log its own outcome once the walk reaches its next directory boundary.
- The grace period is `get_temp_file_cleanup_shutdown_timeout_seconds()` (`XAGENT_TEMP_FILE_CLEANUP_SHUTDOWN_TIMEOUT_SECONDS`, default 10s), following this codebase's timeout-config convention so operators on very large trees can tune it.

The background task logs its own start / duration / count (failures keep `exc_info` since the sweep runs unattended) so a slow sweep stays visible.

**Make the walk cheaper** — `src/xagent/web/api/kb.py`. Replace `os.walk` + `Path(root)/name` with an iterative `os.scandir` traversal seeded with a `str` path that appends `entry.path` directly, so no `Path` object is allocated per entry on a large tree — that is the real win here (`os.walk` is itself already `scandir`-based and iterative, and the old code only called `.stat()` on names that already matched the temp pattern, so this is not a stat-count reduction). A per-entry `OSError` guard skips a file that vanishes mid-scan (a concurrent atomic replace); a directory-level `OSError` (an open failure or a mid-iteration `ESTALE`) skips just that directory, matching `os.walk`'s default tolerance instead of aborting the sweep.

**Symlink behavior (intentional change).** Regular files match exactly as before, but symlinked entries named like temp files are now excluded (`is_file(follow_symlinks=False)`), whereas the old `os.walk` matcher would have `unlink()`ed the link. This is deliberate and the safer choice: such symlinks **do** occur inside the uploads tree — agent file registration (`api/websocket.py` `_register_uploaded_files_for_agent`) calls `candidate.symlink_to(...)` under `workspace.input_dir`, which lives under `get_uploads_dir()`, and `normalize_filename` preserves dots, so an upload named e.g. `data.v1.tmp` produces a real symlink matching the sweep's pattern. Unlinking a symlink that points into a live agent workspace is exactly what we must not do, so excluding symlinks is correct. (Corrects the earlier claim that this was "unreachable"; a test now pins the exclusion.)

## Scope / deliberate non-change

The walk is intentionally left **tree-wide, not scoped**. The fix-plan item offered scoping as an alternative, but `.tmp` / `.tmp-replace` files are written across the uploads tree this function walks (`get_uploads_dir()`) — KB collection ingestion (`api/kb.py`) and managed file refs (`services/managed_file_ref.py`) — so restricting the walk would silently stop reclaiming temp files elsewhere. `get_uploads_dir()` is also the root under which per-task agent workspaces live (`input`/`output`/`temp`), so agent-produced files under a task's own `temp`/`output` can also match the pattern and be swept; that is existing behavior, unchanged here. (The SVG→PNG cache in `api/files.py` also writes `*.tmp`, but under `get_storage_root()/svg_png_cache`, a separate root this walk never touches, so it is out of scope regardless of scoping.) Once the walk is off the critical path, scoping adds risk with no upside.

Otherwise behavior is unchanged: the cleanup still runs only under the existing `auto_migrate` gate, matches the same `*.tmp-replace` / `name.XXXX.tmp` patterns, and uses the same 1-hour age threshold.

## Not addressed here

The **root disease** (item #3) — the 640k directories themselves, which accumulate because task workspaces are reclaimed only on explicit task deletion — is a separate follow-up tracked in #1548. A follow-up direction worth its own issue: this sweep runs once per process and stops at shutdown with no periodic re-scheduling, so on a deployment that restarts more often than one full walk takes, folding it into the existing periodic `run_orphan_upload_gc_loop` (chunked, resumable) would give both a non-blocking startup and eventual completion. This PR only stops the walk from blocking startup and makes it cheaper/safer.

## Verification

- `ruff check` + `ruff format --check` + `pre-commit run --files` (ruff, ruff-format, **mypy**, isort, codespell) pass on all changed files.
- `tests/web/api/test_kb_orphaned_temp_cleanup.py` — matcher (`.tmp-replace`, `name.XXXXXX.tmp`, the two-dot-part `report.tmp` edge case, non-temp names), recursion, missing-dir, `unlink` `OSError` tolerance, **per-directory** `stop_event` granularity (stops mid-walk, not just pre-loop), **symlink exclusion**, directory open-failure and mid-iteration `OSError` tolerance.
- `tests/integration/test_auto_migration_startup.py` — a dedicated `shutdown_event` drive asserts the stop flag is set **before** `flush_langfuse`, the task is **not cancelled**, it unwinds cooperatively, and `app.state` is reset; startup task-count assertions updated for the pytest gate.
- `tests/core/test_config.py` — `get_temp_file_cleanup_shutdown_timeout_seconds` default / override / fallback.

Refs: xorbitsai/xagent#1548, xorbitsai/xagent-saas#231
