### PR TITLE
fix(tools): keep SSH tools for agents whose category selection omits ssh

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -45,6 +45,11 @@ AGENT_CONFIG_UNASSIGNABLE_CATEGORIES: frozenset[str] = frozenset(
     {ToolCategory.OTHER.value, ToolCategory.AGENT.value}
 )
 
+# Categories granted by a per-agent binding the creator enforces itself. The
+# tool-list endpoint cannot enumerate them, so they never reach a saved
+# ``tool_categories`` and must not be gated on it.
+BINDING_AUTHORIZED_CATEGORIES: frozenset[str] = frozenset({ToolCategory.SSH.value})
+
 
 class ToolMetadata(BaseModel):
     name: str

--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -45,9 +45,8 @@ AGENT_CONFIG_UNASSIGNABLE_CATEGORIES: frozenset[str] = frozenset(
     {ToolCategory.OTHER.value, ToolCategory.AGENT.value}
 )
 
-# Categories granted by a per-agent binding the creator enforces itself. The
-# tool-list endpoint cannot enumerate them, so they are never selectable in the
-# builder's category picker and must not be gated on a category selection.
+# Categories granted by a per-agent binding the creator enforces itself. Not
+# selectable in the builder's picker, so never gate them on a selection.
 BINDING_AUTHORIZED_CATEGORIES: frozenset[str] = frozenset({ToolCategory.SSH.value})
 
 

--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -46,8 +46,8 @@ AGENT_CONFIG_UNASSIGNABLE_CATEGORIES: frozenset[str] = frozenset(
 )
 
 # Categories granted by a per-agent binding the creator enforces itself. The
-# tool-list endpoint cannot enumerate them, so they never reach a saved
-# ``tool_categories`` and must not be gated on it.
+# tool-list endpoint cannot enumerate them, so they are never selectable in the
+# builder's category picker and must not be gated on a category selection.
 BINDING_AUTHORIZED_CATEGORIES: frozenset[str] = frozenset({ToolCategory.SSH.value})
 
 

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -212,7 +212,7 @@ class ToolRegistry:
         # After the gates above: a creator carrying both a gate and a
         # binding-authorized category must honour its gate first.
         if declared_cats & BINDING_AUTHORIZED_CATEGORIES:
-            return spec.admits_binding_authorized()
+            return spec.includes_binding_authorized()
 
         return bool(declared_cats & spec.categories)
 
@@ -225,7 +225,7 @@ class ToolRegistry:
         ``spec.categories`` are skipped at the registry level (no
         creator call, no I/O) -- except a creator declaring a
         ``BINDING_AUTHORIZED_CATEGORIES`` category, dispatched per
-        ``spec.admits_binding_authorized()``. Creators with no declared
+        ``spec.includes_binding_authorized()``. Creators with no declared
         categories (dynamic ones: MCP / Custom API / Image / Audio) are always
         dispatched and are responsible for
         short-circuiting internally based on the spec.

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -201,9 +201,6 @@ class ToolRegistry:
         if selection_gate == "published_agent":
             return spec.includes_published_agent()
 
-        if declared_cats & BINDING_AUTHORIZED_CATEGORIES:
-            return spec.admits_binding_authorized()
-
         if selection_gate == "mcp":
             # ``mcp:<server>`` scopes land in ``mcp_servers`` only, leaving
             # ``categories`` without ``"mcp"``. Dispatch must read the spec's
@@ -211,6 +208,11 @@ class ToolRegistry:
             # and a server scope) rather than the category intersection below,
             # or a server-only spec would skip the MCP creator entirely.
             return spec.includes_mcp()
+
+        # After the gates above: a creator carrying both a gate and a
+        # binding-authorized category must honour its gate first.
+        if declared_cats & BINDING_AUTHORIZED_CATEGORIES:
+            return spec.admits_binding_authorized()
 
         return bool(declared_cats & spec.categories)
 

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -202,8 +202,7 @@ class ToolRegistry:
             return spec.includes_published_agent()
 
         if declared_cats & BINDING_AUTHORIZED_CATEGORIES:
-            # NONE is still an explicit zero-tools decision.
-            return spec.is_by_categories()
+            return spec.admits_binding_authorized()
 
         if selection_gate == "mcp":
             # ``mcp:<server>`` scopes land in ``mcp_servers`` only, leaving
@@ -222,7 +221,9 @@ class ToolRegistry:
         When ``config.get_tool_selection_spec()`` returns a spec,
         creators whose declared categories don't intersect
         ``spec.categories`` are skipped at the registry level (no
-        creator call, no I/O). Creators with no declared categories
+        creator call, no I/O) -- except a creator declaring only
+        ``BINDING_AUTHORIZED_CATEGORIES``, which the spec admits
+        alongside any real category selection. Creators with no declared categories
         (dynamic ones: MCP / Custom API / Image / Audio) are always
         dispatched and are responsible for
         short-circuiting internally based on the spec.
@@ -245,7 +246,8 @@ class ToolRegistry:
         for creator, declared_cats, selection_gate in cls._tool_creators:
             # Registry-level skip: declared categories known and no
             # intersection with the spec's allowed categories. The helper
-            # keeps the published-agent workforce exception in one place.
+            # keeps both exceptions (published-agent workforce injection and
+            # binding-authorized categories) in one place.
             if not cls._should_run_creator(declared_cats, spec, selection_gate):
                 continue
             try:

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -201,7 +201,7 @@ class ToolRegistry:
         if selection_gate == "published_agent":
             return spec.includes_published_agent()
 
-        if declared_cats <= BINDING_AUTHORIZED_CATEGORIES:
+        if declared_cats & BINDING_AUTHORIZED_CATEGORIES:
             # NONE is still an explicit zero-tools decision.
             return spec.is_by_categories()
 

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -221,10 +221,10 @@ class ToolRegistry:
         When ``config.get_tool_selection_spec()`` returns a spec,
         creators whose declared categories don't intersect
         ``spec.categories`` are skipped at the registry level (no
-        creator call, no I/O) -- except a creator declaring only
-        ``BINDING_AUTHORIZED_CATEGORIES``, which the spec admits
-        alongside any real category selection. Creators with no declared categories
-        (dynamic ones: MCP / Custom API / Image / Audio) are always
+        creator call, no I/O) -- except a creator declaring a
+        ``BINDING_AUTHORIZED_CATEGORIES`` category, dispatched per
+        ``spec.admits_binding_authorized()``. Creators with no declared
+        categories (dynamic ones: MCP / Custom API / Image / Audio) are always
         dispatched and are responsible for
         short-circuiting internally based on the spec.
 
@@ -246,8 +246,8 @@ class ToolRegistry:
         for creator, declared_cats, selection_gate in cls._tool_creators:
             # Registry-level skip: declared categories known and no
             # intersection with the spec's allowed categories. The helper
-            # keeps both exceptions (published-agent workforce injection and
-            # binding-authorized categories) in one place.
+            # keeps both exceptions (published-agent, binding-authorized)
+            # in one place.
             if not cls._should_run_creator(declared_cats, spec, selection_gate):
                 continue
             try:

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -22,7 +22,7 @@ from .....config import get_uploads_dir
 from .....core.task_runtime import FILE_OPERATION_ACCESS_VERSION_KEY
 from .....core.workspace import TaskWorkspace
 from ...core.knowledge_base_scope import KnowledgeBaseScopeError
-from .base import AbstractBaseTool, Tool
+from .base import BINDING_AUTHORIZED_CATEGORIES, AbstractBaseTool, Tool
 from .config import (
     BaseToolConfig,
     MCPFailurePolicy,
@@ -200,6 +200,10 @@ class ToolRegistry:
 
         if selection_gate == "published_agent":
             return spec.includes_published_agent()
+
+        if declared_cats <= BINDING_AUTHORIZED_CATEGORIES:
+            # NONE is still an explicit zero-tools decision.
+            return spec.is_by_categories()
 
         if selection_gate == "mcp":
             # ``mcp:<server>`` scopes land in ``mcp_servers`` only, leaving

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -53,7 +53,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Set
 
-from .base import AGENT_CONFIG_UNASSIGNABLE_CATEGORIES
+from .base import (
+    AGENT_CONFIG_UNASSIGNABLE_CATEGORIES,
+    BINDING_AUTHORIZED_CATEGORIES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -695,7 +698,7 @@ class _SpecByCategories(ToolSelectionSpec):
             category = str(tool.metadata.category.value)
 
             # Plain category admit (categories holds only plain names).
-            if category in self.categories:
+            if category in self.categories or category in BINDING_AUTHORIZED_CATEGORIES:
                 names.add(tool_name)
                 continue
 

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -26,6 +26,9 @@ Background:
 Mode completeness:
     Each abstract method (``is_*`` / ``includes_*`` /
     ``compute_allowed_names``) must be implemented by every subclass.
+    ``includes_binding_authorized`` is one of them: it decides whether
+    ``BINDING_AUTHORIZED_CATEGORIES`` (granted by a per-agent binding
+    rather than by selection) ride along this spec.
     Missing an implementation is both a mypy error and a runtime
     ``TypeError`` at instantiation time. Adding a new ``includes_*``
     creator-dispatch method on the base forces every subclass to
@@ -169,12 +172,13 @@ class ToolSelectionSpec(ABC):
         """Whether the Published Agent delegation creators should run."""
 
     @abstractmethod
-    def admits_binding_authorized(self) -> bool:
+    def includes_binding_authorized(self) -> bool:
         """Whether ``BINDING_AUTHORIZED_CATEGORIES`` ride along this spec.
 
-        True only alongside a real user category selection: a spec whose
-        only selection is an internal injection (the unconfigured workforce
-        manager's worker tools) stays scoped to that injection.
+        Such a category is never selectable, so its per-agent binding is the
+        opt-in. False for an explicit zero-tools spec and for one whose only
+        selection is an internal injection (the unconfigured workforce
+        manager's worker tools), which stays scoped to that injection.
         """
 
     @abstractmethod
@@ -386,7 +390,9 @@ class ToolSelectionSpec(ABC):
         """Whether the given category passes the spec.
 
         ``ALL`` admits every category; ``NONE`` admits none; and
-        ``BY_CATEGORIES`` admits only members of :attr:`categories`.
+        ``BY_CATEGORIES`` admits members of :attr:`categories`, plus any
+        ``BINDING_AUTHORIZED_CATEGORIES`` member per
+        :meth:`includes_binding_authorized`.
         Existing callers in ``factory.py`` registry-skip and
         creator-internal short-circuits keep using this.
         """
@@ -399,7 +405,7 @@ class ToolSelectionSpec(ABC):
         # but the duck-typed attribute access is also safe here.
         categories: frozenset[str] = getattr(self, "categories", frozenset())
         if cat in BINDING_AUTHORIZED_CATEGORIES:
-            return self.admits_binding_authorized()
+            return self.includes_binding_authorized()
         return cat in categories
 
 
@@ -477,7 +483,7 @@ class _SpecAll(ToolSelectionSpec):
             return False
         return True
 
-    def admits_binding_authorized(self) -> bool:
+    def includes_binding_authorized(self) -> bool:
         return True
 
     def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
@@ -531,7 +537,7 @@ class _SpecNone(ToolSelectionSpec):
     def includes_published_agent(self) -> bool:
         return False
 
-    def admits_binding_authorized(self) -> bool:
+    def includes_binding_authorized(self) -> bool:
         return False
 
     def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
@@ -643,11 +649,14 @@ class _SpecByCategories(ToolSelectionSpec):
             return False
         return "agent" in self.categories or bool(self.published_agent_ids)
 
-    def admits_binding_authorized(self) -> bool:
-        # A connector-only selection (``mcp:<server>`` -> mcp_servers, empty
-        # categories) is still a user opt-in; only a pure name_allowlist
-        # injection (workforce manager worker tools) is not.
-        return bool(self.categories or self.mcp_servers)
+    def includes_binding_authorized(self) -> bool:
+        # Denied only for the injection-only shape: worker tool names with no
+        # dimension a user could have selected. A connector-only selection
+        # (``mcp:<server>`` -> mcp_servers, empty categories) is an opt-in.
+        injection_only = bool(self.name_allowlist) and not (
+            self.categories or self.mcp_servers
+        )
+        return not injection_only
 
     def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
         # Parent/child rule, identical to what compute_allowed_names applies
@@ -674,7 +683,7 @@ class _SpecByCategories(ToolSelectionSpec):
             ``"mcp"`` admits all MCP tools, etc.; DB-backed Custom API
             tools are loaded only for scoped ``mcp:<server>`` connectors);
           - a tool in a ``BINDING_AUTHORIZED_CATEGORIES`` category is
-            admitted per :meth:`admits_binding_authorized` -- its per-agent
+            admitted per :meth:`includes_binding_authorized` -- its per-agent
             binding is the opt-in, since the category is never selectable;
           - otherwise a tool whose ``metadata.source_server`` matches a
             scoped server in ``mcp_servers`` is admitted. ``source_server``
@@ -726,7 +735,7 @@ class _SpecByCategories(ToolSelectionSpec):
             # Plain category admit (categories holds only plain names).
             if category in self.categories or (
                 category in BINDING_AUTHORIZED_CATEGORIES
-                and self.admits_binding_authorized()
+                and self.includes_binding_authorized()
             ):
                 names.add(tool_name)
                 continue

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -644,9 +644,10 @@ class _SpecByCategories(ToolSelectionSpec):
         return "agent" in self.categories or bool(self.published_agent_ids)
 
     def admits_binding_authorized(self) -> bool:
-        # Empty ``categories`` means the only selection is an internal
-        # injection (workforce manager worker tools), not a user opt-in.
-        return bool(self.categories)
+        # A connector-only selection (``mcp:<server>`` -> mcp_servers, empty
+        # categories) is still a user opt-in; only a pure name_allowlist
+        # injection (workforce manager worker tools) is not.
+        return bool(self.categories or self.mcp_servers)
 
     def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
         # Parent/child rule, identical to what compute_allowed_names applies

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -172,12 +172,9 @@ class ToolSelectionSpec(ABC):
     def admits_binding_authorized(self) -> bool:
         """Whether ``BINDING_AUTHORIZED_CATEGORIES`` ride along this spec.
 
-        Such a category is granted by a per-agent binding the creator
-        enforces itself, so it is admitted alongside a real user category
-        selection. It must NOT be granted to a spec whose only selection is
-        an internal injection (empty ``categories`` + ``name_allowlist``,
-        i.e. the unconfigured workforce manager), which is scoped to its
-        worker tools.
+        True only alongside a real user category selection: a spec whose
+        only selection is an internal injection (the unconfigured workforce
+        manager's worker tools) stays scoped to that injection.
         """
 
     @abstractmethod
@@ -676,9 +673,8 @@ class _SpecByCategories(ToolSelectionSpec):
             ``"mcp"`` admits all MCP tools, etc.; DB-backed Custom API
             tools are loaded only for scoped ``mcp:<server>`` connectors);
           - a tool in a ``BINDING_AUTHORIZED_CATEGORIES`` category is
-            admitted whenever :meth:`admits_binding_authorized` holds (its
-            per-agent binding is the opt-in and the category can never be
-            selected);
+            admitted per :meth:`admits_binding_authorized` -- its per-agent
+            binding is the opt-in, since the category is never selectable;
           - otherwise a tool whose ``metadata.source_server`` matches a
             scoped server in ``mcp_servers`` is admitted. ``source_server``
             is the normalized originating-server identity set once at

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -169,6 +169,18 @@ class ToolSelectionSpec(ABC):
         """Whether the Published Agent delegation creators should run."""
 
     @abstractmethod
+    def admits_binding_authorized(self) -> bool:
+        """Whether ``BINDING_AUTHORIZED_CATEGORIES`` ride along this spec.
+
+        Such a category is granted by a per-agent binding the creator
+        enforces itself, so it is admitted alongside a real user category
+        selection. It must NOT be granted to a spec whose only selection is
+        an internal injection (empty ``categories`` + ``name_allowlist``,
+        i.e. the unconfigured workforce manager), which is scoped to its
+        worker tools.
+        """
+
+    @abstractmethod
     def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
         """Pre-build MCP server restriction for the MCP creator.
 
@@ -389,6 +401,8 @@ class ToolSelectionSpec(ABC):
         # through ``is_by_categories()`` narrowing in modern setups,
         # but the duck-typed attribute access is also safe here.
         categories: frozenset[str] = getattr(self, "categories", frozenset())
+        if cat in BINDING_AUTHORIZED_CATEGORIES:
+            return self.admits_binding_authorized()
         return cat in categories
 
 
@@ -466,6 +480,9 @@ class _SpecAll(ToolSelectionSpec):
             return False
         return True
 
+    def admits_binding_authorized(self) -> bool:
+        return True
+
     def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
         # ALL mode: MCP selected without restriction -> initialize every
         # server. (``includes_mcp()`` already honors the legacy
@@ -515,6 +532,9 @@ class _SpecNone(ToolSelectionSpec):
         return False
 
     def includes_published_agent(self) -> bool:
+        return False
+
+    def admits_binding_authorized(self) -> bool:
         return False
 
     def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
@@ -626,6 +646,11 @@ class _SpecByCategories(ToolSelectionSpec):
             return False
         return "agent" in self.categories or bool(self.published_agent_ids)
 
+    def admits_binding_authorized(self) -> bool:
+        # Empty ``categories`` means the only selection is an internal
+        # injection (workforce manager worker tools), not a user opt-in.
+        return bool(self.categories)
+
     def scoped_mcp_servers(self) -> Optional[frozenset[str]]:
         # Parent/child rule, identical to what compute_allowed_names applies
         # post-build: the plain "mcp" parent admits every server, so it means
@@ -650,6 +675,10 @@ class _SpecByCategories(ToolSelectionSpec):
           - a tool whose category ∈ ``categories`` is admitted (plain
             ``"mcp"`` admits all MCP tools, etc.; DB-backed Custom API
             tools are loaded only for scoped ``mcp:<server>`` connectors);
+          - a tool in a ``BINDING_AUTHORIZED_CATEGORIES`` category is
+            admitted whenever :meth:`admits_binding_authorized` holds (its
+            per-agent binding is the opt-in and the category can never be
+            selected);
           - otherwise a tool whose ``metadata.source_server`` matches a
             scoped server in ``mcp_servers`` is admitted. ``source_server``
             is the normalized originating-server identity set once at
@@ -698,7 +727,10 @@ class _SpecByCategories(ToolSelectionSpec):
             category = str(tool.metadata.category.value)
 
             # Plain category admit (categories holds only plain names).
-            if category in self.categories or category in BINDING_AUTHORIZED_CATEGORIES:
+            if category in self.categories or (
+                category in BINDING_AUTHORIZED_CATEGORIES
+                and self.admits_binding_authorized()
+            ):
                 names.add(tool_name)
                 continue
 

--- a/src/xagent/core/tools/adapters/vibe/ssh_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/ssh_tools.py
@@ -273,14 +273,15 @@ def _numeric_task_id(task_id: Any) -> int | None:
     if task_id is None:
         return None
     normalized = str(task_id).strip()
-    for prefix in ("web_task_", "task_"):
-        if normalized.startswith(prefix):
-            value = normalized.removeprefix(prefix)
-            return int(value) if value.isdecimal() else None
+    if normalized.startswith("web_task_"):
+        value = normalized.removeprefix("web_task_")
+        return int(value) if value.isdecimal() else None
     return int(normalized) if normalized.isdecimal() else None
 
 
-def _agent_id_for_task(session_factory: Any, numeric_task_id: int | None) -> int | None:
+def _agent_id_for_task(
+    session_factory: Any, numeric_task_id: int | None, owner_user_id: int
+) -> int | None:
     if numeric_task_id is None:
         return None
     from .....web.models.agent import AgentStatus
@@ -291,6 +292,16 @@ def _agent_id_for_task(session_factory: Any, numeric_task_id: int | None) -> int
     with tool_session_scope(session_factory) as db:
         task = db.query(Task).filter(Task.id == numeric_task_id).first()
         if task is None:
+            return None
+        # Every caller derives both ids from the same task, so a mismatch means
+        # a mis-wired config -- refuse rather than bind another owner's targets.
+        if int(task.user_id) != owner_user_id:
+            logger.warning(
+                "ssh tools: task %s is owned by %s, not the executing user %s",
+                numeric_task_id,
+                task.user_id,
+                owner_user_id,
+            )
             return None
         candidate_id = task.agent_id
         if candidate_id is None:
@@ -380,7 +391,7 @@ async def create_ssh_tools(config: Any) -> list[AbstractBaseTool]:
         logger.error("ssh tools: provider does not implement SshSecretStore; skipping")
         return []
     numeric_task_id = _numeric_task_id(task_id)
-    agent_id = _agent_id_for_task(session_factory, numeric_task_id)
+    agent_id = _agent_id_for_task(session_factory, numeric_task_id, int(user_id))
     if agent_id is None:
         logger.info("ssh tools: skip (unresolved agent_id for task_id=%r)", task_id)
         return []

--- a/src/xagent/core/tools/adapters/vibe/ssh_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/ssh_tools.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from collections.abc import AsyncIterator, Callable, Mapping
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any
@@ -265,17 +264,22 @@ class SshDownloadTool(_SshTransferTool):
 
 
 def _numeric_task_id(task_id: Any) -> int | None:
-    """Extract the DB task id. The tool config hands us a workspace-scoped
-    string like ``"web_task_30"`` (or a non-task id like ``"tools_list"``),
-    not the bare integer primary key."""
+    """Extract the DB task id from the workspace-scoped id the tool config
+    hands us (``"web_task_30"`` -> 30).
+
+    Strict prefix match, never a trailing-digit search: a delegated sub-agent
+    (``agent_7_a1b2cd34``) or a REST preview (``preview_ab12cd34``) would
+    otherwise yield the uuid suffix's trailing digits as somebody else's task
+    id, and the caller resolves the owner scope from whatever row that hits.
+    Anything not of this exact shape is "no task" (fail closed)."""
     if task_id is None:
         return None
-    # Assumption: the DB id is the trailing integer of the workspace-scoped id
-    # (``web_task_30`` → 30); ids with no trailing digits (``tools_list``) are
-    # intentionally treated as "no task". If the id format ever grows an
-    # internal number this trailing-match would need revisiting.
-    match = re.search(r"(\d+)$", str(task_id))
-    return int(match.group(1)) if match else None
+    normalized = str(task_id).strip()
+    for prefix in ("web_task_", "task_"):
+        if normalized.startswith(prefix):
+            value = normalized.removeprefix(prefix)
+            return int(value) if value.isdecimal() else None
+    return int(normalized) if normalized.isdecimal() else None
 
 
 def _agent_id_for_task(session_factory: Any, numeric_task_id: int | None) -> int | None:

--- a/src/xagent/core/tools/adapters/vibe/ssh_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/ssh_tools.py
@@ -265,13 +265,11 @@ class SshDownloadTool(_SshTransferTool):
 
 def _numeric_task_id(task_id: Any) -> int | None:
     """Extract the DB task id from the workspace-scoped id the tool config
-    hands us (``"web_task_30"`` -> 30).
+    hands us (``"web_task_30"`` -> 30); anything else is "no task".
 
-    Strict prefix match, never a trailing-digit search: a delegated sub-agent
-    (``agent_7_a1b2cd34``) or a REST preview (``preview_ab12cd34``) would
-    otherwise yield the uuid suffix's trailing digits as somebody else's task
-    id, and the caller resolves the owner scope from whatever row that hits.
-    Anything not of this exact shape is "no task" (fail closed)."""
+    Strict prefix match, never a trailing-digit search: ``agent_7_a1b2cd34``
+    would otherwise yield 34 -- an unrelated task, whose owner the caller then
+    resolves the SSH bindings against."""
     if task_id is None:
         return None
     normalized = str(task_id).strip()

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -2372,6 +2372,22 @@ def test_ssh_tools_survive_a_selection_that_never_names_ssh() -> None:
     assert sorted(result or []) == ["calculator", "ssh_execute"]
 
 
+def test_connector_only_selection_still_gets_its_ssh_tools() -> None:
+    """A ``mcp:<server>``-only selection lands in ``mcp_servers`` with empty
+    ``categories`` -- still a user opt-in, so the binding rides along."""
+    spec = ToolSelectionSpec.from_raw(tool_categories=["mcp:gmail"])
+    assert spec.categories == frozenset() and spec.mcp_servers == frozenset({"gmail"})
+
+    result = spec.compute_allowed_names(
+        [
+            _mock_tool("mcp_gmail_send", "mcp", source_server="gmail"),
+            _mock_tool("ssh_execute", "ssh"),
+        ],
+    )
+    assert result == frozenset({"mcp_gmail_send", "ssh_execute"})
+    assert ToolRegistry._should_run_creator(frozenset({"ssh"}), spec, None) is True
+
+
 def test_unconfigured_workforce_manager_stays_worker_tools_only() -> None:
     """The binding rides along a real category selection only.
 

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -2357,11 +2357,9 @@ def test_spec_wants_mcp_only_for_explicit_mcp_selection():
 
 
 def test_ssh_tools_survive_a_selection_that_never_names_ssh() -> None:
-    """``ssh`` never reaches a saved ``tool_categories`` (the tool-list
-    endpoint cannot enumerate SSH tools), so filtering on it would leave every
-    configured agent without the tools its target binding grants."""
-    from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
-
+    """``ssh`` is never selectable in the builder's category picker (the
+    tool-list endpoint cannot enumerate SSH tools), so filtering on it would
+    leave every configured agent without the tools its binding grants."""
     result = ToolSelectionSpec.from_raw(
         tool_categories=["basic"]
     ).compute_allowed_names(
@@ -2374,29 +2372,53 @@ def test_ssh_tools_survive_a_selection_that_never_names_ssh() -> None:
     assert sorted(result or []) == ["calculator", "ssh_execute"]
 
 
-def test_explicit_zero_tools_still_rejects_ssh() -> None:
-    """NONE is a deliberate "this agent runs with zero tools" decision and
-    outranks the binding."""
-    from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
+def test_unconfigured_workforce_manager_stays_worker_tools_only() -> None:
+    """The binding rides along a real category selection only.
 
-    result = ToolSelectionSpec.from_raw(tool_categories=[]).compute_allowed_names(
-        [_mock_tool("ssh_execute", "ssh")],
+    An unconfigured workforce manager is BY_CATEGORIES with EMPTY categories
+    plus a worker-tool ``name_allowlist`` -- an internal injection, not a user
+    opt-in -- so it must keep the worker-tools-only invariant even when the
+    manager agent itself carries an SSH binding.
+    """
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=None,
+        published_agent_ids=[7],
+        name_allowlist={"ask_agent_worker1"},
+        extras_only_when_unconfigured=True,
     )
-    assert result == frozenset()
+    assert spec.is_by_categories() and spec.categories == frozenset()
+
+    result = spec.compute_allowed_names(
+        [_mock_tool("ask_agent_worker1", "agent"), _mock_tool("ssh_execute", "ssh")],
+    )
+    assert result == frozenset({"ask_agent_worker1"})
+    assert ToolRegistry._should_run_creator(frozenset({"ssh"}), spec, None) is False, (
+        "an injection-only spec must not dispatch the SSH creator either"
+    )
 
 
 def test_should_run_creator_runs_ssh_for_any_configured_selection() -> None:
     """The SSH creator gates on the target binding itself, so a selection that
     never names ``ssh`` must still dispatch it -- zero-tools must not."""
-    from xagent.core.tools.adapters.vibe.factory import ToolRegistry
-
     declared = frozenset({"ssh"})
     basic_only = ToolSelectionSpec.from_raw(tool_categories=["basic"])
     assert ToolRegistry._should_run_creator(declared, basic_only, None) is True
     zero_tools = ToolSelectionSpec.from_raw(tool_categories=[])
     assert ToolRegistry._should_run_creator(declared, zero_tools, None) is False
 
-    # A creator declaring ssh alongside an unselected category still runs;
-    # its non-ssh tools are dropped by the name filter, not by this gate.
+    # A creator declaring ssh alongside an unselected category still runs, and
+    # the name filter -- not this gate -- drops its non-ssh tools.
     mixed = frozenset({"ssh", "browser"})
     assert ToolRegistry._should_run_creator(mixed, basic_only, None) is True
+    assert basic_only.compute_allowed_names(
+        [_mock_tool("ssh_execute", "ssh"), _mock_tool("browser_open", "browser")],
+    ) == frozenset({"ssh_execute"})
+
+
+def test_includes_category_agrees_with_the_other_two_gates_on_ssh() -> None:
+    """Third gate parity: a future caller asking ``includes_category("ssh")``
+    must get the same answer the dispatch and name filters give."""
+    assert ToolSelectionSpec.from_raw(tool_categories=["basic"]).includes_category(
+        "ssh"
+    )
+    assert not ToolSelectionSpec.from_raw(tool_categories=[]).includes_category("ssh")

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -2431,6 +2431,37 @@ def test_should_run_creator_runs_ssh_for_any_configured_selection() -> None:
     ) == frozenset({"ssh_execute"})
 
 
+def test_selecting_ssh_explicitly_matches_omitting_it() -> None:
+    """``ssh`` is not selectable in the picker, so the binding -- not the
+    category list -- is the authority: an agent with a binding gets the same
+    tools whether the saved list names ``ssh`` or not. Removing it from an
+    already-saved list is therefore a no-op today; a real opt-out means
+    dropping the binding (or its own switch, out of scope here).
+    """
+    tools = [_mock_tool("calculator", "basic"), _mock_tool("ssh_execute", "ssh")]
+    with_ssh = ToolSelectionSpec.from_raw(tool_categories=["basic", "ssh"])
+    without_ssh = ToolSelectionSpec.from_raw(tool_categories=["basic"])
+
+    assert with_ssh.compute_allowed_names(tools) == without_ssh.compute_allowed_names(
+        tools
+    )
+    declared = frozenset({"ssh"})
+    assert ToolRegistry._should_run_creator(
+        declared, with_ssh, None
+    ) is ToolRegistry._should_run_creator(declared, without_ssh, None)
+
+
+def test_published_agent_scope_alone_is_not_an_injection() -> None:
+    """Only the injection-only shape (worker tool names, nothing selectable)
+    is denied -- a spec scoped by ``published_agent_ids`` alone is not it."""
+    spec = ToolSelectionSpec.from_raw(
+        tool_categories=None,
+        published_agent_ids=[7],
+        extras_only_when_unconfigured=True,
+    )
+    assert spec.is_by_categories() and spec.includes_binding_authorized()
+
+
 def test_includes_category_agrees_with_the_other_two_gates_on_ssh() -> None:
     """Third gate parity: a future caller asking ``includes_category("ssh")``
     must get the same answer the dispatch and name filters give."""

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -2395,3 +2395,8 @@ def test_should_run_creator_runs_ssh_for_any_configured_selection() -> None:
     assert ToolRegistry._should_run_creator(declared, basic_only, None) is True
     zero_tools = ToolSelectionSpec.from_raw(tool_categories=[])
     assert ToolRegistry._should_run_creator(declared, zero_tools, None) is False
+
+    # A creator declaring ssh alongside an unselected category still runs;
+    # its non-ssh tools are dropped by the name filter, not by this gate.
+    mixed = frozenset({"ssh", "browser"})
+    assert ToolRegistry._should_run_creator(mixed, basic_only, None) is True

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -2354,3 +2354,44 @@ def test_spec_wants_mcp_only_for_explicit_mcp_selection():
     for spec, expected in specs:
         assert should_load_mcp_server_configs(spec) is expected
         assert _spec_wants_mcp(spec) is expected
+
+
+def test_ssh_tools_survive_a_selection_that_never_names_ssh() -> None:
+    """``ssh`` never reaches a saved ``tool_categories`` (the tool-list
+    endpoint cannot enumerate SSH tools), so filtering on it would leave every
+    configured agent without the tools its target binding grants."""
+    from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
+
+    result = ToolSelectionSpec.from_raw(
+        tool_categories=["basic"]
+    ).compute_allowed_names(
+        [
+            _mock_tool("calculator", "basic"),
+            _mock_tool("ssh_execute", "ssh"),
+            _mock_tool("file_read", "file"),
+        ],
+    )
+    assert sorted(result or []) == ["calculator", "ssh_execute"]
+
+
+def test_explicit_zero_tools_still_rejects_ssh() -> None:
+    """NONE is a deliberate "this agent runs with zero tools" decision and
+    outranks the binding."""
+    from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
+
+    result = ToolSelectionSpec.from_raw(tool_categories=[]).compute_allowed_names(
+        [_mock_tool("ssh_execute", "ssh")],
+    )
+    assert result == frozenset()
+
+
+def test_should_run_creator_runs_ssh_for_any_configured_selection() -> None:
+    """The SSH creator gates on the target binding itself, so a selection that
+    never names ``ssh`` must still dispatch it -- zero-tools must not."""
+    from xagent.core.tools.adapters.vibe.factory import ToolRegistry
+
+    declared = frozenset({"ssh"})
+    basic_only = ToolSelectionSpec.from_raw(tool_categories=["basic"])
+    assert ToolRegistry._should_run_creator(declared, basic_only, None) is True
+    zero_tools = ToolSelectionSpec.from_raw(tool_categories=[])
+    assert ToolRegistry._should_run_creator(declared, zero_tools, None) is False

--- a/tests/core/tools/test_ssh_tools.py
+++ b/tests/core/tools/test_ssh_tools.py
@@ -244,6 +244,14 @@ def test_numeric_task_id_parses_workspace_prefixed_id() -> None:
     assert _numeric_task_id(None) is None
 
 
+def test_numeric_task_id_rejects_ids_that_merely_end_in_digits() -> None:
+    # A trailing-digit search would read the uuid suffix as somebody else's
+    # task id, and the caller derives the owner scope from whatever row it hits.
+    assert _numeric_task_id("agent_7_a1b2cd34") is None
+    assert _numeric_task_id("preview_ab12cd34") is None
+    assert _numeric_task_id("web_task_30x") is None
+
+
 @pytest.fixture
 def task_db(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'ssh-tools.db'}")

--- a/tests/core/tools/test_ssh_tools.py
+++ b/tests/core/tools/test_ssh_tools.py
@@ -472,6 +472,43 @@ def test_agent_id_for_task_rejects_a_task_owned_by_another_user(task_db) -> None
     assert _agent_id_for_task(task_db, int(task.id), int(intruder.id)) is None
 
 
+async def test_binding_authorized_creator_emits_nothing_without_a_binding(
+    task_db,
+) -> None:
+    """The contract behind ``BINDING_AUTHORIZED_CATEGORIES``: admission is
+    unconditional at the selection gates, so the creator itself must refuse to
+    emit anything for an agent with no bound target."""
+    from xagent.core.tools.adapters.vibe import ssh_tools
+    from xagent.core.tools.adapters.vibe.base import BINDING_AUTHORIZED_CATEGORIES
+    from xagent.web.services.ssh_runtime import set_ssh_target_provider_hook
+
+    assert BINDING_AUTHORIZED_CATEGORIES == frozenset({"ssh"}), (
+        "a new member needs the same no-authorization-no-tools proof"
+    )
+
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        agent = _new_agent(db, int(owner.id))
+        task = _new_task(db, int(owner.id), agent_id=int(agent.id))
+    finally:
+        db.close()
+
+    provider = _RecordingTargetProvider()  # no bound targets
+    set_ssh_target_provider_hook(lambda _sf: provider)
+    config = SimpleNamespace(
+        get_session_factory=lambda: task_db,
+        get_user_id=lambda: int(owner.id),
+        get_task_id=lambda: f"web_task_{int(task.id)}",
+        get_workspace_config=lambda: None,
+    )
+    try:
+        assert await ssh_tools.create_ssh_tools(config) == []
+        assert provider.list_calls == 1
+    finally:
+        set_ssh_target_provider_hook(None)
+
+
 async def test_create_ssh_tools_emits_nothing_for_a_delegated_sub_agent(
     task_db,
 ) -> None:

--- a/tests/core/tools/test_ssh_tools.py
+++ b/tests/core/tools/test_ssh_tools.py
@@ -307,7 +307,7 @@ def test_agent_id_for_task_authorizes_owned_direct_agent(task_db, status) -> Non
     finally:
         db.close()
 
-    assert _agent_id_for_task(task_db, int(task.id)) == int(agent.id)
+    assert _agent_id_for_task(task_db, int(task.id), int(owner.id)) == int(agent.id)
 
 
 @pytest.mark.parametrize("status", [AgentStatus.DRAFT, AgentStatus.PUBLISHED])
@@ -324,7 +324,7 @@ def test_agent_id_for_task_authorizes_owned_preview_agent(task_db, status) -> No
     finally:
         db.close()
 
-    assert _agent_id_for_task(task_db, int(task.id)) == int(agent.id)
+    assert _agent_id_for_task(task_db, int(task.id), int(owner.id)) == int(agent.id)
 
 
 def test_agent_id_for_task_rejects_cross_owner_published_direct_agent(task_db) -> None:
@@ -337,7 +337,7 @@ def test_agent_id_for_task_rejects_cross_owner_published_direct_agent(task_db) -
     finally:
         db.close()
 
-    assert _agent_id_for_task(task_db, int(task.id)) is None
+    assert _agent_id_for_task(task_db, int(task.id), int(owner.id)) is None
 
 
 @pytest.mark.parametrize("candidate", ["01", "abc", True, 2**31, str(2**31)])
@@ -355,7 +355,7 @@ def test_agent_id_for_task_rejects_malformed_preview_candidate(
     finally:
         db.close()
 
-    assert _agent_id_for_task(task_db, int(task.id)) is None
+    assert _agent_id_for_task(task_db, int(task.id), int(owner.id)) is None
 
 
 def test_agent_id_for_task_rejects_cross_scope_preview_agent(task_db) -> None:
@@ -372,7 +372,7 @@ def test_agent_id_for_task_rejects_cross_scope_preview_agent(task_db) -> None:
     finally:
         db.close()
 
-    assert _agent_id_for_task(task_db, int(task.id)) is None
+    assert _agent_id_for_task(task_db, int(task.id), int(owner.id)) is None
 
 
 def test_agent_id_for_task_rejects_archived_agent(task_db) -> None:
@@ -388,7 +388,7 @@ def test_agent_id_for_task_rejects_archived_agent(task_db) -> None:
     finally:
         db.close()
 
-    assert _agent_id_for_task(task_db, int(task.id)) is None
+    assert _agent_id_for_task(task_db, int(task.id), int(owner.id)) is None
 
 
 def test_agent_id_for_task_does_not_fallback_after_denied_primary_agent(
@@ -409,7 +409,7 @@ def test_agent_id_for_task_does_not_fallback_after_denied_primary_agent(
     finally:
         db.close()
 
-    assert _agent_id_for_task(task_db, int(task.id)) is None
+    assert _agent_id_for_task(task_db, int(task.id), int(owner.id)) is None
 
 
 def test_agent_id_for_task_allows_team_admin_private_and_member_team_visible(
@@ -444,11 +444,63 @@ def test_agent_id_for_task_allows_team_admin_private_and_member_team_visible(
         )
     )
     try:
-        assert _agent_id_for_task(task_db, int(admin_task.id)) == int(private.id)
-        assert _agent_id_for_task(task_db, int(member_task.id)) == int(shared.id)
-        assert _agent_id_for_task(task_db, int(legacy_task.id)) == int(legacy.id)
+        assert _agent_id_for_task(task_db, int(admin_task.id), int(admin.id)) == int(
+            private.id
+        )
+        assert _agent_id_for_task(task_db, int(member_task.id), int(member.id)) == int(
+            shared.id
+        )
+        assert _agent_id_for_task(task_db, int(legacy_task.id), int(member.id)) == int(
+            legacy.id
+        )
     finally:
         set_agent_team_scope_hook(None)
+
+
+def test_agent_id_for_task_rejects_a_task_owned_by_another_user(task_db) -> None:
+    """The owner scope must come from the executing user, not from whatever row
+    the task id happens to hit."""
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        intruder = _new_user(db, "intruder")
+        agent = _new_agent(db, int(owner.id))
+        task = _new_task(db, int(owner.id), agent_id=int(agent.id))
+    finally:
+        db.close()
+
+    assert _agent_id_for_task(task_db, int(task.id), int(intruder.id)) is None
+
+
+async def test_create_ssh_tools_emits_nothing_for_a_delegated_sub_agent(
+    task_db,
+) -> None:
+    """A delegated sub-agent's task id (``agent_{id}_{uuid8}``) carries no
+    resolvable task, so it must not reach the provider at all."""
+    from xagent.core.tools.adapters.vibe import ssh_tools
+    from xagent.web.services.ssh_runtime import set_ssh_target_provider_hook
+
+    db = task_db()
+    try:
+        owner = _new_user(db, "owner")
+        agent = _new_agent(db, int(owner.id))
+        _new_task(db, int(owner.id), agent_id=int(agent.id))
+    finally:
+        db.close()
+
+    provider = _RecordingTargetProvider()
+    set_ssh_target_provider_hook(lambda _sf: provider)
+    config = SimpleNamespace(
+        get_session_factory=lambda: task_db,
+        get_user_id=lambda: int(owner.id),
+        get_task_id=lambda: f"agent_{int(agent.id)}_a1b2cd34",
+        get_workspace_config=lambda: None,
+    )
+    try:
+        assert await ssh_tools.create_ssh_tools(config) == []
+        assert provider.list_calls == 0
+    finally:
+        set_ssh_target_provider_hook(None)
 
 
 class _RecordingTargetProvider(_Provider):
@@ -841,7 +893,7 @@ async def test_create_ssh_tools_skips_on_boxlite_backend(monkeypatch) -> None:
 
     provider = _Provider(targets=[SimpleNamespace()])  # one bound target
     set_ssh_target_provider_hook(lambda _sf: provider)
-    monkeypatch.setattr(ssh_tools, "_agent_id_for_task", lambda _sf, _tid: 1)
+    monkeypatch.setattr(ssh_tools, "_agent_id_for_task", lambda _sf, _tid, _uid: 1)
     monkeypatch.setattr(sm, "get_sandbox_manager", lambda: _FakeManager(object()))
     monkeypatch.setenv("SANDBOX_IMPLEMENTATION", "boxlite")
     config = SimpleNamespace(


### PR DESCRIPTION
## Symptom

The same instruction works in the Agent Builder preview but not in Agent Chat: the preview calls `ssh_execute` on the bound target, while in chat the model reports that its only tools are `final_answer`, `send_message` and `ask_user_question`.

## Root cause

The two paths source `tool_categories` differently:

- **Preview** injects `ssh` on the fly from the page's own `hasSshBindings` state (`frontend/src/components/build/agent-builder.tsx:1156`).
- **Agent Chat** reads `Agent.tool_categories` from the DB (`api/chat.py` → `_build_tool_selection_spec_for_task`).

`ssh` only reaches the DB when the agent is saved (same file, line 1469), so binding a target without a subsequent save leaves it out. It is not selectable in the picker either: `/api/tools` builds its listing with `task_id="tools_list"`, so `create_ssh_tools` cannot resolve an agent id and returns `[]` — the SSH category never appears in the UI.

For such an agent, `ToolRegistry._should_run_creator` finds no intersection between the creator's declared `{"ssh"}` and the agent's categories and skips the whole SSH creator at the registry level. The name-level filter in `compute_allowed_names` would have dropped the tools anyway.

## Fix

SSH authorization comes from the per-agent target binding, not from the category selection, and `create_ssh_tools` already fails closed on it (no provider hook, no resolvable agent, no bound target → `[]`). This PR names that concept once as `BINDING_AUTHORIZED_CATEGORIES` in `base.py`, with a single predicate deciding when it applies — `ToolSelectionSpec.admits_binding_authorized()` — read by all three gates:

- `factory._should_run_creator` (registry dispatch, after every existing `selection_gate`),
- `_SpecByCategories.compute_allowed_names` (name-level filter),
- `includes_category()` (the general-purpose query the per-category creators use to self-short-circuit), so a future caller asking about `ssh` cannot get an answer the other two gates contradict.

The predicate is true for a real user opt-in — a plain category selection or a connector-only one (`mcp:<server>`, which lands in `mcp_servers` with empty `categories`) — and false for an explicit zero-tools spec (`_SpecNone`) and for an injection-only spec (empty `categories` + `name_allowlist`, i.e. the unconfigured workforce manager, which stays scoped to its worker tools per the invariant at `selection_spec.py:251-256`).

### Task-id parsing tightened alongside it (behaviour change)

The bypass makes `create_ssh_tools` run for essentially every configured agent, which turns `_numeric_task_id`'s trailing-digit search into a live hazard rather than a near-dead one: `agent_7_a1b2cd34` yielded `34`, an unrelated `Task` row whose `user_id` then became the owner scope for `resolve_authorized_agent` — i.e. potentially another tenant's SSH-bound agent. It is now a strict prefix match (mirroring `_coerce_db_task_id` in `agent_tool.py:145-156`); anything else is "no task".

Two consequences worth stating plainly:

- **Delegated sub-agents no longer receive SSH tools at all.** Their task ids (`agent_{id}_{uuid8}`, `agent_tool.py:2151`) now parse to `None`. This is the fail-closed direction and matches the review guidance, but it is a real capability regression for a workforce worker that carries a binding. The id does contain the agent id, so a follow-up can resolve it from the prefix if delegation should support SSH.
- **REST preview** (`preview_<uuid>`) also parses to `None`, which is correct — those runs have no `Task` row. The WS preview path is unaffected: it runs as `web_task_{id}` and still resolves through `agent_config.preview_agent_id`.

### Cost

`create_ssh_tools` now runs on every configured agent's tool-build pass instead of only the ssh-selected one. In this repo's OSS deployment the `provider is None` check fails closed before any query, so there is no added cost. Where a provider hook is installed, each task pays two extra DB round-trips (the task lookup plus `resolve_authorized_agent`) and one `list_bound_targets` call, and an agent with no binding logs one `info` line per task. Folding this lookup into `_build_factory_runtime_load_plan`'s batched prefetch is a reasonable follow-up now that it runs unconditionally.

## Tests

`tests/core/tools/adapters/vibe/test_selection_spec.py` — SSH survives a `["basic"]` selection and a connector-only `["mcp:gmail"]` one; the unconfigured workforce manager stays worker-tools-only (both gates); the creator dispatch honours a mixed declaration while the name filter still drops its non-ssh tools; `includes_category` agrees with the other two gates. `tests/core/tools/test_ssh_tools.py` — ids that merely end in digits are rejected. Each of the two behavioural fixes was mutation-checked: reverting the source change turns the corresponding test red.

`tests/core/tools/adapters/vibe` and `tests/core/tools/test_ssh_tools.py` pass locally; the `test_command_path_guard_bash` and `sandboxed_tool` failures elsewhere in `tests/core/tools` predate this change (verified against a clean tree). CI was green on the first two commits.

## Not in this PR

- The two frontend `push("ssh")` sites are now redundant but harmless.
- `_numeric_task_id`, `agent_tool._coerce_db_task_id` and `WebToolConfig._parse_numeric_task_id` are three near-duplicate parsers with drifting semantics (the third accepts only `web_task_`). Unifying them needs a shared home that does not pull the `web` import chain into `ssh_tools`, so it is left as its own change.
