### PR TITLE
fix(kb): keep tenant-scoped ingestion config out of the shared collection_metadata row

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/LanceDB/schema_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/LanceDB/schema_manager.py
@@ -666,6 +666,7 @@ def ensure_collection_metadata_table(conn: DBConnection) -> None:
             pa.field("collection_locked", pa.bool_()),
             pa.field("allow_mixed_parse_methods", pa.bool_()),
             pa.field("skip_config_validation", pa.bool_()),
+            # Schema-only; tenant config lives in collection_config.
             pa.field("ingestion_config", pa.string()),
             pa.field("created_at", pa.timestamp("us")),
             pa.field("updated_at", pa.timestamp("us")),

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1528,6 +1528,7 @@ class CollectionInfo(BaseModel):
                 "storage_user_id",
                 "can_edit",
                 "can_delete",
+                "ingestion_config",
             }
         )
 

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1537,9 +1537,10 @@ class CollectionInfo(BaseModel):
         # Do not persist owners; they are computed from user_id when listing
         data["owners"] = "[]"
 
-        # Serialize ingestion_config if present
-        if data.get("ingestion_config"):
-            data["ingestion_config"] = json.dumps(data["ingestion_config"])
+        # Serialize ingestion_config if present. pydantic's JSON mode, not
+        # json.dumps: the config carries enum fields the plain encoder rejects.
+        if self.ingestion_config is not None:
+            data["ingestion_config"] = self.ingestion_config.model_dump_json()
         else:
             # Use empty string sentinel instead of None to prevent LanceDB non-null schema errors
             data["ingestion_config"] = LANCEDB_NULL_STR_SENTINEL

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1430,8 +1430,6 @@ class CollectionInfo(BaseModel):
         description="Whether to skip configuration validation during ingestion. Use with caution.",
     )
 
-    # 📝 Transient tenant-scoped ingestion config -- never persisted here;
-    # attached at list time from the collection_config table.
     ingestion_config: Optional[IngestionConfig] = Field(
         default=None,
         description=(
@@ -1485,9 +1483,7 @@ class CollectionInfo(BaseModel):
             data["extra_metadata"] = json.loads(data["extra_metadata"])
         if isinstance(data.get("document_names"), str):
             data["document_names"] = json.loads(data["document_names"])
-        # Owner-neutral row (keyed by name alone), so it can never hydrate a
-        # config that belongs to one (collection, user_id). Callers get theirs
-        # from collection_config at list time.
+        # Owner-neutral row: a config found here belongs to someone else.
         data["ingestion_config"] = None
         # Owners are not stored; they are derived at list time from user_id. Ignore stored value.
         if "owners" in data:
@@ -1541,9 +1537,7 @@ class CollectionInfo(BaseModel):
         # Do not persist owners; they are computed from user_id when listing
         data["owners"] = "[]"
 
-        # Never persisted: this row is keyed by name alone, and an ingestion
-        # config belongs to one (collection, user_id) and may carry a
-        # credential. Empty string, not None: the column is non-null.
+        # Empty string, not None: the column is non-null.
         data["ingestion_config"] = LANCEDB_NULL_STR_SENTINEL
 
         if data.get("embedding_model_id") is None:

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1538,13 +1538,13 @@ class CollectionInfo(BaseModel):
         # Do not persist owners; they are computed from user_id when listing
         data["owners"] = "[]"
 
-        # Serialize ingestion_config if present. pydantic's JSON mode, not
-        # json.dumps: the config carries enum fields the plain encoder rejects.
-        if self.ingestion_config is not None:
-            data["ingestion_config"] = self.ingestion_config.model_dump_json()
-        else:
-            # Use empty string sentinel instead of None to prevent LanceDB non-null schema errors
-            data["ingestion_config"] = LANCEDB_NULL_STR_SENTINEL
+        # Never persisted here. This row is keyed by name alone, while an
+        # ingestion config belongs to one (collection, user_id) and may carry
+        # an embedding_api_key -- writing it would hand one tenant's model
+        # binding and credential to every same-named collection. The
+        # collection_config table owns that data; this column stays empty.
+        # Empty string, not None: the LanceDB schema is non-null.
+        data["ingestion_config"] = LANCEDB_NULL_STR_SENTINEL
 
         if data.get("embedding_model_id") is None:
             data["embedding_model_id"] = LANCEDB_NULL_STR_SENTINEL

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -1430,10 +1430,15 @@ class CollectionInfo(BaseModel):
         description="Whether to skip configuration validation during ingestion. Use with caution.",
     )
 
-    # 📝 Stored Ingestion Config
+    # 📝 Transient tenant-scoped ingestion config -- never persisted here;
+    # attached at list time from the collection_config table.
     ingestion_config: Optional[IngestionConfig] = Field(
         default=None,
-        description="Default ingestion configuration for the collection.",
+        description=(
+            "Tenant-scoped ingestion configuration for one (collection, user_id). "
+            "Transient: excluded from to_storage() and dropped by from_storage(), "
+            "because the collection_metadata row is keyed by name alone."
+        ),
     )
 
     # 🕒 Timestamps
@@ -1480,12 +1485,10 @@ class CollectionInfo(BaseModel):
             data["extra_metadata"] = json.loads(data["extra_metadata"])
         if isinstance(data.get("document_names"), str):
             data["document_names"] = json.loads(data["document_names"])
-        if isinstance(data.get("ingestion_config"), str):
-            raw_ingestion_config = data["ingestion_config"].strip()
-            if raw_ingestion_config:
-                data["ingestion_config"] = json.loads(raw_ingestion_config)
-            else:
-                data["ingestion_config"] = None
+        # Owner-neutral row (keyed by name alone), so it can never hydrate a
+        # config that belongs to one (collection, user_id). Callers get theirs
+        # from collection_config at list time.
+        data["ingestion_config"] = None
         # Owners are not stored; they are derived at list time from user_id. Ignore stored value.
         if "owners" in data:
             data["owners"] = []
@@ -1538,12 +1541,9 @@ class CollectionInfo(BaseModel):
         # Do not persist owners; they are computed from user_id when listing
         data["owners"] = "[]"
 
-        # Never persisted here. This row is keyed by name alone, while an
-        # ingestion config belongs to one (collection, user_id) and may carry
-        # an embedding_api_key -- writing it would hand one tenant's model
-        # binding and credential to every same-named collection. The
-        # collection_config table owns that data; this column stays empty.
-        # Empty string, not None: the LanceDB schema is non-null.
+        # Never persisted: this row is keyed by name alone, and an ingestion
+        # config belongs to one (collection, user_id) and may carry a
+        # credential. Empty string, not None: the column is non-null.
         data["ingestion_config"] = LANCEDB_NULL_STR_SENTINEL
 
         if data.get("embedding_model_id") is None:

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -27,7 +27,7 @@ import pyarrow as pa  # type: ignore
 from ..core.parser_registry import get_supported_parsers, validate_parser_compatibility
 from ..core.schemas import CollectionInfo
 from ..LanceDB.schema_manager import _safe_close_table
-from ..storage.contracts import MetadataStore
+from ..storage.contracts import CollectionNotFoundError, MetadataStore
 from ..storage.factory import get_metadata_store, get_vector_index_store
 from ..utils.lancedb_query_utils import list_table_names
 from ..utils.model_resolver import resolve_embedding_adapter
@@ -344,13 +344,14 @@ class CollectionManager:
 
         async with lock, _collection_thread_guard(collection.name):
             store = self._get_metadata_store()
-            # Only "not found" may reach the insert below; any other read failure
-            # would make it a stale full-row overwrite. ensure_* keeps a missing
-            # table out of that distinction.
+            # Only a missing row may reach the insert below; any other read
+            # failure -- including a row that exists but will not parse -- would
+            # make it a stale full-row overwrite. ensure_* keeps a missing table
+            # out of that distinction.
             await store.ensure_collection_metadata_table()
             try:
                 stored = await store.get_collection(collection.name)
-            except ValueError:
+            except CollectionNotFoundError:
                 logger.debug(
                     "Collection '%s' has no metadata row yet, inserting it whole",
                     collection.name,

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -95,12 +95,19 @@ async def _collection_thread_guard(collection_name: str) -> AsyncIterator[None]:
         lock.release()
 
 
+# Collections whose embedding table yielded a model but no dimension, so the
+# binding was never persisted: without this the resolver rescans every
+# embeddings_* table on every ingest and search, forever.
+_UNPERSISTABLE_INFERRED_MODELS: dict[str, str] = {}
+
+
 def reset_locks_for_testing() -> None:
     """Clear in-memory collection locks for test isolation."""
     with _collection_locks_lock:
         _collection_locks.clear()
     with _collection_thread_locks_guard:
         _collection_thread_locks.clear()
+    _UNPERSISTABLE_INFERRED_MODELS.clear()
 
 
 def _normalize_collection_config_user_id(user_id: Optional[int]) -> int:
@@ -1359,6 +1366,10 @@ def _resolve_effective_embedding_model_sync_impl(
                 )
             return bound_model_id
 
+        cached_model_id = _UNPERSISTABLE_INFERRED_MODELS.get(collection_name)
+        if cached_model_id:
+            return cached_model_id
+
         inferred_model_id: Optional[str] = None
         inferred_dimension: Optional[int] = None
         if collection_info.embeddings > 0:
@@ -1393,6 +1404,7 @@ def _resolve_effective_embedding_model_sync_impl(
                     collection_name,
                     inferred_model_id,
                 )
+                _UNPERSISTABLE_INFERRED_MODELS[collection_name] = inferred_model_id
             else:
                 try:
                     updated_collection = collection_info.model_copy(

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -340,6 +340,12 @@ class CollectionManager:
         not written at all. Falls back to inserting ``collection`` whole when no
         row exists yet.
         """
+        unknown = set(owned_fields) - set(CollectionInfo.model_fields)
+        if unknown:
+            raise ValueError(
+                f"owned_fields are not CollectionInfo fields: {sorted(unknown)}"
+            )
+
         lock = _get_collection_lock(collection.name)
 
         async with lock, _collection_thread_guard(collection.name):

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -448,7 +448,8 @@ class CollectionManager:
                 ("collection_locked", pa.bool_()),
                 ("allow_mixed_parse_methods", pa.bool_()),
                 ("skip_config_validation", pa.bool_()),
-                ("ingestion_config", pa.string()),  # JSON string
+                # Schema-only; not maintained (tenant config lives in collection_config)
+                ("ingestion_config", pa.string()),
                 ("created_at", pa.timestamp("us")),
                 ("updated_at", pa.timestamp("us")),
                 ("last_accessed_at", pa.timestamp("us")),

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -328,6 +328,39 @@ class CollectionManager:
         async with lock, _collection_thread_guard(collection.name):
             await self._save_collection_with_retry(collection)
 
+    async def save_collection_fields(
+        self, collection: CollectionInfo, owned_fields: tuple[str, ...]
+    ) -> None:
+        """Merge only ``owned_fields`` onto the stored row, re-read under the lock.
+
+        For callers holding a snapshot read long before the write: the storage
+        merge overwrites every column, so writing the whole snapshot back would
+        roll back anything a concurrent writer changed in between. The re-read
+        happens inside the same lock hold as the write, and an unchanged row is
+        not written at all. Falls back to inserting ``collection`` whole when no
+        row exists yet.
+        """
+        lock = _get_collection_lock(collection.name)
+
+        async with lock, _collection_thread_guard(collection.name):
+            try:
+                stored = await self._get_metadata_store().get_collection(
+                    collection.name
+                )
+            except Exception as exc:
+                logger.debug(
+                    "No stored row for '%s', inserting whole: %s", collection.name, exc
+                )
+                await self._save_collection_with_retry(collection)
+                return
+
+            merged = stored.model_copy(
+                update={field: getattr(collection, field) for field in owned_fields}
+            )
+            if merged == stored:
+                return
+            await self._save_collection_with_retry(merged)
+
     async def delete_collection_metadata(
         self,
         collection_name: str,
@@ -1269,10 +1302,9 @@ def resolve_effective_embedding_model_sync(
 
     Logic:
     1. If collection is initialized, use its bound model ID.
-    2. Else if collection ingestion_config stores an embedding model, use it.
-    3. Else if existing embedding tables can be inferred for this collection, use that.
-    4. Else if config provides an embedding model, use it.
-    5. If none are available, raise ValueError.
+    2. Else if existing embedding tables can be inferred for this collection, use that.
+    3. Else if config provides an embedding model, use it.
+    4. If none are available, raise ValueError.
 
     Args:
         collection_name: Name of the collection
@@ -1303,11 +1335,6 @@ def _resolve_effective_embedding_model_sync_impl(
         collection_info = get_collection_sync(collection_name)
 
         bound_model_id = _normalize_model_id(collection_info.embedding_model_id)
-        indexed_model_id = _normalize_model_id(
-            collection_info.ingestion_config.embedding_model_id
-            if collection_info.ingestion_config is not None
-            else None
-        )
 
         if collection_info.is_initialized and bound_model_id:
             if config_model_id and config_model_id != bound_model_id:
@@ -1319,22 +1346,6 @@ def _resolve_effective_embedding_model_sync_impl(
                     bound_model_id,
                 )
             return bound_model_id
-
-        if indexed_model_id:
-            if config_model_id and config_model_id != indexed_model_id:
-                logger.warning(
-                    "Config embedding_model_id '%s' overridden by "
-                    "collection '%s' ingestion config model '%s'",
-                    config_model_id,
-                    collection_name,
-                    indexed_model_id,
-                )
-            logger.info(
-                "Collection '%s' using ingestion config embedding_model_id '%s'",
-                collection_name,
-                indexed_model_id,
-            )
-            return indexed_model_id
 
         inferred_model_id: Optional[str] = None
         inferred_dimension: Optional[int] = None
@@ -1411,6 +1422,19 @@ async def rebuild_collection_metadata() -> None:
     Use this to migrate existing data when collection_metadata table is missing or outdated.
     """
     await _get_maintenance_compatibility_facade().rebuild_collection_metadata()
+
+
+# What the rebuild recomputes from the tables and may therefore overwrite. The
+# rest of the listed row is echoed from a pre-loop snapshot and must not be
+# written back. The embedding binding is appended only when it was inferred.
+_REBUILD_OWNED_FIELDS = (
+    "documents",
+    "parses",
+    "chunks",
+    "embeddings",
+    "processed_documents",
+    "document_names",
+)
 
 
 async def _rebuild_collection_metadata_impl() -> None:
@@ -1504,23 +1528,28 @@ async def _rebuild_collection_metadata_impl() -> None:
 
                         break
 
-            # Only overwrite what was actually inferred. save_collection
-            # merges with when_matched_update_all, so writing None for a
-            # collection with no embeddings yet would erase the binding it
-            # already has. Until now the enum TypeError below aborted the
-            # whole row, which is why this never surfaced.
+            # A model without its dimension would still satisfy
+            # CollectionInfo.is_initialized while leaving the previous, possibly
+            # incompatible, dimension in place: bind the pair or neither.
             embedding_updates: dict[str, Any] = {}
-            if embedding_model_id is not None:
+            if embedding_model_id is not None and embedding_dimension is not None:
                 embedding_updates["embedding_model_id"] = embedding_model_id
-            if embedding_dimension is not None:
                 embedding_updates["embedding_dimension"] = embedding_dimension
-            updated_collection = (
+            elif embedding_model_id is not None:
+                logger.warning(
+                    "Collection '%s' embedding table gave model '%s' with no "
+                    "dimension; leaving the stored binding untouched",
+                    collection.name,
+                    embedding_model_id,
+                )
+            candidate = (
                 collection.model_copy(update=embedding_updates)
                 if embedding_updates
                 else collection
             )
 
-            # Use the async save_collection method through sync wrapper
-            _sync_wrapper(collection_manager.save_collection)(updated_collection)
+            _sync_wrapper(collection_manager.save_collection_fields)(
+                candidate, _REBUILD_OWNED_FIELDS + tuple(embedding_updates)
+            )
         except Exception as e:
             logger.error("Failed to rebuild collection '%s': %s", collection.name, e)

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -1504,12 +1504,20 @@ async def _rebuild_collection_metadata_impl() -> None:
 
                         break
 
-            # Update collection with embedding info
-            updated_collection = collection.model_copy(
-                update={
-                    "embedding_model_id": embedding_model_id,
-                    "embedding_dimension": embedding_dimension,
-                }
+            # Only overwrite what was actually inferred. save_collection
+            # merges with when_matched_update_all, so writing None for a
+            # collection with no embeddings yet would erase the binding it
+            # already has. Until now the enum TypeError below aborted the
+            # whole row, which is why this never surfaced.
+            embedding_updates: dict[str, Any] = {}
+            if embedding_model_id is not None:
+                embedding_updates["embedding_model_id"] = embedding_model_id
+            if embedding_dimension is not None:
+                embedding_updates["embedding_dimension"] = embedding_dimension
+            updated_collection = (
+                collection.model_copy(update=embedding_updates)
+                if embedding_updates
+                else collection
             )
 
             # Use the async save_collection method through sync wrapper

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -97,12 +97,13 @@ async def _collection_thread_guard(collection_name: str) -> AsyncIterator[None]:
 
 # Collections whose embedding table yielded a model but no dimension, so the
 # binding was never persisted: without this the resolver rescans every
-# embeddings_* table on every ingest and search, forever.
+# embeddings_* table on every ingest and search, forever. No invalidation
+# path in-process; a later-readable dimension is retried after restart.
 _UNPERSISTABLE_INFERRED_MODELS: dict[str, str] = {}
 
 
 def reset_locks_for_testing() -> None:
-    """Clear in-memory collection locks for test isolation."""
+    """Clear in-memory collection locks and the negative inference cache."""
     with _collection_locks_lock:
         _collection_locks.clear()
     with _collection_thread_locks_guard:

--- a/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collection_manager.py
@@ -343,13 +343,17 @@ class CollectionManager:
         lock = _get_collection_lock(collection.name)
 
         async with lock, _collection_thread_guard(collection.name):
+            store = self._get_metadata_store()
+            # Only "not found" may reach the insert below; any other read failure
+            # would make it a stale full-row overwrite. ensure_* keeps a missing
+            # table out of that distinction.
+            await store.ensure_collection_metadata_table()
             try:
-                stored = await self._get_metadata_store().get_collection(
-                    collection.name
-                )
-            except Exception as exc:
+                stored = await store.get_collection(collection.name)
+            except ValueError:
                 logger.debug(
-                    "No stored row for '%s', inserting whole: %s", collection.name, exc
+                    "Collection '%s' has no metadata row yet, inserting it whole",
+                    collection.name,
                 )
                 await self._save_collection_with_retry(collection)
                 return
@@ -1372,22 +1376,32 @@ def _resolve_effective_embedding_model_sync_impl(
                 collection_name,
                 inferred_model_id,
             )
-            try:
-                updated_collection = collection_info.model_copy(
-                    update={
-                        "embedding_model_id": inferred_model_id,
-                        "embedding_dimension": inferred_dimension
-                        if inferred_dimension is not None
-                        else collection_info.embedding_dimension,
-                    }
-                )
-                _sync_wrapper(collection_manager.save_collection)(updated_collection)
-            except Exception as save_error:
+            # Persisting the model without its dimension would leave the old,
+            # possibly incompatible one in place with is_initialized now True.
+            if inferred_dimension is None:
                 logger.warning(
-                    "Failed to persist inferred embedding metadata for collection '%s': %s",
+                    "Collection '%s' inferred model '%s' with no dimension; "
+                    "not persisting the binding",
                     collection_name,
-                    save_error,
+                    inferred_model_id,
                 )
+            else:
+                try:
+                    updated_collection = collection_info.model_copy(
+                        update={
+                            "embedding_model_id": inferred_model_id,
+                            "embedding_dimension": inferred_dimension,
+                        }
+                    )
+                    _sync_wrapper(collection_manager.save_collection)(
+                        updated_collection
+                    )
+                except Exception as save_error:
+                    logger.warning(
+                        "Failed to persist inferred embedding metadata for collection '%s': %s",
+                        collection_name,
+                        save_error,
+                    )
             return inferred_model_id
 
         if config_model_id:

--- a/src/xagent/core/tools/core/RAG_tools/management/collections.py
+++ b/src/xagent/core/tools/core/RAG_tools/management/collections.py
@@ -923,11 +923,8 @@ async def _list_collections_impl(
                     info = _build_collection_info(
                         collection,
                         metadata_info=existing_metadata_info,
-                        ingestion_config=(
-                            existing_metadata_info.ingestion_config
-                            if existing_metadata_info
-                            else None
-                        ),
+                        # Always None: from_storage drops the tenant-scoped config.
+                        ingestion_config=None,
                         processed_documents=stats[collection]["parses"],
                         timestamp_now=realtime_timestamp,
                     )

--- a/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/contracts.py
@@ -289,6 +289,14 @@ FilterExpression = Union[
 ]
 
 
+class CollectionNotFoundError(ValueError):
+    """No metadata row exists for the collection.
+
+    A ValueError subclass so existing ``except ValueError`` callers keep working;
+    raised only for a missing row, never for one that exists but fails to parse.
+    """
+
+
 class MetadataStore(ABC):
     """Control-plane metadata storage contract."""
 
@@ -303,7 +311,7 @@ class MetadataStore(ABC):
             Collection metadata.
 
         Raises:
-            ValueError: If collection is not found.
+            CollectionNotFoundError: If no row exists for the collection.
         """
 
     @abstractmethod

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -33,6 +33,7 @@ from ..utils.string_utils import (
 )
 from ..utils.user_permissions import UserPermissions
 from .contracts import (
+    CollectionNotFoundError,
     DocumentRecord,
     FilterCondition,
     FilterExpression,
@@ -180,7 +181,9 @@ class LanceDBMetadataStore(MetadataStore):
             safe_name = escape_lancedb_string(collection_name)
             result = table.search().where(f"name = '{safe_name}'").to_arrow()
             if len(result) == 0:
-                raise ValueError(f"Collection '{collection_name}' not found")
+                raise CollectionNotFoundError(
+                    f"Collection '{collection_name}' not found"
+                )
             # Convert Arrow table to list of dicts and take first row
             data = result.to_pylist()[0]
             return CollectionInfo.from_storage(data)

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -427,6 +427,7 @@ class LanceDBMetadataStore(MetadataStore):
                 ("collection_locked", pa.bool_()),
                 ("allow_mixed_parse_methods", pa.bool_()),
                 ("skip_config_validation", pa.bool_()),
+                # Schema-only compat column; tenant config lives in collection_config.
                 ("ingestion_config", pa.string()),
                 ("created_at", pa.timestamp("us")),
                 ("updated_at", pa.timestamp("us")),

--- a/tests/core/tools/core/RAG_tools/core/test_schemas.py
+++ b/tests/core/tools/core/RAG_tools/core/test_schemas.py
@@ -1370,7 +1370,6 @@ class TestCollectionInfo:
             "collection_locked": True,
             "allow_mixed_parse_methods": False,
             "skip_config_validation": False,
-            "ingestion_config": '{"chunk_size": 512}',
             "created_at": "2024-01-01T00:00:00",
             "updated_at": "2024-01-02T00:00:00",
             "last_accessed_at": "2024-01-02T00:00:00",

--- a/tests/core/tools/core/RAG_tools/core/test_schemas.py
+++ b/tests/core/tools/core/RAG_tools/core/test_schemas.py
@@ -1389,8 +1389,25 @@ class TestCollectionInfo:
         assert collection.document_names == ["doc1.pdf", "doc2.md"]
         assert collection.collection_locked is True
         assert collection.extra_metadata == {"key": "value"}
-        assert collection.ingestion_config is not None
-        assert collection.ingestion_config.chunk_size == 512
+
+    def test_from_storage_drops_a_stored_ingestion_config(self):
+        """A current-version row skips migration, so from_storage must drop it.
+
+        The column is owner-neutral and can carry an embedding_api_key, and the
+        hydrated object feeds the embedding-model resolver.
+        """
+        collection = CollectionInfo.from_storage(
+            {
+                "name": "test_collection",
+                "schema_version": "1.0.0",
+                "ingestion_config": (
+                    '{"embedding_model_id": "tenant-a-model", '
+                    '"embedding_api_key": "sk-not-a-real-key"}'
+                ),
+            }
+        )
+
+        assert collection.ingestion_config is None
 
     def test_collection_info_from_storage_migration(self):
         """Test that from_storage handles migration automatically."""

--- a/tests/core/tools/core/RAG_tools/core/test_schemas.py
+++ b/tests/core/tools/core/RAG_tools/core/test_schemas.py
@@ -1,5 +1,6 @@
 """Tests for core data schemas."""
 
+import json
 from datetime import datetime
 
 import pytest
@@ -23,6 +24,7 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     IndexOperation,
     IndexStatus,
     IndexType,
+    IngestionConfig,
     ParseDocumentRequest,
     ParseDocumentResponse,
     ParsedParagraph,
@@ -1432,6 +1434,50 @@ class TestCollectionInfo:
         assert storage_data["documents"] == 5
         assert storage_data["processed_documents"] == 3
         assert storage_data["ingestion_config"] == ""
+
+    def test_collection_info_to_storage_populated_ingestion_config(self):
+        """A populated ingestion_config must serialize, enum fields included."""
+        collection = CollectionInfo(
+            name="test_collection",
+            ingestion_config=IngestionConfig(
+                parse_method=ParseMethod.PYPDF,
+                chunk_strategy=ChunkStrategy.MARKDOWN,
+            ),
+        )
+
+        payload = json.loads(collection.to_storage()["ingestion_config"])
+
+        assert payload["parse_method"] == "pypdf"
+        assert payload["chunk_strategy"] == "markdown"
+
+    def test_collection_info_to_storage_keeps_datetimes_native(self):
+        """LanceDB timestamp columns need datetimes, not ISO strings."""
+        collection = CollectionInfo(
+            name="test_collection",
+            ingestion_config=IngestionConfig(parse_method=ParseMethod.PYPDF),
+        )
+
+        storage_data = collection.to_storage()
+
+        assert isinstance(storage_data["created_at"], datetime)
+        assert isinstance(storage_data["updated_at"], datetime)
+        assert isinstance(storage_data["last_accessed_at"], datetime)
+
+    def test_collection_info_storage_round_trip_restores_enums(self):
+        """from_storage(to_storage()) hands the enum members back."""
+        collection = CollectionInfo(
+            name="test_collection",
+            ingestion_config=IngestionConfig(
+                parse_method=ParseMethod.PYPDF,
+                chunk_strategy=ChunkStrategy.MARKDOWN,
+            ),
+        )
+
+        restored = CollectionInfo.from_storage(collection.to_storage())
+
+        assert restored.ingestion_config is not None
+        assert restored.ingestion_config.parse_method is ParseMethod.PYPDF
+        assert restored.ingestion_config.chunk_strategy is ChunkStrategy.MARKDOWN
 
     def test_collection_info_immutability_by_default(self):
         """Test that CollectionInfo is immutable by default after creation."""

--- a/tests/core/tools/core/RAG_tools/core/test_schemas.py
+++ b/tests/core/tools/core/RAG_tools/core/test_schemas.py
@@ -1435,8 +1435,12 @@ class TestCollectionInfo:
         assert storage_data["processed_documents"] == 3
         assert storage_data["ingestion_config"] == ""
 
-    def test_collection_info_to_storage_populated_ingestion_config(self):
-        """A populated ingestion_config must serialize, enum fields included."""
+    def test_to_storage_does_not_persist_a_populated_ingestion_config(self):
+        """This row is keyed by name alone, so tenant config cannot live in it.
+
+        Serializing it used to raise TypeError on the enum fields, which is the
+        only reason the cross-tenant write never happened.
+        """
         collection = CollectionInfo(
             name="test_collection",
             ingestion_config=IngestionConfig(
@@ -1445,10 +1449,25 @@ class TestCollectionInfo:
             ),
         )
 
-        payload = json.loads(collection.to_storage()["ingestion_config"])
+        storage_data = collection.to_storage()
 
-        assert payload["parse_method"] == "pypdf"
-        assert payload["chunk_strategy"] == "markdown"
+        assert storage_data["ingestion_config"] == ""
+
+    def test_to_storage_never_persists_an_embedding_api_key(self):
+        """A credential must not reach an owner-neutral row."""
+        collection = CollectionInfo(
+            name="test_collection",
+            ingestion_config=IngestionConfig(
+                parse_method=ParseMethod.PYPDF,
+                embedding_api_key="sk-not-a-real-key",
+                embedding_model_id="tenant-a-model",
+            ),
+        )
+
+        serialized = json.dumps(collection.to_storage(), default=str)
+
+        assert "sk-not-a-real-key" not in serialized
+        assert "tenant-a-model" not in serialized
 
     def test_collection_info_to_storage_keeps_datetimes_native(self):
         """LanceDB timestamp columns need datetimes, not ISO strings."""
@@ -1463,8 +1482,8 @@ class TestCollectionInfo:
         assert isinstance(storage_data["updated_at"], datetime)
         assert isinstance(storage_data["last_accessed_at"], datetime)
 
-    def test_collection_info_storage_round_trip_restores_enums(self):
-        """from_storage(to_storage()) hands the enum members back."""
+    def test_storage_round_trip_carries_no_ingestion_config(self):
+        """What went in as tenant config must not come back out of this row."""
         collection = CollectionInfo(
             name="test_collection",
             ingestion_config=IngestionConfig(
@@ -1475,9 +1494,7 @@ class TestCollectionInfo:
 
         restored = CollectionInfo.from_storage(collection.to_storage())
 
-        assert restored.ingestion_config is not None
-        assert restored.ingestion_config.parse_method is ParseMethod.PYPDF
-        assert restored.ingestion_config.chunk_strategy is ChunkStrategy.MARKDOWN
+        assert restored.ingestion_config is None
 
     def test_collection_info_immutability_by_default(self):
         """Test that CollectionInfo is immutable by default after creation."""

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -538,6 +538,63 @@ class TestResolveEffectiveEmbeddingModel:
 # --- rebuild_collection_metadata Tests (Issue #14) ---
 
 
+@patch(
+    "xagent.core.tools.core.RAG_tools.management.collection_manager.get_vector_index_store"
+)
+@patch("xagent.core.tools.core.RAG_tools.management.collections")
+@pytest.mark.asyncio
+async def test_rebuild_keeps_a_binding_it_could_not_infer(
+    mock_collections_module, mock_get_vector_store, monkeypatch
+):
+    """A collection with no embeddings must keep the binding it already has.
+
+    The inference block is skipped when ``embeddings == 0``, and
+    ``save_collection`` merges with when_matched_update_all, so passing the
+    un-inferred Nones through would blank the stored model. The enum TypeError
+    in ``to_storage`` used to abort the row before it landed, which is why this
+    never surfaced.
+    """
+    from types import SimpleNamespace
+
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        CollectionInfo,
+        IngestionConfig,
+        ParseMethod,
+    )
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    listed = CollectionInfo(
+        name="bound_collection",
+        embedding_model_id="text-embedding-v4",
+        embedding_dimension=1024,
+        embeddings=0,
+        # What list_collections attaches from the collection_config table.
+        ingestion_config=IngestionConfig(parse_method=ParseMethod.PYPDF),
+    )
+
+    async def mock_list_collections(**kwargs):
+        return SimpleNamespace(status="success", collections=[listed])
+
+    mock_collections_module.list_collections = mock_list_collections
+
+    mock_vector_store = Mock()
+    mock_get_vector_store.return_value = mock_vector_store
+    mock_vector_store.list_table_names.return_value = ["documents", "chunks"]
+
+    saved = []
+
+    async def capture(collection):
+        saved.append(collection)
+
+    monkeypatch.setattr(cm.collection_manager, "save_collection", capture)
+
+    await cm.rebuild_collection_metadata()
+
+    assert len(saved) == 1
+    assert saved[0].embedding_model_id == "text-embedding-v4"
+    assert saved[0].embedding_dimension == 1024
+
+
 class TestRebuildCollectionMetadata:
     """Test rebuild_collection_metadata function."""
 

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -1,5 +1,7 @@
 """Tests for collection manager functionality."""
 
+import asyncio
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -7,6 +9,7 @@ import pytest
 from xagent.core.tools.core.RAG_tools.core.schemas import (
     CollectionInfo,
     IngestionConfig,
+    ParseMethod,
 )
 from xagent.core.tools.core.RAG_tools.management.collection_manager import (
     CollectionManager,
@@ -421,10 +424,10 @@ class TestResolveEffectiveEmbeddingModel:
     @patch(
         "xagent.core.tools.core.RAG_tools.management.collection_manager.get_collection_sync"
     )
-    def test_ingestion_config_model_used_when_bound_model_missing(
+    def test_ingestion_config_model_does_not_outrank_the_caller(
         self, mock_get_collection: Mock, _mock_mark: Mock
     ) -> None:
-        """Collection ingestion config should supply the search embedding model."""
+        """An attached config is tenant-scoped, so it never wins the resolution."""
         mock_get_collection.return_value = CollectionInfo(
             name="test_collection",
             embedding_model_id=None,
@@ -433,10 +436,10 @@ class TestResolveEffectiveEmbeddingModel:
         )
 
         resolved = resolve_effective_embedding_model_sync(
-            "test_collection", config_model_id=None
+            "test_collection", config_model_id="caller-embed"
         )
 
-        assert resolved == "kb-index-embed"
+        assert resolved == "caller-embed"
 
     @patch(
         "xagent.core.tools.core.RAG_tools.management.collection_manager.mark_collection_accessed_sync"
@@ -444,10 +447,10 @@ class TestResolveEffectiveEmbeddingModel:
     @patch(
         "xagent.core.tools.core.RAG_tools.management.collection_manager.get_collection_sync"
     )
-    def test_none_placeholder_does_not_override_ingestion_config_model(
+    def test_ingestion_config_model_is_not_a_fallback_source(
         self, mock_get_collection: Mock, _mock_mark: Mock
     ) -> None:
-        """Tool placeholder values should still fall back to the indexed model."""
+        """With no bound model and no caller config there is nothing to resolve."""
         mock_get_collection.return_value = CollectionInfo(
             name="test_collection",
             embedding_model_id=None,
@@ -455,11 +458,10 @@ class TestResolveEffectiveEmbeddingModel:
             ingestion_config=IngestionConfig(embedding_model_id="kb-index-embed"),
         )
 
-        resolved = resolve_effective_embedding_model_sync(
-            "test_collection", config_model_id="none"
-        )
-
-        assert resolved == "kb-index-embed"
+        with pytest.raises(ValueError, match="not initialized"):
+            resolve_effective_embedding_model_sync(
+                "test_collection", config_model_id="none"
+            )
 
     @patch(
         "xagent.core.tools.core.RAG_tools.management.collection_manager._sync_wrapper"
@@ -538,31 +540,46 @@ class TestResolveEffectiveEmbeddingModel:
 # --- rebuild_collection_metadata Tests (Issue #14) ---
 
 
-@patch(
-    "xagent.core.tools.core.RAG_tools.management.collection_manager.get_vector_index_store"
-)
-@patch("xagent.core.tools.core.RAG_tools.management.collections")
-@pytest.mark.asyncio
-async def test_rebuild_keeps_a_binding_it_could_not_infer(
-    mock_collections_module, mock_get_vector_store, monkeypatch
+def _run_rebuild_capturing_writes(
+    monkeypatch, listed, *, table_names, row_counts=0, vector_dimension=None
 ):
-    """A collection with no embeddings must keep the binding it already has.
+    """Run the rebuild against a mocked vector store, capturing what it writes.
 
-    The inference block is skipped when ``embeddings == 0``, and
-    ``save_collection`` merges with when_matched_update_all, so passing the
-    un-inferred Nones through would blank the stored model. The enum TypeError
-    in ``to_storage`` used to abort the row before it landed, which is why this
-    never surfaced.
+    Returns the ``(candidate, owned_fields)`` pairs handed to
+    ``save_collection_fields`` -- the fields the rebuild claims to own.
     """
     from types import SimpleNamespace
 
-    from xagent.core.tools.core.RAG_tools.core.schemas import (
-        CollectionInfo,
-        IngestionConfig,
-        ParseMethod,
-    )
     from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+    from xagent.core.tools.core.RAG_tools.management import collections
 
+    async def mock_list_collections(**kwargs):
+        return SimpleNamespace(status="success", collections=[listed])
+
+    mock_vector_store = Mock()
+    mock_vector_store.list_table_names.return_value = table_names
+    mock_vector_store.count_rows_or_zero.return_value = row_counts
+    mock_vector_store.get_vector_dimension.return_value = vector_dimension
+
+    writes: list[tuple[Any, tuple[str, ...]]] = []
+
+    async def capture(collection, owned_fields):
+        writes.append((collection, owned_fields))
+
+    monkeypatch.setattr(collections, "list_collections", mock_list_collections)
+    monkeypatch.setattr(cm, "get_vector_index_store", lambda: mock_vector_store)
+    monkeypatch.setattr(cm.collection_manager, "save_collection_fields", capture)
+
+    asyncio.run(cm.rebuild_collection_metadata())
+    return writes
+
+
+def test_rebuild_does_not_claim_a_binding_it_could_not_infer(monkeypatch):
+    """With no embeddings there is nothing to infer, so nothing to overwrite.
+
+    The storage merge overwrites every column it is given, so claiming the
+    embedding fields here would blank the binding the row already has.
+    """
     listed = CollectionInfo(
         name="bound_collection",
         embedding_model_id="text-embedding-v4",
@@ -572,27 +589,63 @@ async def test_rebuild_keeps_a_binding_it_could_not_infer(
         ingestion_config=IngestionConfig(parse_method=ParseMethod.PYPDF),
     )
 
-    async def mock_list_collections(**kwargs):
-        return SimpleNamespace(status="success", collections=[listed])
+    writes = _run_rebuild_capturing_writes(
+        monkeypatch, listed, table_names=["documents", "chunks"]
+    )
 
-    mock_collections_module.list_collections = mock_list_collections
+    assert len(writes) == 1
+    _, owned_fields = writes[0]
+    assert "embedding_model_id" not in owned_fields
+    assert "embedding_dimension" not in owned_fields
 
-    mock_vector_store = Mock()
-    mock_get_vector_store.return_value = mock_vector_store
-    mock_vector_store.list_table_names.return_value = ["documents", "chunks"]
 
-    saved = []
+def test_rebuild_leaves_the_binding_alone_when_the_dimension_is_unknown(monkeypatch):
+    """A model without its dimension is not a usable pair, so bind neither.
 
-    async def capture(collection):
-        saved.append(collection)
+    ``get_vector_dimension`` legitimately returns None for a variable-length or
+    unreadable schema; writing only the model id would leave the previous,
+    possibly incompatible, dimension in place while ``is_initialized`` reports
+    the collection fully bound.
+    """
+    listed = CollectionInfo(
+        name="legacy_collection",
+        embedding_model_id="old-model",
+        embedding_dimension=1536,
+        embeddings=12,
+    )
 
-    monkeypatch.setattr(cm.collection_manager, "save_collection", capture)
+    writes = _run_rebuild_capturing_writes(
+        monkeypatch,
+        listed,
+        table_names=["embeddings_unmapped_tag"],
+        row_counts=1,
+        vector_dimension=None,
+    )
 
-    await cm.rebuild_collection_metadata()
+    assert len(writes) == 1
+    _, owned_fields = writes[0]
+    assert "embedding_model_id" not in owned_fields
+    assert "embedding_dimension" not in owned_fields
 
-    assert len(saved) == 1
-    assert saved[0].embedding_model_id == "text-embedding-v4"
-    assert saved[0].embedding_dimension == 1024
+
+def test_rebuild_claims_the_binding_when_both_halves_are_known(monkeypatch):
+    """The pair is complete, so the rebuild owns and overwrites both columns."""
+    listed = CollectionInfo(name="legacy_collection", embeddings=12)
+
+    writes = _run_rebuild_capturing_writes(
+        monkeypatch,
+        listed,
+        table_names=["embeddings_unmapped_tag"],
+        row_counts=1,
+        vector_dimension=768,
+    )
+
+    assert len(writes) == 1
+    candidate, owned_fields = writes[0]
+    assert "embedding_model_id" in owned_fields
+    assert "embedding_dimension" in owned_fields
+    assert candidate.embedding_model_id == "unmapped-tag"
+    assert candidate.embedding_dimension == 768
 
 
 class TestRebuildCollectionMetadata:

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -511,6 +511,43 @@ class TestResolveEffectiveEmbeddingModel:
     @patch(
         "xagent.core.tools.core.RAG_tools.utils.migration_utils._infer_embedding_config_from_collection"
     )
+    def test_inferred_model_without_a_dimension_is_not_persisted(
+        self,
+        mock_infer: Mock,
+        mock_get_collection: Mock,
+        _mock_mark: Mock,
+        mock_sync_wrapper: Mock,
+    ) -> None:
+        """Half a binding must not be written on the ingestion hot path.
+
+        Persisting the inferred model while keeping the stored dimension would
+        flip ``is_initialized`` on a pair that may not match.
+        """
+        mock_get_collection.return_value = CollectionInfo(
+            name="legacy_collection",
+            embedding_model_id=None,
+            embedding_dimension=1536,
+            embeddings=12,
+        )
+        mock_infer.return_value = ("legacy-index-embed", None)
+
+        resolved = resolve_effective_embedding_model_sync("legacy_collection")
+
+        assert resolved == "legacy-index-embed"
+        mock_sync_wrapper.assert_not_called()
+
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager._sync_wrapper"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.mark_collection_accessed_sync"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.management.collection_manager.get_collection_sync"
+    )
+    @patch(
+        "xagent.core.tools.core.RAG_tools.utils.migration_utils._infer_embedding_config_from_collection"
+    )
     def test_inference_failure_falls_back_to_config_model(
         self,
         mock_infer: Mock,

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -544,6 +544,13 @@ class TestResolveEffectiveEmbeddingModel:
         assert resolved == "legacy-index-embed"
         mock_save.assert_not_called()
 
+        # Nothing was persisted, so without a cached negative this hot path
+        # rescans every embeddings_* table on every ingest and search.
+        assert resolve_effective_embedding_model_sync("legacy_collection") == (
+            "legacy-index-embed"
+        )
+        assert mock_infer.call_count == 1
+
     @patch(
         "xagent.core.tools.core.RAG_tools.management.collection_manager._sync_wrapper"
     )

--- a/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_manager.py
@@ -427,7 +427,10 @@ class TestResolveEffectiveEmbeddingModel:
     def test_ingestion_config_model_does_not_outrank_the_caller(
         self, mock_get_collection: Mock, _mock_mark: Mock
     ) -> None:
-        """An attached config is tenant-scoped, so it never wins the resolution."""
+        """An attached config is tenant-scoped, so it never wins the resolution.
+
+        Defence in depth: a real get_collection_sync can no longer return one.
+        """
         mock_get_collection.return_value = CollectionInfo(
             name="test_collection",
             embedding_model_id=None,
@@ -450,7 +453,10 @@ class TestResolveEffectiveEmbeddingModel:
     def test_ingestion_config_model_is_not_a_fallback_source(
         self, mock_get_collection: Mock, _mock_mark: Mock
     ) -> None:
-        """With no bound model and no caller config there is nothing to resolve."""
+        """With no bound model and no caller config there is nothing to resolve.
+
+        Defence in depth: a real get_collection_sync can no longer return one.
+        """
         mock_get_collection.return_value = CollectionInfo(
             name="test_collection",
             embedding_model_id=None,
@@ -530,11 +536,13 @@ class TestResolveEffectiveEmbeddingModel:
             embeddings=12,
         )
         mock_infer.return_value = ("legacy-index-embed", None)
+        mock_save = Mock()
+        mock_sync_wrapper.return_value = mock_save
 
         resolved = resolve_effective_embedding_model_sync("legacy_collection")
 
         assert resolved == "legacy-index-embed"
-        mock_sync_wrapper.assert_not_called()
+        mock_save.assert_not_called()
 
     @patch(
         "xagent.core.tools.core.RAG_tools.management.collection_manager._sync_wrapper"
@@ -626,8 +634,14 @@ def test_rebuild_does_not_claim_a_binding_it_could_not_infer(monkeypatch):
         ingestion_config=IngestionConfig(parse_method=ParseMethod.PYPDF),
     )
 
+    # An inferable embeddings table is present: only the embeddings == 0
+    # short-circuit can be keeping the binding out of the write.
     writes = _run_rebuild_capturing_writes(
-        monkeypatch, listed, table_names=["documents", "chunks"]
+        monkeypatch,
+        listed,
+        table_names=["documents", "chunks", "embeddings_unmapped_tag"],
+        row_counts=1,
+        vector_dimension=768,
     )
 
     assert len(writes) == 1

--- a/tests/core/tools/core/RAG_tools/management/test_collection_metadata_tenancy.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_metadata_tenancy.py
@@ -316,7 +316,6 @@ def test_a_written_row_carries_the_migrated_schema_version(metadata_store):
 
     migrated = asyncio.run(metadata_store.get_collection(name))
     assert migrated.schema_version == "1.0.0"
-    assert "schema_version" not in cm._REBUILD_OWNED_FIELDS
 
     recomputed = migrated.model_copy(update={"documents": 4})
     asyncio.run(

--- a/tests/core/tools/core/RAG_tools/management/test_collection_metadata_tenancy.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_metadata_tenancy.py
@@ -104,7 +104,9 @@ def test_same_named_tenants_share_a_row_without_sharing_config(metadata_store):
 
 
 def test_rebuild_style_save_keeps_a_binding_it_could_not_infer(metadata_store):
-    """A save that infers no embedding model must not erase the stored one."""
+    """A rebuild that infers no embedding model must not erase the stored one."""
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
     bound = CollectionInfo(
         name="bound",
         embedding_model_id="text-embedding-v4",
@@ -112,10 +114,14 @@ def test_rebuild_style_save_keeps_a_binding_it_could_not_infer(metadata_store):
     )
     asyncio.run(metadata_store.save_collection(bound))
 
-    listed = asyncio.run(metadata_store.get_collection("bound"))
-    asyncio.run(metadata_store.save_collection(listed))
+    # What the rebuild holds when inference yielded nothing: stats, no binding.
+    inferred_nothing = CollectionInfo(name="bound", documents=3)
+    asyncio.run(
+        cm.collection_manager.save_collection_fields(inferred_nothing, ("documents",))
+    )
 
     readback = asyncio.run(metadata_store.get_collection("bound"))
+    assert readback.documents == 3
     assert readback.embedding_model_id == "text-embedding-v4"
     assert readback.embedding_dimension == 1024
 
@@ -272,6 +278,44 @@ def test_rebuild_skips_the_write_when_nothing_changed(metadata_store):
 
     after = asyncio.run(metadata_store.get_collection(name))
     assert after.updated_at == before.updated_at
+
+
+def test_a_written_row_carries_the_migrated_schema_version(metadata_store):
+    """schema_version rides along on any write without being an owned field.
+
+    The re-read migrates in memory, so the merged row already holds the current
+    version; owning the field would change nothing, and would not rewrite a
+    legacy row whose recomputed stats happen to match either.
+    """
+    from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+        _safe_close_table,
+    )
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    name = "legacy-version"
+    asyncio.run(metadata_store.save_collection(CollectionInfo(name=name, documents=3)))
+
+    table = None
+    try:
+        table = metadata_store.get_raw_connection().open_table("collection_metadata")
+        table.update(f"name = '{name}'", {"schema_version": "0.0.0"})
+    finally:
+        _safe_close_table(table)
+
+    migrated = asyncio.run(metadata_store.get_collection(name))
+    assert migrated.schema_version == "1.0.0"
+    assert "schema_version" not in cm._REBUILD_OWNED_FIELDS
+
+    recomputed = migrated.model_copy(update={"documents": 4})
+    asyncio.run(
+        cm.collection_manager.save_collection_fields(
+            recomputed, cm._REBUILD_OWNED_FIELDS
+        )
+    )
+
+    raw = json.loads(_raw_metadata_rows(metadata_store))
+    row = next(row for row in raw if row["name"] == name)
+    assert row["schema_version"] == "1.0.0"
 
 
 def test_a_brand_new_collection_is_inserted_whole(metadata_store):

--- a/tests/core/tools/core/RAG_tools/management/test_collection_metadata_tenancy.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_metadata_tenancy.py
@@ -126,6 +126,18 @@ def test_rebuild_style_save_keeps_a_binding_it_could_not_infer(metadata_store):
     assert readback.embedding_dimension == 1024
 
 
+def test_unknown_owned_fields_are_rejected(metadata_store):
+    """A typo would otherwise be an AttributeError the rebuild loop swallows."""
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    with pytest.raises(ValueError, match="not_a_field"):
+        asyncio.run(
+            cm.collection_manager.save_collection_fields(
+                CollectionInfo(name="typo"), ("not_a_field",)
+            )
+        )
+
+
 def _seed_two_tenant_configs(metadata_store, name: str) -> None:
     """Two collection_config rows for one name; tenant B is the latest."""
     older = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=1)

--- a/tests/core/tools/core/RAG_tools/management/test_collection_metadata_tenancy.py
+++ b/tests/core/tools/core/RAG_tools/management/test_collection_metadata_tenancy.py
@@ -357,3 +357,39 @@ def test_a_read_failure_does_not_become_a_full_row_overwrite(metadata_store):
     survived = asyncio.run(metadata_store.get_collection(name))
     assert survived.documents == 9
     assert survived.collection_locked is True
+
+
+def test_a_corrupt_row_is_not_mistaken_for_a_missing_one(metadata_store):
+    """A row that exists but will not parse is a read failure, not "no row".
+
+    Both raise from the same call and json/pydantic errors are ValueError
+    subclasses, so only a dedicated not-found error can tell them apart -- and
+    getting it wrong turns a stale snapshot into a full-row overwrite.
+    """
+    from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+        _safe_close_table,
+    )
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    name = "corrupt"
+    asyncio.run(
+        metadata_store.save_collection(
+            CollectionInfo(name=name, documents=9, collection_locked=True)
+        )
+    )
+
+    table = None
+    try:
+        table = metadata_store.get_raw_connection().open_table("collection_metadata")
+        table.update(f"name = '{name}'", {"extra_metadata": "{not json"})
+    finally:
+        _safe_close_table(table)
+
+    stale = CollectionInfo(name=name, documents=1)
+    with pytest.raises(ValueError):
+        asyncio.run(cm.collection_manager.save_collection_fields(stale, ("documents",)))
+
+    raw = json.loads(_raw_metadata_rows(metadata_store))
+    survived = next(row for row in raw if row["name"] == name)
+    assert survived["documents"] == 9
+    assert survived["collection_locked"] is True

--- a/tests/core/tools/core/RAG_tools/storage/test_collection_metadata_tenancy.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_collection_metadata_tenancy.py
@@ -272,3 +272,44 @@ def test_rebuild_skips_the_write_when_nothing_changed(metadata_store):
 
     after = asyncio.run(metadata_store.get_collection(name))
     assert after.updated_at == before.updated_at
+
+
+def test_a_brand_new_collection_is_inserted_whole(metadata_store):
+    """Nothing stored yet -- not even the table -- so the whole row goes in."""
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    fresh = CollectionInfo(name="brand-new", documents=4)
+    asyncio.run(cm.collection_manager.save_collection_fields(fresh, ("documents",)))
+
+    assert asyncio.run(metadata_store.get_collection("brand-new")).documents == 4
+
+
+def test_a_read_failure_does_not_become_a_full_row_overwrite(metadata_store):
+    """Only "not found" may reach the insert-whole path.
+
+    Treating any read failure as "no row" would let one flaky read turn a stale
+    caller snapshot into a full-row overwrite, silently reinstating exactly the
+    concurrent rollback the field merge exists to prevent.
+    """
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    name = "flaky"
+    asyncio.run(
+        metadata_store.save_collection(
+            CollectionInfo(name=name, documents=9, collection_locked=True)
+        )
+    )
+    stale = CollectionInfo(name=name, documents=1)
+
+    async def unavailable(_self, _name):
+        raise RuntimeError("table under compaction")
+
+    with patch.object(type(metadata_store), "get_collection", unavailable):
+        with pytest.raises(RuntimeError):
+            asyncio.run(
+                cm.collection_manager.save_collection_fields(stale, ("documents",))
+            )
+
+    survived = asyncio.run(metadata_store.get_collection(name))
+    assert survived.documents == 9
+    assert survived.collection_locked is True

--- a/tests/core/tools/core/RAG_tools/storage/test_collection_metadata_tenancy.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_collection_metadata_tenancy.py
@@ -1,0 +1,102 @@
+"""The collection_metadata row is owner-neutral (#1567).
+
+Against a real LanceDB table, because the hazard is what survives a write and
+comes back out: `merge_insert(["name"])` merges on the name alone, so two
+tenants owning a same-named collection share one row. A tenant-scoped
+ingestion config -- which can carry an embedding_api_key and a model binding
+that outranks the caller's own config -- must never land in it.
+
+Until the enum TypeError in to_storage() was fixed, it was the only thing
+stopping that write.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    ChunkStrategy,
+    CollectionInfo,
+    IngestionConfig,
+    ParseMethod,
+)
+
+
+@pytest.fixture
+def metadata_store(tmp_path):
+    lancedb = pytest.importorskip("lancedb")
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+        LanceDBMetadataStore,
+    )
+
+    store = LanceDBMetadataStore()
+    store._conn = lancedb.connect(str(tmp_path / "meta"))
+    return store
+
+
+def _tenant_config(model_id: str, api_key: str) -> IngestionConfig:
+    return IngestionConfig(
+        parse_method=ParseMethod.PYPDF,
+        chunk_strategy=ChunkStrategy.MARKDOWN,
+        embedding_model_id=model_id,
+        embedding_api_key=api_key,
+    )
+
+
+def test_same_named_tenants_share_a_row_without_sharing_config(metadata_store):
+    """Two tenants, one collection name, no config or credential in the row."""
+    tenant_a = CollectionInfo(
+        name="shared-name",
+        embedding_model_id="model-a",
+        ingestion_config=_tenant_config("model-a-from-config", "sk-tenant-a"),
+    )
+    tenant_b = CollectionInfo(
+        name="shared-name",
+        embedding_model_id="model-b",
+        ingestion_config=_tenant_config("model-b-from-config", "sk-tenant-b"),
+    )
+
+    asyncio.run(metadata_store.save_collection(tenant_a))
+    asyncio.run(metadata_store.save_collection(tenant_b))
+
+    readback = asyncio.run(metadata_store.get_collection("shared-name"))
+
+    # Neither tenant's config reaches the shared row, so the resolver's
+    # "use the model stored in ingestion_config" step cannot outrank either
+    # caller's own config.
+    assert readback.ingestion_config is None
+
+    table = metadata_store._conn.open_table("collection_metadata")
+    raw = json.dumps(table.to_arrow().to_pylist(), default=str)
+    assert "sk-tenant-a" not in raw
+    assert "sk-tenant-b" not in raw
+    assert "model-a-from-config" not in raw
+    assert "model-b-from-config" not in raw
+
+
+def test_rebuild_style_save_keeps_a_binding_it_could_not_infer(metadata_store):
+    """A save that infers no embedding model must not erase the stored one.
+
+    ``_rebuild_collection_metadata_impl`` leaves both embedding fields None for
+    a collection with no embeddings yet, and merge_insert updates every column,
+    so passing them through would blank the binding. The enum TypeError used to
+    abort that write before it landed.
+    """
+    bound = CollectionInfo(
+        name="bound",
+        embedding_model_id="text-embedding-v4",
+        embedding_dimension=1024,
+    )
+    asyncio.run(metadata_store.save_collection(bound))
+
+    # What the rebuild loop now hands to save_collection: the row as listed,
+    # with nothing overwritten because nothing was inferred.
+    listed = asyncio.run(metadata_store.get_collection("bound"))
+    asyncio.run(metadata_store.save_collection(listed))
+
+    readback = asyncio.run(metadata_store.get_collection("bound"))
+    assert readback.embedding_model_id == "text-embedding-v4"
+    assert readback.embedding_dimension == 1024

--- a/tests/core/tools/core/RAG_tools/storage/test_collection_metadata_tenancy.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_collection_metadata_tenancy.py
@@ -1,19 +1,20 @@
 """The collection_metadata row is owner-neutral (#1567).
 
-Against a real LanceDB table, because the hazard is what survives a write and
-comes back out: `merge_insert(["name"])` merges on the name alone, so two
-tenants owning a same-named collection share one row. A tenant-scoped
-ingestion config -- which can carry an embedding_api_key and a model binding
-that outranks the caller's own config -- must never land in it.
-
-Until the enum TypeError in to_storage() was fixed, it was the only thing
-stopping that write.
+Against a real LanceDB directory, because the hazard is what survives a write
+and comes back out: ``merge_insert(["name"])`` merges on the name alone, so two
+tenants owning a same-named collection share one row. A tenant-scoped ingestion
+config -- which can carry an embedding_api_key and a model binding that would
+outrank the caller's own config -- must never land in it, and must not be
+hydrated back out of it either.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterator
+from unittest.mock import patch
 
 import pytest
 
@@ -21,20 +22,37 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
     ChunkStrategy,
     CollectionInfo,
     IngestionConfig,
+    ListCollectionsResult,
     ParseMethod,
 )
 
 
 @pytest.fixture
-def metadata_store(tmp_path):
-    lancedb = pytest.importorskip("lancedb")
-    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
-        LanceDBMetadataStore,
+def metadata_store(tmp_path, monkeypatch) -> Iterator[Any]:
+    pytest.importorskip("lancedb")
+    from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+        _safe_close_table,
+    )
+    from xagent.core.tools.core.RAG_tools.management.collection_manager import (
+        reset_locks_for_testing,
+    )
+    from xagent.core.tools.core.RAG_tools.storage.factory import (
+        get_metadata_store,
+        reset_rag_storage_for_tests,
     )
 
-    store = LanceDBMetadataStore()
-    store._conn = lancedb.connect(str(tmp_path / "meta"))
-    return store
+    monkeypatch.setenv("LANCEDB_DIR", str(tmp_path / ".lancedb"))
+    reset_rag_storage_for_tests()
+    reset_locks_for_testing()
+    store = get_metadata_store()
+    try:
+        yield store
+    finally:
+        # LanceDB holds file handles per open table/connection; a test that
+        # leaks them keeps the tmp dir mapped for the rest of the session.
+        _safe_close_table(getattr(store, "_conn", None))
+        reset_rag_storage_for_tests()
+        reset_locks_for_testing()
 
 
 def _tenant_config(model_id: str, api_key: str) -> IngestionConfig:
@@ -44,6 +62,19 @@ def _tenant_config(model_id: str, api_key: str) -> IngestionConfig:
         embedding_model_id=model_id,
         embedding_api_key=api_key,
     )
+
+
+def _raw_metadata_rows(metadata_store) -> str:
+    from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+        _safe_close_table,
+    )
+
+    table = None
+    try:
+        table = metadata_store.get_raw_connection().open_table("collection_metadata")
+        return json.dumps(table.to_arrow().to_pylist(), default=str)
+    finally:
+        _safe_close_table(table)
 
 
 def test_same_named_tenants_share_a_row_without_sharing_config(metadata_store):
@@ -63,14 +94,9 @@ def test_same_named_tenants_share_a_row_without_sharing_config(metadata_store):
     asyncio.run(metadata_store.save_collection(tenant_b))
 
     readback = asyncio.run(metadata_store.get_collection("shared-name"))
-
-    # Neither tenant's config reaches the shared row, so the resolver's
-    # "use the model stored in ingestion_config" step cannot outrank either
-    # caller's own config.
     assert readback.ingestion_config is None
 
-    table = metadata_store._conn.open_table("collection_metadata")
-    raw = json.dumps(table.to_arrow().to_pylist(), default=str)
+    raw = _raw_metadata_rows(metadata_store)
     assert "sk-tenant-a" not in raw
     assert "sk-tenant-b" not in raw
     assert "model-a-from-config" not in raw
@@ -78,13 +104,7 @@ def test_same_named_tenants_share_a_row_without_sharing_config(metadata_store):
 
 
 def test_rebuild_style_save_keeps_a_binding_it_could_not_infer(metadata_store):
-    """A save that infers no embedding model must not erase the stored one.
-
-    ``_rebuild_collection_metadata_impl`` leaves both embedding fields None for
-    a collection with no embeddings yet, and merge_insert updates every column,
-    so passing them through would blank the binding. The enum TypeError used to
-    abort that write before it landed.
-    """
+    """A save that infers no embedding model must not erase the stored one."""
     bound = CollectionInfo(
         name="bound",
         embedding_model_id="text-embedding-v4",
@@ -92,11 +112,163 @@ def test_rebuild_style_save_keeps_a_binding_it_could_not_infer(metadata_store):
     )
     asyncio.run(metadata_store.save_collection(bound))
 
-    # What the rebuild loop now hands to save_collection: the row as listed,
-    # with nothing overwritten because nothing was inferred.
     listed = asyncio.run(metadata_store.get_collection("bound"))
     asyncio.run(metadata_store.save_collection(listed))
 
     readback = asyncio.run(metadata_store.get_collection("bound"))
     assert readback.embedding_model_id == "text-embedding-v4"
     assert readback.embedding_dimension == 1024
+
+
+def _seed_two_tenant_configs(metadata_store, name: str) -> None:
+    """Two collection_config rows for one name; tenant B is the latest."""
+    older = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=1)
+    asyncio.run(
+        metadata_store.save_collection_config(
+            name,
+            _tenant_config("model-a-from-config", "sk-tenant-a").model_dump_json(),
+            101,
+        )
+    )
+    asyncio.run(
+        metadata_store.save_collection_config(
+            name,
+            _tenant_config("model-b-from-config", "sk-tenant-b").model_dump_json(),
+            202,
+        )
+    )
+    # Age tenant A so admin's latest-row pick is deterministically tenant B.
+    from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+        _safe_close_table,
+    )
+
+    table = None
+    try:
+        table = metadata_store.get_raw_connection().open_table("collection_config")
+        table.update("user_id = 101", {"updated_at": older})
+    finally:
+        _safe_close_table(table)
+
+
+def test_rebuild_does_not_leak_a_tenant_config_into_the_shared_row(metadata_store):
+    """Full chain: two tenant configs -> admin rebuild -> production readback.
+
+    The rebuild lists collections as admin, which attaches the latest tenant's
+    ingestion config to the in-memory CollectionInfo it then saves. Nothing of
+    that config may reach the shared row, and the resolver must fall through to
+    the caller's own model rather than the tenant's.
+    """
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    name = "shared-name"
+    asyncio.run(metadata_store.save_collection(CollectionInfo(name=name)))
+    _seed_two_tenant_configs(metadata_store, name)
+
+    from xagent.core.tools.core.RAG_tools.management import collections
+
+    listed = asyncio.run(
+        collections.list_collections(is_admin=True, force_realtime=True)
+    )
+    attached = next(c for c in listed.collections if c.name == name)
+    # Precondition: the rebuild really does hold a tenant's config in memory.
+    assert attached.ingestion_config is not None
+    assert attached.ingestion_config.embedding_api_key == "sk-tenant-b"
+
+    asyncio.run(cm.rebuild_collection_metadata())
+
+    readback = asyncio.run(metadata_store.get_collection(name))
+    assert readback.ingestion_config is None
+    assert readback.embedding_model_id is None
+
+    # The rebuild's no-stored-row branch inserts the listed object whole, and is
+    # the only place a config-carrying CollectionInfo reaches storage as a full
+    # row; the merge branch above never passes the column along at all.
+    asyncio.run(metadata_store.delete_collection(name))
+    asyncio.run(cm.collection_manager.save_collection_fields(attached, ("documents",)))
+    assert asyncio.run(metadata_store.get_collection(name)).ingestion_config is None
+
+    raw = _raw_metadata_rows(metadata_store)
+    for secret in (
+        "sk-tenant-a",
+        "sk-tenant-b",
+        "model-a-from-config",
+        "model-b-from-config",
+    ):
+        assert secret not in raw
+
+    # Resolver priority: with nothing bound on the shared row and no tenant
+    # config to hydrate, the caller's own model is what wins.
+    assert (
+        cm.resolve_effective_embedding_model_sync(name, config_model_id="caller-model")
+        == "caller-model"
+    )
+
+
+def test_rebuild_only_writes_the_fields_it_recomputed(metadata_store):
+    """A stale pre-loop snapshot must not roll back another writer's columns.
+
+    The rebuild reads every collection once, then saves them one by one; the
+    storage merge overwrites every column, so anything a concurrent writer
+    changed in between would be reverted to the snapshot.
+    """
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    name = "raced"
+    snapshot = CollectionInfo(name=name, documents=7, chunks=21)
+    asyncio.run(metadata_store.save_collection(snapshot))
+
+    # What the concurrent writer landed after the rebuild's snapshot read.
+    concurrent = CollectionInfo(
+        name=name,
+        documents=1,
+        chunks=1,
+        collection_locked=True,
+        extra_metadata={"pinned": "by-other-writer"},
+    )
+    asyncio.run(metadata_store.save_collection(concurrent))
+
+    async def stale_listing(**kwargs):
+        return ListCollectionsResult(
+            status="success",
+            collections=[snapshot],
+            total_count=1,
+            message="stale snapshot",
+        )
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.management.collections.list_collections",
+        stale_listing,
+    ):
+        asyncio.run(cm.rebuild_collection_metadata())
+
+    readback = asyncio.run(metadata_store.get_collection(name))
+    assert readback.documents == 7
+    assert readback.chunks == 21
+    assert readback.collection_locked is True
+    assert readback.extra_metadata == {"pinned": "by-other-writer"}
+
+
+def test_rebuild_skips_the_write_when_nothing_changed(metadata_store):
+    """A no-op rebuild must not touch the row at all, not even updated_at."""
+    from xagent.core.tools.core.RAG_tools.management import collection_manager as cm
+
+    name = "unchanged"
+    asyncio.run(metadata_store.save_collection(CollectionInfo(name=name, documents=3)))
+    before = asyncio.run(metadata_store.get_collection(name))
+
+    async def same_listing(**kwargs):
+        return ListCollectionsResult(
+            status="success",
+            collections=[before],
+            total_count=1,
+            message="unchanged",
+        )
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.management.collections.list_collections",
+        same_listing,
+    ):
+        asyncio.run(cm.rebuild_collection_metadata())
+
+    after = asyncio.run(metadata_store.get_collection(name))
+    assert after.updated_at == before.updated_at


### PR DESCRIPTION
Closes #1567

`collection_metadata` is keyed by name alone — no `user_id`, and `save_collection` merges on
`merge_insert(["name"])` — so two tenants owning a same-named collection share one row. An
`IngestionConfig` belongs to one `(collection, user_id)` and can carry an `embedding_api_key`,
and `_resolve_effective_embedding_model_sync_impl` consulted the stored config's model ahead of
the caller's own. Writing that config into the shared row would hand one tenant's credential and
model binding to every same-named collection.

The only reason it never happened is a bug: `CollectionInfo.to_storage()` raised `TypeError` for
any populated `ingestion_config` (`model_dump()` in python mode leaves `parse_method` and
`chunk_strategy` as plain `Enum` members, which `json.dumps` cannot encode), and
`rebuild_collection_metadata` swallows that per collection — so the 6-hourly rebuild "succeeded"
while reconciling nothing, for every collection that had a config. That is nearly all of them:
the rebuild feeds on `list_collections(is_admin=True)`, which attaches the config from
`collection_config`.

So this PR does **not** fix the serialization. The column is never written now: `to_storage()`
always stores the sentinel, and `from_storage()` clears the field unconditionally, before the
migration check, so a current-version row that skips migration is covered too. `collection_config`
already owns this data, keyed properly and rewritten on every ingest.

### Making the write succeed uncovered two more hazards on the same path

- `_rebuild_collection_metadata_impl` left both embedding fields `None` when
  `collection.embeddings == 0` and passed them into `model_copy` unconditionally; with
  `when_matched_update_all` that blanks the stored binding. The same half-binding hazard sat on
  the resolver hot path, which is reachable from concurrent ingestion. Both now bind the
  (model, dimension) pair or neither.
- The rebuild wrote back a full-row snapshot read before the loop, so a concurrent writer's
  stats, timestamps or flags could be rolled back. New `CollectionManager.save_collection_fields()`
  re-reads the stored row inside the same lock hold as the write, merges only the fields the
  rebuild recomputed, and writes nothing at all when the merge equals what is stored. "Not found"
  is now a dedicated `CollectionNotFoundError`, so a row that exists but fails to parse is a read
  failure rather than a licence to insert the stale snapshot whole.

### Not in this PR

- The three remaining unguarded read-modify-write call sites
  (`kb/pipeline_compatibility.py:177`, `kb/tool_compatibility.py:369`,
  `kb/api_compatibility.py:472`). Pre-existing, narrower window, tracking issue to follow.
- `list_collections(is_admin=True, force_realtime=True)` still does a bulk full-row
  `save_collections` before the rebuild loop, so the race is narrowed, not eliminated end to end.
- `CollectionInfo.ingestion_config` still serves two roles by provenance (populated from
  `list_collections`, always `None` from storage). Documented in the field's description;
  splitting the listing view is a separate change.
- Legacy rows keep their old `schema_version` on disk when the rebuild finds nothing to write.
  Cosmetic: every read re-runs the in-memory migration.

### Tests

Roughly two thirds of the diff is tests. `tests/.../management/test_collection_metadata_tenancy.py`
runs against a real LanceDB directory: two same-named tenants with distinct model ids and
`embedding_api_key`s; the full chain of two `collection_config` rows → admin latest-row selection
→ real `rebuild_collection_metadata()` → production readback, asserting no config and neither
credential in the raw Arrow rows, and that the resolver returns the caller's model; a stale
snapshot that must not roll back a concurrent writer's columns; a no-op rebuild that must not
touch `updated_at`; and a corrupt-but-present row that must not be mistaken for a missing one.
Each guard was mutation-checked by reverting it and confirming exactly the intended test fails.
