### PR TITLE
fix(jobs): judge background-job staleness by last update, not start time

### DIFF
--- a/example.env
+++ b/example.env
@@ -93,7 +93,9 @@ PORT="80"
 # XAGENT_BACKGROUND_JOB_VISIBILITY_TIMEOUT_SECONDS="3600"
 # Default max attempts for newly-created durable jobs.
 # XAGENT_BACKGROUND_JOB_MAX_RETRIES="3"
-# Stale non-terminal jobs are requeued by the scheduler after this age.
+# Longest a non-terminal job may go without a durable row update (progress
+# or status persistence) before the scheduler requeues it. Not a runtime
+# limit: a job that keeps persisting progress is never requeued for age.
 # XAGENT_BACKGROUND_JOB_STALE_SECONDS="7200"
 # Scheduler interval for scanning stale background jobs.
 # XAGENT_BACKGROUND_JOB_SWEEP_INTERVAL_SECONDS="300"

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -947,7 +947,13 @@ def get_background_job_max_retries() -> int:
 
 
 def get_background_job_stale_seconds() -> int:
-    """Return the age after which non-terminal jobs should be requeued."""
+    """Return the longest gap without a durable row update before requeueing.
+
+    Measured against ``updated_at`` -- progress or status persistence -- not
+    against how long the job has been running, so a job that keeps reporting is
+    never requeued for being long. Liveness rides on whatever the work loop
+    persists; there is no timer heartbeat.
+    """
     return _get_positive_int_env(BACKGROUND_JOB_STALE_SECONDS, 7200, minimum=60)
 
 

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -276,6 +276,10 @@ def requeue_stale_background_jobs(
     Redis/Celery can lose in-flight delivery state during broker loss or worker
     crashes. The database row remains authoritative, so the scheduler can safely
     put old pending/enqueued/running jobs back on the broker.
+
+    Staleness is judged on ``updated_at`` for every status, never ``started_at``:
+    the latter is written once and never advances, so a RUNNING job judged by it
+    is requeued for being long, not for being dead.
     """
     stale_seconds = stale_after_seconds or get_background_job_stale_seconds()
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=stale_seconds)
@@ -291,12 +295,6 @@ def requeue_stale_background_jobs(
         .filter(
             or_(
                 and_(
-                    BackgroundJob.status == BackgroundJobStatus.RUNNING.value,
-                    BackgroundJob.started_at.is_not(None),
-                    BackgroundJob.started_at <= cutoff,
-                ),
-                and_(
-                    BackgroundJob.status != BackgroundJobStatus.RUNNING.value,
                     BackgroundJob.updated_at.is_not(None),
                     BackgroundJob.updated_at <= cutoff,
                 ),

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -29,6 +29,7 @@ from xagent.web.services.background_jobs import (
     enqueue_background_job,
     is_background_job_enqueue_available,
     requeue_stale_background_jobs,
+    update_job_progress,
 )
 from xagent.web.services.triggers import enqueue_trigger_event_job
 
@@ -46,6 +47,10 @@ def _age_job(db, job, *, updated_at=None, started_at=None) -> None:
         values["updated_at"] = updated_at
     if started_at is not None:
         values["started_at"] = started_at
+    if not values:
+        # An empty SET still carries onupdate=func.now(), so this would push
+        # updated_at forward -- the opposite of backdating.
+        raise ValueError("_age_job needs updated_at or started_at")
     db.query(BackgroundJob).filter(BackgroundJob.id == job.id).update(
         values, synchronize_session=False
     )
@@ -1526,9 +1531,17 @@ def test_requeue_spares_running_job_that_is_still_reporting_progress(
         setattr(job, "status", BackgroundJobStatus.RUNNING.value)
         db.add(job)
         db.commit()
-        # Started four hours ago, reported progress just now.
-        _age_job(db, job, started_at=datetime.now(timezone.utc) - timedelta(hours=4))
+        old = datetime.now(timezone.utc) - timedelta(hours=4)
+        _age_job(db, job, updated_at=old, started_at=old)
         db.refresh(job)
+        stale_updated_at = job.updated_at
+
+        # Go through the real reporting path, not a hand-set timestamp: that
+        # progress advances updated_at is the premise the whole predicate rests
+        # on, so the test has to fail if it ever stops holding.
+        update_job_progress(db, job, message="Still working", completed=536, total=699)
+        db.refresh(job)
+        assert job.updated_at > stale_updated_at
 
         requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
 

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -38,6 +38,21 @@ def _init_test_db(path: Path):
     return get_session_local()
 
 
+def _age_job(db, job, *, updated_at=None, started_at=None) -> None:
+    """Backdate a job row. A plain ORM write cannot: ``updated_at`` carries
+    ``onupdate=func.now()``, which any flush would overwrite."""
+    values = {}
+    if updated_at is not None:
+        values["updated_at"] = updated_at
+    if started_at is not None:
+        values["started_at"] = started_at
+    db.query(BackgroundJob).filter(BackgroundJob.id == job.id).update(
+        values, synchronize_session=False
+    )
+    db.commit()
+    db.expire_all()
+
+
 def _create_user(db, username: str = "background-job-test") -> User:
     user = User(username=username, password_hash="x")
     db.add(user)
@@ -1470,9 +1485,9 @@ def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monke
         )
         old = datetime.now(timezone.utc) - timedelta(hours=3)
         setattr(job, "status", BackgroundJobStatus.RUNNING.value)
-        setattr(job, "started_at", old)
         db.add(job)
         db.commit()
+        _age_job(db, job, updated_at=old, started_at=old)
         db.refresh(job)
 
         requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
@@ -1483,6 +1498,75 @@ def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monke
         assert job.celery_task_id is None
         assert job.started_at is None
         assert job.progress["message"] == "Requeued stale background job"
+    finally:
+        db.close()
+
+
+def test_requeue_spares_running_job_that_is_still_reporting_progress(
+    tmp_path, monkeypatch
+):
+    """A long job that keeps working must not be requeued.
+
+    ``started_at`` never advances, so judging a RUNNING job by it means any job
+    outliving the cutoff gets a second copy started alongside it.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-live.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="live-test")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb"},
+        )
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        db.add(job)
+        db.commit()
+        # Started four hours ago, reported progress just now.
+        _age_job(db, job, started_at=datetime.now(timezone.utc) - timedelta(hours=4))
+        db.refresh(job)
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert requeued == []
+        db.refresh(job)
+        assert job.status == BackgroundJobStatus.RUNNING.value
+        assert job.started_at is not None
+    finally:
+        db.close()
+
+
+def test_requeue_reclaims_running_job_that_stopped_reporting(tmp_path, monkeypatch):
+    """A RUNNING job whose heartbeat went stale is still reclaimed."""
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-dead.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="dead-test")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb"},
+        )
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        db.add(job)
+        db.commit()
+        # Started recently, but has not touched the row since.
+        _age_job(db, job, updated_at=datetime.now(timezone.utc) - timedelta(hours=3))
+        db.refresh(job)
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert [item.id for item in requeued] == [job.id]
+        db.refresh(job)
+        assert job.status == BackgroundJobStatus.PENDING.value
     finally:
         db.close()
 


### PR DESCRIPTION
Closes #1565. Part of #1564.

`requeue_stale_background_jobs` decides whether a RUNNING job is stale from `started_at`.
That column is written once by `mark_job_running` and never advances, so for a RUNNING job the
predicate reduces to "has been running a long time" — a statement about duration, not about
liveness. Every other branch of the same query already uses `updated_at`.

The consequence is that any job whose real runtime exceeds
`XAGENT_BACKGROUND_JOB_STALE_SECONDS` (default 7200) gets requeued while it is healthily
working, and a second copy starts executing alongside it. Since `mark_job_running` increments
`attempts` on every entry, the counter then climbs well past `max_attempts` without a single
failure.

The fix drops the RUNNING special case so staleness is judged on `updated_at` for every status.
The predicate goes from three branches to two; the `updated_at IS NULL` fallback to
`created_at` is kept as-is, so rows with no `updated_at` are still reclaimable.

**Testing note.** `updated_at` carries `onupdate=func.now()`, so a stale timestamp cannot be
constructed through an ordinary ORM write — any flush overwrites it. The new `_age_job` helper
backdates via `Query.update()`, whose explicit value wins over `onupdate`. The existing
`test_requeue_stale_background_jobs_marks_old_running_pending` previously created staleness by
setting `started_at`, and now uses the same helper.

**Known limitation.** Liveness is still a side effect of progress reporting.
`update_job_progress` only emits an UPDATE when `progress` actually changes, so for job types
that report no progress — or write the same payload repeatedly — `updated_at` advances only on
status transitions. Web ingestion refreshes it several times a second, which is why this change
fixes the incident on its own; turning liveness into a timer-driven heartbeat is #1535.

**Out of scope.** `attempts` can still exceed `max_attempts`, because the cap is only consulted
inside the `except` branches — that is #1566. This change only stops the counter from being
inflated by redeliveries of a healthy job.

**Verification.** `tests/web/test_background_jobs.py` 37 passed; `tests/web/test_trigger_tasks.py`,
the only call site, is green.
