### PR TITLE
fix(interactions): bind the write path's close, task lookup, and audit identity

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -48,6 +48,7 @@ from ....file_ref import (
 )
 from ....model.chat.exceptions import LLMToolProtocolError
 from ....model.chat.tool_protocol import get_tool_protocol_error
+from ....tools.adapters.vibe.interaction_types import INTERACTION_TYPES
 from ....tools.user_interaction import (
     tool_result_waits_for_user,
     user_interaction_resume_callable,
@@ -1796,15 +1797,7 @@ class ReActPattern(AgentPattern):
                                     "properties": {
                                         "type": {
                                             "type": "string",
-                                            "enum": [
-                                                "select_one",
-                                                "select_multiple",
-                                                "text_input",
-                                                "file_upload",
-                                                "confirm",
-                                                "number_input",
-                                                "action_cards",
-                                            ],
+                                            "enum": list(INTERACTION_TYPES),
                                         },
                                         "field": {"type": "string"},
                                         "label": {"type": "string"},

--- a/src/xagent/core/tools/adapters/vibe/ask_user_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/ask_user_tool.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from .....web.tools.config import WebToolConfig
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 from .factory import register_tool
+from .interaction_types import INTERACTION_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class InteractionOption(BaseModel):
 
 class InteractionArg(BaseModel):
     type: str = Field(
-        description="Type of interaction: select_one, select_multiple, text_input, file_upload, confirm, number_input, action_cards"
+        description="Type of interaction: " + ", ".join(INTERACTION_TYPES)
     )
     field: str = Field(description="Field name for the data")
     label: str = Field(description="Display label for the field")

--- a/src/xagent/core/tools/adapters/vibe/interaction_types.py
+++ b/src/xagent/core/tools/adapters/vibe/interaction_types.py
@@ -1,0 +1,33 @@
+"""The interaction types the ask_user_question render surface implements.
+
+Kept in a module of its own rather than beside ``InteractionArg`` in
+``ask_user_tool``, which is where the model that carries the field lives:
+importing ``ask_user_tool`` pulls in the whole tool-registration chain and
+with it 61 ``xagent.web`` modules, and one of this list's three consumers
+(``core/agent/pattern/react/react.py``) imports nothing from ``xagent.web``
+today. A list of seven strings must not be what changes that. This module
+imports nothing, so any consumer can take it.
+
+Ordered, not a set: two of the three consumers render it into text a model
+reads -- the ``ask_user_question`` JSON-Schema enum and
+``InteractionArg.type``'s own description -- and an unstable order would
+change the prompt from run to run.
+
+The three consumers, all of which used to carry their own copy of these
+seven names:
+
+* ``InteractionArg.type``'s description (``ask_user_tool.py``)
+* the ``ask_user_question`` JSON-Schema enum (``react.py``)
+* the write side's admissibility set (``_V1_INTERACTION_TYPES``,
+  ``web/services/task_interaction_service.py``)
+"""
+
+INTERACTION_TYPES: tuple[str, ...] = (
+    "select_one",
+    "select_multiple",
+    "text_input",
+    "file_upload",
+    "confirm",
+    "number_input",
+    "action_cards",
+)

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -62,6 +62,7 @@ from ..services.task_execution_controller import (
     task_execution_controller,
 )
 from ..services.task_interaction_close import (
+    active_interaction_id_sync,
     clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction,
 )
@@ -322,8 +323,16 @@ RESUME_INPUT_FENCE_UPDATE_COLUMNS = frozenset({"input", "output", "error_message
 def _update_a2a_resume_input_sync(
     task_lease: TaskLease,
     text: str,
+    interaction_id: int | None,
 ) -> bool:
-    """Persist A2A input only while the exact prelease remains current."""
+    """Persist A2A input only while the exact prelease remains current.
+
+    ``interaction_id`` is the active interaction row the caller observed
+    before injecting the message, passed in rather than read here: this
+    function's session does not open until after the injection has already
+    committed. See ``task_interaction_close``'s module docstring for why
+    the read has to precede the injection.
+    """
 
     SessionLocal = get_session_local()
     with SessionLocal() as db:
@@ -369,7 +378,10 @@ def _update_a2a_resume_input_sync(
         assert task_lease.run_id is not None
         if interaction_requests_table_exists(db):
             close_legacy_resume_interaction(
-                db, task_id=task_lease.task_id, run_id=task_lease.run_id
+                db,
+                task_id=task_lease.task_id,
+                run_id=task_lease.run_id,
+                interaction_id=interaction_id,
             )
         db.commit()
         return True
@@ -452,6 +464,12 @@ async def _resume_input_required_a2a_task(
         )
 
     try:
+        # Read before the injection below, not inside
+        # _update_a2a_resume_input_sync, whose session opens only afterwards.
+        # See task_interaction_close's module docstring for why.
+        active_interaction_id = await run_db_io_cancellation_safe(
+            lambda: active_interaction_id_sync(task_id)
+        )
 
         async def inject_user_message() -> tuple[Any, bool]:
             from .chat import get_agent_manager
@@ -495,7 +513,9 @@ async def _resume_input_required_a2a_task(
             )
 
         updated = await run_db_io_cancellation_safe(
-            lambda: _update_a2a_resume_input_sync(task_lease, text)
+            lambda: _update_a2a_resume_input_sync(
+                task_lease, text, active_interaction_id
+            )
         )
         if not updated:
             raise TaskLeaseLostError(

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -467,6 +467,23 @@ async def _resume_input_required_a2a_task(
         # Read before the injection below, not inside
         # _update_a2a_resume_input_sync, whose session opens only afterwards.
         # See task_interaction_close's module docstring for why.
+        #
+        # This site's turn id is deterministic (f"a2a:{task_id}:{message_id}"
+        # below), so a retried A2A message replays the same turn:
+        # AgentRunner.inject_user_message short-circuits a repeated turn id
+        # by returning the existing context without persisting anything, and
+        # reports the same truthy `posted` a first attempt does. On such a
+        # replay the id read here is not the question the replayed message
+        # answered but whatever the resumed agent has asked since, and the
+        # close would retire a live question. Nothing can be retired today:
+        # the only INSERT into task_interaction_requests is
+        # stage_interaction_request (task_interaction_staging.py), which has
+        # no caller in src/ and is held at none by
+        # tests/web/services/test_interaction_staging_production_gate.py, so
+        # this read returns None on every call. Closing the window is a
+        # precondition on the change that wires the first production writer,
+        # stated once at the online WebSocket injection site (websocket.py)
+        # and binding here identically.
         active_interaction_id = await run_db_io_cancellation_safe(
             lambda: active_interaction_id_sync(task_id)
         )

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -60,6 +60,7 @@ from ...services.db_runtime import (
 )
 from ...services.task_execution_controller import TaskControlState
 from ...services.task_interaction_close import (
+    active_interaction_id_sync,
     clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction,
 )
@@ -313,8 +314,17 @@ async def _restore_reply_prelease_isolated(task_lease: TaskLease) -> bool:
 RESUME_INPUT_FENCE_UPDATE_COLUMNS = frozenset({"input", "output", "error_message"})
 
 
-def _update_reply_input_sync(task_lease: TaskLease, text: str) -> bool:
-    """Persist the reply's input only while the exact prelease remains current."""
+def _update_reply_input_sync(
+    task_lease: TaskLease, text: str, interaction_id: int | None
+) -> bool:
+    """Persist the reply's input only while the exact prelease remains current.
+
+    ``interaction_id`` is the active interaction row the caller observed
+    before injecting the message, passed in rather than read here: this
+    function's session does not open until after the injection has already
+    committed. See ``task_interaction_close``'s module docstring for why
+    the read has to precede the injection.
+    """
     SessionLocal = get_session_local()
     with SessionLocal() as db:
         updated = (
@@ -354,7 +364,10 @@ def _update_reply_input_sync(task_lease: TaskLease, text: str) -> bool:
         assert task_lease.run_id is not None
         if interaction_requests_table_exists(db):
             close_legacy_resume_interaction(
-                db, task_id=task_lease.task_id, run_id=task_lease.run_id
+                db,
+                task_id=task_lease.task_id,
+                run_id=task_lease.run_id,
+                interaction_id=interaction_id,
             )
         db.commit()
         return True
@@ -500,6 +513,12 @@ async def reply_to_task(
         return await _restore_reply_prelease_isolated(task_lease)
 
     try:
+        # Read before the injection below, not inside
+        # _update_reply_input_sync, whose session opens only afterwards.
+        # See task_interaction_close's module docstring for why.
+        active_interaction_id = await run_db_io_cancellation_safe(
+            lambda: active_interaction_id_sync(task_id)
+        )
 
         async def inject_user_message() -> tuple[Any, bool]:
             from .. import chat
@@ -538,7 +557,9 @@ async def reply_to_task(
             raise V1ApiError(V1ErrorCode.INTERACTION_NOT_RESUMABLE, 409)
 
         updated = await run_db_io_cancellation_safe(
-            lambda: _update_reply_input_sync(task_lease, ctx.text)
+            lambda: _update_reply_input_sync(
+                task_lease, ctx.text, active_interaction_id
+            )
         )
         if not updated:
             raise TaskLeaseLostError(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -150,6 +150,7 @@ from ..services.task_execution_controller import (
     task_execution_controller,
 )
 from ..services.task_interaction_close import (
+    active_interaction_id_sync,
     clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction_sync,
 )
@@ -3280,11 +3281,17 @@ async def execute_resume_background(
             # apply inside a nested closure.
             assert lease.run_id is not None
             close_run_id = lease.run_id
+            # Observed by the online handler before it injected -- carried
+            # here through pending_user_message rather than read now, since
+            # this path injects later still. Bound to a plain local before
+            # the lambda below, like close_run_id above.
+            close_interaction_id = pending_user_message.get("interaction_id")
             try:
                 await run_db_io_cancellation_safe(
                     lambda: close_legacy_resume_interaction_sync(
                         task_id,
                         close_run_id,
+                        close_interaction_id,
                     )
                 )
             except Exception:
@@ -5944,6 +5951,18 @@ async def _handle_chat_message_unserialized(
                         return
                     delivery_claimed = True
 
+                    # Read before the injection below and before the posted
+                    # fork, so both branches carry the same observation --
+                    # see task_interaction_close's module docstring for why
+                    # it has to precede the injection. The two branches are
+                    # mutually exclusive: posted true closes below with this
+                    # local, posted false hands the same value to
+                    # execute_resume_background through pending_user_message,
+                    # so one observation only ever serves one close.
+                    active_interaction_id = await run_db_io_cancellation_safe(
+                        lambda: active_interaction_id_sync(task_id)
+                    )
+
                     posted = False
                     if live_task_lease is not None:
                         with bind_task_lease_context(live_task_lease):
@@ -6016,6 +6035,12 @@ async def _handle_chat_message_unserialized(
                                     "display_message": display_user_message,
                                     "files": display_file_refs,
                                     "turn_id": turn_id,
+                                    # The pre-injection observation, carried
+                                    # rather than re-read: the deferred path
+                                    # injects later still, so a read there
+                                    # would be even further past the point
+                                    # where the answered row is identifiable.
+                                    "interaction_id": active_interaction_id,
                                 }
                             ),
                             delivery_turn_id=turn_id,
@@ -6076,11 +6101,13 @@ async def _handle_chat_message_unserialized(
                         assert live_task_lease is not None
                         assert live_task_lease.run_id is not None
                         close_run_id = live_task_lease.run_id
+                        close_interaction_id = active_interaction_id
                         try:
                             await run_db_io_cancellation_safe(
                                 lambda: close_legacy_resume_interaction_sync(
                                     task_id,
                                     close_run_id,
+                                    close_interaction_id,
                                 )
                             )
                         except Exception:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -6098,14 +6098,25 @@ async def _handle_chat_message_unserialized(
                         # -- that one was retired by the first attempt -- but
                         # whatever the resumed agent has asked since, and
                         # retiring it discards a live question nobody
-                        # answered. Nothing in the interaction table is
-                        # reachable today (no production writer inserts into
-                        # it yet), so the window costs nothing right now. The
+                        # answered. This close call is live production code --
+                        # it runs on every websocket chat message that
+                        # reaches a running task -- so what makes the window
+                        # harmless today is not that the code is dormant. It
+                        # is that there is nothing for it to retire: the only
+                        # INSERT into task_interaction_requests is
+                        # stage_interaction_request
+                        # (task_interaction_staging.py), which has no caller
+                        # in src/ and is held at none by
+                        # tests/web/services/test_interaction_staging_production_gate.py.
+                        # The pre-injection read therefore returns None on
+                        # every call, and the close matches zero rows. The
                         # change that wires the first production writer has
-                        # to close it before that writer ships: the runner
-                        # has to report whether it persisted a new message or
-                        # replayed an existing turn, and this site has to
-                        # skip the close on the replay answer.
+                        # to close this window before that writer ships:
+                        # the runner has to report whether it persisted a
+                        # new message or replayed an existing turn, and this
+                        # site has to skip the close on the replay answer.
+                        # The A2A injection site (a2a.py) carries the same
+                        # window and the same precondition.
                         #
                         # The run fence
                         # is live_task_lease.run_id, not task_run_id: posted

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -7759,93 +7759,6 @@ async def handle_resume_task(
     )
 
 
-def _active_native_interaction_id_sync(task_id: int) -> int | None:
-    """The id of this task's active native interaction row, scoped to the
-    task's current run, or ``None`` if there is none.
-
-    Uses the identical four-field predicate
-    (``task_interaction_service._active_native_row_criteria``) every reader
-    of "this task's one live row" keys off: status, active_slot, and a join
-    against ``Task.run_id``. That predicate has three call sites in this
-    tree -- ``task_interaction_service``'s own ``list_active`` and
-    ``_active_native_row`` (the latter is how
-    ``materialize_compatibility_view`` reads the row), plus this seam. The
-    answer fence is a fourth, future caller: it does not exist here yet and
-    lands with ``respond()``. All of them must keep changing together, or
-    the read surface, this resume seam, and the fence once it arrives would
-    disagree about which row -- if any -- is "the" live one for a given
-    task. An active row anchored to a run the task has since moved past is
-    invisible here for the same reason it is invisible to the other
-    readers: ``_reclaim_stale_slot_stmt``
-    (``task_interaction_staging.py``) recycles it on the next question, so
-    it carries no obligation for this seam either.
-
-    Gated on ``interaction_requests_table_exists`` for the same reason
-    ``materialize_compatibility_view`` gates on it: a deployment can run
-    this code before the migration that creates
-    ``task_interaction_requests`` has been applied, and this seam must
-    survive that window rather than raising.
-
-    Uses ``get_optional_session_local`` rather than ``get_session_local``,
-    and wraps the read in a broad ``except Exception`` -- the same
-    fail-open shape ``_resolve_read_direction_anchor``
-    (``task_interaction_service.py``) already uses for its own read against
-    this same kind of infrastructure. Every production entry point into
-    this handler runs after ``configure_db()``/``init_db()`` against one
-    database for the life of the process, so neither branch is expected to
-    ever fire there. Both exist for this handler's test callers, which
-    mock the rest of the resume path precisely to avoid needing a database
-    at all, and which do not each get an isolated process: a session
-    factory some other test left installed as the process-global default
-    can point at a since-removed temporary database file by the time an
-    unrelated test reaches this call. Either way, "cannot determine
-    whether there is an active row" is treated as "assume there is not" --
-    refusing every resume because this one read failed would be a worse
-    failure mode than the one legacy-resume window this seam closes.
-    """
-
-    from ..models.database import get_optional_session_local
-    from ..models.task import Task
-    from ..models.task_interaction import TaskInteractionRequest
-    from ..services.task_interaction_schema import interaction_requests_table_exists
-    from ..services.task_interaction_service import _active_native_row_criteria
-
-    SessionLocal = get_optional_session_local()
-    if SessionLocal is None:
-        return None
-    try:
-        db = SessionLocal()
-    except Exception:
-        logger.warning(
-            "resume interaction seam: could not open a session for task_id=%s",
-            task_id,
-            exc_info=True,
-        )
-        return None
-    try:
-        if not interaction_requests_table_exists(db):
-            return None
-        row = (
-            db.query(TaskInteractionRequest.id)
-            .join(Task, Task.id == TaskInteractionRequest.task_id)
-            .filter(
-                TaskInteractionRequest.task_id == task_id,
-                *_active_native_row_criteria(),
-            )
-            .first()
-        )
-        return int(row[0]) if row is not None else None
-    except Exception:
-        logger.warning(
-            "resume interaction seam: active-row lookup failed for task_id=%s",
-            task_id,
-            exc_info=True,
-        )
-        return None
-    finally:
-        db.close()
-
-
 async def _handle_resume_task_unserialized(
     websocket: WebSocket, task_id: int, message_data: dict
 ) -> None:
@@ -7936,7 +7849,12 @@ async def _handle_resume_task_unserialized(
         # continuation respond() staged, refuse rather than let either path
         # append to or replan around an unanswered question. This runs
         # before agent_service is built (below) so a refused request never
-        # pays for constructing one.
+        # pays for constructing one. Gated on tasks.interaction_protocol_
+        # version first, though: under a NULL marker the read below returns
+        # None regardless of whether an active row exists, so this refusal
+        # never fires for that state -- deliberately, matching what the
+        # read surface would show for the same task (see
+        # active_interaction_id_sync's own docstring).
         #
         # Residual window, named here rather than closed here: this lookup
         # opens and closes its own session, and no lock spans it and either
@@ -7944,8 +7862,12 @@ async def _handle_resume_task_unserialized(
         # between this read and the transition. Nothing can drive that
         # change until respond()'s finalizer exists, and that finalizer --
         # not this seam -- is what must own the window when it lands.
+        #
+        # The read itself is task_interaction_close.active_interaction_id_sync
+        # -- the same reader the three legacy-resume injection sites use, so
+        # this gate and the close cannot disagree about which row is live.
         active_interaction_id = await run_db_io_cancellation_safe(
-            lambda: _active_native_interaction_id_sync(task_id)
+            lambda: active_interaction_id_sync(task_id)
         )
         if active_interaction_id is not None:
             receipt_interaction_id = message_data.get("interaction_id")

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -6079,17 +6079,35 @@ async def _handle_chat_message_unserialized(
                                 turn_id,
                                 exc_info=True,
                             )
-                        # `posted` is true, meaning a message with this
-                        # turn id is in a live checkpoint -- written by this
-                        # call, or already present from an earlier attempt
-                        # with the same turn id, which short-circuits without
-                        # persisting anything new (see
-                        # AgentRunner.inject_user_message) -- instead of
-                        # going through the native interaction
-                        # protocol's answer path, so any question this run
-                        # had open under that protocol is answered by other
-                        # means now. Retire it and clear the task's
-                        # marker in the same short transaction. The run fence
+                        # `posted` is true, meaning a message with this turn
+                        # id is in a live checkpoint. Retire the interaction
+                        # row observed before the injection and clear the
+                        # task's marker in the same short transaction: the
+                        # message went in outside the native interaction
+                        # protocol's answer path, so a question this run had
+                        # open under that protocol was answered by other
+                        # means.
+                        #
+                        # That reading holds for a first attempt and not for
+                        # a replay, and `posted` cannot tell the two apart.
+                        # AgentRunner.inject_user_message short-circuits a
+                        # repeated turn id by returning the existing context
+                        # without persisting anything, which reaches here as
+                        # the same `True`. On a replay the id read just above
+                        # is not the question the replayed message answered
+                        # -- that one was retired by the first attempt -- but
+                        # whatever the resumed agent has asked since, and
+                        # retiring it discards a live question nobody
+                        # answered. Nothing in the interaction table is
+                        # reachable today (no production writer inserts into
+                        # it yet), so the window costs nothing right now. The
+                        # change that wires the first production writer has
+                        # to close it before that writer ships: the runner
+                        # has to report whether it persisted a new message or
+                        # replayed an existing turn, and this site has to
+                        # skip the close on the replay answer.
+                        #
+                        # The run fence
                         # is live_task_lease.run_id, not task_run_id: posted
                         # being true only happens by way of the
                         # live_task_lease is not None branch above, which is

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -3281,17 +3281,21 @@ async def execute_resume_background(
             # apply inside a nested closure.
             assert lease.run_id is not None
             close_run_id = lease.run_id
-            # Observed by the online handler before it injected -- carried
-            # here through pending_user_message rather than read now, since
-            # this path injects later still. Bound to a plain local before
-            # the lambda below, like close_run_id above.
+            # Read by the online handler before this message was injected,
+            # and carried here rather than read now for the opposite reason
+            # to the one it looks like: the injection is not still to come,
+            # it is the post_user_message call above and has already
+            # committed by this line. Injecting is what resumes the agent,
+            # so a read here could name a question the resumed agent has
+            # staged since, not the one the message answered. Bound to a
+            # plain local before the lambda below, like close_run_id above.
             close_interaction_id = pending_user_message.get("interaction_id")
             try:
                 await run_db_io_cancellation_safe(
                     lambda: close_legacy_resume_interaction_sync(
-                        task_id,
-                        close_run_id,
-                        close_interaction_id,
+                        task_id=task_id,
+                        run_id=close_run_id,
+                        interaction_id=close_interaction_id,
                     )
                 )
             except Exception:
@@ -6134,9 +6138,9 @@ async def _handle_chat_message_unserialized(
                         try:
                             await run_db_io_cancellation_safe(
                                 lambda: close_legacy_resume_interaction_sync(
-                                    task_id,
-                                    close_run_id,
-                                    close_interaction_id,
+                                    task_id=task_id,
+                                    run_id=close_run_id,
+                                    interaction_id=close_interaction_id,
                                 )
                             )
                         except Exception:

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -228,6 +228,14 @@ class Task(Base):  # type: ignore
     # worker-owned short session of its own rather than a request-scoped
     # one, but it resolves and loads the same Task row before asking, so
     # the same free-attribute-access argument applies to it unchanged.
+    # ``task_interaction_close.active_interaction_id_sync`` reads this same
+    # marker too, ahead of the interaction-table query it guards, but it is
+    # not one of the four above: it never holds a loaded Task row, so it
+    # pays for its own single-column primary-key query rather than getting
+    # the check for free. That is the trade against the alternative it
+    # replaced -- an uncached catalog inspection plus a two-table join --
+    # not a violation of the free-access argument above, which is about the
+    # read surface specifically.
     # While every waiting task predates the native protocol (and during
     # any rollback), the marker is NULL for all of them and the
     # interaction table receives zero queries from the read path.

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -197,12 +197,14 @@ class Task(Base):  # type: ignore
     # finalizers will write it (1 when a row was staged, NULL when staging
     # degraded) and have no writer yet. The four legacy-resume injection
     # sites (the two WebSocket sites, the A2A resume-input path, and the
-    # v1 reply resume-input path) clear it back to NULL unconditionally,
-    # paired with retiring the row they answered; that writer already
-    # exists in task_interaction_close.py
+    # v1 reply resume-input path) retire the row they answered and clear
+    # this column back to NULL in the same transaction, the clear
+    # conditioned on no active row for that run remaining afterwards;
+    # that writer already exists in task_interaction_close.py
     # (close_legacy_resume_interaction). The three resume-abandonment
-    # paths clear it back to NULL only when it no longer names any active
-    # row; that writer also already exists in task_interaction_close.py
+    # paths have no row to retire and only reconcile the column, under
+    # the same condition; that writer also already exists in
+    # task_interaction_close.py
     # (clear_interaction_marker_if_unpaired), called from the A2A prelease
     # restore (a2a.py), the WebSocket lease restore (websocket.py), and
     # the v1 reply prelease restore (task_reply.py), all

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -110,11 +110,21 @@ from .task_lease_service import (
 
 logger = logging.getLogger(__name__)
 
-# Deployment policy, not an invariant: this only bounds how long an
+# The TTL the publication path actually uses: a published row's
+# ``expires_at`` is this added to the moment the round is resolved.
+# Deployment policy, not an invariant -- it only bounds how long an
 # unanswered row sits before a reclaim job retires it. The read surface
 # does not consult ``expires_at`` at all, so a longer-lived row is still
 # shown to whoever is waiting on it; widen or narrow this once real
 # publication volume gives a basis for the number, not before.
+#
+# Distinct from ``_MIN_INTERACTION_TTL_SECONDS`` /
+# ``_MAX_INTERACTION_TTL_SECONDS`` (``task_interaction_service.py``),
+# which are not a TTL at all but the interval a caller's own
+# ``ttl_seconds`` override has to fall inside. The two are deliberately
+# not unified -- one is the value this path publishes with, the other the
+# range a caller may ask for. The only relationship that has to hold
+# between them is that this value falls inside that range.
 CLARIFICATION_REQUEST_TTL = timedelta(hours=24)
 
 # The character domain a payload's free-text leaves may contain, kept

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -161,11 +161,19 @@ def active_interaction_id_sync(task_id: int) -> int | None:
     returns to ``close_legacy_resume_interaction`` -- see this module's
     docstring for why that ordering is the whole point.
 
-    Opens and closes its own short session. All four legacy-resume paths
-    call it from a point where they hold no session of their own: the two
-    fence-transaction paths (``a2a.py``, ``v1/task_reply.py``) open their
-    fence only after the injection has already committed, and the two
-    WebSocket paths hold none at all.
+    Opens and closes its own short session. Three legacy-resume injection
+    paths call it from a point where they hold no session of their own: the
+    two fence-transaction paths (``a2a.py``, ``v1/task_reply.py``) open
+    their fence only after the injection has already committed, and the
+    WebSocket online chat injection holds none at all. The fourth
+    legacy-resume path -- the WebSocket deferred injection reached through
+    ``execute_resume_background`` -- does not call this function itself; it
+    reuses the id the online handler already read, carried through
+    ``pending_user_message["interaction_id"]``
+    (``tests/web/api/test_websocket_owner_actor.py`` pins that it must not
+    read again). A fourth call site does exist in ``src/``, but it is not
+    an injection path at all -- see the resume command seam paragraph
+    below.
 
     Keys off ``_active_native_row_criteria``
     (``task_interaction_service.py``), the same four-field predicate every
@@ -184,32 +192,75 @@ def active_interaction_id_sync(task_id: int) -> int | None:
     unbound predicate when the read fails -- is the retire-the-wrong-row
     bug this function exists to prevent, so an unreadable id must never
     widen what the close matches.
+
+    Two branches decide "no id" before the row lookup runs, and both mean
+    the same thing as an empty lookup, not a failure:
+    ``get_optional_session_local()`` returning ``None`` (no database
+    configured in this process -- expected in tests, never in production),
+    and ``tasks.interaction_protocol_version`` being ``NULL``. The marker
+    gate is the write side of the same first step
+    ``get_pending_interaction_question`` (``task_interaction_read.py``)
+    takes on the read side: a NULL marker means no native row was ever
+    staged for this task's current wait, so the interaction table goes
+    unqueried. Keeping the two sides on one judgment is the point -- a
+    question the read surface will not show must not be a question this
+    close retires -- and the cost it removes is real: this function runs on
+    every A2A resume, every v1 chat reply and every live WebSocket chat
+    message, and under a NULL marker it now costs one primary-key lookup
+    instead of an uncached catalog inspection plus a two-table join.
+
+    This is also the resume command seam's reader (``websocket.py``'s
+    refusal gate for a resume whose payload cannot prove it answered the
+    active question). That seam used to carry a byte-identical copy of the
+    query; one reader is what keeps the close, the refusal gate and the
+    read surface from drifting into three notions of "the live row".
     """
+    from ..models.database import get_optional_session_local
     from .task_interaction_service import _active_native_row_criteria
 
+    SessionLocal = get_optional_session_local()
+    if SessionLocal is None:
+        return None
     try:
-        SessionLocal = get_session_local()
-        with SessionLocal() as db:
-            if not interaction_requests_table_exists(db):
-                return None
-            row = (
-                db.query(TaskInteractionRequest.id)
-                .join(Task, Task.id == TaskInteractionRequest.task_id)
-                .filter(
-                    TaskInteractionRequest.task_id == task_id,
-                    *_active_native_row_criteria(),
-                )
-                .first()
-            )
-            return int(row[0]) if row is not None else None
+        db = SessionLocal()
     except Exception:
         logger.warning(
-            "could not read the active interaction row before injection for "
-            "task_id=%s; the close will match no row",
+            "could not open a session to read the active interaction row "
+            "for task_id=%s; the close will match no row",
             task_id,
             exc_info=True,
         )
         return None
+    try:
+        marker = (
+            db.query(Task.interaction_protocol_version)
+            .filter(Task.id == task_id)
+            .scalar()
+        )
+        if marker is None:
+            return None
+        if not interaction_requests_table_exists(db):
+            return None
+        row = (
+            db.query(TaskInteractionRequest.id)
+            .join(Task, Task.id == TaskInteractionRequest.task_id)
+            .filter(
+                TaskInteractionRequest.task_id == task_id,
+                *_active_native_row_criteria(),
+            )
+            .first()
+        )
+        return int(row[0]) if row is not None else None
+    except Exception:
+        logger.warning(
+            "the active interaction row lookup failed for task_id=%s; "
+            "the close will match no row",
+            task_id,
+            exc_info=True,
+        )
+        return None
+    finally:
+        db.close()
 
 
 def _active_row_exists(*, task_id: int, run_id: str) -> sa.Exists:

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -15,11 +15,14 @@ means.
 
 Three resume-abandonment paths (the WebSocket lease restore, the A2A
 prelease restore, and the v1 reply prelease restore) do the mirror-image
-cleanup when a resume is undone instead of completed: if the marker no
-longer corresponds to any active row, clear it. That clear is conditioned
-on ``NOT EXISTS`` rather than unconditional, because an abandonment can
-also race a resume that never even reached the injection call -- clearing
-unconditionally there would erase a marker that is still correct for a
+cleanup when a resume is undone instead of completed: there is no row to
+retire, only a marker to reconcile. Both clears -- theirs and the
+injection paths' -- are conditioned on the same ``NOT EXISTS``
+(``_active_row_exists``), for the same reason from two directions. An
+abandonment can race a resume that never even reached the injection
+call, and an injection can be handed no id because the pre-injection
+read failed while a question was in fact live; in either case an
+unconditional clear would erase a marker that is still correct for a
 question that is still active.
 
 A fourth WebSocket exit path does not clear the marker at all:
@@ -162,13 +165,15 @@ def active_interaction_id_sync(task_id: int) -> int | None:
 
     Returns ``None`` when the read cannot be made at all -- no table yet,
     no session, a failing query. ``None`` closes nothing: the close
-    statement matches zero rows and the active row survives, which
-    degrades to a reader falling back to the legacy transcript question,
-    the same benign outcome the module docstring describes for a stale
-    marker. The alternative -- closing on the old unbound predicate when
-    the read fails -- is the retire-the-wrong-row bug this function exists
-    to prevent, so an unreadable id must never widen what the close
-    matches.
+    statement matches zero rows and the active row survives -- and so
+    does the marker, because the clear beside the close is conditioned on
+    no active row remaining for this ``(task_id, run_id)`` pair (see
+    ``close_legacy_resume_interaction``). A reader keeps seeing the live
+    native question the read could not see, instead of falling back to
+    the legacy transcript question. The alternative -- closing on the old
+    unbound predicate when the read fails -- is the retire-the-wrong-row
+    bug this function exists to prevent, so an unreadable id must never
+    widen what the close matches.
     """
     from .task_interaction_service import _active_native_row_criteria
 
@@ -197,6 +202,51 @@ def active_interaction_id_sync(task_id: int) -> int | None:
         return None
 
 
+def _active_row_exists(*, task_id: int, run_id: str) -> sa.Exists:
+    """The EXISTS clause both marker clears in this module are conditioned on.
+
+    "This ``(task_id, run_id)`` pair still has a live interaction row":
+    the row's own lifecycle state (``status == "active"`` and
+    ``active_slot IS NOT NULL``) plus the pair itself. Written once and
+    referenced from both UPDATE statements instead of twice, because the
+    two clears mean the same thing by "no longer names any active row"
+    and must not drift into two readings of it.
+
+    Negated at both use sites -- neither clear runs while a live row
+    remains. The ``run_id`` leg compares against the value the caller
+    passed, which in both cases is the run the caller is finishing or
+    abandoning, so a live row belonging to some other run of the same
+    task is out of scope in both directions: it does not hold this
+    clear back, and this clear does not touch its marker.
+
+    Not the same predicate as ``_active_native_row_criteria``
+    (``task_interaction_service.py``), which this module also imports, in
+    ``active_interaction_id_sync``. That one's third leg is
+    ``TaskInteractionRequest.run_id == Task.run_id`` -- a comparison
+    against the task row a reader has already joined -- while this one
+    compares against a caller-supplied value. Today the two select the
+    same rows at both use sites, but only because each outer UPDATE
+    already pins ``Task.run_id == run_id``; the agreement is a
+    consequence of the surrounding statement, not a property of either
+    predicate. Swapping this clause for that one is therefore not a
+    simplification: it would turn both subqueries into correlated
+    subqueries against the row being updated, and it would re-point the
+    compensation paths' clear at whichever run the task currently
+    carries instead of at the run being abandoned.
+    """
+
+    return (
+        sa.select(sa.literal(1))
+        .where(
+            TaskInteractionRequest.task_id == task_id,
+            TaskInteractionRequest.run_id == run_id,
+            TaskInteractionRequest.status == "active",
+            TaskInteractionRequest.active_slot.isnot(None),
+        )
+        .exists()
+    )
+
+
 def close_legacy_resume_interaction(
     db: Session,
     *,
@@ -212,12 +262,18 @@ def close_legacy_resume_interaction(
     docstring carries the argument for why the value has to come from
     before the injection.
 
-    ``interaction_id=None`` means there was no active row to answer at
-    injection time. SQLAlchemy renders it as ``id IS NULL``, which is
-    never true of a primary key, so the close matches zero rows -- and the
-    marker clear below still runs, which is the whole behavior that case
-    needs. Do not "simplify" this into skipping the statement or dropping
-    the predicate: both change which rows the close can touch.
+    ``interaction_id=None`` means the pre-injection read produced no id --
+    either because no row was active at injection time, or because the
+    read could not be made at all (see ``active_interaction_id_sync``).
+    SQLAlchemy renders it as ``id IS NULL``, which is never true of a
+    primary key, so the close matches zero rows. What happens to the
+    marker then is not fixed by this argument and depends on which of
+    those two cases it was: the clear below runs its own check, and
+    zeroes the marker only if nothing active is left. Nothing was ever
+    there in the first case, so the marker clears; a live row the read
+    could not see is still there in the second, so it does not. Do not
+    "simplify" this into skipping the close statement or dropping its id
+    predicate: both change which rows the close can touch.
 
     Caller obligations, because neither happens here: the caller has
     already confirmed ``interaction_requests_table_exists(db)`` -- this
@@ -225,11 +281,24 @@ def close_legacy_resume_interaction(
     targets both tables -- and the caller owns the transaction; this
     function never commits or rolls back.
 
-    Both statements always run, regardless of the close statement's
-    rowcount: the clear is not conditioned on having actually closed a
-    row, because a task's marker can legitimately need clearing even when
-    this run never staged an interaction row at all (today's 100% case,
-    since this table has no production writer yet).
+    Both statements always run, and neither is conditioned on the other's
+    rowcount -- but the clear carries a condition of its own: it zeroes
+    the marker only when no active row for this ``(task_id, run_id)``
+    pair remains once the close above has had its turn. That covers the
+    case this function is normally in (the close retired the one live
+    row, so nothing is left and the marker goes) and today's 100% case
+    (this run never staged a row at all, so nothing was ever there and
+    the marker still goes, since the table has no production writer yet),
+    while refusing the case that used to lose a question: the
+    pre-injection read came back ``None`` -- or came back with an id the
+    close did not match -- while a live row is in fact still sitting
+    there. Zeroing the marker then would point every reader at the legacy
+    transcript question while the native row it named is still active and
+    unanswered.
+
+    The condition is ``_active_row_exists``, the same clause
+    ``clear_interaction_marker_if_unpaired`` is built on: "no active row
+    for this pair" has to mean one thing in this module, not two.
 
     Returns the close statement's rowcount, classified and logged by
     ``_classify_close_rowcount`` -- see the module docstring for why a
@@ -263,7 +332,11 @@ def close_legacy_resume_interaction(
     _classify_close_rowcount(rowcount, task_id=task_id, run_id=run_id)
     db.execute(
         sa.update(Task)
-        .where(Task.id == task_id, Task.run_id == run_id)
+        .where(
+            Task.id == task_id,
+            Task.run_id == run_id,
+            ~_active_row_exists(task_id=task_id, run_id=run_id),
+        )
         .values(interaction_protocol_version=None)
     )
     return rowcount
@@ -354,22 +427,12 @@ def clear_interaction_marker_if_unpaired(
     """
     if not interaction_requests_table_exists(db):
         return
-    still_active = (
-        sa.select(sa.literal(1))
-        .where(
-            TaskInteractionRequest.task_id == task_id,
-            TaskInteractionRequest.run_id == run_id,
-            TaskInteractionRequest.status == "active",
-            TaskInteractionRequest.active_slot.isnot(None),
-        )
-        .exists()
-    )
     db.execute(
         sa.update(Task)
         .where(
             Task.id == task_id,
             Task.run_id == run_id,
-            ~still_active,
+            ~_active_row_exists(task_id=task_id, run_id=run_id),
         )
         .values(interaction_protocol_version=None)
     )

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -65,10 +65,20 @@ together. A crash between those two commits leaves the interaction row
 message already answered the question. That window is benign for the same
 reason as the reader fallback documented above: a reader keys off
 ``status`` first, so a stale active row here just makes it fall back to
-asking the legacy question again -- the same family of harmless window
-as the message-injection replay that
-``AgentRunner.inject_user_message`` short-circuits on a repeated turn
-id.
+asking the legacy question again.
+
+The replay ``AgentRunner.inject_user_message`` short-circuits on a
+repeated turn id is not a window of that same benign family, and is
+not covered by the argument above. A replay persists nothing and still
+reports success to its caller, so an injection site cannot tell it from
+a first attempt; the row that site observed before calling is then not
+the question the replayed message answered but whatever the resumed
+agent has asked since, and closing it retires a live question instead
+of leaving a stale one behind. That is the opposite failure from the
+one this paragraph describes, and it is not fixed here -- see the
+comment at the online WebSocket injection site (``websocket.py``) for
+the precondition it puts on the change that wires the first production
+writer.
 
 The close statement binds to one primary key, read before the injection
 by ``active_interaction_id_sync`` and carried to the close by whichever

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -100,9 +100,13 @@ yet) and logs at debug, carrying with it a short description of why
 nothing matched (``_unmatched_close_row``) -- "nothing was ever there"
 and "something was there and is no longer this run's live question" are
 the same rowcount and different situations; more than one row is
-impossible under
-``uq_task_interaction_active_slot`` (it allows at most one row per task
-with a non-NULL ``active_slot``), but if that schema invariant were ever
+impossible twice over. The close statement binds to a primary key
+(``id == interaction_id``), which matches at most one row on its own, and
+its ``active_slot`` predicate falls under
+``uq_task_interaction_active_slot``, which allows at most one row per task
+with a non-NULL ``active_slot``. Both are named because a rowcount above
+one means a different thing under each: the unique constraint gone, or the
+primary key itself no longer unique. If either schema invariant were ever
 broken, this module logs at error and registers a degradation signal
 rather than raising -- a resume injection or an already-durable input
 write must not be turned into a failure by a check meant only to catch
@@ -260,6 +264,11 @@ def active_interaction_id_sync(task_id: int) -> int | None:
     every A2A resume, every v1 chat reply and every live WebSocket chat
     message, and under a NULL marker it now costs one primary-key lookup
     instead of an uncached catalog inspection plus a two-table join.
+
+    That gate decides every call today: the only statements in ``src/``
+    that write the column are this module's two clears, and both of them
+    write ``NULL``, so the marker is NULL for every task and this branch
+    returns ``None`` before anything below it runs.
 
     This is also the resume command seam's reader (``websocket.py``'s
     refusal gate for a resume whose payload cannot prove it answered the
@@ -469,7 +478,7 @@ def close_legacy_resume_interaction(
 
 
 def close_legacy_resume_interaction_sync(
-    task_id: int, run_id: str, interaction_id: int | None
+    *, task_id: int, run_id: str, interaction_id: int | None
 ) -> int:
     """Close + clear from a synchronous or ``asyncio.to_thread`` caller.
 
@@ -477,6 +486,12 @@ def close_legacy_resume_interaction_sync(
     handler and the deferred ``execute_resume_background`` path): each
     calls this via ``run_db_io_cancellation_safe`` with no transaction of
     its own open first, and this function commits before returning.
+
+    Keyword-only, matching the function it wraps. The three arguments are
+    an int, a str and an optional int, and the two that are ints are a task
+    primary key and an interaction primary key -- a positional call that
+    transposed them would be accepted by every type in the signature and
+    would close some other task's row.
 
     ``interaction_id`` is passed straight through -- see
     ``close_legacy_resume_interaction`` for where it has to come from and

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -96,7 +96,11 @@ way, at the one place the classification happens
 (``_classify_close_rowcount``): exactly one row closed is the expected
 case and logs at info; zero rows is the overwhelmingly common case today
 (no production writer has inserted into ``task_interaction_requests``
-yet) and logs at debug; more than one row is impossible under
+yet) and logs at debug, carrying with it a short description of why
+nothing matched (``_unmatched_close_row``) -- "nothing was ever there"
+and "something was there and is no longer this run's live question" are
+the same rowcount and different situations; more than one row is
+impossible under
 ``uq_task_interaction_active_slot`` (it allows at most one row per task
 with a non-NULL ``active_slot``), but if that schema invariant were ever
 broken, this module logs at error and registers a degradation signal
@@ -126,7 +130,54 @@ from .task_lease_service import _rowcount
 logger = logging.getLogger(__name__)
 
 
-def _classify_close_rowcount(rowcount: int, *, task_id: int, run_id: str) -> None:
+def _unmatched_close_row(db: Session, *, interaction_id: int | None) -> str:
+    """Why the close statement matched nothing, for the zero-rowcount log.
+
+    A zero rowcount folds together outcomes an operator has to tell apart:
+    nothing was ever there to close, and something was there but is no
+    longer this run's live question -- another path retired it first, or it
+    belongs to a run this close is not finishing. The rowcount alone cannot
+    say which, and the difference decides whether a stale marker is the
+    expected 100% case or the trace of a close that lost a race.
+
+    Three answers, in increasing cost. ``no_id_read`` costs nothing and is
+    every call today: the pre-injection read produced no id, either because
+    no row was active or because the read could not be made at all (see
+    ``active_interaction_id_sync``). Only a real id makes this issue a
+    statement, a primary-key lookup on a table the caller's transaction has
+    already written to: ``row_absent`` when no row carries that id at all,
+    and ``row_status=<status>`` when one does -- which is the case that
+    used to be invisible. ``status`` is NOT NULL, so a NULL scalar here
+    means no row, never a row with an unset status.
+
+    A row reported as ``row_status=active`` is not a contradiction: the
+    close also fences on ``task_id`` and ``run_id``, so an id belonging to
+    another task or another run of this task reads back active and still
+    matches nothing.
+    """
+    if interaction_id is None:
+        return "no_id_read"
+    status = db.execute(
+        sa.select(TaskInteractionRequest.status).where(
+            TaskInteractionRequest.id == interaction_id
+        )
+    ).scalar()
+    if status is None:
+        return "row_absent"
+    return f"row_status={status}"
+
+
+def _classify_close_rowcount(
+    rowcount: int, *, task_id: int, run_id: str, unmatched_row: str | None
+) -> None:
+    """Log one close statement's rowcount at the level its case deserves.
+
+    ``unmatched_row`` describes why nothing matched and is read only on the
+    zero branch; the caller passes ``None`` on the other two, where there
+    is nothing unmatched to describe. It is a required argument rather than
+    a defaulted one so that a caller has to decide, instead of silently
+    getting a log line that has lost the distinction.
+    """
     if rowcount == 1:
         logger.info(
             "legacy resume closing the active interaction row task_id=%s run_id=%s",
@@ -136,9 +187,10 @@ def _classify_close_rowcount(rowcount: int, *, task_id: int, run_id: str) -> Non
     elif rowcount == 0:
         logger.debug(
             "legacy resume close matched no active interaction row "
-            "task_id=%s run_id=%s",
+            "task_id=%s run_id=%s unmatched_row=%s",
             task_id,
             run_id,
+            unmatched_row,
         )
     else:
         logger.error(
@@ -390,7 +442,20 @@ def close_legacy_resume_interaction(
         )
     )
     rowcount = _rowcount(close_result)
-    _classify_close_rowcount(rowcount, task_id=task_id, run_id=run_id)
+    _classify_close_rowcount(
+        rowcount,
+        task_id=task_id,
+        run_id=run_id,
+        # Only the zero branch has anything to describe, and only a
+        # non-None id makes this reach the database at all, so today's
+        # every-call path (no id read, zero rows) still issues nothing
+        # extra.
+        unmatched_row=(
+            _unmatched_close_row(db, interaction_id=interaction_id)
+            if rowcount == 0
+            else None
+        ),
+    )
     db.execute(
         sa.update(Task)
         .where(

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -67,6 +67,17 @@ as the message-injection replay that
 ``AgentRunner.inject_user_message`` short-circuits on a repeated turn
 id.
 
+The close statement binds to one primary key, read before the injection
+by ``active_interaction_id_sync`` and carried to the close by whichever
+path is doing the injecting. It is not enough to match on
+``(task_id, run_id, active)``: injecting the message is exactly what
+resumes the agent, and a resumed agent can stage a fresh question before
+the close runs, which an unbound statement would retire as though the
+injected message had answered it. Reading the id at close time instead of
+before the injection leaves that window exactly as wide as it is with no
+key at all -- the value has to be the one observed before the message
+went in.
+
 Every rowcount the close statement below produces is classified the same
 way, at the one place the classification happens
 (``_classify_close_rowcount``): exactly one row closed is the expected
@@ -130,13 +141,83 @@ def _classify_close_rowcount(rowcount: int, *, task_id: int, run_id: str) -> Non
         )
 
 
+def active_interaction_id_sync(task_id: int) -> int | None:
+    """The id of this task's active native interaction row, or ``None``.
+
+    Read this *before* injecting the user message, and pass what it
+    returns to ``close_legacy_resume_interaction`` -- see this module's
+    docstring for why that ordering is the whole point.
+
+    Opens and closes its own short session. All four legacy-resume paths
+    call it from a point where they hold no session of their own: the two
+    fence-transaction paths (``a2a.py``, ``v1/task_reply.py``) open their
+    fence only after the injection has already committed, and the two
+    WebSocket paths hold none at all.
+
+    Keys off ``_active_native_row_criteria``
+    (``task_interaction_service.py``), the same four-field predicate every
+    other reader of "this task's one live row" uses, rather than a
+    predicate of its own -- the close this feeds and the readers that show
+    the question must not disagree about which row is live.
+
+    Returns ``None`` when the read cannot be made at all -- no table yet,
+    no session, a failing query. ``None`` closes nothing: the close
+    statement matches zero rows and the active row survives, which
+    degrades to a reader falling back to the legacy transcript question,
+    the same benign outcome the module docstring describes for a stale
+    marker. The alternative -- closing on the old unbound predicate when
+    the read fails -- is the retire-the-wrong-row bug this function exists
+    to prevent, so an unreadable id must never widen what the close
+    matches.
+    """
+    from .task_interaction_service import _active_native_row_criteria
+
+    try:
+        SessionLocal = get_session_local()
+        with SessionLocal() as db:
+            if not interaction_requests_table_exists(db):
+                return None
+            row = (
+                db.query(TaskInteractionRequest.id)
+                .join(Task, Task.id == TaskInteractionRequest.task_id)
+                .filter(
+                    TaskInteractionRequest.task_id == task_id,
+                    *_active_native_row_criteria(),
+                )
+                .first()
+            )
+            return int(row[0]) if row is not None else None
+    except Exception:
+        logger.warning(
+            "could not read the active interaction row before injection for "
+            "task_id=%s; the close will match no row",
+            task_id,
+            exc_info=True,
+        )
+        return None
+
+
 def close_legacy_resume_interaction(
     db: Session,
     *,
     task_id: int,
     run_id: str,
+    interaction_id: int | None,
 ) -> int:
     """Retire the run's active interaction row and clear the task's marker.
+
+    ``interaction_id`` is the row observed *before* the user message was
+    injected, from ``active_interaction_id_sync``; the close binds to it,
+    so it retires that exact question and nothing else. This module's
+    docstring carries the argument for why the value has to come from
+    before the injection.
+
+    ``interaction_id=None`` means there was no active row to answer at
+    injection time. SQLAlchemy renders it as ``id IS NULL``, which is
+    never true of a primary key, so the close matches zero rows -- and the
+    marker clear below still runs, which is the whole behavior that case
+    needs. Do not "simplify" this into skipping the statement or dropping
+    the predicate: both change which rows the close can touch.
 
     Caller obligations, because neither happens here: the caller has
     already confirmed ``interaction_requests_table_exists(db)`` -- this
@@ -153,24 +234,12 @@ def close_legacy_resume_interaction(
     Returns the close statement's rowcount, classified and logged by
     ``_classify_close_rowcount`` -- see the module docstring for why a
     rowcount greater than 1 is logged, not raised.
-
-    A constraint on the batch that adds a production writer for
-    ``task_interaction_requests``: the close statement matches on
-    ``(task_id, run_id, active)`` alone -- nothing binds it to the
-    specific question the injected user message answered. That is sound
-    only while this run cannot stage a new row between the message write
-    and this close. Injecting the message is exactly what resumes the
-    agent, so once a production writer exists, the resumed agent may
-    stage a fresh question in that window and this statement would
-    retire it as if it had been answered. The writer batch must either
-    key this close on the row observed before injection (read the
-    primary key first) or add a staleness fence; it must not ship the
-    statement as-is.
     """
     now = datetime.now(timezone.utc)
     close_result = db.execute(
         sa.update(TaskInteractionRequest)
         .where(
+            TaskInteractionRequest.id == interaction_id,
             TaskInteractionRequest.task_id == task_id,
             TaskInteractionRequest.run_id == run_id,
             TaskInteractionRequest.status == "active",
@@ -200,13 +269,19 @@ def close_legacy_resume_interaction(
     return rowcount
 
 
-def close_legacy_resume_interaction_sync(task_id: int, run_id: str) -> int:
+def close_legacy_resume_interaction_sync(
+    task_id: int, run_id: str, interaction_id: int | None
+) -> int:
     """Close + clear from a synchronous or ``asyncio.to_thread`` caller.
 
     Shared by both WebSocket legacy-resume injection sites (the online
     handler and the deferred ``execute_resume_background`` path): each
     calls this via ``run_db_io_cancellation_safe`` with no transaction of
     its own open first, and this function commits before returning.
+
+    ``interaction_id`` is passed straight through -- see
+    ``close_legacy_resume_interaction`` for where it has to come from and
+    what ``None`` means.
 
     Skips entirely, without opening the lock read below, when
     ``task_interaction_requests`` does not exist on this deployment -- a
@@ -234,7 +309,9 @@ def close_legacy_resume_interaction_sync(task_id: int, run_id: str) -> int:
         db.execute(
             sa.select(Task.id).where(Task.id == task_id).with_for_update(key_share=True)
         ).first()
-        rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id=run_id)
+        rowcount = close_legacy_resume_interaction(
+            db, task_id=task_id, run_id=run_id, interaction_id=interaction_id
+        )
         db.commit()
         return rowcount
 

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -992,10 +992,15 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
     * ``accept=[]`` on a ``file_upload``. It renders as ``accept=""``,
       which is what the browser does with no restriction at all.
     * ``min``/``max`` on a type that does not render them. Only
-      ``number_input`` reads the pair; on the other six they are an ignored
-      hint, and the question still asks exactly what it asks. The
-      ``min > max`` rule below stays type-agnostic for the same reason: it
-      refuses a range no answer can satisfy, wherever it appears.
+      ``number_input`` reads the pair -- ``clarification-form.tsx`` passes
+      ``min``/``max`` to the input in its ``number_input`` branch and
+      nowhere else -- so on the other six they are an ignored hint, and the
+      question still asks exactly what it asks. The ``min > max`` rule
+      below is scoped to ``number_input`` for that same reason: on the type
+      that reads the pair, an inverted range makes every answer invalid and
+      the write is refused; on the six that ignore it, the pair never
+      reaches the user at all, so an inverted one is a hint nobody reads
+      rather than a question nobody can answer.
 
     Answers are out of scope here and in every other function in this
     module. Until the answer-side field schema lands (issue #1368),
@@ -1084,8 +1089,14 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
                     f"{option.value!r} is duplicated"
                 )
             seen_option_values.add(option.value)
+        # Scoped to the one type that reads the pair. ``number_input`` is
+        # the only branch in ``clarification-form.tsx`` that passes ``min``
+        # and ``max`` to the rendered control, so an inverted range is a
+        # question no answer can satisfy there and an ignored hint
+        # everywhere else.
         if (
-            interaction.min is not None
+            interaction.type == "number_input"
+            and interaction.min is not None
             and interaction.max is not None
             and interaction.min > interaction.max
         ):

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -853,6 +853,105 @@ def build_v1_request_payload(parsed: AskUserQuestionArgs) -> dict[str, Any]:
     return payload
 
 
+# The seven interaction types the render surface implements, kept as a set
+# here rather than as a ``Literal`` on ``InteractionArg.type``: that model
+# is also the ``ask_user_question`` tool's argument schema, so narrowing it
+# would narrow what the model itself is allowed to emit, which is a
+# different decision from what this service is willing to persist. The
+# seven are the same ones the frontend's own normalizer accepts
+# (``frontend/src/contexts/app-context-chat.tsx``); an item typed anything
+# else is dropped there and renders as nothing at all.
+_V1_INTERACTION_TYPES = frozenset(
+    {
+        "select_one",
+        "select_multiple",
+        "text_input",
+        "file_upload",
+        "confirm",
+        "number_input",
+        "action_cards",
+    }
+)
+
+# The three types whose whole purpose is picking from a supplied list, and
+# the four that render their own control and have nothing to pick from.
+# The split is the render surface's, not this module's: ``select_one``,
+# ``select_multiple``, and ``action_cards`` iterate ``interaction.options``
+# (``frontend/src/components/chat/clarification-form.tsx``), while
+# ``confirm`` renders a switch, ``text_input`` a field, ``number_input`` a
+# spinner, and ``file_upload`` a picker -- none of which read ``options``.
+_V1_TYPES_REQUIRING_OPTIONS = frozenset(
+    {"select_one", "select_multiple", "action_cards"}
+)
+_V1_TYPES_REJECTING_OPTIONS = _V1_INTERACTION_TYPES - _V1_TYPES_REQUIRING_OPTIONS
+
+
+def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
+    """Reject a shape-valid v1 payload that must not be persisted.
+
+    Raises ``ValueError`` describing the first violation found; returns
+    ``None`` when the payload may be written.
+
+    Deliberately separate from ``parse_v1_request_payload`` rather than
+    folded into it, because the two directions have different failure
+    policies for the same payload and folding them would collapse both
+    into one. The read direction meets these payloads as rows that are
+    already persisted: a payload it cannot make sense of has to degrade to
+    something the waiting user can still act on, so widening what it
+    rejects turns readable-but-odd rows into unanswerable ones. The write
+    direction meets them before anything is stored, where the only useful
+    answer is to refuse -- a question naming an interaction type no
+    renderer implements, or a select with nothing to select, reaches the
+    user as a form they cannot complete and a run that can never be
+    resumed. ``parse_v1_request_payload`` therefore keeps accepting
+    exactly what it accepts today, and this runs on top of it on the write
+    side only.
+
+    ``build_clarification_payload`` (``task_clarification_draft.py``) is a
+    second producer of this same shape and its output has to keep passing
+    here, pinned by a test that feeds this function that builder's real
+    output. Two of that builder's shapes are the reason for the boundaries
+    drawn below. An empty ``interactions`` list is accepted: a
+    ``send_message``-sourced draft never carries interactions, and an
+    over-size form is deliberately dropped to ``[]`` rather than truncated
+    to half a form -- both are questions with prose and no form, which the
+    read surface renders. A blank ``message`` is rejected, and that costs
+    the builder nothing: ``resolve_publishable_clarification`` already
+    classifies a payload whose message is blank after filtering as
+    ``NotApplicable("empty_question")`` and never offers it for writing.
+
+    Answers are out of scope here and in every other function in this
+    module. Until the answer-side field schema lands (issue #1368),
+    everything downstream of an interaction row must treat
+    ``response_payload`` as unvalidated input: nothing checks a submitted
+    answer against the ``InteractionArg.type`` / ``InteractionArg.field``
+    definitions this function checks on the question side, so a
+    malformed-but-dict-shaped answer is stored as submitted.
+    """
+
+    if not parsed.message.strip():
+        raise ValueError("request_payload.message is blank")
+
+    seen_fields: set[str] = set()
+    for index, interaction in enumerate(parsed.interactions):
+        where = f"request_payload.interactions[{index}]"
+        if interaction.type not in _V1_INTERACTION_TYPES:
+            raise ValueError(f"{where}.type {interaction.type!r} is not a v1 type")
+        if interaction.field in seen_fields:
+            raise ValueError(f"{where}.field {interaction.field!r} is duplicated")
+        seen_fields.add(interaction.field)
+        if interaction.type in _V1_TYPES_REQUIRING_OPTIONS and not interaction.options:
+            raise ValueError(f"{where} is a {interaction.type} carrying no options")
+        if interaction.type in _V1_TYPES_REJECTING_OPTIONS and interaction.options:
+            raise ValueError(f"{where} is a {interaction.type} carrying options")
+        if (
+            interaction.min is not None
+            and interaction.max is not None
+            and interaction.min > interaction.max
+        ):
+            raise ValueError(f"{where} has min greater than max")
+
+
 # TTL policy interval for a create() envelope's optional ttl_seconds
 # override. Enforcing the bound here in the facade is deliberate: clamping
 # silently would be fail-open, and is explicitly rejected in favor of an
@@ -918,7 +1017,10 @@ def create(
     then JSON-serializability with ``allow_nan=False``, via
     ``build_v1_request_payload`` -- a shape-valid payload carrying a
     NaN/Infinity ``default_value`` fails the second check and is rejected
-    the same way a shape failure is), and an optional ``ttl_seconds``
+    the same way a shape failure is -- and then the write side's own
+    admissibility rules, via ``validate_v1_write_payload``, which is where
+    an unrenderable interaction type or a select with no options is
+    refused), and an optional ``ttl_seconds``
     against this facade's policy interval -- out of range is a rejection,
     never a silent clamp. Authorization runs only after every one of those
     passes, against a task this call itself loads.
@@ -1032,6 +1134,16 @@ def create(
         # e.g. a NaN/Infinity default_value: shape-valid per
         # AskUserQuestionArgs, but not JSON-serializable with
         # allow_nan=False -- see build_v1_request_payload's own docstring.
+        return CreateValidationRejected(reason="invalid_values")
+    try:
+        validate_v1_write_payload(parsed_values)
+    except ValueError:
+        # Shape-valid and serializable, but not a question this service is
+        # willing to persist -- an unrenderable interaction type, a select
+        # with nothing to select, a duplicated field name, an inverted
+        # numeric range. Same reason as every other payload rejection: the
+        # caller learns its values were not accepted, not which of the
+        # checks in front of them said so.
         return CreateValidationRejected(reason="invalid_values")
     if envelope.ttl_seconds is not None:
         if isinstance(envelope.ttl_seconds, bool) or not isinstance(

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -983,15 +983,30 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
             raise ValueError(f"{where} has min greater than max")
 
 
-# TTL policy interval for a create() envelope's optional ttl_seconds
-# override. Enforcing the bound here in the facade is deliberate: clamping
-# silently would be fail-open, and is explicitly rejected in favor of an
-# outright validation failure. The concrete numbers are not pinned by
-# anything: no existing config or constant anywhere in this codebase
-# defines an interaction TTL policy today. The two bounds below are this
-# delivery's own placeholder, not a fact recovered from source, logs, or
-# the database -- flagged here as a value that needs an explicit policy
-# decision, not a discovered one.
+# The interval a create() envelope's optional ttl_seconds override must
+# fall inside. Enforcing the bound here in the facade is deliberate:
+# clamping silently would be fail-open, so an out-of-range override is an
+# outright validation failure instead.
+#
+# These two bound what a caller may ask for. Neither is the TTL anything
+# is published with: that is CLARIFICATION_REQUEST_TTL (24 hours,
+# task_clarification_draft.py), the value the publication path adds to
+# "now" to get a row's expires_at. The two are different quantities -- an
+# interval and a value -- and are deliberately not unified; the value sits
+# inside the interval, which is the only relationship between them that
+# has to hold.
+#
+# No config or constant anywhere in this codebase defines an interaction
+# TTL policy, so the numbers are decided here rather than derived: the
+# widest interval whose ends both still mean something. The floor is a
+# minute because a question the user cannot plausibly answer within the
+# window is worse than no question, and because
+# ck_task_interaction_requests_expiry_after_creation
+# (models/task_interaction.py) requires expires_at > created_at -- any
+# positive floor satisfies that constraint and a minute is the smallest
+# one a person answering a question can use. The ceiling is a week
+# because a row that effectively never expires is a row a reclaim job can
+# never retire.
 _MIN_INTERACTION_TTL_SECONDS = 60
 _MAX_INTERACTION_TTL_SECONDS = 7 * 24 * 3600
 
@@ -2340,6 +2355,30 @@ def respond(
     alone and arrive here with nothing to record. Do not "fix" the
     disagreement between the two columns into agreement; they are answers
     to different questions.
+
+    Step 3 letting an admin through without owning the task is the
+    intended behavior, not a missed check, and the reason is that step 3
+    is not the step that authorizes the write. Two guards run, in this
+    order and for different purposes:
+
+    - Step 3, before the idempotency preread, keeps an unauthorized caller
+      from reaching a read at all: without it, anyone who could guess an
+      idempotency key could pull back someone else's receipt. It rejects
+      early and broadly, and being an admin is enough to clear it.
+    - Step 6's answer fence carries `_answer_fence_task_predicate`, whose
+      ownership term requires `principal.user_id` to be the task's owner.
+      An admin does not satisfy it. The fence matches zero rows, the
+      reread classifies the miss, and the call returns
+      `RespondUnauthorized(reason="not_task_principal")`.
+
+    So an admin passes the authorization step and is still refused at the
+    write point -- refused precisely, after the reread has established why,
+    rather than refused early on a guess. Any reader tempted to "align" the
+    two by rejecting admins at step 3 should note that this would change
+    what the service does for admins, not just where it says no, and that
+    the two guards are answering different questions on purpose: one is
+    "may this caller read anything here", the other is "may this caller
+    write this row".
 
     Of the two audit-relevant columns this function fills on the interaction
     row, `responder_identity` is the one a reader can trust to stay

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1040,12 +1040,23 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
         # normalize what gets stored: the model-facing producer
         # (``_normalize_ask_user_interactions``, ``react.py``) already
         # trims a field and substitutes for a blank one before it ever
-        # reaches this validator -- on both the single-tool
-        # ``ask_user_question`` path and the multi-tool waiting path,
-        # whose own dedup loop only appends a numeric suffix to an
-        # already-trimmed base -- so a well-formed field arrives here
+        # reaches this validator, so a well-formed field arrives here
         # pre-trimmed and this pair of checks costs that producer nothing;
         # they exist for whatever reaches this write side some other way.
+        #
+        # Both react.py paths run that normalizer, so both arrive
+        # pre-trimmed, and there the resemblance stops -- whoever wires the
+        # first production writer is wiring one of two different producers.
+        # The single-tool ``ask_user_question`` path calls the normalizer
+        # and stops: it does not deduplicate, so two interactions the model
+        # named the same field reach this validator unchanged and the
+        # duplicate rule below refuses the write, costing that path the
+        # whole question rather than one field. The multi-tool waiting path
+        # (``_pause_for_tool_results``) runs its own dedup loop afterwards
+        # across every waiting tool, appending ``_2``, ``_3`` to a repeated
+        # base: it cannot trip that rule, and the field it hands over is
+        # the renamed one, so the key stored for #1368 to match answers
+        # against is not the key the tool asked under.
         if not interaction.field.strip():
             raise ValueError(f"{where}.field is blank")
         if interaction.field != interaction.field.strip():
@@ -1089,11 +1100,9 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
                     f"{option.value!r} is duplicated"
                 )
             seen_option_values.add(option.value)
-        # Scoped to the one type that reads the pair. ``number_input`` is
-        # the only branch in ``clarification-form.tsx`` that passes ``min``
-        # and ``max`` to the rendered control, so an inverted range is a
-        # question no answer can satisfy there and an ignored hint
-        # everywhere else.
+        # Scoped to ``number_input`` deliberately -- this function's
+        # docstring carries the reason, under the third of the three
+        # deliberately accepted shapes.
         if (
             interaction.type == "number_input"
             and interaction.min is not None
@@ -1206,6 +1215,11 @@ def create(
       never loads a row it does not own.
     - An admin ``"user"`` principal is authorized without owning the task,
       so there is no owner predicate to add; the lookup stays id-only.
+      Authorized here is not allowed to write: ``respond()`` lets an admin
+      clear the same step and then refuses it at the write point, on
+      ``_answer_fence_task_predicate``'s ``Task.user_id`` term. This seam
+      writes nothing and so has no such fence -- a writer wired behind it
+      inherits an admin whose ownership nothing has checked.
     - A ``"guest"`` principal's ownership is split across the two. The
       column-level half is the same ``Task.user_id == principal.user_id``:
       a guest's owning user is the entity owner the guest is chatting
@@ -1224,28 +1238,21 @@ def create(
       refuses exactly that at its write point
       (``_answer_fence_task_predicate``'s ``Task.user_id`` term).
     - A ``"user"`` or ``"guest"`` principal carrying no ``user_id`` is
-      unauthorized before the lookup is even built. An admin passing on
-      the flag alone would reach the write point with no identity to
-      record, and an owner-scoped branch's predicate built from that
-      absent id would reject only by way of ``Task.user_id`` being NOT
-      NULL.
+      unauthorized before the lookup is even built; the guard itself
+      carries why it is placed there.
 
     A principal whose ``kind`` is neither ``"user"`` nor ``"guest"`` is
     always unauthorized -- there is no third branch that defaults to allow
-    -- and is rejected before the lookup is built, not by falling off the
-    end of the branch chain. Both orderings return the same outcome; only
-    the earlier one keeps such a principal off the id-only lookup path,
-    which would otherwise answer ``CreateUnavailable(reason="task_missing")``
-    and tell a caller this module cannot name whether a ``task_id`` exists.
-    This is the authorization-side half of the same judgment
-    ``InteractionPrincipal.identity_string`` makes on the audit side, where
-    an unrecognized ``kind`` raises ``ValueError`` rather than being
-    recorded as a user: neither side has a default that treats an unknown
-    kind as one of the two known ones. The two are not redundant. This gate
-    decides whether the caller may act at all and returns a typed outcome;
-    that one runs at the write point on a caller already authorized, and
-    raises, because a principal that got that far and still cannot be named
-    is a programming error rather than a rejection to report.
+    -- and is rejected before the lookup is built rather than at the end of
+    the branch chain, because an unrecognized kind is not owner-scoped, so
+    the lookup it would have reached is the id-only one that reports
+    ``task_missing``.
+    ``InteractionPrincipal.identity_string`` refuses the same principal on
+    the audit side by raising ``ValueError``; the two are not redundant.
+    This one decides whether a caller may act at all and answers with a
+    typed outcome, while that one runs at the write point on a caller
+    already authorized, where being unnameable is a programming error and
+    not a rejection to report.
 
     A malformed principal that populates zero or more than one of the guest
     entity-binding fields makes the ownership predicate raise
@@ -1260,9 +1267,21 @@ def create(
     exist" and "this task is not yours" are the same empty result set, and
     both return ``CreateUnauthorized(reason="not_task_principal")``.
     Neither principal can use this function to learn whether a ``task_id``
-    exists. ``CreateUnavailable(reason="task_missing")`` remains reachable
-    only from the one id-only branch -- an admin, who is told nothing by it
-    that their own branch does not already tell them.
+    exists. ``CreateUnavailable(reason="task_missing")`` stays reachable
+    from the id-only admin branch, and that puts an obligation on whoever
+    consumes these outcomes: exposing the distinction externally hands the
+    requester a task-existence oracle, so an endpoint mapping this
+    function's outcome onto an HTTP response has to collapse the two into
+    one client-facing shape. The three existing public-chat entry points
+    already do the equivalent one layer up: a task that does not exist and
+    a task whose ``guest_id`` belongs to another visitor both produce the
+    identical not-found-shaped 403. The same obligation covers the
+    respond-side twin pair (``RespondUnavailable(reason="task_missing")``
+    versus ``RespondUnauthorized(reason="not_task_principal")``), which
+    stays distinguishable for every principal kind because ``respond()``
+    loads its task by id under a lock -- and it covers every other outcome
+    consumer built on this module, not only ``create()``'s own two
+    variants.
 
     ``origin`` is deliberately not part of this envelope or this
     validation step in this delivery: the reason vocabulary deliberately
@@ -1287,26 +1306,6 @@ def create(
     function has no call to any of the staging module's exception-raising
     code at all in this delivery, since it never calls
     ``stage_interaction_request``.
-
-    ``CreateUnavailable(reason="task_missing")`` and
-    ``CreateUnauthorized(reason="not_task_principal")`` remain
-    distinguishable outcomes on the id-only admin branch above, and a
-    caller that exposes that distinction externally hands an
-    unauthenticated or unauthorized requester a task-existence oracle:
-    "unavailable" versus "unauthorized" reveals whether ``task_id`` exists
-    at all. Any future endpoint that calls this function directly and maps
-    its outcome onto an HTTP response shape must collapse both to the same
-    client-facing shape. The three existing public-chat entry points
-    already do the equivalent one layer up, at the HTTP boundary: a task
-    that does not exist and a task whose ``guest_id`` belongs to another
-    visitor both produce the identical not-found-shaped 403. The same
-    obligation applies to the respond-side twin pair
-    (``RespondUnavailable(reason="task_missing")`` versus
-    ``RespondUnauthorized(reason="not_task_principal")``): ``respond()``
-    loads its task by id under a lock for every principal kind, so both of
-    its variants stay distinguishable for every caller, and that side
-    carries the obligation in full. This applies to every outcome consumer
-    built on this module, not only to ``create()``'s own two variants.
     """
 
     if principal.kind in ("user", "guest") and principal.user_id is None:
@@ -1342,10 +1341,8 @@ def create(
     task = task_lookup.first()
     if task is None:
         # An owner-scoped lookup cannot tell "no such task" from "not your
-        # task" -- both are the empty result set, and reporting either one
-        # specifically would make this function an existence oracle for a
-        # principal that is not entitled to one. The admin branch, the only
-        # one that loads by id alone, keeps reporting task_missing.
+        # task", and must not appear to -- see the consequence paragraph in
+        # this function's docstring.
         if owner_scoped:
             return CreateUnauthorized(reason="not_task_principal")
         return CreateUnavailable(reason="task_missing")

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -921,21 +921,47 @@ def create(
     the same way a shape failure is), and an optional ``ttl_seconds``
     against this facade's policy interval -- out of range is a rejection,
     never a silent clamp. Authorization runs only after every one of those
-    passes,
-    and only against a task this call itself loads by id: a ``"user"``
-    principal must own the task or be an admin; a ``"guest"`` principal is
-    checked with the same shared ownership predicate ``respond()`` will
-    reuse (``task_is_owned_by_public_principal``), not a re-derived
-    conjunction; a principal whose ``kind`` is neither ``"user"`` nor
-    ``"guest"`` is always unauthorized -- there is no third branch that
-    defaults to allow. A malformed principal that populates zero or more
-    than one of the guest entity-binding fields makes the ownership
-    predicate raise ``ValueError``; this function catches only that one
-    exception type from that one call and treats it as unauthorized, the
-    same fail-closed-on-a-malformed-caller behavior the predicate itself
-    documents. A task that does not exist at all is ``Unavailable``, not
-    ``Unauthorized`` -- that branch is reached before the ownership check
-    even runs, because there is no row to check ownership against.
+    passes, against a task this call itself loads.
+
+    The load is owner-scoped for the branch that can express ownership in
+    SQL and id-only for the two that cannot, and the difference is
+    deliberate:
+
+    - A non-admin ``"user"`` principal's ownership is one equality on a
+      column, so it is a predicate on the lookup itself
+      (``Task.user_id == principal.user_id``) rather than a Python
+      comparison run after the row is already in hand. Such a principal
+      never loads a row it does not own. One carrying no ``user_id`` at
+      all is unauthorized before the lookup is even built, because the
+      predicate would otherwise render as ``Task.user_id IS NULL`` and
+      match every ownerless task.
+    - An admin ``"user"`` principal is authorized without owning the task,
+      so there is no owner predicate to add; the lookup stays id-only.
+    - A ``"guest"`` principal's ownership is
+      ``task_is_owned_by_public_principal``, which reads the task's
+      ``agent_config`` JSON and cannot be compiled into this lookup's WHERE
+      clause. That branch keeps the id-only load and the shared Python
+      predicate ``respond()`` reuses, not a re-derived conjunction.
+
+    A principal whose ``kind`` is neither ``"user"`` nor ``"guest"`` is
+    always unauthorized -- there is no third branch that defaults to allow.
+    A malformed principal that populates zero or more than one of the guest
+    entity-binding fields makes the ownership predicate raise
+    ``ValueError``; this function catches only that one exception type from
+    that one call and treats it as unauthorized, the same
+    fail-closed-on-a-malformed-caller behavior the predicate itself
+    documents.
+
+    Consequence of the owner-scoped lookup, and the reason it is stated
+    here rather than left for a reader to derive from the SQL: for a
+    non-admin ``"user"`` principal, "this task does not exist" and "this
+    task is not yours" are the same empty result set, and both return
+    ``CreateUnauthorized(reason="not_task_principal")``. That principal
+    cannot use this function to learn whether a ``task_id`` exists.
+    ``CreateUnavailable(reason="task_missing")`` remains reachable only
+    from the two id-only branches -- an admin and a guest, neither of whom
+    is told anything by it that their own branch does not already tell
+    them.
 
     ``origin`` is deliberately not part of this envelope or this
     validation step in this delivery: the reason vocabulary deliberately
@@ -962,21 +988,23 @@ def create(
     ``stage_interaction_request``.
 
     ``CreateUnavailable(reason="task_missing")`` and
-    ``CreateUnauthorized(reason="not_task_principal")`` are deliberately
-    distinguishable outcomes inside this function, but a caller that
-    exposes that distinction externally hands an unauthenticated or
-    unauthorized requester a task-existence oracle: "unavailable" versus
-    "unauthorized" reveals whether ``task_id`` exists at all. Any future
-    endpoint that calls this function directly and maps its outcome onto
-    an HTTP response shape must collapse both to the same client-facing
-    shape. The three existing public-chat entry points already do the
-    equivalent one layer up, at the HTTP boundary: a task that does not
-    exist and a task whose ``guest_id`` belongs to another visitor both
-    produce the identical not-found-shaped 403. The same obligation
-    applies to the respond-side twin pair
+    ``CreateUnauthorized(reason="not_task_principal")`` remain
+    distinguishable outcomes on the two id-only branches above, and a
+    caller that exposes that distinction externally hands an
+    unauthenticated or unauthorized requester a task-existence oracle:
+    "unavailable" versus "unauthorized" reveals whether ``task_id`` exists
+    at all. Any future endpoint that calls this function directly and maps
+    its outcome onto an HTTP response shape must collapse both to the same
+    client-facing shape. The three existing public-chat entry points
+    already do the equivalent one layer up, at the HTTP boundary: a task
+    that does not exist and a task whose ``guest_id`` belongs to another
+    visitor both produce the identical not-found-shaped 403. The same
+    obligation applies to the respond-side twin pair
     (``RespondUnavailable(reason="task_missing")`` versus
-    ``RespondUnauthorized(reason="not_task_principal")``) once
-    ``respond()`` has a caller. This applies to every outcome consumer
+    ``RespondUnauthorized(reason="not_task_principal")``): ``respond()``
+    loads its task by id under a lock for every principal kind, so both of
+    its variants stay distinguishable for every caller, and that side
+    carries the obligation in full. This applies to every outcome consumer
     built on this module, not only to ``create()``'s own two variants.
     """
 
@@ -1017,14 +1045,33 @@ def create(
         ):
             return CreateValidationRejected(reason="invalid_values")
 
-    task = db.query(Task).filter(Task.id == task_id).first()
+    owner_scoped = principal.kind == "user" and not principal.is_admin
+    if owner_scoped and principal.user_id is None:
+        # An owner predicate built on a None user id renders as
+        # ``Task.user_id IS NULL``, which matches every ownerless task
+        # instead of matching nothing. Reject before the lookup so the
+        # predicate is never built from an absent identity.
+        return CreateUnauthorized(reason="not_task_principal")
+
+    task_lookup = db.query(Task).filter(Task.id == task_id)
+    if owner_scoped:
+        task_lookup = task_lookup.filter(Task.user_id == principal.user_id)
+    task = task_lookup.first()
     if task is None:
+        # An owner-scoped lookup cannot tell "no such task" from "not your
+        # task" -- both are the empty result set, and reporting either one
+        # specifically would make this function an existence oracle for a
+        # principal that is not entitled to one. The id-only branches
+        # (admin, guest) keep reporting task_missing.
+        if owner_scoped:
+            return CreateUnauthorized(reason="not_task_principal")
         return CreateUnavailable(reason="task_missing")
 
     if principal.kind == "user":
-        authorized = principal.is_admin or (
-            principal.user_id is not None and task.user_id == principal.user_id
-        )
+        # A non-admin reached this line only by matching the owner
+        # predicate in SQL; an admin reached it without one and is
+        # authorized on the flag alone.
+        authorized = True
     elif principal.kind == "guest":
         try:
             authorized = task_is_owned_by_public_principal(task, principal)

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -65,8 +65,10 @@ Not delivered here, and named so a reader does not go looking for them in
 this module: the compatibility seam that routes the existing resume
 coordinator (``websocket.py``'s ``_handle_resume_task_unserialized``)
 through ``_active_native_row_criteria()`` shipped as its own change in this
-same series and has already merged -- ``websocket.py`` now imports
-``_active_native_row_criteria`` from this module -- but is not part of this
+same series and has already merged -- the seam now reads through
+``task_interaction_close.active_interaction_id_sync``, which imports
+``_active_native_row_criteria`` from this module; ``websocket.py`` itself
+no longer imports it directly -- but is not part of this
 change. ``create()``'s own call body -- the write
 that actually stages a row -- is not delivered here either; its own
 zero-production-caller gate

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -902,8 +902,16 @@ def build_v1_request_payload(parsed: AskUserQuestionArgs) -> dict[str, Any]:
 # would narrow what the model itself is allowed to emit, which is a
 # different decision from what this service is willing to persist. The
 # seven are the same ones the frontend's own normalizer accepts
-# (``frontend/src/contexts/app-context-chat.tsx``); an item typed anything
-# else is dropped there and renders as nothing at all.
+# (``normalizeInteractions``, ``frontend/src/contexts/app-context-chat.tsx``),
+# which drops an item typed anything else before it reaches a renderer.
+# That normalizer is not the only way in, though, so an unknown type is
+# not simply invisible: the agent builder's chat
+# (``frontend/src/components/build/agent-builder-chat.tsx``) takes the
+# interactions off its own stream and hands them to the same renderer
+# unnormalized, where an unrecognized type falls to
+# ``clarification-form.tsx``'s ``default`` branch and shows the user a
+# red "unsupported type" line. Rejecting the type here on the write side
+# is what keeps either surface from having to.
 _V1_INTERACTION_TYPES = frozenset(
     {
         "select_one",

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1123,8 +1123,8 @@ _MAX_INTERACTION_TTL_SECONDS = 7 * 24 * 3600
 class CreateInteractionEnvelope:
     """The caller-supplied intent for ``create()``: what interaction to
     publish, not yet validated. Every field is checked by ``create()``'s
-    validation step before anything else runs; none of them are trusted
-    as-is."""
+    validation step, which runs after that call has authorized the
+    principal against the task; none of them are trusted as-is."""
 
     kind: str
     protocol_version: int
@@ -1151,8 +1151,13 @@ def create(
     together -- i.e. the wiring change that supplies this seam's call body,
     not this one.
 
-    Validation order, each step short-circuiting on the first failure:
-    ``kind`` against ``str`` first (a non-string value -- a ``list``, a
+    Authorization runs first, against a task this call itself loads. Only a
+    caller that has been authorized against a real task row reaches the
+    envelope checks below, so a rejection reason describing the payload
+    shape is never returned to a caller that is not entitled to the task in
+    the first place. Validation order within that step, each step
+    short-circuiting on the first failure: ``kind`` against ``str`` first (a
+    non-string value -- a ``list``, a
     ``dict`` -- is rejected before the ``in _KIND_VOCABULARY`` membership
     test ever runs, not caught as a side effect of the ``TypeError:
     unhashable type`` that test would otherwise raise for an unhashable
@@ -1176,8 +1181,7 @@ def create(
     an unrenderable interaction type or a select with no options is
     refused), and an optional ``ttl_seconds``
     against this facade's policy interval -- out of range is a rejection,
-    never a silent clamp. Authorization runs only after every one of those
-    passes, against a task this call itself loads.
+    never a silent clamp.
 
     The load is owner-scoped for the branch that can express ownership in
     SQL and id-only for the two that cannot, and the difference is
@@ -1266,53 +1270,6 @@ def create(
     built on this module, not only to ``create()``'s own two variants.
     """
 
-    if not isinstance(envelope.kind, str) or envelope.kind not in _KIND_VOCABULARY:
-        return CreateValidationRejected(reason="unknown_kind")
-    if (
-        not isinstance(envelope.protocol_version, int)
-        or isinstance(envelope.protocol_version, bool)
-        or envelope.protocol_version != INTERACTION_PROTOCOL_VERSION
-    ):
-        return CreateValidationRejected(reason="unknown_protocol_version")
-    if not isinstance(envelope.request_idempotency_key, str):
-        return CreateValidationRejected(reason="malformed_idempotency_key")
-    try:
-        _normalize_command_id(envelope.request_idempotency_key)
-    except ValueError:
-        return CreateValidationRejected(reason="malformed_idempotency_key")
-    try:
-        parsed_values = parse_v1_request_payload(envelope.values)
-    except _PydanticValidationError:
-        return CreateValidationRejected(reason="invalid_values")
-    try:
-        build_v1_request_payload(parsed_values)
-    except ValueError:
-        # e.g. a NaN/Infinity default_value: shape-valid per
-        # AskUserQuestionArgs, but not JSON-serializable with
-        # allow_nan=False -- see build_v1_request_payload's own docstring.
-        return CreateValidationRejected(reason="invalid_values")
-    try:
-        validate_v1_write_payload(parsed_values)
-    except ValueError:
-        # Shape-valid and serializable, but not a question this service is
-        # willing to persist -- an unrenderable interaction type, a select
-        # with nothing to select, a duplicated field name, an inverted
-        # numeric range. Same reason as every other payload rejection: the
-        # caller learns its values were not accepted, not which of the
-        # checks in front of them said so.
-        return CreateValidationRejected(reason="invalid_values")
-    if envelope.ttl_seconds is not None:
-        if isinstance(envelope.ttl_seconds, bool) or not isinstance(
-            envelope.ttl_seconds, (int, float)
-        ):
-            return CreateValidationRejected(reason="invalid_values")
-        if not (
-            _MIN_INTERACTION_TTL_SECONDS
-            <= envelope.ttl_seconds
-            <= _MAX_INTERACTION_TTL_SECONDS
-        ):
-            return CreateValidationRejected(reason="invalid_values")
-
     if principal.kind == "user" and principal.user_id is None:
         # Rejected before the lookup, on both branches. An admin passing
         # on the flag alone would reach the write point with no identity to
@@ -1353,6 +1310,74 @@ def create(
         authorized = False
     if not authorized:
         return CreateUnauthorized(reason="not_task_principal")
+
+    if not isinstance(envelope.kind, str) or envelope.kind not in _KIND_VOCABULARY:
+        return CreateValidationRejected(reason="unknown_kind")
+    if (
+        not isinstance(envelope.protocol_version, int)
+        or isinstance(envelope.protocol_version, bool)
+        or envelope.protocol_version != INTERACTION_PROTOCOL_VERSION
+    ):
+        return CreateValidationRejected(reason="unknown_protocol_version")
+    if not isinstance(envelope.request_idempotency_key, str):
+        return CreateValidationRejected(reason="malformed_idempotency_key")
+    try:
+        _normalize_command_id(envelope.request_idempotency_key)
+    except ValueError:
+        return CreateValidationRejected(reason="malformed_idempotency_key")
+    try:
+        parsed_values = parse_v1_request_payload(envelope.values)
+    except _PydanticValidationError:
+        return CreateValidationRejected(reason="invalid_values")
+    try:
+        build_v1_request_payload(parsed_values)
+    except ValueError:
+        # e.g. a NaN/Infinity default_value: shape-valid per
+        # AskUserQuestionArgs, but not JSON-serializable with
+        # allow_nan=False -- see build_v1_request_payload's own docstring.
+        return CreateValidationRejected(reason="invalid_values")
+    try:
+        validate_v1_write_payload(parsed_values)
+    except ValueError as exc:
+        # Shape-valid and serializable, but not a question this service is
+        # willing to persist -- an unrenderable interaction type, a select
+        # with nothing to select, a blank or duplicated field name, two
+        # options sharing a value, a blank option half, an inverted numeric
+        # range. Same reason as every other payload rejection: the caller
+        # learns its values were not accepted, not which of the checks in
+        # front of them said so.
+        #
+        # The precise diagnostic is not lost, only kept server-side: this
+        # validator names the exact position it refused
+        # ("request_payload.interactions[3].options[1] has a blank label or
+        # value"), which is the only thing an operator debugging a rejected
+        # write has to go on. Logged at warning, unconditionally -- an
+        # observability line that can be switched off is one that is off
+        # when it is needed.
+        #
+        # What the message can contain: positions, and the two identifiers
+        # the question's author chose -- an interaction's ``field`` and an
+        # option's ``value``, both quoted by the rules that refuse a
+        # duplicate of either. Neither is anything a user typed; the
+        # response side is not reachable from here at all. The payload is
+        # never logged whole.
+        logger.warning(
+            "v1 interaction write payload refused for task_id=%s: %s",
+            task_id,
+            exc,
+        )
+        return CreateValidationRejected(reason="invalid_values")
+    if envelope.ttl_seconds is not None:
+        if isinstance(envelope.ttl_seconds, bool) or not isinstance(
+            envelope.ttl_seconds, (int, float)
+        ):
+            return CreateValidationRejected(reason="invalid_values")
+        if not (
+            _MIN_INTERACTION_TTL_SECONDS
+            <= envelope.ttl_seconds
+            <= _MAX_INTERACTION_TTL_SECONDS
+        ):
+            return CreateValidationRejected(reason="invalid_values")
 
     return CreateNotWired(reason="seam_not_wired")
 

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -196,8 +196,39 @@ class InteractionPrincipal:
     guest_id: str | None = None
 
     def identity_string(self) -> str:
+        """The ``responder_identity`` value for this principal.
+
+        Raises ``ValueError`` for a principal this namespacing cannot
+        describe, rather than rendering the gap into the string. There are
+        two such gaps, and both used to produce something that looks like
+        an identity and is not one: a missing id interpolated into the
+        literal ``"user:None"`` / ``"guest:None"``, and an unrecognized
+        ``kind`` falling through to the user branch and being recorded as a
+        user. Nothing downstream stops either --
+        ``ck_task_interaction_requests_responder_identity_nonempty``
+        (``models/task_interaction.py``) only requires a non-empty string,
+        and both of those are non-empty -- and this column is the one field
+        this table's audit trail can rely on staying populated, so a value
+        it cannot trust is worse here than a failure.
+
+        ``ValueError``, not a typed rejection, because this is a pure
+        function of the principal: reaching it with one this incomplete
+        means the caller built the principal wrong, which is a programming
+        error rather than a request that can be answered. It is what
+        ``task_is_owned_by_public_principal`` already raises for a
+        malformed guest principal. Both write-side facades reject such a
+        principal at their authorization step, so no caller should be in a
+        position to see this raise.
+        """
+
         if self.kind == "guest":
+            if self.guest_id is None:
+                raise ValueError("guest principal carries no guest_id")
             return f"guest:{self.guest_id}"
+        if self.kind != "user":
+            raise ValueError(f"principal kind {self.kind!r} has no identity namespace")
+        if self.user_id is None:
+            raise ValueError("user principal carries no user_id")
         return f"user:{self.user_id}"
 
 
@@ -1033,12 +1064,14 @@ def create(
       column, so it is a predicate on the lookup itself
       (``Task.user_id == principal.user_id``) rather than a Python
       comparison run after the row is already in hand. Such a principal
-      never loads a row it does not own. One carrying no ``user_id`` at
-      all is unauthorized before the lookup is even built, because the
-      predicate would otherwise render as ``Task.user_id IS NULL`` and
-      match every ownerless task.
+      never loads a row it does not own.
     - An admin ``"user"`` principal is authorized without owning the task,
       so there is no owner predicate to add; the lookup stays id-only.
+    - Either way, a ``"user"`` principal carrying no ``user_id`` is
+      unauthorized before the lookup is even built. An admin passing on
+      the flag alone would reach the write point with no identity to
+      record, and a non-admin's owner predicate built from that absent id
+      would reject only by way of ``Task.user_id`` being NOT NULL.
     - A ``"guest"`` principal's ownership is
       ``task_is_owned_by_public_principal``, which reads the task's
       ``agent_config`` JSON and cannot be compiled into this lookup's WHERE
@@ -1157,13 +1190,17 @@ def create(
         ):
             return CreateValidationRejected(reason="invalid_values")
 
-    owner_scoped = principal.kind == "user" and not principal.is_admin
-    if owner_scoped and principal.user_id is None:
-        # An owner predicate built on a None user id renders as
-        # ``Task.user_id IS NULL``, which matches every ownerless task
-        # instead of matching nothing. Reject before the lookup so the
-        # predicate is never built from an absent identity.
+    if principal.kind == "user" and principal.user_id is None:
+        # Rejected before the lookup, on both branches. An admin passing
+        # on the flag alone would reach the write point with no identity to
+        # record as who acted. A non-admin's owner predicate would be built
+        # from that same absent id and render as ``Task.user_id IS NULL``,
+        # which rejects only because ``Task.user_id`` is NOT NULL today --
+        # an explicit rejection here says what is meant instead of
+        # borrowing a schema detail to mean it.
         return CreateUnauthorized(reason="not_task_principal")
+
+    owner_scoped = principal.kind == "user" and not principal.is_admin
 
     task_lookup = db.query(Task).filter(Task.id == task_id)
     if owner_scoped:
@@ -2294,12 +2331,15 @@ def respond(
     it is chatting through, matching the existing `public_chat_access.py`
     precedent of dispatching guest-originated work under the owner's
     identity, and step 3's non-admin branch requires `task.user_id ==
-    principal.user_id` to even reach here. The admin branch carries no such
-    requirement -- `principal.is_admin` authorizes on its own -- so an
-    admin's `actor_user_id` is the admin's own `principal.user_id` (which
-    can be absent, or belong to someone other than the task's owner), not
-    the task owner's. Do not "fix" this into agreement; they are answers to
-    different questions.
+    principal.user_id` to even reach here. The admin branch carries no
+    ownership requirement -- `principal.is_admin` authorizes without one --
+    so an admin's `actor_user_id` is the admin's own `principal.user_id`,
+    belonging to someone other than the task's owner. It is never absent:
+    step 3 requires a `"user"` principal to carry a `user_id` on both
+    branches, so an identity-less caller cannot pass on the admin flag
+    alone and arrive here with nothing to record. Do not "fix" the
+    disagreement between the two columns into agreement; they are answers
+    to different questions.
 
     Of the two audit-relevant columns this function fills on the interaction
     row, `responder_identity` is the one a reader can trust to stay
@@ -2566,8 +2606,12 @@ def respond(
             return RespondUnavailable(reason="task_missing")
 
         if principal.kind == "user":
-            authorized = principal.is_admin or (
-                principal.user_id is not None and task.user_id == principal.user_id
+            # user_id is required of both branches, not only of the owner
+            # comparison: an admin authorized on the flag alone would
+            # otherwise reach step 8 with no identity to write into
+            # responder_identity or actor_user_id.
+            authorized = principal.user_id is not None and (
+                principal.is_admin or task.user_id == principal.user_id
             )
         elif principal.kind == "guest":
             try:

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -204,12 +204,24 @@ class InteractionPrincipal:
         an identity and is not one: a missing id interpolated into the
         literal ``"user:None"`` / ``"guest:None"``, and an unrecognized
         ``kind`` falling through to the user branch and being recorded as a
-        user. Nothing downstream stops either --
+        user.
+
+        Nothing downstream stops either --
         ``ck_task_interaction_requests_responder_identity_nonempty``
         (``models/task_interaction.py``) only requires a non-empty string,
         and both of those are non-empty -- and this column is the one field
         this table's audit trail can rely on staying populated, so a value
         it cannot trust is worse here than a failure.
+
+        The empty string is the same gap wearing a different shape: a
+        ``guest_id`` of ``""`` used to render as the literal ``"guest:"``,
+        another non-empty value the CHECK above lets through, and it names
+        nobody either. The falsy test below is the same one the ownership
+        predicates in this module already use for ``guest_id``. It stops
+        at falsy and does not strip: the two token decoders that build
+        these principals do not agree on whitespace, and the widget path
+        admits a guest id that is only spaces, so stripping here would
+        start rejecting principals that path produces today.
 
         ``ValueError``, not a typed rejection, because this is a pure
         function of the principal: reaching it with one this incomplete
@@ -222,7 +234,7 @@ class InteractionPrincipal:
         """
 
         if self.kind == "guest":
-            if self.guest_id is None:
+            if not self.guest_id:
                 raise ValueError("guest principal carries no guest_id")
             return f"guest:{self.guest_id}"
         if self.kind != "user":
@@ -975,6 +987,23 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
             raise ValueError(f"{where} is a {interaction.type} carrying no options")
         if interaction.type in _V1_TYPES_REJECTING_OPTIONS and interaction.options:
             raise ValueError(f"{where} is a {interaction.type} carrying options")
+        # Either half blank, not both: an option the user can see but not
+        # submit, and one they can submit but not see, are both unusable,
+        # and the renderer already treats them the same way -- its own
+        # filter keeps an option only when value and label are both
+        # truthy (clarification-form.tsx). An option dropped there leaves
+        # a select the user cannot complete, or, if it was the only one, a
+        # form with an empty control; refusing the write is the only place
+        # that outcome can still be prevented. Falsy, not stripped: the
+        # two fields are required ``str`` on ``InteractionOption``
+        # (ask_user_tool.py), so a payload that got this far can only be
+        # blank by being the empty string, and stripping would start
+        # rejecting a whitespace label the renderer does display.
+        for option_index, option in enumerate(interaction.options or ()):
+            if not option.label or not option.value:
+                raise ValueError(
+                    f"{where}.options[{option_index}] has a blank label or value"
+                )
         if (
             interaction.min is not None
             and interaction.max is not None

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -971,6 +971,29 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
     classifies a payload whose message is blank after filtering as
     ``NotApplicable("empty_question")`` and never offers it for writing.
 
+    Every rule here refuses something that makes the *answer* wrong or
+    unrecoverable, and nothing here refuses something that only makes the
+    *rendering* worse. Three shapes are deliberately accepted for that
+    reason, each of them a thing the render surface already handles and
+    none of them changing what answer comes back:
+
+    * A blank interaction-level ``label``. ``clarification-form.tsx``
+      renders ``interaction.label || interaction.field``, so the field name
+      stands in. Refusing it would also start refusing payloads the second
+      producer really emits: ``_normalize_ask_user_interactions``
+      (``react.py``), which every ``ask_user_question`` payload passes
+      through, repairs a blank ``field`` and never touches ``label``, so a
+      model that emits ``label=""`` reaches ``build_clarification_payload``
+      with it -- and losing the whole question to the legacy transcript is
+      a worse outcome than a label that reads as the field name.
+    * ``accept=[]`` on a ``file_upload``. It renders as ``accept=""``,
+      which is what the browser does with no restriction at all.
+    * ``min``/``max`` on a type that does not render them. Only
+      ``number_input`` reads the pair; on the other six they are an ignored
+      hint, and the question still asks exactly what it asks. The
+      ``min > max`` rule below stays type-agnostic for the same reason: it
+      refuses a range no answer can satisfy, wherever it appears.
+
     Answers are out of scope here and in every other function in this
     module. Until the answer-side field schema lands (issue #1368),
     everything downstream of an interaction row must treat
@@ -988,6 +1011,37 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
         where = f"request_payload.interactions[{index}]"
         if interaction.type not in _V1_INTERACTION_TYPES:
             raise ValueError(f"{where}.type {interaction.type!r} is not a v1 type")
+        # A blank field is refused for the same reason a duplicated one is,
+        # and not for the reason the rules above exist. The renderer copes
+        # with both: clarification-form.tsx substitutes ``response_{index}``
+        # for a blank or all-whitespace field and appends ``_{index}`` to a
+        # repeat, so neither one produces a form the user cannot complete.
+        # What neither substitution can fix is that the answer then arrives
+        # under a key the persisted question never named. Today nothing
+        # compares the two; the answer-side field schema (#1368) is what
+        # will, and it will compare against what is stored here. Refusing
+        # the write is the only point at which the stored key can still be
+        # made to be the key the answer will carry.
+        #
+        # Two checks, not one: blank (including all-whitespace) and
+        # surrounding whitespace on an otherwise non-blank field are both
+        # refused, for the same key-integrity reason -- ``" a "`` never
+        # equal-matches an answer keyed ``"a"``, so a stored field with
+        # leading or trailing whitespace is exactly as unmatchable against
+        # #1368 as a blank one. Stripped here only to test, not to
+        # normalize what gets stored: the model-facing producer
+        # (``_normalize_ask_user_interactions``, ``react.py``) already
+        # trims a field and substitutes for a blank one before it ever
+        # reaches this validator -- on both the single-tool
+        # ``ask_user_question`` path and the multi-tool waiting path,
+        # whose own dedup loop only appends a numeric suffix to an
+        # already-trimmed base -- so a well-formed field arrives here
+        # pre-trimmed and this pair of checks costs that producer nothing;
+        # they exist for whatever reaches this write side some other way.
+        if not interaction.field.strip():
+            raise ValueError(f"{where}.field is blank")
+        if interaction.field != interaction.field.strip():
+            raise ValueError(f"{where}.field carries surrounding whitespace")
         if interaction.field in seen_fields:
             raise ValueError(f"{where}.field {interaction.field!r} is duplicated")
         seen_fields.add(interaction.field)
@@ -1012,6 +1066,21 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
                 raise ValueError(
                     f"{where}.options[{option_index}] has a blank label or value"
                 )
+        # Values, not labels: the renderer resolves a submitted answer back
+        # to an option by matching on ``value`` and taking the first hit
+        # (clarification-form.tsx's ``options.find(o => o.value === value)``,
+        # used by select_one, select_multiple and action_cards alike), so two
+        # options sharing a value make the answer unable to say which of them
+        # was chosen. Two options sharing a label are merely confusing to
+        # look at; the answer still names exactly one of them.
+        seen_option_values: set[str] = set()
+        for option_index, option in enumerate(interaction.options or ()):
+            if option.value in seen_option_values:
+                raise ValueError(
+                    f"{where}.options[{option_index}].value "
+                    f"{option.value!r} is duplicated"
+                )
+            seen_option_values.add(option.value)
         if (
             interaction.min is not None
             and interaction.max is not None

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1184,9 +1184,9 @@ def create(
     against this facade's policy interval -- out of range is a rejection,
     never a silent clamp.
 
-    The load is owner-scoped for the branch that can express ownership in
-    SQL and id-only for the two that cannot, and the difference is
-    deliberate:
+    The load is owner-scoped for the two branches whose ownership includes
+    a column-level term and id-only for the one that has none, and the
+    difference is deliberate:
 
     - A non-admin ``"user"`` principal's ownership is one equality on a
       column, so it is a predicate on the lookup itself
@@ -1195,16 +1195,29 @@ def create(
       never loads a row it does not own.
     - An admin ``"user"`` principal is authorized without owning the task,
       so there is no owner predicate to add; the lookup stays id-only.
-    - Either way, a ``"user"`` principal carrying no ``user_id`` is
+    - A ``"guest"`` principal's ownership is split across the two. The
+      column-level half is the same ``Task.user_id == principal.user_id``:
+      a guest's owning user is the entity owner the guest is chatting
+      through, and all three entry points that build a guest principal
+      already load their task under ``Task.user_id ==
+      access_context.user.id`` (``web/api/public_chat_access.py``).
+      ``task_is_owned_by_public_principal`` deliberately excludes that term
+      from its own conjunction and leaves it to whatever loads the task
+      (see its docstring), so this lookup carries it. The rest of the
+      guest conjunction reads the task's ``agent_config`` JSON, which
+      cannot be compiled into this lookup's WHERE clause, and stays in the
+      shared Python predicate ``respond()`` reuses rather than being
+      re-derived here. Without the column-level half, a guest whose
+      ``agent_config`` values happened to match would be authorized
+      against a task belonging to another user; the answer side already
+      refuses exactly that at its write point
+      (``_answer_fence_task_predicate``'s ``Task.user_id`` term).
+    - A ``"user"`` or ``"guest"`` principal carrying no ``user_id`` is
       unauthorized before the lookup is even built. An admin passing on
       the flag alone would reach the write point with no identity to
-      record, and a non-admin's owner predicate built from that absent id
-      would reject only by way of ``Task.user_id`` being NOT NULL.
-    - A ``"guest"`` principal's ownership is
-      ``task_is_owned_by_public_principal``, which reads the task's
-      ``agent_config`` JSON and cannot be compiled into this lookup's WHERE
-      clause. That branch keeps the id-only load and the shared Python
-      predicate ``respond()`` reuses, not a re-derived conjunction.
+      record, and an owner-scoped branch's predicate built from that
+      absent id would reject only by way of ``Task.user_id`` being NOT
+      NULL.
 
     A principal whose ``kind`` is neither ``"user"`` nor ``"guest"`` is
     always unauthorized -- there is no third branch that defaults to allow.
@@ -1217,14 +1230,13 @@ def create(
 
     Consequence of the owner-scoped lookup, and the reason it is stated
     here rather than left for a reader to derive from the SQL: for a
-    non-admin ``"user"`` principal, "this task does not exist" and "this
-    task is not yours" are the same empty result set, and both return
-    ``CreateUnauthorized(reason="not_task_principal")``. That principal
-    cannot use this function to learn whether a ``task_id`` exists.
-    ``CreateUnavailable(reason="task_missing")`` remains reachable only
-    from the two id-only branches -- an admin and a guest, neither of whom
-    is told anything by it that their own branch does not already tell
-    them.
+    non-admin ``"user"`` principal and for a guest, "this task does not
+    exist" and "this task is not yours" are the same empty result set, and
+    both return ``CreateUnauthorized(reason="not_task_principal")``.
+    Neither principal can use this function to learn whether a ``task_id``
+    exists. ``CreateUnavailable(reason="task_missing")`` remains reachable
+    only from the one id-only branch -- an admin, who is told nothing by it
+    that their own branch does not already tell them.
 
     ``origin`` is deliberately not part of this envelope or this
     validation step in this delivery: the reason vocabulary deliberately
@@ -1252,7 +1264,7 @@ def create(
 
     ``CreateUnavailable(reason="task_missing")`` and
     ``CreateUnauthorized(reason="not_task_principal")`` remain
-    distinguishable outcomes on the two id-only branches above, and a
+    distinguishable outcomes on the id-only admin branch above, and a
     caller that exposes that distinction externally hands an
     unauthenticated or unauthorized requester a task-existence oracle:
     "unavailable" versus "unauthorized" reveals whether ``task_id`` exists
@@ -1271,17 +1283,20 @@ def create(
     built on this module, not only to ``create()``'s own two variants.
     """
 
-    if principal.kind == "user" and principal.user_id is None:
-        # Rejected before the lookup, on both branches. An admin passing
-        # on the flag alone would reach the write point with no identity to
-        # record as who acted. A non-admin's owner predicate would be built
-        # from that same absent id and render as ``Task.user_id IS NULL``,
-        # which rejects only because ``Task.user_id`` is NOT NULL today --
-        # an explicit rejection here says what is meant instead of
-        # borrowing a schema detail to mean it.
+    if principal.kind in ("user", "guest") and principal.user_id is None:
+        # Rejected before the lookup, on every branch that carries a
+        # user_id at all. An admin passing on the flag alone would reach
+        # the write point with no identity to record as who acted. An
+        # owner-scoped branch's predicate would be built from that same
+        # absent id and render as ``Task.user_id IS NULL``, which rejects
+        # only because ``Task.user_id`` is NOT NULL today -- an explicit
+        # rejection here says what is meant instead of borrowing a schema
+        # detail to mean it.
         return CreateUnauthorized(reason="not_task_principal")
 
-    owner_scoped = principal.kind == "user" and not principal.is_admin
+    owner_scoped = principal.kind == "guest" or (
+        principal.kind == "user" and not principal.is_admin
+    )
 
     task_lookup = db.query(Task).filter(Task.id == task_id)
     if owner_scoped:
@@ -1291,8 +1306,8 @@ def create(
         # An owner-scoped lookup cannot tell "no such task" from "not your
         # task" -- both are the empty result set, and reporting either one
         # specifically would make this function an existence oracle for a
-        # principal that is not entitled to one. The id-only branches
-        # (admin, guest) keep reporting task_missing.
+        # principal that is not entitled to one. The admin branch, the only
+        # one that loads by id alone, keeps reporting task_missing.
         if owner_scoped:
             return CreateUnauthorized(reason="not_task_principal")
         return CreateUnavailable(reason="task_missing")
@@ -1303,6 +1318,10 @@ def create(
         # authorized on the flag alone.
         authorized = True
     elif principal.kind == "guest":
+        # The owner term is already proved by the lookup above, the same
+        # way the three public-chat entry points prove it; what is left for
+        # the Python predicate is the agent_config conjunction, which no
+        # WHERE clause can express.
         try:
             authorized = task_is_owned_by_public_principal(task, principal)
         except ValueError:
@@ -1356,12 +1375,17 @@ def create(
         # observability line that can be switched off is one that is off
         # when it is needed.
         #
-        # What the message can contain: positions, and the two identifiers
-        # the question's author chose -- an interaction's ``field`` and an
-        # option's ``value``, both quoted by the rules that refuse a
-        # duplicate of either. Neither is anything a user typed; the
-        # response side is not reachable from here at all. The payload is
-        # never logged whole.
+        # What the message can contain: positions, and three identifiers
+        # the question's author chose -- an interaction's ``type`` (quoted
+        # by the rule that refuses a type outside the v1 vocabulary), an
+        # interaction's ``field``, and an option's ``value`` (the latter
+        # two quoted by the rules that refuse a duplicate of either). All
+        # three are unconstrained ``str`` on the tool model, so nothing at
+        # the type level keeps caller text out of them; what keeps it out
+        # today is that no production path puts user input in any of the
+        # three, and the response side is not reachable from here at all.
+        # Constraining them belongs at the schema, not here. The payload
+        # is never logged whole.
         logger.warning(
             "v1 interaction write payload refused for task_id=%s: %s",
             task_id,

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -101,6 +101,7 @@ from ...core.agent.checkpoint import (
     checkpoint_execution_id,
 )
 from ...core.tools.adapters.vibe.ask_user_tool import AskUserQuestionArgs
+from ...core.tools.adapters.vibe.interaction_types import INTERACTION_TYPES
 from ..models.task import Task, TaskStatus, TaskStatusPredicate, TraceEvent
 from ..models.task_command import TaskExecutionCommand
 from ..models.task_interaction import (
@@ -898,12 +899,22 @@ def build_v1_request_payload(parsed: AskUserQuestionArgs) -> dict[str, Any]:
     return payload
 
 
-# The seven interaction types the render surface implements, kept as a set
-# here rather than as a ``Literal`` on ``InteractionArg.type``: that model
-# is also the ``ask_user_question`` tool's argument schema, so narrowing it
-# would narrow what the model itself is allowed to emit, which is a
-# different decision from what this service is willing to persist. The
-# seven are the same ones the frontend's own normalizer accepts
+# The seven interaction types the render surface implements. The list
+# itself lives on ``interaction_types.INTERACTION_TYPES``
+# (``core/tools/adapters/vibe/``), an import-free module beside the tool
+# whose argument schema carries the field; this is the write side's
+# membership view of it. Importing rather than restating is what keeps the tool's
+# JSON-Schema enum, the tool's own argument description and this
+# admissibility set from drifting apart -- all three used to carry the
+# same seven names independently.
+#
+# Deriving the set here does not narrow ``InteractionArg.type`` to a
+# ``Literal``: that model is also the ``ask_user_question`` tool's
+# argument schema, so narrowing it would narrow what the model itself is
+# allowed to emit, which is a different decision from what this service is
+# willing to persist.
+#
+# The seven are the same ones the frontend's own normalizer accepts
 # (``normalizeInteractions``, ``frontend/src/contexts/app-context-chat.tsx``),
 # which drops an item typed anything else before it reaches a renderer.
 # That normalizer is not the only way in, though, so an unknown type is
@@ -914,17 +925,7 @@ def build_v1_request_payload(parsed: AskUserQuestionArgs) -> dict[str, Any]:
 # ``clarification-form.tsx``'s ``default`` branch and shows the user a
 # red "unsupported type" line. Rejecting the type here on the write side
 # is what keeps either surface from having to.
-_V1_INTERACTION_TYPES = frozenset(
-    {
-        "select_one",
-        "select_multiple",
-        "text_input",
-        "file_upload",
-        "confirm",
-        "number_input",
-        "action_cards",
-    }
-)
+_V1_INTERACTION_TYPES = frozenset(INTERACTION_TYPES)
 
 # The three types whose whole purpose is picking from a supplied list, and
 # the four that render their own control and have nothing to pick from.

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1231,7 +1231,22 @@ def create(
       NULL.
 
     A principal whose ``kind`` is neither ``"user"`` nor ``"guest"`` is
-    always unauthorized -- there is no third branch that defaults to allow.
+    always unauthorized -- there is no third branch that defaults to allow
+    -- and is rejected before the lookup is built, not by falling off the
+    end of the branch chain. Both orderings return the same outcome; only
+    the earlier one keeps such a principal off the id-only lookup path,
+    which would otherwise answer ``CreateUnavailable(reason="task_missing")``
+    and tell a caller this module cannot name whether a ``task_id`` exists.
+    This is the authorization-side half of the same judgment
+    ``InteractionPrincipal.identity_string`` makes on the audit side, where
+    an unrecognized ``kind`` raises ``ValueError`` rather than being
+    recorded as a user: neither side has a default that treats an unknown
+    kind as one of the two known ones. The two are not redundant. This gate
+    decides whether the caller may act at all and returns a typed outcome;
+    that one runs at the write point on a caller already authorized, and
+    raises, because a principal that got that far and still cannot be named
+    is a programming error rather than a rejection to report.
+
     A malformed principal that populates zero or more than one of the guest
     entity-binding fields makes the ownership predicate raise
     ``ValueError``; this function catches only that one exception type from
@@ -1303,6 +1318,18 @@ def create(
         # only because ``Task.user_id`` is NOT NULL today -- an explicit
         # rejection here says what is meant instead of borrowing a schema
         # detail to mean it.
+        return CreateUnauthorized(reason="not_task_principal")
+
+    if principal.kind not in ("user", "guest"):
+        # Rejected before the lookup, beside the missing-id guard above and
+        # for the same kind of reason. Such a principal is unauthorized
+        # either way -- the branch chain below has no third arm that
+        # authorizes -- but reaching that chain means the lookup ran first,
+        # and an unrecognized kind is not owner-scoped, so it would have run
+        # by id alone and answered CreateUnavailable(reason="task_missing")
+        # for a task that does not exist. That is the existence oracle the
+        # owner-scoped branches are written to withhold, handed to a
+        # principal this module cannot even name.
         return CreateUnauthorized(reason="not_task_principal")
 
     owner_scoped = principal.kind == "guest" or (

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -3140,6 +3140,78 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
     assert "get_workspace_output_files" not in answer_schema["description"]
 
 
+def test_interaction_type_list_has_one_source() -> None:
+    from xagent.core.tools.adapters.vibe.ask_user_tool import InteractionArg
+    from xagent.core.tools.adapters.vibe.interaction_types import INTERACTION_TYPES
+    from xagent.web.services.task_interaction_service import _V1_INTERACTION_TYPES
+
+    assert INTERACTION_TYPES == (
+        "select_one",
+        "select_multiple",
+        "text_input",
+        "file_upload",
+        "confirm",
+        "number_input",
+        "action_cards",
+    )
+    assert InteractionArg.model_fields["type"].description == (
+        "Type of interaction: select_one, select_multiple, text_input, "
+        "file_upload, confirm, number_input, action_cards"
+    )
+    assert frozenset(INTERACTION_TYPES) == _V1_INTERACTION_TYPES
+
+
+async def test_react_pattern_ask_user_question_schema_derives_its_type_enum_from_one_source() -> (
+    None
+):
+    """The ask_user_question tool's ``interactions[].type`` enum is built
+    from ``interaction_types.INTERACTION_TYPES`` rather than a copy written
+    out in this schema; a name added or reordered there must show up here
+    unchanged."""
+
+    from xagent.core.tools.adapters.vibe.interaction_types import INTERACTION_TYPES
+
+    llm = FakeLLM(responses=[{"content": "No tools needed."}])
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext()
+    context.add_user_message("Say hi")
+
+    result = await pattern.run(
+        context=context,
+        tools=[FakeAskUserTool()],
+        llm=llm,
+    )
+
+    assert result["success"] is True
+    ask_user_schema = next(
+        schema
+        for schema in llm.calls[0]["tools"]
+        if schema["function"]["name"] == "ask_user_question"
+    )["function"]
+    type_enum = ask_user_schema["parameters"]["properties"]["interactions"]["items"][
+        "properties"
+    ]["type"]["enum"]
+    assert type_enum == list(INTERACTION_TYPES)
+
+
+def test_react_module_pulls_in_no_web_modules() -> None:
+    """react.py must not depend on xagent.web. The interaction type list it
+    reads lives in an import-free module for exactly this reason -- putting
+    it beside InteractionArg in ask_user_tool pulls the tool-registration
+    chain and 61 xagent.web modules into every import of this pattern."""
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys; import xagent.core.agent.pattern.react.react; "
+        "print(len([m for m in sys.modules if m.startswith('xagent.web')]))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+    assert out.stdout.strip() == "0"
+
+
 def test_react_final_answer_lookup_instruction_tracks_active_workspace_tool() -> None:
     pattern = ReActPattern()
 

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -849,7 +849,9 @@ def test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence
     stale_lease = TaskLease(
         task_id=task_id, runner_id="a-different-runner", run_id="run-atomicity"
     )
-    updated = a2a_api._update_a2a_resume_input_sync(stale_lease, "attempted text")
+    updated = a2a_api._update_a2a_resume_input_sync(
+        stale_lease, "attempted text", row_id
+    )
 
     assert updated is False
     db = _direct_db_session()
@@ -949,6 +951,83 @@ def test_message_send_closes_the_legacy_resume_interaction_row_on_successful_inj
         assert refreshed.interaction_protocol_version is None
     finally:
         db.close()
+
+
+def test_message_send_reads_the_interaction_row_before_injecting() -> None:
+    """The close is keyed on the row observed *before* the injection,
+    and only the ordering makes that true -- see task_interaction_close's
+    module docstring. Moving the read after the injection leaves the whole
+    change doing nothing while the row-level assertions in the test above
+    stay green."""
+
+    agent_id, full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="legacy resume close ordering",
+            status=TaskStatus.PAUSED,
+            control_state=TaskControlState.PAUSED.value,
+            run_id="run-close-order",
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-close-order"},
+            interaction_protocol_version=1,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+        row_id = _seed_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id="run-close-order",
+            idempotency_key="close-order-q1",
+        )
+    finally:
+        db.close()
+
+    order: list[str] = []
+
+    def record_read(_task_id: int) -> int:
+        order.append("read")
+        return row_id
+
+    async def record_injection(*_args: object, **_kwargs: object) -> bool:
+        order.append("inject")
+        return True
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(side_effect=record_injection)
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with (
+        patch("xagent.web.api.chat.get_agent_manager", return_value=agent_manager),
+        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume"),
+        patch("xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn", new=AsyncMock()),
+        patch(
+            "xagent.web.api.a2a.active_interaction_id_sync",
+            side_effect=record_read,
+        ),
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-close-order",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "answered via legacy resume"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert order == ["read", "inject"]
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -953,12 +953,21 @@ def test_message_send_closes_the_legacy_resume_interaction_row_on_successful_inj
         db.close()
 
 
+# A fabricated id, not the seeded row's -- test_message_send_reads_the_
+# interaction_row_before_injecting hands this to the close instead of the
+# real row id, so a site that re-read the row at close time would hand the
+# close the real id and fail there instead.
+_OBSERVED_INTERACTION_ID = 4321
+
+
 def test_message_send_reads_the_interaction_row_before_injecting() -> None:
     """The close is keyed on the row observed *before* the injection,
     and only the ordering makes that true -- see task_interaction_close's
     module docstring. Moving the read after the injection leaves the whole
     change doing nothing while the row-level assertions in the test above
-    stay green."""
+    stay green. The observed value is a fabricated id, not the seeded row's,
+    so a site that re-read the row at close time would hand the close the
+    real id and fail here."""
 
     agent_id, full_key = _create_published_agent_with_key()
     db = _direct_db_session()
@@ -980,7 +989,11 @@ def test_message_send_reads_the_interaction_row_before_injecting() -> None:
         db.commit()
         db.refresh(task)
         task_id = int(task.id)
-        row_id = _seed_active_interaction_row(
+        # Kept real and distinct from _OBSERVED_INTERACTION_ID: a site that
+        # re-read the row at close time (instead of using the id observed
+        # before injection) would hand the close this real id and fail the
+        # assertion below.
+        _seed_active_interaction_row(
             db,
             task_id=task_id,
             run_id="run-close-order",
@@ -993,7 +1006,7 @@ def test_message_send_reads_the_interaction_row_before_injecting() -> None:
 
     def record_read(_task_id: int) -> int:
         order.append("read")
-        return row_id
+        return _OBSERVED_INTERACTION_ID
 
     async def record_injection(*_args: object, **_kwargs: object) -> bool:
         order.append("inject")
@@ -1011,6 +1024,9 @@ def test_message_send_reads_the_interaction_row_before_injecting() -> None:
             "xagent.web.api.a2a.active_interaction_id_sync",
             side_effect=record_read,
         ),
+        patch(
+            "xagent.web.api.a2a.close_legacy_resume_interaction", return_value=1
+        ) as close_mock,
     ):
         response = client.post(
             f"/api/a2a/agents/{agent_id}/message:send",
@@ -1028,6 +1044,10 @@ def test_message_send_reads_the_interaction_row_before_injecting() -> None:
 
     assert response.status_code == 200, response.text
     assert order == ["read", "inject"]
+    close_mock.assert_called_once()
+    assert close_mock.call_args.kwargs["task_id"] == task_id
+    assert close_mock.call_args.kwargs["run_id"] == "run-close-order"
+    assert close_mock.call_args.kwargs["interaction_id"] == _OBSERVED_INTERACTION_ID
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_public_chat_ownership_helper.py
+++ b/tests/web/api/test_public_chat_ownership_helper.py
@@ -437,6 +437,17 @@ def test_identity_string_for_user_principal() -> None:
         ),
         pytest.param(
             InteractionPrincipal(
+                kind="guest",
+                user_id=7,
+                is_admin=False,
+                auth_mode="widget",
+                widget_agent_id=1,
+                guest_id="",
+            ),
+            id="guest_with_an_empty_guest_id",
+        ),
+        pytest.param(
+            InteractionPrincipal(
                 kind="robot", user_id=7, is_admin=False, auth_mode=None
             ),
             id="unrecognized_kind",

--- a/tests/web/api/test_public_chat_ownership_helper.py
+++ b/tests/web/api/test_public_chat_ownership_helper.py
@@ -405,6 +405,51 @@ def test_identity_string_for_user_principal() -> None:
     assert principal.identity_string() == "user:42"
 
 
+# responder_identity is the one column this table's audit trail can rely on
+# staying populated, and its only database-side check is "non-empty". Every
+# row below used to render into a non-empty string that passes that check
+# and names nobody.
+@pytest.mark.parametrize(
+    "principal",
+    [
+        pytest.param(
+            InteractionPrincipal(
+                kind="user", user_id=None, is_admin=False, auth_mode=None
+            ),
+            id="user_without_a_user_id",
+        ),
+        pytest.param(
+            InteractionPrincipal(
+                kind="user", user_id=None, is_admin=True, auth_mode=None
+            ),
+            id="admin_without_a_user_id",
+        ),
+        pytest.param(
+            InteractionPrincipal(
+                kind="guest",
+                user_id=7,
+                is_admin=False,
+                auth_mode="widget",
+                widget_agent_id=1,
+                guest_id=None,
+            ),
+            id="guest_without_a_guest_id",
+        ),
+        pytest.param(
+            InteractionPrincipal(
+                kind="robot", user_id=7, is_admin=False, auth_mode=None
+            ),
+            id="unrecognized_kind",
+        ),
+    ],
+)
+def test_identity_string_refuses_a_principal_it_cannot_name(
+    principal: InteractionPrincipal,
+) -> None:
+    with pytest.raises(ValueError):
+        principal.identity_string()
+
+
 # ---------------------------------------------------------------------------
 # public_chat_identity_matches: the message-selection slice used by Phase 2
 # ---------------------------------------------------------------------------

--- a/tests/web/api/test_resume_interaction_seam.py
+++ b/tests/web/api/test_resume_interaction_seam.py
@@ -3,10 +3,11 @@ through the interaction lifecycle service: a task that still has an active
 native interaction row must refuse a resume that does not carry the
 receipt ``respond()`` stages, on both of this handler's two resume paths
 (the ``supports_live_control`` branch and the bare ``resume_execution``
-fallback) -- see ``_active_native_interaction_id_sync``'s own docstring in
-``websocket.py`` for the shared predicate this seam keys off, and that
-function's call site for why the check runs before ``agent_service`` is
-built.
+fallback) -- see ``active_interaction_id_sync``'s own docstring in
+``task_interaction_close.py`` for the shared predicate this seam keys off
+(including the ``tasks.interaction_protocol_version`` marker gate ahead of
+it), and that function's call site in ``websocket.py`` for why the check
+runs before ``agent_service`` is built.
 
 Mocking follows ``test_pause_resume_offturn_build_workspace.py``'s
 established shape: a real ``AgentServiceManager``/``TaskSetupSnapshot``
@@ -98,6 +99,7 @@ def _seeded_task(_session_factory) -> int:
         task = db.query(Task).filter(Task.id == task_id).first()
         task.status = TaskStatus.WAITING_FOR_USER
         task.run_id = RUN_ID
+        task.interaction_protocol_version = 1
         db.commit()
         return task_id
     finally:
@@ -311,6 +313,108 @@ async def test_legacy_resume_without_a_receipt_is_refused_on_the_fallback_path(
     sent = connection_manager.send_personal_message.await_args.args[0]
     assert sent["type"] == "error"
     assert "unanswered question" in sent["message"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_resume_is_not_refused_when_the_task_marker_is_null(
+    monkeypatch: pytest.MonkeyPatch, _session_factory, _seeded_task: int
+) -> None:
+    """The refusal gate reads through active_interaction_id_sync, which
+    stops at a NULL tasks.interaction_protocol_version before it queries
+    the interaction table at all. A task carrying an active row under a
+    NULL marker is therefore not refused -- deliberately, and matching what
+    the read surface does with the same state: get_pending_interaction_
+    question (task_interaction_read.py) also stops at the NULL marker and
+    shows the legacy transcript question, so refusing a resume here would
+    be refusing it on account of a row no reader will ever show. The state
+    is unreachable today (nothing in src/ writes the marker to 1), and the
+    change that wires the first writer has to write it -- see the marker's
+    own ownership comment on Task.interaction_protocol_version."""
+
+    import xagent.web.models.database as database_module
+
+    monkeypatch.setattr(
+        database_module, "get_optional_session_local", lambda: _session_factory
+    )
+    _make_active_row(_session_factory, task_id=_seeded_task)
+
+    db = _session_factory()
+    try:
+        db.query(Task).filter(Task.id == _seeded_task).update(
+            {Task.interaction_protocol_version: None}
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    snapshot = _snapshot(task_id=_seeded_task)
+    connection_manager = _connection_manager()
+    background_manager = MagicMock()
+    background_manager.running_tasks = {}
+    background_manager.reserve_resume.return_value = True
+    transition = AsyncMock(
+        return_value=SimpleNamespace(run_id=RUN_ID, status=TaskStatus.WAITING_FOR_USER)
+    )
+    agent_service = MagicMock()
+    agent_service.supports_live_control = MagicMock(return_value=True)
+
+    resume_scheduled = asyncio.Event()
+
+    async def _stub_execute_resume_background(**kwargs: object) -> None:
+        resume_scheduled.set()
+
+    from xagent.web.services import task_setup_snapshot as snapshot_module
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(
+                snapshot_module, "load_task_setup_snapshot_sync", return_value=snapshot
+            )
+        )
+        stack.enter_context(patch.object(websocket_api, "manager", connection_manager))
+        stack.enter_context(
+            patch.object(
+                websocket_api.task_execution_controller, "transition", new=transition
+            )
+        )
+        stack.enter_context(
+            patch.object(websocket_api, "background_task_manager", background_manager)
+        )
+        stack.enter_context(
+            patch.object(
+                websocket_api,
+                "execute_resume_background",
+                side_effect=_stub_execute_resume_background,
+            )
+        )
+        agent_manager = MagicMock()
+        agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+        stack.enter_context(
+            patch.object(chat_api, "get_agent_manager", lambda: agent_manager)
+        )
+
+        await websocket_api._handle_resume_task_unserialized(
+            MagicMock(),
+            _seeded_task,
+            {"user": SimpleNamespace(id=OWNER_ID, is_admin=False)},
+        )
+
+        agent_manager.get_agent_for_task.assert_awaited()
+        await asyncio.wait_for(resume_scheduled.wait(), timeout=1)
+
+    assert resume_scheduled.is_set()
+    refusals = [
+        call.args[0]
+        for call in connection_manager.send_personal_message.await_args_list
+        if isinstance(call.args[0], dict)
+        and call.args[0].get("type") == "error"
+        and "unanswered question" in str(call.args[0].get("message", ""))
+    ]
+    assert refusals == []
+    assert (
+        ops_signals.INTERACTION_LEGACY_RESUME_SHIM
+        not in ops_signals.active_degradations()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -624,130 +728,12 @@ async def test_stale_run_active_row_does_not_trip_the_seam(
     assert resume_scheduled.is_set()
 
 
-# ---------------------------------------------------------------------------
-# _active_native_interaction_id_sync's own four fail-open branches, called
-# directly rather than through the full handler: no database configured yet,
-# a session that fails to open, the interaction table not existing yet, and
-# the row lookup itself raising. The helper's docstring argues at length for
-# why each one resolves to "assume no active row" instead of propagating --
-# these pin that argument down to actual behavior, and distinguish the two
-# branches that are expected in normal operation (no session factory yet,
-# table not migrated yet -- no warning) from the two that represent a genuine
-# failure worth a log line (session open failure, lookup failure).
-# ---------------------------------------------------------------------------
-
-
-def test_active_native_interaction_id_sync_returns_none_without_a_session_factory(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """``get_optional_session_local() is None`` -- no database configured yet
-    for this process -- is the cheap, expected-in-tests case: it must return
-    ``None`` without ever calling the (nonexistent) session factory, and
-    without logging a warning. A caller that removed this branch would fall
-    through to ``SessionLocal()`` with ``SessionLocal is None``, which raises
-    ``TypeError`` and is instead caught by the *next* branch below -- still
-    returning ``None``, but only after logging a warning this branch is
-    specifically here to avoid."""
-
-    import xagent.web.models.database as database_module
-
-    monkeypatch.setattr(database_module, "get_optional_session_local", lambda: None)
-
-    with caplog.at_level("WARNING"):
-        result = websocket_api._active_native_interaction_id_sync(1)
-
-    assert result is None
-    assert caplog.records == []
-
-
-def test_active_native_interaction_id_sync_returns_none_when_opening_a_session_fails(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A session factory that is installed but raises when called -- e.g. a
-    prior test left a factory pointed at a since-removed temporary database
-    file -- must also resolve to "no active row", but unlike the branch
-    above this is a genuine failure and must be logged."""
-
-    import xagent.web.models.database as database_module
-
-    def _broken_session_local() -> None:
-        raise RuntimeError("database file has been removed")
-
-    monkeypatch.setattr(
-        database_module, "get_optional_session_local", lambda: _broken_session_local
-    )
-
-    with caplog.at_level("WARNING"):
-        result = websocket_api._active_native_interaction_id_sync(1)
-
-    assert result is None
-    assert len(caplog.records) == 1
-    assert "could not open a session" in caplog.records[0].message
-
-
-def test_active_native_interaction_id_sync_returns_none_when_the_table_is_missing(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-    _session_factory,
-    _seeded_task: int,
-) -> None:
-    """A deployment that has not yet run the migration creating
-    ``task_interaction_requests`` must not raise -- and, since this is a
-    known, temporary deployment window rather than a bug, must not log a
-    warning either. A real active row is seeded so that a caller which
-    removed this gate would find it -- proving the gate, not an empty table,
-    is what produces ``None`` here."""
-
-    import xagent.web.models.database as database_module
-    import xagent.web.services.task_interaction_schema as schema_module
-
-    monkeypatch.setattr(
-        database_module, "get_optional_session_local", lambda: _session_factory
-    )
-    monkeypatch.setattr(
-        schema_module, "interaction_requests_table_exists", lambda db: False
-    )
-    _make_active_row(_session_factory, task_id=_seeded_task)
-
-    with caplog.at_level("WARNING"):
-        result = websocket_api._active_native_interaction_id_sync(_seeded_task)
-
-    assert result is None
-    assert caplog.records == []
-
-
-def test_active_native_interaction_id_sync_returns_none_when_the_lookup_raises(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-    _session_factory,
-    _seeded_task: int,
-) -> None:
-    """A failure inside the row lookup itself -- reproduced here by making
-    the shared active-row predicate raise, the same seam
-    ``_answer_fence_stmt`` reuses -- must resolve to "no active row" and log
-    a warning naming the lookup, not the session-open failure above's
-    message."""
-
-    import xagent.web.models.database as database_module
-    import xagent.web.services.task_interaction_service as interaction_service_module
-
-    monkeypatch.setattr(
-        database_module, "get_optional_session_local", lambda: _session_factory
-    )
-
-    def _broken_criteria() -> list[object]:
-        raise RuntimeError("criteria unavailable")
-
-    monkeypatch.setattr(
-        interaction_service_module, "_active_native_row_criteria", _broken_criteria
-    )
-    _make_active_row(_session_factory, task_id=_seeded_task)
-
-    with caplog.at_level("WARNING"):
-        result = websocket_api._active_native_interaction_id_sync(_seeded_task)
-
-    assert result is None
-    assert len(caplog.records) == 1
-    assert "active-row lookup failed" in caplog.records[0].message
+# active_interaction_id_sync's own four fail-open branches (no database
+# configured yet, a session that fails to open, the interaction table not
+# existing yet, the row lookup itself raising) used to be pinned here,
+# against websocket.py's own _active_native_interaction_id_sync. That
+# function is gone -- the seam now reads through the same
+# task_interaction_close.active_interaction_id_sync the four legacy-resume
+# injection sites use -- and its four fail-open branches are pinned in
+# tests/web/services/test_task_interaction_close.py instead, alongside the
+# marker gate that reader adds ahead of them.

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -1710,7 +1710,9 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
         )
 
     assert order == ["read", "inject"]
-    close_mock.assert_called_once_with(int(task.id), "close-order-run", 4321)
+    close_mock.assert_called_once_with(
+        task_id=int(task.id), run_id="close-order-run", interaction_id=4321
+    )
 
 
 @pytest.mark.asyncio
@@ -1761,7 +1763,9 @@ async def test_live_close_failure_after_registered_handoff_is_still_accepted(
         )
 
     bg_mgr.register_reserved_resume.assert_called_once()
-    close_mock.assert_called_once_with(int(task.id), "close-failure-run", None)
+    close_mock.assert_called_once_with(
+        task_id=int(task.id), run_id="close-failure-run", interaction_id=None
+    )
     accepted = [
         call.args[0]
         for call in ws_manager.send_personal_message.call_args_list
@@ -1821,7 +1825,9 @@ async def test_live_close_cancellation_does_not_abort_registered_handoff(
         )
 
     bg_mgr.register_reserved_resume.assert_called_once()
-    close_mock.assert_called_once_with(int(task.id), "close-cancel-run", None)
+    close_mock.assert_called_once_with(
+        task_id=int(task.id), run_id="close-cancel-run", interaction_id=None
+    )
     accepted = [
         call.args[0]
         for call in ws_manager.send_personal_message.call_args_list
@@ -3597,9 +3603,7 @@ async def test_deferred_injection_close_failure_does_not_abort_resume(
     # after the `with` block, outside that handler's reach.
     observed_close_calls: list[tuple[int, str, str | None]] = []
 
-    def fail_close(
-        task_id_arg: int, run_id_arg: str, interaction_id_arg: int | None
-    ) -> int:
+    def fail_close(*, task_id: int, run_id: str, interaction_id: int | None) -> int:
         # A fresh session, not db_session: this runs inside the worker
         # thread run_db_io_cancellation_safe schedules it on, while the
         # test's own db_session sits unused on the main thread -- sharing
@@ -3607,10 +3611,10 @@ async def test_deferred_injection_close_failure_does_not_abort_resume(
         # elsewhere.
         probe = next(get_db())
         try:
-            live_run_id = probe.query(Task).filter(Task.id == task_id_arg).one().run_id
+            live_run_id = probe.query(Task).filter(Task.id == task_id).one().run_id
         finally:
             probe.close()
-        observed_close_calls.append((task_id_arg, run_id_arg, live_run_id))
+        observed_close_calls.append((task_id, run_id, live_run_id))
         raise RuntimeError("interaction close unavailable")
 
     with (
@@ -3724,8 +3728,8 @@ async def test_deferred_injection_closes_the_row_the_online_handler_observed(
         )
 
     close_mock.assert_called_once()
-    assert close_mock.call_args.args[0] == int(task.id)
-    assert close_mock.call_args.args[2] == 9876
+    assert close_mock.call_args.kwargs["task_id"] == int(task.id)
+    assert close_mock.call_args.kwargs["interaction_id"] == 9876
 
 
 @pytest.mark.asyncio
@@ -3777,14 +3781,14 @@ async def test_deferred_injection_close_cancellation_does_not_abort_resume(
     observed_close_calls: list[tuple[int, str, str | None]] = []
 
     def raise_cancelled(
-        task_id_arg: int, run_id_arg: str, interaction_id_arg: int | None
+        *, task_id: int, run_id: str, interaction_id: int | None
     ) -> int:
         probe = next(get_db())
         try:
-            live_run_id = probe.query(Task).filter(Task.id == task_id_arg).one().run_id
+            live_run_id = probe.query(Task).filter(Task.id == task_id).one().run_id
         finally:
             probe.close()
-        observed_close_calls.append((task_id_arg, run_id_arg, live_run_id))
+        observed_close_calls.append((task_id, run_id, live_run_id))
         raise asyncio.CancelledError
 
     with (

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -1644,6 +1644,76 @@ async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
 
 
 @pytest.mark.asyncio
+async def test_live_resume_reads_the_interaction_row_before_injecting(
+    db_session,
+) -> None:
+    """The close is keyed on the row observed *before* the injection, and
+    only the ordering makes that true -- see task_interaction_close's
+    module docstring. The read also sits before the ``posted`` fork, so the
+    deferred branch carries the same observation instead of taking one of
+    its own even later."""
+
+    owner = _user(db_session, "close-order-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    task.runner_id = "close-order-runner"
+    task.run_id = "close-order-run"
+    db_session.commit()
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+
+    order: list[str] = []
+
+    def record_read(_task_id: int) -> int:
+        order.append("read")
+        return 4321
+
+    async def record_injection(*_args: object, **_kwargs: object) -> bool:
+        order.append("inject")
+        return True
+
+    agent.post_user_message = AsyncMock(side_effect=record_injection)
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=MagicMock(get_agent_for_task=AsyncMock(return_value=agent)),
+        ),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch("xagent.web.api.websocket.execute_resume_background", AsyncMock()),
+        patch(
+            "xagent.web.api.websocket.active_interaction_id_sync",
+            side_effect=record_read,
+        ),
+        patch(
+            "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
+            return_value=1,
+        ) as close_mock,
+    ):
+        await _handle_chat_message_unserialized(
+            MagicMock(),
+            int(task.id),
+            {
+                "message": "Apply this once",
+                "client_message_id": "close-order-turn",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    assert order == ["read", "inject"]
+    close_mock.assert_called_once_with(int(task.id), "close-order-run", 4321)
+
+
+@pytest.mark.asyncio
 async def test_live_close_failure_after_registered_handoff_is_still_accepted(
     db_session,
 ) -> None:
@@ -1691,7 +1761,7 @@ async def test_live_close_failure_after_registered_handoff_is_still_accepted(
         )
 
     bg_mgr.register_reserved_resume.assert_called_once()
-    close_mock.assert_called_once_with(int(task.id), "close-failure-run")
+    close_mock.assert_called_once_with(int(task.id), "close-failure-run", None)
     accepted = [
         call.args[0]
         for call in ws_manager.send_personal_message.call_args_list
@@ -1751,7 +1821,7 @@ async def test_live_close_cancellation_does_not_abort_registered_handoff(
         )
 
     bg_mgr.register_reserved_resume.assert_called_once()
-    close_mock.assert_called_once_with(int(task.id), "close-cancel-run")
+    close_mock.assert_called_once_with(int(task.id), "close-cancel-run", None)
     accepted = [
         call.args[0]
         for call in ws_manager.send_personal_message.call_args_list
@@ -3527,7 +3597,9 @@ async def test_deferred_injection_close_failure_does_not_abort_resume(
     # after the `with` block, outside that handler's reach.
     observed_close_calls: list[tuple[int, str, str | None]] = []
 
-    def fail_close(task_id_arg: int, run_id_arg: str) -> int:
+    def fail_close(
+        task_id_arg: int, run_id_arg: str, interaction_id_arg: int | None
+    ) -> int:
         # A fresh session, not db_session: this runs inside the worker
         # thread run_db_io_cancellation_safe schedules it on, while the
         # test's own db_session sits unused on the main thread -- sharing
@@ -3579,6 +3651,84 @@ async def test_deferred_injection_close_failure_does_not_abort_resume(
 
 
 @pytest.mark.asyncio
+async def test_deferred_injection_closes_the_row_the_online_handler_observed(
+    db_session,
+) -> None:
+    """The deferred path takes no observation of its own. Its injection is
+    later still than the online one, so a read taken here would be even
+    further past the point where the answered row is identifiable. The
+    online handler's pre-injection observation travels in
+    pending_user_message and is what the close is keyed on."""
+
+    owner = _user(db_session, "deferred-carry-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Deferred guidance",
+            message_type="user_message",
+            turn_id="deferred-carry-turn",
+            delivery_status=DELIVERY_PENDING,
+        )
+    )
+    db_session.commit()
+    context = SimpleNamespace(
+        messages=[
+            SimpleNamespace(role="user", metadata={"turn_id": "deferred-carry-turn"})
+        ]
+    )
+    agent = MagicMock(
+        post_user_message=AsyncMock(return_value=True),
+        resume_execution_by_id=AsyncMock(
+            return_value={
+                "status": "completed",
+                "success": True,
+                "output": "Applied",
+                "agent_result": {"context": context},
+            }
+        ),
+    )
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager.promote_resume_task"),
+        patch(
+            "xagent.web.api.websocket.active_interaction_id_sync",
+            side_effect=AssertionError("the deferred path must not read its own"),
+        ),
+        patch(
+            "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
+            return_value=1,
+        ) as close_mock,
+    ):
+        await execute_resume_background(
+            task_id=int(task.id),
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+            pending_user_message={
+                "execution_message": "Deferred guidance",
+                "display_message": "Deferred guidance",
+                "files": [],
+                "turn_id": "deferred-carry-turn",
+                "interaction_id": 9876,
+            },
+            delivery_turn_id="deferred-carry-turn",
+            delivery_websocket=MagicMock(),
+            delivery_client_message_id="deferred-carry-turn",
+        )
+
+    close_mock.assert_called_once()
+    assert close_mock.call_args.args[0] == int(task.id)
+    assert close_mock.call_args.args[2] == 9876
+
+
+@pytest.mark.asyncio
 async def test_deferred_injection_close_cancellation_does_not_abort_resume(
     db_session,
 ) -> None:
@@ -3626,7 +3776,9 @@ async def test_deferred_injection_close_cancellation_does_not_abort_resume(
     # ``except Exception:`` the same way it swallows an ordinary failure.
     observed_close_calls: list[tuple[int, str, str | None]] = []
 
-    def raise_cancelled(task_id_arg: int, run_id_arg: str) -> int:
+    def raise_cancelled(
+        task_id_arg: int, run_id_arg: str, interaction_id_arg: int | None
+    ) -> int:
         probe = next(get_db())
         try:
             live_run_id = probe.query(Task).filter(Task.id == task_id_arg).one().run_id

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -541,6 +541,53 @@ def test_reply_closes_the_legacy_resume_interaction_row_on_successful_injection(
         db.close()
 
 
+def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
+    """The close is keyed on the row observed *before* the injection,
+    and only the ordering makes that true -- see task_interaction_close's
+    module docstring. Moving the read after the injection leaves the whole
+    change doing nothing while the row-level assertions in the test above
+    stay green."""
+
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id="run-close-order")
+    row_id = _seed_active_interaction_row(
+        task_id, run_id="run-close-order", idempotency_key="reply-close-order-q1"
+    )
+
+    order: list[str] = []
+
+    def record_read(_task_id: int) -> int:
+        order.append("read")
+        return row_id
+
+    async def record_injection(*_args: object, **_kwargs: object) -> bool:
+        order.append("inject")
+        return True
+
+    agent_patch, _agent_service = _patch_agent_service(
+        AsyncMock(side_effect=record_injection)
+    )
+    with (
+        agent_patch,
+        patch(
+            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.api.v1.task_reply.active_interaction_id_sync",
+            side_effect=record_read,
+        ),
+    ):
+        resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+
+    assert resp.status_code == 202, resp.text
+    assert order == ["read", "inject"]
+
+
 def test_update_reply_input_rolls_back_the_interaction_close_with_the_fence() -> None:
     """Mirrors test_a2a_api.py's
     test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence
@@ -585,7 +632,9 @@ def test_update_reply_input_rolls_back_the_interaction_close_with_the_fence() ->
     stale_lease = TaskLease(
         task_id=task_id, runner_id="a-different-runner", run_id="run-reply-atomicity"
     )
-    updated = task_reply_module._update_reply_input_sync(stale_lease, "attempted text")
+    updated = task_reply_module._update_reply_input_sync(
+        stale_lease, "attempted text", row_id
+    )
 
     assert updated is False
     db = _direct_db_session()

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -541,16 +541,29 @@ def test_reply_closes_the_legacy_resume_interaction_row_on_successful_injection(
         db.close()
 
 
+# A fabricated id, not the seeded row's -- test_reply_reads_the_interaction_
+# row_before_injecting hands this to the close instead of the real row id,
+# so a site that re-read the row at close time would hand the close the
+# real id and fail there instead.
+_OBSERVED_INTERACTION_ID = 4321
+
+
 def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
     """The close is keyed on the row observed *before* the injection,
     and only the ordering makes that true -- see task_interaction_close's
     module docstring. Moving the read after the injection leaves the whole
     change doing nothing while the row-level assertions in the test above
-    stay green."""
+    stay green. The observed value is a fabricated id, not the seeded row's,
+    so a site that re-read the row at close time would hand the close the
+    real id and fail here."""
 
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_waiting_task(full_key, agent_id, run_id="run-close-order")
-    row_id = _seed_active_interaction_row(
+    # Kept real and distinct from _OBSERVED_INTERACTION_ID: a site that
+    # re-read the row at close time (instead of using the id observed before
+    # injection) would hand the close this real id and fail the assertion
+    # below.
+    _seed_active_interaction_row(
         task_id, run_id="run-close-order", idempotency_key="reply-close-order-q1"
     )
 
@@ -558,7 +571,7 @@ def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
 
     def record_read(_task_id: int) -> int:
         order.append("read")
-        return row_id
+        return _OBSERVED_INTERACTION_ID
 
     async def record_injection(*_args: object, **_kwargs: object) -> bool:
         order.append("inject")
@@ -577,6 +590,10 @@ def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
             "xagent.web.api.v1.task_reply.active_interaction_id_sync",
             side_effect=record_read,
         ),
+        patch(
+            "xagent.web.api.v1.task_reply.close_legacy_resume_interaction",
+            return_value=1,
+        ) as close_mock,
     ):
         resp = client.post(
             f"/v1/chat/tasks/{task_id}/reply",
@@ -586,6 +603,10 @@ def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
 
     assert resp.status_code == 202, resp.text
     assert order == ["read", "inject"]
+    close_mock.assert_called_once()
+    assert close_mock.call_args.kwargs["task_id"] == task_id
+    assert close_mock.call_args.kwargs["run_id"] == "run-close-order"
+    assert close_mock.call_args.kwargs["interaction_id"] == _OBSERVED_INTERACTION_ID
 
 
 def test_update_reply_input_rolls_back_the_interaction_close_with_the_fence() -> None:

--- a/tests/web/services/task_interaction_schema_shared.py
+++ b/tests/web/services/task_interaction_schema_shared.py
@@ -75,10 +75,12 @@ def tables_excluding_interaction_requests() -> list:
     """Every table this repo's models declare, except the interaction table.
 
     Building a database from this filtered set reproduces the shape of a
-    deployment upgraded through every migration except the (unmerged) one
-    that creates task_interaction_requests -- the table has no inbound
-    foreign keys, so excluding it cannot break create order (verified in the
-    audit: 52 of 53 tables created, zero inbound FKs to the target).
+    deployment upgraded through every migration except the one that creates
+    task_interaction_requests. That migration is merged, so what this shape
+    stands for is a deployment that has not caught up to it yet, not a
+    change that has not landed. The table has no inbound foreign keys, so
+    excluding it cannot break create order (verified in the audit: 52 of 53
+    tables created, zero inbound FKs to the target).
     """
     return [
         table

--- a/tests/web/services/test_interaction_close_lock_ordering.py
+++ b/tests/web/services/test_interaction_close_lock_ordering.py
@@ -418,10 +418,11 @@ def _sa_update_targets(tree: ast.AST) -> list[str]:
 
 def test_close_module_issues_exactly_the_expected_update_statements() -> None:
     """The whole module issues exactly three UPDATE statements: the close
-    (task_interaction_requests), its paired unconditional clear (tasks),
-    and the compensation paths' shared NOT-EXISTS-guarded clear (tasks).
-    A fourth statement, or one against an unexpected table, means either a
-    duplicated write path or a table this design never named."""
+    (task_interaction_requests), its paired clear (tasks), and the
+    compensation paths' clear (tasks) -- both clears guarded by the same
+    NOT EXISTS clause. A fourth statement, or one against an unexpected
+    table, means either a duplicated write path or a table this design
+    never named."""
     targets = _sa_update_targets(ast.parse(_source(task_interaction_close)))
     assert targets == ["TaskInteractionRequest", "Task", "Task"], targets
 

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -62,6 +62,7 @@ from xagent.web.services.task_command_transport import COMMAND_ID_PATTERN
 from xagent.web.services.task_interaction_service import (
     materialize_compatibility_view,
     parse_v1_request_payload,
+    validate_v1_write_payload,
 )
 from xagent.web.services.task_interaction_staging import (
     InteractionAnchor,
@@ -360,6 +361,75 @@ def test_cross_run_anchor_mismatch_still_resolves_as_publishable() -> None:
 # ---------------------------------------------------------------------------
 # Payload construction and parsing
 # ---------------------------------------------------------------------------
+
+
+# This builder and task_interaction_service's write-side rules are two
+# halves of one contract with no shared type to enforce it: everything this
+# builder produces is offered to the write path, so a payload it can build
+# that those rules reject is a clarification that can never be published.
+# The rows below are the shapes it actually produces, fed through the real
+# parser and the real rules rather than through a hand-written mirror.
+@pytest.mark.parametrize(
+    "make_draft",
+    [
+        pytest.param(
+            lambda: _draft(),
+            id="send_message_draft_carries_no_interactions",
+        ),
+        pytest.param(
+            lambda: _draft(
+                source="ask_user_question",
+                interactions=(
+                    {
+                        "type": "select_one",
+                        "field": "colour",
+                        "label": "Colour",
+                        "options": [{"label": "Red", "value": "red"}],
+                    },
+                    {"type": "text_input", "field": "why", "label": "Why?"},
+                ),
+            ),
+            id="ask_user_question_draft_carries_a_form",
+        ),
+        pytest.param(
+            lambda: _draft(
+                source="ask_user_question",
+                interactions=tuple(
+                    {
+                        "type": "text_input",
+                        "field": f"field_{index}",
+                        "label": "x" * 512,
+                    }
+                    for index in range(400)
+                ),
+            ),
+            id="oversized_form_is_dropped_to_an_empty_list",
+        ),
+    ],
+)
+def test_the_clarification_payload_builder_satisfies_the_write_side_rules(
+    make_draft: Any,
+) -> None:
+    payload = build_clarification_payload(make_draft())
+    validate_v1_write_payload(parse_v1_request_payload(payload))
+
+
+def test_an_oversized_clarification_form_really_is_dropped_to_an_empty_list() -> None:
+    """The row above named "oversized" only proves something if the builder
+    actually took its drop branch. Pin that here rather than trusting the
+    row's id."""
+
+    payload = build_clarification_payload(
+        _draft(
+            source="ask_user_question",
+            interactions=tuple(
+                {"type": "text_input", "field": f"field_{index}", "label": "x" * 512}
+                for index in range(400)
+            ),
+        )
+    )
+    assert payload["interactions"] == []
+    assert payload["interactions_dropped"] is True
 
 
 def test_payload_round_trip_matches_the_legacy_reader_shape_for_a_send_message_draft(

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -119,9 +119,11 @@ def test_classify_close_rowcount_logs_debug_for_the_common_no_op_case(
 def test_classify_close_rowcount_logs_error_and_registers_a_signal_for_an_impossible_rowcount(
     caplog,
 ) -> None:
-    """rowcount > 1 is impossible under uq_task_interaction_active_slot
-    unless that constraint has already been violated -- see this module's
-    docstring. Logged at error and surfaced on /health, not raised."""
+    """rowcount > 1 needs either the primary key the close binds to or
+    uq_task_interaction_active_slot to have stopped holding -- see the
+    close module's docstring. Called directly here, because no database
+    this suite can build produces that rowcount. Logged at error and
+    surfaced on /health, not raised."""
     with caplog.at_level(logging.ERROR, logger=_CLOSE_MODULE_NAME):
         _classify_close_rowcount(2, task_id=7, run_id="run-b", unmatched_row=None)
 
@@ -367,7 +369,9 @@ def test_close_sync_opens_its_own_transaction_and_commits(db) -> None:
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
-    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a", row_id)
+    rowcount = close_legacy_resume_interaction_sync(
+        task_id=task_id, run_id="run-a", interaction_id=row_id
+    )
 
     assert rowcount == 1
     assert row_state(db, row_id).status == "terminated"
@@ -424,7 +428,9 @@ def test_close_no_ops_when_the_interaction_table_does_not_exist(
     )
     db.commit()
 
-    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a", None)
+    rowcount = close_legacy_resume_interaction_sync(
+        task_id=task_id, run_id="run-a", interaction_id=None
+    )
 
     assert rowcount == 0
     # The gate is checked before the marker clear too: close_legacy_resume_
@@ -794,7 +800,9 @@ def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
 
     assert observed_id is None
 
-    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a", observed_id)
+    rowcount = close_legacy_resume_interaction_sync(
+        task_id=task_id, run_id="run-a", interaction_id=observed_id
+    )
 
     assert rowcount == 0
     assert row_state(db, row_id).status == "active"

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -91,19 +91,28 @@ def test_classify_close_rowcount_logs_info_for_the_expected_single_row_case(
     caplog,
 ) -> None:
     with caplog.at_level(logging.INFO, logger=_CLOSE_MODULE_NAME):
-        _classify_close_rowcount(1, task_id=1, run_id="run-a")
+        _classify_close_rowcount(1, task_id=1, run_id="run-a", unmatched_row=None)
 
     assert [record.levelno for record in caplog.records] == [logging.INFO]
     assert ops_signals.active_degradations() == {}
 
 
+@pytest.mark.parametrize(
+    "unmatched_row", ["no_id_read", "row_absent", "row_status=terminated"]
+)
 def test_classify_close_rowcount_logs_debug_for_the_common_no_op_case(
-    caplog,
+    caplog, unmatched_row: str
 ) -> None:
+    """The zero branch carries the description through to the log line
+    verbatim: the level says a close matched nothing, and this says which
+    of the situations that fold into that rowcount it was."""
     with caplog.at_level(logging.DEBUG, logger=_CLOSE_MODULE_NAME):
-        _classify_close_rowcount(0, task_id=1, run_id="run-a")
+        _classify_close_rowcount(
+            0, task_id=1, run_id="run-a", unmatched_row=unmatched_row
+        )
 
     assert [record.levelno for record in caplog.records] == [logging.DEBUG]
+    assert f"unmatched_row={unmatched_row}" in caplog.records[0].getMessage()
     assert ops_signals.active_degradations() == {}
 
 
@@ -114,7 +123,7 @@ def test_classify_close_rowcount_logs_error_and_registers_a_signal_for_an_imposs
     unless that constraint has already been violated -- see this module's
     docstring. Logged at error and surfaced on /health, not raised."""
     with caplog.at_level(logging.ERROR, logger=_CLOSE_MODULE_NAME):
-        _classify_close_rowcount(2, task_id=7, run_id="run-b")
+        _classify_close_rowcount(2, task_id=7, run_id="run-b", unmatched_row=None)
 
     assert [record.levelno for record in caplog.records] == [logging.ERROR]
     assert (
@@ -283,6 +292,73 @@ def test_close_retires_only_the_row_it_was_given(
     # The other task's row is out of range of this close regardless.
     assert row_state(db, other_row_id).status == "active"
     assert task_marker(db, task_id) == expected_marker
+
+
+# A zero rowcount is one number for situations an operator has to tell
+# apart, so the debug line carries a description of which one it was,
+# resolved from the database at the close's own call point. Four shapes,
+# all of them misses, and a different set from the grid above: that one
+# keeps the seeded rows fixed and varies only the id the close is handed,
+# including the id that matches; these vary the seeded row too.
+@pytest.mark.parametrize(
+    ("row_to_seed", "id_to_pass", "expected_description"),
+    [
+        pytest.param(None, None, "no_id_read", id="the_read_produced_no_id"),
+        pytest.param(None, 999_999_999, "row_absent", id="the_id_names_no_row"),
+        pytest.param(
+            "terminated",
+            "the_seeded_row",
+            "row_status=terminated",
+            id="another_path_closed_the_row_first",
+        ),
+        pytest.param(
+            "active",
+            "the_seeded_row",
+            "row_status=active",
+            id="the_row_is_live_but_belongs_to_another_run",
+        ),
+    ],
+)
+def test_close_records_why_it_matched_no_row(
+    db,
+    caplog: pytest.LogCaptureFixture,
+    row_to_seed: str | None,
+    id_to_pass: object,
+    expected_description: str,
+) -> None:
+    """The last case is the one that used to be indistinguishable from an
+    empty table: a row that is still active, and still missed, because this
+    close fences on run_id as well as on the id."""
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    seeded_row_id: int | None = None
+    if row_to_seed == "terminated":
+        anchor_id = make_trace_event(db, task_id=task_id)
+        row = TaskInteractionRequest(
+            **make_row(
+                task_id=task_id,
+                resume_trace_event_id=anchor_id,
+                run_id="run-a",
+                status="terminated",
+            )
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        seeded_row_id = int(row.id)
+    elif row_to_seed == "active":
+        seeded_row_id = seed_active_row(db, task_id=task_id, run_id="run-b")
+
+    interaction_id = seeded_row_id if id_to_pass == "the_seeded_row" else id_to_pass
+
+    with caplog.at_level(logging.DEBUG, logger=_CLOSE_MODULE_NAME):
+        rowcount = close_legacy_resume_interaction(
+            db, task_id=task_id, run_id="run-a", interaction_id=interaction_id
+        )
+    db.commit()
+
+    assert rowcount == 0
+    assert [record.levelno for record in caplog.records] == [logging.DEBUG]
+    assert f"unmatched_row={expected_description}" in caplog.records[0].getMessage()
 
 
 def test_close_sync_opens_its_own_transaction_and_commits(db) -> None:

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -19,6 +19,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 import pytest
+import sqlalchemy as sa
 
 from tests.web.services.task_interaction_schema_shared import (
     make_row,
@@ -130,7 +131,9 @@ def test_close_retires_the_active_row_for_its_own_run(db) -> None:
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=row_id
+    )
     db.commit()
 
     assert rowcount == 1
@@ -159,7 +162,9 @@ def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
     row_id = int(row.id)
     original_terminal_reason = row.terminal_reason
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=row_id
+    )
     db.commit()
 
     assert rowcount == 0
@@ -176,7 +181,9 @@ def test_close_is_a_no_op_with_no_interaction_rows_at_all(db) -> None:
     """Today's 100% case: the table has no production writer yet."""
     task_id = seed_task_with_run(db, run_id="run-a", marker=None)
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=None
+    )
     db.commit()
 
     assert rowcount == 0
@@ -187,7 +194,11 @@ def test_close_does_not_touch_a_different_runs_active_row(db) -> None:
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     orphan_row_id = seed_active_row(db, task_id=task_id, run_id="run-b")
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    # The orphan's own id is passed in deliberately, so the run predicate
+    # is the only thing left that can reject it.
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=orphan_row_id
+    )
     db.commit()
 
     assert rowcount == 0
@@ -217,11 +228,53 @@ def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_rea
     db.refresh(row)
     row_id = int(row.id)
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=row_id
+    )
     db.commit()
 
     assert rowcount == 0
     assert row_state(db, row_id).terminal_reason == "run_superseded"
+
+
+# What the primary-key predicate does on its own, holding everything else
+# constant: one active row for this task and run, and only the id handed to
+# the close varies.
+@pytest.mark.parametrize(
+    ("id_to_pass", "expected_rowcount"),
+    [
+        pytest.param("the_active_row", 1, id="the_row_observed_before_injection"),
+        pytest.param(None, 0, id="no_row_was_active_at_injection_time"),
+        pytest.param("another_row", 0, id="a_row_that_is_not_this_tasks_active_one"),
+    ],
+)
+def test_close_retires_only_the_row_it_was_given(
+    db, id_to_pass: str | None, expected_rowcount: int
+) -> None:
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    other_task_id = seed_task_with_run(db, run_id="run-z", marker=1)
+    other_row_id = seed_active_row(db, task_id=other_task_id, run_id="run-z")
+
+    interaction_id = {
+        "the_active_row": row_id,
+        "another_row": other_row_id,
+        None: None,
+    }[id_to_pass]
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=interaction_id
+    )
+    db.commit()
+
+    assert rowcount == expected_rowcount
+    assert (row_state(db, row_id).status == "terminated") is (expected_rowcount == 1)
+    # The other task's row is out of range of this close regardless.
+    assert row_state(db, other_row_id).status == "active"
+    # The marker clear is not conditioned on the close matching anything: a
+    # run that had no active row at injection time still needs its marker
+    # zeroed.
+    assert task_marker(db, task_id) is None
 
 
 def test_close_sync_opens_its_own_transaction_and_commits(db) -> None:
@@ -230,7 +283,7 @@ def test_close_sync_opens_its_own_transaction_and_commits(db) -> None:
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
-    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a")
+    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a", row_id)
 
     assert rowcount == 1
     assert row_state(db, row_id).status == "terminated"
@@ -287,7 +340,7 @@ def test_close_no_ops_when_the_interaction_table_does_not_exist(
     )
     db.commit()
 
-    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a")
+    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a", None)
 
     assert rowcount == 0
     # The gate is checked before the marker clear too: close_legacy_resume_
@@ -371,7 +424,14 @@ def test_clear_marker_if_unpaired_leaves_a_still_active_row_untouched(db) -> Non
 # --------------------------------------------------------------------------
 
 
-def _stage(db, *, task_id: int, run_id: str, anchor_id: int, key: str):
+def _stage(
+    db,
+    *,
+    task_id: int,
+    run_id: str,
+    anchor_id: int,
+    key: str,
+):
     now = datetime.now(timezone.utc)
     return stage_interaction_request(
         db,
@@ -393,6 +453,68 @@ def _stage(db, *, task_id: int, run_id: str, anchor_id: int, key: str):
     )
 
 
+def _stage_a_replacement_question_the_way_a_resumed_agent_would(
+    db, *, task_id: int, run_id: str, anchor_id: int
+):
+    """Put a second question on the same run into the active slot, the way
+    a resumed agent's own ``stage_interaction_request`` call does.
+
+    The first question has to be reclaimable for that INSERT to land at
+    all -- ``uq_task_interaction_active_slot`` allows one active row per
+    task -- so its deadline is moved into the past first, standing in for
+    the time that elapses while a resumed agent works. The second call
+    then takes ``_reclaim_stale_slot_stmt``'s expired-row branch on its
+    own; nothing here reclaims by hand. Returns ``(first_id, second_id)``.
+    """
+    first = _stage(db, task_id=task_id, run_id=run_id, anchor_id=anchor_id, key="q1")
+    db.commit()
+    # Both columns move together: ck_task_interaction_requests_expiry_
+    # after_creation requires expires_at > created_at, so an already-lapsed
+    # deadline has to belong to a row that was also created earlier.
+    staged_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    db.execute(
+        sa.update(TaskInteractionRequest)
+        .where(TaskInteractionRequest.id == first.staged_db_id)
+        .values(created_at=staged_at, expires_at=staged_at + timedelta(minutes=15))
+    )
+    db.commit()
+
+    second = _stage(db, task_id=task_id, run_id=run_id, anchor_id=anchor_id, key="q2")
+    db.commit()
+    assert second.created is True
+    return int(first.staged_db_id), int(second.staged_db_id)
+
+
+def test_close_leaves_a_question_staged_after_the_injection_alone(db) -> None:
+    """The window this close is keyed against. Injecting the user message
+    is what resumes the agent, so between the observation and the close the
+    resumed agent can ask something new. Retiring that new question as
+    "answered via legacy resume" would silently discard a question nobody
+    ever saw."""
+
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    anchor_id = make_trace_event(db, task_id=task_id)
+
+    observed_id, staged_after_injection_id = (
+        _stage_a_replacement_question_the_way_a_resumed_agent_would(
+            db, task_id=task_id, run_id="run-a", anchor_id=anchor_id
+        )
+    )
+
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=observed_id
+    )
+    db.commit()
+
+    assert rowcount == 0
+    survivor = row_state(db, staged_after_injection_id)
+    assert survivor.status == "active"
+    assert survivor.terminal_reason is None
+    # The row that was observed before injection is terminal either way --
+    # the reclaim retired it as expired when the new question took the slot.
+    assert row_state(db, observed_id).status == "terminated"
+
+
 def test_close_lets_a_second_question_on_the_same_run_become_active(db) -> None:
     """Deleting the close call must turn this red: without it, the second
     stage attempt collides with the first question's still-active slot and
@@ -404,7 +526,9 @@ def test_close_lets_a_second_question_on_the_same_run_become_active(db) -> None:
     db.commit()
     assert first.created is True
 
-    close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=first.staged_db_id
+    )
     db.commit()
 
     second = _stage(db, task_id=task_id, run_id="run-a", anchor_id=anchor_id, key="q2")

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -46,6 +46,7 @@ from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services import ops_signals
 from xagent.web.services.task_interaction_close import (
     _classify_close_rowcount,
+    active_interaction_id_sync,
     clear_interaction_marker_if_unpaired,
     close_legacy_resume_interaction,
     close_legacy_resume_interaction_sync,
@@ -372,6 +373,57 @@ def test_clear_marker_if_unpaired_no_ops_when_the_interaction_table_does_not_exi
         db.query(Task).filter(Task.id == task_id).one().interaction_protocol_version
         == 1
     )
+
+
+# --------------------------------------------------------------------------
+# active_interaction_id_sync -- the pre-injection read whose result the close
+# binds to. Every caller reaches it through a patched name, so the body is
+# exercised here: the id it returns for a live row, and the two shapes that
+# must degrade to None rather than to a wrong id.
+# --------------------------------------------------------------------------
+
+
+def test_active_interaction_id_sync_returns_the_live_rows_id(db) -> None:
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    assert active_interaction_id_sync(task_id) == row_id
+
+
+def test_active_interaction_id_sync_returns_none_without_the_interaction_table(
+    db_without_interaction_table,
+) -> None:
+    db = db_without_interaction_table
+    user_id = make_user(db)
+    task_id = make_task(db, user_id=user_id)
+    db.query(Task).filter(Task.id == task_id).update(
+        {Task.run_id: "run-a", Task.interaction_protocol_version: 1}
+    )
+    db.commit()
+
+    assert active_interaction_id_sync(task_id) is None
+
+
+def test_active_interaction_id_sync_returns_none_when_the_read_fails(
+    db, monkeypatch, caplog
+) -> None:
+    """A failing read must return None, not raise: the caller is on the
+    injection path, and None closes nothing, while an exception would take
+    the injection down with it."""
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    def _fail():
+        raise sa.exc.OperationalError("SELECT 1", {}, Exception("database is locked"))
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_interaction_close.get_session_local", _fail
+    )
+
+    with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
+        assert active_interaction_id_sync(task_id) is None
+
+    assert [record.levelno for record in caplog.records] == [logging.WARNING]
 
 
 # --------------------------------------------------------------------------

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -411,32 +411,157 @@ def test_active_interaction_id_sync_returns_none_without_the_interaction_table(
     assert active_interaction_id_sync(task_id) is None
 
 
-def test_active_interaction_id_sync_returns_none_when_the_read_fails(
-    db, monkeypatch, caplog
+def test_active_interaction_id_sync_returns_none_when_the_task_marker_is_null(
+    db, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A failing read must return None, not raise: the caller is on the
-    injection path, and None closes nothing, while an exception would take
-    the injection down with it.
+    """``tasks.interaction_protocol_version`` being ``NULL`` means no native
+    row was ever staged for this task's current wait -- the same first step
+    ``get_pending_interaction_question`` takes on the read side -- so the
+    interaction table goes unqueried even though a real active row exists
+    here. Not a failure, so no warning."""
+
+    task_id = seed_task_with_run(db, run_id="run-a", marker=None)
+    seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
+        result = active_interaction_id_sync(task_id)
+
+    assert result is None
+    assert caplog.records == []
+
+
+def test_active_interaction_id_sync_returns_none_for_an_absent_task(
+    db, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
+        result = active_interaction_id_sync(999_999_999)
+
+    assert result is None
+    assert caplog.records == []
+
+
+# --------------------------------------------------------------------------
+# active_interaction_id_sync's own four fail-open branches, migrated from
+# tests/web/api/test_resume_interaction_seam.py where this function used to
+# live as websocket.py's own _active_native_interaction_id_sync: no database
+# configured yet, a session that fails to open, the interaction table not
+# existing yet, and the row lookup itself raising. The module docstring
+# argues at length for why each one resolves to "assume no active row"
+# instead of propagating -- these pin that argument down to actual
+# behavior, and distinguish the two branches that are expected in normal
+# operation (no session factory yet, table not migrated yet -- no warning)
+# from the two that represent a genuine failure worth a log line (session
+# open failure, lookup failure).
+# --------------------------------------------------------------------------
+
+
+def test_active_interaction_id_sync_returns_none_without_a_session_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``get_optional_session_local() is None`` -- no database configured yet
+    for this process -- is the cheap, expected-in-tests case: it must return
+    ``None`` without ever calling the (nonexistent) session factory, and
+    without logging a warning. A caller that removed this branch would fall
+    through to ``SessionLocal()`` with ``SessionLocal is None``, which raises
+    ``TypeError`` and is instead caught by the *next* branch below -- still
+    returning ``None``, but only after logging a warning this branch is
+    specifically here to avoid."""
+
+    monkeypatch.setattr(database_module, "get_optional_session_local", lambda: None)
+
+    with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
+        result = active_interaction_id_sync(1)
+
+    assert result is None
+    assert caplog.records == []
+
+
+def test_active_interaction_id_sync_returns_none_when_opening_a_session_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A session factory that is installed but raises when called -- e.g. a
+    prior test left a factory pointed at a since-removed temporary database
+    file -- must also resolve to "no active row", but unlike the branch
+    above this is a genuine failure and must be logged.
 
     What "closes nothing" costs is pinned separately, by
     test_close_keeps_the_marker_when_the_pre_injection_read_failed below:
-    the close matches no row and the marker stays, so the live question
-    the read could not see keeps its reader.
+    the close matches no row and the marker stays, so the live question the
+    read could not see keeps its reader.
     """
-    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
-    seed_active_row(db, task_id=task_id, run_id="run-a")
 
-    def _fail():
-        raise sa.exc.OperationalError("SELECT 1", {}, Exception("database is locked"))
+    def _broken_session_local() -> None:
+        raise RuntimeError("database file has been removed")
 
     monkeypatch.setattr(
-        "xagent.web.services.task_interaction_close.get_session_local", _fail
+        database_module, "get_optional_session_local", lambda: _broken_session_local
     )
 
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
-        assert active_interaction_id_sync(task_id) is None
+        result = active_interaction_id_sync(1)
 
-    assert [record.levelno for record in caplog.records] == [logging.WARNING]
+    assert result is None
+    assert len(caplog.records) == 1
+    assert "could not open a session" in caplog.records[0].message
+
+
+def test_active_interaction_id_sync_returns_none_when_the_table_is_missing(
+    db,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A deployment that has not yet run the migration creating
+    ``task_interaction_requests`` must not raise -- and, since this is a
+    known, temporary deployment window rather than a bug, must not log a
+    warning either. A real active row is seeded so that a caller which
+    removed this gate would find it -- proving the gate, not an empty table,
+    is what produces ``None`` here."""
+
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_interaction_close.interaction_requests_table_exists",
+        lambda db: False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
+        result = active_interaction_id_sync(task_id)
+
+    assert result is None
+    assert caplog.records == []
+
+
+def test_active_interaction_id_sync_returns_none_when_the_lookup_raises(
+    db,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failure inside the row lookup itself -- reproduced here by making
+    the shared active-row predicate raise, the same seam
+    ``_answer_fence_stmt`` reuses -- must resolve to "no active row" and log
+    a warning naming the lookup, not the session-open failure above's
+    message."""
+
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    def _broken_criteria() -> list[object]:
+        raise RuntimeError("criteria unavailable")
+
+    monkeypatch.setattr(
+        "xagent.web.services.task_interaction_service._active_native_row_criteria",
+        _broken_criteria,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
+        result = active_interaction_id_sync(task_id)
+
+    assert result is None
+    assert len(caplog.records) == 1
+    assert "the active interaction row lookup failed" in caplog.records[0].message
 
 
 def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
@@ -456,12 +581,12 @@ def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
-    def _fail():
+    def _broken_session_local():
         raise sa.exc.OperationalError("SELECT 1", {}, Exception("database is locked"))
 
     with monkeypatch.context() as failing_read:
         failing_read.setattr(
-            "xagent.web.services.task_interaction_close.get_session_local", _fail
+            database_module, "get_optional_session_local", lambda: _broken_session_local
         )
         observed_id = active_interaction_id_sync(task_id)
 

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -452,6 +452,12 @@ def test_active_interaction_id_sync_returns_none_for_an_absent_task(
 # operation (no session factory yet, table not migrated yet -- no warning)
 # from the two that represent a genuine failure worth a log line (session
 # open failure, lookup failure).
+#
+# The last of the four is reached by two different schema states, and both
+# are covered: a lookup that raises because the shared predicate raises
+# (stubbed, below) and one that raises because the database really is
+# missing a column this function reads -- the pre-migration state built by
+# db_without_the_protocol_version_column further down.
 # --------------------------------------------------------------------------
 
 
@@ -507,17 +513,25 @@ def test_active_interaction_id_sync_returns_none_when_opening_a_session_fails(
     assert "could not open a session" in caplog.records[0].message
 
 
-def test_active_interaction_id_sync_returns_none_when_the_table_is_missing(
+def test_active_interaction_id_sync_returns_none_when_the_table_gate_reports_missing(
     db,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A deployment that has not yet run the migration creating
-    ``task_interaction_requests`` must not raise -- and, since this is a
-    known, temporary deployment window rather than a bug, must not log a
-    warning either. A real active row is seeded so that a caller which
-    removed this gate would find it -- proving the gate, not an empty table,
-    is what produces ``None`` here."""
+    """The table-existence gate, exercised against a database where the
+    table does exist: ``interaction_requests_table_exists`` is stubbed to
+    ``False`` while a real active row sits in a real table. What that
+    isolates is the gate itself -- a caller that removed it would find the
+    row and return its id, so ``None`` here can only have come from the
+    gate, never from an empty table.
+
+    The gate returning ``False`` for the reason it exists for -- a
+    deployment that has not yet run the migration creating
+    ``task_interaction_requests`` -- is covered without any stub by
+    test_active_interaction_id_sync_returns_none_without_the_interaction_table
+    above, which builds that schema shape for real. Both must resolve to
+    ``None`` without a warning: a known deployment window is not a
+    failure."""
 
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     seed_active_row(db, task_id=task_id, run_id="run-a")
@@ -555,6 +569,118 @@ def test_active_interaction_id_sync_returns_none_when_the_lookup_raises(
         "xagent.web.services.task_interaction_service._active_native_row_criteria",
         _broken_criteria,
     )
+
+    with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
+        result = active_interaction_id_sync(task_id)
+
+    assert result is None
+    assert len(caplog.records) == 1
+    assert "the active interaction row lookup failed" in caplog.records[0].message
+
+
+def _schema_without_the_protocol_version_column() -> sa.MetaData:
+    """This repo's full schema, minus ``tasks.interaction_protocol_version``.
+
+    The column and the CHECK constraint that names it
+    (``ck_tasks_interaction_protocol_version``) are both left out, which is
+    what the tasks table looked like before the 2026-08-10 migration added
+    the two together.
+
+    Built by cloning every table into a fresh MetaData and editing the
+    clone, rather than by creating the real schema and dropping the column
+    afterwards: SQLite refuses ``ALTER TABLE tasks DROP COLUMN
+    interaction_protocol_version`` outright while a CHECK constraint still
+    names that column (measured on SQLite 3.53.4: "error in table tasks
+    after drop column: no such column: interaction_protocol_version"), and
+    dropping a CHECK constraint is not something SQLite's ALTER TABLE can
+    do either. Every table is cloned, not just tasks, because a lone tasks
+    clone cannot resolve its own foreign keys to users and the other tables
+    it references.
+
+    ``Table.to_metadata`` has no column filter, so the removal below reaches
+    into the clone's private column collection. It is done to the clone and
+    never to ``Base.metadata``, so the real mapping is untouched.
+    """
+    metadata = sa.MetaData()
+    for table in Base.metadata.sorted_tables:
+        table.to_metadata(metadata)
+    tasks = metadata.tables[Task.__tablename__]
+    tasks._columns.remove(tasks.c.interaction_protocol_version)
+    for constraint in list(tasks.constraints):
+        if isinstance(
+            constraint, sa.CheckConstraint
+        ) and "interaction_protocol_version" in str(constraint.sqltext):
+            tasks.constraints.discard(constraint)
+    return metadata
+
+
+@pytest.fixture()
+def db_without_the_protocol_version_column(tmp_path):
+    """A deployment carrying task_interaction_requests but not the marker
+    column active_interaction_id_sync reads first.
+
+    Not a shape any single migration produces on its own -- the table and
+    the column arrive one migration apart -- but it is what a partially
+    migrated deployment can hold, and it is the one schema state that puts
+    a failing statement in front of this function rather than an empty
+    result set. Bound as the *global* engine and session factory for the
+    same reason db_without_interaction_table above is: the function under
+    test opens its own session through the process-global factory, so a
+    private engine here would leave it reading some other database.
+    """
+    previous_engine = database_module._engine
+    previous_session_local = database_module._SessionLocal
+    configure_db(db_url=f"sqlite:///{tmp_path / 'no_marker_column.db'}")
+    _schema_without_the_protocol_version_column().create_all(bind=get_engine())
+    session = get_session_local()()
+    try:
+        yield session
+    finally:
+        session.close()
+        database_module._engine = previous_engine
+        database_module._SessionLocal = previous_session_local
+
+
+def _seed_task_without_the_marker_column(db, *, run_id: str) -> int:
+    """Insert one task into a tasks table that has no marker column.
+
+    A Core INSERT naming its values explicitly, not the ORM helpers the
+    other fixtures use: those end in ``db.refresh(task)``, which SELECTs
+    every column the Task mapping declares -- including the one this
+    schema does not have -- and would fail in the fixture instead of in the
+    function under test. The INSERT below never names that column, so the
+    statement is legal against this schema even though it is compiled from
+    the full mapping.
+    """
+    user_id = make_user(db)
+    result = db.execute(
+        sa.insert(Task.__table__).values(
+            user_id=user_id, title="pre-migration schema fixture task", run_id=run_id
+        )
+    )
+    db.commit()
+    return int(result.inserted_primary_key[0])
+
+
+def test_active_interaction_id_sync_returns_none_when_the_marker_column_is_missing(
+    db_without_the_protocol_version_column,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The marker read is the first statement this function issues, and on
+    a deployment missing that column it does not come back empty -- it
+    raises OperationalError before any gate has run. The catch-all around
+    the lookup is what turns that into "assume no active row": the function
+    returns None, logs one warning, and lets the caller's close match
+    nothing, instead of failing a resume injection over a schema state the
+    next migration fixes.
+
+    A real active row is seeded to keep the None honest: the table is
+    present and populated here, so nothing but the failing marker read can
+    be producing it.
+    """
+    db = db_without_the_protocol_version_column
+    task_id = _seed_task_without_the_marker_column(db, run_id="run-a")
+    seed_active_row(db, task_id=task_id, run_id="run-a")
 
     with caplog.at_level(logging.WARNING, logger=_CLOSE_MODULE_NAME):
         result = active_interaction_id_sync(task_id)

--- a/tests/web/services/test_task_interaction_close.py
+++ b/tests/web/services/test_task_interaction_close.py
@@ -172,15 +172,23 @@ def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
     row = row_state(db, row_id)
     assert row.status == "terminated"
     assert row.terminal_reason == original_terminal_reason
-    # The clear runs unconditionally: a marker left dangling by an earlier,
-    # incomplete write still gets zeroed even though this close matched no
-    # row of its own.
+    # The clear does not need this close to have matched anything -- it
+    # needs nothing active to be left, and this row is already terminated.
+    # A marker left dangling by an earlier, incomplete write still gets
+    # zeroed here.
     assert task_marker(db, task_id) is None
 
 
-def test_close_is_a_no_op_with_no_interaction_rows_at_all(db) -> None:
-    """Today's 100% case: the table has no production writer yet."""
-    task_id = seed_task_with_run(db, run_id="run-a", marker=None)
+@pytest.mark.parametrize("seeded_marker", [None, 1])
+def test_close_is_a_no_op_with_no_interaction_rows_at_all(
+    db, seeded_marker: int | None
+) -> None:
+    """No interaction row was ever staged for this run -- today's 100%
+    case, since the table has no production writer yet. The condition on
+    the clear is "no active row remains", not "the close matched
+    something", so the marker is zeroed the same way whether it started
+    unset or set."""
+    task_id = seed_task_with_run(db, run_id="run-a", marker=seeded_marker)
 
     rowcount = close_legacy_resume_interaction(
         db, task_id=task_id, run_id="run-a", interaction_id=None
@@ -240,17 +248,19 @@ def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_rea
 
 # What the primary-key predicate does on its own, holding everything else
 # constant: one active row for this task and run, and only the id handed to
-# the close varies.
+# the close varies. The marker follows the row, not the rowcount: it clears
+# when nothing active is left, and survives when the close missed the live
+# row -- whatever the reason it missed.
 @pytest.mark.parametrize(
-    ("id_to_pass", "expected_rowcount"),
+    ("id_to_pass", "expected_rowcount", "expected_marker"),
     [
-        pytest.param("the_active_row", 1, id="the_row_observed_before_injection"),
-        pytest.param(None, 0, id="no_row_was_active_at_injection_time"),
-        pytest.param("another_row", 0, id="a_row_that_is_not_this_tasks_active_one"),
+        pytest.param("the_active_row", 1, None, id="the_row_observed_before_injection"),
+        pytest.param(None, 0, 1, id="no_row_was_active_at_injection_time"),
+        pytest.param("another_row", 0, 1, id="a_row_that_is_not_this_tasks_active_one"),
     ],
 )
 def test_close_retires_only_the_row_it_was_given(
-    db, id_to_pass: str | None, expected_rowcount: int
+    db, id_to_pass: str | None, expected_rowcount: int, expected_marker: int | None
 ) -> None:
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
@@ -272,10 +282,7 @@ def test_close_retires_only_the_row_it_was_given(
     assert (row_state(db, row_id).status == "terminated") is (expected_rowcount == 1)
     # The other task's row is out of range of this close regardless.
     assert row_state(db, other_row_id).status == "active"
-    # The marker clear is not conditioned on the close matching anything: a
-    # run that had no active row at injection time still needs its marker
-    # zeroed.
-    assert task_marker(db, task_id) is None
+    assert task_marker(db, task_id) == expected_marker
 
 
 def test_close_sync_opens_its_own_transaction_and_commits(db) -> None:
@@ -409,7 +416,13 @@ def test_active_interaction_id_sync_returns_none_when_the_read_fails(
 ) -> None:
     """A failing read must return None, not raise: the caller is on the
     injection path, and None closes nothing, while an exception would take
-    the injection down with it."""
+    the injection down with it.
+
+    What "closes nothing" costs is pinned separately, by
+    test_close_keeps_the_marker_when_the_pre_injection_read_failed below:
+    the close matches no row and the marker stays, so the live question
+    the read could not see keeps its reader.
+    """
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     seed_active_row(db, task_id=task_id, run_id="run-a")
 
@@ -424,6 +437,41 @@ def test_active_interaction_id_sync_returns_none_when_the_read_fails(
         assert active_interaction_id_sync(task_id) is None
 
     assert [record.levelno for record in caplog.records] == [logging.WARNING]
+
+
+def test_close_keeps_the_marker_when_the_pre_injection_read_failed(
+    db, monkeypatch
+) -> None:
+    """The two halves composed: the pre-injection read fails, so the close
+    is handed ``None`` and matches nothing -- and the marker survives,
+    because the question the read could not see is still active and still
+    unanswered. Clearing it there would point every reader at the legacy
+    transcript question while the native row it named waits for an answer.
+
+    The failure is injected only for the read: the close below opens its
+    own session through the same factory and has to reach a working
+    database, which is exactly the production shape -- one unreadable
+    query, not an unreachable database.
+    """
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    def _fail():
+        raise sa.exc.OperationalError("SELECT 1", {}, Exception("database is locked"))
+
+    with monkeypatch.context() as failing_read:
+        failing_read.setattr(
+            "xagent.web.services.task_interaction_close.get_session_local", _fail
+        )
+        observed_id = active_interaction_id_sync(task_id)
+
+    assert observed_id is None
+
+    rowcount = close_legacy_resume_interaction_sync(task_id, "run-a", observed_id)
+
+    assert rowcount == 0
+    assert row_state(db, row_id).status == "active"
+    assert task_marker(db, task_id) == 1
 
 
 # --------------------------------------------------------------------------
@@ -565,6 +613,11 @@ def test_close_leaves_a_question_staged_after_the_injection_alone(db) -> None:
     # The row that was observed before injection is terminal either way --
     # the reclaim retired it as expired when the new question took the slot.
     assert row_state(db, observed_id).status == "terminated"
+    # The marker stays with the surviving question. This is the whole
+    # reason the clear is conditioned: the run does have a live native
+    # question, and zeroing the marker would send every reader to the
+    # legacy transcript question instead of to this one.
+    assert task_marker(db, task_id) == 1
 
 
 def test_close_lets_a_second_question_on_the_same_run_become_active(db) -> None:

--- a/tests/web/services/test_task_interaction_close_postgresql.py
+++ b/tests/web/services/test_task_interaction_close_postgresql.py
@@ -44,6 +44,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import sessionmaker
 
 from tests.web.services.task_interaction_schema_shared import (
+    anchor_event_id,
     make_row,
     make_trace_event,
     row_state,
@@ -221,7 +222,7 @@ def _stage_a_replacement_question_the_way_a_resumed_agent_would(
         run_id=run_id,
         anchor=InteractionAnchor(
             trace_event_id=anchor_id,
-            resume_event_id="resume-event-1",
+            resume_event_id=anchor_event_id(db, anchor_id),
             resume_execution_id="resume-exec-1",
             resume_run_partition=run_id,
         ),
@@ -252,7 +253,7 @@ def _stage_a_replacement_question_the_way_a_resumed_agent_would(
         run_id=run_id,
         anchor=InteractionAnchor(
             trace_event_id=anchor_id,
-            resume_event_id="resume-event-1",
+            resume_event_id=anchor_event_id(db, anchor_id),
             resume_execution_id="resume-exec-1",
             resume_run_partition=run_id,
         ),

--- a/tests/web/services/test_task_interaction_close_postgresql.py
+++ b/tests/web/services/test_task_interaction_close_postgresql.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import sqlalchemy as sa
@@ -53,6 +54,10 @@ from tests.web.services.task_interaction_schema_shared import (
 from xagent.web.models.database import Base
 from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.services.task_interaction_close import close_legacy_resume_interaction
+from xagent.web.services.task_interaction_staging import (
+    InteractionAnchor,
+    stage_interaction_request,
+)
 
 pytestmark = pytest.mark.postgresql
 
@@ -97,7 +102,9 @@ def test_close_retires_the_active_row_for_its_own_run(db) -> None:
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=row_id
+    )
     db.commit()
 
     assert rowcount == 1
@@ -126,7 +133,9 @@ def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
     row_id = int(row.id)
     original_terminal_reason = row.terminal_reason
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=row_id
+    )
     db.commit()
 
     assert rowcount == 0
@@ -140,7 +149,9 @@ def test_close_is_a_no_op_with_no_interaction_rows_at_all(db) -> None:
     """Today's 100% case: the table has no production writer yet."""
     task_id = seed_task_with_run(db, run_id="run-a", marker=None)
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=None
+    )
     db.commit()
 
     assert rowcount == 0
@@ -151,7 +162,9 @@ def test_close_does_not_touch_a_different_runs_active_row(db) -> None:
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     orphan_row_id = seed_active_row(db, task_id=task_id, run_id="run-b")
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=orphan_row_id
+    )
     db.commit()
 
     assert rowcount == 0
@@ -179,8 +192,123 @@ def test_close_does_not_overwrite_a_row_already_recycled_by_another_terminal_rea
     db.refresh(row)
     row_id = int(row.id)
 
-    rowcount = close_legacy_resume_interaction(db, task_id=task_id, run_id="run-a")
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=row_id
+    )
     db.commit()
 
     assert rowcount == 0
     assert row_state(db, row_id).terminal_reason == "run_superseded"
+
+
+def _stage_a_replacement_question_the_way_a_resumed_agent_would(
+    db, *, task_id: int, run_id: str
+) -> tuple[int, int]:
+    """Put a second question on the same run into the active slot, the way
+    a resumed agent's own ``stage_interaction_request`` call does.
+
+    ``uq_task_interaction_active_slot`` allows one active row per task, so
+    the first question's deadline is moved into the past first, standing
+    in for the time that elapses while a resumed agent works. The second
+    call then takes ``_reclaim_stale_slot_stmt``'s expired-row branch on
+    its own. Returns ``(first_id, second_id)``.
+    """
+    now = datetime.now(timezone.utc)
+    anchor_id = make_trace_event(db, task_id=task_id)
+    first = stage_interaction_request(
+        db,
+        task_id=task_id,
+        run_id=run_id,
+        anchor=InteractionAnchor(
+            trace_event_id=anchor_id,
+            resume_event_id="resume-event-1",
+            resume_execution_id="resume-exec-1",
+            resume_run_partition=run_id,
+        ),
+        kind="clarification",
+        protocol_version=1,
+        origin="internal",
+        request_payload={"prompt": "q1"},
+        request_idempotency_key="q1",
+        expires_at=now + timedelta(minutes=15),
+        now=now,
+    )
+    db.commit()
+
+    # Both columns move together: ck_task_interaction_requests_expiry_
+    # after_creation requires expires_at > created_at.
+    staged_at = now - timedelta(hours=2)
+    db.execute(
+        sa.update(TaskInteractionRequest)
+        .where(TaskInteractionRequest.id == first.staged_db_id)
+        .values(created_at=staged_at, expires_at=staged_at + timedelta(minutes=15))
+    )
+    db.commit()
+
+    later = datetime.now(timezone.utc)
+    second = stage_interaction_request(
+        db,
+        task_id=task_id,
+        run_id=run_id,
+        anchor=InteractionAnchor(
+            trace_event_id=anchor_id,
+            resume_event_id="resume-event-1",
+            resume_execution_id="resume-exec-1",
+            resume_run_partition=run_id,
+        ),
+        kind="clarification",
+        protocol_version=1,
+        origin="internal",
+        request_payload={"prompt": "q2"},
+        request_idempotency_key="q2",
+        expires_at=later + timedelta(minutes=15),
+        now=later,
+    )
+    db.commit()
+    assert second.created is True
+    return int(first.staged_db_id), int(second.staged_db_id)
+
+
+def test_close_leaves_a_question_staged_after_the_injection_alone(db) -> None:
+    """The window this close is keyed against, on the production backend.
+    Injecting the user message is what resumes the agent, so between the
+    observation and the close the resumed agent can ask something new;
+    retiring that as "answered via legacy resume" would discard a question
+    nobody ever saw."""
+
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    observed_id, staged_after_injection_id = (
+        _stage_a_replacement_question_the_way_a_resumed_agent_would(
+            db, task_id=task_id, run_id="run-a"
+        )
+    )
+
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=observed_id
+    )
+    db.commit()
+
+    assert rowcount == 0
+    survivor = row_state(db, staged_after_injection_id)
+    assert survivor.status == "active"
+    assert survivor.terminal_reason is None
+    assert row_state(db, observed_id).status == "terminated"
+
+
+def test_close_with_no_observed_row_still_clears_the_marker(db) -> None:
+    """interaction_id=None renders as ``id IS NULL``, never true of a
+    primary key, so the close matches nothing -- while the marker clear
+    runs regardless. Identical to the SQLite result, confirmed here
+    because the rendering is the dialect's, not this module's."""
+
+    task_id = seed_task_with_run(db, run_id="run-a", marker=1)
+    row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
+
+    rowcount = close_legacy_resume_interaction(
+        db, task_id=task_id, run_id="run-a", interaction_id=None
+    )
+    db.commit()
+
+    assert rowcount == 0
+    assert row_state(db, row_id).status == "active"
+    assert task_marker(db, task_id) is None

--- a/tests/web/services/test_task_interaction_close_postgresql.py
+++ b/tests/web/services/test_task_interaction_close_postgresql.py
@@ -31,6 +31,16 @@ claims (blocking a concurrent purge, not blocking a concurrent KEY SHARE
 stager) -- every case here runs one session against one fixture at a
 time. The lock-ordering guard is therefore statement-order-in-source-code
 evidence only, not lock-behavior evidence.
+
+The marker column travels with that grid and is asserted here too: the
+clear's own NOT EXISTS subquery is rendered by the dialect, so "the
+marker survives while a live row remains, and goes once none does" is
+not something the SQLite run can settle for PostgreSQL. What stays
+SQLite-only is the composition with a failing pre-injection read
+(test_task_interaction_close.py's
+test_close_keeps_the_marker_when_the_pre_injection_read_failed) --
+that one exercises Python control flow around the same two statements
+and has no dialect content.
 """
 
 from __future__ import annotations
@@ -146,9 +156,16 @@ def test_close_is_a_no_op_replaying_an_already_terminated_row(db) -> None:
     assert task_marker(db, task_id) is None
 
 
-def test_close_is_a_no_op_with_no_interaction_rows_at_all(db) -> None:
-    """Today's 100% case: the table has no production writer yet."""
-    task_id = seed_task_with_run(db, run_id="run-a", marker=None)
+@pytest.mark.parametrize("seeded_marker", [None, 1])
+def test_close_is_a_no_op_with_no_interaction_rows_at_all(
+    db, seeded_marker: int | None
+) -> None:
+    """No interaction row was ever staged for this run -- today's 100%
+    case, since the table has no production writer yet. The condition on
+    the clear is "no active row remains", not "the close matched
+    something", so the marker is zeroed the same way whether it started
+    unset or set."""
+    task_id = seed_task_with_run(db, run_id="run-a", marker=seeded_marker)
 
     rowcount = close_legacy_resume_interaction(
         db, task_id=task_id, run_id="run-a", interaction_id=None
@@ -294,13 +311,18 @@ def test_close_leaves_a_question_staged_after_the_injection_alone(db) -> None:
     assert survivor.status == "active"
     assert survivor.terminal_reason is None
     assert row_state(db, observed_id).status == "terminated"
+    assert task_marker(db, task_id) == 1
 
 
-def test_close_with_no_observed_row_still_clears_the_marker(db) -> None:
+def test_close_keeps_the_marker_when_no_row_was_observed_but_one_is_active(
+    db,
+) -> None:
     """interaction_id=None renders as ``id IS NULL``, never true of a
-    primary key, so the close matches nothing -- while the marker clear
-    runs regardless. Identical to the SQLite result, confirmed here
-    because the rendering is the dialect's, not this module's."""
+    primary key, so the close matches nothing -- and here the marker stays,
+    because the row the pre-injection read failed to name is still active.
+    Identical to the SQLite result, confirmed here because both the ``IS
+    NULL`` rendering and the NOT EXISTS subquery are the dialect's, not
+    this module's."""
 
     task_id = seed_task_with_run(db, run_id="run-a", marker=1)
     row_id = seed_active_row(db, task_id=task_id, run_id="run-a")
@@ -312,4 +334,4 @@ def test_close_with_no_observed_row_still_clears_the_marker(db) -> None:
 
     assert rowcount == 0
     assert row_state(db, row_id).status == "active"
-    assert task_marker(db, task_id) is None
+    assert task_marker(db, task_id) == 1

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -907,6 +907,14 @@ _ABSENT_TASK_ID = 999999999
 # an admin and a guest load by id alone. That difference is what decides
 # which of the two "no row" outcomes each branch can return, so the table
 # below is the single place all of it is asserted.
+#
+# The guest branch's positive cell is not in this table: it needs a task
+# whose agent_config carries the widget binding, which this table's
+# _seeded_task fixture does not build. It lives in
+# test_ca1_guest_principal_is_authorized_on_its_own_task. The row below is
+# the negative half against a real existing row -- the branch whose
+# ownership check is a post-load Python predicate
+# (task_is_owned_by_public_principal) rather than a SQL filter.
 @pytest.mark.parametrize(
     ("make_principal", "task_exists", "expected"),
     [
@@ -947,6 +955,14 @@ _ABSENT_TASK_ID = 999999999
             False,
             svc.CreateUnavailable(reason="task_missing"),
             id="guest_on_an_absent_task",
+        ),
+        pytest.param(
+            lambda owner_id: _widget_workforce_guest_principal(
+                user_id=owner_id, workforce_id=9
+            ),
+            True,
+            svc.CreateUnauthorized(reason="not_task_principal"),
+            id="guest_on_an_existing_non_matching_task",
         ),
     ],
 )
@@ -1128,7 +1144,16 @@ def test_create_never_touches_staging_or_stages_a_row(
 ) -> None:
     """create() must not call stage_interaction_request -- confirmed here
     by asserting the table it would write to stays empty across a
-    successful (CreateNotWired) call."""
+    successful (CreateNotWired) call.
+
+    The principal here is a foreign admin, not the admin-with-no-user-id
+    this test used to carry: create() now rejects the latter before the
+    lookup, so it can no longer reach the staging seam this test is about.
+    That input did not lose its coverage -- it moved to
+    test_ca3_create_rejects_a_user_principal_carrying_no_user_id, whose four
+    cells (is_admin x task_exists) pin the rejection itself. What this test
+    still owns is the seam: a call that gets all the way to CreateNotWired
+    writes no interaction row."""
 
     task = _db.query(Task).filter(Task.id == _seeded_task).first()
     envelope = _valid_envelope()
@@ -2413,42 +2438,6 @@ def test_module_issues_zero_sa_text_calls() -> None:
     assert text_calls == []
 
 
-def test_no_production_module_outside_this_one_renders_a_responder_identity() -> None:
-    """``responder_identity`` values exist only where ``identity_string()``
-    is called, and every such call is in this module -- inside
-    ``respond()``, which the create/respond gate holds at zero production
-    callers.
-
-    That chain is what makes the fail-closed tightening in
-    ``identity_string()`` a no-op for today's behavior rather than a
-    change to it: no production path reaches the function at all, so no
-    caller can be relying on the ``"user:None"`` string it used to
-    produce. Written as a scan rather than as a behavior case because the
-    claim is about the absence of call sites, which no constructed call
-    can demonstrate.
-
-    Shares the blind spots of every AST scan over this package
-    (``interaction_static_scan_shared``): dynamic access, alias chains,
-    the ``scripts/`` tree, and use in value position are all invisible.
-    """
-
-    import ast
-
-    from tests.web.services.interaction_static_scan_shared import _scan_root
-
-    callers = []
-    for path in _scan_root("task_interaction_service"):
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "identity_string"
-            ):
-                callers.append(f"{path.name}:{node.lineno}")
-    assert callers == []
-
-
 # ---------------------------------------------------------------------------
 # respond(): the answer-side entry point. respond() owns and retires its own
 # session (see its docstring), so every test below patches
@@ -3111,6 +3100,63 @@ def test_respond_rejects_a_guest_principal_with_zero_populated_directions(
             interaction_id=interaction_id,
             task_id=task_id,
             principal=guest,
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+@pytest.mark.parametrize(
+    "principal",
+    [
+        pytest.param(
+            svc.InteractionPrincipal(
+                kind="user", user_id=None, is_admin=True, auth_mode=None
+            ),
+            id="user_without_an_id",
+        ),
+        pytest.param(
+            svc.InteractionPrincipal(
+                kind="guest",
+                user_id=1,
+                is_admin=False,
+                auth_mode="widget",
+                widget_workforce_id=9,
+                guest_id="",
+            ),
+            id="guest_with_a_blank_guest_id",
+        ),
+        pytest.param(
+            svc.InteractionPrincipal(
+                kind="service", user_id=1, is_admin=False, auth_mode=None
+            ),
+            id="unrecognized_kind",
+        ),
+    ],
+)
+def test_respond_rejects_every_principal_identity_string_cannot_name(
+    _respond_db, principal: svc.InteractionPrincipal
+) -> None:
+    """``identity_string()`` raises for exactly three principal shapes, and
+    ``respond()`` calls it at four points with no guard of its own. What
+    keeps those four calls safe is the authorization gate above them, which
+    happens to require the same fields -- a real coupling that nothing
+    enforced until this test. Each shape below must come back as
+    ``RespondUnauthorized(reason="not_task_principal")``, never as a raised
+    ``ValueError`` escaping the function."""
+
+    with pytest.raises(ValueError):
+        principal.identity_string()
+
+    _owner_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
             envelope=_respond_envelope(),
         )
 

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -567,12 +567,104 @@ def test_ca1_principal_not_owning_the_task_is_unauthorized(
     assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
 
 
-def test_cu1_missing_task_is_unavailable(_db: Session) -> None:
-    envelope = _valid_envelope()
-    outcome = svc.create(
-        _db, task_id=999999999, principal=_owning_principal(1), envelope=envelope
+def _admin_principal(user_id: int) -> svc.InteractionPrincipal:
+    return svc.InteractionPrincipal(
+        kind="user",
+        user_id=user_id,
+        is_admin=True,
+        auth_mode=None,
     )
-    assert outcome == svc.CreateUnavailable(reason="task_missing")
+
+
+# The id create() is asked about when a scenario wants no matching row.
+_ABSENT_TASK_ID = 999999999
+
+
+# create()'s task lookup, one row per (principal branch x ownership x
+# whether the task exists). The three branches load differently on
+# purpose: a non-admin "user" carries an owner predicate into the lookup,
+# an admin and a guest load by id alone. That difference is what decides
+# which of the two "no row" outcomes each branch can return, so the table
+# below is the single place all of it is asserted.
+@pytest.mark.parametrize(
+    ("make_principal", "task_exists", "expected"),
+    [
+        pytest.param(
+            lambda owner_id: _owning_principal(owner_id),
+            True,
+            svc.CreateNotWired(reason="seam_not_wired"),
+            id="owner_user_on_its_own_task",
+        ),
+        pytest.param(
+            lambda owner_id: _owning_principal(owner_id + 1000),
+            True,
+            svc.CreateUnauthorized(reason="not_task_principal"),
+            id="foreign_user_on_an_existing_task",
+        ),
+        pytest.param(
+            lambda owner_id: _owning_principal(owner_id),
+            False,
+            svc.CreateUnauthorized(reason="not_task_principal"),
+            id="user_on_an_absent_task",
+        ),
+        pytest.param(
+            lambda owner_id: _admin_principal(owner_id + 1000),
+            True,
+            svc.CreateNotWired(reason="seam_not_wired"),
+            id="admin_on_someone_elses_task",
+        ),
+        pytest.param(
+            lambda owner_id: _admin_principal(owner_id + 1000),
+            False,
+            svc.CreateUnavailable(reason="task_missing"),
+            id="admin_on_an_absent_task",
+        ),
+        pytest.param(
+            lambda owner_id: _widget_workforce_guest_principal(
+                user_id=owner_id, workforce_id=9
+            ),
+            False,
+            svc.CreateUnavailable(reason="task_missing"),
+            id="guest_on_an_absent_task",
+        ),
+    ],
+)
+def test_ca2_task_lookup_is_owner_scoped_for_non_admin_user_principals(
+    _db: Session,
+    _seeded_task: int,
+    make_principal: Any,
+    task_exists: bool,
+    expected: Any,
+) -> None:
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
+    task_id = _seeded_task if task_exists else _ABSENT_TASK_ID
+    outcome = svc.create(
+        _db,
+        task_id=task_id,
+        principal=make_principal(task.user_id),
+        envelope=_valid_envelope(),
+    )
+    assert outcome == expected
+
+
+def test_ca2_a_non_admin_user_cannot_tell_a_foreign_task_from_an_absent_one(
+    _db: Session, _seeded_task: int
+) -> None:
+    """The owner predicate lives in the lookup's WHERE clause, so a
+    non-admin "user" principal gets one empty result set for both "this
+    task belongs to someone else" and "there is no such task". Both must
+    produce the identical outcome object, or the pair is an existence
+    oracle for a principal not entitled to one."""
+
+    principal = _owning_principal(999999)
+    on_a_foreign_task = svc.create(
+        _db, task_id=_seeded_task, principal=principal, envelope=_valid_envelope()
+    )
+    on_an_absent_task = svc.create(
+        _db, task_id=_ABSENT_TASK_ID, principal=principal, envelope=_valid_envelope()
+    )
+    assert on_a_foreign_task == on_an_absent_task
+    assert on_a_foreign_task == svc.CreateUnauthorized(reason="not_task_principal")
 
 
 def test_cw1_fully_valid_call_returns_not_wired(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -496,6 +496,146 @@ def test_cv3_values_not_shaped_like_v1_payload_is_rejected(
     assert outcome == svc.CreateValidationRejected(reason="invalid_values")
 
 
+def _interaction(**overrides: Any) -> dict[str, Any]:
+    item: dict[str, Any] = {"type": "text_input", "field": "env", "label": "Env"}
+    item.update(overrides)
+    return item
+
+
+def _values(interactions: list[dict[str, Any]], message: str = "Which one?") -> Any:
+    return {"message": message, "interactions": interactions}
+
+
+# The write side's admissibility rules, one row per rule. Every row here is
+# shape-valid per AskUserQuestionArgs and JSON-serializable, so the only
+# thing that can reject it is validate_v1_write_payload.
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(_values([], message="   "), id="blank_message"),
+        pytest.param(_values([], message=""), id="empty_message"),
+        pytest.param(
+            _values([_interaction(type="carrier_pigeon")]), id="unrenderable_type"
+        ),
+        pytest.param(
+            _values([_interaction(field="env"), _interaction(field="env")]),
+            id="duplicated_field",
+        ),
+        pytest.param(
+            _values([_interaction(type="select_one", options=None)]),
+            id="select_one_without_options",
+        ),
+        pytest.param(
+            _values([_interaction(type="select_one", options=[])]),
+            id="select_one_with_an_empty_option_list",
+        ),
+        pytest.param(
+            _values([_interaction(type="select_multiple", options=None)]),
+            id="select_multiple_without_options",
+        ),
+        pytest.param(
+            _values([_interaction(type="action_cards", options=None)]),
+            id="action_cards_without_options",
+        ),
+        pytest.param(
+            _values(
+                [_interaction(options=[{"label": "Yes", "value": "yes"}])],
+            ),
+            id="text_input_with_options",
+        ),
+        pytest.param(
+            _values(
+                [
+                    _interaction(
+                        type="confirm", options=[{"label": "Yes", "value": "yes"}]
+                    )
+                ],
+            ),
+            id="confirm_with_options",
+        ),
+        pytest.param(
+            _values([_interaction(type="number_input", min=10, max=3)]),
+            id="min_greater_than_max",
+        ),
+    ],
+)
+def test_cv4_write_side_payload_rules_reject_the_envelope(
+    _db: Session, _seeded_task: int, values: Any
+) -> None:
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
+    outcome = svc.create(
+        _db,
+        task_id=_seeded_task,
+        principal=_owning_principal(task.user_id),
+        envelope=_valid_envelope(values=values),
+    )
+    assert outcome == svc.CreateValidationRejected(reason="invalid_values")
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param(
+            _values(
+                [
+                    _interaction(
+                        type="select_one", options=[{"label": "A", "value": "a"}]
+                    ),
+                    _interaction(
+                        type="select_multiple",
+                        field="tags",
+                        options=[{"label": "B", "value": "b"}],
+                    ),
+                    _interaction(type="text_input", field="notes"),
+                    _interaction(type="file_upload", field="doc"),
+                    _interaction(type="confirm", field="agree"),
+                    _interaction(type="number_input", field="count", min=1, max=9),
+                    _interaction(
+                        type="action_cards",
+                        field="action",
+                        options=[{"label": "C", "value": "c"}],
+                    ),
+                ]
+            ),
+            id="one_item_of_every_v1_type",
+        ),
+        pytest.param(_values([]), id="prose_only_question_with_no_form"),
+        pytest.param(
+            _values([_interaction(type="number_input", field="n", min=3, max=3)]),
+            id="min_equal_to_max",
+        ),
+    ],
+)
+def test_cv4_write_side_payload_rules_accept_a_legal_payload(
+    _db: Session, _seeded_task: int, values: Any
+) -> None:
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
+    outcome = svc.create(
+        _db,
+        task_id=_seeded_task,
+        principal=_owning_principal(task.user_id),
+        envelope=_valid_envelope(values=values),
+    )
+    assert outcome == svc.CreateNotWired(reason="seam_not_wired")
+
+
+def test_cv4_the_read_direction_parser_still_accepts_what_the_write_side_rejects(
+    _db: Session, _seeded_task: int
+) -> None:
+    """The two directions have different failure policies for the same
+    payload. parse_v1_request_payload is what the read surface calls on an
+    already-persisted row, and it must keep accepting every payload it
+    accepts today -- widening it would turn readable-but-odd rows into
+    unanswerable ones. Only the write side refuses."""
+
+    values = _values([_interaction(type="select_one", options=None)])
+    parsed = svc.parse_v1_request_payload(values)
+    assert parsed.message == "Which one?"
+    assert parsed.interactions[0].type == "select_one"
+    with pytest.raises(ValueError):
+        svc.validate_v1_write_payload(parsed)
+
+
 def test_cv3_ttl_out_of_policy_range_is_rejected_not_clamped(
     _db: Session, _seeded_task: int
 ) -> None:

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -558,6 +558,32 @@ def _values(interactions: list[dict[str, Any]], message: str = "Which one?") -> 
             _values([_interaction(type="number_input", min=10, max=3)]),
             id="min_greater_than_max",
         ),
+        pytest.param(
+            _values(
+                [_interaction(type="select_one", options=[{"label": "", "value": "a"}])]
+            ),
+            id="option_with_a_blank_label",
+        ),
+        pytest.param(
+            _values(
+                [_interaction(type="select_one", options=[{"label": "A", "value": ""}])]
+            ),
+            id="option_with_a_blank_value",
+        ),
+        pytest.param(
+            _values(
+                [
+                    _interaction(
+                        type="action_cards",
+                        options=[
+                            {"label": "A", "value": "a"},
+                            {"label": "", "value": ""},
+                        ],
+                    )
+                ]
+            ),
+            id="one_blank_option_among_usable_ones",
+        ),
     ],
 )
 def test_cv4_write_side_payload_rules_reject_the_envelope(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -150,6 +150,7 @@ from xagent.web.services.ops_signals import (
     active_degradations,
     clear_degradation,
 )
+from xagent.web.services.task_clarification_draft import CLARIFICATION_REQUEST_TTL
 from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD
 
 _DEGRADATION_SIGNALS_UNDER_TEST = (
@@ -650,6 +651,7 @@ def test_cv3_ttl_out_of_policy_range_is_rejected_not_clamped(
 @pytest.mark.parametrize(
     "ttl_seconds",
     [
+        pytest.param(59, id="one_below_min_rejected"),
         pytest.param(604801, id="one_above_max_rejected"),
         # True is also rejected via the range check below on its own (it
         # compares equal to 1, under the 60-second minimum), independent of
@@ -692,6 +694,22 @@ def test_cv3_ttl_at_policy_boundary_reaches_create_not_wired(
         envelope=envelope,
     )
     assert outcome == svc.CreateNotWired(reason="seam_not_wired")
+
+
+def test_the_published_ttl_falls_inside_the_override_interval() -> None:
+    """The two constants describe different quantities -- one the value
+    the publication path writes into expires_at, the other the range a
+    caller's own override has to fall inside -- and are deliberately not
+    unified. The one relationship that does have to hold between them is
+    pinned here, so that moving either number alone cannot leave the
+    published TTL outside the range this facade would accept for it."""
+
+    published_ttl_seconds = CLARIFICATION_REQUEST_TTL.total_seconds()
+    assert (
+        svc._MIN_INTERACTION_TTL_SECONDS
+        <= published_ttl_seconds
+        <= svc._MAX_INTERACTION_TTL_SECONDS
+    )
 
 
 def test_ca1_principal_not_owning_the_task_is_unauthorized(

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -807,6 +807,32 @@ def test_ca2_a_non_admin_user_cannot_tell_a_foreign_task_from_an_absent_one(
     assert on_a_foreign_task == svc.CreateUnauthorized(reason="not_task_principal")
 
 
+@pytest.mark.parametrize("is_admin", [False, True], ids=["plain_user", "admin"])
+@pytest.mark.parametrize("task_exists", [True, False], ids=["real_task", "absent_task"])
+def test_ca3_create_rejects_a_user_principal_carrying_no_user_id(
+    _db: Session, _seeded_task: int, is_admin: bool, task_exists: bool
+) -> None:
+    """is_admin authorizes without ownership, but not without an identity.
+    Rejected before the lookup on both branches: the owner predicate would
+    otherwise render as Task.user_id IS NULL and match every ownerless
+    task, and an admin passing on the flag alone would reach the write
+    point with nothing to record as who acted."""
+
+    principal = svc.InteractionPrincipal(
+        kind="user",
+        user_id=None,
+        is_admin=is_admin,
+        auth_mode=None,
+    )
+    outcome = svc.create(
+        _db,
+        task_id=_seeded_task if task_exists else _ABSENT_TASK_ID,
+        principal=principal,
+        envelope=_valid_envelope(),
+    )
+    assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
+
+
 def test_cw1_fully_valid_call_returns_not_wired(
     _db: Session, _seeded_task: int
 ) -> None:
@@ -828,13 +854,14 @@ def test_create_never_touches_staging_or_stages_a_row(
     by asserting the table it would write to stays empty across a
     successful (CreateNotWired) call."""
 
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
     envelope = _valid_envelope()
     outcome = svc.create(
         _db,
         task_id=_seeded_task,
         principal=svc.InteractionPrincipal(
             kind="user",
-            user_id=None,
+            user_id=task.user_id + 1000,
             is_admin=True,
             auth_mode=None,
         ),
@@ -2110,6 +2137,42 @@ def test_module_issues_zero_sa_text_calls() -> None:
     assert text_calls == []
 
 
+def test_no_production_module_outside_this_one_renders_a_responder_identity() -> None:
+    """``responder_identity`` values exist only where ``identity_string()``
+    is called, and every such call is in this module -- inside
+    ``respond()``, which the create/respond gate holds at zero production
+    callers.
+
+    That chain is what makes the fail-closed tightening in
+    ``identity_string()`` a no-op for today's behavior rather than a
+    change to it: no production path reaches the function at all, so no
+    caller can be relying on the ``"user:None"`` string it used to
+    produce. Written as a scan rather than as a behavior case because the
+    claim is about the absence of call sites, which no constructed call
+    can demonstrate.
+
+    Shares the blind spots of every AST scan over this package
+    (``interaction_static_scan_shared``): dynamic access, alias chains,
+    the ``scripts/`` tree, and use in value position are all invisible.
+    """
+
+    import ast
+
+    from tests.web.services.interaction_static_scan_shared import _scan_root
+
+    callers = []
+    for path in _scan_root("task_interaction_service"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "identity_string"
+            ):
+                callers.append(f"{path.name}:{node.lineno}")
+    assert callers == []
+
+
 # ---------------------------------------------------------------------------
 # respond(): the answer-side entry point. respond() owns and retires its own
 # session (see its docstring), so every test below patches
@@ -2552,6 +2615,35 @@ def test_respond_rejects_a_user_principal_that_does_not_own_the_task(
             interaction_id=interaction_id,
             task_id=task_id,
             principal=intruder,
+            envelope=_respond_envelope(),
+        )
+
+        assert outcome == svc.RespondUnauthorized(reason="not_task_principal")
+
+
+@pytest.mark.parametrize("is_admin", [False, True], ids=["plain_user", "admin"])
+def test_respond_rejects_a_user_principal_carrying_no_user_id(
+    _respond_db, is_admin: bool
+) -> None:
+    """is_admin authorizes without ownership, but not without an identity:
+    a principal that passed on the flag alone would reach the write point
+    with nothing to record as who answered."""
+
+    _owner_id, task_id = _waiting_task(_respond_db)
+    interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
+    principal = svc.InteractionPrincipal(
+        kind="user",
+        user_id=None,
+        is_admin=is_admin,
+        auth_mode=None,
+    )
+    with _asserts_no_side_effects(
+        _respond_db, task_id=task_id, interaction_id=interaction_id
+    ):
+        outcome = svc.respond(
+            interaction_id=interaction_id,
+            task_id=task_id,
+            principal=principal,
             envelope=_respond_envelope(),
         )
 

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -774,11 +774,23 @@ def test_validate_accepts_min_and_max_on_a_non_number_type(
     _db: Session, _seeded_task: int
 ) -> None:
     """Only number_input reads min/max; on every other type they are an
-    ignored hint, and the question still asks exactly what it asks, so the
-    min > max rule stays type-agnostic rather than being scoped to
-    number_input."""
+    ignored hint, and the question still asks exactly what it asks."""
 
     values = _values([_interaction(type="text_input", min=1, max=5)])
+    parsed = svc.parse_v1_request_payload(values)
+    svc.validate_v1_write_payload(parsed)
+
+
+def test_validate_accepts_an_inverted_min_max_on_a_non_number_type(
+    _db: Session, _seeded_task: int
+) -> None:
+    """The min > max rule is scoped to the one type that reads the pair.
+    ``clarification-form.tsx`` passes min and max to the rendered control
+    only in its number_input branch, so on a text_input an inverted range
+    never reaches the user: it is a hint nobody reads, not a question
+    nobody can answer, and the write is not refused for it."""
+
+    values = _values([_interaction(type="text_input", min=10, max=3)])
     parsed = svc.parse_v1_request_payload(values)
     svc.validate_v1_write_payload(parsed)
 

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -646,6 +646,143 @@ def test_cv4_write_side_payload_rules_accept_a_legal_payload(
     assert outcome == svc.CreateNotWired(reason="seam_not_wired")
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="all_whitespace"),
+    ],
+)
+def test_validate_rejects_a_blank_interaction_field(
+    _db: Session, _seeded_task: int, field: str
+) -> None:
+    values = _values([_interaction(field=field)])
+    parsed = svc.parse_v1_request_payload(values)
+    with pytest.raises(ValueError, match=r"interactions\[0\]\.field is blank"):
+        svc.validate_v1_write_payload(parsed)
+
+
+def test_validate_rejects_a_field_with_surrounding_whitespace(
+    _db: Session, _seeded_task: int
+) -> None:
+    """Non-blank once stripped, but the stored key still would not be the
+    key a strip-agnostic answer-side comparison would need: ``" a "`` never
+    equal-matches an answer keyed ``"a"``, the same key-integrity reason a
+    blank field is refused."""
+
+    values = _values([_interaction(field=" a ")])
+    parsed = svc.parse_v1_request_payload(values)
+    with pytest.raises(
+        ValueError, match=r"interactions\[0\]\.field carries surrounding whitespace"
+    ):
+        svc.validate_v1_write_payload(parsed)
+
+
+def test_validate_accepts_a_field_with_no_surrounding_whitespace(
+    _db: Session, _seeded_task: int
+) -> None:
+    values = _values([_interaction(field="a")])
+    parsed = svc.parse_v1_request_payload(values)
+    svc.validate_v1_write_payload(parsed)
+
+
+def test_validate_reports_a_blank_field_as_blank_not_as_duplicated(
+    _db: Session, _seeded_task: int
+) -> None:
+    """Two blank fields would also be equal to each other, so the blank
+    check has to run before the duplicate check reaches them -- otherwise
+    the caller learns "duplicated" for a payload whose real problem is that
+    neither interaction names a field at all."""
+
+    values = _values([_interaction(field=""), _interaction(field="", label="Second")])
+    parsed = svc.parse_v1_request_payload(values)
+    with pytest.raises(ValueError) as excinfo:
+        svc.validate_v1_write_payload(parsed)
+    assert "field is blank" in str(excinfo.value)
+    assert "is duplicated" not in str(excinfo.value)
+
+
+def test_validate_rejects_duplicate_option_values_within_one_interaction(
+    _db: Session, _seeded_task: int
+) -> None:
+    values = _values(
+        [
+            _interaction(
+                type="select_one",
+                options=[
+                    {"label": "First", "value": "a"},
+                    {"label": "Second", "value": "a"},
+                ],
+            )
+        ]
+    )
+    parsed = svc.parse_v1_request_payload(values)
+    with pytest.raises(
+        ValueError, match=r"interactions\[0\]\.options\[1\]\.value 'a' is duplicated"
+    ):
+        svc.validate_v1_write_payload(parsed)
+
+
+def test_validate_accepts_duplicate_option_labels(
+    _db: Session, _seeded_task: int
+) -> None:
+    """Labels may repeat -- the renderer resolves a submitted answer back to
+    an option by matching on value, so two options sharing a label are only
+    confusing to look at; the answer still names exactly one of them."""
+
+    values = _values(
+        [
+            _interaction(
+                type="select_one",
+                options=[
+                    {"label": "Same", "value": "a"},
+                    {"label": "Same", "value": "b"},
+                ],
+            )
+        ]
+    )
+    parsed = svc.parse_v1_request_payload(values)
+    svc.validate_v1_write_payload(parsed)
+
+
+def test_validate_accepts_a_blank_interaction_label(
+    _db: Session, _seeded_task: int
+) -> None:
+    """This is the decision that a blank ``label`` is not refused, pinned
+    down: ``clarification-form.tsx`` renders ``interaction.label ||
+    interaction.field`` (line 492), so the field name stands in for a blank
+    label, and ``_normalize_ask_user_interactions`` (``react.py``) repairs a
+    blank ``field`` on every ``ask_user_question`` payload but never touches
+    ``label``, so a model that emits ``label=""`` reaches
+    ``build_clarification_payload`` with it. Refusing it would refuse a
+    shape the second producer really emits."""
+
+    values = _values([_interaction(label="")])
+    parsed = svc.parse_v1_request_payload(values)
+    svc.validate_v1_write_payload(parsed)
+
+
+def test_validate_accepts_an_empty_accept_list_on_file_upload(
+    _db: Session, _seeded_task: int
+) -> None:
+    values = _values([_interaction(type="file_upload", field="doc", accept=[])])
+    parsed = svc.parse_v1_request_payload(values)
+    svc.validate_v1_write_payload(parsed)
+
+
+def test_validate_accepts_min_and_max_on_a_non_number_type(
+    _db: Session, _seeded_task: int
+) -> None:
+    """Only number_input reads min/max; on every other type they are an
+    ignored hint, and the question still asks exactly what it asks, so the
+    min > max rule stays type-agnostic rather than being scoped to
+    number_input."""
+
+    values = _values([_interaction(type="text_input", min=1, max=5)])
+    parsed = svc.parse_v1_request_payload(values)
+    svc.validate_v1_write_payload(parsed)
+
+
 def test_cv4_the_read_direction_parser_still_accepts_what_the_write_side_rejects(
     _db: Session, _seeded_task: int
 ) -> None:

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1437,6 +1437,51 @@ def test_ca1_unknown_principal_kind_is_always_unauthorized(
     assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
 
 
+@pytest.mark.parametrize("task_exists", [True, False], ids=["present", "absent"])
+def test_ca1_unknown_principal_kind_is_rejected_before_the_task_lookup(
+    _db: Session, _seeded_task: int, monkeypatch: pytest.MonkeyPatch, task_exists: bool
+) -> None:
+    """An unrecognized kind is not owner-scoped, so a lookup built for it
+    would run by id alone -- and the id-only branch reports
+    Unavailable(task_missing) for a task that does not exist. Rejecting
+    before the lookup is what keeps the two task ids below indistinguishable
+    to such a principal: the same Unauthorized(not_task_principal) for a task
+    that exists and for one that does not.
+
+    The outcome alone cannot show where the rejection happened, since the
+    end of the branch chain returns the same object for the existing task.
+    What separates them is whether the lookup was built at all, so that is
+    asserted too: with the guard in place db.query is never called; delete
+    it and the absent-task case turns Unavailable(task_missing) while the
+    present-task case starts querying."""
+
+    task_id = _seeded_task if task_exists else _seeded_task + 10_000
+    if not task_exists:
+        assert _db.query(Task).filter(Task.id == task_id).first() is None
+
+    queried: list[Any] = []
+    real_query = _db.query
+
+    def _recording_query(*args: Any, **kwargs: Any) -> Any:
+        queried.append(args)
+        return real_query(*args, **kwargs)
+
+    monkeypatch.setattr(_db, "query", _recording_query)
+
+    principal = svc.InteractionPrincipal(
+        kind="service",
+        user_id=1,
+        is_admin=False,
+        auth_mode=None,
+    )
+    outcome = svc.create(
+        _db, task_id=task_id, principal=principal, envelope=_valid_envelope()
+    )
+
+    assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
+    assert queried == []
+
+
 def test_ca1_entity_binding_with_non_int_convertible_config_value_is_rejected_not_raised(
     _db: Session, _session_factory
 ) -> None:

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -1014,6 +1014,101 @@ def test_ca3_create_rejects_a_user_principal_carrying_no_user_id(
     assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
 
 
+def test_ca4_an_unauthorized_principal_learns_nothing_about_the_payload(
+    _db: Session, _seeded_task: int
+) -> None:
+    """A caller with no claim on the task must not learn which envelope
+    shapes this service accepts. Authorization now runs before any envelope
+    check, so a malformed envelope from an unauthorized caller is still
+    reported as unauthorized, not as a validation rejection."""
+
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
+    outcome = svc.create(
+        _db,
+        task_id=_seeded_task,
+        principal=_owning_principal(task.user_id + 1000),
+        envelope=_valid_envelope(kind="not_a_kind"),
+    )
+    assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
+
+
+def test_ca4_an_absent_task_is_reported_before_the_payload_is_judged(
+    _db: Session, _seeded_task: int
+) -> None:
+    """Mirrors the unauthorized case for the other id-only outcome: an
+    admin against a task that does not exist learns task_missing, never a
+    validation reason, regardless of how malformed the envelope is."""
+
+    outcome = svc.create(
+        _db,
+        task_id=_ABSENT_TASK_ID,
+        principal=_admin_principal(1),
+        envelope=_valid_envelope(kind="not_a_kind"),
+    )
+    assert outcome == svc.CreateUnavailable(reason="task_missing")
+
+
+@pytest.mark.parametrize(
+    ("envelope_overrides", "expected_reason"),
+    [
+        pytest.param({"kind": "not_a_kind"}, "unknown_kind", id="bad_kind"),
+        pytest.param(
+            {"protocol_version": 999},
+            "unknown_protocol_version",
+            id="bad_protocol_version",
+        ),
+        pytest.param(
+            {"request_idempotency_key": "not url safe!"},
+            "malformed_idempotency_key",
+            id="bad_idempotency_key",
+        ),
+        pytest.param(
+            {"values": {"not": "a valid payload"}},
+            "invalid_values",
+            id="bad_values",
+        ),
+    ],
+)
+def test_cv_authorized_caller_still_gets_every_validation_reason(
+    _db: Session,
+    _seeded_task: int,
+    envelope_overrides: dict[str, Any],
+    expected_reason: str,
+) -> None:
+    """Authorization moving ahead of validation must not change what an
+    authorized caller sees: the same four reasons, unchanged, for the same
+    four malformed shapes."""
+
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
+    outcome = svc.create(
+        _db,
+        task_id=_seeded_task,
+        principal=_owning_principal(task.user_id),
+        envelope=_valid_envelope(**envelope_overrides),
+    )
+    assert outcome == svc.CreateValidationRejected(reason=expected_reason)
+
+
+def test_create_logs_the_refused_payload_diagnostic(
+    _db: Session, _seeded_task: int, caplog: pytest.LogCaptureFixture
+) -> None:
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
+    values = _values(
+        [_interaction(type="select_one", options=[{"label": "", "value": "a"}])]
+    )
+    with caplog.at_level(logging.WARNING):
+        outcome = svc.create(
+            _db,
+            task_id=_seeded_task,
+            principal=_owning_principal(task.user_id),
+            envelope=_valid_envelope(values=values),
+        )
+
+    assert outcome == svc.CreateValidationRejected(reason="invalid_values")
+    assert [r.levelno for r in caplog.records] == [logging.WARNING]
+    assert "interactions[0].options[0] has a blank label or value" in caplog.text
+
+
 def test_cw1_fully_valid_call_returns_not_wired(
     _db: Session, _seeded_task: int
 ) -> None:

--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -903,18 +903,34 @@ _ABSENT_TASK_ID = 999999999
 
 # create()'s task lookup, one row per (principal branch x ownership x
 # whether the task exists). The three branches load differently on
-# purpose: a non-admin "user" carries an owner predicate into the lookup,
-# an admin and a guest load by id alone. That difference is what decides
-# which of the two "no row" outcomes each branch can return, so the table
-# below is the single place all of it is asserted.
+# purpose: a non-admin "user" and a guest both carry the same owner
+# predicate (Task.user_id == principal.user_id) into the lookup, while an
+# admin loads by id alone. That difference is what decides which of the
+# two "no row" outcomes each branch can return, so the table below is the
+# single place all of it is asserted.
 #
 # The guest branch's positive cell is not in this table: it needs a task
 # whose agent_config carries the widget binding, which this table's
 # _seeded_task fixture does not build. It lives in
-# test_ca1_guest_principal_is_authorized_on_its_own_task. The row below is
-# the negative half against a real existing row -- the branch whose
-# ownership check is a post-load Python predicate
-# (task_is_owned_by_public_principal) rather than a SQL filter.
+# test_ca1_guest_principal_is_authorized_on_its_own_task.
+#
+# The three guest rows below all end in the same outcome and get there by
+# three different routes, which is the point of listing them separately:
+#
+#   guest_on_an_absent_task            no row for that id at all
+#   guest_of_another_owner_...         a row exists, the owner term in the
+#                                      lookup excludes it, so nothing loads
+#   guest_on_an_existing_non_matching  the owner term admits the row, and
+#                                      the post-load Python predicate
+#                                      (task_is_owned_by_public_principal)
+#                                      refuses it on agent_config
+#
+# None of the three separates the owner term from the Python predicate on
+# its own -- _seeded_task carries no agent_config, so the second row would
+# still be refused with the owner term removed. The cell that does
+# separate them needs a task whose agent_config matches in full and whose
+# user_id does not, and it lives in
+# test_ca1_guest_principal_is_rejected_on_another_owners_matching_task.
 @pytest.mark.parametrize(
     ("make_principal", "task_exists", "expected"),
     [
@@ -953,8 +969,16 @@ _ABSENT_TASK_ID = 999999999
                 user_id=owner_id, workforce_id=9
             ),
             False,
-            svc.CreateUnavailable(reason="task_missing"),
+            svc.CreateUnauthorized(reason="not_task_principal"),
             id="guest_on_an_absent_task",
+        ),
+        pytest.param(
+            lambda owner_id: _widget_workforce_guest_principal(
+                user_id=owner_id + 1000, workforce_id=9
+            ),
+            True,
+            svc.CreateUnauthorized(reason="not_task_principal"),
+            id="guest_of_another_owner_on_an_existing_task",
         ),
         pytest.param(
             lambda owner_id: _widget_workforce_guest_principal(
@@ -966,7 +990,7 @@ _ABSENT_TASK_ID = 999999999
         ),
     ],
 )
-def test_ca2_task_lookup_is_owner_scoped_for_non_admin_user_principals(
+def test_ca2_task_lookup_is_owner_scoped_for_every_branch_but_admin(
     _db: Session,
     _seeded_task: int,
     make_principal: Any,
@@ -1267,6 +1291,74 @@ def test_ca1_guest_principal_is_rejected_on_a_non_matching_task(
     assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
 
 
+def test_ca1_guest_principal_is_rejected_on_another_owners_matching_task(
+    _db: Session, _session_factory
+) -> None:
+    """Every conjunct task_is_owned_by_public_principal evaluates matches
+    -- auth_mode, the workforce binding, and guest_id are all the task's
+    own values -- and the task still belongs to a different user. The
+    predicate deliberately does not carry the Task.user_id term (see its
+    docstring: the four public-chat entry points enforce it as a filter on
+    the query that loads the task, never as a post-load check), so the
+    only thing that can refuse this call is create()'s own owner-scoped
+    lookup. Drop Task.user_id from that lookup and this call is
+    authorized against another user's task."""
+
+    db = _session_factory()
+    owner_id = make_user(db)
+    other_user_id = make_user(db)
+    task_id = _widget_workforce_task(db, user_id=owner_id, workforce_id=9)
+    db.close()
+
+    assert other_user_id != owner_id
+    principal = _widget_workforce_guest_principal(user_id=other_user_id, workforce_id=9)
+    outcome = svc.create(
+        _db, task_id=task_id, principal=principal, envelope=_valid_envelope()
+    )
+    assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
+
+
+def test_ca3_create_rejects_a_guest_principal_carrying_no_user_id(
+    _db: Session, _session_factory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guest lookup is owner-scoped, so a guest with no user_id would
+    compile to Task.user_id IS NULL and reject only because the column is
+    NOT NULL. create() rejects before the lookup instead, and the outcome
+    object cannot tell the two apart -- both are
+    Unauthorized(not_task_principal). What separates them is whether the
+    query was built at all, so that is what this test asserts: with the
+    pre-lookup guard in place db.query is never called; delete the guard
+    and it is, even though the outcome stays the same."""
+
+    db = _session_factory()
+    owner_id = make_user(db)
+    task_id = _widget_workforce_task(db, user_id=owner_id, workforce_id=9)
+    db.close()
+
+    queried: list[Any] = []
+    real_query = _db.query
+
+    def _recording_query(*args: Any, **kwargs: Any) -> Any:
+        queried.append(args)
+        return real_query(*args, **kwargs)
+
+    monkeypatch.setattr(_db, "query", _recording_query)
+
+    principal = svc.InteractionPrincipal(
+        kind="guest",
+        user_id=None,
+        is_admin=False,
+        auth_mode="widget",
+        widget_workforce_id=9,
+        guest_id="guest-1",
+    )
+    outcome = svc.create(
+        _db, task_id=task_id, principal=principal, envelope=_valid_envelope()
+    )
+    assert outcome == svc.CreateUnauthorized(reason="not_task_principal")
+    assert queried == []
+
+
 def test_ca1_guest_principal_with_two_populated_directions_is_unauthorized_not_raised(
     _db: Session, _seeded_task: int
 ) -> None:
@@ -1276,9 +1368,14 @@ def test_ca1_guest_principal_with_two_populated_directions_is_unauthorized_not_r
     Unauthorized(not_task_principal), not let it escape as an unhandled
     exception."""
 
+    # The guest lookup is owner-scoped, so this has to be the task's real
+    # owner: a mismatched user_id would return the empty result set and
+    # reject before the predicate is ever called, and this test would pass
+    # without exercising the ValueError translation it exists for.
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
     principal = svc.InteractionPrincipal(
         kind="guest",
-        user_id=1,
+        user_id=task.user_id,
         is_admin=False,
         auth_mode="widget",
         widget_agent_id=1,
@@ -1294,9 +1391,11 @@ def test_ca1_guest_principal_with_two_populated_directions_is_unauthorized_not_r
 def test_ca1_guest_principal_with_zero_populated_directions_is_unauthorized_not_raised(
     _db: Session, _seeded_task: int
 ) -> None:
+    # Owner-scoped for the same reason as the two-directions test above.
+    task = _db.query(Task).filter(Task.id == _seeded_task).first()
     principal = svc.InteractionPrincipal(
         kind="guest",
-        user_id=1,
+        user_id=task.user_id,
         is_admin=False,
         auth_mode="widget",
         guest_id="guest-1",
@@ -3107,35 +3206,51 @@ def test_respond_rejects_a_guest_principal_with_zero_populated_directions(
 
 
 @pytest.mark.parametrize(
-    "principal",
+    ("make_principal", "agent_config"),
     [
         pytest.param(
-            svc.InteractionPrincipal(
+            lambda owner_id: svc.InteractionPrincipal(
                 kind="user", user_id=None, is_admin=True, auth_mode=None
             ),
+            None,
             id="user_without_an_id",
         ),
         pytest.param(
-            svc.InteractionPrincipal(
+            lambda owner_id: svc.InteractionPrincipal(
                 kind="guest",
-                user_id=1,
+                user_id=owner_id,
                 is_admin=False,
                 auth_mode="widget",
                 widget_workforce_id=9,
                 guest_id="",
             ),
+            # Every conjunct ahead of the guest_id pair matches -- the
+            # auth_mode and the workforce binding -- and the task's own
+            # guest_id is blank too, so the equality below the guard
+            # ("" == "") would pass as well. The one thing left to refuse
+            # this call is the guard that requires principal.guest_id to
+            # be non-empty before the comparison runs. Without an
+            # agent_config the task carries none at all, the auth_mode
+            # conjunct does the refusing, and the guard is never the
+            # reason the assertion holds.
+            {
+                "auth_mode": "widget",
+                "widget_workforce_id": 9,
+                "guest_id": "",
+            },
             id="guest_with_a_blank_guest_id",
         ),
         pytest.param(
-            svc.InteractionPrincipal(
-                kind="service", user_id=1, is_admin=False, auth_mode=None
+            lambda owner_id: svc.InteractionPrincipal(
+                kind="service", user_id=owner_id, is_admin=False, auth_mode=None
             ),
+            None,
             id="unrecognized_kind",
         ),
     ],
 )
 def test_respond_rejects_every_principal_identity_string_cannot_name(
-    _respond_db, principal: svc.InteractionPrincipal
+    _respond_db, make_principal: Any, agent_config: dict[str, Any] | None
 ) -> None:
     """``identity_string()`` raises for exactly three principal shapes, and
     ``respond()`` calls it at four points with no guard of its own. What
@@ -3145,10 +3260,12 @@ def test_respond_rejects_every_principal_identity_string_cannot_name(
     ``RespondUnauthorized(reason="not_task_principal")``, never as a raised
     ``ValueError`` escaping the function."""
 
+    owner_id, task_id = _waiting_task(_respond_db, agent_config=agent_config)
+    principal = make_principal(owner_id)
+
     with pytest.raises(ValueError):
         principal.identity_string()
 
-    _owner_id, task_id = _waiting_task(_respond_db)
     interaction_id = _active_row_ready_for_respond(_respond_db, task_id=task_id)
     with _asserts_no_side_effects(
         _respond_db, task_id=task_id, interaction_id=interaction_id

--- a/tests/web/services/test_task_interaction_service_create_gate.py
+++ b/tests/web/services/test_task_interaction_service_create_gate.py
@@ -5,8 +5,10 @@ Replaces the two-name gate this file's predecessor enforced, keeping both
 names under watch. The predecessor named its retirement condition as "the
 change that routes the existing resume coordinator through this module's
 compatibility seam" -- the change meant to give ``respond()`` its first
-production caller. That compatibility seam has since landed: ``websocket.py``
-now imports ``_active_native_row_criteria`` from this module. It does not,
+production caller. That compatibility seam has since landed: it reads
+through ``task_interaction_close.active_interaction_id_sync``, which
+imports ``_active_native_row_criteria`` from this module (``websocket.py``
+itself no longer imports it directly). It does not,
 though, give ``respond()`` a caller -- the seam only reads that filter
 predicate, it never calls ``respond()`` -- so this gate's retirement
 condition is still open. Zero production code anywhere in this package


### PR DESCRIPTION

## Summary

Several guards on the interaction write path name a row, a task, or a
person without being bound to it. The close that retires a question
matched `(task_id, run_id, active)` and never the question that was
actually answered. `create()` loaded a task by id and compared ownership
afterwards in Python. `identity_string()` rendered a principal with no id
into the literal string `"user:None"` and wrote that into the one column
this table's audit trail can rely on staying populated. None of the three
can misfire today: the functions holding them have no production caller
and the table has no production writer, which is what makes fixing them a
no-op for today's behavior rather than a change to it.

Alongside those: the write side gets admissibility rules of its own,
separate from the read-direction parser, and the TTL constants say where
their numbers come from and each names the other.

## What changed

**`create()` loads the task through an owner predicate for a non-admin
`"user"` principal.** Ownership there is one equality on a column, so it
belongs in the lookup's WHERE clause rather than in a comparison run
after the row is already in hand; such a principal never loads a row it
does not own. An admin is authorized without owning the task, so there is
no predicate to add, and a `"guest"` principal's ownership is
`task_is_owned_by_public_principal`, which reads the task's
`agent_config` JSON and cannot be compiled into SQL. Both of those keep
the id-only load.

The consequence is stated in the docstring rather than left for a reader
to derive from the SQL: for a non-admin `"user"` principal, "this task
does not exist" and "this task is not yours" are the same empty result
set, and both now return `CreateUnauthorized(reason="not_task_principal")`.
That principal cannot use `create()` to learn whether a `task_id` exists.
`CreateUnavailable(reason="task_missing")` stays reachable from the two
id-only branches, neither of which is told anything by it that its own
branch does not already tell it. The three existing public-chat entry
points already collapse the pair at the HTTP boundary, so this makes the
service agree with what its callers were doing one layer up.

**A write-side payload rule set, separate from the read-direction
parser.** `validate_v1_write_payload` runs on top of
`parse_v1_request_payload` on the write side only, and refuses a
shape-valid payload that must not be persisted: a blank `message`, an
interaction typed as something no renderer implements, a duplicated
`field` name, a select-style type carrying no options or a
self-rendering type carrying options, and `min` greater than `max`. A
violation returns the existing `CreateValidationRejected(reason="invalid_values")`
— no new reason value, and the caller learns its values were refused, not
which check refused them.

It is deliberately not folded into `parse_v1_request_payload`, because
the two directions have different failure policies for the same payload.
The read direction meets these payloads as rows that are already stored,
where a payload it cannot make sense of has to degrade into something the
waiting user can still act on; widening what it rejects turns
readable-but-odd rows into unanswerable ones. The write direction meets
them before anything is stored, where the only useful answer is to
refuse. `parse_v1_request_payload` therefore keeps accepting exactly what
it accepts today.

An empty `interactions` list is accepted, and the reason is what the
other producer of this shape actually builds:
`build_clarification_payload` emits no interactions at all for a
`send_message`-sourced draft, and deliberately drops an over-size form to
`[]` rather than truncating it to half a form. Both are questions with
prose and no form, which the read surface renders. Whether the write side
should refuse an empty list is issue #1528 and is not decided here.
Answers are out of scope in this module: until the answer-side field
schema of issue #1368 exists, everything downstream of an interaction row
must treat `response_payload` as unvalidated input — nothing checks a
submitted answer against the `InteractionArg.type` / `InteractionArg.field`
definitions this function checks on the question side.

**`identity_string()` raises `ValueError` for a principal it cannot
name.** Three gaps used to produce something that looks like an identity
and is not one: a `"user"` principal with no `user_id`, a `"guest"`
principal with no `guest_id`, and an unrecognized `kind` falling through
to the user branch and being recorded as a user. Nothing downstream
stopped any of them —
`ck_task_interaction_requests_responder_identity_nonempty` only requires
a non-empty string, and `"user:None"` is non-empty. `ValueError` rather
than a typed rejection, because this is a pure function of the
principal: reaching it with one this incomplete means the caller built
the principal wrong. It is what `task_is_owned_by_public_principal`
already raises for a malformed guest principal.

Both write-side facades now reject such a principal at their
authorization step, so no caller should be in a position to see it raise.
`create()` rejects a `"user"` principal with no `user_id` before the
lookup is even built, on both branches, and `respond()`'s authorization
requires `user_id` on both branches too. `is_admin` authorizes without
ownership, but not without an identity: a principal passing on the flag
alone would otherwise reach the write point with nothing to record as who
acted, and a non-admin's owner predicate built from that absent id would
render as `Task.user_id IS NULL` and reject only by way of a schema
detail.

**The two TTL constants say where their numbers come from and point at
each other.** The values are unchanged. What changed is that
`_MIN/_MAX_INTERACTION_TTL_SECONDS` no longer describe themselves as a
placeholder awaiting a decision: they are the interval a caller's own
`ttl_seconds` override has to fall inside, a floor of a minute because a
question the user cannot plausibly answer inside the window is worse than
no question, and a ceiling of a week because a row that effectively never
expires is a row a reclaim job can never retire. `CLARIFICATION_REQUEST_TTL`
is a different quantity — the value the publication path adds to "now" to
get a row's `expires_at` — and each constant now names the other and says
the two are deliberately not unified. The one relationship that has to
hold between them, that the published value falls inside the accepted
interval, is pinned by a test instead of by a comment. The range check
itself is unchanged: an out-of-range override is a rejection, never a
silent clamp.

**`respond()`'s docstring states why step 3 lets an admin through.** The
allowance itself is unchanged — the only code change in that block is the
`user_id` requirement described above. Two guards run, in this order and
for different purposes: step 3, before the idempotency preread, keeps an
unauthorized caller from reaching a read at all, and being an admin
clears it; step 6's answer fence carries an ownership term requiring
`principal.user_id` to be the task's owner, which an admin does not
satisfy, so the fence matches zero rows, the reread classifies the miss,
and the call returns `RespondUnauthorized(reason="not_task_principal")`.
An admin passes the authorization step and is still refused at the write
point — refused precisely, after the reread has established why, rather
than refused early on a guess. Rejecting admins at step 3 would change
what the service does for admins, not just where it says no.

**The close statement binds to one primary key, read before the
injection.** `active_interaction_id_sync` reads the task's active native
interaction row and returns its id. Three of the four legacy-resume paths
call it before injecting the user message, then hand the value to the
close; the deferred WebSocket path takes no read of its own and carries
the online handler's observation instead. Injecting the message is
exactly what resumes the agent, and a resumed
agent can stage a fresh question before the close runs, which the
unbound statement would retire as though the injected message had
answered it. Reading the id at close time instead would leave that window
exactly as wide as no key at all, so the value has to be the one observed
before the message went in.

Details that are easy to get wrong and are therefore fixed in place:

- The two fence-transaction paths (`a2a.py`, `v1/task_reply.py`) read
  through a short session of their own before the injection, because the
  fence session that carries the close does not open until after the
  injection has already committed. The id is a parameter of the fence
  helper, not something it reads.
- The WebSocket online path reads before the `posted` fork, so both
  branches carry the same observation. The deferred path takes none of
  its own — its injection is later still — and receives the online
  handler's value through `pending_user_message`. The two branches are
  mutually exclusive, so one observation only ever serves one close.
- `interaction_id=None` covers two cases the marker clear now tells
  apart. When no active row exists for this run, the close matches zero
  rows and the clear still zeroes the marker. When the read failed while
  a row is still active, the clear's own condition — no active row
  remaining for this `(task_id, run_id)` — keeps the marker, so the live
  question stays visible to every reader instead of going dark.
- `active_interaction_id_sync` returns `None` when the read cannot be
  made at all — no table, no session, a failing query. An unreadable id
  closes nothing; it must never widen what the close matches, because
  falling back to the old unbound predicate is the retire-the-wrong-row
  bug the function exists to prevent.
- The row predicate is `_active_native_row_criteria`, the same
  four-field predicate every other reader of "this task's one live row"
  uses. The close and the readers that show the question must not
  disagree about which row is live.

The close module still issues exactly three UPDATE statements.

## Behavior on merge

Each item's inertness is a fact about this tree, checkable here rather
than asserted:

- `create()` and `respond()` have no production callers, held there by
  `test_task_interaction_service_create_gate.py`, which is re-run green
  and unchanged. The owner-scoped lookup, the write-side payload rules,
  and the two authorization tightenings therefore have nothing calling
  them. `create()`'s last line still returns
  `CreateNotWired(reason="seam_not_wired")` unconditionally.
- `validate_v1_write_payload` has exactly one caller anywhere,
  `create()`. `parse_v1_request_payload` is byte-for-byte unchanged, so
  the read direction's failure surface is untouched.
- Every call to `identity_string()` in the tree is inside
  `task_interaction_service.py` — two of them in helpers whose only
  callers are inside `respond()`, two directly in `respond()`. Behavior
  cells assert `respond()` refuses each principal shape the function
  cannot name, at the authorization gate above those calls. No production
  path reaches the function, so no caller can be relying on the
  `"user:None"` string it used to produce.
- The TTL change is comments plus one assertion. The numbers are the same
  numbers, and the only consumer of the two bounds is `create()`'s range
  check.
- The admin paragraph in `respond()`'s docstring is documentation. That
  authorization branch's behavior for an admin carrying a `user_id` is
  unchanged.
- The close UPDATE matches zero rows today, because the staging entry
  points that would write an active interaction row have no production
  callers — held there by `test_interaction_staging_production_gate.py`.
  This is a statement about that one UPDATE, not about the module: the
  marker clear runs on every legacy resume and really does update the
  task row, exactly as before. What the four paths pay for is one extra
  SELECT on the answer path, at the same frequency as a user pressing
  send, and it is the correctness premise of the change — without the
  read there is no key to bind.

## Test coverage

Behavior is covered as table-driven parametrized cells rather than
copy-pasted bodies:

- `create()`'s task lookup, one row per principal branch crossed with
  ownership and with whether the task exists: owner on its own task,
  foreign user on an existing task, user on an absent task, admin on
  someone else's task, admin on an absent task, guest on an absent task.
  A separate cell asserts the two collapsed outcomes are the identical
  object, which is what makes the pair not an existence oracle. Another
  covers a `"user"` principal with no `user_id`, across admin and
  non-admin and across a real and an absent task.
- The write-side payload rules, one row per rule, plus the inverses: a
  payload carrying one item of every one of the seven types, a prose-only
  question with no form, and `min` equal to `max`. Every rejected row is
  shape-valid and JSON-serializable, so `validate_v1_write_payload` is
  the only thing that can refuse it. One cell drives the same payload
  through `parse_v1_request_payload` and asserts it still parses, pinning
  that the two directions did not get one shared policy.
- The cross-module contract with `build_clarification_payload`, fed the
  builder's real output for three of its shapes — a `send_message` draft
  with no interactions, an `ask_user_question` draft with a form, and an
  over-size form — with a companion cell asserting the over-size case
  really did take the builder's drop branch, so the row proves something
  rather than trusting its own id.
- `identity_string()` refusing each of the four principals it cannot
  name, and behavior cells asserting `respond()`'s authorization gate
  refuses every one of those shapes before the function is reached.
- The TTL range boundary at one below the minimum and one above the
  maximum, and the relationship between the published TTL and the
  override interval.
- The close's primary-key predicate on its own, holding everything else
  constant and varying only the id handed in: the observed row, `None`,
  and a row that is not this task's active one. The marker column is
  asserted per case — zeroed when no active row remains, kept when one
  does — since the clear's condition, not the close's rowcount, decides
  it.
- The window the whole change exists for: a first question is staged, its
  deadline moved into the past to stand in for the time a resumed agent
  works, a second question then takes the active slot through the
  reclaim branch on its own, and the close keyed on the first id leaves
  the second one active with a null terminal reason.
- The read-before-injection ordering, one cell per path — A2A, v1 reply,
  WebSocket online, WebSocket deferred — asserting the observed order and
  the value that reached the close. The deferred cell patches the read to
  raise if called, because that path must carry the online handler's
  observation rather than take one of its own. These cells exist
  separately because moving any of the reads after the injection leaves
  the row-level assertions above green while the change does nothing.

Two PostgreSQL suites run against a real PostgreSQL 16 container,
covering the staged-after-injection window on the production backend and
the marker's per-case behavior under the dialect's own `IS NULL`
rendering. All cells were run, not skipped.

These guards were re-run by name and are green:

- `test_task_interaction_service_create_gate.py`, whole file
- `test_interaction_staging_production_gate.py`, whole file
- `test_clarification_publication_gate.py`, whole file
- `test_interaction_close_lock_ordering.py`, whole file, including the
  statement-target count that would catch a fourth UPDATE and the
  requirement that every module calling `post_user_message` also calls a
  close
- `test_interaction_rollout_guards.py`, including
  `test_tw2a_evaluate_native_publication_has_zero_production_callers`,
  which is unchanged, and the module-import guard that covers `a2a.py`
- `test_ta11_resolve_interaction_anchor_has_zero_production_callers`, and
  the two structural guards over the resolver's six-condition disjunction
- `test_interaction_fence_equivalence.py`
- `test_interaction_handoff_surface.py`
- `tests/architecture/test_architecture_guards.py`

Existing cells kept their expected values apart from four places, all of
them consequences of the changes above rather than adjustments made to
accommodate them: call sites that gained the new argument; the anchor
cell that asserted an empty counter snapshot for the no-pointer outcome,
which now asserts that outcome's counter; the `create()` cell whose
principal was an admin carrying no `user_id`, a combination the
authorization step now rejects, so it was given one; and the absent-task
cell, whose two cases — a user and an admin asking about an id with no
row — no longer share an outcome and are now two rows of the lookup
table.
