### PR TITLE
feat(v1): send a step snapshot on the attach-time close paths

### DIFF
--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1579,22 +1579,27 @@ async def _fast_path_step_snapshot(
 def _fast_path_steps_read_error_frame(
     exc: BaseException, task_id: int, path_name: str
 ) -> str:
-    """Close frame for a failed ``_fast_path_step_snapshot`` call,
-    shared by both attach-time fast paths' ``except`` blocks below.
+    """Close frame for a failure preparing the fast path's step snapshot
+    -- either the cursor baseline read (``read_task_steps_version``, when
+    supplied) or the steps read itself (``_fast_path_step_snapshot``).
+    Both run inside the same ``try`` in ``_fast_path_snapshot_stream``,
+    shared by both attach-time fast paths' ``except`` blocks below, so
+    this is called whichever of the two actually raised and the wording
+    below has to be true of either -- not just the steps read.
 
-    ``read_task_steps_response`` re-resolves the task (see
-    ``TaskStepsResponseReader``) after ``build_event_stream_response``
+    Both readers re-resolve the task (``TaskStepsResponseReader``,
+    ``TaskStepsVersionReader``) after ``build_event_stream_response``
     already resolved it once to pick this fast path -- a task deleted in
-    that gap surfaces here as ``V1ApiError(TASK_NOT_FOUND)``, same as it
-    does to the watchdog (which already emits ``task_deleted`` for it,
-    not ``resync_required``): the task is gone, not merely unreadable,
-    so ``steps()`` + reattach would just 404 instead of resyncing
-    anything. Only that specific shape gets ``task_deleted``; every
-    other failure (a transient DB error, a bug in projection) keeps the
-    existing ``resync_required`` handling and is logged --
-    ``task_deleted`` isn't logged here for the same reason the watchdog
-    path doesn't log it: a deleted task racing the attach isn't a bug
-    in this stream.
+    that gap surfaces here as ``V1ApiError(TASK_NOT_FOUND)`` from
+    whichever one ran, same as it does to the watchdog (which already
+    emits ``task_deleted`` for it, not ``resync_required``): the task is
+    gone, not merely unreadable, so ``steps()`` + reattach would just
+    404 instead of resyncing anything. Only that specific shape gets
+    ``task_deleted``; every other failure (a transient DB error, a bug
+    in projection) keeps the existing ``resync_required`` handling and
+    is logged -- ``task_deleted`` isn't logged here for the same reason
+    the watchdog path doesn't log it: a deleted task racing the attach
+    isn't a bug in this stream.
 
     Must be called from inside the ``except`` block it serves -- the
     ``logger.exception`` call below relies on the caller's still-active
@@ -1603,15 +1608,18 @@ def _fast_path_steps_read_error_frame(
     if isinstance(exc, V1ApiError) and exc.code is V1ErrorCode.TASK_NOT_FOUND:
         return error_frame("task_deleted")
     logger.exception(
-        "v1 SSE %s fast-path steps read failed for task %s; closing for "
-        "resync instead of leaving the client with a bare disconnect and "
-        "no close frame",
+        "v1 SSE %s fast-path step snapshot preparation failed for task "
+        "%s; closing for resync instead of leaving the client with a "
+        "bare disconnect and no close frame",
         path_name,
         task_id,
     )
     return error_frame(
         "resync_required",
-        message="Reading the task's steps failed; call steps() to resync, then re-attach.",
+        message=(
+            "Preparing the task's step snapshot failed; call steps() to "
+            "resync, then re-attach."
+        ),
     )
 
 
@@ -1940,9 +1948,10 @@ async def _fast_path_snapshot_stream(
         )
     except Exception as exc:
         # The conclusion goes out first -- see the docstring above -- so
-        # a step-read failure never also swallows the outcome the
-        # conclusion frame carries. No snapshot was confirmed here, so
-        # the conclusion carries no truncation marker.
+        # a failure reading the cursor baseline or the steps themselves
+        # never also swallows the outcome the conclusion frame carries.
+        # No snapshot was confirmed here, so the conclusion carries no
+        # truncation marker.
         yield build_conclusion(None)
         yield _fast_path_steps_read_error_frame(exc, task_id, path_name)
         return

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -327,6 +327,18 @@ TaskSnapshotReader = Callable[[int, "ApiKeyPrincipal"], Any]
 # and re-projecting the task's full trace history independently.
 TaskStepsResponseReader = Callable[[int, "ApiKeyPrincipal"], Any]
 
+# A sync callable: (task_id, principal) -> ``_TaskStepsVersionSnapshot``-
+# shaped object (duck-typed: ``.task_id`` / ``.agent_id`` /
+# ``.max_event_id``) -- the same cheap ``max(TraceEvent.id)`` read
+# ``tasks.py``'s ``_load_task_steps_version_snapshot`` runs for the
+# ``GET .../steps`` cache key. Distinct from ``TaskSnapshotReader``
+# because the two readers return different shapes: this one carries
+# ``max_event_id``, not ``run_id``/``state_version``. Used only by the
+# attach-time fast paths' steps-cursor fence (see
+# ``_fast_path_steps_cursor_changed``) to catch a trace row landing
+# between the steps read and the fence's recheck.
+TaskStepsVersionReader = Callable[[int, "ApiKeyPrincipal"], Any]
+
 # A callable of one argument -- ``snapshot_total_steps`` -- returning the
 # already-built conclusion frame (``task.completed`` /
 # ``task.input_required``) for one attach-time fast path. Bound by each
@@ -1639,6 +1651,19 @@ async def _fast_path_generation_changed(
     Losing a snapshot costs one ``steps()`` call; pairing a conclusion
     with step content from a generation this path never confirmed has no
     bounded cost.
+
+    This is one of two signals the caller checks before trusting the
+    steps it already read -- see ``_fast_path_steps_cursor_changed`` for
+    the other. Trace rows commit through ``DatabaseTraceHandler``'s own
+    session, and that commit can itself write this same task row: when
+    a checkpoint anchor lands while the task is ``RUNNING``,
+    ``trace_handlers.py`` issues an ``UPDATE tasks`` in the same commit
+    for ``last_checkpoint_event_id``/``last_checkpoint_trace_event_id``.
+    That UPDATE never sets ``run_id`` or ``state_version`` --
+    ``state_version`` has no ``onupdate``, so nothing bumps it but the
+    lifecycle writers named above -- so a trace row landing in the same
+    window this function is guarding still cannot move either field,
+    and this reread alone cannot see it.
     """
     current = await run_db_io_cancellation_safe(
         lambda: read_task_snapshot(original.task_id, principal)
@@ -1649,24 +1674,82 @@ async def _fast_path_generation_changed(
     )
 
 
+async def _fast_path_steps_cursor_changed(
+    task_id: int,
+    original_max_event_id: int,
+    principal: "ApiKeyPrincipal",
+    read_task_steps_version: TaskStepsVersionReader,
+) -> bool:
+    """Whether a trace row has landed since ``original_max_event_id`` was
+    captured, checked by rereading the steps cursor and comparing.
+
+    The companion signal to ``_fast_path_generation_changed``:
+    ``DatabaseTraceHandler`` commits trace rows (mapped to public
+    ``step.*`` content by ``read_task_steps_response``) through its own
+    session, and a checkpoint anchor row's commit can carry its own
+    ``UPDATE tasks`` (``last_checkpoint_event_id``/
+    ``last_checkpoint_trace_event_id``, gated on the task being
+    ``RUNNING``) -- but that UPDATE never sets ``run_id`` or
+    ``state_version``, so a trace row that lands after the steps read
+    returns and before this reread runs is invisible to the
+    run_id/state_version fence even on the commits that do write the
+    row. Reuses the same ``max(TraceEvent.id)`` query ``tasks.py``'s
+    ``_load_task_steps_version_snapshot`` already runs for the
+    ``GET .../steps`` cache key, so a landed row is caught at the same
+    cursor precision that cache already keys reads on.
+
+    ``original_max_event_id`` is captured before the steps read even
+    runs (see the call site in ``_fast_path_snapshot_stream``), not
+    after it returns -- the window this guards starts there, because a
+    trace row can land while that read is still in flight. That makes
+    the window this function actually checks slightly wider than "after
+    the steps read, before this recheck": a row landing *during* the
+    steps read is already reflected in the steps this call receives
+    (they were read after the baseline), yet the cursor still moved
+    between the baseline and this recheck, so this comparison flags it
+    as changed anyway. That is an accepted false positive, the same
+    trade ``_fast_path_generation_changed`` makes for an ordinary
+    intra-run write: the cost is one extra ``steps()`` call for a
+    client that already had a perfectly good snapshot, never a silent
+    gap.
+    """
+    current = await run_db_io_cancellation_safe(
+        lambda: read_task_steps_version(task_id, principal)
+    )
+    return bool(current.max_event_id != original_max_event_id)
+
+
 def _fast_path_generation_reread_error_frame(
     exc: BaseException, task_id: int, path_name: str
 ) -> str:
-    """Close frame for a failed ``_fast_path_generation_changed`` reread,
-    called from inside the ``except`` block it serves (same traceback-
-    attachment requirement as ``_fast_path_steps_read_error_frame``).
+    """Close frame for a failed reread inside the fence, called from
+    inside the ``except`` block it serves (same traceback-attachment
+    requirement as ``_fast_path_steps_read_error_frame``).
 
-    Classifies the same way that function does: a task deleted in the
-    gap between the steps read and this reread surfaces the same
-    ``V1ApiError(TASK_NOT_FOUND)`` and gets the same ``task_deleted``
-    frame; everything else gets ``resync_required``, logged.
+    Shared by two different rereads, and the wording below is written
+    to be true of either: ``_fast_path_generation_changed``'s
+    run_id/state_version reread, and, when it runs,
+    ``_fast_path_steps_cursor_changed``'s cursor recheck that follows
+    it. The two share one ``try``/``except`` (see the call site), so
+    this function cannot tell which of them actually raised -- and by
+    the time the cursor recheck runs at all, the generation reread has
+    already returned cleanly, so a failure here must never be described
+    as a failure to confirm the run/state generation specifically; that
+    part may already be confirmed, with only the cursor check left
+    unresolved.
+
+    Classifies the same way ``_fast_path_steps_read_error_frame`` does:
+    a task deleted in the gap between the steps read and this reread
+    surfaces the same ``V1ApiError(TASK_NOT_FOUND)`` and gets the same
+    ``task_deleted`` frame; everything else gets ``resync_required``,
+    logged.
 
     Kept separate from ``_fast_path_steps_read_error_frame`` rather than
     reused outright because the two failures warrant different
     ``resync_required`` wording -- the steps read never learned anything
-    about the task's generation, while this reread specifically failed
-    to confirm one, so the default steps-read wording would describe a
-    cause this failure didn't have.
+    about the task's generation or cursor, while this reread specifically
+    failed to confirm one of them, so the default steps-read wording
+    would describe a cause this failure didn't have.
     """
     if isinstance(exc, V1ApiError) and exc.code is V1ErrorCode.TASK_NOT_FOUND:
         return error_frame("task_deleted")
@@ -1680,8 +1763,8 @@ def _fast_path_generation_reread_error_frame(
     return error_frame(
         "resync_required",
         message=(
-            "Confirming the task's run/state generation failed; call "
-            "steps() to resync, then re-attach."
+            "Confirming the task's steps are still current failed; "
+            "call steps() to resync, then re-attach."
         ),
     )
 
@@ -1730,6 +1813,7 @@ async def _fast_path_snapshot_stream(
     *,
     build_conclusion: ConclusionFrameBuilder,
     path_name: str,
+    read_task_steps_version: TaskStepsVersionReader | None = None,
 ) -> AsyncIterator[str]:
     """Body shared by both attach-time fast paths (``_terminal_snapshot_stream``,
     ``_input_required_snapshot_stream``): emit ``task.status``, the
@@ -1755,8 +1839,11 @@ async def _fast_path_snapshot_stream(
     failure kind and carries no path label -- see
     ``_fast_path_steps_read_error_frame``.
 
-    ``task.status`` is emitted first, then the steps read runs inside
-    its own ``try``/``except``. A bare exception here
+    ``task.status`` is emitted first, then the steps read runs inside a
+    ``try``/``except`` that also covers the cursor baseline capture
+    below (when ``read_task_steps_version`` is supplied) -- both reads
+    have to succeed before any step content is trusted, so a failure in
+    either is handled identically. A bare exception here
     would not produce a different HTTP status: ``StreamingResponse``
     sends the response start (200, headers) before ever pulling a chunk
     from this generator, so letting the read's exception propagate
@@ -1791,16 +1878,41 @@ async def _fast_path_snapshot_stream(
     conclusion already sent. Step content is the part that can go
     stale, so it goes out only once the task row has been read once
     more and confirmed to still be ``snapshot``'s own generation
-    (``_fast_path_generation_changed``); that reread runs only when
-    there is step content to protect, so a failed steps read (nothing
-    to protect) and an empty one (nothing that could be stale) both
-    skip it. A confirmed match sends the steps, then the conclusion. A
-    confirmed change means the steps just read belong to a generation
-    this path never confirmed against, so the steps are withheld and
+    (``_fast_path_generation_changed``), and, when
+    ``read_task_steps_version`` is supplied, once the steps cursor
+    (``max_event_id``) is confirmed unmoved too
+    (``_fast_path_steps_cursor_changed``). A trace row can land after
+    the steps read and before this recheck; the same commit that lands
+    it can also write this task row's checkpoint-pointer columns
+    (``last_checkpoint_event_id``/``last_checkpoint_trace_event_id``,
+    ``trace_handlers.py``, gated on the task being ``RUNNING``) without
+    ever setting ``run_id`` or ``state_version``, so the
+    run_id/state_version reread alone cannot see that write either way.
+    ``read_task_steps_version`` defaults to ``None`` for callers that
+    don't need this second signal (existing unit tests exercising the
+    run_id/state_version fence on its own); the live attach endpoint
+    always supplies it. When it is supplied, its *baseline* read is
+    unconditional -- captured before the steps read even runs, inside
+    the same guard block described above, whether or not that read
+    ends up returning any steps or fails outright -- because the window
+    this second signal guards starts at that read, not after it. The
+    *recheck* against that baseline is what actually gates on step
+    content: like the run_id/state_version reread, it runs only once
+    there is step content to protect, so a failed steps read and an
+    empty one both skip the recheck (not the baseline, which already
+    ran by then). A step-carrying attach that reaches this fence
+    therefore costs two cursor queries when ``read_task_steps_version``
+    is supplied -- the baseline and the recheck -- on top of the one
+    run_id/state_version reread it already paid; an attach whose steps
+    turn out empty, or whose steps read fails, still pays for the
+    baseline alone. A confirmed match on both signals sends the steps,
+    then the conclusion. A confirmed change on either means the steps
+    just read may belong to content this path never confirmed against,
+    so the steps are withheld and
     the conclusion is followed by ``stream.error(resync_required)``. A
     reread that fails outright can't tell a match from a change and is
     handled the same way, except that its ``stream.error`` names the
-    reread failure rather than claiming the task moved
+    failed confirmation rather than claiming the task moved
     (``_fast_path_generation_reread_error_frame``, same
     ``task_deleted``-vs-everything-else split as
     ``_fast_path_steps_read_error_frame``). Serializing a step can fail
@@ -1811,6 +1923,16 @@ async def _fast_path_snapshot_stream(
     task_id = snapshot.task_id
     yield status_frame(snapshot.status.value)
     try:
+        # Captured before the steps read below, not after: the window this
+        # guards is "a trace row lands after steps are read, before the
+        # fence rechecks", so the reference point has to predate the read
+        # it is meant to protect. See ``_fast_path_steps_cursor_changed``.
+        steps_version_before = None
+        if read_task_steps_version is not None:
+            version_reader = read_task_steps_version
+            steps_version_before = await run_db_io_cancellation_safe(
+                lambda: version_reader(task_id, principal)
+            )
         steps, snapshot_total_steps = await _fast_path_step_snapshot(
             task_id, principal, read_task_steps_response
         )
@@ -1827,6 +1949,18 @@ async def _fast_path_snapshot_stream(
             changed = await _fast_path_generation_changed(
                 snapshot, principal, read_task_snapshot
             )
+            if not changed and read_task_steps_version is not None:
+                # ``steps_version_before`` was captured above under the
+                # same ``read_task_steps_version is not None`` guard, so
+                # it is never ``None`` here -- mypy can't carry that
+                # invariant across the two ``if`` blocks on its own.
+                assert steps_version_before is not None
+                changed = await _fast_path_steps_cursor_changed(
+                    task_id,
+                    steps_version_before.max_event_id,
+                    principal,
+                    read_task_steps_version,
+                )
         except Exception as exc:
             # Same conclusion-first ordering as the steps-read ``except``
             # block above -- see the docstring for why a reread failure
@@ -1866,6 +2000,7 @@ def _terminal_snapshot_stream(
     principal: "ApiKeyPrincipal",
     read_task_steps_response: TaskStepsResponseReader,
     read_task_snapshot: TaskSnapshotReader,
+    read_task_steps_version: TaskStepsVersionReader | None = None,
 ) -> AsyncIterator[str]:
     """Attach-time fast path for an already-terminal task: emit
     ``task.status``, the task's current steps, then ``task.completed``,
@@ -1900,6 +2035,7 @@ def _terminal_snapshot_stream(
         read_task_snapshot,
         build_conclusion=build_conclusion,
         path_name="terminal",
+        read_task_steps_version=read_task_steps_version,
     )
 
 
@@ -1908,6 +2044,7 @@ def _input_required_snapshot_stream(
     principal: "ApiKeyPrincipal",
     read_task_steps_response: TaskStepsResponseReader,
     read_task_snapshot: TaskSnapshotReader,
+    read_task_steps_version: TaskStepsVersionReader | None = None,
 ) -> AsyncIterator[str]:
     """Attach-time fast path for a task already waiting on user input (and
     not mid-resume): emit ``task.status``, the task's current steps, then
@@ -1945,6 +2082,7 @@ def _input_required_snapshot_stream(
         read_task_snapshot,
         build_conclusion=build_conclusion,
         path_name="input-required",
+        read_task_steps_version=read_task_steps_version,
     )
 
 
@@ -2099,6 +2237,7 @@ async def build_event_stream_response(
     initial_snapshot: "_TaskInfoSnapshot",
     read_task_snapshot: TaskSnapshotReader,
     read_task_steps_response: TaskStepsResponseReader,
+    read_task_steps_version: TaskStepsVersionReader | None = None,
     watchdog_interval_seconds: float = WATCHDOG_INTERVAL_SECONDS,
     stream_max_duration_seconds: float = STREAM_MAX_DURATION_SECONDS,
     heartbeat_interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS,
@@ -2118,7 +2257,15 @@ async def build_event_stream_response(
     directly, the same reader that authorized ``initial_snapshot``, to
     reread the task row once their own steps read returns non-empty
     content and confirm nothing restarted the task in between (see
-    ``_fast_path_generation_changed``).
+    ``_fast_path_generation_changed``), and ``read_task_steps_version``
+    to reread the steps cursor (``max_event_id``) the same way -- a
+    trace row can land in that same window, and even the commits that
+    write the task row itself (a checkpoint-pointer ``UPDATE``, see
+    ``_fast_path_steps_cursor_changed``) never touch ``run_id`` or
+    ``state_version``, so the run_id/state_version reread alone cannot
+    see it either way. Defaults to ``None``
+    (skips the cursor reread) only so callers that aren't exercising it
+    don't have to supply a reader; the router below always does.
     """
     close_reason = _stream_close_reason(
         initial_snapshot.status, initial_snapshot.control_state
@@ -2130,6 +2277,7 @@ async def build_event_stream_response(
                 principal,
                 read_task_steps_response,
                 read_task_snapshot,
+                read_task_steps_version=read_task_steps_version,
             )
         )
 
@@ -2140,6 +2288,7 @@ async def build_event_stream_response(
                 principal,
                 read_task_steps_response,
                 read_task_snapshot,
+                read_task_steps_version=read_task_steps_version,
             )
         )
 

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1754,7 +1754,7 @@ def _fast_path_generation_reread_error_frame(
     if isinstance(exc, V1ApiError) and exc.code is V1ErrorCode.TASK_NOT_FOUND:
         return error_frame("task_deleted")
     logger.exception(
-        "v1 SSE %s fast-path generation reread failed for task %s; "
+        "v1 SSE %s fast-path staleness recheck failed for task %s; "
         "closing for resync instead of leaving the client with a bare "
         "disconnect and no close frame",
         path_name,
@@ -1903,7 +1903,9 @@ async def _fast_path_snapshot_stream(
     ran by then). A step-carrying attach that reaches this fence
     therefore costs two cursor queries when ``read_task_steps_version``
     is supplied -- the baseline and the recheck -- on top of the one
-    run_id/state_version reread it already paid; an attach whose steps
+    run_id/state_version reread it already paid, except when that
+    reread already confirmed a change, which short-circuits the
+    recheck; an attach whose steps
     turn out empty, or whose steps read fails, still pays for the
     baseline alone. A confirmed match on both signals sends the steps,
     then the conclusion. A confirmed change on either means the steps
@@ -1973,8 +1975,8 @@ async def _fast_path_snapshot_stream(
             yield error_frame(
                 "resync_required",
                 message=(
-                    "The task moved to a new run while this attach was "
-                    "reading its steps; call steps() to resync, then "
+                    "The task changed while this attach was reading "
+                    "its steps; call steps() to resync, then "
                     "re-attach."
                 ),
             )

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -21,7 +21,12 @@ that step never appears on this stream at all, since its start was
 broadcast before this connection existed.
 Clients attaching mid-task reconcile against
 ``GET /v1/chat/tasks/{task_id}/steps``, which reads the database and
-so is unaffected by when the stream was opened.
+so is unaffected by when the stream was opened. The two attach-time
+fast paths are the exception to all of this: an attach that finds the
+task already terminal, or already waiting on user input, closes without
+ever registering a projector, and sends a bounded one-shot snapshot of
+the task's steps between ``task.status`` and its conclusion frame (see
+``_fast_path_step_snapshot``) instead of projecting anything live.
 
 No ``task.status`` frame is
 ever guaranteed to be fresh or in order, at any point in the stream's
@@ -81,6 +86,17 @@ values it deliberately leaves unbounded, in one place:
     inside ordinary backlog territory, so 4 MiB is the tightest value
     that leaves ordinary traffic alone -- against the ~16 MiB a full
     element-capped queue of maximum frames would otherwise hold.
+  - One attach-time fast-path step snapshot: ``REPLAY_MAX_STEPS`` (512
+    steps). A task with more public steps than that sends only its most
+    recent 512, and the first ``step.*`` frame carries
+    ``snapshot_truncated``/``snapshot_total_steps`` so the client can
+    tell a bounded snapshot from a complete one. This bounds how much
+    one response may hold, not how much backlog may accumulate: the
+    fast paths ``yield`` their frames straight from the generator, so no
+    sink and no outbound queue exist on those paths and neither queue
+    bound above applies to them. Each of those frames is still subject
+    to the 64 KiB per-step ``data`` cap, which is applied per frame
+    wherever the frame is built.
   - Concurrent streams: ``PER_TASK_STREAM_CAP`` (2) and
     ``PER_PRINCIPAL_STREAM_CAP`` (32), both rejected with 429 at
     attach, before any sink exists.
@@ -213,6 +229,16 @@ MAX_QUEUED_WIRE_BYTES = 64 * MAX_FRAME_CONTENT_BYTES
 # delay the completion signal to the watchdog's next cycle instead of
 # firing it immediately.
 MAX_RAW_FRAME_TEXT_CHARS = 4 * MAX_FRAME_CONTENT_BYTES
+# Upper bound on how many steps either attach-time fast path
+# (already-terminal / already-waiting-for-user) puts on the wire in its
+# one-shot response. Those paths emit their whole step snapshot in a
+# single burst and then close, so they have no admission / deadline /
+# heartbeat loop and no per-attach outbound queue of their own to
+# otherwise bound how much one response can hold. Exceeding it keeps
+# only the most recent ``REPLAY_MAX_STEPS`` steps (in ``started_at``
+# order, same as everywhere else) and marks the first frame as
+# truncated -- see ``_fast_path_step_snapshot``.
+REPLAY_MAX_STEPS = 512
 # Floor for the final wait when the 1-hour deadline is close: keeps the
 # queue wait from being called with a near-zero timeout, which would spin
 # the loop instead of actually waiting.
@@ -259,6 +285,18 @@ def _stream_close_reason(status: TaskStatus, control_state: str | None) -> str |
 # owned. Always run through ``run_db_io_cancellation_safe`` by this module
 # -- never called directly.
 TaskSnapshotReader = Callable[[int, "ApiKeyPrincipal"], Any]
+
+# A sync callable: (task_id, principal) -> ``StepsResponse``-shaped
+# object (duck-typed: ``.steps``, a list of already-validated
+# ``PublicStep``), backed by the *same cache* the polling
+# ``GET .../steps`` endpoint uses (keyed by ``max_event_id`` -- see
+# ``tasks.py``'s ``_get_chat_task_steps_sync``). Used only by the two
+# attach-time fast paths (already-terminal / already-waiting-for-user):
+# they're one-shot and need no live pairing state, so a cache hit there
+# collapses a burst of fast-path attaches on the same task into the read
+# ``steps()`` polling already pays for, instead of each one re-reading
+# and re-projecting the task's full trace history independently.
+TaskStepsResponseReader = Callable[[int, "ApiKeyPrincipal"], Any]
 
 
 # -- Wire format --------------------------------------------------------
@@ -317,13 +355,22 @@ _ERROR_MESSAGES = {
 }
 
 
-def error_frame(code: str) -> str:
+def error_frame(code: str, *, message: str | None = None) -> str:
     """Build a ``stream.error`` frame. ``code`` is always the machine-
-    readable value from ``_ERROR_MESSAGES`` (clients branch on it), and
-    the lookup runs unconditionally, so an unrecognized ``code`` raises
-    ``KeyError`` rather than reaching the wire as a frame with no
-    message."""
-    return _sse_frame("stream.error", {"code": code, "message": _ERROR_MESSAGES[code]})
+    readable value from ``_ERROR_MESSAGES`` (clients branch on it) --
+    ``message`` overrides only the human-readable text for a call site
+    whose actual cause ``_ERROR_MESSAGES[code]``'s generic wording
+    doesn't describe (e.g. a DB read failing under the ``resync_required``
+    code, which the default wording describes as a queue overflow).
+    Defaults to ``_ERROR_MESSAGES[code]`` when omitted. The lookup runs
+    either way, so an unrecognized ``code`` raises ``KeyError`` whether
+    or not a ``message`` was passed -- the check is on the code, not on
+    which optional argument the caller supplied.
+    """
+    default_message = _ERROR_MESSAGES[code]
+    return _sse_frame(
+        "stream.error", {"code": code, "message": message or default_message}
+    )
 
 
 # -- Content projection: step.* / message.* --------------------------------
@@ -522,12 +569,42 @@ def _capped_step_data(data: dict[str, Any]) -> dict[str, Any]:
     return bare_marker
 
 
-def step_started_frame(public_step: dict[str, Any]) -> str:
-    return _sse_frame("step.started", {"step": public_step})
+def _step_frame_data(
+    public_step: dict[str, Any], *, snapshot_total_steps: int | None
+) -> dict[str, Any]:
+    """Shared payload builder for ``step_started_frame``/``step_completed_frame``
+    so the truncation-marker fields (see ``REPLAY_MAX_STEPS``) are built
+    identically on both -- a fast path's truncated step snapshot can lead
+    with either a running or an already-resolved step."""
+    data: dict[str, Any] = {"step": public_step}
+    if snapshot_total_steps is not None:
+        # Folded onto this one frame rather than sent as a frame of its
+        # own: a standalone marker would be a 9th SSE event type on top
+        # of the 8 the endpoint docstring documents, for a condition
+        # that's rare (a task with more than ``REPLAY_MAX_STEPS`` public
+        # steps) and already has a client-side recovery story
+        # (``steps()`` for the authoritative full history).
+        data["snapshot_truncated"] = True
+        data["snapshot_total_steps"] = snapshot_total_steps
+    return data
 
 
-def step_completed_frame(public_step: dict[str, Any]) -> str:
-    return _sse_frame("step.completed", {"step": public_step})
+def step_started_frame(
+    public_step: dict[str, Any], *, snapshot_total_steps: int | None = None
+) -> str:
+    return _sse_frame(
+        "step.started",
+        _step_frame_data(public_step, snapshot_total_steps=snapshot_total_steps),
+    )
+
+
+def step_completed_frame(
+    public_step: dict[str, Any], *, snapshot_total_steps: int | None = None
+) -> str:
+    return _sse_frame(
+        "step.completed",
+        _step_frame_data(public_step, snapshot_total_steps=snapshot_total_steps),
+    )
 
 
 def message_delta_frame(message_id: str, text: str) -> str:
@@ -546,19 +623,36 @@ def message_completed_frame(message_id: str, content: str) -> str:
     return _sse_frame("message.completed", data)
 
 
-def _step_wire_frame(public_step_json: dict[str, Any]) -> str:
-    """Pick ``step.started`` vs ``step.completed`` for an already-JSON-safe
-    step dict, after applying the single-frame content cap to its
-    ``data`` sub-object. One status -> event-name rule, and one size cap,
-    in one place: the only producer of step content on this stream is
-    live folding (``_step_content_frame``, below), and keeping the rule
-    here rather than inline there is what lets a second producer be added
-    later without a second copy of it that could disagree.
+def _step_wire_frame(
+    step: "PublicStep", *, snapshot_total_steps: int | None = None
+) -> str:
+    """Turn one validated ``PublicStep`` into its ``step.started`` /
+    ``step.completed`` frame: normalize it to JSON-safe values, apply the
+    single-frame content cap to its ``data`` sub-object, then pick the
+    event name from its status.
+
+    This is the only place step content is normalized for this stream.
+    Both producers route through here -- live folding
+    (``_step_content_frame``, below) and the attach-time fast paths'
+    cached snapshot (``_fast_path_step_snapshot``, consumed frame-by-frame
+    in each fast path's own yield loop) -- so there is one
+    ``model_dump(mode="json")`` call site, one size cap, and one status ->
+    event-name rule, rather than a copy per producer that could drift
+    apart. Taking the model rather than an already-dumped dict is what
+    makes that structural: a caller cannot supply un-normalized values
+    without going around the type.
+
+    ``snapshot_total_steps`` is set on the first frame of a fast-path
+    snapshot that exceeded ``REPLAY_MAX_STEPS`` (see
+    ``_fast_path_step_snapshot``); the live folding caller never passes
+    it, because the live path emits one frame per event and so has
+    nothing to truncate.
     """
+    public_step_json = step.model_dump(mode="json")
     capped = {**public_step_json, "data": _capped_step_data(public_step_json["data"])}
     if capped["status"] == "running":
-        return step_started_frame(capped)
-    return step_completed_frame(capped)
+        return step_started_frame(capped, snapshot_total_steps=snapshot_total_steps)
+    return step_completed_frame(capped, snapshot_total_steps=snapshot_total_steps)
 
 
 def _step_content_frame(step: dict[str, Any]) -> str:
@@ -574,10 +668,14 @@ def _step_content_frame(step: dict[str, Any]) -> str:
     the step had moved past by the time it was actually read out of the
     queue. Routing every field through ``PublicStep`` here is also what
     keeps this wire shape identical to ``steps()``'s -- same validation,
-    same JSON coercion (``started_at``/``completed_at`` in particular),
-    same public step-type list, zero second copy of any of it.
+    same public step-type list, zero second copy of either. The JSON
+    coercion that goes with it (``started_at``/``completed_at`` in
+    particular) happens one level down, in ``_step_wire_frame``, which
+    both producers of step content share; this function's own job is
+    the raw-dict-to-model validation that only the live path needs,
+    because the fast paths read ``PublicStep`` objects already.
     """
-    return _step_wire_frame(PublicStep(**step).model_dump(mode="json"))
+    return _step_wire_frame(PublicStep(**step))
 
 
 def _feed_trace_event(
@@ -1307,28 +1405,403 @@ def _sse_response(body: AsyncIterator[str]) -> StreamingResponse:
     return StreamingResponse(body, media_type="text/event-stream", headers=_SSE_HEADERS)
 
 
+async def _fast_path_step_snapshot(
+    task_id: int,
+    principal: "ApiKeyPrincipal",
+    read_task_steps_response: TaskStepsResponseReader,
+) -> "tuple[list[PublicStep], int | None]":
+    """Shared by both attach-time fast paths: the task's current public
+    steps, read through the same cache ``GET .../steps`` uses (see
+    ``TaskStepsResponseReader``) rather than a fresh trace read, so a
+    burst of fast-path attaches on one task collapses into a cache hit
+    instead of each one re-reading and re-projecting independently.
+
+    Bounded to ``REPLAY_MAX_STEPS``: without that bound, a fast-path
+    attach to a task with an unusually long step history returned every
+    step from this cached list in one shot, with no admission /
+    deadline / heartbeat loop to pace it, unlike everything else this
+    stream serves. The cached list is already in ``started_at`` order
+    (``map_trace_events_to_public_steps``'s own docstring: "in the
+    order their start events first appeared"), so
+    ``steps[-REPLAY_MAX_STEPS:]`` keeps the most recent steps and drops
+    the oldest. Returns the validated
+    ``PublicStep`` objects themselves, not their serialized frame text
+    -- serialization happens one frame at a time in each fast path's own
+    yield loop below instead, so a large step list is never fully
+    materialized as SSE text (or held as a list of strings) all at once.
+    The second element is the task's true total step count
+    (``snapshot_total_steps`` for the first serialized frame) when
+    truncation happened, or ``None`` when the full list fit.
+    """
+    steps_response = await run_db_io_cancellation_safe(
+        lambda: read_task_steps_response(task_id, principal)
+    )
+    steps = steps_response.steps
+    total_steps = len(steps)
+    if total_steps > REPLAY_MAX_STEPS:
+        return steps[-REPLAY_MAX_STEPS:], total_steps
+    return steps, None
+
+
+def _fast_path_steps_read_error_frame(
+    exc: BaseException, task_id: int, path_name: str
+) -> str:
+    """Close frame for a failed ``_fast_path_step_snapshot`` call,
+    shared by both attach-time fast paths' ``except`` blocks below.
+
+    ``read_task_steps_response`` re-resolves the task (see
+    ``TaskStepsResponseReader``) after ``build_event_stream_response``
+    already resolved it once to pick this fast path -- a task deleted in
+    that gap surfaces here as ``V1ApiError(TASK_NOT_FOUND)``, same as it
+    does to the watchdog (which already emits ``task_deleted`` for it,
+    not ``resync_required``): the task is gone, not merely unreadable,
+    so ``steps()`` + reattach would just 404 instead of resyncing
+    anything. Only that specific shape gets ``task_deleted``; every
+    other failure (a transient DB error, a bug in projection) keeps the
+    existing ``resync_required`` handling and is logged --
+    ``task_deleted`` isn't logged here for the same reason the watchdog
+    path doesn't log it: a deleted task racing the attach isn't a bug
+    in this stream.
+
+    Must be called from inside the ``except`` block it serves -- the
+    ``logger.exception`` call below relies on the caller's still-active
+    exception context to attach a traceback.
+    """
+    if isinstance(exc, V1ApiError) and exc.code is V1ErrorCode.TASK_NOT_FOUND:
+        return error_frame("task_deleted")
+    logger.exception(
+        "v1 SSE %s fast-path steps read failed for task %s; closing for "
+        "resync instead of leaving the client with a bare disconnect and "
+        "no close frame",
+        path_name,
+        task_id,
+    )
+    return error_frame(
+        "resync_required",
+        message="Reading the task's steps failed; call steps() to resync, then re-attach.",
+    )
+
+
+async def _fast_path_generation_changed(
+    original: "_TaskInfoSnapshot",
+    principal: "ApiKeyPrincipal",
+    read_task_snapshot: TaskSnapshotReader,
+) -> bool:
+    """Whether the task has moved to a new run/state generation since
+    ``original`` was read, checked by rereading the task row and
+    comparing ``run_id``/``state_version`` against it -- the two fields
+    that change on a restart (a ``POST reply`` resuming a
+    ``WAITING_FOR_USER`` task, or a WS ``APPEND`` resuming a
+    ``COMPLETED``/``FAILED`` one) but not on an ordinary read.
+
+    Called by both attach-time fast paths, and only when their own
+    steps read returned at least one step (see each caller's own
+    docstring for why an empty list skips this call entirely) -- step
+    content only goes out once this call has confirmed it still belongs
+    to ``original``'s own generation, not just whatever generation the
+    steps read happened to observe.
+
+    A reread failure is not folded into the return value: it propagates
+    to the caller instead of being reported as ``True``, so "confirmed
+    changed" and "could not confirm either way" stay two different
+    outcomes rather than collapsing into one. Callers classify the
+    propagated exception themselves (see
+    ``_fast_path_generation_reread_error_frame``), the same way they
+    already classify a failed steps read via
+    ``_fast_path_steps_read_error_frame``.
+    """
+    current = await run_db_io_cancellation_safe(
+        lambda: read_task_snapshot(original.task_id, principal)
+    )
+    return bool(
+        current.run_id != original.run_id
+        or current.state_version != original.state_version
+    )
+
+
+def _fast_path_generation_reread_error_frame(
+    exc: BaseException, task_id: int, path_name: str
+) -> str:
+    """Close frame for a failed ``_fast_path_generation_changed`` reread,
+    called from inside the ``except`` block it serves (same traceback-
+    attachment requirement as ``_fast_path_steps_read_error_frame``).
+
+    Classifies the same way that function does: a task deleted in the
+    gap between the steps read and this reread surfaces the same
+    ``V1ApiError(TASK_NOT_FOUND)`` and gets the same ``task_deleted``
+    frame; everything else gets ``resync_required``, logged.
+
+    Kept separate from ``_fast_path_steps_read_error_frame`` rather than
+    reused outright because the two failures warrant different
+    ``resync_required`` wording -- the steps read never learned anything
+    about the task's generation, while this reread specifically failed
+    to confirm one, so the default steps-read wording would describe a
+    cause this failure didn't have.
+    """
+    if isinstance(exc, V1ApiError) and exc.code is V1ErrorCode.TASK_NOT_FOUND:
+        return error_frame("task_deleted")
+    logger.exception(
+        "v1 SSE %s fast-path generation reread failed for task %s; "
+        "closing for resync instead of leaving the client with a bare "
+        "disconnect and no close frame",
+        path_name,
+        task_id,
+    )
+    return error_frame(
+        "resync_required",
+        message=(
+            "Confirming the task's run/state generation failed; call "
+            "steps() to resync, then re-attach."
+        ),
+    )
+
+
+def _fast_path_step_serialize_error_frame(task_id: int, path_name: str) -> str:
+    """Close frame for a step that could not be serialized onto the wire,
+    called from inside the ``except`` block it serves (same traceback-
+    attachment requirement as ``_fast_path_steps_read_error_frame``).
+
+    Always ``resync_required``, never ``task_deleted``: the task row was
+    already read successfully to get here, so a failure at this point is
+    about one step's own content, not the task's existence.
+    ``PublicStep.data`` is typed ``Any`` because tools return arbitrary
+    JSON, and ``model_dump(mode="json")`` raises
+    ``PydanticSerializationError`` on a value it has no encoding rule
+    for. This loop runs after ``StreamingResponse`` has already sent 200
+    and the headers, a position where an escaped exception becomes an
+    opaque disconnect the client cannot classify as anything but the
+    connection dropping. This guard is a defensive boundary for that
+    position -- exercised in tests through a stub reader, not a live
+    tool result -- the bare disconnect
+    ``_fast_path_steps_read_error_frame`` exists to rule out.
+    """
+    logger.exception(
+        "v1 SSE %s fast-path step serialization failed for task %s; "
+        "closing for resync instead of leaving the client with a bare "
+        "disconnect and no close frame",
+        path_name,
+        task_id,
+    )
+    return error_frame(
+        "resync_required",
+        message=(
+            "Serializing the task's steps failed; call steps() to "
+            "resync, then re-attach."
+        ),
+    )
+
+
 async def _terminal_snapshot_stream(
     snapshot: "_TaskInfoSnapshot",
+    principal: "ApiKeyPrincipal",
+    read_task_steps_response: TaskStepsResponseReader,
+    read_task_snapshot: TaskSnapshotReader,
 ) -> AsyncIterator[str]:
     """Attach-time fast path for an already-terminal task: emit
-    ``task.status`` + ``task.completed`` and end. No sink, no
-    registration, no watchdog -- there's nothing left to watch."""
-    yield status_frame(snapshot.status.value)
-    yield completed_frame(
+    ``task.status``, the task's current steps, then ``task.completed``,
+    and end. No sink, no registration, no watchdog -- there's nothing
+    left to watch.
+
+    ``task.status`` is emitted first, then the steps read runs inside
+    its own ``try``/``except``. A bare exception here
+    would not produce a different HTTP status: ``StreamingResponse``
+    sends the response start (200, headers) before ever pulling a chunk
+    from this generator, so letting the read's exception propagate
+    unguarded just ends an already-started 200 response with no bytes
+    at all -- indistinguishable, from the client's side, from the
+    connection merely dropping. Catching the failure and closing with a
+    ``stream.error`` frame instead keeps this module's own invariant
+    that a close frame is always how a client tells "the task ended"
+    apart from "the stream ended" -- ``task_deleted`` when the task
+    disappeared out from under this read, ``resync_required`` for
+    everything else; see ``_fast_path_steps_read_error_frame``.
+
+    ``snapshot`` was already resolved, from its own authoritative read,
+    before this function was ever called, so ``task.completed``
+    describes the generation this path was picked for. What this path
+    will not do is pair that conclusion with step content from a
+    generation it never confirmed. Step content is a different matter:
+    the steps this path is about to read reflect whatever run/state
+    generation the task row is in *at that read*, and a concurrent
+    restart (a ``POST reply`` resuming a ``WAITING_FOR_USER`` task, or a
+    WS ``APPEND`` resuming a ``COMPLETED``/``FAILED`` one) can move the
+    row to a new generation in the gap between ``snapshot`` and that
+    read. The rule this path enforces: ``task.completed`` goes out on
+    every exit, and the fence decides only whether step content joins
+    it. The conclusion describes ``snapshot``'s own generation -- the
+    authoritative read that selected this fast path -- so a client that
+    tracks only lifecycle gets the same single conclusion frame it
+    would get if this path carried no step content at all. When the
+    reread below confirms a newer generation, ``snapshot`` is
+    superseded, and it is the ``stream.error(resync_required)`` that
+    follows which tells the client to refetch, not a retraction of the
+    conclusion already sent. Step content is the part that can go
+    stale, so it goes out only once the task row has been read once
+    more and confirmed to still be ``snapshot``'s own generation
+    (``_fast_path_generation_changed``); that reread runs only when
+    there is step content to protect, so a failed steps read (nothing
+    to protect) and an empty one (nothing that could be stale) both
+    skip it. A confirmed match sends the steps, then the conclusion. A
+    confirmed change means the steps just read belong to a generation
+    this path never confirmed against, so the steps are withheld and
+    the conclusion is followed by ``stream.error(resync_required)``. A
+    reread that fails outright can't tell a match from a change and is
+    handled the same way, except that its ``stream.error`` names the
+    reread failure rather than claiming the task moved
+    (``_fast_path_generation_reread_error_frame``, same
+    ``task_deleted``-vs-everything-else split as
+    ``_fast_path_steps_read_error_frame``). Serializing a step can fail
+    too -- ``PublicStep.data`` carries arbitrary tool JSON -- which ends
+    the step content there and closes the same way, so no exit leaves
+    the client with an already-started 200 response and no close frame.
+    """
+    # Built once, before anything is read, because every exit below emits
+    # it: it describes ``snapshot``'s own generation -- the authoritative
+    # read that selected this fast path. When the reread below confirms a
+    # newer generation, this snapshot is superseded, and the
+    # ``stream.error(resync_required)`` that follows is what tells the
+    # client to refetch -- not a retraction of the conclusion already
+    # sent. One expression in one place, rather than a copy per exit that
+    # could drift.
+    conclusion = completed_frame(
         status=snapshot.status.value, output=snapshot.output, error=snapshot.error
     )
+    yield status_frame(snapshot.status.value)
+    try:
+        steps, snapshot_total_steps = await _fast_path_step_snapshot(
+            snapshot.task_id, principal, read_task_steps_response
+        )
+    except Exception as exc:
+        # The conclusion goes out first -- see the docstring above -- so a
+        # step-read failure never also swallows the fact that this task
+        # already reached this terminal state.
+        yield conclusion
+        yield _fast_path_steps_read_error_frame(exc, snapshot.task_id, "terminal")
+        return
+    if steps:
+        try:
+            changed = await _fast_path_generation_changed(
+                snapshot, principal, read_task_snapshot
+            )
+        except Exception as exc:
+            # Same conclusion-first ordering as the steps-read ``except``
+            # block above -- see the docstring for why a reread failure
+            # gets the same treatment as a steps-read failure.
+            yield conclusion
+            yield _fast_path_generation_reread_error_frame(
+                exc, snapshot.task_id, "terminal"
+            )
+            return
+        if changed:
+            yield conclusion
+            yield error_frame(
+                "resync_required",
+                message=(
+                    "The task moved to a new run while this attach was "
+                    "reading its steps; call steps() to resync, then "
+                    "re-attach."
+                ),
+            )
+            return
+    for index, step in enumerate(steps):
+        try:
+            step_frame = _step_wire_frame(
+                step,
+                snapshot_total_steps=snapshot_total_steps if index == 0 else None,
+            )
+        except Exception:
+            # Only the serialization is inside the ``try``, not the
+            # ``yield``: a consumer going away arrives as
+            # ``GeneratorExit``/``CancelledError``, both
+            # ``BaseException``, so this handler cannot turn a client
+            # disconnect into a close frame nobody reads.
+            yield conclusion
+            yield _fast_path_step_serialize_error_frame(snapshot.task_id, "terminal")
+            return
+        yield step_frame
+    yield conclusion
 
 
 async def _input_required_snapshot_stream(
     snapshot: "_TaskInfoSnapshot",
+    principal: "ApiKeyPrincipal",
+    read_task_steps_response: TaskStepsResponseReader,
+    read_task_snapshot: TaskSnapshotReader,
 ) -> AsyncIterator[str]:
     """Attach-time fast path for a task already waiting on user input (and
-    not mid-resume): emit ``task.status`` + ``task.input_required`` and
-    end. Same rationale as ``_terminal_snapshot_stream`` -- without this,
-    the same conclusion is only reached via the watchdog's first cycle,
-    up to ``watchdog_interval_seconds`` (30s in production) after attach."""
+    not mid-resume): emit ``task.status``, the task's current steps, then
+    ``task.input_required``, and end. Same rationale as
+    ``_terminal_snapshot_stream`` -- without this, the same conclusion is
+    only reached via the watchdog's first cycle, up to
+    ``watchdog_interval_seconds`` (30s in production) after attach.
+
+    Same ordering, the same read-failure handling, the same pre-steps
+    generation fence, and the same guard around step serialization as
+    ``_terminal_snapshot_stream`` -- see that function's docstring for
+    why the steps read is guarded in its own ``try``/``except`` rather
+    than left to raise past this generator's first ``yield``, why step
+    content is withheld until a reread confirms the task row is still
+    the generation ``snapshot`` was read from, and why
+    ``task.input_required`` goes out on every exit regardless of what
+    the fence decides about step content.
+    """
+    # Built once, before anything is read, for the same reason as
+    # ``_terminal_snapshot_stream``'s own conclusion: every exit below
+    # emits it, and it describes the authoritative read that selected
+    # this fast path.
+    conclusion = input_required_frame(snapshot.task_id, snapshot.pending_question)
     yield status_frame(snapshot.status.value)
-    yield input_required_frame(snapshot.task_id, snapshot.pending_question)
+    try:
+        steps, snapshot_total_steps = await _fast_path_step_snapshot(
+            snapshot.task_id, principal, read_task_steps_response
+        )
+    except Exception as exc:
+        # Same conclusion-first ordering as ``_terminal_snapshot_stream``'s
+        # own ``except`` block -- see that function's docstring.
+        yield conclusion
+        yield _fast_path_steps_read_error_frame(exc, snapshot.task_id, "input-required")
+        return
+    if steps:
+        try:
+            changed = await _fast_path_generation_changed(
+                snapshot, principal, read_task_snapshot
+            )
+        except Exception as exc:
+            # Same conclusion-first ordering as the steps-read ``except``
+            # block above -- see ``_terminal_snapshot_stream``'s docstring.
+            yield conclusion
+            yield _fast_path_generation_reread_error_frame(
+                exc, snapshot.task_id, "input-required"
+            )
+            return
+        if changed:
+            yield conclusion
+            yield error_frame(
+                "resync_required",
+                message=(
+                    "The task moved to a new run while this attach was "
+                    "reading its steps; call steps() to resync, then "
+                    "re-attach."
+                ),
+            )
+            return
+    for index, step in enumerate(steps):
+        try:
+            step_frame = _step_wire_frame(
+                step,
+                snapshot_total_steps=snapshot_total_steps if index == 0 else None,
+            )
+        except Exception:
+            # Same narrow guard as ``_terminal_snapshot_stream``'s own
+            # serialization loop -- only the serialization, not the
+            # ``yield``.
+            yield conclusion
+            yield _fast_path_step_serialize_error_frame(
+                snapshot.task_id, "input-required"
+            )
+            return
+        yield step_frame
+    yield conclusion
 
 
 async def _generate(
@@ -1481,6 +1954,7 @@ async def build_event_stream_response(
     principal: ApiKeyPrincipal,
     initial_snapshot: "_TaskInfoSnapshot",
     read_task_snapshot: TaskSnapshotReader,
+    read_task_steps_response: TaskStepsResponseReader,
     watchdog_interval_seconds: float = WATCHDOG_INTERVAL_SECONDS,
     stream_max_duration_seconds: float = STREAM_MAX_DURATION_SECONDS,
     heartbeat_interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS,
@@ -1492,16 +1966,38 @@ async def build_event_stream_response(
     function does no auth of its own. Concurrency caps (429) are
     checked here, before the generator (and therefore the sink and the
     per-principal reservation) ever exists, so a rejected attach never
-    touches ``manager`` or the per-principal counter.
+    touches ``manager`` or the per-principal counter. Both fast paths
+    below read their step content through ``read_task_steps_response``
+    (see ``TaskStepsResponseReader``), a cache-backed read of the
+    task's current step list -- they're one-shot and don't need a
+    live-foldable projector. They also take ``read_task_snapshot``
+    directly, the same reader that authorized ``initial_snapshot``, to
+    reread the task row once their own steps read returns non-empty
+    content and confirm nothing restarted the task in between (see
+    ``_fast_path_generation_changed``).
     """
     close_reason = _stream_close_reason(
         initial_snapshot.status, initial_snapshot.control_state
     )
     if close_reason == "terminal":
-        return _sse_response(_terminal_snapshot_stream(initial_snapshot))
+        return _sse_response(
+            _terminal_snapshot_stream(
+                initial_snapshot,
+                principal,
+                read_task_steps_response,
+                read_task_snapshot,
+            )
+        )
 
     if close_reason == "input_required":
-        return _sse_response(_input_required_snapshot_stream(initial_snapshot))
+        return _sse_response(
+            _input_required_snapshot_stream(
+                initial_snapshot,
+                principal,
+                read_task_steps_response,
+                read_task_snapshot,
+            )
+        )
 
     if count_task_sinks(task_id) >= PER_TASK_STREAM_CAP:
         raise V1ApiError(V1ErrorCode.RATE_LIMITED, 429)

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1696,7 +1696,142 @@ def _fast_path_step_serialize_error_frame(task_id: int, path_name: str) -> str:
     )
 
 
-async def _terminal_snapshot_stream(
+async def _fast_path_snapshot_stream(
+    snapshot: "_TaskInfoSnapshot",
+    principal: "ApiKeyPrincipal",
+    read_task_steps_response: TaskStepsResponseReader,
+    read_task_snapshot: TaskSnapshotReader,
+    *,
+    conclusion: str,
+    path_name: str,
+) -> AsyncIterator[str]:
+    """Body shared by both attach-time fast paths (``_terminal_snapshot_stream``,
+    ``_input_required_snapshot_stream``): emit ``task.status``, the
+    task's current steps, then ``conclusion``, and end. No sink, no
+    registration, no watchdog -- there's nothing left to watch.
+
+    ``conclusion`` is built by the caller from its own authoritative row
+    read (``completed_frame`` for the terminal path,
+    ``input_required_frame`` for the waiting-for-user one) before this
+    generator is ever entered, and is passed in already built rather
+    than constructed here so the two callers each describe their own
+    generation's conclusion, not a copy that could drift between them.
+    ``path_name`` plays no part in any branching decision in this body;
+    it only labels the log line and the ``resync_required`` /
+    serialization-failure frame text so a client or an operator can tell
+    which fast path emitted them -- see ``_fast_path_steps_read_error_frame``
+    and the other error-frame builders below.
+
+    ``task.status`` is emitted first, then the steps read runs inside
+    its own ``try``/``except``. A bare exception here
+    would not produce a different HTTP status: ``StreamingResponse``
+    sends the response start (200, headers) before ever pulling a chunk
+    from this generator, so letting the read's exception propagate
+    unguarded just ends an already-started 200 response with no bytes
+    at all -- indistinguishable, from the client's side, from the
+    connection merely dropping. Catching the failure and closing with a
+    ``stream.error`` frame instead keeps this module's own invariant
+    that a close frame is always how a client tells "the task ended"
+    apart from "the stream ended" -- ``task_deleted`` when the task
+    disappeared out from under this read, ``resync_required`` for
+    everything else; see ``_fast_path_steps_read_error_frame``.
+
+    ``snapshot`` was already resolved, from its own authoritative read,
+    before this function was ever called, so ``conclusion`` describes
+    the generation this path was picked for. What this path
+    will not do is pair that conclusion with step content from a
+    generation it never confirmed. Step content is a different matter:
+    the steps this path is about to read reflect whatever run/state
+    generation the task row is in *at that read*, and a concurrent
+    restart (a ``POST reply`` resuming a ``WAITING_FOR_USER`` task, or a
+    WS ``APPEND`` resuming a ``COMPLETED``/``FAILED`` one) can move the
+    row to a new generation in the gap between ``snapshot`` and that
+    read. The rule this path enforces: ``conclusion`` goes out on
+    every exit, and the fence decides only whether step content joins
+    it. The conclusion describes ``snapshot``'s own generation -- the
+    authoritative read that selected this fast path -- so a client that
+    tracks only lifecycle gets the same single conclusion frame it
+    would get if this path carried no step content at all. When the
+    reread below confirms a newer generation, ``snapshot`` is
+    superseded, and it is the ``stream.error(resync_required)`` that
+    follows which tells the client to refetch, not a retraction of the
+    conclusion already sent. Step content is the part that can go
+    stale, so it goes out only once the task row has been read once
+    more and confirmed to still be ``snapshot``'s own generation
+    (``_fast_path_generation_changed``); that reread runs only when
+    there is step content to protect, so a failed steps read (nothing
+    to protect) and an empty one (nothing that could be stale) both
+    skip it. A confirmed match sends the steps, then the conclusion. A
+    confirmed change means the steps just read belong to a generation
+    this path never confirmed against, so the steps are withheld and
+    the conclusion is followed by ``stream.error(resync_required)``. A
+    reread that fails outright can't tell a match from a change and is
+    handled the same way, except that its ``stream.error`` names the
+    reread failure rather than claiming the task moved
+    (``_fast_path_generation_reread_error_frame``, same
+    ``task_deleted``-vs-everything-else split as
+    ``_fast_path_steps_read_error_frame``). Serializing a step can fail
+    too -- ``PublicStep.data`` carries arbitrary tool JSON -- which ends
+    the step content there and closes the same way, so no exit leaves
+    the client with an already-started 200 response and no close frame.
+    """
+    yield status_frame(snapshot.status.value)
+    try:
+        steps, snapshot_total_steps = await _fast_path_step_snapshot(
+            snapshot.task_id, principal, read_task_steps_response
+        )
+    except Exception as exc:
+        # The conclusion goes out first -- see the docstring above -- so a
+        # step-read failure never also swallows the fact that this task
+        # already reached this terminal state.
+        yield conclusion
+        yield _fast_path_steps_read_error_frame(exc, snapshot.task_id, path_name)
+        return
+    if steps:
+        try:
+            changed = await _fast_path_generation_changed(
+                snapshot, principal, read_task_snapshot
+            )
+        except Exception as exc:
+            # Same conclusion-first ordering as the steps-read ``except``
+            # block above -- see the docstring for why a reread failure
+            # gets the same treatment as a steps-read failure.
+            yield conclusion
+            yield _fast_path_generation_reread_error_frame(
+                exc, snapshot.task_id, path_name
+            )
+            return
+        if changed:
+            yield conclusion
+            yield error_frame(
+                "resync_required",
+                message=(
+                    "The task moved to a new run while this attach was "
+                    "reading its steps; call steps() to resync, then "
+                    "re-attach."
+                ),
+            )
+            return
+    for index, step in enumerate(steps):
+        try:
+            step_frame = _step_wire_frame(
+                step,
+                snapshot_total_steps=snapshot_total_steps if index == 0 else None,
+            )
+        except Exception:
+            # Only the serialization is inside the ``try``, not the
+            # ``yield``: a consumer going away arrives as
+            # ``GeneratorExit``/``CancelledError``, both
+            # ``BaseException``, so this handler cannot turn a client
+            # disconnect into a close frame nobody reads.
+            yield conclusion
+            yield _fast_path_step_serialize_error_frame(snapshot.task_id, path_name)
+            return
+        yield step_frame
+    yield conclusion
+
+
+def _terminal_snapshot_stream(
     snapshot: "_TaskInfoSnapshot",
     principal: "ApiKeyPrincipal",
     read_task_steps_response: TaskStepsResponseReader,
@@ -1759,75 +1894,30 @@ async def _terminal_snapshot_stream(
     too -- ``PublicStep.data`` carries arbitrary tool JSON -- which ends
     the step content there and closes the same way, so no exit leaves
     the client with an already-started 200 response and no close frame.
+
+    The body both fast paths share lives in
+    ``_fast_path_snapshot_stream``; this function supplies the
+    conclusion frame and the path label.
     """
-    # Built once, before anything is read, because every exit below emits
-    # it: it describes ``snapshot``'s own generation -- the authoritative
-    # read that selected this fast path. When the reread below confirms a
-    # newer generation, this snapshot is superseded, and the
-    # ``stream.error(resync_required)`` that follows is what tells the
-    # client to refetch -- not a retraction of the conclusion already
-    # sent. One expression in one place, rather than a copy per exit that
-    # could drift.
+    # Built here, before the shared body is entered, from ``snapshot``'s
+    # own authoritative read -- the read that selected this fast path --
+    # so that read is what the conclusion describes, not whatever the
+    # steps read or the generation reread inside the shared body observe
+    # afterward.
     conclusion = completed_frame(
         status=snapshot.status.value, output=snapshot.output, error=snapshot.error
     )
-    yield status_frame(snapshot.status.value)
-    try:
-        steps, snapshot_total_steps = await _fast_path_step_snapshot(
-            snapshot.task_id, principal, read_task_steps_response
-        )
-    except Exception as exc:
-        # The conclusion goes out first -- see the docstring above -- so a
-        # step-read failure never also swallows the fact that this task
-        # already reached this terminal state.
-        yield conclusion
-        yield _fast_path_steps_read_error_frame(exc, snapshot.task_id, "terminal")
-        return
-    if steps:
-        try:
-            changed = await _fast_path_generation_changed(
-                snapshot, principal, read_task_snapshot
-            )
-        except Exception as exc:
-            # Same conclusion-first ordering as the steps-read ``except``
-            # block above -- see the docstring for why a reread failure
-            # gets the same treatment as a steps-read failure.
-            yield conclusion
-            yield _fast_path_generation_reread_error_frame(
-                exc, snapshot.task_id, "terminal"
-            )
-            return
-        if changed:
-            yield conclusion
-            yield error_frame(
-                "resync_required",
-                message=(
-                    "The task moved to a new run while this attach was "
-                    "reading its steps; call steps() to resync, then "
-                    "re-attach."
-                ),
-            )
-            return
-    for index, step in enumerate(steps):
-        try:
-            step_frame = _step_wire_frame(
-                step,
-                snapshot_total_steps=snapshot_total_steps if index == 0 else None,
-            )
-        except Exception:
-            # Only the serialization is inside the ``try``, not the
-            # ``yield``: a consumer going away arrives as
-            # ``GeneratorExit``/``CancelledError``, both
-            # ``BaseException``, so this handler cannot turn a client
-            # disconnect into a close frame nobody reads.
-            yield conclusion
-            yield _fast_path_step_serialize_error_frame(snapshot.task_id, "terminal")
-            return
-        yield step_frame
-    yield conclusion
+    return _fast_path_snapshot_stream(
+        snapshot,
+        principal,
+        read_task_steps_response,
+        read_task_snapshot,
+        conclusion=conclusion,
+        path_name="terminal",
+    )
 
 
-async def _input_required_snapshot_stream(
+def _input_required_snapshot_stream(
     snapshot: "_TaskInfoSnapshot",
     principal: "ApiKeyPrincipal",
     read_task_steps_response: TaskStepsResponseReader,
@@ -1850,63 +1940,19 @@ async def _input_required_snapshot_stream(
     ``task.input_required`` goes out on every exit regardless of what
     the fence decides about step content.
     """
-    # Built once, before anything is read, for the same reason as
-    # ``_terminal_snapshot_stream``'s own conclusion: every exit below
-    # emits it, and it describes the authoritative read that selected
-    # this fast path.
+    # Built here, before the shared body is entered, for the same reason
+    # as ``_terminal_snapshot_stream``'s own conclusion: it describes the
+    # authoritative read that selected this fast path, not whatever the
+    # shared body's own reads observe afterward.
     conclusion = input_required_frame(snapshot.task_id, snapshot.pending_question)
-    yield status_frame(snapshot.status.value)
-    try:
-        steps, snapshot_total_steps = await _fast_path_step_snapshot(
-            snapshot.task_id, principal, read_task_steps_response
-        )
-    except Exception as exc:
-        # Same conclusion-first ordering as ``_terminal_snapshot_stream``'s
-        # own ``except`` block -- see that function's docstring.
-        yield conclusion
-        yield _fast_path_steps_read_error_frame(exc, snapshot.task_id, "input-required")
-        return
-    if steps:
-        try:
-            changed = await _fast_path_generation_changed(
-                snapshot, principal, read_task_snapshot
-            )
-        except Exception as exc:
-            # Same conclusion-first ordering as the steps-read ``except``
-            # block above -- see ``_terminal_snapshot_stream``'s docstring.
-            yield conclusion
-            yield _fast_path_generation_reread_error_frame(
-                exc, snapshot.task_id, "input-required"
-            )
-            return
-        if changed:
-            yield conclusion
-            yield error_frame(
-                "resync_required",
-                message=(
-                    "The task moved to a new run while this attach was "
-                    "reading its steps; call steps() to resync, then "
-                    "re-attach."
-                ),
-            )
-            return
-    for index, step in enumerate(steps):
-        try:
-            step_frame = _step_wire_frame(
-                step,
-                snapshot_total_steps=snapshot_total_steps if index == 0 else None,
-            )
-        except Exception:
-            # Same narrow guard as ``_terminal_snapshot_stream``'s own
-            # serialization loop -- only the serialization, not the
-            # ``yield``.
-            yield conclusion
-            yield _fast_path_step_serialize_error_frame(
-                snapshot.task_id, "input-required"
-            )
-            return
-        yield step_frame
-    yield conclusion
+    return _fast_path_snapshot_stream(
+        snapshot,
+        principal,
+        read_task_steps_response,
+        read_task_snapshot,
+        conclusion=conclusion,
+        path_name="input-required",
+    )
 
 
 async def _generate(

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1613,10 +1613,12 @@ async def _fast_path_generation_changed(
     ``run_id``/``state_version`` against it.
 
     ``state_version`` is the field that actually carries this. Every
-    lifecycle write increments it monotonically
-    (``services/task_execution_controller.py`` bumps it unconditionally
-    on the same UPDATE that sets the control state), whether or not a
-    new run begins. ``run_id`` is the narrower of the two and cannot
+    lifecycle transition increments it
+    (``web/services/task_execution_controller.py`` bumps it
+    unconditionally on the same UPDATE that sets the control state, and
+    the lease service's own case bumps it whenever a write changes the
+    row's (status, control_state) pair), whether or not a new run
+    begins. ``run_id`` is the narrower of the two and cannot
     stand alone: a ``POST reply`` resuming a ``WAITING_FOR_USER`` task
     deliberately keeps the same ``run_id`` (``task_lease_service``'s
     ``lease_run_id_case`` writes the same candidate back for that

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -261,18 +261,12 @@ MAX_RAW_FRAME_TEXT_CHARS = 4 * MAX_FRAME_CONTENT_BYTES
 REPLAY_MAX_STEPS = 512
 # The attach-time snapshot's second bound, on the total wire bytes one
 # response may hold rather than on its step count -- the fast paths'
-# analogue of the queue's ``MAX_QUEUED_WIRE_BYTES``, and sized the same
-# way (64 largest-possible content frames, expressed against
-# ``MAX_FRAME_CONTENT_BYTES`` so it tracks that cap instead of drifting
-# from it). ``REPLAY_MAX_STEPS`` alone does not bound size: 512 steps
-# each carrying a ``data`` sub-object right at the 64 KiB cap is ~32 MiB
-# generated into a single response, and these paths return before the
-# per-task / per-principal caps are checked, so nothing bounds how many
-# of those run concurrently. Strictly over the budget stops the
-# snapshot, exactly on it does not -- the same boundary rule the queue
-# budget and ``MAX_RAW_FRAME_TEXT_CHARS`` use. Frames are pure ASCII
-# (``json.dumps`` runs with the default ``ensure_ascii=True``), so
-# ``len(frame_text)`` is the wire byte count and no encode is needed.
+# analogue of the queue's ``MAX_QUEUED_WIRE_BYTES``, sized the same way
+# and measured the same way. Why this value, and why the step-count cap
+# alone leaves the response unbounded, is argued once in the module
+# docstring's size-bounds section, not repeated here. Strictly over the
+# budget stops the snapshot, exactly on it does not -- the same boundary
+# rule the queue budget and ``MAX_RAW_FRAME_TEXT_CHARS`` use.
 MAX_SNAPSHOT_WIRE_BYTES = 64 * MAX_FRAME_CONTENT_BYTES
 # Floor for the final wait when the 1-hour deadline is close: keeps the
 # queue wait from being called with a near-zero timeout, which would spin

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1812,10 +1812,11 @@ async def _fast_path_snapshot_stream(
     the step content there and closes the same way, so no exit leaves
     the client with an already-started 200 response and no close frame.
     """
+    task_id = snapshot.task_id
     yield status_frame(snapshot.status.value)
     try:
         steps, snapshot_total_steps = await _fast_path_step_snapshot(
-            snapshot.task_id, principal, read_task_steps_response
+            task_id, principal, read_task_steps_response
         )
     except Exception as exc:
         # The conclusion goes out first -- see the docstring above -- so
@@ -1823,7 +1824,7 @@ async def _fast_path_snapshot_stream(
         # conclusion frame carries. No snapshot was confirmed here, so
         # the conclusion carries no truncation marker.
         yield build_conclusion(None)
-        yield _fast_path_steps_read_error_frame(exc, snapshot.task_id, path_name)
+        yield _fast_path_steps_read_error_frame(exc, task_id, path_name)
         return
     if steps:
         try:
@@ -1835,9 +1836,7 @@ async def _fast_path_snapshot_stream(
             # block above -- see the docstring for why a reread failure
             # gets the same treatment as a steps-read failure.
             yield build_conclusion(None)
-            yield _fast_path_generation_reread_error_frame(
-                exc, snapshot.task_id, path_name
-            )
+            yield _fast_path_generation_reread_error_frame(exc, task_id, path_name)
             return
         if changed:
             yield build_conclusion(None)
@@ -1860,7 +1859,7 @@ async def _fast_path_snapshot_stream(
             # ``BaseException``, so this handler cannot turn a client
             # disconnect into a close frame nobody reads.
             yield build_conclusion(None)
-            yield _fast_path_step_serialize_error_frame(snapshot.task_id, path_name)
+            yield _fast_path_step_serialize_error_frame(task_id, path_name)
             return
         yield step_frame
     yield build_conclusion(snapshot_total_steps)

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1545,11 +1545,15 @@ async def _fast_path_step_snapshot(
     returned every step from this cached list in one shot, with no
     admission / deadline / heartbeat loop to pace it, unlike everything
     else this stream serves. The cached list is already in
-    ``started_at`` order (``map_trace_events_to_public_steps``'s own
-    docstring: "in the order their start events first appeared"), so
-    ``steps[-REPLAY_MAX_STEPS:]`` keeps the most recent steps and drops
-    the oldest; the byte budget is then applied to that window from its
-    oldest end (see ``_snapshot_steps_within_wire_budget`` for why a
+    ``started_at`` order -- the public contract ``GET .../steps``
+    documents (``schemas/v1.py``'s ``StepsResponse``: "Steps are
+    returned in monotonic started_at order") and
+    ``map_trace_events_to_public_steps`` enforces with an explicit final
+    sort (``_step_mapping.py:640-643``), not a property its projection's
+    own fold order already guarantees on its own -- that sort is exactly
+    why it's needed. ``steps[-REPLAY_MAX_STEPS:]`` keeps the most recent
+    steps and drops the oldest; the byte budget is then applied to that
+    window from its oldest end (see ``_snapshot_steps_within_wire_budget`` for why a
     prefix, not a suffix, is what it keeps). Returns the validated
     ``PublicStep`` objects themselves, not their serialized frame text
     -- serialization happens one frame at a time in each fast path's own

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -96,14 +96,21 @@ values it deliberately leaves unbounded, in one place:
     below, so nothing else bounds how many such responses run at once.
     The step cap keeps the most recent steps (in ``started_at`` order);
     the byte budget then admits that window from its oldest end, so the
-    snapshot stays a contiguous run in wire order. Either way the first
-    ``step.*`` frame carries ``snapshot_truncated`` (``true``) and
-    ``snapshot_total_steps`` (the task's full public step count), so the
-    client can tell a bounded snapshot from a complete one and knows how
-    much of it is missing -- ``GET .../steps`` is the authoritative full
-    history. These bound how much one response may hold, not how much
-    backlog may accumulate: the fast paths ``yield`` their frames
-    straight from the generator, so no sink and no outbound queue exist
+    snapshot stays a contiguous run in wire order. Either way the
+    conclusion frame (``task.completed`` / ``task.input_required``)
+    carries ``snapshot_truncated`` (``true``) and ``snapshot_total_steps``
+    (the task's full public step count), so the client can tell a bounded
+    snapshot from a complete one and knows how much of it is missing --
+    ``GET .../steps`` is the authoritative full history. The conclusion
+    carries it, not a ``step.*`` frame, because the conclusion is the one
+    frame every exit of these paths emits: a snapshot the byte budget cut
+    to zero steps still has to be reportable, and a ``step.*`` frame that
+    does not exist cannot report it. ``MAX_SNAPSHOT_WIRE_BYTES`` measures
+    only the step frames' own wire bytes -- the marker riding the
+    conclusion is not part of what it bounds. These bound how much one
+    response may hold, not how much backlog may accumulate: the fast
+    paths ``yield`` their frames straight from the generator, so no sink
+    and no outbound queue exist
     on those paths and neither queue bound above applies to them. Each
     of those frames is still subject to the 64 KiB per-step ``data``
     cap, which is applied per frame wherever the frame is built.
@@ -248,9 +255,9 @@ MAX_RAW_FRAME_TEXT_CHARS = 4 * MAX_FRAME_CONTENT_BYTES
 # heartbeat loop and no per-attach outbound queue of their own to
 # otherwise bound how much one response can hold. Exceeding it keeps
 # only the most recent ``REPLAY_MAX_STEPS`` steps (in ``started_at``
-# order, same as everywhere else) and marks the first frame as
-# truncated -- see ``_fast_path_step_snapshot``. Bounds the count only;
-# ``MAX_SNAPSHOT_WIRE_BYTES`` below bounds the size.
+# order, same as everywhere else) and marks the response's conclusion
+# frame as truncated -- see ``_fast_path_step_snapshot``. Bounds the
+# count only; ``MAX_SNAPSHOT_WIRE_BYTES`` below bounds the size.
 REPLAY_MAX_STEPS = 512
 # The attach-time snapshot's second bound, on the total wire bytes one
 # response may hold rather than on its step count -- the fast paths'
@@ -326,6 +333,17 @@ TaskSnapshotReader = Callable[[int, "ApiKeyPrincipal"], Any]
 # and re-projecting the task's full trace history independently.
 TaskStepsResponseReader = Callable[[int, "ApiKeyPrincipal"], Any]
 
+# A callable of one argument -- ``snapshot_total_steps`` -- returning the
+# already-built conclusion frame (``task.completed`` /
+# ``task.input_required``) for one attach-time fast path. Bound by each
+# fast path to its own authoritative snapshot (see
+# ``_terminal_snapshot_stream`` / ``_input_required_snapshot_stream``), so
+# the shared body (``_fast_path_snapshot_stream``) can supply the one
+# thing only it knows -- whether the step snapshot it just read was cut
+# short -- without either caller handing over a pre-built string that
+# could go stale by the time the body decides how to build it.
+ConclusionFrameBuilder = Callable[[int | None], str]
+
 
 # -- Wire format --------------------------------------------------------
 
@@ -364,13 +382,27 @@ def status_frame(status: str) -> str:
 # ``GET /v1/chat/tasks/{task_id}/events`` documents for these paths.
 # What this exemption bounds is how many times the uncapped payload
 # itself goes out, which is once either way.
-def completed_frame(*, status: str, output: str | None, error: str | None) -> str:
+def completed_frame(
+    *,
+    status: str,
+    output: str | None,
+    error: str | None,
+    snapshot_total_steps: int | None = None,
+) -> str:
     return _sse_frame(
-        "task.completed", {"status": status, "output": output, "error": error}
+        "task.completed",
+        {
+            "status": status,
+            "output": output,
+            "error": error,
+            **_snapshot_marker_fields(snapshot_total_steps),
+        },
     )
 
 
-def input_required_frame(task_id: int, prompt: str | None) -> str:
+def input_required_frame(
+    task_id: int, prompt: str | None, *, snapshot_total_steps: int | None = None
+) -> str:
     # ``prompt`` is uncapped for the reason stated above
     # ``completed_frame``, which covers both conclusion-frame fields.
     # ``prompt`` comes straight from ``_TaskInfoSnapshot.pending_question``
@@ -380,7 +412,14 @@ def input_required_frame(task_id: int, prompt: str | None) -> str:
     # snapshot in hand from its own authoritative row read, so this
     # never triggers a query of its
     # own and never sniffs live agent_message frames for question text.
-    return _sse_frame("task.input_required", {"task_id": task_id, "prompt": prompt})
+    return _sse_frame(
+        "task.input_required",
+        {
+            "task_id": task_id,
+            "prompt": prompt,
+            **_snapshot_marker_fields(snapshot_total_steps),
+        },
+    )
 
 
 _ERROR_MESSAGES = {
@@ -612,42 +651,33 @@ def _capped_step_data(data: dict[str, Any]) -> dict[str, Any]:
     return bare_marker
 
 
-def _step_frame_data(
-    public_step: dict[str, Any], *, snapshot_total_steps: int | None
-) -> dict[str, Any]:
-    """Shared payload builder for ``step_started_frame``/``step_completed_frame``
-    so the truncation-marker fields (see ``REPLAY_MAX_STEPS``) are built
-    identically on both -- a fast path's truncated step snapshot can lead
-    with either a running or an already-resolved step."""
-    data: dict[str, Any] = {"step": public_step}
-    if snapshot_total_steps is not None:
-        # Folded onto this one frame rather than sent as a frame of its
-        # own: a standalone marker would be a 9th SSE event type on top
-        # of the 8 the endpoint docstring documents, for a condition
-        # that's rare (a task with more than ``REPLAY_MAX_STEPS`` public
-        # steps) and already has a client-side recovery story
-        # (``steps()`` for the authoritative full history).
-        data["snapshot_truncated"] = True
-        data["snapshot_total_steps"] = snapshot_total_steps
-    return data
+def _snapshot_marker_fields(snapshot_total_steps: int | None) -> dict[str, Any]:
+    """The attach-time snapshot's truncation marker, or nothing when the
+    snapshot was complete.
+
+    Folded onto the conclusion frame rather than sent as a frame of its
+    own: a standalone marker would be a 9th SSE event type on top of the
+    8 the endpoint docstring documents, for a condition that already has
+    a client-side recovery story (``steps()`` for the authoritative full
+    history). The conclusion is the carrier because it is the one frame
+    every exit of these paths emits -- a snapshot the byte budget cut to
+    zero steps still has to be reportable, and a ``step.*`` frame that
+    does not exist cannot report it.
+    """
+    if snapshot_total_steps is None:
+        return {}
+    return {
+        "snapshot_truncated": True,
+        "snapshot_total_steps": snapshot_total_steps,
+    }
 
 
-def step_started_frame(
-    public_step: dict[str, Any], *, snapshot_total_steps: int | None = None
-) -> str:
-    return _sse_frame(
-        "step.started",
-        _step_frame_data(public_step, snapshot_total_steps=snapshot_total_steps),
-    )
+def step_started_frame(public_step: dict[str, Any]) -> str:
+    return _sse_frame("step.started", {"step": public_step})
 
 
-def step_completed_frame(
-    public_step: dict[str, Any], *, snapshot_total_steps: int | None = None
-) -> str:
-    return _sse_frame(
-        "step.completed",
-        _step_frame_data(public_step, snapshot_total_steps=snapshot_total_steps),
-    )
+def step_completed_frame(public_step: dict[str, Any]) -> str:
+    return _sse_frame("step.completed", {"step": public_step})
 
 
 def message_delta_frame(message_id: str, text: str) -> str:
@@ -666,9 +696,7 @@ def message_completed_frame(message_id: str, content: str) -> str:
     return _sse_frame("message.completed", data)
 
 
-def _step_wire_frame(
-    step: "PublicStep", *, snapshot_total_steps: int | None = None
-) -> str:
+def _step_wire_frame(step: "PublicStep") -> str:
     """Turn one validated ``PublicStep`` into its ``step.started`` /
     ``step.completed`` frame: normalize it to JSON-safe values, apply the
     single-frame content cap to its ``data`` sub-object, then pick the
@@ -684,18 +712,12 @@ def _step_wire_frame(
     apart. Taking the model rather than an already-dumped dict is what
     makes that structural: a caller cannot supply un-normalized values
     without going around the type.
-
-    ``snapshot_total_steps`` is set on the first frame of a fast-path
-    snapshot that exceeded ``REPLAY_MAX_STEPS`` (see
-    ``_fast_path_step_snapshot``); the live folding caller never passes
-    it, because the live path emits one frame per event and so has
-    nothing to truncate.
     """
     public_step_json = step.model_dump(mode="json")
     capped = {**public_step_json, "data": _capped_step_data(public_step_json["data"])}
     if capped["status"] == "running":
-        return step_started_frame(capped, snapshot_total_steps=snapshot_total_steps)
-    return step_completed_frame(capped, snapshot_total_steps=snapshot_total_steps)
+        return step_started_frame(capped)
+    return step_completed_frame(capped)
 
 
 def _step_content_frame(step: dict[str, Any]) -> str:
@@ -1478,8 +1500,9 @@ def _snapshot_steps_within_wire_budget(
     the window, where it suppresses every good step behind it, or force
     the failure to be folded into "snapshot truncated" and never
     reported. The budget only binds on a window averaging more than 8 KiB
-    per step, and a client whose snapshot was cut is told so by
-    ``snapshot_truncated`` and sent to ``GET .../steps`` either way.
+    per step, and a client whose snapshot was cut is told so by the
+    conclusion frame's ``snapshot_truncated`` and sent to
+    ``GET .../steps`` either way.
     """
     budget_remaining = MAX_SNAPSHOT_WIRE_BYTES
     admitted = 0
@@ -1531,11 +1554,10 @@ async def _fast_path_step_snapshot(
     function's docstring).
     The second element is the task's true total public step count
     whenever the returned list is short of it, by either bound, or
-    ``None`` when the whole history fits. The first serialized frame's
-    truncation marker then costs it about 52 bytes more than the
-    measuring pass counted for it -- a bounded overrun, accepted the same
-    way the queue's own byte budget leaves its per-string object header
-    uncounted.
+    ``None`` when the whole history fits. The truncation marker built
+    from it rides the conclusion frame, not a step frame, so it is never
+    counted against ``MAX_SNAPSHOT_WIRE_BYTES``: what the measuring pass
+    above counts is exactly what the step frames put on the wire.
     """
     steps_response = await run_db_io_cancellation_safe(
         lambda: read_task_steps_response(task_id, principal)
@@ -1702,20 +1724,25 @@ async def _fast_path_snapshot_stream(
     read_task_steps_response: TaskStepsResponseReader,
     read_task_snapshot: TaskSnapshotReader,
     *,
-    conclusion: str,
+    build_conclusion: ConclusionFrameBuilder,
     path_name: str,
 ) -> AsyncIterator[str]:
     """Body shared by both attach-time fast paths (``_terminal_snapshot_stream``,
     ``_input_required_snapshot_stream``): emit ``task.status``, the
-    task's current steps, then ``conclusion``, and end. No sink, no
+    task's current steps, then the conclusion frame, and end. No sink, no
     registration, no watchdog -- there's nothing left to watch.
 
-    ``conclusion`` is built by the caller from its own authoritative row
-    read (``completed_frame`` for the terminal path,
-    ``input_required_frame`` for the waiting-for-user one) before this
-    generator is ever entered, and is passed in already built rather
-    than constructed here so the two callers each describe their own
-    generation's conclusion, not a copy that could drift between them.
+    ``build_conclusion`` is supplied by the caller, bound to its own
+    authoritative row read (``completed_frame`` for the terminal path,
+    ``input_required_frame`` for the waiting-for-user one), before this
+    generator is ever entered -- so each caller's own generation is what
+    its conclusion describes, not a copy that could drift between them.
+    This body calls it with the one field only it knows: the step
+    snapshot's ``snapshot_total_steps`` on the one exit that confirmed and
+    sent that snapshot in full, ``None`` on every other exit -- a failed
+    steps read, a withheld generation mismatch, or a failed step
+    serialization never confirmed a snapshot to report a truncation count
+    for.
     ``path_name`` plays no part in any branching decision in this body;
     it only labels the log line and the ``resync_required`` /
     serialization-failure frame text so a client or an operator can tell
@@ -1737,7 +1764,7 @@ async def _fast_path_snapshot_stream(
     everything else; see ``_fast_path_steps_read_error_frame``.
 
     ``snapshot`` was already resolved, from its own authoritative read,
-    before this function was ever called, so ``conclusion`` describes
+    before this function was ever called, so the conclusion describes
     the generation this path was picked for. What this path
     will not do is pair that conclusion with step content from a
     generation it never confirmed. Step content is a different matter:
@@ -1746,7 +1773,7 @@ async def _fast_path_snapshot_stream(
     restart (a ``POST reply`` resuming a ``WAITING_FOR_USER`` task, or a
     WS ``APPEND`` resuming a ``COMPLETED``/``FAILED`` one) can move the
     row to a new generation in the gap between ``snapshot`` and that
-    read. The rule this path enforces: ``conclusion`` goes out on
+    read. The rule this path enforces: the conclusion goes out on
     every exit, and the fence decides only whether step content joins
     it. The conclusion describes ``snapshot``'s own generation -- the
     authoritative read that selected this fast path -- so a client that
@@ -1783,8 +1810,9 @@ async def _fast_path_snapshot_stream(
     except Exception as exc:
         # The conclusion goes out first -- see the docstring above -- so
         # a step-read failure never also swallows the outcome the
-        # conclusion frame carries.
-        yield conclusion
+        # conclusion frame carries. No snapshot was confirmed here, so
+        # the conclusion carries no truncation marker.
+        yield build_conclusion(None)
         yield _fast_path_steps_read_error_frame(exc, snapshot.task_id, path_name)
         return
     if steps:
@@ -1796,13 +1824,13 @@ async def _fast_path_snapshot_stream(
             # Same conclusion-first ordering as the steps-read ``except``
             # block above -- see the docstring for why a reread failure
             # gets the same treatment as a steps-read failure.
-            yield conclusion
+            yield build_conclusion(None)
             yield _fast_path_generation_reread_error_frame(
                 exc, snapshot.task_id, path_name
             )
             return
         if changed:
-            yield conclusion
+            yield build_conclusion(None)
             yield error_frame(
                 "resync_required",
                 message=(
@@ -1812,23 +1840,20 @@ async def _fast_path_snapshot_stream(
                 ),
             )
             return
-    for index, step in enumerate(steps):
+    for step in steps:
         try:
-            step_frame = _step_wire_frame(
-                step,
-                snapshot_total_steps=snapshot_total_steps if index == 0 else None,
-            )
+            step_frame = _step_wire_frame(step)
         except Exception:
             # Only the serialization is inside the ``try``, not the
             # ``yield``: a consumer going away arrives as
             # ``GeneratorExit``/``CancelledError``, both
             # ``BaseException``, so this handler cannot turn a client
             # disconnect into a close frame nobody reads.
-            yield conclusion
+            yield build_conclusion(None)
             yield _fast_path_step_serialize_error_frame(snapshot.task_id, path_name)
             return
         yield step_frame
-    yield conclusion
+    yield build_conclusion(snapshot_total_steps)
 
 
 def _terminal_snapshot_stream(
@@ -1848,20 +1873,27 @@ def _terminal_snapshot_stream(
     conclusion frame -- built from the authoritative read that selected
     this path -- and the ``"terminal"`` path label.
     """
-    # Built here, before the shared body is entered, from ``snapshot``'s
-    # own authoritative read -- the read that selected this fast path --
-    # so that read is what the conclusion describes, not whatever the
-    # steps read or the generation reread inside the shared body observe
-    # afterward.
-    conclusion = completed_frame(
-        status=snapshot.status.value, output=snapshot.output, error=snapshot.error
-    )
+
+    # Bound here, before the shared body is entered, to ``snapshot``'s own
+    # authoritative read -- the read that selected this fast path -- so
+    # that read is what every call the shared body makes describes, not
+    # whatever the steps read or the generation reread inside the shared
+    # body observe afterward. The shared body supplies only the one field
+    # it alone knows: whether the step snapshot it read was truncated.
+    def build_conclusion(snapshot_total_steps: int | None) -> str:
+        return completed_frame(
+            status=snapshot.status.value,
+            output=snapshot.output,
+            error=snapshot.error,
+            snapshot_total_steps=snapshot_total_steps,
+        )
+
     return _fast_path_snapshot_stream(
         snapshot,
         principal,
         read_task_steps_response,
         read_task_snapshot,
-        conclusion=conclusion,
+        build_conclusion=build_conclusion,
         path_name="terminal",
     )
 
@@ -1889,17 +1921,24 @@ def _input_required_snapshot_stream(
     was read from, and why the conclusion goes out on every exit
     regardless of what the fence decides about step content.
     """
-    # Built here, before the shared body is entered, for the same reason
-    # as ``_terminal_snapshot_stream``'s own conclusion: it describes the
-    # authoritative read that selected this fast path, not whatever the
-    # shared body's own reads observe afterward.
-    conclusion = input_required_frame(snapshot.task_id, snapshot.pending_question)
+
+    # Bound here, before the shared body is entered, for the same reason
+    # as ``_terminal_snapshot_stream``'s own ``build_conclusion``: it
+    # describes the authoritative read that selected this fast path, not
+    # whatever the shared body's own reads observe afterward.
+    def build_conclusion(snapshot_total_steps: int | None) -> str:
+        return input_required_frame(
+            snapshot.task_id,
+            snapshot.pending_question,
+            snapshot_total_steps=snapshot_total_steps,
+        )
+
     return _fast_path_snapshot_stream(
         snapshot,
         principal,
         read_task_steps_response,
         read_task_snapshot,
-        conclusion=conclusion,
+        build_conclusion=build_conclusion,
         path_name="input-required",
     )
 

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1614,28 +1614,35 @@ async def _fast_path_generation_changed(
     principal: "ApiKeyPrincipal",
     read_task_snapshot: TaskSnapshotReader,
 ) -> bool:
-    """Whether the task has moved to a new run/state generation since
-    ``original`` was read, checked by rereading the task row and
-    comparing ``run_id``/``state_version`` against it -- the two fields
-    that change on a restart (a ``POST reply`` resuming a
-    ``WAITING_FOR_USER`` task, or a WS ``APPEND`` resuming a
-    ``COMPLETED``/``FAILED`` one) but not on an ordinary read.
+    """Whether the task row has been written at all since ``original``
+    was read, checked by rereading it and comparing
+    ``run_id``/``state_version`` against it.
 
-    Called by both attach-time fast paths, and only when their own
-    steps read returned at least one step (see each caller's own
-    docstring for why an empty list skips this call entirely) -- step
-    content only goes out once this call has confirmed it still belongs
-    to ``original``'s own generation, not just whatever generation the
-    steps read happened to observe.
+    ``state_version`` is the field that actually carries this. Every
+    lifecycle write increments it monotonically
+    (``services/task_execution_controller.py`` bumps it unconditionally
+    on the same UPDATE that sets the control state), whether or not a
+    new run begins. ``run_id`` is the narrower of the two and cannot
+    stand alone: a ``POST reply`` resuming a ``WAITING_FOR_USER`` task
+    deliberately keeps the same ``run_id`` (``task_lease_service``'s
+    ``lease_run_id_case`` writes the same candidate back for that
+    status), and that resume is the most common trigger of the
+    waiting-for-user fast path. A fence comparing ``run_id`` alone would
+    be a no-op for exactly that case.
 
-    A reread failure is not folded into the return value: it propagates
-    to the caller instead of being reported as ``True``, so "confirmed
-    changed" and "could not confirm either way" stay two different
-    outcomes rather than collapsing into one. Callers classify the
-    propagated exception themselves (see
-    ``_fast_path_generation_reread_error_frame``), the same way they
-    already classify a failed steps read via
-    ``_fast_path_steps_read_error_frame``.
+    So the contract enforced here is "any lifecycle write invalidates
+    this snapshot", not "a new run started". Ordinary intra-run writes
+    -- finalizing into COMPLETED/FAILED/WAITING_FOR_USER/PAUSED, a lease
+    release, a lease-expiry recovery -- bump ``state_version`` without
+    touching ``run_id``, and each of them can land in the window right
+    after the task reaches the state that selected this fast path. A
+    write there withholds a snapshot that was in fact still current and
+    sends the client to ``steps()`` instead. That is the deliberate
+    trade: this reread cannot tell a write that superseded the snapshot
+    from one that did not, so it treats every write as superseding.
+    Losing a snapshot costs one ``steps()`` call; pairing a conclusion
+    with step content from a generation this path never confirmed has no
+    bounded cost.
     """
     current = await run_db_io_cancellation_safe(
         lambda: read_task_snapshot(original.task_id, principal)
@@ -1691,8 +1698,9 @@ def _fast_path_step_serialize_error_frame(task_id: int, path_name: str) -> str:
     Always ``resync_required``, never ``task_deleted``: the task row was
     already read successfully to get here, so a failure at this point is
     about one step's own content, not the task's existence.
-    ``PublicStep.data`` is typed ``Any`` because tools return arbitrary
-    JSON, and ``model_dump(mode="json")`` raises
+    ``PublicStep.data`` is a ``Dict[str, Any]`` -- the keys are fixed per
+    step type, the values are arbitrary tool JSON -- and
+    ``model_dump(mode="json")`` raises
     ``PydanticSerializationError`` on a value it has no encoding rule
     for. This loop runs after ``StreamingResponse`` has already sent 200
     and the headers, a position where an escaped exception becomes an
@@ -1743,11 +1751,13 @@ async def _fast_path_snapshot_stream(
     steps read, a withheld generation mismatch, or a failed step
     serialization never confirmed a snapshot to report a truncation count
     for.
-    ``path_name`` plays no part in any branching decision in this body;
-    it only labels the log line and the ``resync_required`` /
-    serialization-failure frame text so a client or an operator can tell
-    which fast path emitted them -- see ``_fast_path_steps_read_error_frame``
-    and the other error-frame builders below.
+    ``path_name`` plays no part in any branching decision in this body,
+    and never reaches the client: it is passed only into the
+    ``logger.exception`` calls inside the error-frame builders below, so
+    an operator reading the logs can tell which fast path failed. The
+    ``stream.error`` text those builders put on the wire is fixed per
+    failure kind and carries no path label -- see
+    ``_fast_path_steps_read_error_frame``.
 
     ``task.status`` is emitted first, then the steps read runs inside
     its own ``try``/``except``. A bare exception here

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1781,9 +1781,9 @@ async def _fast_path_snapshot_stream(
             snapshot.task_id, principal, read_task_steps_response
         )
     except Exception as exc:
-        # The conclusion goes out first -- see the docstring above -- so a
-        # step-read failure never also swallows the fact that this task
-        # already reached this terminal state.
+        # The conclusion goes out first -- see the docstring above -- so
+        # a step-read failure never also swallows the outcome the
+        # conclusion frame carries.
         yield conclusion
         yield _fast_path_steps_read_error_frame(exc, snapshot.task_id, path_name)
         return
@@ -1842,62 +1842,11 @@ def _terminal_snapshot_stream(
     and end. No sink, no registration, no watchdog -- there's nothing
     left to watch.
 
-    ``task.status`` is emitted first, then the steps read runs inside
-    its own ``try``/``except``. A bare exception here
-    would not produce a different HTTP status: ``StreamingResponse``
-    sends the response start (200, headers) before ever pulling a chunk
-    from this generator, so letting the read's exception propagate
-    unguarded just ends an already-started 200 response with no bytes
-    at all -- indistinguishable, from the client's side, from the
-    connection merely dropping. Catching the failure and closing with a
-    ``stream.error`` frame instead keeps this module's own invariant
-    that a close frame is always how a client tells "the task ended"
-    apart from "the stream ended" -- ``task_deleted`` when the task
-    disappeared out from under this read, ``resync_required`` for
-    everything else; see ``_fast_path_steps_read_error_frame``.
-
-    ``snapshot`` was already resolved, from its own authoritative read,
-    before this function was ever called, so ``task.completed``
-    describes the generation this path was picked for. What this path
-    will not do is pair that conclusion with step content from a
-    generation it never confirmed. Step content is a different matter:
-    the steps this path is about to read reflect whatever run/state
-    generation the task row is in *at that read*, and a concurrent
-    restart (a ``POST reply`` resuming a ``WAITING_FOR_USER`` task, or a
-    WS ``APPEND`` resuming a ``COMPLETED``/``FAILED`` one) can move the
-    row to a new generation in the gap between ``snapshot`` and that
-    read. The rule this path enforces: ``task.completed`` goes out on
-    every exit, and the fence decides only whether step content joins
-    it. The conclusion describes ``snapshot``'s own generation -- the
-    authoritative read that selected this fast path -- so a client that
-    tracks only lifecycle gets the same single conclusion frame it
-    would get if this path carried no step content at all. When the
-    reread below confirms a newer generation, ``snapshot`` is
-    superseded, and it is the ``stream.error(resync_required)`` that
-    follows which tells the client to refetch, not a retraction of the
-    conclusion already sent. Step content is the part that can go
-    stale, so it goes out only once the task row has been read once
-    more and confirmed to still be ``snapshot``'s own generation
-    (``_fast_path_generation_changed``); that reread runs only when
-    there is step content to protect, so a failed steps read (nothing
-    to protect) and an empty one (nothing that could be stale) both
-    skip it. A confirmed match sends the steps, then the conclusion. A
-    confirmed change means the steps just read belong to a generation
-    this path never confirmed against, so the steps are withheld and
-    the conclusion is followed by ``stream.error(resync_required)``. A
-    reread that fails outright can't tell a match from a change and is
-    handled the same way, except that its ``stream.error`` names the
-    reread failure rather than claiming the task moved
-    (``_fast_path_generation_reread_error_frame``, same
-    ``task_deleted``-vs-everything-else split as
-    ``_fast_path_steps_read_error_frame``). Serializing a step can fail
-    too -- ``PublicStep.data`` carries arbitrary tool JSON -- which ends
-    the step content there and closes the same way, so no exit leaves
-    the client with an already-started 200 response and no close frame.
-
-    The body both fast paths share lives in
-    ``_fast_path_snapshot_stream``; this function supplies the
-    conclusion frame and the path label.
+    The frame order, the generation fence, and how every failure exit
+    still closes with a frame all live in ``_fast_path_snapshot_stream``,
+    the body both fast paths share; this function supplies the
+    conclusion frame -- built from the authoritative read that selected
+    this path -- and the ``"terminal"`` path label.
     """
     # Built here, before the shared body is entered, from ``snapshot``'s
     # own authoritative read -- the read that selected this fast path --
@@ -1932,13 +1881,13 @@ def _input_required_snapshot_stream(
 
     Same ordering, the same read-failure handling, the same pre-steps
     generation fence, and the same guard around step serialization as
-    ``_terminal_snapshot_stream`` -- see that function's docstring for
-    why the steps read is guarded in its own ``try``/``except`` rather
-    than left to raise past this generator's first ``yield``, why step
-    content is withheld until a reread confirms the task row is still
-    the generation ``snapshot`` was read from, and why
-    ``task.input_required`` goes out on every exit regardless of what
-    the fence decides about step content.
+    ``_terminal_snapshot_stream`` -- ``_fast_path_snapshot_stream``, the
+    body both paths share, documents why the steps read is guarded in
+    its own ``try``/``except`` rather than left to raise past the
+    generator's first ``yield``, why step content is withheld until a
+    reread confirms the task row is still the generation ``snapshot``
+    was read from, and why the conclusion goes out on every exit
+    regardless of what the fence decides about step content.
     """
     # Built here, before the shared body is entered, for the same reason
     # as ``_terminal_snapshot_stream``'s own conclusion: it describes the

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -323,9 +323,19 @@ def status_frame(status: str) -> str:
 # untruncated ``data``. The recovery channel for these two is
 # ``GET /v1/chat/tasks/{task_id}``: ``TaskInfoResponse.output`` and
 # ``TaskInfoResponse.pending_interaction.question``. Cost of the
-# exemption is bounded by construction: each is sent once per stream, as
-# its closing frame (``enqueue_close`` on the live path, the last yield
-# on each attach-time fast path), never repeatedly.
+# exemption is bounded by construction: each is sent exactly once per
+# stream, as that stream's conclusion frame -- ``enqueue_close`` on the
+# live path, and on each attach-time fast path the frame every exit
+# emits before returning. On the fast paths that conclusion is not
+# necessarily the last frame on the wire: four of the five exits follow
+# it with a ``stream.error`` (a failed steps read, a failed generation
+# reread, a confirmed generation change, or a failed step
+# serialization), and only the ordinary exit ends there. That two-frame
+# close order -- conclusion first, then the error naming why the step
+# snapshot is incomplete -- is what
+# ``GET /v1/chat/tasks/{task_id}/events`` documents for these paths.
+# What this exemption bounds is how many times the uncapped payload
+# itself goes out, which is once either way.
 def completed_frame(*, status: str, output: str | None, error: str | None) -> str:
     return _sse_frame(
         "task.completed", {"status": status, "output": output, "error": error}

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -87,16 +87,26 @@ values it deliberately leaves unbounded, in one place:
     that leaves ordinary traffic alone -- against the ~16 MiB a full
     element-capped queue of maximum frames would otherwise hold.
   - One attach-time fast-path step snapshot: ``REPLAY_MAX_STEPS`` (512
-    steps). A task with more public steps than that sends only its most
-    recent 512, and the first ``step.*`` frame carries
-    ``snapshot_truncated``/``snapshot_total_steps`` so the client can
-    tell a bounded snapshot from a complete one. This bounds how much
-    one response may hold, not how much backlog may accumulate: the
-    fast paths ``yield`` their frames straight from the generator, so no
-    sink and no outbound queue exist on those paths and neither queue
-    bound above applies to them. Each of those frames is still subject
-    to the 64 KiB per-step ``data`` cap, which is applied per frame
-    wherever the frame is built.
+    steps) *and* ``MAX_SNAPSHOT_WIRE_BYTES`` (4 MiB of serialized frame
+    text). Whichever binds first cuts the snapshot short: the step cap
+    binds on a long history of ordinary steps, the byte budget on a
+    short history of large ones -- 512 steps each carrying a ``data``
+    sub-object right at the 64 KiB cap is ~32 MiB generated into one
+    response, and these paths are exempt from the concurrency caps
+    below, so nothing else bounds how many such responses run at once.
+    The step cap keeps the most recent steps (in ``started_at`` order);
+    the byte budget then admits that window from its oldest end, so the
+    snapshot stays a contiguous run in wire order. Either way the first
+    ``step.*`` frame carries ``snapshot_truncated`` (``true``) and
+    ``snapshot_total_steps`` (the task's full public step count), so the
+    client can tell a bounded snapshot from a complete one and knows how
+    much of it is missing -- ``GET .../steps`` is the authoritative full
+    history. These bound how much one response may hold, not how much
+    backlog may accumulate: the fast paths ``yield`` their frames
+    straight from the generator, so no sink and no outbound queue exist
+    on those paths and neither queue bound above applies to them. Each
+    of those frames is still subject to the 64 KiB per-step ``data``
+    cap, which is applied per frame wherever the frame is built.
   - Concurrent streams: ``PER_TASK_STREAM_CAP`` (2) and
     ``PER_PRINCIPAL_STREAM_CAP`` (32), both rejected with 429 at
     attach, before any sink exists.
@@ -117,7 +127,9 @@ values it deliberately leaves unbounded, in one place:
     sits outside the ``data`` sub-object the 64 KiB cap covers. A step
     id derives from the event's own ``tool_call_id``/``step_id``, so
     what bounds it is the 256 KiB check on the inbound frame carrying
-    it, and the queue's byte budget bounds ids in aggregate. Today's
+    it, and in aggregate the queue's byte budget on the live path or
+    ``MAX_SNAPSHOT_WIRE_BYTES`` on the two attach-time fast paths, which
+    have no queue of their own. Today's
     only ``message_id`` producer emits a fixed 45 characters
     (``f"final_answer_{uuid4().hex}"``,
     ``core/agent/runtime.py``'s ``start_final_answer_stream``), but
@@ -237,8 +249,24 @@ MAX_RAW_FRAME_TEXT_CHARS = 4 * MAX_FRAME_CONTENT_BYTES
 # otherwise bound how much one response can hold. Exceeding it keeps
 # only the most recent ``REPLAY_MAX_STEPS`` steps (in ``started_at``
 # order, same as everywhere else) and marks the first frame as
-# truncated -- see ``_fast_path_step_snapshot``.
+# truncated -- see ``_fast_path_step_snapshot``. Bounds the count only;
+# ``MAX_SNAPSHOT_WIRE_BYTES`` below bounds the size.
 REPLAY_MAX_STEPS = 512
+# The attach-time snapshot's second bound, on the total wire bytes one
+# response may hold rather than on its step count -- the fast paths'
+# analogue of the queue's ``MAX_QUEUED_WIRE_BYTES``, and sized the same
+# way (64 largest-possible content frames, expressed against
+# ``MAX_FRAME_CONTENT_BYTES`` so it tracks that cap instead of drifting
+# from it). ``REPLAY_MAX_STEPS`` alone does not bound size: 512 steps
+# each carrying a ``data`` sub-object right at the 64 KiB cap is ~32 MiB
+# generated into a single response, and these paths return before the
+# per-task / per-principal caps are checked, so nothing bounds how many
+# of those run concurrently. Strictly over the budget stops the
+# snapshot, exactly on it does not -- the same boundary rule the queue
+# budget and ``MAX_RAW_FRAME_TEXT_CHARS`` use. Frames are pure ASCII
+# (``json.dumps`` runs with the default ``ensure_ascii=True``), so
+# ``len(frame_text)`` is the wire byte count and no encode is needed.
+MAX_SNAPSHOT_WIRE_BYTES = 64 * MAX_FRAME_CONTENT_BYTES
 # Floor for the final wait when the 1-hour deadline is close: keeps the
 # queue wait from being called with a near-zero timeout, which would spin
 # the loop instead of actually waiting.
@@ -1420,6 +1448,56 @@ def _sse_response(body: AsyncIterator[str]) -> StreamingResponse:
     return StreamingResponse(body, media_type="text/event-stream", headers=_SSE_HEADERS)
 
 
+def _snapshot_steps_within_wire_budget(
+    steps: "list[PublicStep]",
+) -> "list[PublicStep]":
+    """The longest prefix of ``steps`` whose serialized frames fit
+    ``MAX_SNAPSHOT_WIRE_BYTES``.
+
+    Measures with ``_step_wire_frame`` -- the same builder the emit loop
+    uses -- and throws the text away, so at most one frame is
+    materialized at a time. Serializing twice is what buys that: the fast
+    paths return before the per-task / per-principal caps are checked, so
+    a design that held the admitted frames to avoid the second pass would
+    hold up to the whole budget per attach with nothing bounding how many
+    attaches run at once. The doubled work is bounded by the budget
+    itself (2 x 4 MiB), against the ~32 MiB a single unbounded snapshot
+    could serialize today, so this pass lowers the worst case rather than
+    adding to it. ``_step_wire_frame`` is a pure function of the step
+    (``_capped_step_data`` builds new dicts and never mutates its input),
+    so the second pass produces byte-identical frames.
+
+    A prefix, not a suffix, even though ``REPLAY_MAX_STEPS`` keeps the
+    most recent steps: a step whose ``data`` cannot be serialized cannot
+    be measured either, and admitting it here is what keeps the emit loop
+    reaching it and reporting it through
+    ``_fast_path_step_serialize_error_frame`` -- with the steps before it
+    already on the wire, which is the behavior
+    ``GET /v1/chat/tasks/{task_id}/events`` documents. Dropping from the
+    oldest end instead would put an unserializable step at the head of
+    the window, where it suppresses every good step behind it, or force
+    the failure to be folded into "snapshot truncated" and never
+    reported. The budget only binds on a window averaging more than 8 KiB
+    per step, and a client whose snapshot was cut is told so by
+    ``snapshot_truncated`` and sent to ``GET .../steps`` either way.
+    """
+    budget_remaining = MAX_SNAPSHOT_WIRE_BYTES
+    admitted = 0
+    for step in steps:
+        try:
+            frame_bytes = len(_step_wire_frame(step))
+        except Exception:
+            # Unmeasurable: admit it so the emit loop fails on it -- see
+            # the docstring above.
+            admitted += 1
+            break
+        if frame_bytes > budget_remaining:
+            break
+        budget_remaining -= frame_bytes
+        admitted += 1
+    return steps[:admitted]
+
+
 async def _fast_path_step_snapshot(
     task_id: int,
     principal: "ApiKeyPrincipal",
@@ -1431,31 +1509,43 @@ async def _fast_path_step_snapshot(
     burst of fast-path attaches on one task collapses into a cache hit
     instead of each one re-reading and re-projecting independently.
 
-    Bounded to ``REPLAY_MAX_STEPS``: without that bound, a fast-path
-    attach to a task with an unusually long step history returned every
-    step from this cached list in one shot, with no admission /
-    deadline / heartbeat loop to pace it, unlike everything else this
-    stream serves. The cached list is already in ``started_at`` order
-    (``map_trace_events_to_public_steps``'s own docstring: "in the
-    order their start events first appeared"), so
+    Bounded by two caps, whichever binds first: ``REPLAY_MAX_STEPS``
+    (step count) and ``MAX_SNAPSHOT_WIRE_BYTES`` (serialized size, via
+    ``_snapshot_steps_within_wire_budget``). Without them, a fast-path
+    attach to a task with an unusually long or heavy step history
+    returned every step from this cached list in one shot, with no
+    admission / deadline / heartbeat loop to pace it, unlike everything
+    else this stream serves. The cached list is already in
+    ``started_at`` order (``map_trace_events_to_public_steps``'s own
+    docstring: "in the order their start events first appeared"), so
     ``steps[-REPLAY_MAX_STEPS:]`` keeps the most recent steps and drops
-    the oldest. Returns the validated
+    the oldest; the byte budget is then applied to that window from its
+    oldest end (see ``_snapshot_steps_within_wire_budget`` for why a
+    prefix, not a suffix, is what it keeps). Returns the validated
     ``PublicStep`` objects themselves, not their serialized frame text
     -- serialization happens one frame at a time in each fast path's own
     yield loop below instead, so a large step list is never fully
-    materialized as SSE text (or held as a list of strings) all at once.
-    The second element is the task's true total step count
-    (``snapshot_total_steps`` for the first serialized frame) when
-    truncation happened, or ``None`` when the full list fit.
+    materialized as SSE text (or held as a list of strings) all at once;
+    the byte budget's own measuring pass is the one place that comes
+    close, and it holds at most one frame's text at a time (see that
+    function's docstring).
+    The second element is the task's true total public step count
+    whenever the returned list is short of it, by either bound, or
+    ``None`` when the whole history fits. The first serialized frame's
+    truncation marker then costs it about 52 bytes more than the
+    measuring pass counted for it -- a bounded overrun, accepted the same
+    way the queue's own byte budget leaves its per-string object header
+    uncounted.
     """
     steps_response = await run_db_io_cancellation_safe(
         lambda: read_task_steps_response(task_id, principal)
     )
     steps = steps_response.steps
     total_steps = len(steps)
-    if total_steps > REPLAY_MAX_STEPS:
-        return steps[-REPLAY_MAX_STEPS:], total_steps
-    return steps, None
+    admitted = _snapshot_steps_within_wire_budget(steps[-REPLAY_MAX_STEPS:])
+    if len(admitted) < total_steps:
+        return admitted, total_steps
+    return admitted, None
 
 
 def _fast_path_steps_read_error_frame(

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -376,10 +376,15 @@ def error_frame(code: str, *, message: str | None = None) -> str:
     either way, so an unrecognized ``code`` raises ``KeyError`` whether
     or not a ``message`` was passed -- the check is on the code, not on
     which optional argument the caller supplied.
+
+    An explicitly empty ``message`` is kept as-is rather than falling
+    back to the default: only an omitted override (``None``) selects
+    ``_ERROR_MESSAGES[code]``.
     """
     default_message = _ERROR_MESSAGES[code]
     return _sse_frame(
-        "stream.error", {"code": code, "message": message or default_message}
+        "stream.error",
+        {"code": code, "message": message if message is not None else default_message},
     )
 
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1245,7 +1245,15 @@ async def stream_chat_task_events(
       - ``step.started``: ``{step}``, a running ``PublicStep``.
       - ``step.completed``: ``{step}``, the same step once its end event
         (or failure) resolves it -- ``status`` is ``"completed"`` or
-        ``"failed"``.
+        ``"failed"``. On the two attach-time fast paths below (the task
+        is already finished, or already waiting on user input), the
+        first ``step.*`` frame carries two extra fields,
+        ``snapshot_truncated: true`` and ``snapshot_total_steps``, when
+        that one-shot step snapshot was bounded because the task has
+        more public steps than this stream sends at once (512) --
+        absent otherwise. ``snapshot_total_steps`` is the task's full
+        step count at attach time; the frames themselves are always its
+        most recent steps in ``started_at`` order.
       - ``message.delta``: ``{message_id, text}``, one chunk of a
         streamed final answer as the agent generates it.
       - ``message.completed``: ``{message_id, content}``, that same
@@ -1332,20 +1340,20 @@ async def stream_chat_task_events(
         line is sent whenever 15s pass without any other frame going
         out, to keep the connection alive -- not on a fixed 15s
         cadence regardless of activity.
-      - This stream carries only what happens after the connection
-        opens; it never sends the steps that already happened, on any
-        path. That has two consequences a client must handle. First, a
-        step that was already running at attach time does not appear on
-        this stream at all: its ``step.started`` was broadcast before
-        this connection existed, and its end event arrives here with no
-        matching start, so that end is dropped rather than sent. The
-        client sees neither half of the step -- it is absent, not left
-        at ``"running"``. Second, an attach that arrives once the task
-        has already finished (or is already waiting on user input) has
-        no live content left to carry, so it closes with the lifecycle
-        frames alone. Either way, ``GET .../steps`` reads the database
-        and is unaffected by when the stream was opened, so that is
-        where a client reconciles what this stream did not carry.
+      - A stream that goes live carries only what happens after the
+        connection opens; it never resends the steps that already
+        happened. (The two attach-time fast paths below are the
+        exception: they send a one-shot snapshot of the task's steps
+        and close, rather than going live at all.) That has one
+        consequence a client must handle: a step that was already
+        running at attach time does not appear on this stream at all.
+        Its ``step.started`` was broadcast before this connection
+        existed, and its end event arrives here with no matching
+        start, so that end is dropped rather than sent -- the client
+        sees neither half of the step. ``GET .../steps`` reads the
+        database and is unaffected by when the stream was opened, so a
+        client attaching to an already-running task reconciles there
+        rather than expecting this stream to fill the gap.
       - Frame sequence into ``task.completed``: a task that fails emits
         ``task.status`` (``"failed"``) from the failure broadcast first,
         then the watchdog's authoritative ``task.completed`` close
@@ -1399,22 +1407,52 @@ async def stream_chat_task_events(
         content frame arrived" as "nothing happened". A task that
         succeeds has no intermediate status broadcast, so it goes
         straight to ``task.completed`` with no preceding
-        ``task.status``.
+        ``task.status``. Attaching to a task that's already terminal
+        (the fast path below) always sends the conclusion frame; the
+        generation reread below decides only whether step content
+        accompanies it, sending ``resync_required`` in place of the
+        steps on a confirmed change.
       - Attaching to an already-finished task is not an error: the
-        stream opens, emits ``task.status`` then ``task.completed``,
-        and closes immediately, with no ``step.*`` frames in between --
-        that task's steps are read through ``GET .../steps``.
+        stream opens, emits ``task.status``, the task's steps, then
+        ``task.completed``, and closes immediately. If reading those
+        steps fails, this fast path (and the waiting-for-user one
+        below) still sends its conclusion frame -- ``task.completed``
+        here, ``task.input_required`` there -- before closing with a
+        ``stream.error`` frame naming why -- ``task_deleted`` when the
+        row is gone by the time the steps are read, ``resync_required``
+        otherwise: a step-read failure on either fast path never
+        costs the client the lifecycle conclusion it already had in
+        hand from the snapshot that picked this path. Step content goes
+        out at all only once the task row has been read once more and
+        confirmed to still be the same run/state generation as the
+        snapshot that picked this path -- a task that restarted in
+        between (a ``POST reply`` resuming a waiting task, or a WS
+        append resuming a finished one) moves the row to a new
+        generation, which means the steps just read may already belong
+        to it while the conclusion still describes the old one. A
+        confirmed match sends both the steps and the conclusion; a
+        confirmed change still sends the conclusion but withholds the
+        steps, closing with ``resync_required`` instead; and a reread
+        that fails outright is treated like the steps-read failure
+        above -- no step content goes out, but the conclusion (already
+        known-good, independent of this reread) still does, followed by
+        ``stream.error`` naming why -- ``task_deleted`` or
+        ``resync_required`` by the same rule. A failure while
+        serializing an individual step is handled the same way: the
+        conclusion frame goes out, followed by
+        ``stream.error(resync_required)``, and the step list sent
+        before the failure may be partial.
       - The stream force-closes with ``task.input_required`` if the task
-        is found waiting on user input (same shape: ``task.status``,
-        then ``task.input_required``, then close); with ``stream.error``
-        if the API key is revoked/paused, the task row disappears
-        (within one watchdog cycle, 30s in production, of the delete),
-        the client can't keep up (``resync_required``), or the stream
-        has been open for the 1-hour maximum (``stream_expired``,
-        emitted before the connection closes so it's distinguishable
-        from a clean end). After any ``stream.error``, re-attaching is
-        the supported recovery path (no replay of missed frames --
-        reconcile via ``steps()`` first).
+        is found waiting on user input (same steps-then-close shape:
+        ``task.status``, the task's steps, then ``task.input_required``);
+        with ``stream.error`` if the API key is revoked/paused, the task
+        row disappears (within one watchdog cycle, 30s in production, of
+        the delete), the client can't keep up (``resync_required``), or
+        the stream has been open for the 1-hour maximum
+        (``stream_expired``, emitted before the connection closes so
+        it's distinguishable from a clean end). After any
+        ``stream.error``, re-attaching is the supported recovery path
+        (no replay of missed frames -- reconcile via ``steps()`` first).
       - A task that's ``paused`` does not close the stream (matching
         SDK ``wait()`` semantics: another process may resume it); the
         1-hour cap is what eventually ends an orphaned paused stream.
@@ -1453,8 +1491,25 @@ async def stream_chat_task_events(
             times the worker count. An attach that takes the terminal
             or waiting-for-user fast path (see Behavior above) never
             registers a sink at all, so it never counts toward either
-            cap. Broadcast delivery is per-process too: a sink only
-            receives the broadcasts fanned out by its own worker
+            cap -- its step snapshot read goes through the same
+            ``max_event_id``-keyed cache ``GET .../steps`` uses. That
+            snapshot is bounded: a task with more public steps than the
+            cap returns only its most recent ones on this fast path,
+            with the ``snapshot_truncated``/``snapshot_total_steps`` marker
+            on the first ``step.*`` frame described above. When a
+            shared cache backend is configured (Redis; see
+            ``hot_path_cache.get_cache_backend``), a burst of fast-path
+            attaches on one task (or repeated attaches after it's
+            already terminal) usually collapses into cache hits rather
+            than each one re-reading and re-projecting the task's full
+            trace history. Without one configured -- ``NoOpCache``, what
+            this reads through whenever Redis is disabled -- every
+            attach re-reads and re-projects the task's full trace
+            history regardless of this shared code path; the cache-hit
+            collapsing only actually happens with a real backend behind
+            it. Broadcast delivery is per-process
+            too: a sink only receives the broadcasts fanned out by its
+            own worker
             process's connection manager, so a task transition driven
             by a different worker reaches this stream only once the
             watchdog's 30s database poll picks it up, not via broadcast.
@@ -1478,4 +1533,5 @@ async def stream_chat_task_events(
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=_load_task_info_snapshot,
+        read_task_steps_response=_get_chat_task_steps_sync,
     )

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1437,18 +1437,25 @@ async def stream_chat_task_events(
         hand from the snapshot that picked this path. Step content goes
         out at all only once the task row has been read once more and
         confirmed to still be the same run/state generation as the
-        snapshot that picked this path -- a task that restarted in
-        between (a ``POST reply`` resuming a waiting task, or a WS
-        append resuming a finished one) moves the row to a new
+        snapshot that picked this path, *and* the steps cursor
+        (``max_event_id``) is confirmed unmoved since -- a task that
+        restarted in between (a ``POST reply`` resuming a waiting task,
+        or a WS append resuming a finished one) moves the row to a new
         generation, which means the steps just read may already belong
-        to it while the conclusion still describes the old one. A
-        confirmed match sends both the steps and the conclusion; a
-        confirmed change still sends the conclusion but withholds the
-        steps, closing with ``resync_required`` instead; and a reread
-        that fails outright is treated like the steps-read failure
-        above -- no step content goes out, but the conclusion (already
-        known-good, independent of this reread) still does, followed by
-        ``stream.error`` naming why -- ``task_deleted`` or
+        to it while the conclusion still describes the old one; a trace
+        row landing in that same window can advance the cursor without
+        touching ``run_id``/``state_version`` at all (trace rows write
+        through their own commit, which can update the task row's own
+        checkpoint-pointer columns while the task is running but never
+        touches those two fields), so the generation check alone cannot
+        see it. Both checks have to pass for the steps to go out: a
+        confirmed match on both sends the steps, then the conclusion; a
+        confirmed change on either still sends the conclusion but
+        withholds the steps, closing with ``resync_required`` instead;
+        and a reread that fails outright is treated like the steps-read
+        failure above -- no step content goes out, but the conclusion
+        (already known-good, independent of this reread) still does,
+        followed by ``stream.error`` naming why -- ``task_deleted`` or
         ``resync_required`` by the same rule. A failure while
         serializing an individual step is handled the same way: the
         conclusion frame goes out, followed by
@@ -1546,4 +1553,5 @@ async def stream_chat_task_events(
         initial_snapshot=snapshot,
         read_task_snapshot=_load_task_info_snapshot,
         read_task_steps_response=_get_chat_task_steps_sync,
+        read_task_steps_version=_load_task_steps_version_snapshot,
     )

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1248,12 +1248,17 @@ async def stream_chat_task_events(
         ``"failed"``. On the two attach-time fast paths below (the task
         is already finished, or already waiting on user input), the
         first ``step.*`` frame carries two extra fields,
-        ``snapshot_truncated: true`` and ``snapshot_total_steps``, when
-        that one-shot step snapshot was bounded because the task has
-        more public steps than this stream sends at once (512) --
-        absent otherwise. ``snapshot_total_steps`` is the task's full
-        step count at attach time; the frames themselves are always its
-        most recent steps in ``started_at`` order.
+        ``snapshot_truncated: true`` and ``snapshot_total_steps``,
+        whenever that one-shot step snapshot sends fewer steps than the
+        task has -- absent otherwise. Two bounds can cut it short: a
+        step-count cap (512), and a total-wire-bytes budget over the
+        snapshot's serialized frames. ``snapshot_total_steps`` is the
+        task's full step count at attach time. The frames are in
+        ``started_at`` order, drawn from the task's most recent steps
+        up to the count cap; when the byte budget is what binds, it
+        keeps that window's oldest contiguous run, so the very latest
+        steps may be the ones missing -- ``GET .../steps`` is the
+        authoritative full history either way.
       - ``message.delta``: ``{message_id, text}``, one chunk of a
         streamed final answer as the agent generates it.
       - ``message.completed``: ``{message_id, content}``, that same
@@ -1493,10 +1498,10 @@ async def stream_chat_task_events(
             registers a sink at all, so it never counts toward either
             cap -- its step snapshot read goes through the same
             ``max_event_id``-keyed cache ``GET .../steps`` uses. That
-            snapshot is bounded: a task with more public steps than the
-            cap returns only its most recent ones on this fast path,
-            with the ``snapshot_truncated``/``snapshot_total_steps`` marker
-            on the first ``step.*`` frame described above. When a
+            snapshot is bounded by a step-count cap and a
+            total-wire-bytes budget; a snapshot cut short by either
+            carries the ``snapshot_truncated``/``snapshot_total_steps``
+            marker on the first ``step.*`` frame described above. When a
             shared cache backend is configured (Redis; see
             ``hot_path_cache.get_cache_backend``), a burst of fast-path
             attaches on one task (or repeated attaches after it's

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1237,6 +1237,17 @@ async def stream_chat_task_events(
         elsewhere in this router; the two error-code vocabularies do
         not overlap.
 
+      On the two attach-time fast paths described under Behavior below,
+      whichever of these two conclusion frames the path emits carries two
+      extra fields, ``snapshot_truncated: true`` and
+      ``snapshot_total_steps`` (the task's full public step count at
+      attach time), whenever that attach's one-shot step snapshot sent
+      fewer steps than the task has -- absent otherwise, and absent on
+      every other producer of these two frames. They ride the conclusion
+      rather than a ``step.*`` frame because the snapshot's byte budget
+      can admit no steps at all, leaving no ``step.*`` frame to carry
+      them.
+
     The other four project the task's step-by-step execution and
     streamed message text onto the same connection, from the same
     ``PublicStep`` shape and public step-type list ``GET
@@ -1246,19 +1257,15 @@ async def stream_chat_task_events(
       - ``step.completed``: ``{step}``, the same step once its end event
         (or failure) resolves it -- ``status`` is ``"completed"`` or
         ``"failed"``. On the two attach-time fast paths below (the task
-        is already finished, or already waiting on user input), the
-        first ``step.*`` frame carries two extra fields,
-        ``snapshot_truncated: true`` and ``snapshot_total_steps``,
-        whenever that one-shot step snapshot sends fewer steps than the
-        task has -- absent otherwise. Two bounds can cut it short: a
-        step-count cap (512), and a total-wire-bytes budget over the
-        snapshot's serialized frames. ``snapshot_total_steps`` is the
-        task's full step count at attach time. The frames are in
+        is already finished, or already waiting on user input), these
+        frames are that attach's one-shot step snapshot: in
         ``started_at`` order, drawn from the task's most recent steps
-        up to the count cap; when the byte budget is what binds, it
-        keeps that window's oldest contiguous run, so the very latest
-        steps may be the ones missing -- ``GET .../steps`` is the
-        authoritative full history either way.
+        up to a step-count cap (512) and a total-wire-bytes budget over the
+        snapshot's serialized frames. When the byte budget is what binds,
+        it keeps that window's oldest contiguous run, so the very latest
+        steps may be the ones missing. Whether the snapshot was cut short
+        is reported on the conclusion frame, not on these -- ``GET
+        .../steps`` is the authoritative full history either way.
       - ``message.delta``: ``{message_id, text}``, one chunk of a
         streamed final answer as the agent generates it.
       - ``message.completed``: ``{message_id, content}``, that same
@@ -1501,7 +1508,7 @@ async def stream_chat_task_events(
             snapshot is bounded by a step-count cap and a
             total-wire-bytes budget; a snapshot cut short by either
             carries the ``snapshot_truncated``/``snapshot_total_steps``
-            marker on the first ``step.*`` frame described above. When a
+            marker on its conclusion frame as described above. When a
             shared cache backend is configured (Redis; see
             ``hot_path_cache.get_cache_backend``), a burst of fast-path
             attaches on one task (or repeated attaches after it's

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -267,6 +267,24 @@ def _long_intervals(**overrides: float) -> dict[str, float]:
     }
 
 
+def _parse_error_frame(body: str) -> dict:
+    """Extract and parse the one ``stream.error`` frame's JSON payload out
+    of a full SSE response body.
+
+    Asserts there is exactly one -- a caller relying on the returned
+    ``code``/``message`` needs the frame that actually closed the
+    stream, not whichever one a substring search happened to match, and
+    a body with zero or more than one ``stream.error`` frame is itself a
+    sign the test's premise is wrong.
+    """
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    error_blocks = [b for b in blocks if b.startswith("event: stream.error")]
+    assert len(error_blocks) == 1, (
+        f"expected exactly one stream.error frame, got {len(error_blocks)}: {body!r}"
+    )
+    return json.loads(error_blocks[0].split("data: ", 1)[1])
+
+
 # ===== error_frame code validation =====
 
 
@@ -2727,7 +2745,14 @@ async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bar
     ``stream.error``, conclusion first -- a step-read failure only costs
     the client the step content, never the fact that the task already
     reached this state. This test's ``principal`` is ``None`` -- it's
-    only testing the steps-read failure, not authorization."""
+    only testing the steps-read failure, not authorization.
+
+    The message is pinned exactly, not by substring: it has to be true
+    of a failure preparing the snapshot in general, not name the steps
+    read specifically -- the cursor baseline read shares this same
+    ``except`` (see ``_fast_path_steps_read_error_frame``) and a wording
+    that only fits one of the two would misdescribe the other whenever
+    it's the one that actually failed."""
 
     def _broken_read_task_steps_response(task_id_, principal_):
         raise RuntimeError("transient DB error reading cached steps")
@@ -2752,8 +2777,12 @@ async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bar
     terminal_body = "".join(terminal_frames)
     assert terminal_body.count("event: task.status") == 1
     assert terminal_body.count("event: task.completed") == 1
-    assert terminal_body.count("event: stream.error") == 1
-    assert "resync_required" in terminal_body
+    terminal_error = _parse_error_frame(terminal_body)
+    assert terminal_error["code"] == "resync_required"
+    assert terminal_error["message"] == (
+        "Preparing the task's step snapshot failed; call steps() to "
+        "resync, then re-attach."
+    )
     # Order matters: the conclusion frame is the authoritative one and
     # must reach the client even if the error frame that follows it is
     # somehow lost -- not the other way around.
@@ -2779,8 +2808,12 @@ async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bar
     waiting_body = "".join(waiting_frames)
     assert waiting_body.count("event: task.status") == 1
     assert waiting_body.count("event: task.input_required") == 1
-    assert waiting_body.count("event: stream.error") == 1
-    assert "resync_required" in waiting_body
+    waiting_error = _parse_error_frame(waiting_body)
+    assert waiting_error["code"] == "resync_required"
+    assert waiting_error["message"] == (
+        "Preparing the task's step snapshot failed; call steps() to "
+        "resync, then re-attach."
+    )
     assert waiting_body.index("event: task.input_required") < waiting_body.index(
         "event: stream.error"
     )
@@ -2826,9 +2859,7 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
         )
     ]
     terminal_body = "".join(terminal_frames)
-    assert terminal_body.count("event: stream.error") == 1
-    assert "task_deleted" in terminal_body
-    assert "resync_required" not in terminal_body
+    assert _parse_error_frame(terminal_body)["code"] == "task_deleted"
     assert terminal_body.count("event: task.completed") == 1
     assert terminal_body.index("event: task.completed") < terminal_body.index(
         "event: stream.error"
@@ -2850,9 +2881,7 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
         )
     ]
     waiting_body = "".join(waiting_frames)
-    assert waiting_body.count("event: stream.error") == 1
-    assert "task_deleted" in waiting_body
-    assert "resync_required" not in waiting_body
+    assert _parse_error_frame(waiting_body)["code"] == "task_deleted"
     assert waiting_body.count("event: task.input_required") == 1
     assert waiting_body.index("event: task.input_required") < waiting_body.index(
         "event: stream.error"

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -393,10 +393,37 @@ def test_events_not_owned_404():
 # ===== attach on an already-terminal task =====
 
 
-def test_events_terminal_task_immediate_close():
+@pytest.mark.parametrize(
+    ("status", "output", "error_message", "expected_completed_data"),
+    [
+        pytest.param(
+            TaskStatus.COMPLETED,
+            "the answer",
+            None,
+            {"status": "completed", "output": "the answer", "error": None},
+            id="completed",
+        ),
+        pytest.param(
+            TaskStatus.FAILED,
+            None,
+            "the tool call raised",
+            {"status": "failed", "output": None, "error": "the tool call raised"},
+            id="failed",
+        ),
+    ],
+)
+def test_events_terminal_task_immediate_close(
+    status, output, error_message, expected_completed_data
+):
+    """Both terminal statuses (``_TERMINAL_STATUSES``: completed and
+    failed) take this fast path and their own field -- ``output`` for a
+    completed task, ``error`` for a failed one -- has to actually reach
+    the ``task.completed`` frame; a test pinning only the completed leg
+    would miss a regression that dropped ``error`` from the frame while
+    leaving ``output`` alone."""
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)
-    _set_task_status(task_id, TaskStatus.COMPLETED, output="the answer")
+    _set_task_status(task_id, status, output=output, error_message=error_message)
 
     resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
     assert resp.status_code == 200
@@ -407,12 +434,8 @@ def test_events_terminal_task_immediate_close():
     blocks = [b for b in body.split("\n\n") if b.strip()]
     status_data = json.loads(blocks[0].split("data: ", 1)[1])
     completed_data = json.loads(blocks[1].split("data: ", 1)[1])
-    assert status_data == {"status": "completed"}
-    assert completed_data == {
-        "status": "completed",
-        "output": "the answer",
-        "error": None,
-    }
+    assert status_data == {"status": status.value}
+    assert completed_data == expected_completed_data
     # No sink is registered for the terminal fast path -- nothing to close.
     assert es.count_task_sinks(task_id) == 0
 
@@ -2888,6 +2911,19 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
     )
 
 
+def test_fast_path_snapshot_bounds_match_the_documented_endpoint_contract():
+    """Pins the two literal values the attach-time snapshot is bounded
+    by. These aren't free internal tuning: ``tasks.py``'s endpoint
+    docstring documents ``REPLAY_MAX_STEPS`` as the literal number 512
+    (not a symbolic reference to this module) for API consumers reading
+    the ``GET /v1/chat/tasks/{task_id}/events`` contract, so a change to
+    either constant here has to be paired with updating that docstring
+    -- this test exists so such a change doesn't slip through silently.
+    """
+    assert es.REPLAY_MAX_STEPS == 512
+    assert es.MAX_SNAPSHOT_WIRE_BYTES == 4 * 1024 * 1024
+
+
 @pytest.mark.parametrize(
     ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
     [
@@ -2972,6 +3008,197 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps(
     conclusion_data = json.loads(conclusion_block.split("data: ", 1)[1])
     assert conclusion_data["snapshot_truncated"] is True
     assert conclusion_data["snapshot_total_steps"] == total
+
+
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_step_snapshot_applies_the_replay_cap_before_the_byte_budget(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
+    """The two admission bounds are applied in a fixed order --
+    ``REPLAY_MAX_STEPS`` first (keep the newest window), the byte
+    budget second (trim that window from its oldest end) -- not the
+    other way around. Pinned with a history where the two orders
+    produce entirely different output: 88 old steps each carrying ~48
+    KiB of ``data`` (enough on their own to exhaust the byte budget),
+    then 512 new, tiny ones. Applying ``REPLAY_MAX_STEPS`` first keeps
+    only the 512 tiny steps -- the byte budget never binds on them, so
+    all 512 go out untouched. Applying the byte budget first, over the
+    full 600-step history from its oldest end the way
+    ``_snapshot_steps_within_wire_budget`` walks, would instead spend
+    the whole budget on roughly the first 85 large steps and never even
+    reach the 512 tiny ones behind them -- a reversal this test would
+    catch by the wrong count and the wrong first step id below.
+    """
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    old_large = [
+        es.PublicStep(
+            id=f"tool_call:old-{i}",
+            type="tool_call",
+            status="completed",
+            started_at=base,
+            completed_at=base,
+            data={"name": "search", "result": "x" * (48 * 1024)},
+        )
+        for i in range(88)
+    ]
+    new_tiny = [
+        es.PublicStep(
+            id=f"tool_call:new-{i}",
+            type="tool_call",
+            status="completed",
+            started_at=base,
+            completed_at=base,
+            data={"name": "search", "result": "ok"},
+        )
+        for i in range(es.REPLAY_MAX_STEPS)
+    ]
+    steps = old_large + new_tiny
+    total = len(steps)
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=steps)
+
+    def _unchanged_read_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unchanged_read_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: step.completed") == es.REPLAY_MAX_STEPS
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    first_step_data = json.loads(blocks[1].split("data: ", 1)[1])
+    assert first_step_data["step"]["id"] == "tool_call:new-0"
+    assert body.count(f"event: {conclusion_event}") == 1
+    conclusion_block = next(
+        b for b in blocks if b.startswith(f"event: {conclusion_event}")
+    )
+    conclusion_data = json.loads(conclusion_block.split("data: ", 1)[1])
+    assert conclusion_data["snapshot_truncated"] is True
+    assert conclusion_data["snapshot_total_steps"] == total
+
+
+@pytest.mark.parametrize(
+    ("total", "expect_truncated"),
+    [
+        pytest.param(es.REPLAY_MAX_STEPS, False, id="exactly-at-cap"),
+        pytest.param(es.REPLAY_MAX_STEPS + 1, True, id="one-over-cap"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_step_snapshot_replay_max_steps_boundary(
+    stream_fn, status, conclusion_event, extra_snapshot, total, expect_truncated
+):
+    """``REPLAY_MAX_STEPS`` is a strict-over boundary, the same rule
+    every other size cap in this module uses (see ``_put_or_overflow``
+    and ``MAX_RAW_FRAME_TEXT_CHARS``'s own comments): a history of
+    exactly 512 steps fits whole and is not truncated, one more tips it
+    over. Expressed against ``es.REPLAY_MAX_STEPS`` rather than the
+    literal 512/513 so this test keeps pinning the boundary itself even
+    if the constant's value ever changes -- that value is pinned
+    separately, by
+    ``test_fast_path_snapshot_bounds_match_the_documented_endpoint_contract``.
+    """
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    steps = [
+        es.PublicStep(
+            id=f"tool_call:call-{i}",
+            type="tool_call",
+            status="completed",
+            started_at=base,
+            completed_at=base,
+            data={"name": "search", "result": "ok"},
+        )
+        for i in range(total)
+    ]
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=steps)
+
+    def _unchanged_read_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unchanged_read_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: step.completed") == min(total, es.REPLAY_MAX_STEPS)
+    assert body.count(f"event: {conclusion_event}") == 1
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    conclusion_block = next(
+        b for b in blocks if b.startswith(f"event: {conclusion_event}")
+    )
+    conclusion_data = json.loads(conclusion_block.split("data: ", 1)[1])
+    if expect_truncated:
+        assert conclusion_data["snapshot_truncated"] is True
+        assert conclusion_data["snapshot_total_steps"] == total
+    else:
+        assert "snapshot_truncated" not in conclusion_data
+        assert "snapshot_total_steps" not in conclusion_data
 
 
 @pytest.mark.parametrize(
@@ -3353,6 +3580,206 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
     assert conclusion_marker in body
     assert steps_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
     assert reread_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
+
+
+@pytest.mark.parametrize(
+    ("changed_field", "changed_value"),
+    [
+        pytest.param("run_id", "run-new", id="run-id-moved"),
+        pytest.param("state_version", 2, id="state-version-moved"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_confirmed_generation_change_short_circuits_the_cursor_recheck(
+    stream_fn, status, conclusion_event, extra_snapshot, changed_field, changed_value
+):
+    """The fence's cursor recheck only runs ``if not changed`` (see the
+    call site in ``_fast_path_snapshot_stream``): ``changed`` is
+    assigned, not OR'd, from ``_fast_path_steps_cursor_changed``'s
+    return value, so that guard is a short circuit, not just an
+    optimization -- without it, a generation reread that already
+    confirmed a change would have its ``True`` overwritten by whatever
+    the cursor recheck itself returns. A generation change can leave
+    the steps cursor unmoved (a lease release, or a resume that hasn't
+    re-run any tool yet), which is exactly the case pinned here: the
+    cursor reader always reports the same ``max_event_id`` it gave the
+    baseline, so a cursor recheck that ran anyway would report
+    "unchanged" and silently flip the fence back open, sending steps
+    the generation reread had already ruled stale.
+
+    Pinned by recording every call the cursor reader receives: the
+    short circuit means it must be called exactly once (the baseline,
+    captured before the steps read), never a second time for the
+    recheck, once the generation reread alone has already confirmed a
+    change.
+    """
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+    original = {"run_id": "run-1", "state_version": 1}
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[step])
+
+    def _reread_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(**{**original, changed_field: changed_value})
+
+    version_calls: list[tuple[int, object]] = []
+
+    def _read_task_steps_version(task_id_, principal_):
+        # Constant across calls: a recheck that ran anyway would see the
+        # same cursor it saw at baseline and report "unchanged" -- the
+        # scenario that makes an un-short-circuited recheck dangerous.
+        version_calls.append((task_id_, principal_))
+        return SimpleNamespace(max_event_id=100)
+
+    snapshot = SimpleNamespace(
+        task_id=1, agent_id=1, status=status, **original, **extra_snapshot
+    )
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=_FENCE_PRINCIPAL,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_reread_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
+        )
+    ]
+    body = "".join(frames)
+    # The short circuit's own contract: exactly the baseline call, never
+    # a recheck once the generation reread alone confirmed a change.
+    assert version_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
+    assert body.count(f"event: {conclusion_event}") == 1
+    assert "event: step.completed" not in body
+    error_data = _parse_error_frame(body)
+    assert error_data["code"] == "resync_required"
+    assert "The task changed while this attach was reading" in error_data["message"]
+
+
+@pytest.mark.parametrize("failure_exit", ["steps_read_failure", "generation_changed"])
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_failure_exits_never_carry_the_truncation_marker(
+    stream_fn, status, conclusion_event, extra_snapshot, failure_exit
+):
+    """Every failure/withhold exit on the fast paths calls
+    ``build_conclusion(None)`` (see ``_fast_path_snapshot_stream``'s own
+    docstring: "No snapshot was confirmed here, so the conclusion
+    carries no truncation marker"). This pins that even when the
+    underlying history is large enough that a *successful* read would
+    have truncated it -- 600 steps, over ``REPLAY_MAX_STEPS`` -- neither
+    failure exit's conclusion frame leaks ``snapshot_truncated`` /
+    ``snapshot_total_steps``.
+
+    The two exits differ in how far they get before failing:
+    ``steps_read_failure`` never learns the history's size at all (the
+    steps read itself raises), while ``generation_changed`` does read
+    all 600 steps -- ``_fast_path_step_snapshot`` internally admits the
+    most recent 512 and reports ``total_steps=600`` -- and only then
+    gets withheld by the fence, so it's the one exit that actually has a
+    computed truncation count in hand and still has to not send it.
+    """
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    total = es.REPLAY_MAX_STEPS + 88
+
+    if failure_exit == "steps_read_failure":
+
+        def _read_task_steps_response(task_id_, principal_):
+            raise RuntimeError("transient DB error reading cached steps")
+
+        def _read_task_snapshot(task_id_, principal_):
+            raise AssertionError(
+                "the generation reread must not run when the steps read itself failed"
+            )
+    else:
+
+        def _read_task_steps_response(task_id_, principal_):
+            return SimpleNamespace(
+                steps=[
+                    es.PublicStep(
+                        id=f"tool_call:call-{i}",
+                        type="tool_call",
+                        status="completed",
+                        started_at=base,
+                        completed_at=base,
+                        data={"name": "search", "result": "ok"},
+                    )
+                    for i in range(total)
+                ]
+            )
+
+        def _read_task_snapshot(task_id_, principal_):
+            return SimpleNamespace(run_id="run-new", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_read_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count(f"event: {conclusion_event}") == 1
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    conclusion_block = next(
+        b for b in blocks if b.startswith(f"event: {conclusion_event}")
+    )
+    conclusion_data = json.loads(conclusion_block.split("data: ", 1)[1])
+    assert "snapshot_truncated" not in conclusion_data
+    assert "snapshot_total_steps" not in conclusion_data
+    assert body.count("event: stream.error") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -1352,9 +1352,7 @@ async def test_events_per_task_cap_third_stream_429():
         (TaskStatus.WAITING_FOR_USER, "event: task.input_required"),
     ],
 )
-async def test_fast_path_attach_exempt_from_both_caps(
-    fast_path_status, closing_event, monkeypatch
-):
+async def test_fast_path_attach_exempt_from_both_caps(fast_path_status, closing_event):
     """``build_event_stream_response`` checks ``_stream_close_reason``
     before either concurrency cap (see its own docstring): a task that's
     already terminal or already waiting for user input takes the
@@ -1368,14 +1366,9 @@ async def test_fast_path_attach_exempt_from_both_caps(
     there is no way to fill that cap through it. Only after both caps
     are full does the task row flip to the fast-path status under test.
 
-    Also covers two properties of the fast path's step snapshot that a
-    frame-count-only assertion would miss entirely: it actually emits a
-    ``step.*`` frame for pre-existing history (not just the two
-    lifecycle frames alone -- a regression here would have
-    left ``PER_TASK_STREAM_CAP``-saturating cap coverage green while
-    silently dropping the step snapshot), and a second fast-path attach on the
-    same task reuses the ``steps()`` cache instead of repeating the
-    full trace read.
+    Also asserts one step frame goes out, so a regression that dropped
+    the snapshot could not hide behind the frame counts this test is
+    really about.
     """
     set_cache_backend_for_testing(InMemoryTTLCache())
     try:
@@ -1432,39 +1425,13 @@ async def test_fast_path_attach_exempt_from_both_caps(
         else:
             _set_task_status(task_id, fast_path_status, output="done")
 
-        calls: list[int] = []
-        original = v1_tasks._load_task_steps_snapshot
-
-        def _tracking(task_id_, principal_):
-            calls.append(1)
-            return original(task_id_, principal_)
-
-        monkeypatch.setattr(v1_tasks, "_load_task_steps_snapshot", _tracking)
-
         resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("text/event-stream")
         body = resp.text
         assert body.count("event: task.status") == 1
         assert body.count(closing_event) == 1
-        # The fast path really did emit the pre-existing step, not just
-        # the two lifecycle frames.
         assert body.count("event: step.completed") == 1
-        blocks = [b for b in body.split("\n\n") if b.strip()]
-        step = json.loads(blocks[1].split("data: ", 1)[1])["step"]
-        assert step["id"] == "tool_call:call-1"
-        assert step["status"] == "completed"
-        # First attach: a cache miss, so the full trace read did run once.
-        assert calls == [1]
-
-        # A second fast-path attach on the same, still-terminal task
-        # reuses the steps() cache instead of repeating that read.
-        resp2 = client.get(
-            f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key)
-        )
-        assert resp2.status_code == 200
-        assert resp2.text.count("event: step.completed") == 1
-        assert calls == [1]  # unchanged -- second attach was a cache hit
 
         # The fast path never registers a sink, so the count above -- entirely
         # made up of the cap-filling streams -- is unchanged.

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -2769,7 +2769,28 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
     )
 
 
-async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps():
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
     """The attach-time step snapshot is the one thing this stream sends
     in a single unpaced burst -- no admission/deadline/heartbeat loop --
     so it needs its own bound. This pins it: a task with 600 public
@@ -2796,19 +2817,18 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps():
     def _unchanged_read_task_snapshot(task_id_, principal_):
         return SimpleNamespace(run_id="run-1", state_version=1)
 
-    terminal_snapshot = SimpleNamespace(
+    snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
-        status=TaskStatus.COMPLETED,
-        output="done",
-        error=None,
+        status=status,
         run_id="run-1",
         state_version=1,
+        **extra_snapshot,
     )
     frames = [
         chunk
-        async for chunk in es._terminal_snapshot_stream(
-            terminal_snapshot,
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
             principal=None,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_unchanged_read_task_snapshot,
@@ -2827,6 +2847,7 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps():
     )
     second_step_data = json.loads(blocks[2].split("data: ", 1)[1])
     assert "snapshot_truncated" not in second_step_data
+    assert body.count(f"event: {conclusion_event}") == 1
 
 
 @pytest.mark.parametrize(
@@ -3059,7 +3080,28 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
     assert conclusion_marker in body
 
 
-async def test_fast_path_terminal_empty_steps_skips_the_generation_reread():
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_empty_steps_skips_the_generation_reread(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
     """An empty step list carries no step content from a possibly-newer
     run, so there is nothing for the generation reread to protect
     against -- this pins that the fast path skips it entirely rather
@@ -3077,15 +3119,14 @@ async def test_fast_path_terminal_empty_steps_skips_the_generation_reread():
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
-        status=TaskStatus.COMPLETED,
-        output="done",
-        error=None,
+        status=status,
         run_id="run-1",
         state_version=1,
+        **extra_snapshot,
     )
     frames = [
         chunk
-        async for chunk in es._terminal_snapshot_stream(
+        async for chunk in getattr(es, stream_fn)(
             snapshot,
             principal=None,
             read_task_steps_response=_read_task_steps_response,
@@ -3094,7 +3135,7 @@ async def test_fast_path_terminal_empty_steps_skips_the_generation_reread():
     ]
     body = "".join(frames)
     assert reread_calls == []
-    assert body.count("event: task.completed") == 1
+    assert body.count(f"event: {conclusion_event}") == 1
     assert "resync_required" not in body
 
 
@@ -3175,7 +3216,28 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
     assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
 
 
-async def test_fast_path_terminal_generation_reread_task_deleted_closes_with_task_deleted():
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_generation_reread_task_deleted_closes_with_task_deleted(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
     """A task deleted in the gap between the steps read and the
     generation reread surfaces from the reread as
     ``V1ApiError(TASK_NOT_FOUND)``, the same exception shape a task
@@ -3205,15 +3267,14 @@ async def test_fast_path_terminal_generation_reread_task_deleted_closes_with_tas
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
-        status=TaskStatus.COMPLETED,
-        output="done",
-        error=None,
+        status=status,
         run_id="run-1",
         state_version=1,
+        **extra_snapshot,
     )
     frames = [
         chunk
-        async for chunk in es._terminal_snapshot_stream(
+        async for chunk in getattr(es, stream_fn)(
             snapshot,
             principal=None,
             read_task_steps_response=_read_task_steps_response,
@@ -3222,11 +3283,14 @@ async def test_fast_path_terminal_generation_reread_task_deleted_closes_with_tas
     ]
     body = "".join(frames)
     assert body.count("event: task.status") == 1
-    assert body.count("event: task.completed") == 1
+    assert body.count(f"event: {conclusion_event}") == 1
     assert "event: step.completed" not in body
     assert body.count("event: stream.error") == 1
     assert "task_deleted" in body
     assert "resync_required" not in body
+    # The conclusion precedes the error, same ordering pinned on every
+    # other failure exit on this path.
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
 
 
 # ===== fast-path step serialization failure (after the first yield) =====

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3,8 +3,8 @@
 Covers registration, the sink's frame filter and exception discipline,
 the watchdog, the 1-hour cap, concurrency caps, and the ``step.*`` /
 ``message.*`` content projection layered on top of that transport
-(classification, filtering, and the per-frame content caps). Tests
-either drive ``_events_stream`` directly (fast,
+(classification, filtering, and the fast paths' cached step
+snapshot). Tests either drive ``_events_stream`` directly (fast,
 deterministic -- used whenever a test needs injected short intervals or
 precise control over the race between the watchdog and the deadline) or
 go through the real HTTP endpoint (used for the 401/404/429/terminal-
@@ -16,6 +16,7 @@ import asyncio
 import json
 import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -54,6 +55,10 @@ from xagent.web.api.ws_trace_handlers import (
 )
 from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.services.hot_path_cache import (
+    InMemoryTTLCache,
+    set_cache_backend_for_testing,
+)
 
 from ..conftest import (
     _admin_headers,
@@ -265,19 +270,20 @@ def _long_intervals(**overrides: float) -> dict[str, float]:
 # ===== error_frame code validation =====
 
 
-def test_error_frame_rejects_an_unknown_code_without_reaching_the_wire():
+def test_error_frame_rejects_an_unknown_code_with_or_without_a_message():
     """``_ERROR_MESSAGES[code]`` is looked up unconditionally, so an
-    unrecognized code raises ``KeyError`` instead of producing a
-    ``stream.error`` frame whose ``message`` a client cannot render."""
+    unrecognized code raises ``KeyError`` whether or not a ``message``
+    override was also passed -- the check is on the code, not on which
+    optional argument the caller supplied."""
     with pytest.raises(KeyError):
         es.error_frame("nope")
+    with pytest.raises(KeyError):
+        es.error_frame("nope", message="anything")
 
-    frame = es.error_frame("task_deleted")
+    # A known code still honors the message override.
+    frame = es.error_frame("task_deleted", message="custom text")
     data = json.loads(frame.split("data: ", 1)[1])
-    assert data == {
-        "code": "task_deleted",
-        "message": es._ERROR_MESSAGES["task_deleted"],
-    }
+    assert data == {"code": "task_deleted", "message": "custom text"}
 
 
 # ===== sink.send_text never raises =====
@@ -427,6 +433,7 @@ async def test_events_paused_attach_does_not_take_a_fast_path():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -467,6 +474,7 @@ async def test_sse_responses_disable_proxy_buffering(task_state):
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     try:
@@ -583,6 +591,7 @@ async def test_generator_read_path_keeps_queued_wire_bytes_at_zero_between_frame
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -810,6 +819,7 @@ async def test_real_delete_route_closes_stream_with_task_deleted():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(watchdog_interval_seconds=0.01),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -862,6 +872,7 @@ async def test_watchdog_survives_transient_check_failure_and_still_closes():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=flaky_reader,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(watchdog_interval_seconds=0.01),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -949,6 +960,7 @@ async def test_sink_unregistered_after_generator_teardown():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     first = await resp.body_iterator.__anext__()
@@ -986,6 +998,7 @@ async def test_unstarted_generator_leaves_no_registration_or_reservation():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     # No __anext__() call at all -- the generator body has never run.
@@ -1041,6 +1054,7 @@ async def test_principal_slot_released_after_real_stream_teardown():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     await resp.body_iterator.__anext__()
@@ -1127,6 +1141,7 @@ async def test_absolute_deadline_emits_expired_then_closes():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(
             stream_max_duration_seconds=0.05, heartbeat_interval_seconds=0.01
         ),
@@ -1160,6 +1175,7 @@ async def test_deadline_wait_budget_shrinks_below_the_heartbeat():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(
             stream_max_duration_seconds=0.05, heartbeat_interval_seconds=5.0
         ),
@@ -1263,6 +1279,7 @@ async def test_close_exactly_once_under_watchdog_deadline_race():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         watchdog_interval_seconds=0.001,
         stream_max_duration_seconds=0.001,
         heartbeat_interval_seconds=0.001,
@@ -1299,6 +1316,7 @@ async def test_events_per_task_cap_third_stream_429():
             principal=principal,
             initial_snapshot=snapshot,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
+            read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
             **_long_intervals(),
         )
         # Real delivery (Starlette) always pulls the first chunk before a
@@ -1314,6 +1332,7 @@ async def test_events_per_task_cap_third_stream_429():
             principal=principal,
             initial_snapshot=snapshot,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
+            read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         )
     assert exc_info.value.code is V1ErrorCode.RATE_LIMITED
     assert exc_info.value.http_status == 429
@@ -1333,7 +1352,9 @@ async def test_events_per_task_cap_third_stream_429():
         (TaskStatus.WAITING_FOR_USER, "event: task.input_required"),
     ],
 )
-async def test_fast_path_attach_exempt_from_both_caps(fast_path_status, closing_event):
+async def test_fast_path_attach_exempt_from_both_caps(
+    fast_path_status, closing_event, monkeypatch
+):
     """``build_event_stream_response`` checks ``_stream_close_reason``
     before either concurrency cap (see its own docstring): a task that's
     already terminal or already waiting for user input takes the
@@ -1346,61 +1367,119 @@ async def test_fast_path_attach_exempt_from_both_caps(fast_path_status, closing_
     never registers a sink -- once the task row is already terminal
     there is no way to fill that cap through it. Only after both caps
     are full does the task row flip to the fast-path status under test.
+
+    Also covers two properties of the fast path's step snapshot that a
+    frame-count-only assertion would miss entirely: it actually emits a
+    ``step.*`` frame for pre-existing history (not just the two
+    lifecycle frames alone -- a regression here would have
+    left ``PER_TASK_STREAM_CAP``-saturating cap coverage green while
+    silently dropping the step snapshot), and a second fast-path attach on the
+    same task reuses the ``steps()`` cache instead of repeating the
+    full trace read.
     """
-    agent_id, full_key = _create_agent_with_key()
-    task_id = _create_task(full_key, agent_id)
-    principal = _principal_for(full_key)
-    key_prefix = _key_prefix_for_agent(agent_id)
-    running_snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
-
-    # Fill the per-task cap with real streams while the task is running.
-    responses = []
-    for _ in range(es.PER_TASK_STREAM_CAP):
-        resp = await es.build_event_stream_response(
+    set_cache_backend_for_testing(InMemoryTTLCache())
+    try:
+        agent_id, full_key = _create_agent_with_key()
+        task_id = _create_task(full_key, agent_id)
+        principal = _principal_for(full_key)
+        key_prefix = _key_prefix_for_agent(agent_id)
+        running_snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+        base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        _insert_trace_event(
             task_id=task_id,
-            principal=principal,
-            initial_snapshot=running_snapshot,
-            read_task_snapshot=v1_tasks._load_task_info_snapshot,
-            **_long_intervals(),
+            event_type="tool_execution_start",
+            event_id="hist-1",
+            timestamp=base,
+            step_id="step-1",
+            data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
         )
-        await resp.body_iterator.__anext__()
-        responses.append(resp)
-    assert es.count_task_sinks(task_id) == es.PER_TASK_STREAM_CAP
+        _insert_trace_event(
+            task_id=task_id,
+            event_type="tool_execution_end",
+            event_id="hist-2",
+            timestamp=base,
+            step_id="step-1",
+            data={"tool_call_id": "call-1", "success": True, "result": "sunny"},
+        )
 
-    # Fill the rest of the per-principal cap too -- opening the streams
-    # above already reserved one principal slot per stream (`_generate`
-    # reserves on the same key_prefix), so only the remainder needs
-    # filling here.
-    already_reserved = es._principal_stream_counts.get(key_prefix, 0)
-    for _ in range(es.PER_PRINCIPAL_STREAM_CAP - already_reserved):
-        assert es.try_reserve_principal_slot(key_prefix)
-    assert es._principal_stream_counts[key_prefix] == es.PER_PRINCIPAL_STREAM_CAP
+        # Fill the per-task cap with real streams while the task is running.
+        responses = []
+        for _ in range(es.PER_TASK_STREAM_CAP):
+            resp = await es.build_event_stream_response(
+                task_id=task_id,
+                principal=principal,
+                initial_snapshot=running_snapshot,
+                read_task_snapshot=v1_tasks._load_task_info_snapshot,
+                read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+                **_long_intervals(),
+            )
+            await resp.body_iterator.__anext__()
+            responses.append(resp)
+        assert es.count_task_sinks(task_id) == es.PER_TASK_STREAM_CAP
 
-    # Now flip the task row to the fast-path status under test.
-    if fast_path_status is TaskStatus.WAITING_FOR_USER:
-        _set_task_status(task_id, fast_path_status, control_state="idle")
-    else:
-        _set_task_status(task_id, fast_path_status, output="done")
+        # Fill the rest of the per-principal cap too -- opening the streams
+        # above already reserved one principal slot per stream (`_generate`
+        # reserves on the same key_prefix), so only the remainder needs
+        # filling here.
+        already_reserved = es._principal_stream_counts.get(key_prefix, 0)
+        for _ in range(es.PER_PRINCIPAL_STREAM_CAP - already_reserved):
+            assert es.try_reserve_principal_slot(key_prefix)
+        assert es._principal_stream_counts[key_prefix] == es.PER_PRINCIPAL_STREAM_CAP
 
-    resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
-    assert resp.status_code == 200
-    assert resp.headers["content-type"].startswith("text/event-stream")
-    body = resp.text
-    assert body.count("event: task.status") == 1
-    assert body.count(closing_event) == 1
+        # Now flip the task row to the fast-path status under test.
+        if fast_path_status is TaskStatus.WAITING_FOR_USER:
+            _set_task_status(task_id, fast_path_status, control_state="idle")
+        else:
+            _set_task_status(task_id, fast_path_status, output="done")
 
-    # The fast path never registers a sink, so the count above -- entirely
-    # made up of the cap-filling streams -- is unchanged.
-    assert es.count_task_sinks(task_id) == es.PER_TASK_STREAM_CAP
+        calls: list[int] = []
+        original = v1_tasks._load_task_steps_snapshot
 
-    for resp in responses:
-        await resp.body_iterator.aclose()
-    assert es.count_task_sinks(task_id) == 0
-    # Closing each stream above already released its own reserved slot;
-    # release only the ones this test reserved manually.
-    for _ in range(es.PER_PRINCIPAL_STREAM_CAP - already_reserved):
-        es.release_principal_slot(key_prefix)
-    assert es._principal_stream_counts.get(key_prefix, 0) == 0
+        def _tracking(task_id_, principal_):
+            calls.append(1)
+            return original(task_id_, principal_)
+
+        monkeypatch.setattr(v1_tasks, "_load_task_steps_snapshot", _tracking)
+
+        resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        body = resp.text
+        assert body.count("event: task.status") == 1
+        assert body.count(closing_event) == 1
+        # The fast path really did emit the pre-existing step, not just
+        # the two lifecycle frames.
+        assert body.count("event: step.completed") == 1
+        blocks = [b for b in body.split("\n\n") if b.strip()]
+        step = json.loads(blocks[1].split("data: ", 1)[1])["step"]
+        assert step["id"] == "tool_call:call-1"
+        assert step["status"] == "completed"
+        # First attach: a cache miss, so the full trace read did run once.
+        assert calls == [1]
+
+        # A second fast-path attach on the same, still-terminal task
+        # reuses the steps() cache instead of repeating that read.
+        resp2 = client.get(
+            f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key)
+        )
+        assert resp2.status_code == 200
+        assert resp2.text.count("event: step.completed") == 1
+        assert calls == [1]  # unchanged -- second attach was a cache hit
+
+        # The fast path never registers a sink, so the count above -- entirely
+        # made up of the cap-filling streams -- is unchanged.
+        assert es.count_task_sinks(task_id) == es.PER_TASK_STREAM_CAP
+
+        for resp in responses:
+            await resp.body_iterator.aclose()
+        assert es.count_task_sinks(task_id) == 0
+        # Closing each stream above already released its own reserved slot;
+        # release only the ones this test reserved manually.
+        for _ in range(es.PER_PRINCIPAL_STREAM_CAP - already_reserved):
+            es.release_principal_slot(key_prefix)
+        assert es._principal_stream_counts.get(key_prefix, 0) == 0
+    finally:
+        set_cache_backend_for_testing(None)
 
 
 # ===== the sink never touches the database on its per-frame path =====
@@ -1477,6 +1556,7 @@ async def test_heartbeat_actually_sent_when_idle():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(heartbeat_interval_seconds=0.01),
     )
     pings = 0
@@ -1529,6 +1609,7 @@ async def test_broadcast_frame_reaches_generator_output_as_task_status():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -1582,6 +1663,7 @@ async def test_broadcast_content_frames_reach_generator_output_as_step_and_messa
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -1727,6 +1809,7 @@ async def test_completion_hint_wakes_watchdog_before_its_next_periodic_tick():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         **_long_intervals(),
     )
     await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -2466,6 +2549,745 @@ async def test_poisoned_live_frame_increments_dropped_frame_count_only_once(
     assert sink.queue.empty()
 
 
+def test_fast_path_terminal_attach_includes_current_steps():
+    """The attach-time fast path for an already-terminal task carries the
+    task's steps (from the cached ``steps()`` read), between
+    ``task.status`` and ``task.completed`` -- not just the two lifecycle
+    frames alone."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_start",
+        event_id="hist-1",
+        timestamp=base,
+        step_id="step-1",
+        data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+    )
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_end",
+        event_id="hist-2",
+        timestamp=base,
+        step_id="step-1",
+        data={"tool_call_id": "call-1", "success": True, "result": "sunny"},
+    )
+    _set_task_status(task_id, TaskStatus.COMPLETED, output="done")
+
+    resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
+    assert resp.status_code == 200
+    body = resp.text
+    assert body.count("event: task.status") == 1
+    assert body.count("event: step.completed") == 1
+    assert body.count("event: task.completed") == 1
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    step = json.loads(blocks[1].split("data: ", 1)[1])["step"]
+    assert step["id"] == "tool_call:call-1"
+    assert step["status"] == "completed"
+    assert step["data"]["result"] == "sunny"
+
+
+def test_fast_path_step_snapshot_hits_the_steps_cache(monkeypatch):
+    """The fast paths' step snapshot goes through the same
+    ``max_event_id``-keyed cache the polling ``steps()`` endpoint uses --
+    once that cache is warm (as it would be for a client that's been
+    polling ``steps()`` and then also attaches to the stream), a fast-
+    path attach doesn't repeat the full trace read
+    (``_load_task_steps_snapshot``) that produced it.
+
+    Needs a real cache backend (the default test backend is a no-op),
+    or this test would pass vacuously without ever exercising a cache
+    hit -- same rationale as ``test_tasks.py``'s cache tests.
+    """
+    set_cache_backend_for_testing(InMemoryTTLCache())
+    try:
+        agent_id, full_key = _create_agent_with_key()
+        task_id = _create_task(full_key, agent_id)
+        base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        _insert_trace_event(
+            task_id=task_id,
+            event_type="tool_execution_start",
+            event_id="hist-1",
+            timestamp=base,
+            step_id="step-1",
+            data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+        )
+        _set_task_status(task_id, TaskStatus.COMPLETED, output="done")
+
+        # Warm the steps() cache the same way a polling client would.
+        steps_resp = client.get(
+            f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+        )
+        assert steps_resp.status_code == 200
+
+        calls: list[int] = []
+        original = v1_tasks._load_task_steps_snapshot
+
+        def _tracking(task_id_, principal_):
+            calls.append(1)
+            return original(task_id_, principal_)
+
+        monkeypatch.setattr(v1_tasks, "_load_task_steps_snapshot", _tracking)
+
+        resp = client.get(f"/v1/chat/tasks/{task_id}/events", headers=_bearer(full_key))
+        assert resp.status_code == 200
+        assert "event: step.started" in resp.text
+        assert calls == []  # cache hit -- the uncached full trace read never ran
+    finally:
+        set_cache_backend_for_testing(None)
+
+
+async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bare_disconnect():
+    """Both attach-time fast paths now catch a snapshot-read failure and
+    close with ``stream.error {resync_required}``
+    -- not a bare exception out of the generator. That distinction
+    matters here specifically because ``StreamingResponse`` sends the
+    HTTP response start (200, headers) before ever pulling a chunk from
+    the body iterator: an uncaught raise doesn't turn into a different
+    HTTP status, it just ends an already-started 200 response with no
+    bytes and no close frame, indistinguishable from the client's side
+    from the connection merely dropping. ``task.status`` is emitted
+    first either way.
+
+    A step-read failure on either fast path does not cancel that path's
+    own lifecycle conclusion: the snapshot
+    that picked the fast path was already read, successfully, before
+    either generator started, so ``task.completed``/``task.input_required``
+    is known-good independent of the steps read below it. Both bodies
+    must therefore carry their conclusion frame *and* the
+    ``stream.error``, conclusion first -- a step-read failure only costs
+    the client the step content, never the fact that the task already
+    reached this state. This test's ``principal`` is ``None`` -- it's
+    only testing the steps-read failure, not authorization."""
+
+    def _broken_read_task_steps_response(task_id_, principal_):
+        raise RuntimeError("transient DB error reading cached steps")
+
+    def _unused_read_task_snapshot(task_id_, principal_):
+        raise AssertionError(
+            "the generation reread must not run when the steps read itself failed"
+        )
+
+    terminal_snapshot = SimpleNamespace(
+        task_id=1, agent_id=1, status=TaskStatus.COMPLETED, output="done", error=None
+    )
+    terminal_frames = [
+        chunk
+        async for chunk in es._terminal_snapshot_stream(
+            terminal_snapshot,
+            principal=None,
+            read_task_steps_response=_broken_read_task_steps_response,
+            read_task_snapshot=_unused_read_task_snapshot,
+        )
+    ]
+    terminal_body = "".join(terminal_frames)
+    assert terminal_body.count("event: task.status") == 1
+    assert terminal_body.count("event: task.completed") == 1
+    assert terminal_body.count("event: stream.error") == 1
+    assert "resync_required" in terminal_body
+    # Order matters: the conclusion frame is the authoritative one and
+    # must reach the client even if the error frame that follows it is
+    # somehow lost -- not the other way around.
+    assert terminal_body.index("event: task.completed") < terminal_body.index(
+        "event: stream.error"
+    )
+
+    waiting_snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.WAITING_FOR_USER,
+        pending_question="what next?",
+    )
+    waiting_frames = [
+        chunk
+        async for chunk in es._input_required_snapshot_stream(
+            waiting_snapshot,
+            principal=None,
+            read_task_steps_response=_broken_read_task_steps_response,
+            read_task_snapshot=_unused_read_task_snapshot,
+        )
+    ]
+    waiting_body = "".join(waiting_frames)
+    assert waiting_body.count("event: task.status") == 1
+    assert waiting_body.count("event: task.input_required") == 1
+    assert waiting_body.count("event: stream.error") == 1
+    assert "resync_required" in waiting_body
+    assert waiting_body.index("event: task.input_required") < waiting_body.index(
+        "event: stream.error"
+    )
+
+
+async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_required():
+    """Both attach-time fast paths must distinguish a deleted task from
+    an ordinary read failure: ``read_task_steps_response`` re-resolves
+    the task (see ``TaskStepsResponseReader``) after
+    ``build_event_stream_response`` already resolved it once to pick
+    this fast path, so a task deleted in that exact gap surfaces here as
+    ``V1ApiError(TASK_NOT_FOUND)`` -- the same condition the watchdog
+    already reports as ``task_deleted``, not ``resync_required``.
+    Asking a client to ``steps()`` and reattach
+    for a task that's gone would just 404 instead of resyncing anything.
+
+    The conclusion frame still goes out first in this case too: the
+    snapshot that picked the fast path was read before the delete, so
+    it's already in hand and does not depend on the re-resolve that
+    just 404ed.
+
+    ``principal`` is ``None`` here too -- see the companion read-failure
+    test above for why the key check is patched to succeed."""
+
+    def _deleted_read_task_steps_response(task_id_, principal_):
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
+
+    def _unused_read_task_snapshot(task_id_, principal_):
+        raise AssertionError(
+            "the generation reread must not run when the steps read itself failed"
+        )
+
+    terminal_snapshot = SimpleNamespace(
+        task_id=1, agent_id=1, status=TaskStatus.COMPLETED, output="done", error=None
+    )
+    terminal_frames = [
+        chunk
+        async for chunk in es._terminal_snapshot_stream(
+            terminal_snapshot,
+            principal=None,
+            read_task_steps_response=_deleted_read_task_steps_response,
+            read_task_snapshot=_unused_read_task_snapshot,
+        )
+    ]
+    terminal_body = "".join(terminal_frames)
+    assert terminal_body.count("event: stream.error") == 1
+    assert "task_deleted" in terminal_body
+    assert "resync_required" not in terminal_body
+    assert terminal_body.count("event: task.completed") == 1
+    assert terminal_body.index("event: task.completed") < terminal_body.index(
+        "event: stream.error"
+    )
+
+    waiting_snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.WAITING_FOR_USER,
+        pending_question="what next?",
+    )
+    waiting_frames = [
+        chunk
+        async for chunk in es._input_required_snapshot_stream(
+            waiting_snapshot,
+            principal=None,
+            read_task_steps_response=_deleted_read_task_steps_response,
+            read_task_snapshot=_unused_read_task_snapshot,
+        )
+    ]
+    waiting_body = "".join(waiting_frames)
+    assert waiting_body.count("event: stream.error") == 1
+    assert "task_deleted" in waiting_body
+    assert "resync_required" not in waiting_body
+    assert waiting_body.count("event: task.input_required") == 1
+    assert waiting_body.index("event: task.input_required") < waiting_body.index(
+        "event: stream.error"
+    )
+
+
+async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps():
+    """The attach-time step snapshot is the one thing this stream sends
+    in a single unpaced burst -- no admission/deadline/heartbeat loop --
+    so it needs its own bound. This pins it: a task with 600 public
+    steps (more than ``REPLAY_MAX_STEPS`` == 512) gets only its most
+    recent 512, with a ``snapshot_truncated``/``snapshot_total_steps``
+    marker on the first one."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    total = es.REPLAY_MAX_STEPS + 88
+    steps = [
+        es.PublicStep(
+            id=f"tool_call:call-{i}",
+            type="tool_call",
+            status="completed",
+            started_at=base,
+            completed_at=base,
+            data={"name": "search", "result": "ok"},
+        )
+        for i in range(total)
+    ]
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=steps)
+
+    def _unchanged_read_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    terminal_snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.COMPLETED,
+        output="done",
+        error=None,
+        run_id="run-1",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._terminal_snapshot_stream(
+            terminal_snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unchanged_read_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: step.completed") == es.REPLAY_MAX_STEPS
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    first_step_data = json.loads(blocks[1].split("data: ", 1)[1])
+    assert first_step_data["snapshot_truncated"] is True
+    assert first_step_data["snapshot_total_steps"] == total
+    # The emitted frames are the *most recent* steps -- the first one
+    # here is the (total - REPLAY_MAX_STEPS)'th step, not the very first.
+    assert (
+        first_step_data["step"]["id"] == f"tool_call:call-{total - es.REPLAY_MAX_STEPS}"
+    )
+    second_step_data = json.loads(blocks[2].split("data: ", 1)[1])
+    assert "snapshot_truncated" not in second_step_data
+
+
+# ===== fast-path generation fence (steps read outlives the snapshot) =====
+
+
+async def test_fast_path_terminal_generation_changed_withholds_steps_but_still_concludes():
+    """Between the snapshot that picked this fast path and the steps
+    read a few lines below it, the task row can move to a new run (a
+    ``POST reply`` restarting a ``WAITING_FOR_USER`` task, or a WS
+    ``APPEND`` restarting a ``COMPLETED``/``FAILED`` one). The steps
+    this path reads afterward already belong to that new run. Simulated
+    here by handing back one step from ``read_task_steps_response`` and
+    a reread whose ``run_id`` differs from the original snapshot's --
+    the shape a real restart leaves behind, without needing to drive an
+    actual restart through the DB. What the fence withholds is the
+    step, not the conclusion: ``task.completed`` describes
+    ``snapshot``'s own authoritative read, the read that selected this
+    fast path, so it goes out here exactly as it does when the reread
+    fails and when the step list is empty. ``stream.error(resync_required)``
+    follows it and names the restart. This is the same three-frame
+    shape a lifecycle-only client gets from every other exit of this
+    path."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[step])
+
+    def _reread_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-new", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.COMPLETED,
+        output="stale output from the superseded run",
+        error=None,
+        run_id="run-old",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._terminal_snapshot_stream(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_reread_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: task.status") == 1
+    assert body.count("event: task.completed") == 1
+    assert "event: step.completed" not in body
+    assert body.count("event: stream.error") == 1
+    assert "resync_required" in body
+    # The conclusion precedes the error, same ordering as every other
+    # failure exit on this path.
+    assert body.index("event: task.completed") < body.index("event: stream.error")
+    # The conclusion still carries ``snapshot``'s own values, not a
+    # placeholder standing in for the superseded run.
+    assert "stale output from the superseded run" in body
+
+
+async def test_fast_path_waiting_for_user_generation_changed_withholds_steps_but_still_concludes():
+    """Same race as the terminal case above, exercised on the other fast
+    path (``_input_required_snapshot_stream``) and triggered through
+    ``state_version`` instead of ``run_id`` -- either field moving is
+    enough to mean the reread's snapshot is not the one that picked
+    this path. Same rule as the terminal case too: the step is
+    withheld, ``task.input_required`` still goes out, and
+    ``stream.error(resync_required)`` follows it."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[step])
+
+    def _reread_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=2)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.WAITING_FOR_USER,
+        pending_question="what next?",
+        run_id="run-1",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._input_required_snapshot_stream(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_reread_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: task.status") == 1
+    assert body.count("event: task.input_required") == 1
+    assert "event: step.completed" not in body
+    assert body.count("event: stream.error") == 1
+    assert "resync_required" in body
+    assert body.index("event: task.input_required") < body.index("event: stream.error")
+    assert "what next?" in body
+
+
+async def test_fast_path_terminal_empty_steps_skips_the_generation_reread():
+    """An empty step list carries no step content from a possibly-newer
+    run, so there is nothing for the generation reread to protect
+    against -- this pins that the fast path skips it entirely rather
+    than paying for a read whose answer can't change the outcome."""
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[])
+
+    reread_calls: list[int] = []
+
+    def _reread_task_snapshot(task_id_, principal_):
+        reread_calls.append(1)
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.COMPLETED,
+        output="done",
+        error=None,
+        run_id="run-1",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._terminal_snapshot_stream(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_reread_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert reread_calls == []
+    assert body.count("event: task.completed") == 1
+    assert "resync_required" not in body
+
+
+async def test_fast_path_terminal_generation_reread_failure_closes_with_resync_required_and_no_steps():
+    """The generation reread can fail the same way any other DB read in
+    this module can (a transient error) -- that answers neither
+    "unchanged" nor "changed", so it is treated like the steps-read
+    failure just above it in this path: the conclusion still goes out
+    (it was already known-good from ``snapshot``, independent of this
+    reread), but the step this path read is withheld, since its
+    generation was never confirmed to match. The accompanying
+    ``stream.error`` must describe what actually happened -- the reread
+    itself failed -- not claim the task moved to a new run, since that
+    was never established one way or the other."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[step])
+
+    def _raising_reread(task_id_, principal_):
+        raise RuntimeError("transient DB error rereading task snapshot")
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.COMPLETED,
+        output="done",
+        error=None,
+        run_id="run-1",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._terminal_snapshot_stream(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_raising_reread,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: task.status") == 1
+    assert body.count("event: task.completed") == 1
+    assert "event: step.completed" not in body
+    assert body.count("event: stream.error") == 1
+    assert "resync_required" in body
+    assert "moved to a new run" not in body
+
+
+async def test_fast_path_waiting_for_user_generation_reread_failure_closes_with_resync_required_and_no_steps():
+    """Same reread failure as the terminal case above, exercised on
+    ``_input_required_snapshot_stream``."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[step])
+
+    def _raising_reread(task_id_, principal_):
+        raise RuntimeError("transient DB error rereading task snapshot")
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.WAITING_FOR_USER,
+        pending_question="what next?",
+        run_id="run-1",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._input_required_snapshot_stream(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_raising_reread,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: task.status") == 1
+    assert body.count("event: task.input_required") == 1
+    assert "event: step.completed" not in body
+    assert body.count("event: stream.error") == 1
+    assert "resync_required" in body
+    assert "moved to a new run" not in body
+
+
+async def test_fast_path_terminal_generation_reread_task_deleted_closes_with_task_deleted():
+    """A task deleted in the gap between the steps read and the
+    generation reread surfaces from the reread as
+    ``V1ApiError(TASK_NOT_FOUND)``, the same exception shape a task
+    deleted during the steps read itself already gets classified by
+    (``_fast_path_steps_read_error_frame``). The generation reread's own
+    classifier must recognize it the same way rather than falling
+    through to the generic ``resync_required`` every other reread
+    failure gets: the task isn't merely unreadable here, it's gone, so
+    ``steps()`` + reattach would just 404 instead of resyncing
+    anything."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[step])
+
+    def _deleted_reread(task_id_, principal_):
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.COMPLETED,
+        output="done",
+        error=None,
+        run_id="run-1",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._terminal_snapshot_stream(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_deleted_reread,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: task.status") == 1
+    assert body.count("event: task.completed") == 1
+    assert "event: step.completed" not in body
+    assert body.count("event: stream.error") == 1
+    assert "task_deleted" in body
+    assert "resync_required" not in body
+
+
+# ===== fast-path step serialization failure (after the first yield) =====
+
+
+async def test_fast_path_terminal_unserializable_step_concludes_then_closes_for_resync():
+    """The fast path's serialization loop runs after
+    ``StreamingResponse`` has sent 200, and ``model_dump(mode="json")``
+    raises ``PydanticSerializationError`` on a value it has no encoding
+    rule for. In production the injected steps reader dumps its own
+    response first, inside the steps-read guard, so this loop's guard is
+    a defensive boundary; the stub reader here hands the loop a
+    ``PublicStep`` that reader could not have produced, to pin what the
+    boundary does. The raise happens after
+    ``StreamingResponse`` has already sent 200 and the headers, so an
+    unguarded raise would end the response with no close frame at all --
+    indistinguishable, to the client, from the connection dropping.
+    Instead the conclusion goes out, then
+    ``stream.error(resync_required)``, and the steps before the failing
+    one are kept."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    class _Unserializable:
+        pass
+
+    good = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+    bad = es.PublicStep(
+        id="tool_call:call-2",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": _Unserializable()},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[good, bad])
+
+    def _reread_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.COMPLETED,
+        output="done",
+        error=None,
+        run_id="run-1",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._terminal_snapshot_stream(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_reread_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: task.status") == 1
+    assert body.count("event: step.completed") == 1  # the good step survived
+    assert "tool_call:call-1" in body
+    assert "tool_call:call-2" not in body
+    assert body.count("event: task.completed") == 1
+    assert body.count("event: stream.error") == 1
+    assert "resync_required" in body
+    assert body.index("event: task.completed") < body.index("event: stream.error")
+    # The wording names serialization, not a read and not a restart.
+    assert "Serializing the task's steps failed" in body
+    assert "moved to a new run" not in body
+
+
+async def test_fast_path_waiting_for_user_unserializable_step_concludes_then_closes():
+    """Same serialization failure on the other fast path: the conclusion
+    is ``task.input_required`` and the close frame is the same."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    class _Unserializable:
+        pass
+
+    bad = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": _Unserializable()},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[bad])
+
+    def _reread_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.WAITING_FOR_USER,
+        pending_question="what next?",
+        run_id="run-1",
+        state_version=1,
+    )
+    frames = [
+        chunk
+        async for chunk in es._input_required_snapshot_stream(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_reread_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert "event: step.completed" not in body
+    assert body.count("event: task.input_required") == 1
+    assert body.count("event: stream.error") == 1
+    assert "Serializing the task's steps failed" in body
+    assert body.index("event: task.input_required") < body.index("event: stream.error")
+
+
 # ===== single-frame content byte cap =====
 
 
@@ -2837,24 +3659,28 @@ async def test_nonfinite_step_data_values_are_normalized_to_null_on_the_wire():
     ``NaN``/``Infinity``/``-Infinity``, which a strict ``JSON.parse``
     client rejects outright.
 
-    A ``step.*`` frame's only producer, live projection
-    (``_step_content_frame``), funnels
-    through ``_step_wire_frame``, which receives its dict only after a
-    ``PublicStep(**step).model_dump(mode="json")`` call. Pydantic v2's
-    JSON serialization mode normalizes non-finite floats to ``null`` for
-    any field typed ``Any`` (verified directly below), independent of a
-    field's nesting depth -- so every ``step.*`` frame this module emits
-    is already immune to this failure mode with no additional guard in
-    ``_step_wire_frame`` itself. This test pins that implicit
-    invariant by handing three-deep nested non-finite values to
-    ``_step_content_frame`` -- production's only caller of
-    ``_step_wire_frame``, and where the normalization actually happens
-    -- and asserting the resulting wire text is strict-JSON-clean. The
-    raw dict goes in exactly as a projector produces it; normalizing it
-    in test setup first would have left the assertions green even if
-    ``_step_content_frame`` regressed to passing the raw dict straight
-    through. It changes no production code -- if that regression ever
-    happens, this test is the tripwire.
+    Both producers of a ``step.*`` frame -- live projection
+    (``_step_content_frame``) and the attach-time fast paths' cached
+    snapshot -- funnel through ``_step_wire_frame``, and that function
+    is where the single ``model_dump(mode="json")`` runs: it takes the
+    ``PublicStep`` model, not an already-dumped dict, so neither
+    producer can reach a frame builder with un-normalized values.
+    Pydantic v2's JSON serialization mode normalizes non-finite floats
+    to ``null`` for any field typed ``Any`` (verified directly below),
+    independent of a field's nesting depth -- so every ``step.*`` frame
+    this module emits is already immune to this failure mode with no
+    additional guard in ``_step_wire_frame`` itself. This test pins
+    that implicit invariant by handing three-deep nested non-finite
+    values to ``_step_content_frame`` -- the live path's entry into
+    that shared normalizer -- and asserting the resulting wire text is
+    strict-JSON-clean. The raw dict goes in exactly as a projector
+    produces it; normalizing it in test setup first would have left the
+    assertions green even if the normalization regressed to passing the
+    raw dict straight through. Because that normalization sits in
+    ``_step_wire_frame``, which both producers must go through to build
+    a frame at all, this one assertion covers the fast paths too. It
+    changes no production code -- if that regression ever happens, this
+    test is the tripwire.
     """
     nested_nonfinite_data = {
         "name": "search",

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3194,6 +3194,14 @@ async def test_fast_path_snapshot_marks_truncation_when_the_window_ends_unmeasur
     assert total_steps == 3
 
 
+# A sentinel distinguishable from any real ``ApiKeyPrincipal`` (and from
+# ``None``, the placeholder every other fast-path test in this file
+# passes), so the fence tests below can pin that the reread genuinely
+# receives the same ``(task_id, principal)`` pair the steps read did,
+# not just some value.
+_FENCE_PRINCIPAL = object()
+
+
 # ===== fast-path generation fence (steps read outlives the snapshot) =====
 
 
@@ -3264,11 +3272,15 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
         data={"name": "search", "result": "ok"},
     )
     original = {"run_id": "run-1", "state_version": 1}
+    steps_calls: list[tuple[int, object]] = []
+    reread_calls: list[tuple[int, object]] = []
 
     def _read_task_steps_response(task_id_, principal_):
+        steps_calls.append((task_id_, principal_))
         return SimpleNamespace(steps=[step])
 
     def _reread_task_snapshot(task_id_, principal_):
+        reread_calls.append((task_id_, principal_))
         return SimpleNamespace(**{**original, changed_field: changed_value})
 
     snapshot = SimpleNamespace(
@@ -3278,7 +3290,7 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
         chunk
         async for chunk in getattr(es, stream_fn)(
             snapshot,
-            principal=None,
+            principal=_FENCE_PRINCIPAL,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_reread_task_snapshot,
         )
@@ -3295,6 +3307,8 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
     # The conclusion still carries ``snapshot``'s own values, not a
     # placeholder standing in for the superseded run.
     assert conclusion_marker in body
+    assert steps_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
+    assert reread_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
 
 
 @pytest.mark.parametrize(
@@ -3324,13 +3338,16 @@ async def test_fast_path_empty_steps_skips_the_generation_reread(
     against -- this pins that the fast path skips it entirely rather
     than paying for a read whose answer can't change the outcome."""
 
+    steps_calls: list[tuple[int, object]] = []
+
     def _read_task_steps_response(task_id_, principal_):
+        steps_calls.append((task_id_, principal_))
         return SimpleNamespace(steps=[])
 
-    reread_calls: list[int] = []
+    reread_calls: list[tuple[int, object]] = []
 
     def _reread_task_snapshot(task_id_, principal_):
-        reread_calls.append(1)
+        reread_calls.append((task_id_, principal_))
         return SimpleNamespace(run_id="run-1", state_version=1)
 
     snapshot = SimpleNamespace(
@@ -3345,12 +3362,13 @@ async def test_fast_path_empty_steps_skips_the_generation_reread(
         chunk
         async for chunk in getattr(es, stream_fn)(
             snapshot,
-            principal=None,
+            principal=_FENCE_PRINCIPAL,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_reread_task_snapshot,
         )
     ]
     body = "".join(frames)
+    assert steps_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
     assert reread_calls == []
     assert body.count(f"event: {conclusion_event}") == 1
     assert "resync_required" not in body
@@ -3398,10 +3416,15 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
         data={"name": "search", "result": "ok"},
     )
 
+    steps_calls: list[tuple[int, object]] = []
+    reread_calls: list[tuple[int, object]] = []
+
     def _read_task_steps_response(task_id_, principal_):
+        steps_calls.append((task_id_, principal_))
         return SimpleNamespace(steps=[step])
 
     def _raising_reread(task_id_, principal_):
+        reread_calls.append((task_id_, principal_))
         raise RuntimeError("transient DB error rereading task snapshot")
 
     snapshot = SimpleNamespace(
@@ -3416,7 +3439,7 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
         chunk
         async for chunk in getattr(es, stream_fn)(
             snapshot,
-            principal=None,
+            principal=_FENCE_PRINCIPAL,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_raising_reread,
         )
@@ -3431,6 +3454,8 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
     # The conclusion precedes the error on this exit too -- neither leg
     # asserted that before, so a reordered yield would have passed both.
     assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
+    assert steps_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
+    assert reread_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
 
 
 @pytest.mark.parametrize(
@@ -3475,10 +3500,15 @@ async def test_fast_path_generation_reread_task_deleted_closes_with_task_deleted
         data={"name": "search", "result": "ok"},
     )
 
+    steps_calls: list[tuple[int, object]] = []
+    reread_calls: list[tuple[int, object]] = []
+
     def _read_task_steps_response(task_id_, principal_):
+        steps_calls.append((task_id_, principal_))
         return SimpleNamespace(steps=[step])
 
     def _deleted_reread(task_id_, principal_):
+        reread_calls.append((task_id_, principal_))
         raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
 
     snapshot = SimpleNamespace(
@@ -3493,7 +3523,7 @@ async def test_fast_path_generation_reread_task_deleted_closes_with_task_deleted
         chunk
         async for chunk in getattr(es, stream_fn)(
             snapshot,
-            principal=None,
+            principal=_FENCE_PRINCIPAL,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_deleted_reread,
         )
@@ -3508,6 +3538,8 @@ async def test_fast_path_generation_reread_task_deleted_closes_with_task_deleted
     # The conclusion precedes the error, same ordering pinned on every
     # other failure exit on this path.
     assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
+    assert steps_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
+    assert reread_calls == [(snapshot.task_id, _FENCE_PRINCIPAL)]
 
 
 # ===== fast-path step serialization failure (after the first yield) =====

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3320,6 +3320,403 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
 
 
 @pytest.mark.parametrize(
+    ("second_max_event_id", "expect_resync"),
+    [
+        pytest.param(101, True, id="trace-row-landed"),
+        pytest.param(100, False, id="cursor-unchanged"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_trace_row_landing_between_reads_forces_resync(
+    stream_fn,
+    status,
+    conclusion_event,
+    extra_snapshot,
+    second_max_event_id,
+    expect_resync,
+):
+    """``DatabaseTraceHandler`` commits trace rows through its own
+    session; even on the commits that also write this task row's own
+    checkpoint-pointer columns, that write never touches ``run_id`` or
+    ``state_version``. So a trace row that lands after the steps read
+    and before the fence's recheck moves the steps cursor
+    (``max_event_id``) without moving either of those fields -- invisible
+    to ``_fast_path_generation_changed`` on its own. This pins the
+    second signal, ``_fast_path_steps_cursor_changed``: the cursor is
+    read once before the steps read and once more after the generation
+    reread passes, and a moved cursor takes the same withhold-and-resync
+    exit a moved generation does. The cursor-unchanged leg pins the
+    negative: two matching reads never withhold the step or close with
+    an error.
+    """
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[step])
+
+    def _unchanged_read_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    version_calls: list[tuple[int, object]] = []
+    version_replies = iter([100, second_max_event_id])
+
+    def _read_task_steps_version(task_id_, principal_):
+        version_calls.append((task_id_, principal_))
+        return SimpleNamespace(max_event_id=next(version_replies))
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=_FENCE_PRINCIPAL,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unchanged_read_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
+        )
+    ]
+    body = "".join(frames)
+    assert version_calls == [
+        (snapshot.task_id, _FENCE_PRINCIPAL),
+        (snapshot.task_id, _FENCE_PRINCIPAL),
+    ]
+    assert body.count(f"event: {conclusion_event}") == 1
+    if expect_resync:
+        assert "event: step.completed" not in body
+        assert body.count("event: stream.error") == 1
+        assert "resync_required" in body
+        assert body.index(f"event: {conclusion_event}") < body.index(
+            "event: stream.error"
+        )
+    else:
+        assert body.count("event: step.completed") == 1
+        assert "event: stream.error" not in body
+
+
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_steps_cursor_baseline_is_captured_before_the_steps_read(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
+    """The cursor baseline (``read_task_steps_version``'s first call) is
+    captured before the steps read runs, not after it returns -- pinned
+    here with a steps-read stub that advances the cursor as a side
+    effect, the shape a trace row landing mid-read actually takes: the
+    read and the row's commit interleave, rather than the row landing
+    only after the read has already finished. If the baseline were
+    captured after the steps read instead, it would already observe the
+    advanced cursor, and the recheck that follows would see no further
+    movement -- silently hiding exactly the race this second signal
+    exists to catch. The trace-row-landing test above stubs the version
+    reader with a fixed two-value sequence, which can't tell "captured
+    before the read" from "captured after" apart; this test can, because
+    the cursor's own value moves as a side effect of the steps read
+    itself.
+    """
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+    cursor_state = {"max_event_id": 100}
+
+    def _read_task_steps_response(task_id_, principal_):
+        # A trace row commits while this read is "in flight" -- the
+        # cursor moves as a side effect of the steps read itself, not
+        # via a separately-scripted later call.
+        cursor_state["max_event_id"] = 101
+        return SimpleNamespace(steps=[step])
+
+    def _unchanged_read_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    version_calls: list[int] = []
+
+    def _read_task_steps_version(task_id_, principal_):
+        version_calls.append(cursor_state["max_event_id"])
+        return SimpleNamespace(max_event_id=cursor_state["max_event_id"])
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=_FENCE_PRINCIPAL,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unchanged_read_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
+        )
+    ]
+    body = "".join(frames)
+    # The baseline call observed 100 (before the steps read mutated the
+    # counter); the recheck call observed 101 (after). A baseline
+    # captured post-read would have observed 101 both times, and the
+    # assertions below would fail.
+    assert version_calls == [100, 101]
+    assert "event: step.completed" not in body
+    assert body.count("event: stream.error") == 1
+    assert "resync_required" in body
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
+
+
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_steps_cursor_baseline_read_failure_closes_before_the_steps_read(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
+    """The cursor baseline read can fail the same way any other DB read
+    in this module can, and it fails before the steps read is ever
+    reached (see the call site in ``_fast_path_snapshot_stream``) -- so
+    the steps reader must never run, and the failure is classified
+    exactly like a failed steps read
+    (``_fast_path_steps_read_error_frame``): a task deleted in the gap
+    gets ``task_deleted``, everything else gets ``resync_required``. The
+    conclusion frame (already known-good from ``snapshot``) goes out
+    first either way.
+    """
+
+    def _unreachable_read_task_steps_response(task_id_, principal_):
+        raise AssertionError(
+            "the steps read must not run when the cursor baseline read failed"
+        )
+
+    def _unreachable_read_task_snapshot(task_id_, principal_):
+        raise AssertionError(
+            "the generation reread must not run when the cursor baseline read failed"
+        )
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+
+    def _transient_read_task_steps_version(task_id_, principal_):
+        raise RuntimeError("transient DB error reading the steps cursor")
+
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_unreachable_read_task_steps_response,
+            read_task_snapshot=_unreachable_read_task_snapshot,
+            read_task_steps_version=_transient_read_task_steps_version,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count(f"event: {conclusion_event}") == 1
+    assert body.count("event: stream.error") == 1
+    assert "resync_required" in body
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
+
+    def _deleted_read_task_steps_version(task_id_, principal_):
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
+
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_unreachable_read_task_steps_response,
+            read_task_snapshot=_unreachable_read_task_snapshot,
+            read_task_steps_version=_deleted_read_task_steps_version,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count(f"event: {conclusion_event}") == 1
+    assert "task_deleted" in body
+    assert "resync_required" not in body
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
+
+
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_steps_cursor_recheck_failure_closes_for_resync_or_deleted(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
+    """The cursor recheck (``read_task_steps_version``'s second call,
+    which only runs once the run_id/state_version reread has already
+    confirmed no change) can itself fail. It shares
+    ``_fast_path_generation_reread_error_frame`` with the
+    run_id/state_version reread's own failure -- by the time this call
+    raises, the generation was already confirmed unchanged, only the
+    cursor wasn't, which is exactly why that shared frame builder's
+    wording no longer names "generation" specifically.
+    """
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=[step])
+
+    def _unchanged_read_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+
+    calls = {"n": 0}
+
+    def _flaky_read_task_steps_version(task_id_, principal_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return SimpleNamespace(max_event_id=100)
+        raise RuntimeError("transient DB error rereading the steps cursor")
+
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unchanged_read_task_snapshot,
+            read_task_steps_version=_flaky_read_task_steps_version,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count(f"event: {conclusion_event}") == 1
+    assert body.count("event: stream.error") == 1
+    assert "resync_required" in body
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
+
+    calls2 = {"n": 0}
+
+    def _flaky_read_task_steps_version_deleted(task_id_, principal_):
+        calls2["n"] += 1
+        if calls2["n"] == 1:
+            return SimpleNamespace(max_event_id=100)
+        raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
+
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unchanged_read_task_snapshot,
+            read_task_steps_version=_flaky_read_task_steps_version_deleted,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count(f"event: {conclusion_event}") == 1
+    assert "task_deleted" in body
+    assert "resync_required" not in body
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
+
+
+@pytest.mark.parametrize(
     ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
     [
         pytest.param(
@@ -3412,7 +3809,11 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
     this path read is withheld since its generation was never confirmed,
     and the accompanying ``stream.error`` must describe what actually
     happened -- the reread itself failed -- not claim the task moved to a
-    new run, which was never established either way.
+    new run, which was never established either way. ``read_task_steps_version``
+    is not supplied here, so this exercises
+    ``_fast_path_generation_reread_error_frame``'s generic wording on
+    its own, independent of the cursor recheck that can also route
+    through it (see ``test_fast_path_steps_cursor_recheck_failure_closes_for_resync_or_deleted``).
     """
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     step = es.PublicStep(
@@ -3458,6 +3859,10 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
     assert "event: step.completed" not in body
     assert body.count("event: stream.error") == 1
     assert "resync_required" in body
+    # The wording names what actually failed to confirm -- the reread --
+    # not a claim that the task moved to a new run, which this failure
+    # never established either way.
+    assert "Confirming the task's steps are still current failed" in body
     assert "moved to a new run" not in body
     # The conclusion precedes the error on this exit too -- neither leg
     # asserted that before, so a reordered yield would have passed both.

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -2644,6 +2644,8 @@ def test_fast_path_terminal_attach_includes_current_steps():
     assert step["id"] == "tool_call:call-1"
     assert step["status"] == "completed"
     assert step["data"]["result"] == "sunny"
+    conclusion_data = json.loads(blocks[2].split("data: ", 1)[1])
+    assert "snapshot_truncated" not in conclusion_data
 
 
 def test_fast_path_step_snapshot_hits_the_steps_cache(monkeypatch):
@@ -2918,8 +2920,7 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps(
     assert body.count("event: step.completed") == es.REPLAY_MAX_STEPS
     blocks = [b for b in body.split("\n\n") if b.strip()]
     first_step_data = json.loads(blocks[1].split("data: ", 1)[1])
-    assert first_step_data["snapshot_truncated"] is True
-    assert first_step_data["snapshot_total_steps"] == total
+    assert "snapshot_truncated" not in first_step_data
     # The emitted frames are the *most recent* steps -- the first one
     # here is the (total - REPLAY_MAX_STEPS)'th step, not the very first.
     assert (
@@ -2928,6 +2929,12 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps(
     second_step_data = json.loads(blocks[2].split("data: ", 1)[1])
     assert "snapshot_truncated" not in second_step_data
     assert body.count(f"event: {conclusion_event}") == 1
+    conclusion_block = next(
+        b for b in blocks if b.startswith(f"event: {conclusion_event}")
+    )
+    conclusion_data = json.loads(conclusion_block.split("data: ", 1)[1])
+    assert conclusion_data["snapshot_truncated"] is True
+    assert conclusion_data["snapshot_total_steps"] == total
 
 
 @pytest.mark.parametrize(
@@ -3000,21 +3007,112 @@ async def test_fast_path_step_snapshot_is_bounded_by_the_wire_byte_budget(
     # The byte budget bound this well short of all 128 steps -- not zero
     # (some steps still fit) and not all of them (the budget did bind).
     assert 0 < len(step_frames) < total
-    # The truncation marker on the first frame costs a little more than
-    # the measuring pass counted for it (see
-    # ``_fast_path_step_snapshot``'s docstring) -- a bounded overrun, not
-    # an unbounded one.
-    assert sum(len(chunk) for chunk in step_frames) <= es.MAX_SNAPSHOT_WIRE_BYTES + 64
+    # The truncation marker now rides the conclusion frame, not a step
+    # frame, so the measuring pass's count is exactly what the step
+    # frames put on the wire -- no marker overrun left to allow for.
+    assert sum(len(chunk) for chunk in step_frames) <= es.MAX_SNAPSHOT_WIRE_BYTES
     first_step_block = next(
         block for block in body.split("\n\n") if block.startswith("event: step.")
     )
     first_step_data = json.loads(first_step_block.split("data: ", 1)[1])
-    assert first_step_data["snapshot_truncated"] is True
-    assert first_step_data["snapshot_total_steps"] == total
+    assert "snapshot_truncated" not in first_step_data
     assert body.count(f"event: {conclusion_event}") == 1
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    conclusion_block = next(
+        b for b in blocks if b.startswith(f"event: {conclusion_event}")
+    )
+    conclusion_data = json.loads(conclusion_block.split("data: ", 1)[1])
+    assert conclusion_data["snapshot_truncated"] is True
+    assert conclusion_data["snapshot_total_steps"] == total
     # A byte-budget cut is a truncated snapshot, not a stream error -- the
     # client is told via ``snapshot_truncated``, not a close frame.
     assert "event: stream.error" not in body
+
+
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_snapshot_marks_truncation_when_the_budget_admits_no_steps(
+    monkeypatch, stream_fn, status, conclusion_event, extra_snapshot
+):
+    """The byte budget can cut a snapshot to zero steps, not just to a
+    shorter one: with the budget set below a single step's own wire
+    length, ``_snapshot_steps_within_wire_budget`` admits none of the
+    task's steps at all. No ``step.*`` frame is ever emitted in that
+    case, so the truncation marker has nowhere to ride but the
+    conclusion frame -- this pins that it still gets there. Production
+    can reach this without an artificially tiny budget: ``PublicStep.id``
+    is built from the event's own ``tool_call_id``, which nothing in
+    this stream bounds the length of, so one tool call minting an
+    unusually long id can by itself push that step's frame past
+    ``MAX_SNAPSHOT_WIRE_BYTES``.
+    """
+    monkeypatch.setattr(es, "MAX_SNAPSHOT_WIRE_BYTES", 8)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    steps = [
+        es.PublicStep(
+            id=f"tool_call:call-{i}",
+            type="tool_call",
+            status="completed",
+            started_at=base,
+            completed_at=base,
+            data={"name": "search", "result": "ok"},
+        )
+        for i in range(2)
+    ]
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=steps)
+
+    def _unused_read_task_snapshot(task_id_, principal_):
+        raise AssertionError(
+            "the generation reread must not run when no step was admitted"
+        )
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unused_read_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    assert body.count("event: step.") == 0
+    assert body.count(f"event: {conclusion_event}") == 1
+    assert "event: stream.error" not in body
+    blocks = [b for b in body.split("\n\n") if b.strip()]
+    conclusion_block = next(
+        b for b in blocks if b.startswith(f"event: {conclusion_event}")
+    )
+    conclusion_data = json.loads(conclusion_block.split("data: ", 1)[1])
+    assert conclusion_data["snapshot_truncated"] is True
+    assert conclusion_data["snapshot_total_steps"] == 2
 
 
 async def test_fast_path_snapshot_admits_a_frame_exactly_at_the_byte_budget(

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -2854,23 +2854,63 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps():
 # ===== fast-path generation fence (steps read outlives the snapshot) =====
 
 
-async def test_fast_path_terminal_generation_changed_withholds_steps_but_still_concludes():
-    """Between the snapshot that picked this fast path and the steps
-    read a few lines below it, the task row can move to a new run (a
-    ``POST reply`` restarting a ``WAITING_FOR_USER`` task, or a WS
-    ``APPEND`` restarting a ``COMPLETED``/``FAILED`` one). The steps
-    this path reads afterward already belong to that new run. Simulated
-    here by handing back one step from ``read_task_steps_response`` and
-    a reread whose ``run_id`` differs from the original snapshot's --
-    the shape a real restart leaves behind, without needing to drive an
-    actual restart through the DB. What the fence withholds is the
-    step, not the conclusion: ``task.completed`` describes
-    ``snapshot``'s own authoritative read, the read that selected this
-    fast path, so it goes out here exactly as it does when the reread
-    fails and when the step list is empty. ``stream.error(resync_required)``
-    follows it and names the restart. This is the same three-frame
-    shape a lifecycle-only client gets from every other exit of this
-    path."""
+@pytest.mark.parametrize(
+    ("changed_field", "changed_value"),
+    [
+        pytest.param("run_id", "run-new", id="run-id-moved"),
+        pytest.param("state_version", 2, id="state-version-moved"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot", "conclusion_marker"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "stale output from the superseded run", "error": None},
+            "stale output from the superseded run",
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            "what next?",
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
+    stream_fn,
+    status,
+    conclusion_event,
+    extra_snapshot,
+    conclusion_marker,
+    changed_field,
+    changed_value,
+):
+    """Between the snapshot that picked a fast path and that path's own
+    steps read, the task row can move to a new run (a ``POST reply``
+    restarting a ``WAITING_FOR_USER`` task, or a WS ``APPEND`` restarting
+    a ``COMPLETED``/``FAILED`` one), and the steps read afterward already
+    belong to that new run. Simulated by handing back one step and a
+    reread whose generation differs -- the shape a real restart leaves
+    behind, without driving an actual restart through the DB.
+
+    What the fence withholds is the step, not the conclusion: the
+    conclusion describes ``snapshot``'s own authoritative read, the read
+    that selected this path, so it goes out here exactly as it does when
+    the reread fails and when the step list is empty, and
+    ``stream.error(resync_required)`` follows it naming the restart.
+
+    Four cells: both fast paths crossed with both fields the fence
+    compares. Either field moving on its own is enough, so a fence that
+    only compared ``run_id`` would pass the ``run-id-moved`` cells and
+    fail the ``state-version-moved`` ones -- which a single-field pair
+    could not distinguish.
+    """
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     step = es.PublicStep(
         id="tool_call:call-1",
@@ -2880,25 +2920,20 @@ async def test_fast_path_terminal_generation_changed_withholds_steps_but_still_c
         completed_at=base,
         data={"name": "search", "result": "ok"},
     )
+    original = {"run_id": "run-1", "state_version": 1}
 
     def _read_task_steps_response(task_id_, principal_):
         return SimpleNamespace(steps=[step])
 
     def _reread_task_snapshot(task_id_, principal_):
-        return SimpleNamespace(run_id="run-new", state_version=1)
+        return SimpleNamespace(**{**original, changed_field: changed_value})
 
     snapshot = SimpleNamespace(
-        task_id=1,
-        agent_id=1,
-        status=TaskStatus.COMPLETED,
-        output="stale output from the superseded run",
-        error=None,
-        run_id="run-old",
-        state_version=1,
+        task_id=1, agent_id=1, status=status, **original, **extra_snapshot
     )
     frames = [
         chunk
-        async for chunk in es._terminal_snapshot_stream(
+        async for chunk in getattr(es, stream_fn)(
             snapshot,
             principal=None,
             read_task_steps_response=_read_task_steps_response,
@@ -2907,67 +2942,16 @@ async def test_fast_path_terminal_generation_changed_withholds_steps_but_still_c
     ]
     body = "".join(frames)
     assert body.count("event: task.status") == 1
-    assert body.count("event: task.completed") == 1
+    assert body.count(f"event: {conclusion_event}") == 1
     assert "event: step.completed" not in body
     assert body.count("event: stream.error") == 1
     assert "resync_required" in body
     # The conclusion precedes the error, same ordering as every other
     # failure exit on this path.
-    assert body.index("event: task.completed") < body.index("event: stream.error")
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
     # The conclusion still carries ``snapshot``'s own values, not a
     # placeholder standing in for the superseded run.
-    assert "stale output from the superseded run" in body
-
-
-async def test_fast_path_waiting_for_user_generation_changed_withholds_steps_but_still_concludes():
-    """Same race as the terminal case above, exercised on the other fast
-    path (``_input_required_snapshot_stream``) and triggered through
-    ``state_version`` instead of ``run_id`` -- either field moving is
-    enough to mean the reread's snapshot is not the one that picked
-    this path. Same rule as the terminal case too: the step is
-    withheld, ``task.input_required`` still goes out, and
-    ``stream.error(resync_required)`` follows it."""
-    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-    step = es.PublicStep(
-        id="tool_call:call-1",
-        type="tool_call",
-        status="completed",
-        started_at=base,
-        completed_at=base,
-        data={"name": "search", "result": "ok"},
-    )
-
-    def _read_task_steps_response(task_id_, principal_):
-        return SimpleNamespace(steps=[step])
-
-    def _reread_task_snapshot(task_id_, principal_):
-        return SimpleNamespace(run_id="run-1", state_version=2)
-
-    snapshot = SimpleNamespace(
-        task_id=1,
-        agent_id=1,
-        status=TaskStatus.WAITING_FOR_USER,
-        pending_question="what next?",
-        run_id="run-1",
-        state_version=1,
-    )
-    frames = [
-        chunk
-        async for chunk in es._input_required_snapshot_stream(
-            snapshot,
-            principal=None,
-            read_task_steps_response=_read_task_steps_response,
-            read_task_snapshot=_reread_task_snapshot,
-        )
-    ]
-    body = "".join(frames)
-    assert body.count("event: task.status") == 1
-    assert body.count("event: task.input_required") == 1
-    assert "event: step.completed" not in body
-    assert body.count("event: stream.error") == 1
-    assert "resync_required" in body
-    assert body.index("event: task.input_required") < body.index("event: stream.error")
-    assert "what next?" in body
+    assert conclusion_marker in body
 
 
 async def test_fast_path_terminal_empty_steps_skips_the_generation_reread():
@@ -3009,17 +2993,38 @@ async def test_fast_path_terminal_empty_steps_skips_the_generation_reread():
     assert "resync_required" not in body
 
 
-async def test_fast_path_terminal_generation_reread_failure_closes_with_resync_required_and_no_steps():
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_generation_reread_failure_concludes_then_closes_for_resync(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
     """The generation reread can fail the same way any other DB read in
     this module can (a transient error) -- that answers neither
     "unchanged" nor "changed", so it is treated like the steps-read
-    failure just above it in this path: the conclusion still goes out
-    (it was already known-good from ``snapshot``, independent of this
-    reread), but the step this path read is withheld, since its
-    generation was never confirmed to match. The accompanying
-    ``stream.error`` must describe what actually happened -- the reread
-    itself failed -- not claim the task moved to a new run, since that
-    was never established one way or the other."""
+    failure just above it: the conclusion still goes out (it was already
+    known-good from ``snapshot``, independent of this reread), the step
+    this path read is withheld since its generation was never confirmed,
+    and the accompanying ``stream.error`` must describe what actually
+    happened -- the reread itself failed -- not claim the task moved to a
+    new run, which was never established either way.
+    """
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     step = es.PublicStep(
         id="tool_call:call-1",
@@ -3039,15 +3044,14 @@ async def test_fast_path_terminal_generation_reread_failure_closes_with_resync_r
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
-        status=TaskStatus.COMPLETED,
-        output="done",
-        error=None,
+        status=status,
         run_id="run-1",
         state_version=1,
+        **extra_snapshot,
     )
     frames = [
         chunk
-        async for chunk in es._terminal_snapshot_stream(
+        async for chunk in getattr(es, stream_fn)(
             snapshot,
             principal=None,
             read_task_steps_response=_read_task_steps_response,
@@ -3056,56 +3060,14 @@ async def test_fast_path_terminal_generation_reread_failure_closes_with_resync_r
     ]
     body = "".join(frames)
     assert body.count("event: task.status") == 1
-    assert body.count("event: task.completed") == 1
+    assert body.count(f"event: {conclusion_event}") == 1
     assert "event: step.completed" not in body
     assert body.count("event: stream.error") == 1
     assert "resync_required" in body
     assert "moved to a new run" not in body
-
-
-async def test_fast_path_waiting_for_user_generation_reread_failure_closes_with_resync_required_and_no_steps():
-    """Same reread failure as the terminal case above, exercised on
-    ``_input_required_snapshot_stream``."""
-    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-    step = es.PublicStep(
-        id="tool_call:call-1",
-        type="tool_call",
-        status="completed",
-        started_at=base,
-        completed_at=base,
-        data={"name": "search", "result": "ok"},
-    )
-
-    def _read_task_steps_response(task_id_, principal_):
-        return SimpleNamespace(steps=[step])
-
-    def _raising_reread(task_id_, principal_):
-        raise RuntimeError("transient DB error rereading task snapshot")
-
-    snapshot = SimpleNamespace(
-        task_id=1,
-        agent_id=1,
-        status=TaskStatus.WAITING_FOR_USER,
-        pending_question="what next?",
-        run_id="run-1",
-        state_version=1,
-    )
-    frames = [
-        chunk
-        async for chunk in es._input_required_snapshot_stream(
-            snapshot,
-            principal=None,
-            read_task_steps_response=_read_task_steps_response,
-            read_task_snapshot=_raising_reread,
-        )
-    ]
-    body = "".join(frames)
-    assert body.count("event: task.status") == 1
-    assert body.count("event: task.input_required") == 1
-    assert "event: step.completed" not in body
-    assert body.count("event: stream.error") == 1
-    assert "resync_required" in body
-    assert "moved to a new run" not in body
+    # The conclusion precedes the error on this exit too -- neither leg
+    # asserted that before, so a reordered yield would have passed both.
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
 
 
 async def test_fast_path_terminal_generation_reread_task_deleted_closes_with_task_deleted():
@@ -3165,7 +3127,28 @@ async def test_fast_path_terminal_generation_reread_task_deleted_closes_with_tas
 # ===== fast-path step serialization failure (after the first yield) =====
 
 
-async def test_fast_path_terminal_unserializable_step_concludes_then_closes_for_resync():
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_unserializable_step_concludes_then_closes_for_resync(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
     """The fast path's serialization loop runs after
     ``StreamingResponse`` has sent 200, and ``model_dump(mode="json")``
     raises ``PydanticSerializationError`` on a value it has no encoding
@@ -3173,13 +3156,18 @@ async def test_fast_path_terminal_unserializable_step_concludes_then_closes_for_
     response first, inside the steps-read guard, so this loop's guard is
     a defensive boundary; the stub reader here hands the loop a
     ``PublicStep`` that reader could not have produced, to pin what the
-    boundary does. The raise happens after
-    ``StreamingResponse`` has already sent 200 and the headers, so an
-    unguarded raise would end the response with no close frame at all --
-    indistinguishable, to the client, from the connection dropping.
-    Instead the conclusion goes out, then
-    ``stream.error(resync_required)``, and the steps before the failing
-    one are kept."""
+    boundary does. The raise happens after ``StreamingResponse`` has
+    already sent 200 and the headers, so an unguarded raise would end the
+    response with no close frame at all -- indistinguishable, to the
+    client, from the connection dropping. Instead the conclusion goes out,
+    then ``stream.error(resync_required)``, and the steps before the
+    failing one are kept.
+
+    Both legs use a ``[good, bad]`` step list so both assert the
+    partial-send behavior, not just the terminal one: a guard that
+    discarded the whole list on the first failure would still satisfy a
+    single-step leg.
+    """
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
 
     class _Unserializable:
@@ -3211,15 +3199,14 @@ async def test_fast_path_terminal_unserializable_step_concludes_then_closes_for_
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
-        status=TaskStatus.COMPLETED,
-        output="done",
-        error=None,
+        status=status,
         run_id="run-1",
         state_version=1,
+        **extra_snapshot,
     )
     frames = [
         chunk
-        async for chunk in es._terminal_snapshot_stream(
+        async for chunk in getattr(es, stream_fn)(
             snapshot,
             principal=None,
             read_task_steps_response=_read_task_steps_response,
@@ -3231,61 +3218,13 @@ async def test_fast_path_terminal_unserializable_step_concludes_then_closes_for_
     assert body.count("event: step.completed") == 1  # the good step survived
     assert "tool_call:call-1" in body
     assert "tool_call:call-2" not in body
-    assert body.count("event: task.completed") == 1
+    assert body.count(f"event: {conclusion_event}") == 1
     assert body.count("event: stream.error") == 1
     assert "resync_required" in body
-    assert body.index("event: task.completed") < body.index("event: stream.error")
+    assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")
     # The wording names serialization, not a read and not a restart.
     assert "Serializing the task's steps failed" in body
     assert "moved to a new run" not in body
-
-
-async def test_fast_path_waiting_for_user_unserializable_step_concludes_then_closes():
-    """Same serialization failure on the other fast path: the conclusion
-    is ``task.input_required`` and the close frame is the same."""
-    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
-
-    class _Unserializable:
-        pass
-
-    bad = es.PublicStep(
-        id="tool_call:call-1",
-        type="tool_call",
-        status="completed",
-        started_at=base,
-        completed_at=base,
-        data={"name": "search", "result": _Unserializable()},
-    )
-
-    def _read_task_steps_response(task_id_, principal_):
-        return SimpleNamespace(steps=[bad])
-
-    def _reread_task_snapshot(task_id_, principal_):
-        return SimpleNamespace(run_id="run-1", state_version=1)
-
-    snapshot = SimpleNamespace(
-        task_id=1,
-        agent_id=1,
-        status=TaskStatus.WAITING_FOR_USER,
-        pending_question="what next?",
-        run_id="run-1",
-        state_version=1,
-    )
-    frames = [
-        chunk
-        async for chunk in es._input_required_snapshot_stream(
-            snapshot,
-            principal=None,
-            read_task_steps_response=_read_task_steps_response,
-            read_task_snapshot=_reread_task_snapshot,
-        )
-    ]
-    body = "".join(frames)
-    assert "event: step.completed" not in body
-    assert body.count("event: task.input_required") == 1
-    assert body.count("event: stream.error") == 1
-    assert "Serializing the task's steps failed" in body
-    assert body.index("event: task.input_required") < body.index("event: stream.error")
 
 
 # ===== single-frame content byte cap =====

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -297,6 +297,14 @@ def test_error_frame_keeps_an_explicitly_empty_message():
     assert data == {"code": "task_deleted", "message": ""}
 
 
+def test_error_frame_defaults_to_the_code_s_own_message():
+    """The default wording is part of what a client reads; a dedup pass
+    left it with no assertion of its own."""
+    frame = es.error_frame("task_deleted")
+    data = json.loads(frame.split("data: ", 1)[1])
+    assert data == {"code": "task_deleted", "message": "The task no longer exists."}
+
+
 # ===== sink.send_text never raises =====
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -495,6 +495,86 @@ async def test_sse_responses_disable_proxy_buffering(task_state):
         await resp.body_iterator.aclose()
 
 
+async def test_fast_path_failure_sends_the_response_start_before_its_close_frames():
+    """The fast paths' failure exits (see
+    ``_fast_path_steps_read_error_frame``) rely on ``StreamingResponse``
+    having already sent the 200 response start and headers before the
+    first chunk is ever pulled from the generator -- that is what makes
+    catching the failure and closing with a ``stream.error`` frame
+    meaningful instead of redundant. Every other test in this file only
+    checks the frame *text* (``resp.text`` via the real HTTP client, or
+    the chunks read off ``resp.body_iterator``), never the raw ASGI
+    messages the response actually sends on the wire. This is the only
+    test in the suite that drives the response's ASGI interface
+    directly and inspects the message sequence, to pin that the 200 and
+    its headers really do arrive as the first message, before
+    ``task.status`` and everything after it -- not merely that the text
+    ends up assembled in the right order once it has all been read.
+
+    ``scope["asgi"]["spec_version"]`` is set to ``"2.4"`` so
+    ``StreamingResponse.__call__`` takes the branch that awaits
+    ``stream_response(send)`` directly without ever touching
+    ``receive``. ``receive`` here is defined but never invoked on that
+    branch; it is shaped to await forever rather than return or raise,
+    so that on the older branch (which awaits ``receive`` in a second
+    task and cancels it once ``stream_response`` finishes) this test
+    would still behave correctly instead of finishing early or
+    erroring -- both branches are correct with this ``receive``, only
+    the 2.4 one is actually exercised here.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    _set_task_status(task_id, TaskStatus.COMPLETED, output="done")
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    def _broken_read_task_steps_response(task_id_, principal_):
+        raise RuntimeError("boom - transient read failure")
+
+    def _unreachable_read_task_snapshot(task_id_, principal_):
+        raise AssertionError(
+            "the generation reread must not run when the steps read itself failed"
+        )
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=_unreachable_read_task_snapshot,
+        read_task_steps_response=_broken_read_task_steps_response,
+    )
+
+    messages: list[dict] = []
+
+    async def send(message):
+        messages.append(message)
+
+    async def receive():
+        await asyncio.Event().wait()
+
+    scope = {"type": "http", "asgi": {"version": "3.0", "spec_version": "2.4"}}
+    await resp(scope, receive, send)
+
+    assert messages[0]["type"] == "http.response.start"
+    assert messages[0]["status"] == 200
+    headers = dict(messages[0]["headers"])
+    assert headers[b"content-type"].startswith(b"text/event-stream")
+    assert headers[b"x-accel-buffering"] == b"no"
+    assert all(message["type"] == "http.response.body" for message in messages[1:])
+
+    body = b"".join(message["body"] for message in messages[1:]).decode()
+    # Conclusion-first, error-second -- the same ordering every other
+    # steps-read-failure test in this file pins on the assembled text;
+    # this test's own job is only the ASGI message layer around it.
+    assert body.index("event: task.status") < body.index("event: task.completed")
+    assert body.index("event: task.completed") < body.index("event: stream.error")
+    assert "resync_required" in body
+
+    last_message = messages[-1]
+    assert last_message["body"] == b""
+    assert last_message["more_body"] is False
+
+
 # ===== bounded outbound queue, overflow closes with resync_required =====
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -286,6 +286,17 @@ def test_error_frame_rejects_an_unknown_code_with_or_without_a_message():
     assert data == {"code": "task_deleted", "message": "custom text"}
 
 
+def test_error_frame_keeps_an_explicitly_empty_message():
+    """``message or default_message`` used to fold an explicitly empty
+    string into the code's default wording -- indistinguishable from
+    the caller never having passed an override at all. Only an omitted
+    override (``None``) should select the default; an explicit ``""``
+    is a value the caller chose and must reach the client as-is."""
+    frame = es.error_frame("task_deleted", message="")
+    data = json.loads(frame.split("data: ", 1)[1])
+    assert data == {"code": "task_deleted", "message": ""}
+
+
 # ===== sink.send_text never raises =====
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3309,6 +3309,13 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
     assert "event: step.completed" not in body
     assert body.count("event: stream.error") == 1
     assert "resync_required" in body
+    # The wording names what the fence actually knows -- a lifecycle
+    # write -- not a claim that a new run started: an intra-run write
+    # (a reply resume, a lease release) bumps state_version without
+    # touching run_id at all, and this leg's own ``run-id-moved`` case
+    # is the only one of the two that even could be a new run.
+    assert "The task changed while this attach was reading" in body
+    assert "moved to a new run" not in body
     # The conclusion precedes the error, same ordering as every other
     # failure exit on this path.
     assert body.index(f"event: {conclusion_event}") < body.index("event: stream.error")

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -2885,8 +2885,8 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps(
     in a single unpaced burst -- no admission/deadline/heartbeat loop --
     so it needs its own bound. This pins it: a task with 600 public
     steps (more than ``REPLAY_MAX_STEPS`` == 512) gets only its most
-    recent 512, with a ``snapshot_truncated``/``snapshot_total_steps``
-    marker on the first one."""
+    recent 512, with the ``snapshot_truncated``/``snapshot_total_steps``
+    marker on the conclusion frame and on no ``step.*`` frame."""
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     total = es.REPLAY_MAX_STEPS + 88
     steps = [

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3057,6 +3057,45 @@ async def test_fast_path_snapshot_admits_a_frame_exactly_at_the_byte_budget(
     assert total_steps == 2
 
 
+async def test_fast_path_snapshot_marks_truncation_when_the_window_ends_unmeasurable():
+    """An unserializable step is admitted so the emit loop can reach it
+    and report it (see ``_snapshot_steps_within_wire_budget``), but
+    admitting it also ends the measuring pass, so any steps behind it
+    fall out of the snapshot. The returned total must then mark the
+    snapshot truncated -- fewer steps go out than the task has -- even
+    though the step-count cap alone never bound anything here.
+    """
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    class _Unserializable:
+        pass
+
+    def _step(step_id, data):
+        return es.PublicStep(
+            id=step_id,
+            type="tool_call",
+            status="completed",
+            started_at=base,
+            completed_at=base,
+            data=data,
+        )
+
+    steps = [
+        _step("tool_call:call-1", {"name": "search", "result": "ok"}),
+        _step("tool_call:call-2", {"x": _Unserializable()}),
+        _step("tool_call:call-3", {"name": "search", "result": "ok"}),
+    ]
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=steps)
+
+    admitted, total_steps = await es._fast_path_step_snapshot(
+        1, None, _read_task_steps_response
+    )
+    assert [s.id for s in admitted] == ["tool_call:call-1", "tool_call:call-2"]
+    assert total_steps == 3
+
+
 # ===== fast-path generation fence (steps read outlives the snapshot) =====
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -2829,6 +2829,133 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps():
     assert "snapshot_truncated" not in second_step_data
 
 
+@pytest.mark.parametrize(
+    ("stream_fn", "status", "conclusion_event", "extra_snapshot"),
+    [
+        pytest.param(
+            "_terminal_snapshot_stream",
+            TaskStatus.COMPLETED,
+            "task.completed",
+            {"output": "done", "error": None},
+            id="terminal",
+        ),
+        pytest.param(
+            "_input_required_snapshot_stream",
+            TaskStatus.WAITING_FOR_USER,
+            "task.input_required",
+            {"pending_question": "what next?"},
+            id="waiting-for-user",
+        ),
+    ],
+)
+async def test_fast_path_step_snapshot_is_bounded_by_the_wire_byte_budget(
+    stream_fn, status, conclusion_event, extra_snapshot
+):
+    """``REPLAY_MAX_STEPS`` alone doesn't stop a snapshot from getting
+    huge: 128 steps at 48 KiB of ``data`` each (well under the 64 KiB
+    per-step cap, so ``_capped_step_data`` never fires) is ~6 MiB, over
+    ``MAX_SNAPSHOT_WIRE_BYTES`` (4 MiB) while nowhere near
+    ``REPLAY_MAX_STEPS`` (512). This pins that the byte budget -- not
+    the step count -- is what cuts this particular snapshot short."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    total = 128
+    steps = [
+        es.PublicStep(
+            id=f"tool_call:call-{i}",
+            type="tool_call",
+            status="completed",
+            started_at=base,
+            completed_at=base,
+            data={"name": "search", "result": "x" * (48 * 1024)},
+        )
+        for i in range(total)
+    ]
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=steps)
+
+    def _unchanged_read_task_snapshot(task_id_, principal_):
+        return SimpleNamespace(run_id="run-1", state_version=1)
+
+    snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=status,
+        run_id="run-1",
+        state_version=1,
+        **extra_snapshot,
+    )
+    frames = [
+        chunk
+        async for chunk in getattr(es, stream_fn)(
+            snapshot,
+            principal=None,
+            read_task_steps_response=_read_task_steps_response,
+            read_task_snapshot=_unchanged_read_task_snapshot,
+        )
+    ]
+    body = "".join(frames)
+    step_frames = [chunk for chunk in frames if "event: step." in chunk]
+    # The byte budget bound this well short of all 128 steps -- not zero
+    # (some steps still fit) and not all of them (the budget did bind).
+    assert 0 < len(step_frames) < total
+    # The truncation marker on the first frame costs a little more than
+    # the measuring pass counted for it (see
+    # ``_fast_path_step_snapshot``'s docstring) -- a bounded overrun, not
+    # an unbounded one.
+    assert sum(len(chunk) for chunk in step_frames) <= es.MAX_SNAPSHOT_WIRE_BYTES + 64
+    first_step_block = next(
+        block for block in body.split("\n\n") if block.startswith("event: step.")
+    )
+    first_step_data = json.loads(first_step_block.split("data: ", 1)[1])
+    assert first_step_data["snapshot_truncated"] is True
+    assert first_step_data["snapshot_total_steps"] == total
+    assert body.count(f"event: {conclusion_event}") == 1
+    # A byte-budget cut is a truncated snapshot, not a stream error -- the
+    # client is told via ``snapshot_truncated``, not a close frame.
+    assert "event: stream.error" not in body
+
+
+async def test_fast_path_snapshot_admits_a_frame_exactly_at_the_byte_budget(
+    monkeypatch,
+):
+    """Same boundary rule as the queue's own byte budget (see
+    ``test_backlog_exactly_at_the_byte_budget_does_not_close``): strictly
+    over the budget cuts the snapshot short, landing exactly on it does
+    not. Drives ``_fast_path_step_snapshot`` directly with two identical
+    steps and a budget set to exactly two frames' worth of wire bytes,
+    then one byte short of that, so the boundary is pinned to the exact
+    byte that tips it rather than one before or after."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    step = es.PublicStep(
+        id="tool_call:call-1",
+        type="tool_call",
+        status="completed",
+        started_at=base,
+        completed_at=base,
+        data={"name": "search", "result": "ok"},
+    )
+    frame_len = len(es._step_wire_frame(step))
+    steps = [step, step]
+
+    def _read_task_steps_response(task_id_, principal_):
+        return SimpleNamespace(steps=steps)
+
+    monkeypatch.setattr(es, "MAX_SNAPSHOT_WIRE_BYTES", frame_len * 2)
+    admitted, total_steps = await es._fast_path_step_snapshot(
+        1, None, _read_task_steps_response
+    )
+    assert len(admitted) == 2
+    assert total_steps is None
+
+    monkeypatch.setattr(es, "MAX_SNAPSHOT_WIRE_BYTES", frame_len * 2 - 1)
+    admitted, total_steps = await es._fast_path_step_snapshot(
+        1, None, _read_task_steps_response
+    )
+    assert len(admitted) == 1
+    assert total_steps == 2
+
+
 # ===== fast-path generation fence (steps read outlives the snapshot) =====
 
 


### PR DESCRIPTION
## What

The v1 chat-task event stream (`GET /v1/chat/tasks/{task_id}/events`) has two attach-time fast paths: an attach that lands on a task which is already terminal, or already waiting on user input, closes immediately with a lifecycle frame and never registers a live projector. Today those two paths send nothing else, so a client has no step content until it separately calls `steps()`.

This PR makes both paths send a one-shot snapshot of the task's current public steps between `task.status` and the closing frame (`task.completed` or `task.input_required`). The snapshot is read through the same `max_event_id`-keyed cache that `GET .../steps` already uses, so a burst of fast-path attaches on one task collapses into cache hits instead of each one re-reading and re-projecting the task's full trace history independently.

The snapshot is bounded twice, whichever binds first: a step-count cap (`REPLAY_MAX_STEPS`, 512) and a total-wire-bytes budget over its serialized frames (`MAX_SNAPSHOT_WIRE_BYTES`, 4 MiB). The count cap binds on a long history of ordinary steps, the byte budget on a short history of large ones -- 512 steps each carrying a `data` sub-object at the 64 KiB per-step cap would be roughly 32 MiB generated into one response. The count cap keeps the most recent steps in `started_at` order; the byte budget then admits that window from its oldest end, so the snapshot stays a contiguous run in wire order.

Whenever either bound sends fewer steps than the task has, the conclusion frame -- `task.completed` or `task.input_required` -- carries `snapshot_truncated: true` and `snapshot_total_steps` (the task's real total), so a client can tell a bounded snapshot from a complete one and knows how much is missing. The conclusion is the carrier because it is the one frame every exit of these paths emits: the byte budget can admit no steps at all, and a `step.*` frame that does not exist cannot carry a marker. Both fields are absent when the snapshot is complete, and absent on every other producer of those two frames. `GET .../steps` remains the authoritative full history.

## The contract

- **Generation fence.** The steps snapshot is read once, but the task row it was selected from can be written in the gap between selecting this fast path and reading its steps. So before any step content goes on the wire, the task row is read once more and its `run_id`/`state_version` are compared against the snapshot that picked this path. `state_version` is what carries this comparison: it is incremented on every lifecycle transition, whether or not a new run begins. `run_id` changes only when a genuinely new run starts -- a `POST reply` resuming a waiting task deliberately keeps the same `run_id` -- so it is the narrower field and cannot stand alone. The contract is therefore "any lifecycle write invalidates this snapshot", not "a new run started": ordinary intra-run writes such as finalization, lease release and lease-expiry recovery also trip it, and they can land in the window right after the task reaches the state that selects these paths. That is deliberate -- the reread cannot tell a write that superseded the snapshot from one that did not, and a false positive costs one `steps()` call while a false negative pairs a conclusion with step content from an unconfirmed generation. A confirmed match sends the steps, then the conclusion. A confirmed change, or a reread that fails outright, withholds the steps and sends the conclusion followed by `stream.error(resync_required)` instead -- the conclusion always goes out, since it describes the generation that was already authoritatively read before this fast path started. The reread is skipped when the steps read came back empty, since there is nothing that could go stale.
- **No outbound queue on this path.** These fast paths `yield` frames straight from the generator; there is no sink and no per-attach outbound queue. Neither of the module's existing queue-size bounds (element count, queued bytes) applies here. The two bounds that exist for this path specifically are `REPLAY_MAX_STEPS` and `MAX_SNAPSHOT_WIRE_BYTES`. The existing 64 KiB per-step `data` cap still applies, since it is enforced per frame wherever the frame is built.
- **Serialization failures don't become bare disconnects.** `StreamingResponse` sends the 200 and headers before this generator's first `yield`, so any unguarded exception after that point would end the response with no close frame — indistinguishable from the connection just dropping. A step that fails to serialize (`PublicStep.data` is a `Dict[str, Any]`, so a tool result can contain a value `model_dump(mode="json")` has no encoding rule for) is caught in its own step; the conclusion frame and a `stream.error(resync_required)` still go out.
- **Failure classification.** A steps read or generation reread that fails with `V1ApiError(TASK_NOT_FOUND)` — the task row was deleted in the gap since the earlier authoritative read — closes with `task_deleted`, matching how the watchdog already classifies that case. Every other failure closes with `resync_required` and is logged.

## Stacked on

This is a follow-up to the live-projection change (#1382), which is already merged. That PR built the live SSE projection for tasks that are still running at attach time; this PR only adds the one-shot step snapshot on the two paths that skip live projection entirely because the task is already done. It touches no live-projection code.

## Normalization ownership

Both producers of a `step.*` frame — live projection and this PR's fast-path snapshot — now funnel through the same `_step_wire_frame`, which takes the `PublicStep` model itself (not an already-dumped dict) and runs the single `model_dump(mode="json")` call for both. That's a structural, not just a documented, single owner: a caller can't reach a frame builder with un-normalized values without going around the type. `test_nonfinite_step_data_values_are_normalized_to_null_on_the_wire` pins this by exercising only the live path's entry point (`_step_content_frame`) with non-finite floats nested three levels deep; because both producers share `_step_wire_frame`, that one assertion also covers the fast-path snapshot, with no separate test needed to duplicate it.

## Tests

`tests/web/api/v1/test_events_stream.py` gains 22 test cases (`pytest -k fast_path`) covering: steps-read failure and task-not-found classification, the 512-step truncation marker, the generation fence on both a confirmed change and a failed reread (parametrized across both fast paths and both of the fields the fence compares, `run_id` and `state_version`), the empty-steps skip of the reread, unserializable-step handling, the cache-hit behavior of the shared steps reader, and exemption from the two per-attach concurrency caps (since these paths never register a sink). An additional pass over the pre-existing tests for these fence cases removed duplicated assertions that had drifted between the two fast paths' copies, so the same case is checked identically on both paths rather than by two copies that could disagree.

